### PR TITLE
fix: Restore activity with RN Screens fragment

### DIFF
--- a/android/app/src/main/java/no/mittatb/MainActivity.java
+++ b/android/app/src/main/java/no/mittatb/MainActivity.java
@@ -1,5 +1,7 @@
 package no.mittatb;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
@@ -15,7 +17,12 @@ public class MainActivity extends ReactActivity {
   protected String getMainComponentName() {
     return "atb";
   }
-  
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
+  }
+
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
     return new ReactActivityDelegate(this, getMainComponentName()) {


### PR DESCRIPTION
Fixes AtB-AS/kundevendt#1247 

As per recommended fix https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067

I have tested this and it resolves the bug when the app is attempted to be restored after idling for quite some time. This does not seem to have any ill consequences when just backgrounding app and resuming. 

Have also looked into the RN framework code, and the `Bundle` instance does not seem to be in use there neither: https://github.com/facebook/react-native/blob/aee88b6843cea63d6aa0b5879ad6ef9da4701846/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java#L74