### PR TITLE
refactor: Internalization text in text-file facade

### DIFF
--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -4,13 +4,14 @@ import {TicketingStackParams} from '../';
 import Header from '../../../../ScreenHeader';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {StyleSheet, useTheme} from '../../../../theme';
-import ThemeText from '../../../../components/text';
 import {DismissableStackNavigationProp} from '../../../../navigation/createDismissableStackNavigator';
 import {ButtonInput, Section} from '../../../../components/sections';
-import {screenReaderPause} from '../../../../components/accessible-text';
+import AccessibleText, {
+  screenReaderPause,
+} from '../../../../components/accessible-text';
 import {
-  Language,
   TariffZonesTexts,
+  TariffZonesTextsFacade,
   useTranslation,
 } from '../../../../translations';
 import {TariffZone} from '../../../../api/tariffZones';
@@ -19,7 +20,6 @@ import ThemeIcon from '../../../../components/theme-icon';
 import {ArrowLeft} from '../../../../assets/svg/icons/navigation';
 import Button from '../../../../components/button';
 import {Confirm} from '../../../../assets/svg/icons/actions';
-import {TFunc} from '@leile/lobo-t';
 
 type TariffZonesRouteName = 'TariffZones';
 const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
@@ -48,12 +48,6 @@ type Props = {
   navigation: NavigationProps;
   route: RouteProps;
 };
