### PR TITLE
fix: Trip details should still be visible even when outdated

### DIFF
--- a/src/screens/TripDetailsModal/Details/index.tsx
+++ b/src/screens/TripDetailsModal/Details/index.tsx
@@ -80,7 +80,7 @@ const TripDetailsModal: React.FC<Props> = (props) => {
         {error && (
           <MessageBox type="warning">
             <Text>
-              Kunne ikke hente ut oppdatering forreiseforslaget. Det kan være
+              Kunne ikke hente ut oppdatering for reiseforslaget. Det kan være
               at reisen har endret seg eller ikke lengre er tilgjengelig.
             </Text>
           </MessageBox>


### PR DESCRIPTION
Trip details should still be visible even if we could not fetch an updated version from backend

Also a minor text change suggestion:
From 
"Kunne ikke hente ut reiseforslag. Det kan være at reisen har endret seg eller ikke lengre er tilgjengelig."
To
"Kunne ikke hente ut oppdatering for reiseforslaget. Det kan være at reisen har endret seg eller ikke lengre er tilgjengelig."