### PR TITLE
fix: Broken logic on choosing language initial app install

### DIFF
--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -25,21 +25,14 @@ function useLanguage() {
   } = usePreferences();
 
   useEffect(() => {
-    if (!useSystemLanguage) {
-      const newLanguage = getAsAppLanguage(
-        userPreferencedLanguage ?? DEFAULT_LANGUAGE,
-      );
-      setCurrentLanguage(newLanguage);
-    } else {
-      const onChange = () => {
-        setLocale(preferredLocale);
-      };
-      RNLocalize.addEventListener('change', onChange);
-      return () => {
-        RNLocalize.removeEventListener('change', onChange);
-      };
-    }
-  }, [useSystemLanguage, userPreferencedLanguage]);
+    const onChange = () => {
+      setLocale(preferredLocale);
+    };
+    RNLocalize.addEventListener('change', onChange);
+    return () => {
+      RNLocalize.removeEventListener('change', onChange);
+    };
+  }, []);
 
   useEffect(() => {
     if (useSystemLanguage) {
@@ -47,8 +40,13 @@ function useLanguage() {
         ? getAsAppLanguage(locale.languageCode)
         : DEFAULT_LANGUAGE;
       setCurrentLanguage(language);
+    } else {
+      const newLanguage = getAsAppLanguage(
+        userPreferencedLanguage ?? DEFAULT_LANGUAGE,
+      );
+      setCurrentLanguage(newLanguage);
     }
-  }, [locale, useSystemLanguage]);
+  }, [userPreferencedLanguage, useSystemLanguage]);
 
   return currentLanguage;
 }

--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -24,13 +24,11 @@ function useLanguage() {
     preferences: {useSystemLanguage, language: userPreferencedLanguage},
   } = usePreferences();
 
-  // Usage of system setting not explicitly chosen, and user preferenced language has value
-  const shouldUseUserPreferenced =
-    !useSystemLanguage && !!userPreferencedLanguage;
-
   useEffect(() => {
-    if (shouldUseUserPreferenced) {
-      const newLanguage = getAsAppLanguage(userPreferencedLanguage);
+    if (!useSystemLanguage) {
+      const newLanguage = getAsAppLanguage(
+        userPreferencedLanguage ?? DEFAULT_LANGUAGE,
+      );
       setCurrentLanguage(newLanguage);
     } else {
       const onChange = () => {
@@ -44,7 +42,7 @@ function useLanguage() {
   }, [useSystemLanguage, userPreferencedLanguage]);
 
   useEffect(() => {
-    if (!shouldUseUserPreferenced) {
+    if (useSystemLanguage) {
       const language = locale
         ? getAsAppLanguage(locale.languageCode)
         : DEFAULT_LANGUAGE;


### PR DESCRIPTION
Fixed broken langugage logic on initial app install, choosing locale based language instead of default preference selected language.

closes #843 