### PR TITLE
Add option for border in Profile Buttons

### DIFF
--- a/src/screens/Profile/Button.tsx
+++ b/src/screens/Profile/Button.tsx
@@ -12,12 +12,14 @@ import {StyleSheet, Theme} from '../../theme';
 type ButtonProps = {
   onPress(): void;
   mode?: 'primary' | 'destructive' | 'secondary';
+  border?: boolean;
   textContainerStyle?: StyleProp<ViewStyle>;
   IconComponent?: React.ElementType;
 } & TouchableOpacityProperties;
 const Button: React.FC<ButtonProps> = ({
   onPress,
   mode = 'primary',
+  border = true,
   IconComponent,
   children,
   disabled,
@@ -31,6 +33,7 @@ const Button: React.FC<ButtonProps> = ({
     mode === 'secondary' ? css.buttonSecondary : undefined,
     mode === 'destructive' ? css.buttonDestructive : undefined,
   ];
+  if (!border) styleContainer.push({borderWidth: 0});
   const styleText = [
     css.text,
     mode === 'destructive' ? css.textDestructive : undefined,

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -34,7 +34,6 @@ export default function Profile({navigation}: ProfileScreenProps) {
   const {favorites} = useFavorites();
   const items = favorites ?? [];
 
-
   const navigateToEdit = (item: LocationFavorite) => {
     navigation.navigate('AddEditFavorite', {editItem: item});
   };
@@ -90,6 +89,7 @@ function AddFavoriteButton({onPress}: {onPress(): void}) {
         marginLeft: 12,
       }}
       mode="secondary"
+      border={false}
       IconComponent={PlusIcon}
     >
       Legg til favorittsted


### PR DESCRIPTION
Probably can extract these elements to a shared folder soon

Seems like add favorites shouldn't have a border according to design:
![image](https://user-images.githubusercontent.com/4932625/77141328-c4e43300-6a7c-11ea-8534-b3b41676646c.png)
