### PR TITLE
fix: Removed shared elements

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -430,8 +430,6 @@ PODS:
     - React
   - RNScreens (2.7.0):
     - React
-  - RNSharedElement (0.7.0):
-    - React
   - RNSVG (12.1.0):
     - React
   - Yoga (1.14.0)
@@ -493,7 +491,6 @@ DEPENDENCIES:
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
-  - RNSharedElement (from `../node_modules/react-native-shared-element`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -620,8 +617,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
-  RNSharedElement:
-    :path: "../node_modules/react-native-shared-element"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   Yoga:
@@ -701,7 +696,6 @@ SPEC CHECKSUMS:
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8
   RNReanimated: 955cf4068714003d2f1a6e2bae3fb1118f359aff
   RNScreens: cf198f915f8a2bf163de94ca9f5bfc8d326c3706
-  RNSharedElement: 00b1a1420d213a34459bb9a5aacabb38107d7948
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/package.json
+++ b/package.json
@@ -58,10 +58,8 @@
     "react-native-reanimated": "^1.8.0",
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.7.0",
-    "react-native-shared-element": "^0.7.0",
     "react-native-svg": "^12.1.0",
     "react-native-webview": "^9.4.0",
-    "react-navigation-shared-element": "^5.0.0-alpha1",
     "search-params": "^3.0.0",
     "string.fromcodepoint": "^1.0.0",
     "uuid": "^8.0.0"

--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -15,7 +15,6 @@ import {useGeocoder} from './useGeocoder';
 import LocationResults from './LocationResults';
 import FavoriteChips from './FavoriteChips';
 import {useGeolocationState} from '../GeolocationContext';
-import {SharedElement} from 'react-navigation-shared-element';
 import {RootStackParamList} from '../navigation';
 import {useSearchHistory} from '../search-history';
 import {Close} from '../assets/svg/icons/actions';
@@ -100,21 +99,19 @@ const LocationSearch: React.FC<Props> = ({
 
   return (
     <View style={styles.container}>
-      <SharedElement id="locationSearchInput">
-        <View style={styles.contentBlock}>
-          <Input
-            ref={inputRef}
-            label={label}
-            value={text}
-            onChangeText={setText}
-            showClear={Boolean(text?.length)}
-            onClear={() => setText('')}
-            placeholder="Søk etter adresse eller stoppested"
-            autoCorrect={false}
-            autoCompleteType="off"
-          />
-        </View>
-      </SharedElement>
+      <View style={styles.contentBlock}>
+        <Input
+          ref={inputRef}
+          label={label}
+          value={text}
+          onChangeText={setText}
+          showClear={Boolean(text?.length)}
+          onClear={() => setText('')}
+          placeholder="Søk etter adresse eller stoppested"
+          autoCorrect={false}
+          autoCompleteType="off"
+        />
+      </View>
 
       <FavoriteChips
         onSelectLocation={onSelect}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -10,12 +10,11 @@ import LocationSearch, {
 import TabNavigator from './TabNavigator';
 import {Close} from '../assets/svg/icons/actions';
 import {useTheme} from '../theme';
-import {createSharedElementStackNavigator} from 'react-navigation-shared-element';
 import transitionSpec from './transitionSpec';
 import TripDetailsModal, {
   RouteParams as TripDetailsModalParams,
 } from '../screens/TripDetailsModal';
-import {TransitionPresets} from '@react-navigation/stack';
+import {TransitionPresets, createStackNavigator} from '@react-navigation/stack';
 import DepartureDetails, {
   DepartureDetailsRouteParams,
 } from '../screens/TripDetailsModal/DepartureDetails';
@@ -29,7 +28,7 @@ export type RootStackParamList = {
   DepartureDetailsModal: DepartureDetailsRouteParams;
 };
 
-const SharedStack = createSharedElementStackNavigator<RootStackParamList>();
+const Stack = createStackNavigator<RootStackParamList>();
 
 const NavigationRoot = () => {
   const {isLoading, onboarded} = useAppState();
@@ -49,23 +48,21 @@ const NavigationRoot = () => {
       />
       <NavigationContainer onStateChange={trackNavigation}>
         <Host>
-          <SharedStack.Navigator
-            mode={isLoading || !onboarded ? 'card' : 'modal'}
-          >
+          <Stack.Navigator mode={isLoading || !onboarded ? 'card' : 'modal'}>
             {!onboarded ? (
-              <SharedStack.Screen
+              <Stack.Screen
                 name="Onboarding"
                 component={Onboarding}
                 options={{headerShown: false}}
               />
             ) : (
               <>
-                <SharedStack.Screen
+                <Stack.Screen
                   name="TabNavigator"
                   component={TabNavigator}
                   options={{headerShown: false}}
                 />
-                <SharedStack.Screen
+                <Stack.Screen
                   name="TripDetailsModal"
                   component={TripDetailsModal}
                   options={{
@@ -75,7 +72,7 @@ const NavigationRoot = () => {
                     ...TransitionPresets.ModalPresentationIOS,
                   }}
                 />
-                <SharedStack.Screen
+                <Stack.Screen
                   name="DepartureDetailsModal"
                   component={DepartureDetails}
                   options={{
@@ -85,17 +82,9 @@ const NavigationRoot = () => {
                     ...TransitionPresets.ModalPresentationIOS,
                   }}
                 />
-                <SharedStack.Screen
+                <Stack.Screen
                   name="LocationSearch"
                   component={LocationSearch}
-                  sharedElementsConfig={() => [
-                    {
-                      id: 'locationSearchInput',
-                      animation: 'fade',
-                      resize: 'clip',
-                      align: 'center-bottom',
-                    },
-                  ]}
                   options={{
                     title: 'Søk',
                     headerBackTitleVisible: false,
@@ -125,7 +114,7 @@ const NavigationRoot = () => {
                 />
               </>
             )}
-          </SharedStack.Navigator>
+          </Stack.Navigator>
         </Host>
       </NavigationContainer>
     </>

--- a/src/screens/Assistant/index.tsx
+++ b/src/screens/Assistant/index.tsx
@@ -4,7 +4,6 @@ import React, {useCallback, useEffect, useMemo, useState, useRef} from 'react';
 import {View} from 'react-native';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {SharedElement} from 'react-navigation-shared-element';
 import {searchTrip} from '../../api';
 import {CancelToken, isCancel} from '../../api/client';
 import {Swap} from '../../assets/svg/icons/actions';
@@ -142,14 +141,14 @@ const Assistant: React.FC<Props> = ({
       />
       <SearchGroup>
         <View style={styles.searchButtonContainer}>
-          <SharedElement style={styles.styleButton} id="locationSearchInput">
+          <View style={styles.styleButton}>
             <LocationButton
               title="Fra"
               placeholder="Søk etter adresse eller sted"
               location={from}
               onPress={() => openLocationSearch('fromLocation', from?.name)}
             />
-          </SharedElement>
+          </View>
 
           <TouchableOpacity
             style={styles.clickableIcon}
@@ -161,14 +160,14 @@ const Assistant: React.FC<Props> = ({
         </View>
 
         <View style={styles.searchButtonContainer}>
-          <SharedElement id="locationSearchInput" style={styles.styleButton}>
+          <View style={styles.styleButton}>
             <LocationButton
               title="Til"
               placeholder="Søk etter adresse eller sted"
               location={to}
               onPress={() => openLocationSearch('toLocation', to?.name)}
             />
-          </SharedElement>
+          </View>
 
           <TouchableOpacity
             style={styles.clickableIcon}

--- a/src/screens/Nearby/index.tsx
+++ b/src/screens/Nearby/index.tsx
@@ -2,7 +2,6 @@ import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useCallback, useMemo} from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {SharedElement} from 'react-navigation-shared-element';
 import {getDepartures} from '../../api/departures';
 import {LocationButton} from '../../components/search-button';
 import SearchLocationIcon from '../../components/search-location-icon';
@@ -99,19 +98,17 @@ const NearbyOverview: React.FC<Props> = ({currentLocation, navigation}) => {
         rightButton={{icon: chatIcon, onPress: openChat}}
       />
       <SearchGroup>
-        <SharedElement id="locationSearchInput">
-          <LocationButton
-            title="Fra"
-            placeholder="Søk etter adresse eller sted"
-            location={fromLocation}
-            icon={
-              <View style={{marginLeft: 2}}>
-                <SearchLocationIcon location={fromLocation} />
-              </View>
-            }
-            onPress={() => openLocationSearch()}
-          />
-        </SharedElement>
+        <LocationButton
+          title="Fra"
+          placeholder="Søk etter adresse eller sted"
+          location={fromLocation}
+          icon={
+            <View style={{marginLeft: 2}}>
+              <SearchLocationIcon location={fromLocation} />
+            </View>
+          }
+          onPress={() => openLocationSearch()}
+        />
       </SearchGroup>
 
       <NearbyResults

--- a/src/screens/Profile/AddEditFavorite/index.tsx
+++ b/src/screens/Profile/AddEditFavorite/index.tsx
@@ -27,7 +27,6 @@ import {StyleSheet, Theme, useTheme} from '../../../theme';
 import Button from '../../../components/button';
 import EmojiPopup from './EmojiPopup';
 import {Search} from '../../../assets/svg/icons/actions';
-import {SharedElement} from 'react-navigation-shared-element';
 import {RootStackParamList} from '../../../navigation';
 import {useLocationSearchValue} from '../../../location-search';
 import ScreenHeader from '../../../ScreenHeader';
@@ -145,24 +144,22 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
       />
 
       <View style={css.innerContainer}>
-        <SharedElement id="locationSearchInput">
-          <Input
-            label="Sted"
-            value={location?.label}
-            placeholder="Søk etter adresse eller stoppested"
-            onFocus={() =>
-              navigation.navigate('LocationSearch', {
-                callerRouteName: AddEditRouteNameStatic,
-                callerRouteParam: 'searchLocation',
-                label: 'Sted',
-                hideFavorites: true,
-                initialText: location?.name,
-              })
-            }
-            autoCorrect={false}
-            autoCompleteType="off"
-          />
-        </SharedElement>
+        <Input
+          label="Sted"
+          value={location?.label}
+          placeholder="Søk etter adresse eller stoppested"
+          onFocus={() =>
+            navigation.navigate('LocationSearch', {
+              callerRouteName: AddEditRouteNameStatic,
+              callerRouteParam: 'searchLocation',
+              label: 'Sted',
+              hideFavorites: true,
+              initialText: location?.name,
+            })
+          }
+          autoCorrect={false}
+          autoCompleteType="off"
+        />
 
         <Input
           label="Navn"

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import {createSharedElementStackNavigator} from 'react-navigation-shared-element';
 import AddEditFavorite from './AddEditFavorite';
 import Profile from './FavoriteList';
 import {LocationFavorite, Location} from '../../favorites/types';
+import {createStackNavigator} from '@react-navigation/stack';
 
 export type ProfileStackParams = {
   Profile: undefined;
@@ -12,7 +12,7 @@ export type ProfileStackParams = {
   };
 };
 
-const Stack = createSharedElementStackNavigator<ProfileStackParams>();
+const Stack = createStackNavigator<ProfileStackParams>();
 
 export default function ProfileScreen() {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4617,13 +4617,6 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
-
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -7446,7 +7439,7 @@ react-devtools-core@^4.0.6:
     shell-quote "^1.6.1"
     ws "^7"
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7565,11 +7558,6 @@ react-native-screens@^2.7.0:
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.7.0.tgz#2d3cf3c39a665e9ca1c774264fccdb90e7944047"
   integrity sha512-n/23IBOkrTKCfuUd6tFeRkn3lB2QZ3cmvoubRscR0JU/Zl4/ZyKmwnFmUv1/Fr+2GH/H8UTX59kEKDYYg3dMgA==
 
-react-native-shared-element@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-shared-element/-/react-native-shared-element-0.7.0.tgz#c5e02eb372f6e38e48eb1030fd59be8f3d8c7a1f"
-  integrity sha512-TJTGwQceABYete+vH3ahNSgzVzXz7X2SPv3thT91gdcFCrm7ht7IKXBXJiYjOA+4TfdqnGEAWkspCy80oEnOgw==
-
 react-native-svg@^12.1.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.1.0.tgz#acfe48c35cd5fca3d5fd767abae0560c36cfc03d"
@@ -7622,13 +7610,6 @@ react-native@0.62.1:
     stacktrace-parser "^0.1.3"
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
-
-react-navigation-shared-element@^5.0.0-alpha1:
-  version "5.0.0-alpha1"
-  resolved "https://registry.yarnpkg.com/react-navigation-shared-element/-/react-navigation-shared-element-5.0.0-alpha1.tgz#29f2090d3f0eef626df93b8572ce5c192d5c46f2"
-  integrity sha512-zPlpvUV6RGsZv3lTDanIN3ARvqABHDrqIOKcD6NpUKXarua8F2kukJ0MqD0Py+oZR3e5ksjDHAISDU05iGmPwQ==
-  dependencies:
-    hoist-non-react-statics "^3.3.2"
 
 react-refresh@^0.4.0:
   version "0.4.2"


### PR DESCRIPTION
https://app.bugsnag.com/atb-as/mittatb/errors/5e832f21d5144f00170cbe70?filters[event.since][0]=30d&filters[error.status][0]=open

All the errors related to shared elements transitions are experienced by Android-users. On iOS the animations can be experienced as a bit janky as well (see feedback on Intercom). We currently depend on a preview version of the lib, and some of these issues are probably related to that.

Since we have no concrete plan how to use these animations yet though, I've decided to remove the lib for now on both platforms. It's mostly a layover from previous design iterations anyway.

We can revisit how we want to do these at a later point.