### PR TITLE
Removes updating state onselect for search modal

### DIFF
--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -56,7 +56,6 @@ const LocationSearch: React.FC<Props> = ({
     if (location.resultType === 'search') {
       addSearchEntry(location);
     }
-    setText(location.label ?? location.name);
     navigation.navigate(callerRouteName, {
       [callerRouteParam]: location,
     });


### PR DESCRIPTION
We get yellowbox on updating state after unmount. As far as I can tell it originates from this line where we set text when navigating away from the component.

I don't know what the intention of this was, but it doesn't seem to have any effect when removing it. Also I feel this doesn't make any sense? We're navigating away, so what we set as state is trashed anyways?