### PR TITLE
fix statusbar color in dark mode (#81)

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, StatusBar} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import trackNavigation from '../diagnostics/trackNavigation';
@@ -38,6 +38,7 @@ const NavigationRoot = () => {
 
   return (
     <SafeAreaProvider>
+      <StatusBar barStyle="dark-content"/>
       <NavigationContainer onStateChange={trackNavigation}>
         <SharedStack.Navigator
           mode={isLoading || !onboarded ? 'card' : 'modal'}


### PR DESCRIPTION
Statusbar is currently invisible in dark mode on iOS.

Use the `barStyle` property to force use of dark foreground color, regardless of dark mode or not.