### PR TITLE
fix: Special style for add favorite button in light theme

### DIFF
--- a/src/favorite-chips/index.tsx
+++ b/src/favorite-chips/index.tsx
@@ -21,7 +21,6 @@ import colors from '../theme/colors';
 import {StyleSheet} from '../theme';
 import ThemeIcon from '../components/theme-icon';
 import {screenReaderPause} from '../components/accessible-text';
-import Button from '../components/button';
 
 type Props = {
   onSelectLocation: (location: LocationWithMetadata) => void;


### PR DESCRIPTION
A regression on "Legg til favoritt", a themed button style was applied inaccurately on a button that should have its own custom style in light theme,

![image](https://user-images.githubusercontent.com/61825573/97419319-36853900-190a-11eb-92e7-7f6480ae4be5.png)


Fix: 
![image](https://user-images.githubusercontent.com/61825573/97419416-54529e00-190a-11eb-967c-3e05052c59c3.png)
