### PR TITLE
feat: Move to spreadable text styles for theme

### DIFF
--- a/src/ScreenHeader/animated-header.tsx
+++ b/src/ScreenHeader/animated-header.tsx
@@ -1,9 +1,8 @@
 import React, {useEffect, useRef} from 'react';
-import {Animated, Text, View, ViewProps, TouchableOpacity} from 'react-native';
+import {Animated, View, ViewProps} from 'react-native';
+import ThemeText from '../components/text';
 import {StyleSheet} from '../theme';
-import insets from '../utils/insets';
 import HeaderButton, {IconButton} from './HeaderButton';
-import LogoOutline from './LogoOutline';
 type ScreenHeaderProps = ViewProps & {
   leftButton?: IconButton;
   rightButton?: IconButton;
@@ -71,7 +70,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
             {transform: [{translateY: titleOffset}]},
           ]}
         >
-          <Text style={style.text}>{title}</Text>
+          <ThemeText type="paragraphHeadline">{title}</ThemeText>
         </Animated.View>
         {altTitle}
       </View>
@@ -112,10 +111,5 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'center',
     alignItems: 'center',
     position: 'absolute',
-  },
-  text: {
-    color: theme.text.colors.primary,
-    fontSize: 16,
-    fontWeight: 'bold',
   },
 }));

--- a/src/ScreenHeader/index.tsx
+++ b/src/ScreenHeader/index.tsx
@@ -1,7 +1,8 @@
-import {View, Text, ViewStyle} from 'react-native';
+import {View, ViewStyle} from 'react-native';
 import React from 'react';
 import {StyleSheet} from '../theme';
 import HeaderButton, {IconButton} from './HeaderButton';
+import ThemeText from '../components/text';
 
 type ScreenHeaderProps = {
   leftButton?: IconButton;
@@ -32,7 +33,7 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   return (
     <View style={[css.container, style]}>
       <View style={css.iconContainerLeft}>{leftIcon}</View>
-      <Text style={css.text}>{title}</Text>
+      <ThemeText type="paragraphHeadline">{title}</ThemeText>
       <View style={css.iconContainerRight}>{rightIcon}</View>
     </View>
   );
@@ -53,10 +54,5 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
   iconContainerRight: {
     position: 'absolute',
     right: 12,
-  },
-  text: {
-    color: theme.text.colors.primary,
-    fontSize: 16,
-    fontWeight: 'bold',
   },
 }));

--- a/src/components/accessible-text/index.tsx
+++ b/src/components/accessible-text/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {TextProps} from 'react-native';
-import ThemeText from '../text';
+import ThemeText, {ThemeTextProps} from '../text';
 
