### PR TITLE
feat: Adds favorite departures (closes #680)

### DIFF
--- a/src/ScreenHeader/animated-header.tsx
+++ b/src/ScreenHeader/animated-header.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React from 'react';
 import {Animated, View, ViewProps} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import ThemeText from '../components/text';
@@ -29,6 +29,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
     outputRange: [0, -HEADER_HEIGHT],
     extrapolate: 'clamp',
   });
+
   const altTitleOffset = Animated.add(titleOffset, HEADER_HEIGHT);
   const leftIcon = leftButton ? <HeaderButton {...leftButton} /> : <View />;
   const rightIcon = rightButton ? <HeaderButton {...rightButton} /> : <View />;

--- a/src/api/departures/types.ts
+++ b/src/api/departures/types.ts
@@ -2,7 +2,7 @@ import {Situation, TransportMode, TransportSubmode} from '../../sdk';
 
 type Notice = {text?: string};
 
-type DepartureLineInfo = {
+export type DepartureLineInfo = {
   lineName: string;
   lineNumber: string;
   transportMode?: TransportMode;
@@ -26,7 +26,7 @@ export type DepartureGroup = {
   departures: DepartureTime[];
 };
 
-type StopPlaceInfo = {
+export type StopPlaceInfo = {
   id: string;
   description?: string | undefined;
   name: string;

--- a/src/components/disappearing-header/simple.tsx
+++ b/src/components/disappearing-header/simple.tsx
@@ -78,6 +78,7 @@ const SimpleDisappearingHeader: React.FC<Props> = ({
   const styles = useThemeStyles();
   const {theme} = useTheme();
   const scrollYRef = useRef(new Animated.Value(0)).current;
+  const nullRef = useRef(new Animated.Value(0)).current;
 
   const headerTranslate = scrollYRef.interpolate({
     inputRange: [0, contentHeight],
@@ -119,7 +120,7 @@ const SimpleDisappearingHeader: React.FC<Props> = ({
           title={headerTitle}
           rightButton={chatIcon}
           alternativeTitleComponent={alternativeTitleComponent}
-          scrollRef={scrollYRef}
+          scrollRef={isRefreshing ? nullRef : scrollYRef}
           leftButton={{
             onPress: logoClick?.callback,
             icon: <ThemeIcon svg={LogoOutline} />,

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -28,11 +28,15 @@ export default function ActionItem({
 
   if (mode === 'toggle') {
     return (
-      <View style={[style.spaceBetween, topContainer]} {...accessibility}>
+      <View style={[style.spaceBetween, topContainer]}>
         <ThemeText type="body" style={contentContainer}>
           {text}
         </ThemeText>
-        <Switch value={checked} onValueChange={(v) => onPress?.(v)} />
+        <Switch
+          value={checked}
+          onValueChange={(v) => onPress?.(v)}
+          {...accessibility}
+        />
       </View>
     );
   }

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -29,12 +29,13 @@ export default function ActionItem({
   if (mode === 'toggle') {
     return (
       <View style={[style.spaceBetween, topContainer]}>
-        <ThemeText type="body" style={contentContainer}>
+        <ThemeText accessible={false} type="body" style={contentContainer}>
           {text}
         </ThemeText>
         <Switch
           value={checked}
           onValueChange={(v) => onPress?.(v)}
+          accessibilityLabel={text}
           {...accessibility}
         />
       </View>

--- a/src/components/transportation-icon/index.tsx
+++ b/src/components/transportation-icon/index.tsx
@@ -67,6 +67,7 @@ function InnerIcon({
 
   switch (mode) {
     case 'bus':
+    case 'coach':
       return <BusSide key="bus" {...innerIconProps} />;
     case 'tram':
       return <TramSide key="tram" {...innerIconProps} />;

--- a/src/favorites/index.tsx
+++ b/src/favorites/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {MapPointPin} from '../assets/svg/icons/places';
 import ThemeText from '../components/text';
 import ThemeIcon from '../components/theme-icon';
+import {FavoriteDeparture, UserFavoriteDepartures} from './types';
 
 export type FavoriteIconProps = {
   favorite?: {emoji?: string};
@@ -18,6 +19,24 @@ export function FavoriteIcon({favorite, fill}: FavoriteIconProps) {
       {favorite.emoji}
     </ThemeText>
   );
+}
+
+type FavoriteDepartureId = {
+  stopId: string;
+  lineName: string;
+  lineId: string;
+};
+export function getFavoriteDeparture(
+  line: FavoriteDepartureId,
+  favorites: UserFavoriteDepartures,
+) {
+  return favorites.find(function (favorite) {
+    return (
+      favorite.lineId == line.lineId &&
+      favorite.lineName == line.lineName &&
+      favorite.stopId == line.stopId
+    );
+  });
 }
 
 export {

--- a/src/favorites/types.ts
+++ b/src/favorites/types.ts
@@ -1,18 +1,19 @@
 import {Feature} from '../sdk';
-import {Coordinates} from '@entur/sdk';
+import {Coordinates, TransportMode, TransportSubmode} from '@entur/sdk';
+import {StoredType} from './storage';
 
 export type Location = Feature['properties'] & {
   coordinates: Coordinates;
 };
 
-export type UserFavorites = LocationFavorite[];
-
 export type LocationFavorite = {
-  id: string;
   location: Location;
   emoji?: string;
   name?: string;
 };
+
+export type StoredLocationFavorite = StoredType<LocationFavorite>;
+export type UserFavorites = StoredLocationFavorite[];
 
 export type LocationWithMetadata = Location &
   (
@@ -21,3 +22,21 @@ export type LocationWithMetadata = Location &
       }
     | {resultType: 'favorite'; favoriteId: string}
   );
+
+export type FavoriteDepartureId = {
+  stopId: string;
+  lineName: string;
+  lineId: string;
+};
+
+export type FavoriteDeparture = FavoriteDepartureId & {
+  lineLineNumber?: string;
+  lineTransportationMode?: TransportMode;
+  lineTransportationSubMode?: TransportSubmode;
+  quayName: string;
+  quayId: string;
+  quayPublicCode?: string;
+};
+
+export type StoredFavoriteDeparture = StoredType<FavoriteDeparture>;
+export type UserFavoriteDepartures = StoredFavoriteDeparture[];

--- a/src/location-search/types.ts
+++ b/src/location-search/types.ts
@@ -1,6 +1,6 @@
-import {Location, LocationFavorite} from '../favorites/types';
+import {Location, StoredLocationFavorite} from '../favorites/types';
 
 export type LocationSearchResult = {
   location: Location;
-  favoriteInfo?: Omit<LocationFavorite, 'location'>;
+  favoriteInfo?: Omit<StoredLocationFavorite, 'location'>;
 };

--- a/src/screens/Nearby/NearbyResults.tsx
+++ b/src/screens/Nearby/NearbyResults.tsx
@@ -3,6 +3,7 @@ import sortBy from 'lodash.sortby';
 import React, {useEffect, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {QuayGroup, StopPlaceGroup} from '../../api/departures/types';
+import ScreenReaderAnnouncement from '../../components/screen-reader-announcement';
 import {ActionItem} from '../../components/sections';
 import ThemeText from '../../components/text';
 import {Location} from '../../favorites/types';
@@ -43,25 +44,22 @@ export default function NearbyResults({
     return (
       <View style={styles.container}>
         <MessageBox type="info">
-          <ThemeText>
-            {showOnlyFavorites
-              ? t(NearbyTexts.results.messages.initial)
-              : t(NearbyTexts.results.messages.initial)}
-          </ThemeText>
+          <ThemeText>{t(NearbyTexts.results.messages.initial)}</ThemeText>
         </MessageBox>
       </View>
     );
   }
 
   if (!isLoading && hasNoQuaysWithDepartures(departures)) {
+    const message = !showOnlyFavorites
+      ? t(NearbyTexts.results.messages.emptyResult)
+      : t(NearbyTexts.results.messages.emptyResultFavorites);
     return (
       <View style={styles.container}>
+        <ScreenReaderAnnouncement message={message} />
+
         <MessageBox type="info">
-          <ThemeText>
-            {!showOnlyFavorites
-              ? t(NearbyTexts.results.messages.emptyResult)
-              : t(NearbyTexts.results.messages.emptyResultFavorites)}
-          </ThemeText>
+          <ThemeText>{message}</ThemeText>
         </MessageBox>
       </View>
     );
@@ -70,11 +68,14 @@ export default function NearbyResults({
   return (
     <View style={styles.container}>
       {error && (
-        <MessageBox
-          type="warning"
-          message={error}
-          containerStyle={{marginBottom: 24}}
-        />
+        <>
+          <ScreenReaderAnnouncement message={error} />
+          <MessageBox
+            type="warning"
+            message={error}
+            containerStyle={{marginBottom: 24}}
+          />
+        </>
       )}
 
       {departures && (

--- a/src/screens/Nearby/NearbyResults.tsx
+++ b/src/screens/Nearby/NearbyResults.tsx
@@ -18,17 +18,23 @@ type NearbyResultsProps = {
   lastUpdated?: Date;
   currentLocation?: Location;
   isFetchingMore?: boolean;
+  isLoading?: boolean;
   error?: string;
   isInitialScreen: boolean;
+
+  showOnlyFavorites: boolean;
 };
 
 export default function NearbyResults({
   departures,
   lastUpdated,
   isFetchingMore = false,
+  isLoading = false,
   error,
   isInitialScreen,
   currentLocation,
+
+  showOnlyFavorites,
 }: NearbyResultsProps) {
   const styles = useResultsStyle();
   const {t} = useTranslation();
@@ -37,17 +43,25 @@ export default function NearbyResults({
     return (
       <View style={styles.container}>
         <MessageBox type="info">
-          <ThemeText>{t(NearbyTexts.results.messages.initial)}</ThemeText>
+          <ThemeText>
+            {showOnlyFavorites
+              ? t(NearbyTexts.results.messages.initial)
+              : t(NearbyTexts.results.messages.initial)}
+          </ThemeText>
         </MessageBox>
       </View>
     );
   }
 
-  if (hasNoQuaysWithDepartures(departures)) {
+  if (!isLoading && hasNoQuaysWithDepartures(departures)) {
     return (
       <View style={styles.container}>
         <MessageBox type="info">
-          <ThemeText>{t(NearbyTexts.results.messages.emptyResult)}</ThemeText>
+          <ThemeText>
+            {!showOnlyFavorites
+              ? t(NearbyTexts.results.messages.emptyResult)
+              : t(NearbyTexts.results.messages.emptyResultFavorites)}
+          </ThemeText>
         </MessageBox>
       </View>
     );
@@ -82,7 +96,7 @@ export default function NearbyResults({
 }
 const useResultsStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
-    padding: theme.spacings.medium,
+    paddingHorizontal: theme.spacings.medium,
   },
   centerText: {
     textAlign: 'center',
@@ -156,6 +170,7 @@ const StopDepartures = React.memo(function StopDepartures({
         orderedQuays.map(([distance, quayGroup]) => (
           <QuaySection
             key={quayGroup.quay.id}
+            stop={stopPlaceGroup.stopPlace}
             quayGroup={quayGroup}
             distance={distance}
             lastUpdated={lastUpdated}

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -309,6 +309,7 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
       accessibilityLabel={t(
         label(`${line.lineNumber} ${line.lineName}`, stop.name),
       )}
+      hitSlop={insets.symmetric(14, 8)}
     >
       <ThemeIcon svg={Icon} />
     </TouchableOpacity>

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -251,6 +251,9 @@ const useItemStyles = StyleSheet.createThemeHook((theme, themeName) => ({
   departureText: {
     fontVariant: ['tabular-nums'],
   },
+  favoriteButton: {
+    paddingLeft: theme.spacings.medium,
+  },
 }));
 
 type FavoriteStarProps = {
@@ -265,6 +268,7 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
     removeFavoriteDeparture,
   } = useFavorites();
   const {t} = useTranslation();
+  const styles = useItemStyles();
 
   if (!line) {
     return null;
@@ -310,6 +314,7 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
         label(`${line.lineNumber} ${line.lineName}`, stop.name),
       )}
       hitSlop={insets.symmetric(14, 8)}
+      style={styles.favoriteButton}
     >
       <ThemeIcon svg={Icon} />
     </TouchableOpacity>

--- a/src/screens/Nearby/section-items/quay-section.tsx
+++ b/src/screens/Nearby/section-items/quay-section.tsx
@@ -1,7 +1,7 @@
 import sortBy from 'lodash.sortby';
 import React, {Fragment, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
-import {QuayGroup} from '../../../api/departures/types';
+import {QuayGroup, StopPlaceInfo} from '../../../api/departures/types';
 import {Section} from '../../../components/sections';
 import {useTheme} from '../../../theme';
 import {NearbyTexts, useTranslation} from '../../../translations';
@@ -14,6 +14,7 @@ const LIMIT_SIZE = 5;
 
 type QuaySectionProps = {
   quayGroup: QuayGroup;
+  stop: StopPlaceInfo;
   distance?: number;
   lastUpdated?: Date;
   hidden?: Date;
@@ -21,6 +22,7 @@ type QuaySectionProps = {
 
 const QuaySection = React.memo(function QuaySection({
   quayGroup,
+  stop,
   distance,
   lastUpdated,
 }: QuaySectionProps) {
@@ -52,6 +54,8 @@ const QuaySection = React.memo(function QuaySection({
         {sorted.map((group) => (
           <LineItem
             group={group}
+            stop={stop}
+            quay={quayGroup.quay}
             key={group.lineInfo?.lineId + String(group.lineInfo?.lineName)}
           />
         ))}

--- a/src/screens/Profile/AddEditFavorite/index.tsx
+++ b/src/screens/Profile/AddEditFavorite/index.tsx
@@ -15,14 +15,13 @@ import * as Sections from '../../../components/sections';
 import ThemeText from '../../../components/text';
 import ThemeIcon from '../../../components/theme-icon';
 import {useFavorites} from '../../../favorites/FavoritesContext';
-import {LocationFavorite} from '../../../favorites/types';
+import {StoredLocationFavorite} from '../../../favorites/types';
 import {useLocationSearchValue} from '../../../location-search';
 import MessageBox from '../../../message-box';
 import {RootStackParamList} from '../../../navigation';
 import {StyleSheet, Theme} from '../../../theme';
-import BackHeader from '../BackHeader';
 import {AddEditFavoriteTexts, useTranslation} from '../../../translations';
-
+import BackHeader from '../BackHeader';
 import EmojiPopup from './EmojiPopup';
 
 type AddEditRouteName = 'AddEditFavorite';
@@ -36,7 +35,7 @@ export type AddEditNavigationProp = CompositeNavigationProp<
 type AddEditScreenRouteProp = RouteProp<RootStackParamList, AddEditRouteName>;
 
 export type AddEditParams = {
-  editItem?: LocationFavorite;
+  editItem?: StoredLocationFavorite;
   searchLocation?: Location;
 };
 
@@ -47,7 +46,11 @@ type AddEditProps = {
 
 export default function AddEditFavorite({navigation, route}: AddEditProps) {
   const css = useScreenStyle();
-  const {addFavorite, removeFavorite, updateFavorite} = useFavorites();
+  const {
+    addFavoriteLocation: addFavorite,
+    removeFavoriteLocation: removeFavorite,
+    updateFavoriteLocation: updateFavorite,
+  } = useFavorites();
   const editItem = route?.params?.editItem;
   const {t} = useTranslation();
 

--- a/src/screens/Profile/FavoriteList/SortFavorites.tsx
+++ b/src/screens/Profile/FavoriteList/SortFavorites.tsx
@@ -36,7 +36,7 @@ type ProfileScreenProps = {
 
 export default function SortableFavoriteList({navigation}: ProfileScreenProps) {
   const style = useProfileStyle();
-  const {favorites, setFavorites} = useFavorites();
+  const {favorites, setFavoriteLocationss: setFavorites} = useFavorites();
   const items = favorites ?? [];
   const [sortedItems, setSortedItems] = useState(items);
   const [error, setError] = useState<string | null>(null);

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -8,7 +8,7 @@ import SvgReorder from '../../../assets/svg/icons/actions/Reorder';
 import * as Sections from '../../../components/sections';
 import ThemeIcon from '../../../components/theme-icon';
 import {useFavorites} from '../../../favorites/FavoritesContext';
-import {LocationFavorite} from '../../../favorites/types';
+import {StoredLocationFavorite} from '../../../favorites/types';
 import MessageBox from '../../../message-box';
 import {RootStackParamList} from '../../../navigation';
 import {StyleSheet, Theme} from '../../../theme';
@@ -30,7 +30,7 @@ export default function FavoriteList({navigation}: ProfileScreenProps) {
   const {t} = useTranslation();
   const items = favorites ?? [];
 
-  const navigateToEdit = (item: LocationFavorite) => {
+  const navigateToEdit = (item: StoredLocationFavorite) => {
     navigation.navigate('AddEditFavorite', {editItem: item});
   };
   const onAddButtonClick = () => navigation.push('AddEditFavorite', {});

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -4,6 +4,7 @@ import Bugsnag from '@bugsnag/react-native';
 
 export type StorageModel = {
   stored_user_locations: string;
+  '@ATB_user_departures': string;
   '@ATB_user_preferences': string;
   install_id: string;
   customer_id: string;

--- a/src/translations/screens/Nearby.ts
+++ b/src/translations/screens/Nearby.ts
@@ -52,18 +52,18 @@ const NearbyTexts = {
       initial: _(
         'Søk etter avganger fra holdeplasser eller i nærheten av steder.',
       ),
-      emptyResult: _('Fant ingen avganger på valgt plass'),
+      emptyResult: _('Fant ingen avganger på valgt plass.'),
       emptyResultFavorites: _('Fant ingen favorittavganger på valgt plass.'),
     },
     quayResult: {
       platformHeader: {
         accessibilityLabel: (name: string, publicCode: string) =>
-          _(`Avganger fra plattform ${name} ${publicCode}`),
+          _(`Avganger fra plattform ${name} ${publicCode}.`),
         accessibilityLabelNoPublicCode: (name: string) =>
-          _(`Avganger fra plattform på holdeplassen ${name}`),
+          _(`Avganger fra plattform på holdeplassen ${name}.`),
         distance: {
           label: (distance: string) =>
-            _(`Det er rundt ${distance} til plattform`),
+            _(`Det er rundt ${distance} til plattform.`),
         },
       },
       showMoreToggler: {

--- a/src/translations/screens/Nearby.ts
+++ b/src/translations/screens/Nearby.ts
@@ -10,6 +10,9 @@ const NearbyTexts = {
       a11yLabel: _('Gå til startskjerm'),
     },
   },
+  favorites: {
+    toggle: _('Vis kun favorittavganger'),
+  },
   location: {
     departurePicker: {
       placeholder: _('Søk etter adresse eller sted', 'Search for a place'),
@@ -49,7 +52,8 @@ const NearbyTexts = {
       initial: _(
         'Søk etter avganger fra holdeplasser eller i nærheten av steder.',
       ),
-      emptyResult: _('Fant ingen avganger i nærheten'),
+      emptyResult: _('Fant ingen avganger på valgt plass'),
+      emptyResultFavorites: _('Fant ingen favorittavganger på valgt plass.'),
     },
     quayResult: {
       platformHeader: {
@@ -74,6 +78,16 @@ const NearbyTexts = {
       lineNameAccessibilityHint: _(
         'Aktiver for detaljer om avgang og oversikt over kommende avganger.',
       ),
+      favorite: {
+        addFavorite: (name: string, place: string) =>
+          _(`Legg til favorittavgang: ${name} fra ${place}`),
+        removeFavorite: (name: string, place: string) =>
+          _(`Fjern favorittavgang: ${name} fra ${place}`),
+        message: {
+          saved: _(`Lagt til.`),
+          removed: _(`Fjernet.`),
+        },
+      },
     },
     departure: {
       hasPassedAccessibilityLabel: (time: string) =>

--- a/src/utils/transportation-color.ts
+++ b/src/utils/transportation-color.ts
@@ -9,6 +9,7 @@ export function transportationColor(
 ): string {
   switch (mode) {
     case 'bus':
+    case 'coach':
       if (subMode === 'localBus') {
         return colors.primary.green_500;
       }

--- a/src/utils/transportation-names.ts
+++ b/src/utils/transportation-names.ts
@@ -32,6 +32,7 @@ export function getTranslatedModeName(
   const legModeNames = dictionary.travel.legModes;
   switch (mode) {
     case 'bus':
+    case 'coach':
       return legModeNames.bus;
     case 'rail':
       return legModeNames.rail;


### PR DESCRIPTION
**This is dependent on production deployment of the BFF. It is also dependent on #775 which should be merged first**

This adds favorite departures from the departure screen. Only scoped to #680 where we can add favorites directly from results. Currently, this is the only way to add favorite departures.

For Code Review, see Acceptance Criteria on #680.

## Examples

![image](https://user-images.githubusercontent.com/606374/102527096-ef5f2d00-409c-11eb-859a-83ed12c0cf78.png)

![image](https://user-images.githubusercontent.com/606374/102527103-f1c18700-409c-11eb-9dc2-97ed90d3962b.png)
