### PR TITLE
Changes scroll bar position and chip list padding in search modal

### DIFF
--- a/src/location-search/FavoriteChips.tsx
+++ b/src/location-search/FavoriteChips.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, StyleSheet, ViewStyle} from 'react-native';
+import {View, Text, StyleSheet, ViewStyle, StyleProp} from 'react-native';
 import {ScrollView, TouchableOpacity} from 'react-native-gesture-handler';
 import colors from '../theme/colors';
 import {useFavorites} from '../favorites/FavoritesContext';
@@ -13,11 +13,13 @@ type Props = {
   geolocation: GeolocationResponse | null;
   onSelectLocation: (location: LocationWithSearchMetadata) => void;
   hideFavorites: boolean;
+  containerStyle?: StyleProp<ViewStyle>;
 };
 
 const FavoriteChips: React.FC<Props> = ({
   onSelectLocation,
   geolocation,
+  containerStyle,
   hideFavorites,
 }) => {
   const {favorites} = useFavorites();
@@ -35,7 +37,11 @@ const FavoriteChips: React.FC<Props> = ({
         height: 44,
       }}
     >
-      <ScrollView horizontal={true} showsHorizontalScrollIndicator={false}>
+      <ScrollView
+        horizontal={true}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={containerStyle}
+      >
         {currentLocation && (
           <FavoriteChip
             text="Min posisjon"

--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -88,41 +88,45 @@ const LocationSearch: React.FC<Props> = ({
 
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>Adresse eller stoppested</Text>
-      <SharedElement id="locationSearchInput">
-        <View style={styles.inputContainer}>
-          <TextInput
-            ref={inputRef}
-            style={styles.input}
-            value={text}
-            onChangeText={setText}
-            placeholder="Søk etter adresse eller stoppested"
-            autoCorrect={false}
-            autoCompleteType="off"
-            placeholderTextColor={(styles.placeholder as TextStyle).color}
-          />
-          <InputSearchIcon style={styles.searchIcon} />
-          {text?.length ? (
-            <View style={styles.searchClear}>
-              <TouchableOpacity
-                hitSlop={{right: 8, left: 8, top: 8, bottom: 8}}
-                onPress={() => setText('')}
-              >
-                <CancelCrossIcon />
-              </TouchableOpacity>
-            </View>
-          ) : null}
-        </View>
-      </SharedElement>
+      <View style={styles.contentBlock}>
+        <Text style={styles.label}>Adresse eller stoppested</Text>
+        <SharedElement id="locationSearchInput">
+          <View style={styles.inputContainer}>
+            <TextInput
+              ref={inputRef}
+              style={styles.input}
+              value={text}
+              onChangeText={setText}
+              placeholder="Søk etter adresse eller stoppested"
+              autoCorrect={false}
+              autoCompleteType="off"
+              placeholderTextColor={(styles.placeholder as TextStyle).color}
+            />
+            <InputSearchIcon style={styles.searchIcon} />
+            {text?.length ? (
+              <View style={styles.searchClear}>
+                <TouchableOpacity
+                  hitSlop={{right: 8, left: 8, top: 8, bottom: 8}}
+                  onPress={() => setText('')}
+                >
+                  <CancelCrossIcon />
+                </TouchableOpacity>
+              </View>
+            ) : null}
+          </View>
+        </SharedElement>
+      </View>
+
       {!hasResults && (
         <FavoriteChips
           onSelectLocation={onSelect}
           geolocation={geolocation}
           hideFavorites={!!hideFavorites}
+          containerStyle={styles.contentBlock}
         />
       )}
       {hasAnyResult ? (
-        <ScrollView>
+        <ScrollView style={styles.contentBlock}>
           {hasPreviousResults && (
             <LocationResults
               title="Tidligere søk"
@@ -141,7 +145,7 @@ const LocationSearch: React.FC<Props> = ({
           )}
         </ScrollView>
       ) : (
-        <View>
+        <View style={styles.contentBlock}>
           <Text>Fant ingen søkeresultat</Text>
         </View>
       )}
@@ -172,7 +176,10 @@ const useThemeStyles = StyleSheet.createThemeHook(theme => ({
   container: {
     backgroundColor: theme.background.secondary,
     flex: 1,
-    padding: theme.sizes.pagePadding,
+    paddingTop: 12,
+  },
+  contentBlock: {
+    paddingHorizontal: theme.sizes.pagePadding,
   },
   label: {
     fontSize: 12,


### PR DESCRIPTION
I'm not sure what is better practice on mobiles, but to me, the scroll bar position looked odd. This sets the padding to the scroll view instead.

Also, the chips in the design are shown to take the entire width. This PR updates that as well.

<img width="573" alt="Screenshot 2020-03-30 at 10 00 20" src="https://user-images.githubusercontent.com/606374/77888973-60d82080-726d-11ea-9416-3cd94d0370d5.png">
<img width="573" alt="Screenshot 2020-03-30 at 10 00 18" src="https://user-images.githubusercontent.com/606374/77888982-646ba780-726d-11ea-924d-225a225e761d.png">
<img width="573" alt="Screenshot 2020-03-30 at 10 00 12" src="https://user-images.githubusercontent.com/606374/77888984-65043e00-726d-11ea-8bb4-255f3c5929a1.png">
