### PR TITLE
Use custom header for add favorite screen. Solves #89

### DIFF
--- a/src/ScreenHeader/index.tsx
+++ b/src/ScreenHeader/index.tsx
@@ -20,7 +20,17 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   const iconEl = iconElement ?? defaultIcon;
 
   const icon = onClose ? (
-    <TouchableOpacity onPress={onClose}>{iconEl}</TouchableOpacity>
+    <TouchableOpacity
+      onPress={onClose}
+      hitSlop={{
+        top: 8,
+        left: 8,
+        right: 8,
+        bottom: 8,
+      }}
+    >
+      {iconEl}
+    </TouchableOpacity>
   ) : (
     iconEl
   );

--- a/src/screens/Profile/AddEditFavorite/index.tsx
+++ b/src/screens/Profile/AddEditFavorite/index.tsx
@@ -1,7 +1,15 @@
 import {RouteProp, CompositeNavigationProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useState, useEffect} from 'react';
-import {Alert, StyleProp, Text, View, ViewStyle, TextStyle} from 'react-native';
+import {
+  Alert,
+  StyleProp,
+  Text,
+  View,
+  ViewStyle,
+  TextStyle,
+  SafeAreaView,
+} from 'react-native';
 import {TextInput, TouchableOpacity} from 'react-native-gesture-handler';
 import {ProfileStackParams} from '..';
 import CancelCrossIcon from '../../../assets/svg/CancelCrossIcon';
@@ -18,6 +26,8 @@ import InputSearchIcon from '../../../location-search/svg/InputSearchIcon';
 import {SharedElement} from 'react-navigation-shared-element';
 import {RootStackParamList} from '../../../navigation';
 import {useLocationSearchValue} from '../../../location-search';
+import ScreenHeader from '../../../ScreenHeader';
+import ChevronLeftIcon from '../../../assets/svg/ChevronLeftIcon';
 
 type AddEditRouteName = 'AddEditFavorite';
 const AddEditRouteNameStatic: AddEditRouteName = 'AddEditFavorite';
@@ -96,7 +106,10 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
   const cancel = () => navigation.goBack();
 
   return (
-    <View style={css.container}>
+    <SafeAreaView style={css.container}>
+      <ScreenHeader onClose={cancel} iconElement={<ChevronLeftIcon />}>
+        Legg til favorittsted
+      </ScreenHeader>
       <EmojiPopup
         onClose={() => setEmojiVisible(false)}
         open={isEmojiVisible}
@@ -181,7 +194,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
           Avbryt
         </Button>
       </View>
-    </View>
+    </SafeAreaView>
   );
 }
 const useScreenStyle = StyleSheet.createThemeHook((theme: Theme) => ({

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -29,7 +29,7 @@ export default function ProfileScreen() {
         name="AddEditFavorite"
         component={AddEditFavorite}
         options={{
-          title: 'Legg til favorittsted',
+          headerShown: false,
         }}
       />
     </Stack.Navigator>


### PR DESCRIPTION
Rewrite add favorite view to use the custom header as with the rest of the app. See the example below.

![image](https://user-images.githubusercontent.com/606374/77406662-4e656f00-6db5-11ea-8169-f8e09cc119ba.png)
