### PR TITLE
feat: adds user preference to select start screen

### DIFF
--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -1,4 +1,8 @@
+// Sections
 export {default as Section} from './section';
+export {default as RadioSection} from './radio-section';
+
+// Links and actions
 export {default as LinkItem} from './link-item';
 export {default as HeaderItem} from './header-item';
 export {default as FavoriteItem} from './favorite-item';

--- a/src/components/sections/radio-section.tsx
+++ b/src/components/sections/radio-section.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import ActionItem from './action-item';
+import SectionGroup, {SectionProps} from './section';
+
+export type RadioSectionProps<T> = Omit<SectionProps, 'type' | 'children'> & {
+  items: T[];
+  selected?: T;
+  keyExtractor(item: T, index: number): string;
+  itemToText(item: T, index: number): string;
+  onSelect?(item: T, index: number): void;
+};
+
+export default function RadioSectionGroup<T>({
+  keyExtractor,
+  itemToText,
+  items,
+  selected,
+  onSelect,
+  ...props
+}: RadioSectionProps<T>) {
+  return (
+    <SectionGroup {...props}>
+      {items.map((item: T, index) => (
+        <ActionItem
+          key={keyExtractor(item, index)}
+          mode="check"
+          checked={item == selected}
+          text={itemToText(item, index)}
+          onPress={() => onSelect?.(item, index)}
+        />
+      ))}
+    </SectionGroup>
+  );
+}

