### PR TITLE
fix: Default use system language

### DIFF
--- a/src/screens/Profile/Language/index.tsx
+++ b/src/screens/Profile/Language/index.tsx
@@ -15,7 +15,7 @@ const identity = (s: string) => s;
 export default function Language() {
   const {
     setPreference,
-    preferences: {useSystemLanguage, language},
+    preferences: {useSystemLanguage = true, language},
   } = usePreferences();
 
   const style = useStyle();

--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -21,7 +21,7 @@ function useLanguage() {
   const [currentLanguage, setCurrentLanguage] = useState(DEFAULT_LANGUAGE);
   const [locale, setLocale] = useState(preferredLocale);
   const {
-    preferences: {useSystemLanguage, language: userPreferencedLanguage},
+    preferences: {useSystemLanguage = true, language: userPreferencedLanguage},
   } = usePreferences();
 
   useEffect(() => {

--- a/src/translations/commons.ts
+++ b/src/translations/commons.ts
@@ -8,7 +8,7 @@ export enum Language {
 }
 export const appLanguages = ['nb', 'en'] as const;
 
-export const DEFAULT_LANGUAGE = Language.Norwegian;
+export const DEFAULT_LANGUAGE = Language.English;
 export type TranslatedString = Translatable<typeof Language, string>;
 
 export const lobot = initLobot<typeof Language>(DEFAULT_LANGUAGE);


### PR DESCRIPTION
In cases where the user is onboarded to the app for the first time, it makes more sense to choose language based on system preference than having Norwegian set as default.

This is still not a perfect solution:
- System preferred language isn't always the preferred app language. 
- We only support Norwegian and English. All other system languages will be ignored, and default app language chosen. One might think that a foreigner could be more familiar with Norwegian than English

User is still able to able override language in app settings.