### PR TITLE
fix: hack/workaround for offset issues in header animation. NOT proper fix

### DIFF
--- a/src/screens/Assistant/FadeBetween.tsx
+++ b/src/screens/Assistant/FadeBetween.tsx
@@ -71,7 +71,7 @@ function AnimatedChild({
   visibleKey: string;
   progress: Animated.Value<number>;
 }) {
-  const visibleChild = child.key !== visibleKey;
+  const visibleChild = child.key === visibleKey;
 
   const opacity = Animated.interpolate(progress, {
     inputRange: [0, 1],

--- a/src/screens/Assistant/index.tsx
+++ b/src/screens/Assistant/index.tsx
@@ -243,7 +243,7 @@ const Assistant: React.FC<Props> = ({
         </View>
 
         <FadeBetween
-          visibleKey={isHeaderFullHeight ? 'dateInput' : 'favoriteChips'}
+          visibleKey={isHeaderFullHeight ? 'favoriteChips' : 'dateInput'}
         >
           <FavoriteChips
             key="favoriteChips"
@@ -336,6 +336,7 @@ const Assistant: React.FC<Props> = ({
       onRefresh={reload}
       isRefreshing={isSearching}
       useScroll={useScroll}
+      headerMargin={24}
       headerTitle="Reiseassistent"
       isFullHeight={isHeaderFullHeight}
       alternativeTitleComponent={altHeaderComp}

--- a/src/screens/Nearby/index.tsx
+++ b/src/screens/Nearby/index.tsx
@@ -199,10 +199,10 @@ const NearbyOverview: React.FC<Props> = ({
     <DisappearingHeader
       onRefresh={refresh}
       isRefreshing={isLoading}
-      headerHeight={59}
       renderHeader={renderHeader}
       headerTitle="Avganger"
       useScroll={activateScroll}
+      headerMargin={0}
       logoClick={{
         callback: navigateHome,
         accessibilityLabel: 'Gå til startside',


### PR DESCRIPTION
This is ridiculous, I know. Some of this doesn't make any sense and is brittle as a wood glued vase. However, it seems to workaround with our current issues with animated header for now. I think we should rethink this component and look into shared elements to do this instead, but that would require more work now and postpone the wanted release. But we should do proper QA-ing of this.

The issues seem to be caused by `scrollY` animated value being triggered by RefreshControl and when animating back to the initial state after refreshing, it's no longer the correct value. Not an issue on Android as the animation is positioned absolute and elevated. This doesn't seem to be possible on iOS with the current implementation.

Should properly check on Android also as the implementation has changed some. Initial tests seem OK