### PR TITLE
feat: workflow: update reference data & remote config

### DIFF
--- a/.github/workflows/publish_remote_config.yml
+++ b/.github/workflows/publish_remote_config.yml
@@ -1,0 +1,30 @@
+name: Publish remote config
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - name: Publish remote config
+        env:
+          SERVICE_ACCOUNT_KEY: ${{secrets.SERVICE_ACCOUNT_KEY}}
+          PROJECT_ID: atb-mobility-platform
+        run: |
+          set -euo pipefail
+          go get github.com/atb-as/remoteconfig/cmd/rc
+          ARGS=()
+          for FILE in src/reference-data/*.json
+          do
+            CONFIG_KEY=$(basename ${FILE} .json | sed 's/-/_/g')
+            JSON=$(jq -c < ${FILE} .)
+            ARGS+=("${CONFIG_KEY}"="${JSON}")
+          done
+          $HOME/go/bin/rc -project=$PROJECT_ID "${ARGS[@]}"

--- a/.github/workflows/update_reference_data.yml
+++ b/.github/workflows/update_reference_data.yml
@@ -1,0 +1,33 @@
+name: Update reference data
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+ 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.4
+      - name: Fetch latest reference data
+        run: |
+          set -exo pipefail
+          ENTITIES=('preassigned-fare-products' 'tariff-zones' 'user-profiles')
+          for e in ${ENTITIES[@]}
+          do
+            curl --silent --fail https://remoteconfig.dev.mittatb.no/v1/${e} | \
+            npx prettier --format json > src/reference-data/${e}.json
+          done
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: 'chore: update reference data'
+          committer: 'AtB Automation'
+          branch: automation/update-reference-data
+          delete-branch: true
+          title: 'chore: update reference data'
+          body: Please review 
+            

--- a/.github/workflows/update_reference_data.yml
+++ b/.github/workflows/update_reference_data.yml
@@ -25,7 +25,6 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: 'chore: update reference data'
-          committer: 'AtB Automation'
           branch: automation/update-reference-data
           delete-branch: true
           title: 'chore: update reference data'


### PR DESCRIPTION
Syncs src/reference-data/*.json every hour and opens a PR if there are any diffs.

On push: uses an external tool: github.com/atb-as/remoteconfig/cmd/rc that lets you publish key=value pairs as default values in remote config. Need to revisit later when we need to differentiate on environments.