### PR TITLE
fix(assistant): Fixes possible bug when incorrect data is returned for trip patterns

### DIFF
--- a/src/screens/Assistant/index.tsx
+++ b/src/screens/Assistant/index.tsx
@@ -577,12 +577,15 @@ function useTripPatterns(
           },
         );
         source.token.throwIfRequested();
-        setTripPatterns(response.data);
-        setSearchState(
-          response.data.length >= 1 ? 'search-success' : 'search-empty-result',
-        );
-
         setTimeOfSearch(searchDate);
+        if (Array.isArray(response.data)) {
+          setTripPatterns(response.data);
+          setSearchState(
+            response.data.length >= 1
+              ? 'search-success'
+              : 'search-empty-result',
+          );
+        }
       } catch (e) {
         if (!isCancel(e)) {
           setErrorType(getAxiosErrorType(e));


### PR DESCRIPTION
fixes AtB-AS/kundevendt#796

This is kind of silly, I'll admit. See comment AtB-AS/kundevendt#796. There exists a possibility that response data is something other than what we expect. Should probably have some proper validation here (and for API data layers in general, but we can do that as a part of the technical rewrites with the BFF). In the meantime, since this has happened once, it can happen again – even if I don't know the root cause of this. Again, yes, silly.