### PR TITLE
fix: Header height on normal screen Header

### DIFF
--- a/src/ScreenHeader/index.tsx
+++ b/src/ScreenHeader/index.tsx
@@ -54,6 +54,7 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     padding: theme.sizes.pagePadding,
+    height: 64,
   },
   iconContainerLeft: {
     position: 'absolute',
@@ -66,6 +67,6 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
   text: {
     color: theme.text.primary,
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: 'bold',
   },
 }));


### PR DESCRIPTION
Hurray for magic numbers. AnimatedHeader height is `HEADER_HEIGHT = 40` + 2x padding (`12`) = `64`.

So I set the ScreenHeader height to `64`. Also fixed the font weight which differed between animated and non-animated.

![wwwwaslkjhldkjas](https://user-images.githubusercontent.com/4932625/93095005-e0826c00-f6a2-11ea-89ff-a9990a2575e5.png)

