### PR TITLE
fix: Wraps remote config fetching with error handling

### DIFF
--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -49,7 +49,10 @@ const RemoteConfigContextProvider: React.FC = ({children}) => {
         if (!isUserInfo(userInfo)) {
           throw e;
         }
-        if (isUserInfo(userInfo) && userInfo.code === 'failure') {
+        if (
+          isUserInfo(userInfo) &&
+          (userInfo.code === 'failure' || userInfo.fatal)
+        ) {
           Bugsnag.notify(e, function (event) {
             event.addMetadata('metadata', {userInfo});
           });


### PR DESCRIPTION
Fixes AtB-AS/kundevendt#909

I'm not entirely sure what do to in what cases, but opening this to have a discussion for the best approach. I've investigated the native source code what the error returns (see TS type). We have the information we need to choose what errors to pass to bugsnag I think.