### PR TITLE
fix: Improve text breakpoints

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -64,7 +64,7 @@ const ResultItemHeader: React.FC<{
   const wordSpacing = ' ';
   return (
     <View style={styles.resultHeader}>
-      <Text>
+      <Text style={styles.resultHeaderLabel}>
         Fra{wordSpacing}
         {quayName}
         {wordSpacing}
@@ -159,14 +159,17 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   resultHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     paddingBottom: 8,
     marginBottom: 8,
     borderBottomColor: theme.background.level1,
     borderBottomWidth: 1,
   },
+  resultHeaderLabel: {
+    flex: 7,
+  },
   durationContainer: {
-    flex: 1,
+    flex: 2,
     alignItems: 'flex-end',
   },
   warningIcon: {

--- a/src/screens/TripDetailsModal/Details/index.tsx
+++ b/src/screens/TripDetailsModal/Details/index.tsx
@@ -273,6 +273,7 @@ const useDetailsStyle = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
   },
   scrollViewContent: {
+    paddingRight: theme.spacings.medium,
     paddingBottom: 100,
   },
   textStyle: {


### PR DESCRIPTION
Adjustments for result item header content break. Add some right side padding for the details content.

Before
![image](https://user-images.githubusercontent.com/61825573/95731680-1dc92200-0c80-11eb-8423-c3e883251265.png)
![image](https://user-images.githubusercontent.com/61825573/95731709-24579980-0c80-11eb-983e-3ddb1306e157.png)

After
![Screenshot_1602492207](https://user-images.githubusercontent.com/61825573/95731590-00945380-0c80-11eb-9649-71c4d1c20de5.png)
![Screenshot_1602493182](https://user-images.githubusercontent.com/61825573/95731591-012cea00-0c80-11eb-94fb-43aa9486e581.png)
