### PR TITLE
fix: bottom padding in favorite lists

### DIFF
--- a/src/screens/Profile/FavoriteDepartures/index.tsx
+++ b/src/screens/Profile/FavoriteDepartures/index.tsx
@@ -53,7 +53,7 @@ export default function FavoriteDepartures({
   };
 
   return (
-    <SafeAreaView style={style.container}>
+    <SafeAreaView style={style.container} edges={['right', 'top', 'left']}>
       <BackHeader title={t(FavoriteDeparturesTexts.header.title)} />
 
       <ScrollView>
@@ -90,7 +90,6 @@ const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     flexDirection: 'column',
     justifyContent: 'flex-start',
     alignItems: 'stretch',
-    paddingBottom: 0,
   },
   empty: {
     margin: theme.spacings.medium,

--- a/src/screens/Profile/FavoriteList/SortFavorites.tsx
+++ b/src/screens/Profile/FavoriteList/SortFavorites.tsx
@@ -56,7 +56,7 @@ export default function SortableFavoriteList({navigation}: ProfileScreenProps) {
   };
 
   return (
-    <SafeAreaView style={style.container}>
+    <SafeAreaView style={style.container} edges={['right', 'top', 'left']}>
       <BackHeader title="Endre rekkefølge" closeIcon />
 
       {error && (

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -37,7 +37,7 @@ export default function FavoriteList({navigation}: ProfileScreenProps) {
   const onSortClick = () => navigation.push('SortableFavoriteList');
 
   return (
-    <SafeAreaView style={style.container}>
+    <SafeAreaView style={style.container} edges={['right', 'top', 'left']}>
       <BackHeader title={t(FavoriteListTexts.header.title)} />
 
       <ScrollView>
@@ -87,7 +87,6 @@ const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     flexDirection: 'column',
     justifyContent: 'flex-start',
     alignItems: 'stretch',
-    paddingBottom: 0,
   },
   empty: {
     margin: theme.spacings.medium,


### PR DESCRIPTION
There's a bug when showing many favorites where the bottom padding on safe area sets bottom margin when we have bottom tabs. This deactivates bottom edge from safe area to avoid double padding (both in tab bar and content view).