--- a/src/components/sections/section.tsx
+++ b/src/components/sections/section.tsx
@@ -16,7 +16,10 @@ export default function SectionGroup({
   type = 'block',
 }: SectionProps) {
   const style = useInputGroupStyle();
-  const len = React.Children.count(children) - 1;
+  const len =
+    (React.Children.map(children, (child) =>
+      Number(React.isValidElement(child)),
+    )?.reduce((a, b) => a + b) ?? 1) - 1;
 
   const containerStyle = [
     withPadding ? style.container__padded : undefined,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import {loadLocalConfig} from './local-config';
 import Bugsnag from '@bugsnag/react-native';
 import {setInstallId as setApiInstallId} from './api/client';
 import ErrorBoundary from './error-boundary';
+import {PreferencesContextProvider} from './preferences';
 
 if (!__DEV__) {
   Bugsnag.start();
@@ -60,19 +61,21 @@ const App = () => {
     <SafeAreaProvider>
       <ErrorBoundary>
         <AppContextProvider>
-          <ThemeContextProvider>
-            <FavoritesContextProvider>
-              <SearchHistoryContextProvider>
-                <GeolocationContextProvider>
-                  <TicketContextProvider>
-                    <RemoteConfigContextProvider>
-                      <NavigationRoot />
-                    </RemoteConfigContextProvider>
-                  </TicketContextProvider>
-                </GeolocationContextProvider>
-              </SearchHistoryContextProvider>
-            </FavoritesContextProvider>
-          </ThemeContextProvider>
+          <PreferencesContextProvider>
+            <ThemeContextProvider>
+              <FavoritesContextProvider>
+                <SearchHistoryContextProvider>
+                  <GeolocationContextProvider>
+                    <TicketContextProvider>
+                      <RemoteConfigContextProvider>
+                        <NavigationRoot />
+                      </RemoteConfigContextProvider>
+                    </TicketContextProvider>
+                  </GeolocationContextProvider>
+                </SearchHistoryContextProvider>
+              </FavoritesContextProvider>
+            </ThemeContextProvider>
+          </PreferencesContextProvider>
         </AppContextProvider>
       </ErrorBoundary>
     </SafeAreaProvider>

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -11,6 +11,10 @@ import {
 } from '../assets/svg/icons/tab-bar';
 import ThemeText from '../components/text';
 import {LocationWithMetadata} from '../favorites/types';
+import {
+  Preference_ScreenAlternatives,
+  usePreferenceItems,
+} from '../preferences';
 import Assistant from '../screens/Assistant';
 import NearbyScreen from '../screens/Nearby';
 import ProfileScreen, {ProfileStackParams} from '../screens/Profile';
@@ -37,6 +41,7 @@ const Tab = createBottomTabNavigator<TabNavigatorParams>();
 
 const NavigationRoot = () => {
   const {theme} = useTheme();
+  const {startScreen} = usePreferenceItems();
   return (
     <Tab.Navigator
       tabBarOptions={{
@@ -48,6 +53,7 @@ const NavigationRoot = () => {
           color: theme.text.colors.faded,
         },
       }}
+      initialRouteName={settingToRouteName(startScreen)}
     >
       <Tab.Screen
         name="Assistant"
@@ -100,4 +106,19 @@ function tabSettings(
     ),
     tabBarIcon: ({color}) => <Icon fill={color} />,
   };
+}
+
+function settingToRouteName(
+  setting?: Preference_ScreenAlternatives,
+): keyof TabNavigatorParams {
+  switch (setting) {
+    case 'assistant':
+      return 'Assistant';
+    case 'departures':
+      return 'Nearest';
+    case 'ticketing':
+      return 'Ticketing';
+    default:
+      return 'Assistant';
+  }
 }

--- a/src/preferences/PreferencesContext.tsx
+++ b/src/preferences/PreferencesContext.tsx
@@ -1,8 +1,9 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
+import {useColorScheme} from 'react-native';
 import {
   getPreferences as getPreferences_storage,
-  setPreference as setPreference_storage,
   resetPreference as resetPreference_storage,
+  setPreference as setPreference_storage,
 } from './storage';
 import {PreferenceItem, UserPreferences} from './types';
 
@@ -16,7 +17,9 @@ const PreferencesContext = createContext<PreferencesContextState | undefined>(
 );
 
 const PreferencesContextProvider: React.FC = ({children}) => {
-  const [preferences, setPreferencesState] = useState<UserPreferences>({});
+  let [preferences, setPreferencesState] = useState<UserPreferences>({});
+  let colorScheme = useColorScheme();
+
   async function populatePreferences() {
     let preferences = await getPreferences_storage();
     setPreferencesState(preferences);
@@ -27,7 +30,10 @@ const PreferencesContextProvider: React.FC = ({children}) => {
   }, []);
 
   const contextValue: PreferencesContextState = {
-    preferences,
+    preferences: {
+      colorScheme,
+      ...preferences,
+    },
     async setPreference(items: UserPreferences) {
       const preferences = await setPreference_storage(items);
       setPreferencesState(preferences);

--- a/src/preferences/PreferencesContext.tsx
+++ b/src/preferences/PreferencesContext.tsx
@@ -1,0 +1,69 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+import {
+  getPreferences as getPreferences_storage,
+  setPreference as setPreference_storage,
+  resetPreference as resetPreference_storage,
+} from './storage';
+import {PreferenceItem, UserPreferences} from './types';
+
+type PreferencesContextState = {
+  preferences: UserPreferences;
+  setPreference(items: UserPreferences): void;
+  resetPreference(key: PreferenceItem): void;
+};
+const PreferencesContext = createContext<PreferencesContextState | undefined>(
+  undefined,
+);
+
+const PreferencesContextProvider: React.FC = ({children}) => {
+  const [preferences, setPreferencesState] = useState<UserPreferences>({});
+  async function populatePreferences() {
+    let preferences = await getPreferences_storage();
+    setPreferencesState(preferences);
+  }
+
+  useEffect(() => {
+    populatePreferences();
+  }, []);
+
+  const contextValue: PreferencesContextState = {
+    preferences,
+    async setPreference(items: UserPreferences) {
+      const preferences = await setPreference_storage(items);
+      setPreferencesState(preferences);
+    },
+
+    async resetPreference(key: PreferenceItem) {
+      const preferences = await resetPreference_storage(key);
+      setPreferencesState(preferences);
+    },
+  };
+
+  return (
+    <PreferencesContext.Provider value={contextValue}>
+      {children}
+    </PreferencesContext.Provider>
+  );
+};
+
+export function usePreferences() {
+  const context = useContext(PreferencesContext);
+  if (context === undefined) {
+    throw new Error(
+      'usePreferences must be used within a PreferencesContextProvider',
+    );
+  }
+  return context;
+}
+
+export function usePreferenceItems() {
+  const context = useContext(PreferencesContext);
+  if (context === undefined) {
+    throw new Error(
+      'usePreferences must be used within a PreferencesContextProvider',
+    );
+  }
+  return context.preferences;
+}
+
+export default PreferencesContextProvider;

--- a/src/preferences/index.tsx
+++ b/src/preferences/index.tsx
@@ -1,0 +1,7 @@
+export {
+  usePreferences,
+  usePreferenceItems,
+  default as PreferencesContextProvider,
+} from './PreferencesContext';
+
+export * from './types';

--- a/src/preferences/storage.ts
+++ b/src/preferences/storage.ts
@@ -1,0 +1,38 @@
+import storage, {StorageModelTypes} from '../storage';
+import {v4 as uuid} from 'uuid';
+import {PreferenceItem, UserPreferences} from './types';
+
+const STORAGE_KEY: StorageModelTypes = '@ATB_user_preferences';
+
+export async function getPreferences(): Promise<UserPreferences> {
+  const preferences = await storage.get(STORAGE_KEY);
+  if (!preferences) return {};
+  let data = (preferences ? JSON.parse(preferences) : []) as UserPreferences;
+  return data;
+}
+
+async function setPreferences(
+  preferences: UserPreferences,
+): Promise<UserPreferences> {
+  await storage.set(STORAGE_KEY, JSON.stringify(preferences));
+  return preferences;
+}
+
+export async function setPreference(
+  items: UserPreferences,
+): Promise<UserPreferences> {
+  let preferences = (await getPreferences()) ?? {};
+  preferences = {
+    ...preferences,
+    ...items,
+  };
+  return await setPreferences(preferences);
+}
+
+export async function resetPreference(
+  key: PreferenceItem,
+): Promise<UserPreferences> {
+  let preferences = (await getPreferences()) ?? {};
+  delete preferences[key];
+  return await setPreference(preferences);
+}

--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -1,0 +1,12 @@
+export const preference_screenAlternatives = [
+  'assistant',
+  'departures',
+  'ticketing',
+] as const;
+export type Preference_ScreenAlternatives = typeof preference_screenAlternatives[number];
+
+export type UserPreferences = {
+  startScreen?: Preference_ScreenAlternatives;
+};
+
+export type PreferenceItem = keyof UserPreferences;

--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -1,3 +1,5 @@
+import {ColorSchemeName} from 'react-native';
+
 export const preference_screenAlternatives = [
   'assistant',
   'departures',
@@ -7,6 +9,8 @@ export type Preference_ScreenAlternatives = typeof preference_screenAlternatives
 
 export type UserPreferences = {
   startScreen?: Preference_ScreenAlternatives;
+  colorScheme?: ColorSchemeName;
+  overrideColorScheme?: boolean;
 };
 
 export type PreferenceItem = keyof UserPreferences;

--- a/src/screens/Profile/Appearance/index.tsx
+++ b/src/screens/Profile/Appearance/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {ActionItem, Section} from '../../../components/sections';
+import {usePreferences} from '../../../preferences';
+import {StyleSheet, Theme} from '../../../theme';
+import BackHeader from '../BackHeader';
+
+export default function Appearance() {
+  const {
+    setPreference,
+    preferences: {colorScheme, overrideColorScheme},
+  } = usePreferences();
+  const style = useProfileHomeStyle();
+
+  return (
+    <SafeAreaView style={style.container}>
+      <BackHeader title="Utseende" />
+
+      <ScrollView>
+        <Section withTopPadding withPadding>
+          <ActionItem
+            mode="toggle"
+            text="Overstyr mørk modus"
+            checked={overrideColorScheme}
+            onPress={(checked) => setPreference({overrideColorScheme: checked})}
+          />
+
+          {overrideColorScheme && (
+            <ActionItem
+              mode="toggle"
+              text="Mørk modus"
+              checked={colorScheme === 'dark'}
+              onPress={(checked) =>
+                setPreference({colorScheme: checked ? 'dark' : 'light'})
+              }
+            />
+          )}
+        </Section>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    backgroundColor: theme.background.level1,
+    flex: 1,
+  },
+}));

--- a/src/screens/Profile/Appearance/index.tsx
+++ b/src/screens/Profile/Appearance/index.tsx
@@ -21,9 +21,11 @@ export default function Appearance() {
         <Section withTopPadding withPadding>
           <ActionItem
             mode="toggle"
-            text="Overstyr mørk modus"
-            checked={overrideColorScheme}
-            onPress={(checked) => setPreference({overrideColorScheme: checked})}
+            text="Bruk telefoninnstillinger"
+            checked={!overrideColorScheme}
+            onPress={(checked) =>
+              setPreference({overrideColorScheme: !checked})
+            }
           />
 
           {overrideColorScheme && (

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -47,6 +47,15 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
 
       <ScrollView>
         <Sections.Section withPadding withTopPadding>
+          <Sections.HeaderItem text="Innstillinger" mode="subheading" />
+          <Sections.LinkItem
+            text="Startside"
+            icon="arrow-right"
+            onPress={() => navigation.navigate('SelectStartScreen')}
+          />
+        </Sections.Section>
+
+        <Sections.Section withPadding>
           <Sections.HeaderItem text="Favoritter" mode="subheading" />
           <Sections.LinkItem
             text="Steder"

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -49,8 +49,11 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
         <Sections.Section withPadding withTopPadding>
           <Sections.HeaderItem text="Innstillinger" mode="subheading" />
           <Sections.LinkItem
+            text="Utseende"
+            onPress={() => navigation.navigate('Appearance')}
+          />
+          <Sections.LinkItem
             text="Startside"
-            icon="arrow-right"
             onPress={() => navigation.navigate('SelectStartScreen')}
           />
         </Sections.Section>
@@ -59,7 +62,6 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
           <Sections.HeaderItem text="Favoritter" mode="subheading" />
           <Sections.LinkItem
             text="Steder"
-            icon="arrow-right"
             onPress={() => navigation.navigate('FavoriteList')}
           />
         </Sections.Section>
@@ -68,7 +70,6 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
           <Sections.HeaderItem text="Personvern" mode="subheading" />
           <Sections.LinkItem
             text="Personvernerklæring"
-            icon="arrow-right"
             accessibility={{
               accessibilityHint:
                 'Aktivér for å lese personvernerklæring på ekstern side',

--- a/src/screens/Profile/SelectStartScreen/index.tsx
+++ b/src/screens/Profile/SelectStartScreen/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {RadioSection} from '../../../components/sections';
+import {
+  Preference_ScreenAlternatives,
+  preference_screenAlternatives,
+  usePreferences,
+} from '../../../preferences';
+import {StyleSheet, Theme} from '../../../theme';
+import BackHeader from '../BackHeader';
+
+const identity = (s: string) => s;
+function toName(alt: Preference_ScreenAlternatives): string {
+  switch (alt) {
+    case 'assistant':
+      return 'Reiseassistent';
+    case 'departures':
+      return 'Avganger';
+    case 'ticketing':
+      return 'Billetter';
+  }
+}
+
+export default function SelectStartScreen() {
+  const {
+    setPreference,
+    preferences: {startScreen},
+  } = usePreferences();
+  const style = useProfileHomeStyle();
+  const items = Array.from(preference_screenAlternatives);
+
+  return (
+    <SafeAreaView style={style.container}>
+      <BackHeader title="Velg startside" />
+
+      <ScrollView>
+        <RadioSection<Preference_ScreenAlternatives>
+          withPadding
+          withTopPadding
+          items={items}
+          keyExtractor={identity}
+          itemToText={toName}
+          selected={startScreen ?? items[0]}
+          onSelect={(startScreen) => setPreference({startScreen})}
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    backgroundColor: theme.background.level1,
+    flex: 1,
+  },
+}));

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -1,5 +1,6 @@
 import {createStackNavigator} from '@react-navigation/stack';
 import React from 'react';
+import Appearance from './Appearance';
 import FavoriteList from './FavoriteList';
 import ProfileHome from './Home';
 import SelectStartScreen from './SelectStartScreen';
@@ -8,6 +9,7 @@ export type ProfileStackParams = {
   ProfileHome: undefined;
   FavoriteList: undefined;
   SelectStartScreen: undefined;
+  Appearance: undefined;
 };
 
 const Stack = createStackNavigator<ProfileStackParams>();
@@ -19,8 +21,9 @@ export default function ProfileScreen() {
       screenOptions={{headerShown: false}}
     >
       <Stack.Screen name="ProfileHome" component={ProfileHome} />
-      <Stack.Screen name="SelectStartScreen" component={SelectStartScreen} />
       <Stack.Screen name="FavoriteList" component={FavoriteList} />
+      <Stack.Screen name="SelectStartScreen" component={SelectStartScreen} />
+      <Stack.Screen name="Appearance" component={Appearance} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -2,10 +2,12 @@ import {createStackNavigator} from '@react-navigation/stack';
 import React from 'react';
 import FavoriteList from './FavoriteList';
 import ProfileHome from './Home';
+import SelectStartScreen from './SelectStartScreen';
 
 export type ProfileStackParams = {
   ProfileHome: undefined;
   FavoriteList: undefined;
+  SelectStartScreen: undefined;
 };
 
 const Stack = createStackNavigator<ProfileStackParams>();
@@ -17,6 +19,7 @@ export default function ProfileScreen() {
       screenOptions={{headerShown: false}}
     >
       <Stack.Screen name="ProfileHome" component={ProfileHome} />
+      <Stack.Screen name="SelectStartScreen" component={SelectStartScreen} />
       <Stack.Screen name="FavoriteList" component={FavoriteList} />
     </Stack.Navigator>
   );

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -2,13 +2,16 @@ import LegacyStorage from '@react-native-community/async-storage-backend-legacy'
 import AsyncStorageFactory from '@react-native-community/async-storage';
 import Bugsnag from '@bugsnag/react-native';
 
-type StorageModel = {
+export type StorageModel = {
   stored_user_locations: string;
+  '@ATB_user_preferences': string;
   install_id: string;
   customer_id: string;
   onboarded: string;
   '@ATB_search-history': string;
 };
+
+export type StorageModelTypes = keyof StorageModel;
 
 const legacyStorage = new LegacyStorage();
 

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,6 +1,7 @@
-import React, {createContext, useContext, useState, useEffect} from 'react';
-import {themes, Theme, Themes, Mode} from './colors';
+import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useColorScheme} from 'react-native';
+import {usePreferenceItems} from '../preferences';
+import {Mode, Theme, themes, Themes} from './colors';
 
 interface ThemeContextValue {
   theme: Theme;
@@ -25,7 +26,15 @@ export function useTheme() {
 }
 
 const ThemeContextProvider: React.FC = ({children}) => {
-  const colorScheme = useColorScheme();
+  let colorScheme = useColorScheme();
+  const {
+    colorScheme: storedColorScheme,
+    overrideColorScheme,
+  } = usePreferenceItems();
+
+  if (overrideColorScheme && storedColorScheme) {
+    colorScheme = storedColorScheme;
+  }
   const defaultTheme = colorScheme ?? 'light';
   const [themeName, setThemeName] = useState<keyof Themes>(defaultTheme);
 


### PR DESCRIPTION
Adds user preferences context to app. Also adds two settings:

- Setting preferred startup screen
- Overriding dark mode locally (not listening to phone settings)

Note: From the design I've added an option "override phone". Logically I have a hard time managing if it should show dark mode or not when not explicitly saying override. Imagine scenario: We toggle to dark mode in-app, but switch back to non-dark mode. And then we go back to phone settings and activate darkmode, but the app is still light. Now there is no option to ever let the phone decide darkmode or not. Another option is to only ever override darkmode, so setting darkmode option to true sets option but deactivating it removes the option. But this would cause you not to be able to override to have light mode if the phone it self is in dark mode. So having a flag saying to override I think is the most pragmatic choice.


![image](https://user-images.githubusercontent.com/606374/100018961-9540b400-2ddd-11eb-9976-4575d55a306a.png)

![image](https://user-images.githubusercontent.com/606374/100018982-9d98ef00-2ddd-11eb-8b39-7f812cbad8c3.png)

![image](https://user-images.githubusercontent.com/606374/100018998-a689c080-2ddd-11eb-9176-92c6ef1c3993.png)
