### PR TITLE
fix: Delay DisappearingHeader recalculation till after animation

### DIFF
--- a/src/screens/Assistant/index.tsx
+++ b/src/screens/Assistant/index.tsx
@@ -282,7 +282,6 @@ const Assistant: React.FC<Props> = ({
 
         <FadeBetween
           visibleKey={isHeaderFullHeight ? 'dateInput' : 'favoriteChips'}
-          isParentAnimating={isParentAnimating}
         >
           <FavoriteChips
             key="favoriteChips"

--- a/src/utils/use-conditional-memo.ts
+++ b/src/utils/use-conditional-memo.ts
@@ -1,0 +1,30 @@
+import React, {DependencyList} from 'react';
+
+/**
+ * useConditionalMemo will only recompute the memoized value when one of the deps has changed, AND if the
+ * predicate allows it.
+ *
+ * @template T
+ * @param {() => T} factory
+ * @param {(DependencyList | undefined)} deps
+ * @param {() => boolean} predicate
+ * @returns T | undefined
+ */
+function useConditionalMemo<T>(
+  factory: () => T,
+  predicate: () => boolean,
+  initial: T,
+  deps: DependencyList,
+) {
+  const lastMemoValue = React.useRef<T>(initial);
+
+  const value = React.useMemo<T>(
+    () => (predicate() ? factory() : lastMemoValue.current),
+    [...deps, predicate, initial],
+  );
+
+  lastMemoValue.current = value;
+  return value;
+}
+
+export default useConditionalMemo;


### PR DESCRIPTION
Think this is a bit better than the fix from last evening, since it forces DisappearingHeader to wait with content height recalculation till after animation is done.

Also fixes glitch in FadeBetween so it doesn't enable animation till after component mount