### PR TITLE
fix: Only short-circuit effect if initial param is undefined

### DIFF
--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -239,7 +239,10 @@ export function useLocationSearchValue<
   >(defaultLocation && {...defaultLocation, resultType: 'search'});
 
   React.useEffect(() => {
-    if (firstTimeRef.current && !route.params?.[callerRouteParam]) {
+    if (
+      firstTimeRef.current &&
+      route.params?.[callerRouteParam] === undefined
+    ) {
       firstTimeRef.current = false;
       return;
     }


### PR DESCRIPTION
Not a real problem yet, just avoiding a footgun