### PR TITLE
fix: Should invalidate apk cache if node_modules has changed

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -44,7 +44,7 @@ jobs:
         id: apk-cache
         with:
           path: 'app-staging.apk'
-          key: ${{ runner.os }}-android-cache-${{ hashFiles('android/**') }}
+          key: ${{ runner.os }}-android-cache-${{ hashFiles('android/**') }-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}
       - name: Get Android keystore
         run: sh ./scripts/android/create-keystore-file.sh
         env:


### PR DESCRIPTION
A little bit of a derp here, but since Android dependencies are autolinked, the `android` project folder will not change if depdendencies change. Need to re-run native build if `node_modules` change as well.

This is not the case for iOS, since there the `Podfile` / `Podfile.lock` will change if native deps change, which in turn will be caught by hashing the `ios` project folder.