### PR TITLE
fix: More accessible onboarding!

### DIFF
--- a/src/screens/Onboarding/components/NavigationControls.tsx
+++ b/src/screens/Onboarding/components/NavigationControls.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View, Text} from 'react-native';
 import {Dot} from '../../../assets/svg/icons/other';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {TouchableOpacity} from 'react-native';
 import {ArrowRight} from '../../../assets/svg/icons/navigation';
 import {StyleSheet} from '../../../theme';
 import colors from '../../../theme/colors';

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -66,7 +66,7 @@ const StepOne: React.FC<StepProps> = ({navigation}) => {
     <>
       <Illustration Svg={Onboarding1} />
       <StepOuterContainer>
-        <View style={styles.textContainer}>
+        <View style={styles.textContainer} accessible={true}>
           <Text style={[styles.title, styles.text]}>
             Velkommen som testpilot!{' '}
           </Text>
@@ -90,7 +90,7 @@ const StepTwo: React.FC<StepProps> = ({navigation}) => {
     <>
       <Illustration Svg={Onboarding2} />
       <StepOuterContainer>
-        <View style={styles.textContainer}>
+        <View style={styles.textContainer} accessible={true}>
           <Text style={[styles.title, styles.text]}>
             Bidra til å gjøre appen bedre
           </Text>
@@ -124,7 +124,7 @@ const StepThree: React.FC<StepProps> = ({navigation}) => {
     <>
       <Illustration Svg={Onboarding3} />
       <StepOuterContainer>
-        <View style={styles.textContainer}>
+        <View style={styles.textContainer} accessible={true}>
           <Text style={[styles.title, styles.text]}>
             Bedre opplevelse med posisjonsdeling
           </Text>


### PR DESCRIPTION
Learned that we actually need to mark views/text holding text accessible to achieve "natural" screen reader behavior when navigating from one screen to another: The screen reader will, when navigating, read out loud the first accessible element. 