### PR TITLE
fix: Terminal payment redirect load needs time to finish

### DIFF
--- a/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
@@ -61,7 +61,6 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
     loadingState,
     terminalUrl,
     onWebViewLoadEnd,
-    onWebViewLoadStart,
     error,
     restartTerminal,
   } = useTerminalState(offers, cancelTerminal, dismissAndActivatePolling);
@@ -88,7 +87,6 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
             source={{
               uri: terminalUrl,
             }}
-            onLoadStart={onWebViewLoadStart}
             onLoadEnd={onWebViewLoadEnd}
           />
         )}

--- a/src/screens/Ticketing/Purchase/Payment/CreditCard/use-terminal-state.ts
+++ b/src/screens/Ticketing/Purchase/Payment/CreditCard/use-terminal-state.ts
@@ -139,6 +139,8 @@ export default function useTerminalState(
   const onWebViewLoadEnd = ({
     nativeEvent,
   }: WebViewNavigationEvent | WebViewErrorEvent) => {
+    const {url} = nativeEvent;
+
     // load events might be called several times
     // for each type of resource, html, assets, etc
     // so we have a "loading guard" here
@@ -153,19 +155,8 @@ export default function useTerminalState(
       } else {
         dispatch({type: 'TERMINAL_LOADED'});
       }
-    }
-  };
-
-  const paymentRedirectCompleteRef = useRef<boolean>(false);
-
-  const onWebViewLoadStart = async ({
-    nativeEvent,
-  }: WebViewNavigationEvent | WebViewErrorEvent) => {
-    const {url} = nativeEvent;
-    // load events might be called several times
-    // for each type of resource, html, assets, etc
-    // so we have a "payment redirect guard" here
-    if (
+      // "payment redirect guard" here
+    } else if (
       !paymentRedirectCompleteRef.current &&
       url.includes('/ticket/v1/payments/')
     ) {
@@ -177,6 +168,8 @@ export default function useTerminalState(
       else console.warn('No response code');
     }
   };
+
+  const paymentRedirectCompleteRef = useRef<boolean>(false);
 
   useEffect(() => {
     switch (paymentResponseCode) {
@@ -201,7 +194,6 @@ export default function useTerminalState(
     terminalUrl: reservation?.url,
     loadingState,
     onWebViewLoadEnd,
-    onWebViewLoadStart,
     error,
     restartTerminal,
   };


### PR DESCRIPTION
Move payment redirect check to `loadEnd` so race condition where callback is cancelled if we navigate away from the WebView too fast.