### PR TITLE
feat: Adds ability to remove favorite departure

### DIFF
--- a/assets/svgs/mono-icons/actions/Delete.svg
+++ b/assets/svgs/mono-icons/actions/Delete.svg
@@ -1,6 +1,6 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none"
   xmlns="http://www.w3.org/2000/svg">
-  <path d="M7.5 15V8H9.5V15H7.5Z" fill="white"/>
-  <path d="M10.5 8V15H12.5V8H10.5Z" fill="white"/>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M7 2C7 1.44772 7.44772 1 8 1H12C12.5523 1 13 1.44772 13 2V4H18V6H16.5V18C16.5 18.5523 16.0523 19 15.5 19H4.5C3.94772 19 3.5 18.5523 3.5 18V6H2V4H7V2ZM9 4H11V3H9V4ZM5.5 6V17H14.5V6H5.5Z" fill="white"/>
+  <path d="M7.5 15V8H9.5V15H7.5Z" />
+  <path d="M10.5 8V15H12.5V8H10.5Z" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M7 2C7 1.44772 7.44772 1 8 1H12C12.5523 1 13 1.44772 13 2V4H18V6H16.5V18C16.5 18.5523 16.0523 19 15.5 19H4.5C3.94772 19 3.5 18.5523 3.5 18V6H2V4H7V2ZM9 4H11V3H9V4ZM5.5 6V17H14.5V6H5.5Z" />
 </svg>

