### PR TITLE
feat: Highlight departures without real time information

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -8,6 +8,7 @@ import {
   secondsBetween,
   secondsToMinutesShort,
   formatToClockOrRelativeMinutes,
+  missingRealtimePrefix,
 } from '../../utils/date';
 import TransportationIcon from '../../components/transportation-icon';
 import insets from '../../utils/insets';
@@ -37,20 +38,29 @@ function getFromLeg(legs: Leg[]) {
   const found = legs.find(legWithQuay);
   const fromQuay = (found?.fromEstimatedCall ?? found?.fromPlace)?.quay;
   if (!fromQuay) {
-    return legs[0].fromPlace.name ?? 'ukjent holdeplass';
+    return (legs[0].fromPlace.name ?? 'ukjent holdeplass') + ' ';
   }
   return `${fromQuay.name} ${fromQuay.publicCode ?? ''}`;
 }
-
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
 }> = ({tripPattern}) => {
   const quayName = getFromLeg(tripPattern.legs);
   const styles = useThemeStyles();
   const durationText = secondsToDurationShort(tripPattern.duration);
+
+  const quayLeg = tripPattern.legs.find(legWithQuay);
+  const timePrefix =
+    !!quayLeg && !quayLeg.realtime ? missingRealtimePrefix : '';
+  const quayStartTime =
+    quayLeg?.expectedStartTime ?? tripPattern.legs[0].expectedStartTime;
   return (
     <View style={styles.resultHeader}>
-      <Text>Fra {quayName}</Text>
+      <Text>
+        Fra {quayName}
+        {timePrefix}
+        {formatToClockOrRelativeMinutes(quayStartTime)}
+      </Text>
       <TextHiddenSupportPrefix prefix="Reisetid">
         {durationText}
       </TextHiddenSupportPrefix>

--- a/src/screens/Nearby/NearbyResults.tsx
+++ b/src/screens/Nearby/NearbyResults.tsx
@@ -15,10 +15,8 @@ import {StyleSheet} from '../../theme';
 import {
   formatToClockOrRelativeMinutes,
   isInThePast,
-  isSameDay,
-  formatToSimpleDate,
-  daysBetween,
   isSeveralDays,
+  missingRealtimePrefix,
 } from '../../utils/date';
 import {getLineNameFromEstimatedCall} from '../../utils/transportation-names';
 import {useNavigation} from '@react-navigation/native';
@@ -276,7 +274,8 @@ const NearbyResultItem: React.FC<NearbyResultItemProps> = React.memo(
           onPress={() => onPress?.(departure)}
         >
           <TextHiddenSupportPrefix prefix="Avgang" style={styles.time}>
-            {formatToClockOrRelativeMinutes(departure.expectedDepartureTime)}
+            {(!departure.realtime ? missingRealtimePrefix : '') +
+              formatToClockOrRelativeMinutes(departure.expectedDepartureTime)}
           </TextHiddenSupportPrefix>
           <TransportationIcon
             mode={departure.serviceJourney.journeyPattern?.line.transportMode}

--- a/src/screens/TripDetailsModal/DepartureDetails/index.tsx
+++ b/src/screens/TripDetailsModal/DepartureDetails/index.tsx
@@ -4,7 +4,7 @@ import {DetailsModalStackParams, DetailsModalNavigationProp} from '..';
 import {RouteProp} from '@react-navigation/native';
 import {View, Text, ActivityIndicator, TouchableOpacity} from 'react-native';
 import {Dot} from '../../../assets/svg/icons/other';
-import {formatToClock} from '../../../utils/date';
+import {formatToClock, missingRealtimePrefix} from '../../../utils/date';
 import colors from '../../../theme/colors';
 import LocationRow from '../LocationRow';
 import {StyleSheet} from '../../../theme';
@@ -115,6 +115,17 @@ function CallGroup({type, calls, mode, publicCode}: CallGroupProps) {
   const shouldDropMarginBottom = (i: number) =>
     (type === 'after' || isOnRoute) && i == calls.length - 1;
   const shouldHaveMarginTop = (i: number) => type === 'after' && i == 0;
+  const departureTimeString = (
+    call: EstimatedCall,
+    indicateMissingRealtime: boolean = false,
+  ) => {
+    const timeString = formatToClock(call.expectedDepartureTime);
+    if (call.realtime || !indicateMissingRealtime) {
+      return timeString;
+    } else {
+      return missingRealtimePrefix + timeString;
+    }
+  };
 
   const [collapsed, setCollapsed] = useState(isBefore);
   const styles = useStopsStyle();
@@ -173,11 +184,9 @@ function CallGroup({type, calls, mode, publicCode}: CallGroupProps) {
               shouldHaveMarginTop(i) ? {marginTop: 24} : undefined,
             ]}
             location={getQuayName(call.quay)}
-            time={formatToClock(call.expectedDepartureTime)}
+            time={departureTimeString(call, isStartPlace(i))}
             timeStyle={
-              isOnRoute && i === 0
-                ? {fontWeight: 'bold', fontSize: 16}
-                : undefined
+              isStartPlace(i) ? {fontWeight: 'bold', fontSize: 16} : undefined
             }
             aimedTime={
               isStartPlace(i) && call.realtime

--- a/src/screens/TripDetailsModal/Details/TransportDetail.tsx
+++ b/src/screens/TripDetailsModal/Details/TransportDetail.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Text, View, StyleSheet, TouchableOpacity} from 'react-native';
 import Dash from 'react-native-dash';
-import {formatToClock} from '../../../utils/date';
+import {formatToClock, missingRealtimePrefix} from '../../../utils/date';
 import {Dot} from '../../../assets/svg/icons/other';
 import LocationRow from '../LocationRow';
 import {LegDetailProps, DetailScreenNavigationProp} from '.';
@@ -27,6 +27,12 @@ const TransportDetail: React.FC<LegDetailProps> = ({
   const showWaitTime = isIntermediateTravelLeg && Boolean(nextLeg);
   const {fill} = transportationColor(leg.mode, leg.line?.publicCode);
 
+  const timeString = (time: string) => {
+    if (!leg.realtime) {
+      return missingRealtimePrefix + formatToClock(time);
+    }
+    return formatToClock(time);
+  };
   return (
     <View style={{marginTop: -6}}>
       <TouchableOpacity
@@ -59,7 +65,7 @@ const TransportDetail: React.FC<LegDetailProps> = ({
               />
             }
             location={getQuayNameFromStartLeg(leg)}
-            time={formatToClock(leg.expectedStartTime)}
+            time={timeString(leg.expectedStartTime)}
             aimedTime={
               leg.realtime
                 ? getAimedTimeIfLargeDifference(leg.fromEstimatedCall)
@@ -75,7 +81,7 @@ const TransportDetail: React.FC<LegDetailProps> = ({
         <LocationRow
           icon={<Dot fill={fill} />}
           location={getQuayNameFromStopLeg(leg)}
-          time={formatToClock(leg.expectedEndTime)}
+          time={timeString(leg.expectedEndTime)}
           aimedTime={
             leg.realtime
               ? getAimedTimeIfLargeDifference(leg.toEstimatedCall)

--- a/src/screens/TripDetailsModal/Details/index.tsx
+++ b/src/screens/TripDetailsModal/Details/index.tsx
@@ -5,7 +5,7 @@ import {NavigationProp, RouteProp} from '@react-navigation/native';
 import {Leg, TripPattern} from '../../../sdk';
 import WalkDetail from './WalkDetail';
 import TransportDetail from './TransportDetail';
-import {formatToClock} from '../../../utils/date';
+import {formatToClock, missingRealtimePrefix} from '../../../utils/date';
 import LocationRow from '../LocationRow';
 import {StyleSheet} from '../../../theme';
 import Header from '../../../ScreenHeader';
@@ -112,6 +112,15 @@ const DetailsContent: React.FC<{
     tripPattern.legs?.length > 0 &&
     tripPattern.legs[tripPattern.legs.length - 1].mode === 'foot';
 
+  const startLeg = tripPattern.legs[0];
+  const timeString = (leg: Leg, time: string) => {
+    let timeString = formatToClock(time);
+    if (leg.mode !== 'foot' && !leg.realtime) {
+      timeString = missingRealtimePrefix + timeString;
+    }
+    return timeString;
+  };
+
   return (
     <>
       {shortTime && (
@@ -126,8 +135,8 @@ const DetailsContent: React.FC<{
             <Dot fill={colors.general.black} />
           )
         }
-        location={getQuayNameFromStartLeg(tripPattern.legs[0], from.name)}
-        time={formatToClock(tripPattern.startTime)}
+        location={getQuayNameFromStartLeg(startLeg, from.name)}
+        time={timeString(startLeg, tripPattern.startTime)}
         textStyle={styles.textStyle}
       />
       {tripPattern.legs.map((leg, i, legs) => (

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -26,6 +26,7 @@ const shortHumanizer = humanizeDuration.humanizer({
   },
 });
 
+export const missingRealtimePrefix = 'ca. ';
 export function secondsToDurationShort(seconds: number): string {
   return shortHumanizer(seconds * 1000, {
     units: ['d', 'h', 'm'],


### PR DESCRIPTION
Missing realtime prefix on "Nearby" departures creates a visual offset for the rest of the row, but this will be sorted out when the new design is implemented.
![Skjermdump fra 2020-09-08 13-10-33](https://user-images.githubusercontent.com/61825573/92471342-15d91680-f1d8-11ea-824e-4c6ed3de62e3.png)
![](https://user-images.githubusercontent.com/56530785/92104519-b77bf480-ede1-11ea-8968-315364cf6487.png)
