### PR TITLE
ci: Fix generated URL for AppCenter

### DIFF
--- a/github.sh
+++ b/github.sh
@@ -12,7 +12,7 @@
 
 USER=AtB-AS
 
-build_url=https://appcenter.ms/users/$USER/apps/$APP_NAME/build/branches/$APPCENTER_BRANCH/builds/$BUILD_BUILDNUMBER
+build_url=https://appcenter.ms/users/$USER/apps/$APP_NAME/build/branches/$APPCENTER_BRANCH/builds/$BUILD_BUILDID
 
 github_set_status() {
     local status job_status


### PR DESCRIPTION
Old one used to be `BUILD_BUILD_ID`, before I changed it to `BUILD_BUILDNUMBER` - which was also wrong.