--- a/src/assets/svg/icons/actions/Delete.tsx
+++ b/src/assets/svg/icons/actions/Delete.tsx
@@ -4,9 +4,8 @@ import Svg, {Path, SvgProps} from 'react-native-svg';
 function SvgDelete(props: SvgProps) {
   return (
     <Svg width={20} height={20} fill="black" viewBox="0 0 20 20" {...props}>
-      <Path fill="#fff" d="M7.5 15V8h2v7h-2zm3-7v7h2V8h-2z" />
+      <Path d="M7.5 15V8h2v7h-2zm3-7v7h2V8h-2z" />
       <Path
-        fill="#fff"
         fillRule="evenodd"
         d="M7 2a1 1 0 011-1h4a1 1 0 011 1v2h5v2h-1.5v12a1 1 0 01-1 1h-11a1 1 0 01-1-1V6H2V4h5V2zm2 2h2V3H9v1zM5.5 6v11h9V6h-9z"
         clipRule="evenodd"

--- a/src/components/sections/favorite-departure-item.tsx
+++ b/src/components/sections/favorite-departure-item.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  AccessibilityProps,
+  GestureResponderEvent,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import SvgDelete from '../../assets/svg/icons/actions/Delete';
+import {StoredFavoriteDeparture} from '../../favorites/types';
+import {useTheme} from '../../theme';
+import {SectionTexts, useTranslation} from '../../translations';
+import {screenReaderPause} from '../accessible-text';
+import ThemeText from '../text';
+import TransportationIcon from '../transportation-icon';
+import {SectionItem, useSectionItem, useSectionStyle} from './section-utils';
+
+type BaseProps = {
+  favorite: StoredFavoriteDeparture;
+  icon?: JSX.Element;
+};
+type WithOnPress = BaseProps & {
+  onPress(
+    favorite: StoredFavoriteDeparture,
+    event: GestureResponderEvent,
+  ): void;
+  accessibility?: AccessibilityProps;
+};
+
+export type FavoriteDepartureItemProps = SectionItem<BaseProps | WithOnPress>;
+export default function FavoriteDepartureItem(
+  props: FavoriteDepartureItemProps,
+) {
+  if (!withOnPress(props)) {
+    return <FavoriteItemContent {...props} />;
+  }
+  const favorite = props.favorite;
+  const a11yLabel = favorite.quayPublicCode
+    ? `${favorite.lineLineNumber} ${favorite.lineName}, ${favorite.quayName} ${favorite.quayPublicCode}`
+    : `${favorite.lineLineNumber} ${favorite.lineName}, ${favorite.quayName}`;
+
+  return (
+    <TouchableOpacity
+      accessible
+      accessibilityLabel={a11yLabel + screenReaderPause}
+      accessibilityRole="button"
+      onPress={(e) => props.onPress(props.favorite, e)}
+      {...props.accessibility}
+    >
+      <FavoriteItemContent {...props} />
+    </TouchableOpacity>
+  );
+}
+
+function withOnPress(a: any): a is WithOnPress {
+  return 'onPress' in a;
+}
+
+function FavoriteItemContent({favorite, icon, ...props}: BaseProps) {
+  const {contentContainer, topContainer} = useSectionItem(props);
+  const style = useSectionStyle();
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+
+  return (
+    <View style={[style.spaceBetween, topContainer, favoriteStyle.flexStart]}>
+      <View style={favoriteStyle.favorite__icon}>
+        <TransportationIcon
+          mode={favorite.lineTransportationMode}
+          subMode={favorite.lineTransportationSubMode}
+        />
+      </View>
+      <View style={contentContainer}>
+        <ThemeText>
+          {favorite.lineLineNumber} {favorite.lineName}
+        </ThemeText>
+        <ThemeText type="lead" color="faded">
+          {t(SectionTexts.favoriteDeparture.from)} {favorite.quayName}{' '}
+          {favorite.quayPublicCode ?? ''}
+        </ThemeText>
+      </View>
+      {icon ?? <SvgDelete fill={theme.background.destructive} />}
+    </View>
+  );
+}
+
+const favoriteStyle = StyleSheet.create({
+  flexStart: {
+    alignItems: 'flex-start',
+  },
+  favorite__icon: {
+    minWidth: 30,
+  },
+});

--- a/src/components/sections/favorite-item.tsx
+++ b/src/components/sections/favorite-item.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-native';
 import {Edit} from '../../assets/svg/icons/actions';
 import {FavoriteIcon} from '../../favorites';
-import {LocationFavorite} from '../../favorites/types';
+import {StoredLocationFavorite} from '../../favorites/types';
 import {StyleSheet} from '../../theme';
 import {screenReaderPause} from '../accessible-text';
 import ThemeText from '../text';
@@ -15,11 +15,11 @@ import ThemeIcon from '../theme-icon';
 import {SectionItem, useSectionItem, useSectionStyle} from './section-utils';
 
 type BaseProps = {
-  favorite: LocationFavorite;
+  favorite: StoredLocationFavorite;
   icon?: JSX.Element;
 };
 type WithOnPress = BaseProps & {
-  onPress(favorite: LocationFavorite, event: GestureResponderEvent): void;
+  onPress(favorite: StoredLocationFavorite, event: GestureResponderEvent): void;
   accessibility?: AccessibilityProps;
 };
 

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -5,9 +5,10 @@ export {default as RadioSection} from './radio-section';
 // Links and actions
 export {default as LinkItem} from './link-item';
 export {default as HeaderItem} from './header-item';
-export {default as FavoriteItem} from './favorite-item';
 export {default as ActionItem} from './action-item';
 export {default as GenericItem} from './generic-item';
+export {default as FavoriteItem} from './favorite-item';
+export {default as FavoriteDepartureItem} from './favorite-departure-item';
 
 // Inputs
 export {default as TextInput} from './text-input';

--- a/src/screens/Profile/FavoriteDepartures/index.tsx
+++ b/src/screens/Profile/FavoriteDepartures/index.tsx
@@ -1,0 +1,98 @@
+import {StackNavigationProp} from '@react-navigation/stack';
+import React from 'react';
+import {Alert, LayoutAnimation} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {ProfileStackParams} from '..';
+import * as Sections from '../../../components/sections';
+import {useFavorites} from '../../../favorites/FavoritesContext';
+import {StoredFavoriteDeparture} from '../../../favorites/types';
+import MessageBox from '../../../message-box';
+import {RootStackParamList} from '../../../navigation';
+import {StyleSheet, Theme} from '../../../theme';
+import {FavoriteDeparturesTexts, useTranslation} from '../../../translations';
+import BackHeader from '../BackHeader';
+
+export type ProfileScreenNavigationProp = StackNavigationProp<
+  ProfileStackParams,
+  'FavoriteDepartures'
+>;
+
+type FavoriteDeparturesProps = {
+  navigation: StackNavigationProp<RootStackParamList>;
+};
+
+export default function FavoriteDepartures({
+  navigation,
+}: FavoriteDeparturesProps) {
+  const style = useProfileStyle();
+  const {favoriteDepartures, removeFavoriteDeparture} = useFavorites();
+  const {t} = useTranslation();
+
+  const onDeletePress = (item: StoredFavoriteDeparture) => {
+    Alert.alert(
+      t(FavoriteDeparturesTexts.delete.label),
+      t(FavoriteDeparturesTexts.delete.confirmWarning),
+      [
+        {
+          text: t(FavoriteDeparturesTexts.delete.cancel),
+          style: 'cancel',
+        },
+        {
+          text: t(FavoriteDeparturesTexts.delete.delete),
+          style: 'destructive',
+          onPress: async () => {
+            LayoutAnimation.configureNext(
+              LayoutAnimation.Presets.easeInEaseOut,
+            );
+            removeFavoriteDeparture(item.id);
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <SafeAreaView style={style.container}>
+      <BackHeader title={t(FavoriteDeparturesTexts.header.title)} />
+
+      <ScrollView>
+        {!favoriteDepartures.length && (
+          <MessageBox
+            containerStyle={style.empty}
+            message={t(FavoriteDeparturesTexts.noFavorites)}
+            type="info"
+          />
+        )}
+
+        <Sections.Section withTopPadding withPadding>
+          {favoriteDepartures.map((favorite) => (
+            <Sections.FavoriteDepartureItem
+              key={favorite.id}
+              favorite={favorite}
+              accessibility={{
+                accessibilityHint: t(
+                  FavoriteDeparturesTexts.favoriteItemDelete.a11yHint,
+                ),
+              }}
+              onPress={onDeletePress}
+            />
+          ))}
+        </Sections.Section>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    backgroundColor: theme.background.level2,
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+    paddingBottom: 0,
+  },
+  empty: {
+    margin: theme.spacings.medium,
+  },
+}));

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -72,6 +72,10 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             text={t(ProfileTexts.sections.favorites.linkItems.places.label)}
             onPress={() => navigation.navigate('FavoriteList')}
           />
+          <Sections.LinkItem
+            text={t(ProfileTexts.sections.favorites.linkItems.departures.label)}
+            onPress={() => navigation.navigate('FavoriteDepartures')}
+          />
         </Sections.Section>
 
         <Sections.Section withPadding>

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -1,6 +1,7 @@
 import {createStackNavigator} from '@react-navigation/stack';
 import React from 'react';
 import Appearance from './Appearance';
+import FavoriteDepartures from './FavoriteDepartures';
 import FavoriteList from './FavoriteList';
 import ProfileHome from './Home';
 import SelectStartScreen from './SelectStartScreen';
@@ -8,6 +9,7 @@ import SelectStartScreen from './SelectStartScreen';
 export type ProfileStackParams = {
   ProfileHome: undefined;
   FavoriteList: undefined;
+  FavoriteDepartures: undefined;
   SelectStartScreen: undefined;
   Appearance: undefined;
 };
@@ -22,6 +24,7 @@ export default function ProfileScreen() {
     >
       <Stack.Screen name="ProfileHome" component={ProfileHome} />
       <Stack.Screen name="FavoriteList" component={FavoriteList} />
+      <Stack.Screen name="FavoriteDepartures" component={FavoriteDepartures} />
       <Stack.Screen name="SelectStartScreen" component={SelectStartScreen} />
       <Stack.Screen name="Appearance" component={Appearance} />
     </Stack.Navigator>

--- a/src/translations/components/Section.ts
+++ b/src/translations/components/Section.ts
@@ -7,5 +7,8 @@ const SectionTexts = {
     placeholder: _('Søk etter adresse eller sted', 'Search for a place'),
     a11yValue: (currentLocation: string) => _(`${currentLocation} er valgt.`),
   },
+  favoriteDeparture: {
+    from: _('Fra'),
+  },
 };
 export default SectionTexts;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -22,6 +22,7 @@ export {default as TicketTexts} from './screens/Ticket';
 export {default as NearbyTexts} from './screens/Nearby';
 export {default as AddEditFavoriteTexts} from './screens/subscreens/AddEditFavorite';
 export {default as FavoriteListTexts} from './screens/subscreens/FavoriteList';
+export {default as FavoriteDeparturesTexts} from './screens/subscreens/FavoriteDepartures';
 export {default as TripDetailsTexts} from './screens/subscreens/TripDetails';
 export {default as DepartureDetailsTexts} from './screens/subscreens/DepartureDetails';
 export {default as SelectStartScreenTexts} from './screens/subscreens/SelectStartScreen';

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -28,6 +28,9 @@ const ProfileTexts = {
         places: {
           label: _('Steder'),
         },
+        departures: {
+          label: _('Avganger'),
+        },
       },
     },
     privacy: {

--- a/src/translations/screens/subscreens/FavoriteDepartures.ts
+++ b/src/translations/screens/subscreens/FavoriteDepartures.ts
@@ -1,0 +1,19 @@
+import {translation as _} from '../../commons';
+const FavoriteDeparturesTexts = {
+  header: {
+    title: _('Favorittavganger'),
+  },
+  noFavorites: _(
+    'Du har ingen favorittavganger. Du kan legge til med å stjernemarkere i Avganger-visningen.',
+  ),
+  favoriteItemDelete: {
+    a11yHint: _('Aktivér for å fjerne favorittavgang'),
+  },
+  delete: {
+    label: _('Fjerne avgang?'),
+    confirmWarning: _('Sikker på at du vil fjerne favorittavgang?'),
+    cancel: _('Avbryt'),
+    delete: _('Slett'),
+  },
+};
+export default FavoriteDeparturesTexts;


### PR DESCRIPTION
**This is dependent on production deployment of the BFF. It is also dependent on #783 which should be merged first**

This could be merged into #783 as it is a small change

I think this should be a separate change from adding favorite through profile screen. Adding through wizard is a larger change which technically is nice to have (though very nice, don't get me wrong). But I think we can try to QA this and the other dependant changes and deploy that before implementing new add favorite flow.


## Examples

![image](https://user-images.githubusercontent.com/606374/102535301-4fa79c00-40a8-11eb-9231-c84378318f56.png)

![image](https://user-images.githubusercontent.com/606374/102535312-52a28c80-40a8-11eb-9b02-bbdd1dee0fad.png)

![image](https://user-images.githubusercontent.com/606374/102535337-5d5d2180-40a8-11eb-91ba-13a8a0fd23a7.png)
