### PR TITLE
fix: Make dash paddding half of LocationRow height

### DIFF
--- a/src/screens/TripDetailsModal/Details/TransportDetail.tsx
+++ b/src/screens/TripDetailsModal/Details/TransportDetail.tsx
@@ -17,6 +17,7 @@ import WaitRow from './WaitRow';
 import transportationColor from '../../../utils/transportation-color';
 import SituationRow from '../SituationRow';
 import colors from '../../../theme/colors';
+import {useLayout} from '../../../utils/use-layout';
 
 const TransportDetail: React.FC<LegDetailProps> = ({
   leg,
@@ -37,6 +38,9 @@ const TransportDetail: React.FC<LegDetailProps> = ({
     return formatToClock(time);
   };
 
+  const {height: fromHeight, onLayout: onFromLayout} = useLayout();
+  const {height: toHeight, onLayout: onToLayout} = useLayout();
+
   return (
     <View style={{marginTop: -6}}>
       <TouchableOpacity
@@ -51,7 +55,12 @@ const TransportDetail: React.FC<LegDetailProps> = ({
           })
         }
       >
-        <View style={styles.dashContainer}>
+        <View
+          style={[
+            styles.dashContainer,
+            {paddingTop: fromHeight / 2, paddingBottom: toHeight / 2},
+          ]}
+        >
           <Dash
             dashGap={0}
             dashThickness={8}
@@ -78,6 +87,7 @@ const TransportDetail: React.FC<LegDetailProps> = ({
             timeStyle={{fontWeight: 'bold', fontSize: 16}}
             textStyle={styles.textStyle}
             dashThroughIcon={true}
+            onLayout={onFromLayout}
           />
         )}
         <Text style={styles.lineName}>{getLineName(leg)}</Text>
@@ -98,6 +108,7 @@ const TransportDetail: React.FC<LegDetailProps> = ({
           }
           textStyle={styles.textStyle}
           dashThroughIcon={true}
+          onLayout={onToLayout}
         />
       </TouchableOpacity>
       {showWaitTime && (
@@ -137,7 +148,6 @@ const styles = StyleSheet.create({
     marginLeft: 120,
     fontSize: 16,
     fontWeight: '600',
-    marginVertical: 12,
   },
   dashContainer: {
     marginLeft: 95,

--- a/src/screens/TripDetailsModal/LocationRow.tsx
+++ b/src/screens/TripDetailsModal/LocationRow.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import {View, Text, TextStyle, StyleProp, ViewStyle} from 'react-native';
+import {
+  View,
+  Text,
+  TextStyle,
+  StyleProp,
+  ViewStyle,
+  LayoutChangeEvent,
+} from 'react-native';
 import {StyleSheet, useTheme} from '../../theme';
 
 const LocationRow: React.FC<{
@@ -13,6 +20,7 @@ const LocationRow: React.FC<{
   rowStyle?: StyleProp<ViewStyle>;
   iconContainerStyle?: StyleProp<ViewStyle>;
   dashThroughIcon?: boolean;
+  onLayout?: (event: LayoutChangeEvent) => void;
 }> = ({
   icon,
   labelIcon,
@@ -24,12 +32,13 @@ const LocationRow: React.FC<{
   timeStyle,
   iconContainerStyle,
   dashThroughIcon,
+  onLayout,
 }) => {
   const styles = useLocationRowStyle();
   const {theme} = useTheme();
 
   return (
-    <View style={[styles.row, rowStyle]}>
+    <View style={[styles.row, rowStyle]} onLayout={onLayout}>
       <View style={styles.iconLocationContainer}>
         <View style={styles.timeContainer}>
           <Text style={[styles.time, textStyle, timeStyle]}>{time}</Text>


### PR DESCRIPTION
This means the dash starts from the middle of the Dot, and should work on arbitrary lengths

A little bit hacky - but best I could think of till we redesign this view

See screenshot, no matter how large I make the text, the line still starts behind the dot

![arbitrary](https://user-images.githubusercontent.com/4932625/95363442-c158b200-08cf-11eb-938a-327165a04846.png)
