### PR TITLE
Add shorthand createThemeHook function

### DIFF
--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -66,3 +66,31 @@ const style = StyleSheet.createTheme((theme: Theme) => ({
   },
 }));
 ```
+
+Optionally shorthand API for using the `useStyle` is if you use `StyleSheet.createThemeHook` function:
+
+```tsx
+import {StyleSheet} from './theme';
+
+export default function MyComponent() {
+  const styles = useThemeStyles();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Hello</Text>
+    </View>
+  );
+}
+
+const useThemeStyles = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    backgroundColor: theme.background.primary,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: theme.text.primary,
+  },
+}));
+```

--- a/src/theme/StyleSheet.ts
+++ b/src/theme/StyleSheet.ts
@@ -5,6 +5,7 @@ import {
   ImageStyle,
 } from 'react-native';
 import {Theme} from './colors';
+import {useTheme} from './ThemeContext';
 
 export type NamedStyles<T> = {
   [P in keyof T]: ViewStyle | TextStyle | ImageStyle;
@@ -13,13 +14,35 @@ export type ThemedStyles<T> = (theme: Theme) => T;
 
 type StyleSheetType = typeof StyleSheetNative;
 interface StyleSheet extends StyleSheetType {
+  createThemeHook<T>(input: ThemedStyles<NamedStyles<T>>): () => NamedStyles<T>;
   createTheme<T>(
     input: ThemedStyles<NamedStyles<T>>,
   ): ThemedStyles<NamedStyles<T>>;
 }
 
+export function useStyle<T extends NamedStyles<T>>(
+  style: ThemedStyles<T> | T,
+): T {
+  const {theme} = useTheme();
+  if (!isThemedStyles<T>(style)) {
+    return style;
+  }
+  return style(theme);
+}
+
+function isThemedStyles<T>(style: any): style is ThemedStyles<T> {
+  return typeof style === 'function';
+}
+
 const StyleSheetImpl: StyleSheet = {
   ...StyleSheetNative,
+  createThemeHook<T>(
+    input: ThemedStyles<NamedStyles<T>>,
+  ): () => NamedStyles<T> {
+    return function useThemeStyle() {
+      return useStyle(input);
+    };
+  },
   createTheme<T>(
     input: ThemedStyles<NamedStyles<T>>,
   ): ThemedStyles<NamedStyles<T>> {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,22 +1,5 @@
-import {ThemedStyles, NamedStyles} from './StyleSheet';
-import {useTheme} from './ThemeContext';
-
 import {Theme as ThemeM} from './colors';
 
 export type Theme = ThemeM;
-export {default as StyleSheet} from './StyleSheet';
+export {default as StyleSheet, useStyle} from './StyleSheet';
 export {useTheme} from './ThemeContext';
-
-export function useStyle<T extends NamedStyles<T>>(
-  style: ThemedStyles<T> | T,
-): T {
-  const {theme} = useTheme();
-  if (!isThemedStyles<T>(style)) {
-    return style;
-  }
-  return style(theme);
-}
-
-function isThemedStyles<T>(style: any): style is ThemedStyles<T> {
-  return typeof style === 'function';
-}


### PR DESCRIPTION
Idea: Shorthand `createThemeHook` function on `StyleSheet`.

Purpose is to avoid having to pass in styles explicitly as an argument