### PR TITLE
Adds prettier as a dev dependency to handle correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "metro-react-native-babel-preset": "^0.58.0",
     "patch-package": "^6.2.0",
     "postinstall-postinstall": "^2.0.0",
+    "prettier": "^2.0.4",
     "react-native-dotenv": "^0.2.0",
     "react-test-renderer": "16.11.0",
     "typescript": "^3.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6612,6 +6612,11 @@ prettier@1.17.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
   integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
+prettier@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
+  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
+
 pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"


### PR DESCRIPTION
Now we don't have an explicit dependency to prettier, though we use it. So e.g. VSCode uses locally installed in node_modules through react-script eslint something, but it runs an old version (1.17). We can probably set prettier in editors to use a globally installed tool, but it's better to explicitly set version and use local tools to ensure we all use the same versions.