### PR TITLE
fix: Use new offers endpoint which allow two zones

### DIFF
--- a/src/api/fareContracts.ts
+++ b/src/api/fareContracts.ts
@@ -21,7 +21,7 @@ export async function search(
   params: OfferSearchParams,
   opts?: AxiosRequestConfig,
 ): Promise<Offer[]> {
-  const url = 'ticket/v1/search';
+  const url = 'ticket/v1/search/zones';
   const response = await client.post<Offer[]>(url, params, opts);
 
   return response.data;


### PR DESCRIPTION
The old search offers endpoint was not working properly when the travel
was through more than one zone.