### PR TITLE
fix: Remove links to AtB Mobillett

### DIFF
--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -92,9 +92,7 @@ const Travellers: React.FC<Props> = ({navigation, route: {params}}) => {
         <MessageBox type="info" title="Beta-begrensning">
           <ThemeText type="label">
             Det er foreløpig kun mulig å kjøpe enkeltbillett voksen for buss og
-            trikk. Bruk{' '}
-            <Text style={{textDecorationLine: 'underline'}}>AtB Mobillett</Text>{' '}
-            for å kjøpe andre billetter.
+            trikk. Bruk AtB Mobillett for å kjøpe andre billetter.
           </ThemeText>
         </MessageBox>
       )}

--- a/src/screens/Ticketing/Splash/index.tsx
+++ b/src/screens/Ticketing/Splash/index.tsx
@@ -62,12 +62,6 @@ export default function Splash() {
             <ThemeText style={styles.text}>
               Her kan du snart kjøpe og administrere billetter til reisen din.
             </ThemeText>
-            <ThemeText style={styles.text}>
-              Frem til da kan du kjøpe billett fra{'\n'}
-              <Text onPress={openOtherTicketingApp} style={styles.underline}>
-                AtB Mobillett
-              </Text>
-            </ThemeText>
           </View>
           <View style={styles.buttonContainer}>
             <Button


### PR DESCRIPTION
Since Google is adamant that these are ads (they are not but whatever), best to just remove them.