### PR TITLE
fix: Hide JSON response from WebView when redirecting

### DIFF
--- a/src/screens/Ticketing/Payment/CreditCard/index.tsx
+++ b/src/screens/Ticketing/Payment/CreditCard/index.tsx
@@ -23,19 +23,19 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
   const {url, transaction_id, payment_id} = route.params;
   const isCaptureInProgressRef = useRef(false);
 
-  const onLoadEnd = () => {
-    if (isLoading) {
+  const onLoadEnd = ({
+    nativeEvent: {url},
+  }: WebViewNavigationEvent | WebViewErrorEvent) => {
+    if (isLoading && !url.includes('/EnturPaymentRedirect')) {
       setIsLoading(false);
     }
   };
 
-  const onLoadStart = async (
-    event: WebViewNavigationEvent | WebViewErrorEvent,
-  ) => {
-    const {
-      nativeEvent: {url},
-    } = event;
+  const onLoadStart = async ({
+    nativeEvent: {url},
+  }: WebViewNavigationEvent | WebViewErrorEvent) => {
     if (url.includes('/EnturPaymentRedirect')) {
+      setIsLoading(true);
       const params = parseURL(url);
       const responseCode = params['responseCode'];
       if (responseCode === 'OK') {


### PR DESCRIPTION
Ref: AtB-AS/kundevendt#1253

This will hide the WebView when redirecting, so the JSON-response from the redirect is not displayed. Hopefully this will be solved in a better way when we build the actual screens for the pilot.