-
-export const tariffZonesSummary = (
-  fromTariffZone: TariffZoneWithMetadata,
-  toTariffZone: TariffZoneWithMetadata,
-  t: TFunc<typeof Language>,
-) => t(TariffZonesTexts.zoneSummary.text(fromTariffZone, toTariffZone));
 
 const TariffZones: React.FC<Props> = ({navigation, route}) => {
   const styles = useStyles();
@@ -98,7 +92,7 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
           <ButtonInput
             accessibilityLabel={
               t(
-                TariffZonesTexts.location.departurePicker.a11yLabel(
+                TariffZonesTextsFacade.location.departurePicker.a11yLabel(
                   fromTariffZone,
                 ),
               ) + screenReaderPause
@@ -108,7 +102,9 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
             )}
             accessibilityRole="button"
             value={t(
-              TariffZonesTexts.location.departurePicker.value(fromTariffZone),
+              TariffZonesTextsFacade.location.departurePicker.value(
+                fromTariffZone,
+              ),
             )}
             label={t(TariffZonesTexts.location.departurePicker.label)}
             placeholder={t(TariffZonesTexts.location.departurePicker.label)}
@@ -120,7 +116,7 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
           <ButtonInput
             accessibilityLabel={
               t(
-                TariffZonesTexts.location.destinationPicker.a11yLabel(
+                TariffZonesTextsFacade.location.destinationPicker.a11yLabel(
                   toTariffZone,
                 ),
               ) + screenReaderPause
@@ -130,7 +126,7 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
             )}
             accessibilityRole="button"
             value={t(
-              TariffZonesTexts.location.destinationPicker.value(
+              TariffZonesTextsFacade.location.destinationPicker.value(
                 fromTariffZone,
                 toTariffZone,
               ),
@@ -142,18 +138,18 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
             }
           />
         </Section>
-        <ThemeText
+        <AccessibleText
           type={'body'}
           style={styles.tariffZoneText}
-          accessibilityLabel={t(
-            TariffZonesTexts.zoneSummary.a11yLabel(
+          prefix={t(TariffZonesTexts.zoneSummary.a11yLabelPrefix)}
+        >
+          {t(
+            TariffZonesTextsFacade.zoneSummary.text(
               fromTariffZone,
               toTariffZone,
             ),
           )}
-        >
-          {tariffZonesSummary(fromTariffZone, toTariffZone, t)}
-        </ThemeText>
+        </AccessibleText>
       </View>
       <View
         style={{

--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -18,8 +18,12 @@ import {CreditCard, Vipps} from '../../../../assets/svg/icons/ticketing';
 import * as Sections from '../../../../components/sections';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useTicketState} from '../../../../TicketContext';
-import {tariffZonesSummary, TariffZoneWithMetadata} from '../TariffZones';
-import {TravellersTexts, useTranslation} from '../../../../translations';
+import {TariffZoneWithMetadata} from '../TariffZones';
+import {
+  TariffZonesTextsFacade,
+  TravellersTexts,
+  useTranslation,
+} from '../../../../translations';
 
 export type TravellersProps = {
   navigation: DismissableStackNavigationProp<
@@ -130,7 +134,12 @@ const Travellers: React.FC<TravellersProps> = ({
 
         <Sections.Section withPadding>
           <Sections.LinkItem
-            text={tariffZonesSummary(fromTariffZone, toTariffZone, t)}
+            text={t(
+              TariffZonesTextsFacade.zoneSummary.text(
+                fromTariffZone,
+                toTariffZone,
+              ),
+            )}
             onPress={() => {
               navigation.push('TariffZones', {
                 fromTariffZone,

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -16,7 +16,10 @@ export {default as MapTexts} from './components/Map';
 export {default as DateInputTexts} from './components/DateInput';
 export {default as LocationSearchTexts} from './screens/subscreens/LocationSearch';
 export {default as TravellersTexts} from './screens/subscreens/Travellers';
-export {default as TariffZonesTexts} from './screens/subscreens/TariffZones';
+export {
+  default as TariffZonesTexts,
+  Facade as TariffZonesTextsFacade,
+} from './screens/subscreens/TariffZones';
 export {default as TariffZoneSearchTexts} from './screens/subscreens/TariffZoneSearch';
 export {default as ProfileTexts} from './screens/Profile';
 export {default as TicketTexts} from './screens/Ticket';

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -1,33 +1,80 @@
 import {translation as _} from '../../commons';
 import {TariffZoneWithMetadata} from '../../../screens/Ticketing/Purchase/TariffZones';
 
-const textForTariffZone = (zoneText: string, sourceText?: string) =>
-  sourceText ? `${sourceText} (${zoneText})` : `${zoneText}`;
-
-const tariffZoneSummaryText = (
-  from: TariffZoneWithMetadata,
-  to: TariffZoneWithMetadata,
-) =>
-  from.id === to.id
-    ? `Reise gjennom 1 sone (Sone ${from.name.value})`
-    : `Reise fra sone ${from.name.value} til sone ${to.name.value}`;
-
-const getSourceVenueText = (tf: TariffZoneWithMetadata, positionText: string) =>
-  tf.resultType === 'geolocation' ? positionText : tf.venueName;
-
-const getBasedOnVenueTextNorwegian = (
-  tf: TariffZoneWithMetadata,
-  fromOrTo: 'from' | 'to',
-) => {
-  const zoneText = fromOrTo === 'from' ? 'avreisesone' : 'ankomstsone';
-  const baseText = `Valgt ${zoneText} er sone ${tf.name.value}`;
-  if (tf.resultType === 'geolocation') {
-    return `${baseText} basert på min posisjon`;
-  } else if (tf.venueName) {
-    return `${baseText} basert på stoppested ${tf.venueName}`;
-  } else {
-    return baseText;
-  }
+export const Facade = {
+  zoneSummary: {
+    text: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) => {
+      if (from.id === to.id) {
+        return TariffZonesTexts.zoneSummary.text.singleZone(from.name.value);
+      } else {
+        return TariffZonesTexts.zoneSummary.text.multipleZone(
+          from.name.value,
+          to.name.value,
+        );
+      }
+    },
+  },
+  location: {
+    departurePicker: {
+      a11yLabel: (from: TariffZoneWithMetadata) => {
+        if (from.venueName)
+          return TariffZonesTexts.location.departurePicker.a11yLabel.withVenue(
+            from.name.value,
+            from.venueName,
+          );
+        else {
+          return TariffZonesTexts.location.departurePicker.a11yLabel.noVenue(
+            from.name.value,
+          );
+        }
+      },
+      value: (from: TariffZoneWithMetadata) => {
+        if (from.venueName)
+          return TariffZonesTexts.location.departurePicker.value.withVenue(
+            from.name.value,
+            from.venueName,
+          );
+        else {
+          return TariffZonesTexts.location.departurePicker.value.noVenue(
+            from.name.value,
+          );
+        }
+      },
+    },
+    destinationPicker: {
+      a11yLabel: (to: TariffZoneWithMetadata) => {
+        if (to.venueName)
+          return TariffZonesTexts.location.destinationPicker.a11yLabel.withVenue(
+            to.name.value,
+            to.venueName,
+          );
+        else {
+          return TariffZonesTexts.location.destinationPicker.a11yLabel.noVenue(
+            to.name.value,
+          );
+        }
+      },
+      value: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) => {
+        if (from.id === to.id && to.venueName) {
+          return TariffZonesTexts.location.destinationPicker.value.withVenueSameZone(
+            to.venueName,
+          );
+        } else if (from.id === to.id && !to.venueName) {
+          return TariffZonesTexts.location.destinationPicker.value
+            .noVenueSameZone;
+        } else if (to.venueName) {
+          return TariffZonesTexts.location.departurePicker.value.withVenue(
+            to.name.value,
+            to.venueName,
+          );
+        } else {
+          return TariffZonesTexts.location.departurePicker.value.noVenue(
+            to.name.value,
+          );
+        }
+      },
+    },
+  },
 };
 
 const TariffZonesTexts = {
@@ -38,43 +85,64 @@ const TariffZonesTexts = {
     },
   },
   zoneSummary: {
-    a11yLabel: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) =>
-      _(`Sonevalget er ${tariffZoneSummaryText(from, to)}`),
-    text: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) =>
-      _(tariffZoneSummaryText(from, to)),
+    a11yLabelPrefix: _(`Sonevalget er`, `The zone selection is`),
+    text: {
+      singleZone: (zoneName: string) =>
+        _(
+          `Reise gjennom 1 sone (Sone ${zoneName})`,
+          `Travel through 1 zone (Zone ${zoneName})`,
+        ),
+      multipleZone: (zoneNameFrom: string, zoneNameTo: string) =>
+        _(
+          `Reise fra sone ${zoneNameFrom} til sone ${zoneNameTo}`,
+          `Travel from zone ${zoneNameFrom} to zone ${zoneNameTo})`,
+        ),
+    },
   },
 
   location: {
     departurePicker: {
-      value: (from: TariffZoneWithMetadata) =>
-        _(
-          textForTariffZone(
-            `Sone ${from.name.value}`,
-            getSourceVenueText(from, 'Min posisjon'),
+      value: {
+        noVenue: (zoneName: string) =>
+          _(`Sone ${zoneName}`, `Zone ${zoneName}`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Sone ${zoneName} (${venueName})`,
+            `Zone ${zoneName} (${venueName})`,
           ),
-        ),
+      },
       label: _('Fra', 'From'),
-      a11yLabel: (from: TariffZoneWithMetadata) =>
-        _(getBasedOnVenueTextNorwegian(from, 'from')),
+      a11yLabel: {
+        noVenue: (zoneName: string) => _(`Valgt avreisesone er ${zoneName}`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Valgt avreisesone er ${zoneName} basert på stoppested ${venueName}`,
+          ),
+      },
       a11yHint: _('Aktivér for å søke etter avreisesone'),
       placeholder: _('Søk etter avreisesone'),
     },
     destinationPicker: {
-      value: (from: TariffZoneWithMetadata, to: TariffZoneWithMetadata) =>
-        _(
-          from.id === to.id
-            ? textForTariffZone(
-                `Samme sone`,
-                getSourceVenueText(to, 'Min posisjon'),
-              )
-            : textForTariffZone(
-                `Sone ${to.name.value}`,
-                getSourceVenueText(to, 'Min posisjon'),
-              ),
-        ),
+      value: {
+        noVenue: (zoneName: string) =>
+          _(`Sone ${zoneName}`, `Zone ${zoneName}`),
+        noVenueSameZone: _(`Samme sone`, `Same zone`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Sone ${zoneName} (${venueName})`,
+            `Zone ${zoneName} (${venueName})`,
+          ),
+        withVenueSameZone: (venueName: string) =>
+          _(`Samme sone (${venueName})`, `Same zone (${venueName})`),
+      },
       label: _('Til', 'To'),
-      a11yLabel: (to: TariffZoneWithMetadata) =>
-        _(getBasedOnVenueTextNorwegian(to, 'to')),
+      a11yLabel: {
+        noVenue: (zoneName: string) => _(`Valgt ankomstsone er ${zoneName}`),
+        withVenue: (zoneName: string, venueName: string) =>
+          _(
+            `Valgt ankomstsone er ${zoneName} basert på stoppested ${venueName}`,
+          ),
+      },
       a11yHint: _('Aktivér for å søke etter ankomstsone'),
       placeholder: _('Søk etter ankomstsone'),
     },


### PR DESCRIPTION
A commit showing how the logic would be distributed with text in a facade in the texts-files. The main texts in the text-files are still cleanly written, while the text logic is added to the Facade. This is only a PoC of setup where the text-logic is contained somewhere "between" the React component and texts-file.