### PR TITLE
fix: Treat situations as empty array if undefined. fixes #498

### DIFF
--- a/src/situations/index.tsx
+++ b/src/situations/index.tsx
@@ -49,19 +49,20 @@ export function SituationWarningIcon({
 }
 
 export function hasSituations(situations: Situation[]) {
-  return situations.some((s) => s.description.length);
+  return situations?.some((s) => s.description.length) ?? false;
 }
 
 export function getSituationDiff(situations: Situation[], parent: Situation[]) {
-  const notInParent = situations.filter((situation) => {
-    return parent.every(
-      (pSituation) => pSituation.situationNumber != situation.situationNumber,
-    );
-  });
+  const notInParent =
+    situations?.filter((situation) => {
+      return parent.every(
+        (pSituation) => pSituation.situationNumber != situation.situationNumber,
+      );
+    }) ?? [];
   return notInParent;
 }
 
-export function getUniqueSituations(situations: Situation[]) {
+export function getUniqueSituations(situations: Situation[] = []) {
   let uniqueSituations: {[id: string]: string} = {};
   for (let situation of situations) {
     if (uniqueSituations[situation.situationNumber]) continue;


### PR DESCRIPTION
Apparently, situations are in some cases undefined. We should just treat them as undefined. Types should prevent this, but type help is only as good as the accuracy of the models themself. Not solving the type part now as I want to do more work on the data module with better type safety across the stack. 