### PR TITLE
fix: disables map when on iOS with voice over to prevent brutal crash

### DIFF
--- a/src/favorite-chips/index.tsx
+++ b/src/favorite-chips/index.tsx
@@ -14,6 +14,7 @@ import {useReverseGeocoder} from '../geocoder';
 import {useGeolocationState} from '../GeolocationContext';
 import {RootStackParamList} from '../navigation';
 import {StyleSheet, useTheme} from '../theme';
+import useDisableMapCheck from '../utils/use-disable-map-check';
 
 type Props = {
   onSelectLocation: (location: LocationWithMetadata) => void;
@@ -41,6 +42,7 @@ const FavoriteChips: React.FC<Props> = ({
   const {favorites} = useFavorites();
   const styles = useStyles();
   const {onCurrentLocation} = useCurrentLocationChip(onSelectLocation);
+  const disableMap = useDisableMapCheck();
   const activeType = (type: ChipTypeGroup) => chipTypes.includes(type);
 
   return (
@@ -57,7 +59,7 @@ const FavoriteChips: React.FC<Props> = ({
               onPress={onCurrentLocation}
             />
           )}
-          {activeType('map') && (
+          {activeType('map') && !disableMap && (
             <FavoriteChip
               text="Velg i kart"
               accessibilityRole="button"

--- a/src/screens/TripDetailsModal/Map/CompactMap.tsx
+++ b/src/screens/TripDetailsModal/Map/CompactMap.tsx
@@ -1,17 +1,18 @@
-import React, {useState} from 'react';
+import Bugsnag from '@bugsnag/react-native';
 import MapboxGL from '@react-native-mapbox-gl/maps';
+import React, {useState} from 'react';
 import {View} from 'react-native';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {MapIcon} from '../../../assets/svg/map';
-import {getMapBounds, legsToMapLines, pointOf} from './utils';
-import MapRoute from './MapRoute';
-import MapLabel from './MapLabel';
-import {MapViewConfig, MapCameraConfig} from '../../../components/map/';
-import insets from '../../../utils/insets';
-import {Leg} from '../../../sdk';
-import Bugsnag from '@bugsnag/react-native';
-import {StyleSheet} from '../../../theme';
+import {MapCameraConfig, MapViewConfig} from '../../../components/map/';
 import ThemeText from '../../../components/text';
+import {Leg} from '../../../sdk';
+import {StyleSheet} from '../../../theme';
+import insets from '../../../utils/insets';
+import useDisableMapCheck from '../../../utils/use-disable-map-check';
+import MapLabel from './MapLabel';
+import MapRoute from './MapRoute';
+import {getMapBounds, legsToMapLines, pointOf} from './utils';
 
 export type MapProps = {
   legs: Leg[];
@@ -24,6 +25,7 @@ export const CompactMap: React.FC<MapProps> = ({legs, darkMode, onExpand}) => {
   const startPoint = pointOf(legs[0].fromPlace);
   const endPoint = pointOf(legs[legs.length - 1].toPlace);
   const bounds = getMapBounds(features);
+  const disableMap = useDisableMapCheck();
 
   const [loadingMap, setLoadingMap] = useState(true);
   const styles = useStyles();
@@ -31,6 +33,10 @@ export const CompactMap: React.FC<MapProps> = ({legs, darkMode, onExpand}) => {
   const expandMap = () => {
     if (!loadingMap) onExpand();
   };
+
+  if (disableMap) {
+    return null;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/utils/use-disable-map-check.ts
+++ b/src/utils/use-disable-map-check.ts
@@ -1,0 +1,14 @@
+import {Platform} from 'react-native';
+import useIsScreenReaderEnabled from './use-is-screen-reader-enabled';
+
+// There are currently issues with VoiceOver and MapBox on iOS.
+// A proper fix is in the works but seem non-trivial.
+// Currently best workaround is to disable map integration
+// when voice over is active. Not ideal by any means,
+// but for now better than crashing the entire application.
+// @TODO This should be removed as soon as possible.
+export default function useDisableMapCheck() {
+  const hasScreenReader = useIsScreenReaderEnabled();
+  const disableMap = hasScreenReader && Platform.OS === 'ios';
+  return disableMap;
+}


### PR DESCRIPTION
- Disable map for now when Voice Over is active on iOS. This is to prevent brutal app crash which is out of our control. Should be reverted as soon as possible.