### PR TITLE
feat: Language preferences in profile settings (behind feature flag)

### DIFF
--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -1,16 +1,21 @@
 import {ColorSchemeName} from 'react-native';
-
+import {appLanguages} from '../translations';
 export const preference_screenAlternatives = [
   'assistant',
   'departures',
   'ticketing',
 ] as const;
+
 export type Preference_ScreenAlternatives = typeof preference_screenAlternatives[number];
+
+export type Preference_Language = typeof appLanguages[number];
 
 export type UserPreferences = {
   startScreen?: Preference_ScreenAlternatives;
   colorScheme?: ColorSchemeName;
   overrideColorScheme?: boolean;
+  language?: Preference_Language;
+  useSystemLanguage?: boolean;
 };
 
 export type PreferenceItem = keyof UserPreferences;

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -14,6 +14,7 @@ import LogoOutline from '../../../ScreenHeader/LogoOutline';
 import {StyleSheet, Theme} from '../../../theme';
 import {useNavigateToStartScreen} from '../../../utils/navigation';
 import {useTranslation, ProfileTexts} from '../../../translations';
+import {useRemoteConfig} from '../../../RemoteConfigContext';
 
 export type ProfileScreenNavigationProp = StackNavigationProp<
   ProfileStackParams,
@@ -31,6 +32,7 @@ type ProfileScreenProps = {
 
 export default function ProfileHome({navigation}: ProfileScreenProps) {
   const navigateHome = useNavigateToStartScreen();
+  const {enable_i18n} = useRemoteConfig();
   const chatIcon = useChatIcon();
   const style = useProfileHomeStyle();
   const {t} = useTranslation();
@@ -61,6 +63,12 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             text={t(ProfileTexts.sections.settings.linkItems.startScreen.label)}
             onPress={() => navigation.navigate('SelectStartScreen')}
           />
+          {enable_i18n && (
+            <Sections.LinkItem
+              text={t(ProfileTexts.sections.settings.linkItems.language.label)}
+              onPress={() => navigation.navigate('Language')}
+            />
+          )}
         </Sections.Section>
 
         <Sections.Section withPadding>

--- a/src/screens/Profile/Language/index.tsx
+++ b/src/screens/Profile/Language/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {ActionItem, RadioSection, Section} from '../../../components/sections';
+import {Preference_Language, usePreferences} from '../../../preferences';
+import {StyleSheet, Theme} from '../../../theme';
+import BackHeader from '../BackHeader';
+import {
+  useTranslation,
+  LanguageSettingsTexts,
+  DEFAULT_LANGUAGE,
+  appLanguages,
+} from '../../../translations';
+const identity = (s: string) => s;
+export default function Language() {
+  const {
+    setPreference,
+    preferences: {useSystemLanguage, language},
+  } = usePreferences();
+
+  const style = useStyle();
+  const {t} = useTranslation();
+
+  const languages = Array.from(appLanguages);
+
+  return (
+    <SafeAreaView style={style.container}>
+      <BackHeader title={t(LanguageSettingsTexts.header.title)} />
+      <ScrollView>
+        <Section withPadding withTopPadding>
+          <ActionItem
+            mode="toggle"
+            text={t(LanguageSettingsTexts.usePhoneSettings)}
+            checked={useSystemLanguage}
+            onPress={(checked) => setPreference({useSystemLanguage: checked})}
+          />
+        </Section>
+        {!useSystemLanguage && (
+          <RadioSection<Preference_Language>
+            withPadding
+            items={languages}
+            keyExtractor={identity}
+            itemToText={(item) => {
+              return t(LanguageSettingsTexts.options[item]);
+            }}
+            selected={language ?? languages.find((l) => l == DEFAULT_LANGUAGE)}
+            onSelect={(language) => setPreference({language})}
+          />
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    backgroundColor: theme.background.level1,
+    flex: 1,
+  },
+}));

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -4,6 +4,7 @@ import Appearance from './Appearance';
 import FavoriteDepartures from './FavoriteDepartures';
 import FavoriteList from './FavoriteList';
 import ProfileHome from './Home';
+import Language from './Language';
 import SelectStartScreen from './SelectStartScreen';
 
 export type ProfileStackParams = {
@@ -12,6 +13,7 @@ export type ProfileStackParams = {
   FavoriteDepartures: undefined;
   SelectStartScreen: undefined;
   Appearance: undefined;
+  Language: undefined;
 };
 
 const Stack = createStackNavigator<ProfileStackParams>();
@@ -27,6 +29,7 @@ export default function ProfileScreen() {
       <Stack.Screen name="FavoriteDepartures" component={FavoriteDepartures} />
       <Stack.Screen name="SelectStartScreen" component={SelectStartScreen} />
       <Stack.Screen name="Appearance" component={Appearance} />
+      <Stack.Screen name="Language" component={Language} />
     </Stack.Navigator>
   );
 }

--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -41,7 +41,7 @@ function useLanguage() {
         RNLocalize.removeEventListener('change', onChange);
       };
     }
-  }, [shouldUseUserPreferenced]);
+  }, [useSystemLanguage, userPreferencedLanguage]);
 
   useEffect(() => {
     if (!shouldUseUserPreferenced) {

--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -28,16 +28,10 @@ function useLanguage() {
   const shouldUseUserPreferenced =
     !useSystemLanguage && !!userPreferencedLanguage;
 
-  const getAndSetPreferencedLanguage = () => {
+  useEffect(() => {
     if (shouldUseUserPreferenced) {
       const newLanguage = getAsAppLanguage(userPreferencedLanguage);
       setCurrentLanguage(newLanguage);
-    }
-  };
-
-  useEffect(() => {
-    if (shouldUseUserPreferenced) {
-      getAndSetPreferencedLanguage();
     } else {
       const onChange = () => {
         setLocale(preferredLocale);
@@ -47,7 +41,7 @@ function useLanguage() {
         RNLocalize.removeEventListener('change', onChange);
       };
     }
-  }, []);
+  }, [shouldUseUserPreferenced]);
 
   useEffect(() => {
     if (!shouldUseUserPreferenced) {
@@ -58,7 +52,6 @@ function useLanguage() {
     }
   }, [locale, useSystemLanguage]);
 
-  useEffect(getAndSetPreferencedLanguage, [userPreferencedLanguage]);
   return currentLanguage;
 }
 

--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -3,6 +3,7 @@ import * as RNLocalize from 'react-native-localize';
 import {useState, useEffect} from 'react';
 import {Language, lobot, DEFAULT_LANGUAGE} from './';
 import {useRemoteConfig} from '../RemoteConfigContext';
+import {usePreferences} from '../preferences';
 
 const AppLanguageProvider: React.FC = ({children}) => {
   const currentLanguage = useLanguage();
@@ -19,26 +20,48 @@ const AppLanguageProvider: React.FC = ({children}) => {
 function useLanguage() {
   const [currentLanguage, setCurrentLanguage] = useState(DEFAULT_LANGUAGE);
   const [locale, setLocale] = useState(preferredLocale);
+  const {
+    preferences: {useSystemLanguage, language: userPreferencedLanguage},
+  } = usePreferences();
+
+  // Usage of system setting not explicitly chosen, and user preferenced language has value
+  const shouldUseUserPreferenced =
+    !useSystemLanguage && !!userPreferencedLanguage;
+
+  const getAndSetPreferencedLanguage = () => {
+    if (shouldUseUserPreferenced) {
+      const newLanguage = getAsAppLanguage(userPreferencedLanguage);
+      setCurrentLanguage(newLanguage);
+    }
+  };
 
   useEffect(() => {
-    const onChange = () => {
-      setLocale(preferredLocale);
-    };
-    RNLocalize.addEventListener('change', onChange);
-    return () => {
-      RNLocalize.removeEventListener('change', onChange);
-    };
+    if (shouldUseUserPreferenced) {
+      getAndSetPreferencedLanguage();
+    } else {
+      const onChange = () => {
+        setLocale(preferredLocale);
+      };
+      RNLocalize.addEventListener('change', onChange);
+      return () => {
+        RNLocalize.removeEventListener('change', onChange);
+      };
+    }
   }, []);
 
   useEffect(() => {
-    const language = locale
-      ? getAsAppLanguage(locale.languageCode) ?? DEFAULT_LANGUAGE
-      : DEFAULT_LANGUAGE;
-    setCurrentLanguage(language);
-  }, [locale]);
+    if (!shouldUseUserPreferenced) {
+      const language = locale
+        ? getAsAppLanguage(locale.languageCode)
+        : DEFAULT_LANGUAGE;
+      setCurrentLanguage(language);
+    }
+  }, [locale, useSystemLanguage]);
 
+  useEffect(getAndSetPreferencedLanguage, [userPreferencedLanguage]);
   return currentLanguage;
 }
+
 function preferredLocale(): RNLocalize.Locale | undefined {
   const preferredSystemLocales = RNLocalize.getLocales();
   const locale = preferredSystemLocales.find(
@@ -46,8 +69,13 @@ function preferredLocale(): RNLocalize.Locale | undefined {
   );
   return locale;
 }
-function getAsAppLanguage(arg: string): Language | undefined {
-  if (arg == Language.English) return Language.English;
-  if (arg == Language.Norwegian) return Language.Norwegian;
+function getAsAppLanguage(arg?: string): Language {
+  if (arg == Language.English) {
+    return Language.English;
+  }
+  if (arg == Language.Norwegian) {
+    return Language.Norwegian;
+  }
+  return DEFAULT_LANGUAGE;
 }
 export default AppLanguageProvider;

--- a/src/translations/commons.ts
+++ b/src/translations/commons.ts
@@ -1,12 +1,14 @@
 import {TFunc} from '@leile/lobo-t';
 
 import {initLobot, Translatable} from '@leile/lobo-t';
+
 export enum Language {
   Norwegian = 'nb',
   English = 'en',
 }
-export const DEFAULT_LANGUAGE = Language.Norwegian;
+export const appLanguages = ['nb', 'en'] as const;
 
+export const DEFAULT_LANGUAGE = Language.Norwegian;
 export type TranslatedString = Translatable<typeof Language, string>;
 
 export const lobot = initLobot<typeof Language>(DEFAULT_LANGUAGE);

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -4,6 +4,7 @@ export {
   DEFAULT_LANGUAGE,
   lobot,
   useTranslation,
+  appLanguages,
   translation,
 } from './commons';
 
@@ -27,4 +28,5 @@ export {default as TripDetailsTexts} from './screens/subscreens/TripDetails';
 export {default as DepartureDetailsTexts} from './screens/subscreens/DepartureDetails';
 export {default as SelectStartScreenTexts} from './screens/subscreens/SelectStartScreen';
 export {default as AppearanceSettingsTexts} from './screens/subscreens/AppearanceSettings';
+export {default as LanguageSettingsTexts} from './screens/subscreens/LanguageSettingsTexts';
 export {default as dictionary} from './dictionary';

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -20,6 +20,9 @@ const ProfileTexts = {
         startScreen: {
           label: _('Startside'),
         },
+        language: {
+          label: _('Språk'),
+        },
       },
     },
     favorites: {

--- a/src/translations/screens/subscreens/LanguageSettingsTexts.ts
+++ b/src/translations/screens/subscreens/LanguageSettingsTexts.ts
@@ -1,0 +1,12 @@
+import {translation as _} from '../../commons';
+const LanguageSettingsTexts = {
+  header: {
+    title: _('Språk'),
+  },
+  usePhoneSettings: _('Bruk telefoninnstillinger'),
+  options: {
+    nb: _('Norsk bokmål'),
+    en: _('English'),
+  },
+};
+export default LanguageSettingsTexts;


### PR DESCRIPTION
Defaults to "default language", currently set to "Norsk bokmål".

Using phone settings is optional - App then gets system locale, and decides on what will be considered the best app language.

User can choose app language explicitly from "Mitt AtB".

![image](https://user-images.githubusercontent.com/61825573/102788278-aa8c0c80-43a2-11eb-9e79-4d1d20b58dde.png)


closes #780 