### PR TITLE
fix: Increase touchable area for details full map toggler

### DIFF
--- a/src/screens/TripDetailsModal/Map/CompactMap.tsx
+++ b/src/screens/TripDetailsModal/Map/CompactMap.tsx
@@ -61,7 +61,11 @@ export const CompactMap: React.FC<MapProps> = ({legs, onExpand}) => {
       )}
       {!!snapshot && <Image style={styles.map} source={{uri: snapshot}} />}
       <View style={styles.togglerContainer}>
-        <TouchableOpacity style={styles.toggler} onPress={onExpand} hitSlop={insets.symmetric(8,12)}>
+        <TouchableOpacity
+          style={styles.toggler}
+          onPress={onExpand}
+          hitSlop={insets.symmetric(8, 12)}
+        >
           <Text style={styles.toggleText}>Utvid kart</Text>
           <MapIcon style={styles.toggleIcon} />
         </TouchableOpacity>
@@ -79,13 +83,13 @@ const styles = StyleSheet.create({
   togglerContainer: {
     position: 'absolute',
     right: 0,
-    bottom: 0
+    bottom: 0,
   },
   toggler: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 12,
-    paddingVertical: 8
+    paddingVertical: 8,
   },
   toggleText: {
     fontSize: 14,


### PR DESCRIPTION
As discussed, increasing the touchable area of "Utvid kart" 
Created padding for the touchable, and added increased hitslop

![image](https://user-images.githubusercontent.com/61825573/94418343-8e047d80-0181-11eb-9c2d-b3b7850bfcc9.png)
