### PR TITLE
fix: Reduces timeout for nearby screen to avoid warnings on Android

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -7,9 +7,6 @@ import {Leg, LegMode, TripPattern} from '../../sdk';
 import {StyleSheet} from '../../theme';
 import colors from '../../theme/colors';
 import {formatToClock, secondsToDuration} from '../../utils/date';
-import JourneyBusIcon from './svg/JourneyBusIcon';
-import JourneyTrainIcon from './svg/JourneyTrainIcon';
-import JourneyTramIcon from './svg/JourneyTramIcon';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import RealTimeLocationIcon from '../../components/location-icon/real-time';
 

--- a/src/screens/Nearby/index.tsx
+++ b/src/screens/Nearby/index.tsx
@@ -79,7 +79,7 @@ const NearbyOverview: React.FC<Props> = ({currentLocation, navigation}) => {
     // Searching nearest is a really heavy operation,
     // so polling every 30 seconds is costly. Might
     // be a better way to do this and having subscription model for real time data.
-    fromLocation?.layer === 'venue' ? 30 : 120 ?? 0,
+    fromLocation?.layer === 'venue' ? 30 : 60 ?? 0,
   );
 
   const openLocationSearch = () =>


### PR DESCRIPTION
Now there is a warning from React Native on long timeout times (over 60 seconds) for potential performance issues and not running as a part of background task. But we don't want to do background tasks, but just ensure that the realtime data is as up to date as possible (ideally we would not have to poll).

By just reducing it to 60 seconds we avoid the warning (without having to explicitly ignore yellowbox warning and risk not catching similar but real issues in the future). It seems as it is working as intended, also when exiting the app and re-activating it. If opening again after the specified timeout, data result is re-fetched if window is in focus.

Only possible non-wanted feature now is when opening models we refetch data. This might be unnecessary.


Fixes AtB-AS/kundevendt#1242.