### PR TITLE
feat: Adds ability to disable intercom chat icon remotely

### DIFF
--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -4,9 +4,15 @@ import Intercom from 'react-native-intercom';
 import {Chat, ChatUnread} from '../assets/svg/icons/actions';
 import useChatUnreadCount from './use-chat-unread-count';
 import colors from '../theme/colors';
+import {useRemoteConfig} from '../RemoteConfigContext';
 
 export default function useChatIcon() {
+  const config = useRemoteConfig();
   const unreadCount = useChatUnreadCount();
+
+  if (!config.enable_intercom) {
+    return undefined;
+  }
 
   return {
     icon: (
@@ -19,7 +25,7 @@ export default function useChatIcon() {
         {unreadCount ? <ChatUnread /> : <Chat />}
       </View>
     ),
-    openChat: () =>
+    onPress: () =>
       unreadCount
         ? Intercom.displayMessenger()
         : Intercom.displayConversationsList(),

--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -87,7 +87,7 @@ const DisappearingHeader: React.FC<Props> = ({
     }),
   );
 
-  const {icon: chatIcon, openChat} = useChatIcon();
+  const chatIcon = useChatIcon();
   const [scrollYValue, setScrollY] = useState<number>(0);
   const styles = useThemeStyles();
   const scrollYRef = useRef(new Animated.Value(IS_IOS ? -contentOffset : 0))
@@ -175,7 +175,7 @@ const DisappearingHeader: React.FC<Props> = ({
         <AnimatedScreenHeader
           onLayout={onScreenHeaderLayout}
           title={headerTitle}
-          rightButton={{onPress: openChat, icon: chatIcon}}
+          rightButton={chatIcon}
           alternativeTitleComponent={alternativeTitleComponent}
           alternativeTitleVisible={showAltTitle}
           leftButton={{

--- a/src/error-boundary/ErrorView.tsx
+++ b/src/error-boundary/ErrorView.tsx
@@ -16,16 +16,13 @@ type ErrorProps = {
 };
 
 const ErrorView: React.FC<ErrorProps> = ({onRestartApp, errorCode}) => {
-  const {icon: chatIcon, openChat} = useChatIcon();
+  const chatIcon = useChatIcon();
   const buildNumber = getBuildNumber();
   const config = useLocalConfig();
 
   return (
     <SafeAreaView style={styles.safearea}>
-      <ScreenHeader
-        title=""
-        rightButton={{onPress: openChat, icon: chatIcon}}
-      />
+      <ScreenHeader title="" rightButton={chatIcon} />
       <View style={styles.svgContainer}>
         <CrashParachute width="100%" height="100%" />
       </View>

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -2,14 +2,17 @@ import remoteConfig from '@react-native-firebase/remote-config';
 
 export type RemoteConfig = {
   enable_ticketing: boolean;
+  enable_intercom: boolean;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
   enable_ticketing: false,
+  enable_intercom: true,
 };
 
 export async function getConfig(): Promise<RemoteConfig> {
   const values = remoteConfig().getAll();
   const enable_ticketing = !!(values['enable_ticketing']?.value ?? false);
-  return {enable_ticketing};
+  const enable_intercom = !!(values['enable_intercom']?.value ?? true);
+  return {enable_ticketing, enable_intercom};
 }

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -54,7 +54,7 @@ export default function Profile({navigation}: ProfileScreenProps) {
   const onAddButtonClick = () => navigation.push('AddEditFavorite', {});
 
   const navigateHome = useNavigateHome();
-  const {icon: chatIcon, openChat} = useChatIcon();
+  const chatIcon = useChatIcon();
 
   return (
     <SafeAreaView style={css.container}>
@@ -65,7 +65,7 @@ export default function Profile({navigation}: ProfileScreenProps) {
           onPress: navigateHome,
           accessibilityLabel: 'Gå til startskjerm',
         }}
-        rightButton={{icon: chatIcon, onPress: openChat}}
+        rightButton={chatIcon}
       />
 
       <ScrollView>

--- a/src/screens/Ticketing/Splash.tsx
+++ b/src/screens/Ticketing/Splash.tsx
@@ -24,7 +24,7 @@ type Props = {
   navigation: StackNavigationProp<TabNavigatorParams>;
 };
 export default function Splash({navigation}: Props) {
-  const {icon: chatIcon, openChat} = useChatIcon();
+  const chatIcon = useChatIcon();
   const {width: windowWidth} = useWindowDimensions();
   const navigateHome = useNavigateHome();
 
@@ -32,7 +32,7 @@ export default function Splash({navigation}: Props) {
     <SafeAreaView style={styles.container}>
       <Header
         title="Billetter"
-        rightButton={{icon: chatIcon, onPress: openChat}}
+        rightButton={chatIcon}
         leftButton={{
           icon: <LogoOutline />,
           onPress: navigateHome,


### PR DESCRIPTION
Default remote config to enable intercom. Feature toggle only toggles access to the feature (button), not intercom in its entirety. I think keeping intercom, in any case, is smart as we can get info on crash, etc.

Not added any entry at Firebase yet as the default is to activate Intercom.