### PR TITLE
fix: Use closest location from reverse geo lookup

### DIFF
--- a/src/favorite-chips/index.tsx
+++ b/src/favorite-chips/index.tsx
@@ -143,11 +143,9 @@ function useCurrentLocationChip(
   onSelectLocation: (location: LocationWithMetadata) => void,
 ) {
   const {location, requestPermission} = useGeolocationState();
-  const {locations: reverseLookupLocations} =
-    useReverseGeocoder(location?.coords ?? null) ?? [];
-  const currentLocation = reverseLookupLocations?.length
-    ? reverseLookupLocations[1]
-    : null;
+  const {closestLocation: currentLocation} = useReverseGeocoder(
+    location?.coords ?? null,
+  );
 
   const [recentlyAllowedGeo, setsetRecentlyAllowedGeo] = useState(false);
 

--- a/src/geocoder/use-reverse-geocoder.ts
+++ b/src/geocoder/use-reverse-geocoder.ts
@@ -5,10 +5,13 @@ import {reverse} from '../api';
 import {mapFeatureToLocation} from './utils';
 import useGeocoderReducer, {GeocoderState} from './use-geocoder-reducer';
 import {getAxiosErrorType} from '../api/utils';
+import {Location} from '../favorites/types';
+
+type ReverseGeocoderState = GeocoderState & {closestLocation?: Location};
 
 export default function useReverseGeocoder(
   coords: Coordinates | null,
-): GeocoderState {
+): ReverseGeocoderState {
   const [state, dispatch] = useGeocoderReducer();
 
   useEffect(() => {
@@ -43,5 +46,8 @@ export default function useReverseGeocoder(
     return () => source.cancel('Cancelling previous reverse');
   }, [coords?.latitude, coords?.longitude]);
 
-  return state;
+  return {
+    ...state,
+    closestLocation: state.locations?.[0],
+  };
 }

--- a/src/location-search/map-selection/index.tsx
+++ b/src/location-search/map-selection/index.tsx
@@ -64,13 +64,11 @@ const MapSelection: React.FC<Props> = ({
     ],
   );
 
-  const {locations, isSearching, error} = useReverseGeocoder(
+  const {closestLocation: location, isSearching, error} = useReverseGeocoder(
     centeredCoordinates,
   );
 
   const {location: geolocation} = useGeolocationState();
-
-  const location = locations?.[0];
 
   const onSelect = () => {
     location &&

--- a/src/screens/Assistant/index.tsx
+++ b/src/screens/Assistant/index.tsx
@@ -69,11 +69,9 @@ const AssistantRoot: React.FC<RootProps> = ({navigation}) => {
     requestPermission: requestGeoPermission,
   } = useGeolocationState();
 
-  const {locations: reverseLookupLocations} =
-    useReverseGeocoder(location?.coords ?? null) ?? [];
-  const currentLocation = reverseLookupLocations?.length
-    ? reverseLookupLocations[1]
-    : undefined;
+  const {closestLocation: currentLocation} = useReverseGeocoder(
+    location?.coords ?? null,
+  );
 
   if (!status) {
     return <Loading />;

--- a/src/screens/Nearby/index.tsx
+++ b/src/screens/Nearby/index.tsx
@@ -78,11 +78,9 @@ const NearbyScreen: React.FC<RootProps> = ({navigation}) => {
     requestPermission,
   } = useGeolocationState();
 
-  const {locations: reverseLookupLocations} =
-    useReverseGeocoder(location?.coords ?? null) ?? [];
-  const currentLocation = reverseLookupLocations?.length
-    ? reverseLookupLocations[1]
-    : undefined;
+  const {closestLocation: currentLocation} = useReverseGeocoder(
+    location?.coords ?? null,
+  );
 
   if (!status) {
     return <Loading />;


### PR DESCRIPTION
Fixed a bug (three places) where the second closest location from the
hook useReverseGeocoder was used as the current location.

As every usage of useReverseGeocoder was mainly interested in only the
closest location, this was added as an own field in the returned state.