### PR TITLE
Style statusbar differently on ios and android. Fixes #126.

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -49,7 +49,12 @@ const NavigationRoot = () => {
 
   return (
     <SafeAreaProvider>
-      <StatusBar barStyle="dark-content" />
+      <StatusBar
+        barStyle={Platform.select({
+          ios: 'dark-content',
+          android: 'light-content',
+        })}
+      />
       <NavigationContainer onStateChange={trackNavigation}>
         <SharedStack.Navigator
           mode={


### PR DESCRIPTION
Must set barstyle explicitly to avoid problems in dark mode. However, on Android the default is light-content, and on iOS the default is dark-content.