### PR TITLE
Adds fallback time to wait row in details panel

### DIFF
--- a/src/screens/TripDetailsModal/Details/TransportDetail.tsx
+++ b/src/screens/TripDetailsModal/Details/TransportDetail.tsx
@@ -112,7 +112,10 @@ function WaitRow({
   currentLeg,
   nextLeg,
 }: WaitRowProps) {
-  const time = secondsBetween(currentLeg.aimedEndTime, nextLeg.aimedStartTime);
+  const time = secondsBetween(
+    currentLeg.aimedEndTime ?? currentLeg.expectedEndTime ?? 0,
+    nextLeg.aimedStartTime ?? currentLeg.expectedStartTime ?? 0,
+  );
   useEffect(() => {
     if (!visible) return;
     onCalculateTime(time);


### PR DESCRIPTION
Ref: https://app.bugsnag.com/atb-as/mittatb/errors/5e78dfa0a6eed40017ed692d?event_id=5e78dfc40058f073382b0000&i=sk&m=fx

Think the issue might be missing aimed(End|Start)Time. Adds fallback to expected if that is the case. And if nothing, just use 0.