### PR TITLE
fix: tab height issue on iOS and max scale

### DIFF
--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -345,11 +345,11 @@ function useCalculateHeaderContentHeight(isAnimating: boolean) {
     height: screenHeaderHeight,
   } = useLayout();
   const {onLayout: onHeaderContentLayout, height: contentHeight} = useLayout();
-  const {top, bottom} = useSafeAreaInsets();
+  const {top} = useSafeAreaInsets();
 
-  const {height: bottomTabBarHeight} = useBottomNavigationStyles();
+  const {minHeight: bottomTabBarHeight} = useBottomNavigationStyles();
   const boxHeight =
-    actualHeight - screenHeaderHeight - top - bottom - bottomTabBarHeight;
+    actualHeight - screenHeaderHeight - top - bottomTabBarHeight;
 
   const calculatedHeights = {
     boxHeight,

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -2,6 +2,7 @@ import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {LabelPosition} from '@react-navigation/bottom-tabs/lib/typescript/src/types';
 import {ParamListBase} from '@react-navigation/native';
 import React from 'react';
+import {Platform} from 'react-native';
 import {SvgProps} from 'react-native-svg';
 import {
   Assistant as AssistantIcon,
@@ -40,6 +41,8 @@ export type TabNavigatorParams = {
 
 const Tab = createBottomTabNavigator<TabNavigatorParams>();
 
+const softhyphen = Platform.OS === 'ios' ? '\u00AD' : '\u200B';
+
 const NavigationRoot = () => {
   const {theme} = useTheme();
   const {startScreen} = usePreferenceItems();
@@ -60,12 +63,12 @@ const NavigationRoot = () => {
       <Tab.Screen
         name="Assistant"
         component={Assistant}
-        options={tabSettings('Reisesøk', AssistantIcon)}
+        options={tabSettings(`Reise${softhyphen}søk`, AssistantIcon)}
       />
       <Tab.Screen
         name="Nearest"
         component={NearbyScreen}
-        options={tabSettings('Avganger', Nearby)}
+        options={tabSettings(`Av${softhyphen}ganger`, Nearby)}
       />
       <Tab.Screen
         name="Ticketing"
@@ -102,7 +105,10 @@ function tabSettings(
 ): TabSettings {
   return {
     tabBarLabel: ({color}) => (
-      <ThemeText type="lead" style={{color, lineHeight: 14}}>
+      <ThemeText
+        type="lead"
+        style={{color, textAlign: 'center', lineHeight: 14}}
+      >
         {tabBarLabel}
       </ThemeText>
     ),

--- a/src/utils/navigation.tsx
+++ b/src/utils/navigation.tsx
@@ -1,17 +1,21 @@
 import analytics from '@react-native-firebase/analytics';
 import {useNavigation} from '@react-navigation/native';
 import {useCallback} from 'react';
-import {
-  usePreferenceItems,
-  Preference_ScreenAlternatives,
-} from '../preferences';
-import {TabNavigatorParams} from '../navigation/TabNavigator';
 import {useWindowDimensions} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {TabNavigatorParams} from '../navigation/TabNavigator';
+import {
+  Preference_ScreenAlternatives,
+  usePreferenceItems,
+} from '../preferences';
 
-export const useBottomNavigationStyles = (): {height: number} => {
+export const useBottomNavigationStyles = (
+  maxScale: number = 2,
+): {minHeight: number} => {
   const {fontScale} = useWindowDimensions();
+  const {bottom} = useSafeAreaInsets();
   return {
-    height: 44 * fontScale,
+    minHeight: 44 * Math.min(fontScale, maxScale) + bottom,
   };
 };
 export const useNavigateToStartScreen = () => {

--- a/src/utils/navigation.tsx
+++ b/src/utils/navigation.tsx
@@ -9,13 +9,18 @@ import {
   usePreferenceItems,
 } from '../preferences';
 
+// This is code from react-navigation, for regular tab bar
+// (not compact). Should be a better way to set this or
+// get it from React Navigation, but alas not.
+const DEFAULT_TABBAR_HEIGHT = 44;
+
 export const useBottomNavigationStyles = (
   maxScale: number = 2,
 ): {minHeight: number} => {
   const {fontScale} = useWindowDimensions();
   const {bottom} = useSafeAreaInsets();
   return {
-    minHeight: 44 * Math.min(fontScale, maxScale) + bottom,
+    minHeight: DEFAULT_TABBAR_HEIGHT * Math.min(fontScale, maxScale) + bottom,
   };
 };
 export const useNavigateToStartScreen = () => {


### PR DESCRIPTION
My Android Emulator crashed hard now, need to do a full reset. Could you check, @rikkekantega ?

Max size for iOS:

![image](https://user-images.githubusercontent.com/606374/100322701-f676ac00-2fc4-11eb-8902-551d0ecf128f.png)
