### PR TITLE
fix: Better map controls positions cross-platform

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -359,7 +359,7 @@ PODS:
     - "@react-native-mapbox-gl-mapbox-static (~> 5.8)"
     - Mapbox-iOS-SDK (~> 5.8)
     - React
-  - react-native-safe-area-context (0.7.3):
+  - react-native-safe-area-context (3.1.7):
     - React
   - react-native-webview (9.4.0):
     - React
@@ -722,7 +722,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: 2b7500cdb68066aba87cdccd97067c29e16ffe95
   react-native-intercom: 4916f5d0fee8b73535a6284721ccf7f9cc664fac
   react-native-mapbox-gl: 18785637738ca8b25c3633db431d6614ec7fc9bf
-  react-native-safe-area-context: e200d4433aba6b7e60b52da5f37af11f7a0b0392
+  react-native-safe-area-context: 955ecfce672683b495d9294d2f154a9ad1d9796b
   react-native-webview: cf5527893252b3b036eea024a1da6996f7344c74
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-permissions": "^2.1.4",
     "react-native-portalize": "^1.0.3",
     "react-native-reanimated": "^1.8.0",
-    "react-native-safe-area-context": "^0.7.3",
+    "react-native-safe-area-context": "^3.1.7",
     "react-native-screens": "^2.7.0",
     "react-native-svg": "^12.1.0",
     "react-native-webview": "^9.4.0",

