### PR TITLE
fix(details): Fixes details view where wait time is shown on two lines (text overflow)

### DIFF
--- a/src/screens/TripDetailsModal/Details/TransportDetail.tsx
+++ b/src/screens/TripDetailsModal/Details/TransportDetail.tsx
@@ -135,7 +135,7 @@ function WaitRow({onCalculateTime, currentLeg, nextLeg}: WaitRowProps) {
 }
 function formatTime(time: number) {
   // Show 'minutter' -> 'min'. Found no way to do this through date-fns.
-  return secondsToDuration(time, nb).replace('utter', '');
+  return secondsToDuration(time, nb).replace('utter', '').replace('utt', '');
 }
 const waitStyles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Fixes AtB-AS/kundevendt#1265 

I didn't find a way to show "short units" for format distance in date-fns. I saw a similar solution to this previously which was removed, so I figured as for now without i18n this is fine.