### PR TITLE
Adds default location to argument of useLocationSearchValue

### DIFF
--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -190,11 +190,11 @@ export type LocationWithSearchMetadata = Location & {
 
 export function useLocationSearchValue<
   T extends RouteProp<any, any> & {params: ParamListBase}
->(callerRouteParam: keyof T['params']) {
+>(callerRouteParam: keyof T['params'], defaultLocation?: Location) {
   const route = useRoute<T>();
   const [location, setLocation] = React.useState<
     LocationWithSearchMetadata | undefined
-  >(undefined);
+  >(defaultLocation && {...defaultLocation, resultType: 'search'});
 
   React.useEffect(() => {
     if (route.params?.[callerRouteParam]) {

--- a/src/screens/Profile/AddEditFavorite/index.tsx
+++ b/src/screens/Profile/AddEditFavorite/index.tsx
@@ -46,15 +46,10 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
   const [isEmojiVisible, setEmojiVisible] = useState<boolean>(false);
   const [emoji, setEmoji] = useState<RenderedEmoji | undefined>(undefined);
   const [name, setName] = useState<string>(editItem?.name ?? '');
-  const [location, setLocation] = useState<Location | undefined>(
+  const location = useLocationSearchValue<AddEditScreenRouteProp>(
+    'searchLocation',
     editItem?.location,
   );
-  const searchLocation = useLocationSearchValue<AddEditScreenRouteProp>(
-    'searchLocation',
-  );
-  useEffect(() => {
-    setLocation(searchLocation);
-  }, [searchLocation]);
 
   const hasSelectedValues = Boolean(location);
 


### PR DESCRIPTION
I honestly feel this makes more sense. While I see your point (https://github.com/AtB-AS/mittatb-app/pull/54#discussion_r393886365) of coupling between the component and the `useLocationSearchValue` hook, I think the same argument could have been made with a regular `input` + `useState` hook.

This is a very common pattern:

```js
function MyComponent () {
  const [foo, setFoo] = useState('defaultValue');
  return <input value={foo} onChange={(e) => setFoo(e.currentTarget.value)} />;
}
```

and our usage is almost similar:

```js
function MyComponent () {
  const location = useLocationSearchValue('defaultValue');
  return <input value={location} />;
}
```

But the big difference is the updater is backed in the hook it self. 