--- a/patches/@react-native-mapbox-gl+maps+8.1.0-rc.2.patch
+++ b/patches/@react-native-mapbox-gl+maps+8.1.0-rc.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@react-native-mapbox-gl/maps/index.d.ts b/node_modules/@react-native-mapbox-gl/maps/index.d.ts
+index 58939cd..2d64b79 100644
+--- a/node_modules/@react-native-mapbox-gl/maps/index.d.ts
++++ b/node_modules/@react-native-mapbox-gl/maps/index.d.ts
+@@ -373,7 +373,7 @@ export interface MapViewProps extends ViewProps {
+   logoEnabled?: boolean;
+   compassEnabled?: boolean;
+   compassViewPosition?: number;
+-  compassViewMargins?: Point;
++  compassViewMargins?: {x: number; y:number};
+   surfaceView?: boolean;
+   regionWillChangeDebounceTime?: number;
+   regionDidChangeDebounceTime?: number;

--- a/src/location-search/map-selection/index.tsx
+++ b/src/location-search/map-selection/index.tsx
@@ -1,6 +1,6 @@
 import {RouteProp} from '@react-navigation/native';
 import React, {useState, useRef, useMemo} from 'react';
-import {Text, View, TouchableOpacity} from 'react-native';
+import {Text, Platform, View, TouchableOpacity, ViewStyle} from 'react-native';
 
 import MapboxGL, {RegionPayload} from '@react-native-mapbox-gl/maps';
 import {useReverseGeocoder} from '../../geocoder';
@@ -11,12 +11,13 @@ import MapControls from './MapControls';
 import {useGeolocationState} from '../../GeolocationContext';
 import LocationBar from './LocationBar';
 import {ArrowLeft} from '../../assets/svg/icons/navigation';
-import {StyleSheet} from '../../theme';
+import {StyleSheet, useTheme} from '../../theme';
 import shadows from './shadows';
 import {Coordinates} from '@entur/sdk';
 import {CurrentLocationArrow} from '../../assets/svg/icons/places';
 import SelectionPin, {PinMode} from './SelectionPin';
 import {Feature} from 'geojson';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 export type RouteParams = {
   callerRouteName: string;
@@ -101,6 +102,8 @@ const MapSelection: React.FC<Props> = ({
     }
   };
 
+  const controlStyles = useControlPositionsStyle();
+
   return (
     <View style={styles.container}>
       <MapboxGL.MapView
@@ -115,6 +118,16 @@ const MapSelection: React.FC<Props> = ({
           setRegionEvent({isMoving: true, region: regionEvent?.region})
         }
         onPress={flyToFeature}
+        compassViewPosition={3}
+        compassEnabled={true}
+        compassViewMargins={{
+          x: Platform.select({default: 10, android: 6}),
+          y: 90,
+        }}
+        attributionPosition={Platform.select({
+          default: {bottom: 8, left: 95},
+          android: {bottom: 5, left: 90},
+        })}
       >
         <MapboxGL.Camera
           ref={mapCameraRef}
@@ -135,20 +148,20 @@ const MapSelection: React.FC<Props> = ({
           />
         </TouchableOpacity>
       </View>
-      <View style={styles.backArrowContainer}>
+      <View style={controlStyles.backArrowContainer}>
         <BackArrow onBack={() => navigation.goBack()} />
       </View>
-      <View style={styles.positionArrowContainer}>
+      <View style={controlStyles.positionArrowContainer}>
         <PositionArrow flyToCurrentLocation={flyToCurrentLocation} />
       </View>
-      <View style={styles.locationContainer}>
+      <View style={controlStyles.locationContainer}>
         <LocationBar
           location={location}
           onSelect={onSelect}
           isSearching={!!regionEvent?.isMoving || isSearching}
         />
       </View>
-      <View style={styles.controlsContainer}>
+      <View style={controlStyles.controlsContainer}>
         <MapControls zoomIn={zoomIn} zoomOut={zoomOut} />
       </View>
     </View>
@@ -177,6 +190,38 @@ const BackArrow: React.FC<{onBack(): void}> = ({onBack}) => {
   );
 };
 
+function useControlPositionsStyle() {
+  const {top, bottom} = useSafeAreaInsets();
+  const {theme} = useTheme();
+
+  return useMemo<{[key: string]: ViewStyle}>(
+    () => ({
+      backArrowContainer: {
+        position: 'absolute',
+        top: top + theme.sizes.pagePadding,
+        left: theme.sizes.pagePadding,
+      },
+      positionArrowContainer: {
+        position: 'absolute',
+        top: top + theme.sizes.pagePadding,
+        right: theme.sizes.pagePadding,
+      },
+      controlsContainer: {
+        position: 'absolute',
+        bottom: bottom + theme.sizes.pagePadding,
+        right: theme.sizes.pagePadding,
+      },
+      locationContainer: {
+        position: 'absolute',
+        top: top + theme.sizes.pagePadding + 28 + theme.sizes.pagePadding,
+        paddingHorizontal: theme.sizes.pagePadding,
+        width: '100%',
+      },
+    }),
+    [bottom, top],
+  );
+}
+
 const PositionArrow: React.FC<{flyToCurrentLocation(): void}> = ({
   flyToCurrentLocation,
 }) => {
@@ -201,15 +246,6 @@ const styles = StyleSheet.create({
     right: '50%',
   },
   pin: {position: 'absolute', top: -40, right: -20, ...shadows},
-  backArrowContainer: {position: 'absolute', top: 80, left: 20},
-  positionArrowContainer: {position: 'absolute', top: 80, right: 20},
-  controlsContainer: {position: 'absolute', bottom: 80, right: 20},
-  locationContainer: {
-    position: 'absolute',
-    top: 120,
-    paddingHorizontal: 20,
-    width: '100%',
-  },
   backArrow: {
     backgroundColor: colors.primary.gray,
     borderRadius: 8,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7615,10 +7615,10 @@ react-native-reanimated@^1.8.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
-  integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
+react-native-safe-area-context@^3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.7.tgz#fc9e636dfb168f992a2172d363509ce0611a8403"
+  integrity sha512-qSyg/pVMwVPgAy8yCvw349Q+uEUhtRBV33eVXHHkfoou1vCChJxI7SmNR47/6M3BLdjWcyc4lcd018Kx+jhQCw==
 
 react-native-safe-modules@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Better positioning and use of real estate in map

### Changes

- Upgraded RN safe area context lib
- Moved compass to lower-right quadrant near zoom
- Moved attribution to lower-left quadrant on both platforms
- General (after QA with @pettersuul) more consistent positioning of map controls cross-platform

#### Before
![wwwworsepositions](https://user-images.githubusercontent.com/4932625/93333405-8e1c8900-f823-11ea-983e-c9c97f8bdd23.png)

#### Now
![wwwwconsistentmapcontrols](https://user-images.githubusercontent.com/4932625/93333426-94ab0080-f823-11ea-9600-e057555d5259.png)
