### PR TITLE
chore: Sort tariff zones for easier selection

### DIFF
--- a/src/api/tariffZones.ts
+++ b/src/api/tariffZones.ts
@@ -4,7 +4,9 @@ import client from './client';
 export async function list() {
   const url = 'reference-data/v1/ATB/tariff-zones';
   const response = await client.get<TariffZone[]>(url);
-  return response.data;
+  return response.data.sort((t1, t2) =>
+    t1.name.value.localeCompare(t2.name.value),
+  );
 }
 
 export type TariffZone = {


### PR DESCRIPTION
This will also make A the default tariff zone as it is the first tariff
zone in the array.