### PR TITLE
feat(nearby): Bug fixes and making stops clickable from departure screen

### DIFF
--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -4,6 +4,7 @@ import client from './client';
 import qs from 'query-string';
 import {stringifyUrl} from './utils';
 import {AxiosRequestConfig} from 'axios';
+import {StopPlace, StopPlaceDetails, Coordinates} from '@entur/sdk';
 
 const TRONDHEIM_CENTRAL_STATION = {
   latitude: 63.43457,
@@ -37,4 +38,22 @@ export async function reverse(
   });
 
   return await client.get<Feature[]>(stringifyUrl(url, query), config);
+}
+
+export async function venueToFeature(
+  loc: Coordinates,
+  config?: AxiosRequestConfig,
+): Promise<Feature | undefined> {
+  const url = 'bff/v1/geocoder/reverse';
+  const query = qs.stringify({
+    lat: loc.latitude,
+    lon: loc.longitude,
+    limit: 1,
+    radius: 1,
+    layers: ['venue'],
+  });
+
+  const result = await client.get<Feature[]>(stringifyUrl(url, query), config);
+  if (!result?.data?.length) return;
+  return result?.data[0];
 }

--- a/src/components/pressable-venue/index.tsx
+++ b/src/components/pressable-venue/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {Coordinates} from '@entur/sdk';
+import {venueToFeature} from '../../api/geocoder';
+import {mapFeatureToLocation} from '../../utils/location';
+import {Location} from '../../favorites/types';
+import {TouchableOpacity} from 'react-native-gesture-handler';
+
+type Props = {
+  coordinates: Coordinates;
+  onPress?(loc: Location): void;
+};
+const PressableVenue: React.FC<Props> = ({onPress, coordinates, children}) => {
+  const onPressInternal = async () => {
+    const localityResult = await venueToFeature(coordinates);
+    if (!localityResult) return;
+    onPress?.(mapFeatureToLocation(localityResult));
+  };
+
+  if (!onPress) {
+    return <>{children}</>;
+  }
+
+  return (
+    <TouchableOpacity onPress={onPressInternal}>{children}</TouchableOpacity>
+  );
+};
+
+export default PressableVenue;

--- a/src/location-search/useGeocoder.ts
+++ b/src/location-search/useGeocoder.ts
@@ -4,6 +4,7 @@ import {Feature} from '../sdk';
 import {autocomplete, reverse} from '../api';
 import {Location} from '../favorites/types';
 import {CancelToken, isCancel} from '../api/client';
+import {mapFeatureToLocation} from '../utils/location';
 
 export function useGeocoder(
   text: string | null,
@@ -70,14 +71,3 @@ export function useReverseGeocoder(location: GeolocationResponse | null) {
 
   return locations;
 }
-
-// IMPORTANT: Feature coordinate-array is [long, lat] :sadface:. Mapping to lat/long object for less bugs downstream.
-const mapFeatureToLocation = ({
-  geometry: {
-    coordinates: [longitude, latitude],
-  },
-  properties,
-}: Feature): Location => ({
-  ...properties,
-  coordinates: {latitude, longitude},
-});

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -1,5 +1,6 @@
 import haversine from 'haversine-distance';
 import {Location} from '../favorites/types';
+import {Feature} from '../sdk';
 
 type SortedLocation = {
   location: Location;
@@ -17,3 +18,14 @@ export function sortNearestLocations(
     }))
     .sort((a, b) => a.distance - b.distance);
 }
+
+// IMPORTANT: Feature coordinate-array is [long, lat] :sadface:. Mapping to lat/long object for less bugs downstream.
+export const mapFeatureToLocation = ({
+  geometry: {
+    coordinates: [longitude, latitude],
+  },
+  properties,
+}: Feature): Location => ({
+  ...properties,
+  coordinates: {latitude, longitude},
+});


### PR DESCRIPTION
Adds ability to press stops on departure screens to navigate to search from that particular stop. I think this functionality can be rewritten as part of #367 . Awaiting merge there before marking this as ready for review.