### PR TITLE
Explicitly exclude unneeded Android libs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -175,6 +175,20 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            packagingOptions {
+                exclude "lib/arm64-v8a/libhermes-executor-debug.so"
+                exclude "lib/arm64-v8a/libhermes-inspector.so"
+                exclude "lib/arm64-v8a/libjscexecutor.so"
+                exclude "lib/armeabi-v7a/libhermes-executor-debug.so"
+                exclude "lib/armeabi-v7a/libhermes-inspector.so"
+                exclude "lib/armeabi-v7a/libjscexecutor.so"
+                exclude "lib/x86/libhermes-executor-debug.so"
+                exclude "lib/x86/libhermes-inspector.so"
+                exclude "lib/x86/libjscexecutor.so"
+                exclude "lib/x86_64/libhermes-executor-debug.so"
+                exclude "lib/x86_64/libhermes-inspector.so"
+                exclude "lib/x86_64/libjscexecutor.so"
+            }
         }
     }
 


### PR DESCRIPTION
As I've mentioned before, I do not think the `react.gradle` exclusion code works for stripping debug-libs for Hermes in release builds of apps. 

I've tested this through AppCenter and explicitly excluding the files in our release-build seems to strip off 2.22 MB in total. Would be interesting to see how much is shaved off in a store distribution, which on my Android-device at least is a 7.7 MB download. Stripping off ~2 MB off that is a huge gain.