### PR TITLE
refactor: Internalization text in component

### DIFF
--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -4,22 +4,18 @@ import {TicketingStackParams} from '../';
 import Header from '../../../../ScreenHeader';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {StyleSheet, useTheme} from '../../../../theme';
-import ThemeText from '../../../../components/text';
 import {DismissableStackNavigationProp} from '../../../../navigation/createDismissableStackNavigator';
 import {ButtonInput, Section} from '../../../../components/sections';
-import {screenReaderPause} from '../../../../components/accessible-text';
-import {
-  Language,
-  TariffZonesTexts,
-  useTranslation,
-} from '../../../../translations';
+import AccessibleText, {
+  screenReaderPause,
+} from '../../../../components/accessible-text';
+import {TariffZonesTexts, useTranslation} from '../../../../translations';
 import {TariffZone} from '../../../../api/tariffZones';
 import {View} from 'react-native';
 import ThemeIcon from '../../../../components/theme-icon';
 import {ArrowLeft} from '../../../../assets/svg/icons/navigation';
 import Button from '../../../../components/button';
 import {Confirm} from '../../../../assets/svg/icons/actions';
-import {TFunc} from '@leile/lobo-t';
 
 type TariffZonesRouteName = 'TariffZones';
 const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
@@ -52,8 +48,83 @@ type Props = {
 export const tariffZonesSummary = (
   fromTariffZone: TariffZoneWithMetadata,
   toTariffZone: TariffZoneWithMetadata,
-  t: TFunc<typeof Language>,
-) => t(TariffZonesTexts.zoneSummary.text(fromTariffZone, toTariffZone));
+) => {
+  if (fromTariffZone.id === toTariffZone.id) {
+    return TariffZonesTexts.zoneSummary.text.singleZone(
+      fromTariffZone.name.value,
+    );
+  } else {
+    return TariffZonesTexts.zoneSummary.text.multipleZone(
+      fromTariffZone.name.value,
+      toTariffZone.name.value,
+    );
+  }
+};
+
+const departurePickerAccessibilityLabel = (
+  fromTariffZone: TariffZoneWithMetadata,
+) => {
+  if (fromTariffZone.venueName)
+    return TariffZonesTexts.location.departurePicker.a11yLabel.withVenue(
+      fromTariffZone.name.value,
+      fromTariffZone.venueName,
+    );
+  else {
+    return TariffZonesTexts.location.departurePicker.a11yLabel.noVenue(
+      fromTariffZone.name.value,
+    );
+  }
+};
+
+const destinationPickerAccessibilityLabel = (
+  toTariffZone: TariffZoneWithMetadata,
+) => {
+  if (toTariffZone.venueName)
+    return TariffZonesTexts.location.destinationPicker.a11yLabel.withVenue(
+      toTariffZone.name.value,
+      toTariffZone.venueName,
+    );
+  else {
+    return TariffZonesTexts.location.destinationPicker.a11yLabel.noVenue(
+      toTariffZone.name.value,
+    );
+  }
+};
+
+const departurePickerValue = (fromTariffZone: TariffZoneWithMetadata) => {
+  if (fromTariffZone.venueName)
+    return TariffZonesTexts.location.departurePicker.value.withVenue(
+      fromTariffZone.name.value,
+      fromTariffZone.venueName,
+    );
+  else {
+    return TariffZonesTexts.location.departurePicker.value.noVenue(
+      fromTariffZone.name.value,
+    );
+  }
+};
+
+const destinationPickerValue = (
+  fromTariffZone: TariffZoneWithMetadata,
+  toTariffZone: TariffZoneWithMetadata,
+) => {
+  if (fromTariffZone.id === toTariffZone.id && toTariffZone.venueName) {
+    return TariffZonesTexts.location.destinationPicker.value.withVenueSameZone(
+      toTariffZone.venueName,
+    );
+  } else if (fromTariffZone.id === toTariffZone.id && !toTariffZone.venueName) {
+    return TariffZonesTexts.location.destinationPicker.value.noVenueSameZone;
+  } else if (toTariffZone.venueName) {
+    return TariffZonesTexts.location.departurePicker.value.withVenue(
+      toTariffZone.name.value,
+      toTariffZone.venueName,
+    );
+  } else {
+    return TariffZonesTexts.location.departurePicker.value.noVenue(
+      toTariffZone.name.value,
+    );
+  }
+};
 
 const TariffZones: React.FC<Props> = ({navigation, route}) => {
   const styles = useStyles();
@@ -97,19 +168,14 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
         <Section withPadding>
           <ButtonInput
             accessibilityLabel={
-              t(
-                TariffZonesTexts.location.departurePicker.a11yLabel(
-                  fromTariffZone,
-                ),
-              ) + screenReaderPause
+              t(departurePickerAccessibilityLabel(fromTariffZone)) +
+              screenReaderPause
             }
             accessibilityHint={t(
               TariffZonesTexts.location.departurePicker.a11yHint,
             )}
             accessibilityRole="button"
-            value={t(
-              TariffZonesTexts.location.departurePicker.value(fromTariffZone),
-            )}
+            value={t(departurePickerValue(fromTariffZone))}
             label={t(TariffZonesTexts.location.departurePicker.label)}
             placeholder={t(TariffZonesTexts.location.departurePicker.label)}
             onPress={() =>
@@ -119,22 +185,14 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
 
           <ButtonInput
             accessibilityLabel={
-              t(
-                TariffZonesTexts.location.destinationPicker.a11yLabel(
-                  toTariffZone,
-                ),
-              ) + screenReaderPause
+              t(destinationPickerAccessibilityLabel(toTariffZone)) +
+              screenReaderPause
             }
             accessibilityHint={t(
               TariffZonesTexts.location.destinationPicker.a11yHint,
             )}
             accessibilityRole="button"
-            value={t(
-              TariffZonesTexts.location.destinationPicker.value(
-                fromTariffZone,
-                toTariffZone,
-              ),
-            )}
+            value={t(destinationPickerValue(fromTariffZone, toTariffZone))}
             label={t(TariffZonesTexts.location.destinationPicker.label)}
             placeholder={t(TariffZonesTexts.location.destinationPicker.label)}
             onPress={() =>
@@ -142,18 +200,13 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
             }
           />
         </Section>
-        <ThemeText
+        <AccessibleText
           type={'body'}
           style={styles.tariffZoneText}
-          accessibilityLabel={t(
-            TariffZonesTexts.zoneSummary.a11yLabel(
-              fromTariffZone,
-              toTariffZone,
-            ),
-          )}
+          prefix={t(TariffZonesTexts.zoneSummary.a11yLabelPrefix)}
         >
-          {tariffZonesSummary(fromTariffZone, toTariffZone, t)}
-        </ThemeText>
+          {t(tariffZonesSummary(fromTariffZone, toTariffZone))}
+        </AccessibleText>
       </View>
       <View
         style={{

--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -130,7 +130,7 @@ const Travellers: React.FC<TravellersProps> = ({
 
         <Sections.Section withPadding>
           <Sections.LinkItem
-            text={tariffZonesSummary(fromTariffZone, toTariffZone, t)}
+            text={t(tariffZonesSummary(fromTariffZone, toTariffZone))}
             onPress={() => {
               navigation.push('TariffZones', {
                 fromTariffZone,

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -1,34 +1,4 @@
 import {translation as _} from '../../commons';
-import {TariffZoneWithMetadata} from '../../../screens/Ticketing/Purchase/TariffZones';
-
-const textForTariffZone = (zoneText: string, sourceText?: string) =>
-  sourceText ? `${sourceText} (${zoneText})` : `${zoneText}`;
-
-const tariffZoneSummaryText = (
-  from: TariffZoneWithMetadata,
-  to: TariffZoneWithMetadata,
-) =>
-  from.id === to.id
-    ? `Reise gjennom 1 sone (Sone ${from.name.value})`
-    : `Reise fra sone ${from.name.value} til sone ${to.name.value}`;
-
-const getSourceVenueText = (tf: TariffZoneWithMetadata, positionText: string) =>
-  tf.resultType === 'geolocation' ? positionText : tf.venueName;
-
-const getBasedOnVenueTextNorwegian = (
-  tf: TariffZoneWithMetadata,
-  fromOrTo: 'from' | 'to',
-) => {
-  const zoneText = fromOrTo === 'from' ? 'avreisesone' : 'ankomstsone';
-  const baseText = `Valgt ${zoneText} er sone ${tf.name.value}`;
-  if (tf.resultType === 'geolocation') {
-    return `${baseText} basert på min posisjon`;
-  } else if (tf.venueName) {
-    return `${baseText} basert på stoppested ${tf.venueName}`;
-  } else {
-    return baseText;
-  }
-};
 
 const TariffZonesTexts = {
   header: {
@@ -38,43 +8,64 @@ const TariffZonesTexts = {
     },
   },
   zoneSummary: {
-    a11yLabel: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) =>
-      _(`Sonevalget er ${tariffZoneSummaryText(from, to)}`),
-    text: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) =>
-      _(tariffZoneSummaryText(from, to)),
+    a11yLabelPrefix: _(`Sonevalget er`, `The zone selection is`),
+    text: {
+      singleZone: (zoneName: string) =>
+        _(
+          `Reise gjennom 1 sone (Sone ${zoneName})`,
+          `Travel through 1 zone (Zone ${zoneName})`,
+        ),
+      multipleZone: (zoneNameFrom: string, zoneNameTo: string) =>
+        _(
+          `Reise fra sone ${zoneNameFrom} til sone ${zoneNameTo}`,
+          `Travel from zone ${zoneNameFrom} to zone ${zoneNameTo})`,
+        ),
+    },
   },
 
   location: {
     departurePicker: {
-      value: (from: TariffZoneWithMetadata) =>
-        _(
-          textForTariffZone(
-            `Sone ${from.name.value}`,
-            getSourceVenueText(from, 'Min posisjon'),
+      value: {
+        noVenue: (zoneName: string) =>
+          _(`Sone ${zoneName}`, `Zone ${zoneName}`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Sone ${zoneName} (${venueName})`,
+            `Zone ${zoneName} (${venueName})`,
           ),
-        ),
+      },
       label: _('Fra', 'From'),
-      a11yLabel: (from: TariffZoneWithMetadata) =>
-        _(getBasedOnVenueTextNorwegian(from, 'from')),
+      a11yLabel: {
+        noVenue: (zoneName: string) => _(`Valgt avreisesone er ${zoneName}`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Valgt avreisesone er ${zoneName} basert på stoppested ${venueName}`,
+          ),
+      },
       a11yHint: _('Aktivér for å søke etter avreisesone'),
       placeholder: _('Søk etter avreisesone'),
     },
     destinationPicker: {
-      value: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) =>
-        _(
-          from.id === to.id
-            ? textForTariffZone(
-                `Samme sone`,
-                getSourceVenueText(to, 'Min posisjon'),
-              )
-            : textForTariffZone(
-                `Sone ${to.name.value}`,
-                getSourceVenueText(to, 'Min posisjon'),
-              ),
-        ),
+      value: {
+        noVenue: (zoneName: string) =>
+          _(`Sone ${zoneName}`, `Zone ${zoneName}`),
+        noVenueSameZone: _(`Samme sone`, `Same zone`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Sone ${zoneName} (${venueName})`,
+            `Zone ${zoneName} (${venueName})`,
+          ),
+        withVenueSameZone: (venueName: string) =>
+          _(`Samme sone (${venueName})`, `Same zone (${venueName})`),
+      },
       label: _('Til', 'To'),
-      a11yLabel: (to: TariffZoneWithMetadata) =>
-        _(getBasedOnVenueTextNorwegian(to, 'to')),
+      a11yLabel: {
+        noVenue: (zoneName: string) => _(`Valgt ankomstsone er ${zoneName}`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Valgt ankomstsone er ${zoneName} basert på stoppested ${venueName}`,
+          ),
+      },
       a11yHint: _('Aktivér for å søke etter ankomstsone'),
       placeholder: _('Søk etter ankomstsone'),
     },


### PR DESCRIPTION
A commit showing how the logic would be distributed with text logic in the React components as opposed in the texts-files. The texts-files ends up much cleaner, but with the cost of increasing the size of the React component with text logic.