### PR TITLE
fix: Fixes on tabbar click scroll and jumping header animation

### DIFF
--- a/src/components/disappearing-header/index .tsx
+++ b/src/components/disappearing-header/index .tsx
@@ -199,7 +199,7 @@ const DisappearingHeader: React.FC<Props> = ({
                   // causes the content animation to jump when refresh control
                   // is triggered. Not ideal having native driver false
                   // but for now this is the best I can do. -mb
-                  useNativeDriver: false,
+                  useNativeDriver: !IS_IOS,
                   listener: (e: NativeSyntheticEvent<NativeScrollEvent>) => {
                     onScrolling(e.nativeEvent);
                   },


### PR DESCRIPTION
There are some bugs with the new disappearing header implementation on iOS. Mainly when triggering the refresh controller the animation jumps and is reset. See comment in code:

```ts
                  // For some reason native driver true her (which is preffered)
                  // causes the content animation to jump when refresh control
                  // is triggered. Not ideal having native driver false
                  // but for now this is the best I can do. -mb
```

This isn't actually a fix, but seems to avoid the issue. Probably for a performance cost (especially on older devices), but currently it seems as the most pragmatic solution.