### PR TITLE
fix: Removes bugsnag logging on location errors

### DIFF
--- a/src/GeolocationContext.tsx
+++ b/src/GeolocationContext.tsx
@@ -69,19 +69,6 @@ const defaultState: GeolocationState = {
   location: null,
 };
 
-const translateErrorCode = (code: number) => {
-  switch (code) {
-    case 1:
-      return 'PERMISSION_DENIED';
-    case 2:
-      return 'POSITION_UNAVAILABLE';
-    case 3:
-      return 'TIMEOUT';
-    default:
-      return 'UNKNOWN';
-  }
-};
-
 const GeolocationContextProvider: React.FC = ({children}) => {
   const [state, dispatch] = useReducer<GeolocationReducer>(
     geolocationReducer,


### PR DESCRIPTION
Proposing to remove the bugsnag logging on location errors. I'm unsure of what value we get from it other than just "noise". We do error handling to recover/set the location data to disabled if we have issues.

Adding this also to avoid AtB-AS/kundevendt#852 (fixes AtB-AS/kundevendt#852 ). But we can leave this open a day or two to reflect if we need to log or not.