### PR TITLE
fix: QA adjustments on improved voiceover

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -108,6 +108,8 @@ const Button: React.FC<ButtonProps> = ({
         onPress={onPress}
         disabled={disabled}
         accessibilityRole="button"
+        importantForAccessibility={disabled ? 'no-hide-descendants' : 'auto'}
+        accessibilityElementsHidden={!!disabled}
         {...props}
       >
         {Icon && iconPosition === 'left' && (

--- a/src/screens/TripDetails/components/TripSummary.tsx
+++ b/src/screens/TripDetails/components/TripSummary.tsx
@@ -16,6 +16,7 @@ const Summary: React.FC<TripPattern> = ({walkDistance, duration}) => {
   const {t} = useTranslation();
   const time = secondsToDuration(duration);
   const summaryTexts = TripDetailsTexts.trip.summary;
+  const readableDistance = walkDistance.toFixed();
   return (
     <View style={styles.summary}>
       <View style={styles.summaryDetail}>
@@ -34,8 +35,14 @@ const Summary: React.FC<TripPattern> = ({walkDistance, duration}) => {
           style={styles.leftIcon}
           svg={WalkingPerson}
         />
-        <ThemeText color="faded">
-          {t(summaryTexts.walkDistance.label(walkDistance.toFixed()))}
+        <ThemeText
+          color="faded"
+          accessible={true}
+          accessibilityLabel={t(
+            summaryTexts.walkDistance.a11yLabel(readableDistance),
+          )}
+        >
+          {t(summaryTexts.walkDistance.label(readableDistance))}
         </ThemeText>
       </View>
     </View>

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -8,8 +8,8 @@ const TripDetailsTexts = {
   },
   trip: {
     leg: {
-      a11yHelper: (step: number, travelMode: string) =>
-        _(`${step}. steg, ${travelMode}`),
+      a11yHelper: (stepNumber: number, travelMode: string) =>
+        _(`Steg ${stepNumber}, ${travelMode}`),
 
       start: {
         a11yLabel: {
@@ -73,6 +73,8 @@ const TripDetailsTexts = {
       walkDistance: {
         label: (distanceInMetres: string) =>
           _(`Gangavstand: ${distanceInMetres} m`),
+        a11yLabel: (distanceInMetres: string) =>
+          _(`Total gangavstand: ${distanceInMetres} m`),
       },
     },
   },


### PR DESCRIPTION
- Rephrased "Nth step" to "Step n", in hope of more understandable iOS Voiceover reading
- Added "Total" to a11yLabel for total walk distance.
- Make screen readers ignore disabled buttons (discussable, perhaps an "inactive/disabled" a11y description is better?)