-type LabelProps = TextProps & {
+type LabelProps = ThemeTextProps & {
   prefix?: string;
   suffix?: string;
   children?: string;

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,7 +1,6 @@
 import {
   TouchableOpacityProperties,
   View,
-  Text,
   StyleProp,
   ViewStyle,
   TouchableOpacity,
@@ -9,6 +8,7 @@ import {
 } from 'react-native';
 import React from 'react';
 import {StyleSheet, Theme, useTheme} from '../../theme';
+import ThemeText from '../text';
 
 type ButtonProps = {
   onPress(): void;
@@ -55,7 +55,9 @@ const Button: React.FC<ButtonProps> = ({
           </View>
         )}
         <View style={[css.textContainer, textContainerStyle]}>
-          <Text style={[styleText, textStyle]}>{text}</Text>
+          <ThemeText type="paragraphHeadline" style={[styleText, textStyle]}>
+            {text}
+          </ThemeText>
         </View>
       </TouchableOpacity>
     </View>
@@ -92,9 +94,6 @@ const useButtonStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     alignItems: 'center',
   },
   text: {
-    fontSize: theme.text.sizes.body,
-    lineHeight: theme.text.lineHeight.body,
-    fontWeight: '600',
     color: theme.text.colors.primary,
   },
   textDestructive: {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -71,7 +71,9 @@ const Input = forwardRef<TextInput, InputProps>(
             </TouchableOpacity>
           </View>
         ) : null}
-        <ThemeText style={style.label}>{label}</ThemeText>
+        <ThemeText type="lead" style={style.label}>
+          {label}
+        </ThemeText>
       </View>
     );
   },
@@ -88,7 +90,7 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     paddingLeft: 60,
     paddingRight: 40,
     padding: theme.spacings.medium,
-    fontSize: theme.text.sizes.body,
+    fontSize: theme.text.body.fontSize,
   },
   container: {
     marginBottom: theme.spacings.medium,
@@ -98,8 +100,6 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
   label: {
     position: 'absolute',
     left: theme.spacings.medium,
-    fontSize: theme.text.sizes.lead,
-    lineHeight: theme.text.lineHeight.body,
   },
   inputClear: {
     position: 'absolute',

--- a/src/components/optional-day-header/index.tsx
+++ b/src/components/optional-day-header/index.tsx
@@ -1,9 +1,9 @@
 import {parseISO} from 'date-fns';
 import React from 'react';
-import {Text} from 'react-native';
 import {EstimatedCall} from '../../sdk';
 import {StyleSheet} from '../../theme';
 import {formatToSimpleDate, isSameDay, daysBetween} from '../../utils/date';
+import ThemeText from '../text';
 
 type OptionalNextDayLabelProps = {
   departureTime: string;
@@ -24,12 +24,12 @@ export default function OptionalNextDayLabel({
 
   if ((isFirst && !allSameDay) || !isSameDay(prevDate, departureDate)) {
     return (
-      <Text style={style.title}>
+      <ThemeText type="lead" style={style.title}>
         {getHumanizedDepartureDatePrefixed(
           departureDate,
           formatToSimpleDate(departureDate),
         )}
-      </Text>
+      </ThemeText>
     );
   }
 
@@ -37,7 +37,6 @@ export default function OptionalNextDayLabel({
 }
 const useDayTextStyle = StyleSheet.createThemeHook((theme) => ({
   title: {
-    fontSize: theme.text.sizes.lead,
     padding: theme.spacings.medium,
     color: theme.text.colors.faded,
   },

--- a/src/components/search-button/index.tsx
+++ b/src/components/search-button/index.tsx
@@ -38,9 +38,11 @@ const SearchButton: React.FC<SearchButtonProps> = ({
         style={styles.button}
         onPress={onPress}
       >
-        <ThemeText style={styles.title}>{title}</ThemeText>
+        <ThemeText type="body" style={styles.title}>
+          {title}
+        </ThemeText>
         <View style={styles.icon}>{icon}</View>
-        <ThemeText style={styles.buttonText} numberOfLines={1}>
+        <ThemeText type="body" style={styles.buttonText} numberOfLines={1}>
           {text ?? <Text style={styles.placeholder}>{placeholder}</Text>}
         </ThemeText>
       </TouchableOpacity>
@@ -82,8 +84,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   },
   title: {width: 40},
   buttonText: {
-    fontSize: theme.text.sizes.body,
-    lineHeight: theme.text.lineHeight.body,
     flex: 1,
     marginLeft: theme.spacings.large,
   },

--- a/src/components/search-button/search-group.tsx
+++ b/src/components/search-button/search-group.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, StyleProp, ViewStyle} from 'react-native';
+import {View, StyleProp, ViewStyle} from 'react-native';
 import {StyleSheet} from '../../theme';
 
 type ResultItemProps = {

--- a/src/components/section-header/index.tsx
+++ b/src/components/section-header/index.tsx
@@ -14,7 +14,9 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   const styles = useProfileStyle();
   return (
     <View style={[styles.header, extraStyles]}>
-      <ThemeText style={styles.headerText}>{children}</ThemeText>
+      <ThemeText type="label" style={styles.headerText}>
+        {children}
+      </ThemeText>
       <View style={styles.headerDecorator}></View>
     </View>
   );
@@ -29,8 +31,6 @@ const useProfileStyle = StyleSheet.createThemeHook((theme) => ({
   },
   headerText: {
     paddingEnd: 10,
-    fontSize: theme.text.sizes.label,
-    lineHeight: theme.text.lineHeight.label,
   },
 }));
 

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import {Text, TextProps} from 'react-native';
-import {fontSizes} from '../../theme/colors';
+import {TextColors, TextNames} from '../../theme/colors';
 import {useTheme} from '../../theme';
 
-type StyledTextProps = TextProps & {
-  type?: keyof typeof fontSizes;
+export type ThemeTextProps = TextProps & {
+  type?: TextNames;
+  color?: TextColors;
 };
 
-const ThemeText: React.FC<StyledTextProps> = ({
+const ThemeText: React.FC<ThemeTextProps> = ({
   type: fontType = 'body',
+  color = 'primary',
   style,
   children,
   ...props
@@ -16,9 +18,8 @@ const ThemeText: React.FC<StyledTextProps> = ({
   const {theme} = useTheme();
 
   const typeStyle = {
-    fontSize: theme.text.sizes[fontType],
-    lineHeight: theme.text.lineHeight[fontType],
-    color: theme.text.colors.primary,
+    ...theme.text[fontType],
+    color: theme.text.colors[color],
   };
 
   return (

--- a/src/error-boundary/ErrorView.tsx
+++ b/src/error-boundary/ErrorView.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import ScreenHeader from '../ScreenHeader';
-import {Text, View, StyleSheet} from 'react-native';
+import {View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {getBuildNumber} from 'react-native-device-info';
 
 import useChatIcon from '../chat/use-chat-icon';
-import colors from '../theme/colors';
 import {CrashParachute} from '../assets/svg/illustrations';
 import Button from '../components/button';
 import useLocalConfig from '../utils/use-local-config';
+import ThemeText from '../components/text';
+import {StyleSheet} from '../theme';
 
 type ErrorProps = {
   onRestartApp: () => void;
@@ -16,6 +17,7 @@ type ErrorProps = {
 };
 
 const ErrorView: React.FC<ErrorProps> = ({onRestartApp, errorCode}) => {
+  const styles = useStyles();
   const chatIcon = useChatIcon();
   const buildNumber = getBuildNumber();
   const config = useLocalConfig();
@@ -28,8 +30,10 @@ const ErrorView: React.FC<ErrorProps> = ({onRestartApp, errorCode}) => {
       </View>
       <View style={styles.container}>
         <View>
-          <Text style={styles.title}>Appen krasja - håper du lander mykt!</Text>
-          <Text style={styles.message}>
+          <ThemeText type="paragraphHeadline" style={styles.title}>
+            Appen krasja - håper du lander mykt!
+          </ThemeText>
+          <ThemeText style={styles.message}>
             Appen er i læringsmodus, og slike krasj er akkurat det vi trenger
             for å gjøre den enda mer robust.
             {'\n'}
@@ -38,7 +42,7 @@ const ErrorView: React.FC<ErrorProps> = ({onRestartApp, errorCode}) => {
             {'\n'}
             {'\n'}
             Tusen takk for at du gjør oss bedre!
-          </Text>
+          </ThemeText>
           <Button
             text="Start appen på nytt"
             onPress={onRestartApp}
@@ -46,19 +50,19 @@ const ErrorView: React.FC<ErrorProps> = ({onRestartApp, errorCode}) => {
           />
         </View>
         <View style={{alignItems: 'center'}}>
-          {errorCode && <Text>Feilkode: {errorCode}</Text>}
-          <Text>Build-id: {buildNumber}</Text>
-          {config?.installId && <Text>Id: {config.installId}</Text>}
+          {errorCode && <ThemeText>Feilkode: {errorCode}</ThemeText>}
+          <ThemeText>Build-id: {buildNumber}</ThemeText>
+          {config?.installId && <ThemeText>Id: {config.installId}</ThemeText>}
         </View>
       </View>
     </SafeAreaView>
   );
 };
 
-const styles = StyleSheet.create({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   safearea: {
     flex: 1,
-    backgroundColor: colors.secondary.gray_Level2,
+    backgroundColor: theme.background.level2,
   },
   svgContainer: {
     aspectRatio: 1,
@@ -70,18 +74,15 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   title: {
-    fontSize: 16,
-    fontWeight: 'bold',
     textAlign: 'center',
   },
   message: {
-    fontSize: 16,
     marginTop: 12,
     textAlign: 'center',
   },
   button: {
     marginVertical: 24,
   },
-});
+}));
 
 export default ErrorView;

--- a/src/favorite-chips/index.tsx
+++ b/src/favorite-chips/index.tsx
@@ -4,7 +4,6 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {
   AccessibilityProps,
   StyleProp,
-  Text,
   TouchableOpacity,
   ViewStyle,
 } from 'react-native';
@@ -21,6 +20,7 @@ import colors from '../theme/colors';
 import {StyleSheet} from '../theme';
 import ThemeIcon from '../components/theme-icon';
 import {screenReaderPause} from '../components/accessible-text';
+import ThemeText from '../components/text';
 
 type Props = {
   onSelectLocation: (location: LocationWithMetadata) => void;
@@ -148,7 +148,8 @@ const FavoriteChip: React.FC<ChipProps> = ({
       {...accessibilityProps}
     >
       {icon}
-      <Text
+      <ThemeText
+        type="body"
         style={[
           chipStyles.text,
           mode == 'light' && chipStyles.text__light,
@@ -156,7 +157,7 @@ const FavoriteChip: React.FC<ChipProps> = ({
         ]}
       >
         {text}
-      </Text>
+      </ThemeText>
     </TouchableOpacity>
   );
 };
@@ -177,7 +178,6 @@ const useChipStyles = StyleSheet.createThemeHook((theme, themeName) => ({
     marginLeft: theme.spacings.xSmall,
     marginRight: theme.spacings.xSmall,
     color: colors.general.white,
-    fontSize: theme.text.sizes.body,
     fontWeight: 'bold',
     letterSpacing: -0.31,
   },

--- a/src/favorites/index.tsx
+++ b/src/favorites/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {Text} from 'react-native';
 import {MapPointPin} from '../assets/svg/icons/places';
+import ThemeText from '../components/text';
 import ThemeIcon from '../components/theme-icon';
 
 export type FavoriteIconProps = {
@@ -11,7 +11,7 @@ export function FavoriteIcon({favorite}: FavoriteIconProps) {
   if (!favorite || !favorite.emoji) {
     return <ThemeIcon svg={MapPointPin} />;
   }
-  return <Text>{favorite.emoji}</Text>;
+  return <ThemeText>{favorite.emoji}</ThemeText>;
 }
 
 export {

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -293,37 +293,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   chipBox: {
     marginBottom: theme.spacings.medium,
   },
-  label: {
-    fontSize: theme.text.sizes.lead,
-    lineHeight: theme.text.lineHeight.body,
-    position: 'absolute',
-    left: theme.spacings.medium,
-  },
-  placeholder: {
-    color: theme.text.colors.faded,
-  },
-  inputContainer: {
-    width: '100%',
-    height: 46,
-    flexDirection: 'column',
-    marginBottom: theme.spacings.xLarge,
-    justifyContent: 'center',
-  },
-  input: {
-    flex: 1,
-    fontSize: theme.text.sizes.body,
-    paddingLeft: 60,
-    backgroundColor: theme.background.level1,
-    borderWidth: 1,
-    borderColor: theme.border.primary,
-    borderRadius: theme.border.borderRadius.small,
-    color: theme.text.colors.primary,
-  },
-  searchIcon: {
-    position: 'absolute',
-    left: 14,
-    alignSelf: 'center',
-  },
 }));
 
 export default LocationSearch;

--- a/src/location-search/map-selection/LocationBar.tsx
+++ b/src/location-search/map-selection/LocationBar.tsx
@@ -74,13 +74,12 @@ const LocationText: React.FC<{
   location?: Location;
   error?: ErrorType;
 }> = ({location, error}) => {
-  const styles = useStyles();
   const {title, subtitle} = getLocationText(location, error);
 
   return (
     <>
-      <ThemeText style={styles.title}>{title}</ThemeText>
-      <ThemeText style={styles.subtitle}>{subtitle}</ThemeText>
+      <ThemeText type="lead">{title}</ThemeText>
+      <ThemeText type="label">{subtitle}</ThemeText>
     </>
   );
 };
@@ -137,14 +136,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
   },
   locationContainer: {flexDirection: 'row', alignItems: 'center', height: 44},
-  title: {
-    fontSize: theme.text.sizes.lead,
-    lineHeight: theme.text.lineHeight.body,
-  },
-  subtitle: {
-    fontSize: theme.text.sizes.label,
-    lineHeight: theme.text.lineHeight.label,
-  },
   button: {
     width: 44,
     alignItems: 'center',

--- a/src/location-search/map-selection/SelectionPin.tsx
+++ b/src/location-search/map-selection/SelectionPin.tsx
@@ -1,5 +1,5 @@
 import React, {useRef, useEffect} from 'react';
-import {Text, Animated, View} from 'react-native';
+import {Animated, View} from 'react-native';
 import {
   SelectionPinConfirm,
   SelectionPinUnknown,

--- a/src/message-box/index.tsx
+++ b/src/message-box/index.tsx
@@ -59,7 +59,7 @@ const useBoxStyle = StyleSheet.createThemeHook((theme) => ({
     marginBottom: 8,
   },
   text: {
-    fontSize: theme.text.sizes.body,
+    ...theme.text.body,
     color: theme.text.colors.primary,
   },
   container__info: {

--- a/src/screens/Assistant/DateInput.tsx
+++ b/src/screens/Assistant/DateInput.tsx
@@ -2,12 +2,7 @@ import * as React from 'react';
 import {StyleSheet} from '../../theme';
 import {Portal} from 'react-native-portalize';
 import {Modalize} from 'react-native-modalize';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  AccessibilityProperties,
-} from 'react-native';
+import {View, TouchableOpacity, AccessibilityProperties} from 'react-native';
 import {useState, useRef, useEffect} from 'react';
 import DatePicker from 'react-native-date-picker';
 import Button from '../../components/button';
@@ -19,6 +14,7 @@ import subDays from 'date-fns/subDays';
 import insets from '../../utils/insets';
 import {screenReaderPause} from '../../components/accessible-text';
 import ThemeIcon from '../../components/theme-icon';
+import ThemeText from '../../components/text';
 
 type DateTypesWithoutNow = 'departure' | 'arrival';
 type DateTypes = DateTypesWithoutNow | 'now';
@@ -86,7 +82,7 @@ const DateTypeButton: React.FC<
         hitSlop={insets.symmetric(12, 8)}
         {...props}
       >
-        <Text style={style.dateTypeButtonText}>{dateTypeToText(type)}</Text>
+        <ThemeText type="paragraphHeadline">{dateTypeToText(type)}</ThemeText>
       </TouchableOpacity>
     </View>
   );
@@ -177,7 +173,7 @@ const DateInput: React.FC<DateInputProps> = ({
           <View style={style.container}>
             <View style={style.header}>
               <View style={style.headerTextContainer}>
-                <Text style={style.headerText}>Velg tidspunkt</Text>
+                <ThemeText type="paragraphHeadline">Velg tidspunkt</ThemeText>
               </View>
               <TouchableOpacity onPress={onClose}>
                 <ThemeIcon svg={Close} />
@@ -256,16 +252,9 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
     marginLeft: 20,
     alignItems: 'center',
   },
-  headerText: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
   dateTypeButton: {
     paddingBottom: 4,
     marginHorizontal: 6,
-  },
-  dateTypeButtonText: {
-    fontWeight: '600',
   },
   dateTypeButtonSelected: {
     borderBottomColor: theme.background.accent,

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -132,34 +132,13 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.background.level0,
     borderRadius: theme.border.borderRadius.regular,
   },
-  stopName: {
-    fontSize: theme.text.sizes.body,
-    color: theme.text.colors.primary,
-    flexShrink: 1,
-  },
-  lineContainer: {
-    flexShrink: 1,
-    flexWrap: 'wrap',
-  },
   time: {
     fontSize: 32,
     color: theme.text.colors.primary,
     marginVertical: 8,
   },
-  lineName: {
-    fontSize: theme.text.sizes.body,
-    fontWeight: '600',
-    color: theme.text.colors.primary,
-    textAlign: 'center',
-    marginLeft: 8,
-  },
   detailsContainer: {
     flexDirection: 'column',
-  },
-  transferText: {fontSize: theme.text.sizes.body},
-  detailsText: {
-    fontSize: theme.text.sizes.label,
-    textDecorationLine: 'underline',
   },
   resultHeader: {
     flexDirection: 'row',
@@ -213,13 +192,21 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
 
   return (
     <View style={styles.legContainer}>
-      <ThemeText style={[styles.textDeprioritized, styles.time]}>
+      <ThemeText
+        type="label"
+        color="faded"
+        style={[styles.textDeprioritized, styles.time]}
+      >
         {formatToClockOrRelativeMinutes(leg.expectedStartTime)}
       </ThemeText>
       <View style={styles.iconContainer}>
         <ThemeIcon svg={WalkingPerson} opacity={0.6} />
       </View>
-      <ThemeText style={[styles.textContent, styles.textDeprioritized]}>
+      <ThemeText
+        type="lead"
+        color="faded"
+        style={[styles.textContent, styles.textDeprioritized]}
+      >
         {text}
       </ThemeText>
     </View>
@@ -262,12 +249,9 @@ const useLegStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     flexWrap: 'wrap',
   },
-  text: {
-    fontSize: theme.text.sizes.body,
-  },
   textDeprioritized: {
+    ...theme.text.lead,
     fontWeight: 'normal',
-    fontSize: theme.text.sizes.lead,
     color: theme.text.colors.faded,
   },
   textBold: {
@@ -282,13 +266,13 @@ const TransportationLeg = ({leg}: {leg: Leg}) => {
   const styles = useLegStyles();
   return (
     <View style={styles.legContainer}>
-      <ThemeText style={[styles.text, styles.time]}>
+      <ThemeText type="body" style={styles.time}>
         {formatToClockOrRelativeMinutes(leg.expectedStartTime)}
       </ThemeText>
       <View style={styles.iconContainer}>
         <TransportationIcon mode={leg.mode} publicCode={leg.line?.publicCode} />
       </View>
-      <ThemeText style={[styles.textContent, styles.text]}>
+      <ThemeText type="body" style={styles.textContent}>
         <LineDisplayName leg={leg} />
       </ThemeText>
     </View>

--- a/src/screens/Assistant/index.tsx
+++ b/src/screens/Assistant/index.tsx
@@ -2,7 +2,6 @@ import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
-  Text,
   TouchableOpacity,
   View,
   ViewStyle,
@@ -53,6 +52,7 @@ import {screenReaderPause} from '../../components/accessible-text';
 import colors from '../../theme/colors';
 import ThemeIcon from '../../components/theme-icon';
 import ScreenReaderAnnouncement from '../../components/screen-reader-announcement';
+import ThemeText from '../../components/text';
 
 type AssistantRouteName = 'Assistant';
 const AssistantRouteNameStatic: AssistantRouteName = 'Assistant';
@@ -326,7 +326,8 @@ const Assistant: React.FC<Props> = ({
 
   const altHeaderComp = (
     <View accessible={true} onLayout={onAltLayout} style={styles.altTitle}>
-      <Text
+      <ThemeText
+        type="paragraphHeadline"
         style={[
           styles.altTitleText,
           styles.altTitleText__right,
@@ -335,17 +336,22 @@ const Assistant: React.FC<Props> = ({
         numberOfLines={1}
       >
         {from?.name}
-      </Text>
-      <Text accessibilityLabel="til" style={styles.altTitleText}>
+      </ThemeText>
+      <ThemeText
+        type="paragraphHeadline"
+        accessibilityLabel="til"
+        style={styles.altTitleText}
+      >
         {' '}
         –{' '}
-      </Text>
-      <Text
+      </ThemeText>
+      <ThemeText
+        type="paragraphHeadline"
         style={[styles.altTitleText, {maxWidth: altWidth / 2}]}
         numberOfLines={1}
       >
         {to?.name}
-      </Text>
+      </ThemeText>
     </View>
   );
 
@@ -427,9 +433,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   altTitleText: {
     overflow: 'hidden',
-    fontSize: theme.text.sizes.body,
-    color: theme.text.colors.primary,
-    fontWeight: 'bold',
   },
   altTitleText__right: {
     textAlign: 'right',

--- a/src/screens/Loading/index.tsx
+++ b/src/screens/Loading/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {ActivityIndicator, Text, View, StyleSheet} from 'react-native';
+import {ActivityIndicator, View, StyleSheet} from 'react-native';
+import ThemeText from '../../components/text';
 import colors from '../../theme/colors';
 
 const Loading: React.FC<{text?: string}> = ({text}) => {
@@ -10,7 +11,11 @@ const Loading: React.FC<{text?: string}> = ({text}) => {
         size="large"
         color={colors.general.white}
       />
-      {text ? <Text style={styles.text}>{text}</Text> : null}
+      {text ? (
+        <ThemeText type="paragraphHeadline" style={styles.text}>
+          {text}
+        </ThemeText>
+      ) : null}
     </View>
   );
 };
@@ -23,9 +28,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   text: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: colors.general.white,
     marginTop: 10,
   },
 });

--- a/src/screens/Nearby/NearbyResults.tsx
+++ b/src/screens/Nearby/NearbyResults.tsx
@@ -225,7 +225,7 @@ const ShowMoreButton: React.FC<ShowMoreButtonProps> = ({onPress}) => {
       hitSlop={insets.symmetric(8, 12)}
     >
       <View style={style.showMoreButton}>
-        <ThemeText style={style.text}>Vis flere avganger</ThemeText>
+        <ThemeText type="body">Vis flere avganger</ThemeText>
         <ThemeIcon svg={Expand} />
       </View>
     </TouchableOpacity>
@@ -237,9 +237,6 @@ const useShowMoreButtonStyle = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
-  },
-  text: {
-    fontSize: theme.text.sizes.body,
   },
 }));
 
@@ -296,7 +293,7 @@ const NearbyResultItem: React.FC<NearbyResultItemProps> = React.memo(
             circleStyle={{margin: 0}}
           />
           <View style={styles.textWrapper}>
-            <ThemeText style={styles.textContent} numberOfLines={1}>
+            <ThemeText type="body" numberOfLines={1}>
               {publicCode && (
                 <Text style={{fontWeight: 'bold'}}>{publicCode} </Text>
               )}
@@ -305,7 +302,7 @@ const NearbyResultItem: React.FC<NearbyResultItemProps> = React.memo(
           </View>
           <SituationWarningIcon situations={departure.situations} />
 
-          <AccessibleText prefix="Avgang" style={styles.time}>
+          <AccessibleText type="body" prefix="Avgang" style={styles.time}>
             {(!departure.realtime ? missingRealtimePrefix : '') +
               formatToClockOrRelativeMinutes(departure.expectedDepartureTime)}
           </AccessibleText>
@@ -345,22 +342,17 @@ const useResultItemStyles = StyleSheet.createThemeHook((theme) => ({
   platformHeader: {
     padding: theme.spacings.medium,
     color: theme.text.colors.faded,
-    fontSize: theme.text.sizes.label,
     borderBottomColor: theme.background.level1,
     borderBottomWidth: 1,
   },
   time: {
     width: 78,
     textAlign: 'right',
-    fontSize: theme.text.sizes.body,
     color: theme.text.colors.primary,
     fontWeight: 'bold',
     paddingVertical: theme.spacings.xSmall,
     marginRight: theme.spacings.small,
     fontVariant: ['tabular-nums'],
-  },
-  textContent: {
-    fontSize: theme.text.sizes.body,
   },
   textWrapper: {
     flex: 1,
@@ -378,8 +370,6 @@ const useResultItemStyles = StyleSheet.createThemeHook((theme) => ({
     borderBottomWidth: 1,
   },
   resultHeaderText: {
-    fontSize: theme.text.sizes.body,
-    lineHeight: theme.text.lineHeight.body,
     fontWeight: 'bold',
     color: theme.text.colors.primary,
   },

--- a/src/screens/Onboarding/components/NavigationControls.tsx
+++ b/src/screens/Onboarding/components/NavigationControls.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {View, Text} from 'react-native';
+import {View} from 'react-native';
 import {Dot} from '../../../assets/svg/icons/other';
 import {TouchableOpacity} from 'react-native';
 import {ArrowRight} from '../../../assets/svg/icons/navigation';
 import {StyleSheet} from '../../../theme';
 import colors from '../../../theme/colors';
 import ThemeIcon from '../../../components/theme-icon';
+import ThemeText from '../../../components/text';
 
 type NavigateButtonProps = {
   onNavigate(): void;
@@ -35,7 +36,7 @@ const NavigationControls: React.FC<NavigateButtonProps> = ({
         ))}
       </View>
       <TouchableOpacity style={styles.button} onPress={onNavigate}>
-        <Text style={styles.buttonText}>{title}</Text>
+        <ThemeText type="paragraphHeadline">{title}</ThemeText>
         {arrow && <ThemeIcon svg={ArrowRight} style={styles.buttonIcon} />}
       </TouchableOpacity>
       {children}
@@ -65,11 +66,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  buttonText: {
-    fontSize: theme.text.sizes.body,
-    fontWeight: '600',
-    color: theme.button.primary.color,
-  },
+
   buttonIcon: {
     position: 'absolute',
     right: theme.spacings.medium,

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -147,7 +147,7 @@ const StepThree: React.FC<StepProps> = () => {
               Linking.openURL(PRIVACY_POLICY_URL ?? 'https://www.atb.no')
             }
           >
-            <ThemeText style={[styles.text, styles.privacyPolicy]}>
+            <ThemeText type="body" style={[styles.text, styles.privacyPolicy]}>
               Les vår personvernerklæring
             </ThemeText>
           </TouchableOpacity>
@@ -167,8 +167,6 @@ const useStyles = StyleSheet.createThemeHook((theme, themeName) => ({
     fontWeight: 'bold',
   },
   text: {
-    fontSize: theme.text.sizes.body,
-    color: theme.text.colors.primary,
     marginTop: theme.spacings.medium,
   },
   privacyPolicy: {

--- a/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
+++ b/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
@@ -6,7 +6,6 @@
  */
 import React, {useRef, useEffect, forwardRef, useState} from 'react';
 import {
-  Text,
   TouchableOpacity,
   View,
   Platform,
@@ -23,6 +22,7 @@ import {Modalize} from 'react-native-modalize';
 import {Portal} from 'react-native-portalize';
 import composeRefs from '@seznam/compose-react-refs';
 import {StyleSheet} from '../../../theme';
+import ThemeText from '../../../components/text';
 
 // Polyfill for Android
 require('string.fromcodepoint');
@@ -114,13 +114,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     justifyContent: 'flex-start',
   },
-
   clearButton: {
     padding: theme.spacings.medium,
     textAlign: 'center',
-    color: theme.text.colors.primary,
     textAlignVertical: 'center',
-    fontSize: theme.text.sizes.body,
   },
 }));
 
@@ -134,9 +131,9 @@ const ClearButton: React.FC<{
   if (!value) return null;
   return (
     <TouchableOpacity onPress={() => onEmojiSelected(null)}>
-      <Text style={[styles.clearButton, clearButtonStyle]}>
+      <ThemeText type="body" style={[styles.clearButton, clearButtonStyle]}>
         {clearButtonText ?? 'Fjern emoji'}
-      </Text>
+      </ThemeText>
     </TouchableOpacity>
   );
 };
@@ -177,12 +174,14 @@ const EmojiCategory: React.FC<EmojiCategory> = ({
 
   return (
     <View style={styles.categoryOuter}>
-      <Text style={[styles.headerText, headerStyle]}>{categoryText}</Text>
+      <ThemeText style={[styles.headerText, headerStyle]}>
+        {categoryText}
+      </ThemeText>
       <View style={styles.categoryInner}>
         {emojis.map((e: string) => (
-          <Text style={style} key={e} onPress={() => onEmojiSelected(e)}>
+          <ThemeText style={style} key={e} onPress={() => onEmojiSelected(e)}>
             {e}
-          </Text>
+          </ThemeText>
         ))}
       </View>
     </View>

--- a/src/screens/Profile/AddEditFavorite/index.tsx
+++ b/src/screens/Profile/AddEditFavorite/index.tsx
@@ -247,8 +247,8 @@ const useScreenStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     flexDirection: 'row',
   },
   searchInput: {
+    ...theme.text.body,
     flex: 1,
-    fontSize: theme.text.sizes.body,
     paddingLeft: 60,
     backgroundColor: theme.background.level1,
     borderRadius: theme.border.borderRadius.small,
@@ -280,7 +280,7 @@ const SymbolPicker: React.FC<SymbolPickerProps> = ({onPress, value}) => {
         {!value ? (
           <ThemeIcon svg={MapPointPin} style={css.emojiIcon} />
         ) : (
-          <ThemeText style={css.emojiText}>{value}</ThemeText>
+          <ThemeText type="body">{value}</ThemeText>
         )}
       </View>
       <ThemeIcon svg={Expand} />
@@ -304,9 +304,6 @@ const useSymbolPickerStyle = StyleSheet.createThemeHook((theme) => ({
     paddingTop: 3,
     paddingBottom: 3,
   },
-  emojiText: {
-    fontSize: theme.text.sizes.body,
-  },
 }));
 
 type InputGroupProps = {
@@ -319,7 +316,9 @@ const InputGroup: React.FC<InputGroupProps> = ({title, boxStyle, children}) => {
   return (
     <View style={[css.container, boxStyle]}>
       {children}
-      <ThemeText style={css.label}>{title}</ThemeText>
+      <ThemeText type="lead" style={css.label}>
+        {title}
+      </ThemeText>
     </View>
   );
 };
@@ -332,7 +331,5 @@ const useGroupStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   label: {
     position: 'absolute',
     left: theme.spacings.medium,
-    fontSize: theme.text.sizes.lead,
-    lineHeight: theme.text.lineHeight.body,
   },
 }));

--- a/src/screens/Profile/FavoriteList/EditableListGroup.tsx
+++ b/src/screens/Profile/FavoriteList/EditableListGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text as RNText} from 'react-native';
+import {View} from 'react-native';
 import {StyleSheet, Theme} from '../../../theme';
 import SectionHeader from '../../../components/section-header';
 import ThemeText from '../../../components/text';

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -1,5 +1,5 @@
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {View, Text, Linking, TouchableOpacity} from 'react-native';
+import {View, Linking, TouchableOpacity} from 'react-native';
 import React from 'react';
 import {StyleSheet, Theme} from '../../../theme';
 import {ScrollView} from 'react-native-gesture-handler';
@@ -19,6 +19,7 @@ import {PRIVACY_POLICY_URL} from '@env';
 import LogoOutline from '../../../ScreenHeader/LogoOutline';
 import {useNavigateHome} from '../../../utils/navigation';
 import ThemeIcon from '../../../components/theme-icon';
+import ThemeText from '../../../components/text';
 
 export type ProfileScreenNavigationProp = StackNavigationProp<
   ProfileStackParams,
@@ -91,7 +92,9 @@ export default function Profile({navigation}: ProfileScreenProps) {
           Linking.openURL(PRIVACY_POLICY_URL ?? 'https://www.atb.no')
         }
       >
-        <Text style={css.privacyPolicy}>Les vår personvernerklæring</Text>
+        <ThemeText type="body__link" style={css.privacyPolicy}>
+          Les vår personvernerklæring
+        </ThemeText>
       </TouchableOpacity>
     </SafeAreaView>
   );
@@ -109,10 +112,7 @@ const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     color: theme.text.colors.primary,
   },
   privacyPolicy: {
-    fontSize: theme.text.sizes.body,
     textAlign: 'center',
-    textDecorationLine: 'underline',
-    color: theme.text.colors.primary,
     marginBottom: theme.spacings.xLarge,
   },
 }));
@@ -123,7 +123,7 @@ function AddFavoriteButton({onPress}: {onPress(): void}) {
     <TouchableOpacity style={css.item} onPress={onPress}>
       <ThemeIcon svg={Add} />
       <View style={css.textContainer}>
-        <Text style={css.text}>Legg til favorittsted</Text>
+        <ThemeText style={css.text}>Legg til favorittsted</ThemeText>
       </View>
     </TouchableOpacity>
   );
@@ -139,13 +139,13 @@ const Item: React.FC<ItemProps> = ({item, onEdit, onClick}) => {
 
   const content = item.name ? (
     <>
-      <Text style={[css.textName, css.text]}>
+      <ThemeText type="paragraphHeadline" style={css.text}>
         {item.name ?? item.location.name}
-      </Text>
-      <Text style={css.text}>{item.location.label}</Text>
+      </ThemeText>
+      <ThemeText style={css.text}>{item.location.label}</ThemeText>
     </>
   ) : (
-    <Text>{item.location.label}</Text>
+    <ThemeText>{item.location.label}</ThemeText>
   );
 
   const clickable = onClick ? (
@@ -204,9 +204,5 @@ const useItemStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   },
   text: {
     color: theme.text.colors.primary,
-  },
-  textName: {
-    fontSize: theme.text.sizes.body,
-    fontWeight: '600',
   },
 }));

--- a/src/screens/Ticketing/Splash/InviteModal.tsx
+++ b/src/screens/Ticketing/Splash/InviteModal.tsx
@@ -65,10 +65,10 @@ export default forwardRef<Modalize, Props>(function InviteModal(
             <ActivityIndicator style={styles.loading} />
           ) : (
             <>
-              <ThemeText style={styles.title}>
+              <ThemeText type="paragraphHeadline" style={styles.title}>
                 Registrer deg som testpilot for billettkjøp
               </ThemeText>
-              <ThemeText style={styles.text}>
+              <ThemeText type="body" style={styles.text}>
                 Send oss invitasjonskoden din og bli først ute med å teste
                 billettkjøp direkte fra reiseappen.
               </ThemeText>
@@ -106,13 +106,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacings.medium,
   },
   title: {
-    fontSize: theme.text.sizes.body,
-    fontWeight: 'bold',
     textAlign: 'center',
     marginBottom: theme.spacings.medium,
   },
   text: {
-    fontSize: theme.text.sizes.body,
     marginBottom: theme.spacings.medium,
   },
   messageBox: {

--- a/src/screens/Ticketing/Splash/index.tsx
+++ b/src/screens/Ticketing/Splash/index.tsx
@@ -89,8 +89,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
   },
   text: {
-    fontSize: theme.text.sizes.body,
-    lineHeight: theme.text.lineHeight.body,
     textAlign: 'center',
     marginBottom: theme.spacings.large,
   },

--- a/src/screens/TripDetailsModal/DepartureDetails/index.tsx
+++ b/src/screens/TripDetailsModal/DepartureDetails/index.tsx
@@ -1,7 +1,7 @@
 import {LegMode} from '@entur/sdk';
 import {RouteProp} from '@react-navigation/native';
 import React, {Fragment, useCallback, useState} from 'react';
-import {ActivityIndicator, Text, TouchableOpacity, View} from 'react-native';
+import {ActivityIndicator, TouchableOpacity, View} from 'react-native';
 import Dash from 'react-native-dash';
 import {ScrollView} from 'react-native-gesture-handler';
 import {DetailsModalNavigationProp, DetailsModalStackParams} from '..';
@@ -27,6 +27,7 @@ import LocationRow from '../LocationRow';
 import SituationRow from '../SituationRow';
 import {getAimedTimeIfLargeDifference} from '../utils';
 import ThemeIcon from '../../../components/theme-icon';
+import ThemeText from '../../../components/text';
 
 export type DepartureDetailsRouteParams = {
   title: string;
@@ -241,7 +242,11 @@ function CollapseButtonRow({
   setCollapsed,
 }: CollapseButtonRowProps) {
   const styles = useCollapseButtonStyle();
-  const text = <Text style={styles.text}>{numberOfStops} Mellomstopp</Text>;
+  const text = (
+    <ThemeText color="faded" style={styles.text}>
+      {numberOfStops} Mellomstopp
+    </ThemeText>
+  );
   const child = collapsed ? (
     <>
       <ThemeIcon svg={Expand} />
@@ -267,7 +272,6 @@ const useCollapseButtonStyle = StyleSheet.createThemeHook((theme) => ({
   },
   text: {
     marginLeft: 12,
-    color: theme.text.colors.faded,
   },
 }));
 

--- a/src/screens/TripDetailsModal/Details/TransportDetail.tsx
+++ b/src/screens/TripDetailsModal/Details/TransportDetail.tsx
@@ -147,13 +147,11 @@ const TransportDetail: React.FC<LegDetailProps> = ({
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   textStyle: {
-    fontSize: theme.text.sizes.lead,
-    lineHeight: theme.text.lineHeight.body,
+    ...theme.text.lead,
   },
   lineName: {
     marginLeft: 120,
-    fontSize: theme.text.sizes.body,
-    fontWeight: '600',
+    ...theme.text.paragraphHeadline,
   },
   dashContainer: {
     marginLeft: 95,

--- a/src/screens/TripDetailsModal/Details/index.tsx
+++ b/src/screens/TripDetailsModal/Details/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@react-navigation/native';
 import Axios, {AxiosError} from 'axios';
 import React, {useCallback, useState} from 'react';
-import {ActivityIndicator, Text, View} from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {DetailsModalNavigationProp, DetailsModalStackParams} from '..';
 import {getSingleTripPattern} from '../../../api/trips';
@@ -279,9 +279,7 @@ const useDetailsStyle = StyleSheet.createThemeHook((theme) => ({
     paddingRight: theme.spacings.medium,
     paddingBottom: 100,
   },
-  textStyle: {
-    fontSize: theme.text.sizes.body,
-  },
+  textStyle: theme.text.body,
 }));
 
 export default TripDetailsModal;

--- a/src/screens/TripDetailsModal/LocationRow.tsx
+++ b/src/screens/TripDetailsModal/LocationRow.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
   View,
-  Text,
   TextStyle,
   StyleProp,
   ViewStyle,
   LayoutChangeEvent,
 } from 'react-native';
+import ThemeText from '../../components/text';
 import {StyleSheet, useTheme} from '../../theme';
 
 const LocationRow: React.FC<{
@@ -41,8 +41,14 @@ const LocationRow: React.FC<{
     <View style={[styles.row, rowStyle]} onLayout={onLayout}>
       <View style={styles.iconLocationContainer}>
         <View style={styles.timeContainer}>
-          <Text style={[styles.time, textStyle, timeStyle]}>{time}</Text>
-          {aimedTime && <Text style={styles.aimedTime}>{aimedTime}</Text>}
+          <ThemeText style={[styles.time, textStyle, timeStyle]}>
+            {time}
+          </ThemeText>
+          {aimedTime && (
+            <ThemeText type="label" style={styles.aimedTime}>
+              {aimedTime}
+            </ThemeText>
+          )}
         </View>
         <View
           style={[
@@ -58,8 +64,10 @@ const LocationRow: React.FC<{
           {icon}
         </View>
         <View style={styles.labelContainer}>
-          {!!labelIcon && <Text style={styles.labelIcon}>{labelIcon}</Text>}
-          <Text style={[styles.label, textStyle]}>{label}</Text>
+          {!!labelIcon && (
+            <ThemeText style={styles.labelIcon}>{labelIcon}</ThemeText>
+          )}
+          <ThemeText style={textStyle}>{label}</ThemeText>
         </View>
       </View>
     </View>
@@ -93,9 +101,6 @@ const useLocationRowStyle = StyleSheet.createThemeHook((theme) => ({
   labelIcon: {
     marginRight: 6,
   },
-  label: {
-    color: theme.text.colors.primary,
-  },
   timeContainer: {
     width: 78,
     alignItems: 'flex-end',
@@ -103,16 +108,11 @@ const useLocationRowStyle = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'flex-end',
   },
   time: {
-    color: theme.text.colors.primary,
     fontVariant: ['tabular-nums'],
   },
   aimedTime: {
     position: 'absolute',
     top: '50%',
-    color: theme.text.colors.primary,
-    fontSize: 12,
-    lineHeight: theme.text.lineHeight.label,
-    fontWeight: 'normal',
     textDecorationLine: 'line-through',
     textDecorationStyle: 'solid',
     fontVariant: ['tabular-nums'],

--- a/src/screens/TripDetailsModal/Map/CompactMap.tsx
+++ b/src/screens/TripDetailsModal/Map/CompactMap.tsx
@@ -1,17 +1,17 @@
-import React, {useRef, useState} from 'react';
+import React, {useState} from 'react';
 import MapboxGL from '@react-native-mapbox-gl/maps';
-import {Text, View} from 'react-native';
+import {View} from 'react-native';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {MapIcon} from '../../../assets/svg/map';
 import {getMapBounds, legsToMapLines, pointOf} from './utils';
 import MapRoute from './MapRoute';
 import MapLabel from './MapLabel';
-import colors from '../../../theme/colors';
 import {MapViewConfig, MapCameraConfig} from '../../../components/map/';
 import insets from '../../../utils/insets';
 import {Leg} from '../../../sdk';
 import Bugsnag from '@bugsnag/react-native';
 import {StyleSheet} from '../../../theme';
+import ThemeText from '../../../components/text';
 
 export type MapProps = {
   legs: Leg[];
@@ -64,7 +64,9 @@ export const CompactMap: React.FC<MapProps> = ({legs, darkMode, onExpand}) => {
           onPress={expandMap}
           hitSlop={insets.symmetric(8, 12)}
         >
-          <Text style={styles.toggleText}>Utvid kart</Text>
+          <ThemeText type="lead" style={styles.toggleText}>
+            Utvid kart
+          </ThemeText>
           <MapIcon style={styles.toggleIcon} />
         </TouchableOpacity>
       </View>
@@ -89,9 +91,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingVertical: theme.spacings.small,
   },
   toggleText: {
-    fontSize: theme.text.sizes.lead,
-    lineHeight: theme.text.lineHeight.body,
-    color: theme.text.colors.primary,
     textShadowColor: theme.background.level0,
     textShadowOffset: {height: 1, width: 1},
     textShadowRadius: 1,

--- a/src/situations/index.tsx
+++ b/src/situations/index.tsx
@@ -1,6 +1,6 @@
 import React, {ComponentProps} from 'react';
-import {Text} from 'react-native';
 import {Warning} from '../assets/svg/situations';
+import ThemeText from '../components/text';
 import MessageBox, {MessageBoxProps} from '../message-box';
 import {Situation} from '../sdk';
 
@@ -24,7 +24,7 @@ export default function SituationMessages({
   return (
     <MessageBox type="warning" icon={icon} containerStyle={containerStyle}>
       {Object.entries(uniqueSituations).map(([id, situation]) => (
-        <Text key={id}>{situation}</Text>
+        <ThemeText key={id}>{situation}</ThemeText>
       ))}
     </MessageBox>
   );

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,4 @@
-import {StatusBarProps} from 'react-native';
+import {StatusBarProps, TextStyle} from 'react-native';
 
 const backgrounds = {
   light__level0: '#FFFFFF',
@@ -62,16 +62,34 @@ const spacings = {
   small: 8,
   xSmall: 4,
 };
-export const fontSizes = {
-  body: 16,
-  lead: 14,
-  label: 12,
+
+export type TextNames =
+  | 'heroTitle'
+  | 'pageTitle'
+  | 'sectionHeadline'
+  | 'itemHeadline'
+  | 'paragraphHeadline'
+  | 'body'
+  | 'body__link'
+  | 'lead'
+  | 'label'
+  | 'label__link';
+
+export type TextColors = 'primary' | 'destructive' | 'faded' | 'focus';
+
+export const textTypes: {[key in TextNames]: TextStyle} = {
+  heroTitle: {fontSize: 32, lineHeight: 40},
+  pageTitle: {fontSize: 26, lineHeight: 32},
+  sectionHeadline: {fontSize: 23, lineHeight: 28},
+  itemHeadline: {fontSize: 20, lineHeight: 24},
+  paragraphHeadline: {fontSize: 16, lineHeight: 20, fontWeight: '600'},
+  body: {fontSize: 16, lineHeight: 20},
+  body__link: {fontSize: 16, lineHeight: 20, textDecorationLine: 'underline'},
+  lead: {fontSize: 14, lineHeight: 20},
+  label: {fontSize: 12, lineHeight: 16},
+  label__link: {fontSize: 12, lineHeight: 16, textDecorationLine: 'underline'},
 };
-const lineHeights = {
-  body: 20,
-  lead: 20,
-  label: 16,
-};
+
 const borderRadius = {
   regular: 8,
   small: 4,
@@ -102,15 +120,8 @@ export interface Theme {
     accent: string;
   };
   text: {
-    colors: {
-      primary: string;
-      destructive: string;
-      faded: string;
-      focus: string;
-    };
-    lineHeight: typeof lineHeights;
-    sizes: typeof fontSizes;
-  };
+    colors: {[key in TextColors]: string};
+  } & typeof textTypes;
   border: {
     primary: string;
     secondary: string;
@@ -151,8 +162,7 @@ export const themes: Themes = {
         faded: colors.general.gray400,
         focus: colors.secondary.blue_500,
       },
-      lineHeight: lineHeights,
-      sizes: fontSizes,
+      ...textTypes,
     },
     border: {
       primary: colors.general.gray,
@@ -193,8 +203,7 @@ export const themes: Themes = {
         faded: colors.general.gray100,
         focus: colors.secondary.cyan_500,
       },
-      sizes: fontSizes,
-      lineHeight: lineHeights,
+      ...textTypes,
     },
     border: {
       primary: colors.general.white,


### PR DESCRIPTION
Important bit is at [`cbrevik/text-theme-update?expand=1`#diff-a274c7da67](https://github.com/AtB-AS/mittatb-app/compare/cbrevik/text-theme-update?expand=1#diff-a274c7da6745d160eea40d93ebc2355288194baea2f19e3f30ceb057f4f9e31fR66) which now should match 1-1 typography defined here: https://www.figma.com/file/2gNei6Vw8PUKAV75wnR1yF/AtB-Typography?node-id=0%3A1&viewport=520%2C133%2C0.6827828288078308

Also updated [`cbrevik/text-theme-update?expand=1`#diff-73e01dbb72](https://github.com/AtB-AS/mittatb-app/compare/cbrevik/text-theme-update?expand=1#diff-73e01dbb723b9fc6ec8f0ca5badfa913f28397a0b3cfc9bad0ac8c8d34ef61f8R6) to support colors as well as the new text types.

The rest is just a massive set of refactoring to support the new structure, as well as update a lot of other places which had not yet moved to `ThemeText`

This will most likely cause regressions :D