### PR TITLE
fix: Add mode "coach" to transport color/icon

### DIFF
--- a/src/components/transportation-icon/index.tsx
+++ b/src/components/transportation-icon/index.tsx
@@ -67,6 +67,7 @@ function InnerIcon({
 
   switch (mode) {
     case 'bus':
+    case 'coach':
       return <BusSide key="bus" {...innerIconProps} />;
     case 'tram':
       return <TramSide key="tram" {...innerIconProps} />;

--- a/src/utils/transportation-color.ts
+++ b/src/utils/transportation-color.ts
@@ -9,6 +9,7 @@ export function transportationColor(
 ): string {
   switch (mode) {
     case 'bus':
+    case 'coach':
       if (subMode === 'localBus') {
         return colors.primary.green_500;
       }

--- a/src/utils/transportation-names.ts
+++ b/src/utils/transportation-names.ts
@@ -32,6 +32,7 @@ export function getTranslatedModeName(
   const legModeNames = dictionary.travel.legModes;
   switch (mode) {
     case 'bus':
+    case 'coach':
       return legModeNames.bus;
     case 'rail':
       return legModeNames.rail;


### PR DESCRIPTION
Noticed when running through favorite branch locally that we weren't handling transport mode "coach". Seems like coach mode is a type of bus. Entur also display it as a bus. I've added this to existing icon/color functions.

![image](https://user-images.githubusercontent.com/61825573/102599672-16117800-411e-11eb-892a-b065470a007c.png)
