### PR TITLE
fix: Time label line break on different font size for android versions

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -216,7 +216,7 @@ const useLegStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
   },
   time: {
-    width: 50,
+    minWidth: 50,
     fontVariant: ['tabular-nums'],
   },
   iconContainer: {

--- a/src/screens/Nearby/NearbyResults.tsx
+++ b/src/screens/Nearby/NearbyResults.tsx
@@ -333,7 +333,6 @@ const useResultItemStyles = StyleSheet.createThemeHook((theme) => ({
     fontVariant: ['tabular-nums'],
   },
   textContent: {
-    flex: 1,
     fontSize: theme.text.sizes.body,
   },
   textWrapper: {


### PR DESCRIPTION
I've tested through a variety of different emulated devices. 

In the end, the true edge case of having a 320px wide screen with font size adjusted to the biggest size possible (in settings -> accessibility)

I am assuming that we are okay with "ca." prefix and actual clock/minute indicator breaking on two lines.

Seems that the recent changes in departure screen has fixed the time break error there.

In assistant, time break error is solved by changing the fixed width setting to minWidth. This preserves time label width on bigger devices, and also allows for more space on really small devices with large font sizes. 

Please note that we do still have som issues besides the time labels on devices that are really small/using increased font size setting. This PR is only related to the time label break described in AtB-AS/kundevendt#865 

Screenshots are from an Android device with 320x480px resolution and font size set to "Largest":

![Skjermdump fra 2020-09-28 13-58-07](https://user-images.githubusercontent.com/61825573/94433452-a207a980-0198-11eb-85ce-23890851dbca.png)
![Skjermdump fra 2020-09-28 14-24-13](https://user-images.githubusercontent.com/61825573/94433453-a2a04000-0198-11eb-9548-05fcc5f7a8c0.png)

