### PR TITLE
fix: support for arbitrary falsey items in section

### DIFF
--- a/src/components/sections/section.tsx
+++ b/src/components/sections/section.tsx
@@ -16,10 +16,10 @@ export default function SectionGroup({
   type = 'block',
 }: SectionProps) {
   const style = useInputGroupStyle();
-  const len =
-    (React.Children.map(children, (child) =>
-      Number(React.isValidElement(child)),
-    )?.reduce((a, b) => a + b, 0) ?? 1) - 1;
+  const validChildren: boolean[] =
+    React.Children.map(children, React.isValidElement) ?? [];
+  const firstIndex = validChildren.indexOf(true);
+  const lastIndex = validChildren.lastIndexOf(true);
 
   const containerStyle = [
     withPadding ? style.container__padded : undefined,
@@ -32,7 +32,7 @@ export default function SectionGroup({
         if (!React.isValidElement(child)) return child;
 
         let additionalProps: Partial<SectionItemProps> = {
-          radius: toRadius(index, len),
+          radius: toRadius(index, lastIndex, firstIndex),
           radiusSize: 'regular',
           type,
           ...child.props,
@@ -41,7 +41,7 @@ export default function SectionGroup({
         return (
           <>
             {React.cloneElement(child, additionalProps)}
-            {index !== len && <View style={style.separator} />}
+            {index !== lastIndex && <View style={style.separator} />}
           </>
         );
       })}
@@ -49,9 +49,9 @@ export default function SectionGroup({
   );
 }
 
-function toRadius(index: number, len: number) {
-  const isFirst = index === 0;
-  const isLast = index === len;
+function toRadius(index: number, lastIndex: number, firstIndex: number) {
+  const isFirst = index === firstIndex;
+  const isLast = index === lastIndex;
 
   if (isFirst && isLast) {
     return 'top-bottom';


### PR DESCRIPTION
There were some issues with handling falsey values in section wrapper. This checks for actual first and last index of valid child to set proper radius.

Point is now to get a list indicating what is valid children and not. With that list we find both first and last index that is valid. These should get radiuses set. Technically valid children can be strings, but I think that is kind of outside the scope to patch that kind of usage. 