### PR TITLE
feat: Changes button to pressable type and adds bounce/opacity effect

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, TouchableOpacity, Text, AccessibilityProps} from 'react-native';
+import {View, Text, AccessibilityProps} from 'react-native';
 import {Leg, TripPattern} from '../../sdk';
 import {StyleSheet} from '../../theme';
 import {
@@ -25,6 +25,7 @@ import {flatMap} from '../../utils/array';
 import {getReadableModeName} from '../../utils/transportation-names';
 import ThemeText from '../../components/text';
 import ThemeIcon from '../../components/theme-icon';
+import {BouncePressable} from '../../components/button';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -95,7 +96,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   if (!tripPattern?.legs?.length) return null;
 
   return (
-    <TouchableOpacity
+    <BouncePressable
       style={{paddingVertical: 4}}
       onPress={() => onDetailsPressed(tripPattern)}
       hitSlop={insets.symmetric(8, 16)}
@@ -121,7 +122,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
           <DestinationLeg tripPattern={tripPattern} />
         </View>
       </View>
-    </TouchableOpacity>
+    </BouncePressable>
   );
 };
 


### PR DESCRIPTION
Experimenting with using Pressable instead of `TouchableOpacity`. Adds `BouncePressable` as named export to Button as a "low level" alternative to `TouchableOpacity` which can be used by other entities that are not buttons.

This is more of an RFC to start the discussion. We should probably move `BouncePressable` to a different spot, and evaluate if we want this or not, etc. But this `BouncePressable` adds a cool effect to things like `ResultItem`.