### PR TITLE
fix: margin for no-result box on location search

### DIFF
--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -213,7 +213,7 @@ const LocationSearch: React.FC<Props> = ({
       ) : (
         !error &&
         !!text && (
-          <View style={styles.contentBlock}>
+          <View style={styles.withMargin}>
             <MessageBox type="info">
               <ThemeText>Fant ingen søkeresultat</ThemeText>
             </MessageBox>


### PR DESCRIPTION
Now: 

![image](https://user-images.githubusercontent.com/606374/100712444-0de1da80-33b3-11eb-805e-f79019992170.png)


Before:

![image](https://user-images.githubusercontent.com/606374/100712466-15a17f00-33b3-11eb-8317-7d582d305b43.png)
