### PR TITLE
Enable react-native-screens for native navigation components

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -308,7 +308,7 @@ PODS:
     - React
   - RNReanimated (1.7.0):
     - React
-  - RNScreens (2.0.0-beta.8):
+  - RNScreens (2.2.0):
     - React
   - RNSVG (10.1.0):
     - React
@@ -498,7 +498,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: dde546180bf24af0b5f737c8ad04b6f3fa51609a
   RNPermissions: 2f74237e97b08beda01e914301e12524ddddf5b8
   RNReanimated: 031fe8d9ea93c2bd689a40f05320ef9d96f74d7f
-  RNScreens: d56b2da8367a56bbc9840e16d968339eb0ec7e7f
+  RNScreens: 812b79d384e2bea7eebc4ec981469160d4948fd5
   RNSVG: 069864be08c9fe065a2cf7e63656a34c78653c99
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-native-permissions": "^2.0.9",
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^0.7.3",
-    "react-native-screens": "^2.0.0-beta.8",
+    "react-native-screens": "^2.2.0",
     "react-native-svg": "^10.1.0",
     "uuid": "^3.4.0"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {enableScreens} from 'react-native-screens';
 import AppContextProvider from './AppContext';
 import GeolocationContextProvider from './GeolocationContext';
 import NavigationRoot from './NavigationRoot';
@@ -6,6 +7,7 @@ import trackAppState from './diagnostics/trackAppState';
 import ThemeContextProvider from './theme/ThemeContext';
 
 trackAppState();
+enableScreens();
 
 const App = () => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6069,10 +6069,10 @@ react-native-safe-area-context@^0.7.3:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
   integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
 
-react-native-screens@^2.0.0-beta.8:
-  version "2.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-beta.8.tgz#f302c5a93b1bf067739026dd64ac553145659ecd"
-  integrity sha512-UCu5to8SM52aLhmKQPcwQ0cXekFUdCza9VU76gDAsodJS3kvmNaCkjlSQ0eFucqYEhMqCCZ/fYxpdMbSsiYHGg==
+react-native-screens@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.2.0.tgz#cc4cdf17426fdda97ad93a5e812a1899390f1978"
+  integrity sha512-a0VzxOWot7F9B/GQyDSssBRd3jUJazFnTQS61IiyReWB6aHlFhf3Xz10jBRoURXy1EMCDCHgenmTVTkKHpKyqQ==
   dependencies:
     debounce "^1.2.0"
 


### PR DESCRIPTION
Enable `react-native-screens` to take advantage of native containers to improve memory: https://twitter.com/janicduplessis/status/1039979591815897088?s=21

This library is deeply integrated in `react-navigation`.

Requires a `pod install`