### PR TITLE
fix: Disappearing header height and favorite chips

### DIFF
--- a/src/ScreenHeader/animated-header.tsx
+++ b/src/ScreenHeader/animated-header.tsx
@@ -48,7 +48,6 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
 
   const altTitle = alternativeTitleComponent && (
     <Animated.View
-      {...props}
       style={[
         style.regularContainer,
         {transform: [{translateY: altTitleOffset}]},
@@ -59,7 +58,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
   );
 
   return (
-    <View style={style.container}>
+    <View style={style.container} {...props}>
       <View style={style.iconContainerLeft}>{leftIcon}</View>
       <View
         accessible={true}

--- a/src/components/disappearing-header/index .tsx
+++ b/src/components/disappearing-header/index .tsx
@@ -12,8 +12,9 @@ import {
   View,
   Easing,
   AccessibilityProps,
+  StatusBar,
 } from 'react-native';
-import {useSafeArea} from 'react-native-safe-area-context';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import useChatIcon from '../../chat/use-chat-icon';
 import AnimatedScreenHeader from '../../ScreenHeader/animated-header';
 import {StyleSheet} from '../../theme';
@@ -331,14 +332,7 @@ function useCalculateHeaderContentHeight() {
     height: screenHeaderHeight,
   } = useLayout();
   const {onLayout: onHeaderContentLayout, height: contentHeight} = useLayout();
-  const {top, bottom} = useSafeArea();
-
-  // Calculate padding of tabbar. Adjusted code from react-navigation
-  // component.
-  const tabBarPadding = Math.max(
-    Platform.select({ios: bottom - 10, default: DEFAULT_TABBAR_HEIGHT}),
-    0,
-  );
+  const {top, bottom} = useSafeAreaInsets();
 
   const boxHeight =
     windowHeight -
@@ -346,7 +340,7 @@ function useCalculateHeaderContentHeight() {
     top -
     bottom -
     DEFAULT_TABBAR_HEIGHT -
-    tabBarPadding;
+    (StatusBar.currentHeight ?? 0);
 
   return {
     boxHeight,

--- a/src/utils/use-layout.ts
+++ b/src/utils/use-layout.ts
@@ -1,13 +1,16 @@
 import {useState, useCallback} from 'react';
-
+import {LayoutChangeEvent, LayoutRectangle} from 'react-native';
 export function useLayout() {
-  const [layout, setLayout] = useState({
+  const [layout, setLayout] = useState<LayoutRectangle>({
     x: 0,
     y: 0,
     width: 0,
     height: 0,
   });
-  const onLayout = useCallback((e) => setLayout(e.nativeEvent.layout), []);
+  const onLayout = useCallback(
+    (e: LayoutChangeEvent) => setLayout(e.nativeEvent.layout),
+    [],
+  );
 
   return {
     onLayout,


### PR DESCRIPTION
This fixes the issue on iPhone 7 for favorite chips on start screen

### Changes

- Move props in animated-header up to parent so `onLayout` includes padding as well as height
- Include StatusBar-height in calculation for Android

![wwwdisappaear](https://user-images.githubusercontent.com/4932625/93346852-b5c81d00-f834-11ea-8ec8-6ad797271e9b.png)
