### PR TITLE
feat: Show ref data names in correct langauge

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -50,36 +50,3 @@ export const getAxiosErrorMetadata = (error: AxiosError): ErrorMetadata => ({
 });
 
 export const stringifyUrl = (url: string, query: string) => `${url}?${query}`;
-
-/**
- * Get the text of a field in a NeTeX entity in the correct language. If English
- * is requested, it will fallback to Norwegian if no English text is found. If
- * neither English nor Norwegian is found the first text in the provided texts
- * array is returned.
- */
-export const getTextInLanguage = (
-  texts: LanguageAndText[],
-  language: Language,
-) => {
-  if (language === Language.English) {
-    const englishText = texts.find((t) => t.lang === 'eng');
-    if (englishText) return englishText.value;
-  }
-  const norwegianText = texts.find((t) => t.lang === 'nor' || t.lang === 'nob');
-  if (norwegianText) return norwegianText.value;
-
-  return texts[0].value;
-};
-
-/**
- * Wrapper for getting the name of a NeTeX entity in the given language.
- */
-export const getNameInLanguage = <
-  T extends {
-    name: LanguageAndText;
-    alternativeNames?: LanguageAndText[];
-  }
->(
-  {name, alternativeNames}: T,
-  language: Language,
-) => getTextInLanguage([name, ...(alternativeNames || [])], language);

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,7 +1,5 @@
 import axios, {AxiosError} from 'axios';
 import {RequestIdHeaderName} from './headers';
-import {LanguageAndText} from '../reference-data/types';
-import {Language} from '../translations';
 
 export type ErrorType =
   | 'unknown'

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,5 +1,7 @@
 import axios, {AxiosError} from 'axios';
 import {RequestIdHeaderName} from './headers';
+import {LanguageAndText} from '../reference-data/types';
+import {Language} from '../translations';
 
 export type ErrorType =
   | 'unknown'
@@ -48,3 +50,36 @@ export const getAxiosErrorMetadata = (error: AxiosError): ErrorMetadata => ({
 });
 
 export const stringifyUrl = (url: string, query: string) => `${url}?${query}`;
+
+/**
+ * Get the text of a field in a NeTeX entity in the correct language. If English
+ * is requested, it will fallback to Norwegian if no English text is found. If
+ * neither English nor Norwegian is found the first text in the provided texts
+ * array is returned.
+ */
+export const getTextInLanguage = (
+  texts: LanguageAndText[],
+  language: Language,
+) => {
+  if (language === Language.English) {
+    const englishText = texts.find((t) => t.lang === 'eng');
+    if (englishText) return englishText.value;
+  }
+  const norwegianText = texts.find((t) => t.lang === 'nor' || t.lang === 'nob');
+  if (norwegianText) return norwegianText.value;
+
+  return texts[0].value;
+};
+
+/**
+ * Wrapper for getting the name of a NeTeX entity in the given language.
+ */
+export const getNameInLanguage = <
+  T extends {
+    name: LanguageAndText;
+    alternativeNames?: LanguageAndText[];
+  }
+>(
+  {name, alternativeNames}: T,
+  language: Language,
+) => getTextInLanguage([name, ...(alternativeNames || [])], language);

--- a/src/reference-data/utils.ts
+++ b/src/reference-data/utils.ts
@@ -1,0 +1,32 @@
+import {LanguageAndText} from './types';
+import {Language} from '../translations';
+
+/**
+ * Get the text of a field in a NeTeX entity in the correct language. If English
+ * is requested, it will fallback to Norwegian if no English text is found. If
+ * neither English nor Norwegian is found the first text in the provided texts
+ * array is returned.
+ */
+const getReferenceDataText = (texts: LanguageAndText[], language: Language) => {
+  if (language === Language.English) {
+    const englishText = texts.find((t) => t.lang === 'eng');
+    if (englishText) return englishText.value;
+  }
+  const norwegianText = texts.find((t) => t.lang === 'nor' || t.lang === 'nob');
+  if (norwegianText) return norwegianText.value;
+
+  return texts[0].value;
+};
+
+/**
+ * Wrapper for getting the name of a NeTeX entity in the given language.
+ */
+export const getReferenceDataName = <
+  T extends {
+    name: LanguageAndText;
+    alternativeNames?: LanguageAndText[];
+  }
+>(
+  {name, alternativeNames}: T,
+  language: Language,
+) => getReferenceDataText([name, ...(alternativeNames || [])], language);

--- a/src/reference-data/utils.ts
+++ b/src/reference-data/utils.ts
@@ -15,7 +15,7 @@ const getReferenceDataText = (texts: LanguageAndText[], language: Language) => {
   const norwegianText = texts.find((t) => t.lang === 'nor' || t.lang === 'nob');
   if (norwegianText) return norwegianText.value;
 
-  return texts[0].value;
+  return texts[0]?.value;
 };
 
 /**

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -19,8 +19,9 @@ import {
 import * as Sections from '../../../../components/sections';
 import {ReserveOffer} from '../../../../api/fareContracts';
 import {useRemoteConfig} from '../../../../RemoteConfigContext';
+import {getNameInLanguage} from '../../../../api/utils';
 
-export type TravellersProps = {
+export type ConfirmationProps = {
   navigation: DismissableStackNavigationProp<
     TicketingStackParams,
     'Confirmation'
@@ -28,13 +29,13 @@ export type TravellersProps = {
   route: RouteProp<TicketingStackParams, 'Confirmation'>;
 };
 
-const Confirmation: React.FC<TravellersProps> = ({
+const Confirmation: React.FC<ConfirmationProps> = ({
   navigation,
   route: {params},
 }) => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const {enable_creditcard: enableCreditCard} = useRemoteConfig();
 
@@ -100,7 +101,7 @@ const Confirmation: React.FC<TravellersProps> = ({
   return (
     <View style={[styles.container, {paddingTop: safeAreaTop}]}>
       <Header
-        title={params.preassignedFareProduct.name.value}
+        title={getNameInLanguage(preassignedFareProduct, language)}
         leftButton={{
           icon: (
             <ThemeText>
@@ -137,7 +138,7 @@ const Confirmation: React.FC<TravellersProps> = ({
                     ]}
                   >
                     <ThemeText>
-                      {u.count} {u.name.value}
+                      {u.count} {getNameInLanguage(u, language)}
                     </ThemeText>
                     <ThemeText>
                       {u.count * (u.offer.prices[0].amount_float || 0)},-
@@ -147,7 +148,9 @@ const Confirmation: React.FC<TravellersProps> = ({
               </Sections.GenericItem>
               <Sections.GenericItem>
                 <View>
-                  <ThemeText>{preassignedFareProduct.name.value}</ThemeText>
+                  <ThemeText>
+                    {getNameInLanguage(preassignedFareProduct, language)}
+                  </ThemeText>
                   <ThemeText
                     style={styles.smallTopMargin}
                     type="lead"
@@ -156,13 +159,13 @@ const Confirmation: React.FC<TravellersProps> = ({
                     {fromTariffZone.id === toTariffZone.id
                       ? t(
                           PurchaseConfirmationTexts.validityTexts.zone.single(
-                            fromTariffZone.name.value,
+                            getNameInLanguage(fromTariffZone, language),
                           ),
                         )
                       : t(
                           PurchaseConfirmationTexts.validityTexts.zone.multiple(
-                            fromTariffZone.name.value,
-                            toTariffZone.name.value,
+                            getNameInLanguage(fromTariffZone, language),
+                            getNameInLanguage(toTariffZone, language),
                           ),
                         )}
                   </ThemeText>

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -19,7 +19,7 @@ import {
 import * as Sections from '../../../../components/sections';
 import {ReserveOffer} from '../../../../api/fareContracts';
 import {useRemoteConfig} from '../../../../RemoteConfigContext';
-import {getNameInLanguage} from '../../../../api/utils';
+import {getReferenceDataName} from '../../../../reference-data/utils';
 
 export type ConfirmationProps = {
   navigation: DismissableStackNavigationProp<
@@ -101,7 +101,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
   return (
     <View style={[styles.container, {paddingTop: safeAreaTop}]}>
       <Header
-        title={getNameInLanguage(preassignedFareProduct, language)}
+        title={getReferenceDataName(preassignedFareProduct, language)}
         leftButton={{
           icon: (
             <ThemeText>
@@ -138,7 +138,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                     ]}
                   >
                     <ThemeText>
-                      {u.count} {getNameInLanguage(u, language)}
+                      {u.count} {getReferenceDataName(u, language)}
                     </ThemeText>
                     <ThemeText>
                       {u.count * (u.offer.prices[0].amount_float || 0)},-
@@ -149,7 +149,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
               <Sections.GenericItem>
                 <View>
                   <ThemeText>
-                    {getNameInLanguage(preassignedFareProduct, language)}
+                    {getReferenceDataName(preassignedFareProduct, language)}
                   </ThemeText>
                   <ThemeText
                     style={styles.smallTopMargin}
@@ -159,13 +159,13 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                     {fromTariffZone.id === toTariffZone.id
                       ? t(
                           PurchaseConfirmationTexts.validityTexts.zone.single(
-                            getNameInLanguage(fromTariffZone, language),
+                            getReferenceDataName(fromTariffZone, language),
                           ),
                         )
                       : t(
                           PurchaseConfirmationTexts.validityTexts.zone.multiple(
-                            getNameInLanguage(fromTariffZone, language),
-                            getNameInLanguage(toTariffZone, language),
+                            getReferenceDataName(fromTariffZone, language),
+                            getReferenceDataName(toTariffZone, language),
                           ),
                         )}
                   </ThemeText>

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../../../translations';
 import {useRemoteConfig} from '../../../../RemoteConfigContext';
 import {UserProfileWithCount} from '../Travellers/use-user-count-state';
-import {getNameInLanguage} from '../../../../api/utils';
+import {getReferenceDataName} from '../../../../reference-data/utils';
 
 export type OverviewProps = {
   navigation: DismissableStackNavigationProp<
@@ -113,7 +113,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
 
         <Sections.Section>
           <Sections.LinkItem
-            text={getNameInLanguage(preassignedFareProduct, language)}
+            text={getReferenceDataName(preassignedFareProduct, language)}
             onPress={() => {}}
             disabled={true}
             icon={<ThemeIcon svg={Edit} />}
@@ -186,7 +186,7 @@ const createTravellersText = (
     return t(PurchaseOverviewTexts.travellers.travellersCount(totalCount));
   } else {
     return chosenUserProfiles
-      .map((u) => `${u.count} ${getNameInLanguage(u, language)}`)
+      .map((u) => `${u.count} ${getReferenceDataName(u, language)}`)
       .join(', ');
   }
 };

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -14,14 +14,16 @@ import MessageBox from '../../../../message-box';
 import * as Sections from '../../../../components/sections';
 import {tariffZonesSummary, TariffZoneWithMetadata} from '../TariffZones';
 import {
+  Language,
   PurchaseOverviewTexts,
   TranslateFunction,
   useTranslation,
 } from '../../../../translations';
 import {useRemoteConfig} from '../../../../RemoteConfigContext';
 import {UserProfileWithCount} from '../Travellers/use-user-count-state';
+import {getNameInLanguage} from '../../../../api/utils';
 
-export type TravellersProps = {
+export type OverviewProps = {
   navigation: DismissableStackNavigationProp<
     TicketingStackParams,
     'PurchaseOverview'
@@ -29,12 +31,12 @@ export type TravellersProps = {
   route: RouteProp<TicketingStackParams, 'PurchaseOverview'>;
 };
 
-const PurchaseOverview: React.FC<TravellersProps> = ({
+const PurchaseOverview: React.FC<OverviewProps> = ({
   navigation,
   route: {params},
 }) => {
   const styles = useStyles();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const {
     tariff_zones: tariffZones,
@@ -111,13 +113,13 @@ const PurchaseOverview: React.FC<TravellersProps> = ({
 
         <Sections.Section>
           <Sections.LinkItem
-            text={preassignedFareProduct.name.value}
+            text={getNameInLanguage(preassignedFareProduct, language)}
             onPress={() => {}}
             disabled={true}
             icon={<ThemeIcon svg={Edit} />}
           />
           <Sections.LinkItem
-            text={createTravellersText(userProfilesWithCount, t)}
+            text={createTravellersText(userProfilesWithCount, t, language)}
             onPress={() => {
               navigation.push('Travellers', {
                 userProfilesWithCount,
@@ -135,7 +137,7 @@ const PurchaseOverview: React.FC<TravellersProps> = ({
             icon={<ThemeIcon svg={Edit} />}
           />
           <Sections.LinkItem
-            text={t(tariffZonesSummary(fromTariffZone, toTariffZone))}
+            text={t(tariffZonesSummary(fromTariffZone, toTariffZone, language))}
             onPress={() => {
               navigation.push('TariffZones', {
                 fromTariffZone,
@@ -173,6 +175,7 @@ const PurchaseOverview: React.FC<TravellersProps> = ({
 const createTravellersText = (
   userProfilesWithCount: UserProfileWithCount[],
   t: TranslateFunction,
+  language: Language,
 ) => {
   const chosenUserProfiles = userProfilesWithCount.filter((u) => u.count);
   if (chosenUserProfiles.length > 2) {
@@ -183,7 +186,7 @@ const createTravellersText = (
     return t(PurchaseOverviewTexts.travellers.travellersCount(totalCount));
   } else {
     return chosenUserProfiles
-      .map((u) => `${u.count} ${u.name.value}`)
+      .map((u) => `${u.count} ${getNameInLanguage(u, language)}`)
       .join(', ');
   }
 };

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -20,7 +20,7 @@ import {ArrowLeft} from '../../../../assets/svg/icons/navigation';
 import Button from '../../../../components/button';
 import {Confirm} from '../../../../assets/svg/icons/actions';
 import {TariffZone} from '../../../../reference-data/types';
-import {getNameInLanguage} from '../../../../api/utils';
+import {getReferenceDataName} from '../../../../reference-data/utils';
 
 type TariffZonesRouteName = 'TariffZones';
 const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
@@ -57,12 +57,12 @@ export const tariffZonesSummary = (
 ) => {
   if (fromTariffZone.id === toTariffZone.id) {
     return TariffZonesTexts.zoneSummary.text.singleZone(
-      getNameInLanguage(fromTariffZone, language),
+      getReferenceDataName(fromTariffZone, language),
     );
   } else {
     return TariffZonesTexts.zoneSummary.text.multipleZone(
-      getNameInLanguage(fromTariffZone, language),
-      getNameInLanguage(toTariffZone, language),
+      getReferenceDataName(fromTariffZone, language),
+      getReferenceDataName(toTariffZone, language),
     );
   }
 };
@@ -73,12 +73,12 @@ const departurePickerAccessibilityLabel = (
 ) => {
   if (fromTariffZone.venueName)
     return TariffZonesTexts.location.departurePicker.a11yLabel.withVenue(
-      getNameInLanguage(fromTariffZone, language),
+      getReferenceDataName(fromTariffZone, language),
       fromTariffZone.venueName,
     );
   else {
     return TariffZonesTexts.location.departurePicker.a11yLabel.noVenue(
-      getNameInLanguage(fromTariffZone, language),
+      getReferenceDataName(fromTariffZone, language),
     );
   }
 };
@@ -89,12 +89,12 @@ const destinationPickerAccessibilityLabel = (
 ) => {
   if (toTariffZone.venueName)
     return TariffZonesTexts.location.destinationPicker.a11yLabel.withVenue(
-      getNameInLanguage(toTariffZone, language),
+      getReferenceDataName(toTariffZone, language),
       toTariffZone.venueName,
     );
   else {
     return TariffZonesTexts.location.destinationPicker.a11yLabel.noVenue(
-      getNameInLanguage(toTariffZone, language),
+      getReferenceDataName(toTariffZone, language),
     );
   }
 };
@@ -105,12 +105,12 @@ const departurePickerValue = (
 ) => {
   if (fromTariffZone.venueName)
     return TariffZonesTexts.location.departurePicker.value.withVenue(
-      getNameInLanguage(fromTariffZone, language),
+      getReferenceDataName(fromTariffZone, language),
       fromTariffZone.venueName,
     );
   else {
     return TariffZonesTexts.location.departurePicker.value.noVenue(
-      getNameInLanguage(fromTariffZone, language),
+      getReferenceDataName(fromTariffZone, language),
     );
   }
 };
@@ -128,12 +128,12 @@ const destinationPickerValue = (
     return TariffZonesTexts.location.destinationPicker.value.noVenueSameZone;
   } else if (toTariffZone.venueName) {
     return TariffZonesTexts.location.departurePicker.value.withVenue(
-      getNameInLanguage(toTariffZone, language),
+      getReferenceDataName(toTariffZone, language),
       toTariffZone.venueName,
     );
   } else {
     return TariffZonesTexts.location.departurePicker.value.noVenue(
-      getNameInLanguage(toTariffZone, language),
+      getReferenceDataName(toTariffZone, language),
     );
   }
 };

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -9,13 +9,18 @@ import {ButtonInput, Section} from '../../../../components/sections';
 import AccessibleText, {
   screenReaderPause,
 } from '../../../../components/accessible-text';
-import {TariffZonesTexts, useTranslation} from '../../../../translations';
+import {
+  Language,
+  TariffZonesTexts,
+  useTranslation,
+} from '../../../../translations';
 import {View} from 'react-native';
 import ThemeIcon from '../../../../components/theme-icon';
 import {ArrowLeft} from '../../../../assets/svg/icons/navigation';
 import Button from '../../../../components/button';
 import {Confirm} from '../../../../assets/svg/icons/actions';
 import {TariffZone} from '../../../../reference-data/types';
+import {getNameInLanguage} from '../../../../api/utils';
 
 type TariffZonesRouteName = 'TariffZones';
 const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
@@ -48,58 +53,64 @@ type Props = {
 export const tariffZonesSummary = (
   fromTariffZone: TariffZoneWithMetadata,
   toTariffZone: TariffZoneWithMetadata,
+  language: Language,
 ) => {
   if (fromTariffZone.id === toTariffZone.id) {
     return TariffZonesTexts.zoneSummary.text.singleZone(
-      fromTariffZone.name.value,
+      getNameInLanguage(fromTariffZone, language),
     );
   } else {
     return TariffZonesTexts.zoneSummary.text.multipleZone(
-      fromTariffZone.name.value,
-      toTariffZone.name.value,
+      getNameInLanguage(fromTariffZone, language),
+      getNameInLanguage(toTariffZone, language),
     );
   }
 };
 
 const departurePickerAccessibilityLabel = (
   fromTariffZone: TariffZoneWithMetadata,
+  language: Language,
 ) => {
   if (fromTariffZone.venueName)
     return TariffZonesTexts.location.departurePicker.a11yLabel.withVenue(
-      fromTariffZone.name.value,
+      getNameInLanguage(fromTariffZone, language),
       fromTariffZone.venueName,
     );
   else {
     return TariffZonesTexts.location.departurePicker.a11yLabel.noVenue(
-      fromTariffZone.name.value,
+      getNameInLanguage(fromTariffZone, language),
     );
   }
 };
 
 const destinationPickerAccessibilityLabel = (
   toTariffZone: TariffZoneWithMetadata,
+  language: Language,
 ) => {
   if (toTariffZone.venueName)
     return TariffZonesTexts.location.destinationPicker.a11yLabel.withVenue(
-      toTariffZone.name.value,
+      getNameInLanguage(toTariffZone, language),
       toTariffZone.venueName,
     );
   else {
     return TariffZonesTexts.location.destinationPicker.a11yLabel.noVenue(
-      toTariffZone.name.value,
+      getNameInLanguage(toTariffZone, language),
     );
   }
 };
 
-const departurePickerValue = (fromTariffZone: TariffZoneWithMetadata) => {
+const departurePickerValue = (
+  fromTariffZone: TariffZoneWithMetadata,
+  language: Language,
+) => {
   if (fromTariffZone.venueName)
     return TariffZonesTexts.location.departurePicker.value.withVenue(
-      fromTariffZone.name.value,
+      getNameInLanguage(fromTariffZone, language),
       fromTariffZone.venueName,
     );
   else {
     return TariffZonesTexts.location.departurePicker.value.noVenue(
-      fromTariffZone.name.value,
+      getNameInLanguage(fromTariffZone, language),
     );
   }
 };
@@ -107,6 +118,7 @@ const departurePickerValue = (fromTariffZone: TariffZoneWithMetadata) => {
 const destinationPickerValue = (
   fromTariffZone: TariffZoneWithMetadata,
   toTariffZone: TariffZoneWithMetadata,
+  language: Language,
 ) => {
   if (fromTariffZone.id === toTariffZone.id && toTariffZone.venueName) {
     return TariffZonesTexts.location.destinationPicker.value.withVenueSameZone(
@@ -116,12 +128,12 @@ const destinationPickerValue = (
     return TariffZonesTexts.location.destinationPicker.value.noVenueSameZone;
   } else if (toTariffZone.venueName) {
     return TariffZonesTexts.location.departurePicker.value.withVenue(
-      toTariffZone.name.value,
+      getNameInLanguage(toTariffZone, language),
       toTariffZone.venueName,
     );
   } else {
     return TariffZonesTexts.location.departurePicker.value.noVenue(
-      toTariffZone.name.value,
+      getNameInLanguage(toTariffZone, language),
     );
   }
 };
@@ -130,7 +142,7 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
   const styles = useStyles();
   const {theme} = useTheme();
 
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const {fromTariffZone, toTariffZone} = route.params;
 
@@ -168,14 +180,14 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
         <Section withPadding>
           <ButtonInput
             accessibilityLabel={
-              t(departurePickerAccessibilityLabel(fromTariffZone)) +
+              t(departurePickerAccessibilityLabel(fromTariffZone, language)) +
               screenReaderPause
             }
             accessibilityHint={t(
               TariffZonesTexts.location.departurePicker.a11yHint,
             )}
             accessibilityRole="button"
-            value={t(departurePickerValue(fromTariffZone))}
+            value={t(departurePickerValue(fromTariffZone, language))}
             label={t(TariffZonesTexts.location.departurePicker.label)}
             placeholder={t(TariffZonesTexts.location.departurePicker.label)}
             onPress={() =>
@@ -185,14 +197,16 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
 
           <ButtonInput
             accessibilityLabel={
-              t(destinationPickerAccessibilityLabel(toTariffZone)) +
+              t(destinationPickerAccessibilityLabel(toTariffZone, language)) +
               screenReaderPause
             }
             accessibilityHint={t(
               TariffZonesTexts.location.destinationPicker.a11yHint,
             )}
             accessibilityRole="button"
-            value={t(destinationPickerValue(fromTariffZone, toTariffZone))}
+            value={t(
+              destinationPickerValue(fromTariffZone, toTariffZone, language),
+            )}
             label={t(TariffZonesTexts.location.destinationPicker.label)}
             placeholder={t(TariffZonesTexts.location.destinationPicker.label)}
             onPress={() =>
@@ -205,7 +219,7 @@ const TariffZones: React.FC<Props> = ({navigation, route}) => {
           style={styles.tariffZoneText}
           prefix={t(TariffZonesTexts.zoneSummary.a11yLabelPrefix)}
         >
-          {t(tariffZonesSummary(fromTariffZone, toTariffZone))}
+          {t(tariffZonesSummary(fromTariffZone, toTariffZone, language))}
         </AccessibleText>
       </View>
       <View

--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -13,7 +13,7 @@ import {TravellersTexts, useTranslation} from '../../../../translations';
 import Button from '../../../../components/button';
 import ThemeIcon from '../../../../components/theme-icon';
 import {ArrowLeft} from '../../../../assets/svg/icons/navigation';
-import {getNameInLanguage} from '../../../../api/utils';
+import {getReferenceDataName} from '../../../../reference-data/utils';
 
 export type TravellersProps = {
   navigation: DismissableStackNavigationProp<
@@ -55,7 +55,7 @@ const Travellers: React.FC<TravellersProps> = ({
           {userProfilesWithCount.map((u) => (
             <Sections.CounterInput
               key={u.userTypeString}
-              text={getNameInLanguage(u, language)}
+              text={getReferenceDataName(u, language)}
               count={u.count}
               addCount={() => addCount(u.userTypeString)}
               removeCount={() => removeCount(u.userTypeString)}

--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -13,6 +13,7 @@ import {TravellersTexts, useTranslation} from '../../../../translations';
 import Button from '../../../../components/button';
 import ThemeIcon from '../../../../components/theme-icon';
 import {ArrowLeft} from '../../../../assets/svg/icons/navigation';
+import {getNameInLanguage} from '../../../../api/utils';
 
 export type TravellersProps = {
   navigation: DismissableStackNavigationProp<
@@ -28,7 +29,7 @@ const Travellers: React.FC<TravellersProps> = ({
 }) => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const {userProfilesWithCount, addCount, removeCount} = useUserCountState(
     params.userProfilesWithCount,
@@ -54,7 +55,7 @@ const Travellers: React.FC<TravellersProps> = ({
           {userProfilesWithCount.map((u) => (
             <Sections.CounterInput
               key={u.userTypeString}
-              text={t(TravellersTexts.travellerCounter.text(u))}
+              text={getNameInLanguage(u, language)}
               count={u.count}
               addCount={() => addCount(u.userTypeString)}
               removeCount={() => removeCount(u.userTypeString)}

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {View} from 'react-native';
 import {useRemoteConfig} from '../../../RemoteConfigContext';
 import {UserProfile} from '../../../reference-data/types';
-import {getNameInLanguage} from '../../../api/utils';
+import {getReferenceDataName} from '../../../reference-data/utils';
 
 const TicketInfo = ({fareContract: fc}: {fareContract: FareContract}) => {
   const {t, language} = useTranslation();
@@ -38,7 +38,7 @@ const TicketInfo = ({fareContract: fc}: {fareContract: FareContract}) => {
       </View>
       {preassignedFareProduct && (
         <ThemeText style={{paddingTop: 4}} type="lead" color="faded">
-          {getNameInLanguage(preassignedFareProduct, language)}
+          {getReferenceDataName(preassignedFareProduct, language)}
         </ThemeText>
       )}
       {fromTariffZone && toTariffZone && (
@@ -46,13 +46,13 @@ const TicketInfo = ({fareContract: fc}: {fareContract: FareContract}) => {
           {fromTariffZone.id === toTariffZone.id
             ? t(
                 TicketTexts.zone.single(
-                  getNameInLanguage(fromTariffZone, language),
+                  getReferenceDataName(fromTariffZone, language),
                 ),
               )
             : t(
                 TicketTexts.zone.multiple(
-                  getNameInLanguage(fromTariffZone, language),
-                  getNameInLanguage(toTariffZone, language),
+                  getReferenceDataName(fromTariffZone, language),
+                  getReferenceDataName(toTariffZone, language),
                 ),
               )}
         </ThemeText>
@@ -94,7 +94,7 @@ const groupByUserProfileNames = (
     .map((idAndCount) => {
       const userProfile = findById(userProfiles, idAndCount.userProfileId);
       const name = userProfile
-        ? getNameInLanguage(userProfile, language)
+        ? getReferenceDataName(userProfile, language)
         : undefined;
       return {
         name,

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -1,13 +1,14 @@
 import {FareContract, FareContractTraveller} from '../../../api/fareContracts';
 import ThemeText from '../../../components/text';
-import {TicketTexts, useTranslation} from '../../../translations';
+import {Language, TicketTexts, useTranslation} from '../../../translations';
 import React from 'react';
 import {View} from 'react-native';
 import {useRemoteConfig} from '../../../RemoteConfigContext';
 import {UserProfile} from '../../../reference-data/types';
+import {getNameInLanguage} from '../../../api/utils';
 
 const TicketInfo = ({fareContract: fc}: {fareContract: FareContract}) => {
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const {
     tariff_zones: tariffZones,
     preassigned_fare_products: preassignedFareProducts,
@@ -22,7 +23,11 @@ const TicketInfo = ({fareContract: fc}: {fareContract: FareContract}) => {
   const fromTariffZone = findById(tariffZones, firstZone);
   const toTariffZone = findById(tariffZones, lastZone);
 
-  const namesAndCounts = groupByUserProfileNames(fc.travellers, userProfiles);
+  const namesAndCounts = groupByUserProfileNames(
+    fc.travellers,
+    userProfiles,
+    language,
+  );
 
   return (
     <View>
@@ -33,17 +38,21 @@ const TicketInfo = ({fareContract: fc}: {fareContract: FareContract}) => {
       </View>
       {preassignedFareProduct && (
         <ThemeText style={{paddingTop: 4}} type="lead" color="faded">
-          {preassignedFareProduct?.name.value}
+          {getNameInLanguage(preassignedFareProduct, language)}
         </ThemeText>
       )}
       {fromTariffZone && toTariffZone && (
         <ThemeText type="lead" color="faded">
           {fromTariffZone.id === toTariffZone.id
-            ? t(TicketTexts.zone.single(fromTariffZone.name.value))
+            ? t(
+                TicketTexts.zone.single(
+                  getNameInLanguage(fromTariffZone, language),
+                ),
+              )
             : t(
                 TicketTexts.zone.multiple(
-                  fromTariffZone.name.value,
-                  toTariffZone.name.value,
+                  getNameInLanguage(fromTariffZone, language),
+                  getNameInLanguage(toTariffZone, language),
                 ),
               )}
         </ThemeText>
@@ -69,6 +78,7 @@ type NameAndCount = {name: string; count: number};
 const groupByUserProfileNames = (
   travellers: FareContractTraveller[],
   userProfiles: UserProfile[],
+  language: Language,
 ): NameAndCount[] =>
   travellers
     .reduce((groupedById, t) => {
@@ -81,10 +91,16 @@ const groupByUserProfileNames = (
       }
       return [...groupedById, {userProfileId: t.user_profile_ref, count: 1}];
     }, [] as {userProfileId: string; count: number}[])
-    .map((idAndCount) => ({
-      name: findById(userProfiles, idAndCount.userProfileId)?.name.value,
-      count: idAndCount.count,
-    }))
+    .map((idAndCount) => {
+      const userProfile = findById(userProfiles, idAndCount.userProfileId);
+      const name = userProfile
+        ? getNameInLanguage(userProfile, language)
+        : undefined;
+      return {
+        name,
+        count: idAndCount.count,
+      };
+    })
     .filter(
       (nameAndCount): nameAndCount is NameAndCount => nameAndCount.name != null,
     );

--- a/src/screens/Ticketing/Tickets/TicketOptions.tsx
+++ b/src/screens/Ticketing/Tickets/TicketOptions.tsx
@@ -4,6 +4,8 @@ import {StyleSheet} from '../../../theme';
 import Button from '../../../components/button';
 import {TicketingScreenNavigationProp} from './Tabs';
 import {PreassignedFareProduct} from '../../../reference-data/types';
+import {getNameInLanguage} from '../../../api/utils';
+import {useTranslation} from '../../../translations';
 
 type Props = {
   preassignedFareProducts: PreassignedFareProduct[];
@@ -15,11 +17,12 @@ const TicketOptions: React.FC<Props> = ({
   navigation,
 }) => {
   const styles = useStyles();
+  const {language} = useTranslation();
   const buttons = preassignedFareProducts.map((preassignedFareProduct) => (
     <View key={preassignedFareProduct.id} style={styles.buttonContainer}>
       <Button
         mode="primary"
-        text={preassignedFareProduct.name.value}
+        text={getNameInLanguage(preassignedFareProduct, language)}
         onPress={() =>
           navigation.navigate('TicketPurchase', {preassignedFareProduct})
         }

--- a/src/screens/Ticketing/Tickets/TicketOptions.tsx
+++ b/src/screens/Ticketing/Tickets/TicketOptions.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from '../../../theme';
 import Button from '../../../components/button';
 import {TicketingScreenNavigationProp} from './Tabs';
 import {PreassignedFareProduct} from '../../../reference-data/types';
-import {getNameInLanguage} from '../../../api/utils';
+import {getReferenceDataName} from '../../../reference-data/utils';
 import {useTranslation} from '../../../translations';
 
 type Props = {
@@ -22,7 +22,7 @@ const TicketOptions: React.FC<Props> = ({
     <View key={preassignedFareProduct.id} style={styles.buttonContainer}>
       <Button
         mode="primary"
-        text={getNameInLanguage(preassignedFareProduct, language)}
+        text={getReferenceDataName(preassignedFareProduct, language)}
         onPress={() =>
           navigation.navigate('TicketPurchase', {preassignedFareProduct})
         }

--- a/src/tariff-zone-search/TariffZoneMapSelection.tsx
+++ b/src/tariff-zone-search/TariffZoneMapSelection.tsx
@@ -31,7 +31,7 @@ import {TRONDHEIM_CENTRAL_STATION} from '../api/geocoder';
 import colors from '../theme/colors';
 import {useGeolocationState} from '../GeolocationContext';
 import {Coordinates} from '@entur/sdk';
-import {getNameInLanguage} from '../api/utils';
+import {getReferenceDataName} from '../reference-data/utils';
 
 export type RouteParams = {
   callerRouteName: string;
@@ -170,7 +170,7 @@ const TariffZoneMapSelection: React.FC<Props> = ({
               highlightedTariffZone
                 ? t(
                     TariffZoneMapSelectionTexts.button.label.selected(
-                      getNameInLanguage(highlightedTariffZone, language),
+                      getReferenceDataName(highlightedTariffZone, language),
                     ),
                   )
                 : t(TariffZoneMapSelectionTexts.button.label.noneSelected)
@@ -260,7 +260,7 @@ const mapZonesToFeatureCollection = (
     type: 'Feature',
     id: t.id,
     properties: {
-      name: getNameInLanguage(t, language),
+      name: getReferenceDataName(t, language),
     },
     geometry: t.geometry,
   })),

--- a/src/tariff-zone-search/TariffZoneMapSelection.tsx
+++ b/src/tariff-zone-search/TariffZoneMapSelection.tsx
@@ -16,9 +16,8 @@ import ThemeIcon from '../components/theme-icon';
 import FullScreenHeader from '../ScreenHeader/full-header';
 import {StyleSheet} from '../theme';
 import {
-  LocationSearchTexts,
+  Language,
   TariffZoneMapSelectionTexts,
-  TariffZonesTexts,
   useTranslation,
 } from '../translations';
 import {ButtonInput, Section} from '../components/sections';
@@ -32,7 +31,7 @@ import {TRONDHEIM_CENTRAL_STATION} from '../api/geocoder';
 import colors from '../theme/colors';
 import {useGeolocationState} from '../GeolocationContext';
 import {Coordinates} from '@entur/sdk';
-import {screenReaderPause} from '../components/accessible-text';
+import {getNameInLanguage} from '../api/utils';
 
 export type RouteParams = {
   callerRouteName: string;
@@ -141,9 +140,9 @@ const TariffZoneMapSelection: React.FC<Props> = ({
 
   const styles = useMapStyles();
   const controlStyles = useControlPositionsStyle();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
-  const featureCollection = mapZonesToFeatureCollection(tariffZones);
+  const featureCollection = mapZonesToFeatureCollection(tariffZones, language);
 
   return (
     <View style={styles.container}>
@@ -171,7 +170,7 @@ const TariffZoneMapSelection: React.FC<Props> = ({
               highlightedTariffZone
                 ? t(
                     TariffZoneMapSelectionTexts.button.label.selected(
-                      highlightedTariffZone.name.value,
+                      getNameInLanguage(highlightedTariffZone, language),
                     ),
                   )
                 : t(TariffZoneMapSelectionTexts.button.label.noneSelected)
@@ -254,13 +253,14 @@ const TariffZoneMapSelection: React.FC<Props> = ({
 
 const mapZonesToFeatureCollection = (
   zones: TariffZone[],
+  language: Language,
 ): FeatureCollection<Polygon> => ({
   type: 'FeatureCollection',
   features: zones.map((t) => ({
     type: 'Feature',
     id: t.id,
     properties: {
-      name: t.name.value,
+      name: getNameInLanguage(t, language),
     },
     geometry: t.geometry,
   })),

--- a/src/tariff-zone-search/TariffZoneResults.tsx
+++ b/src/tariff-zone-search/TariffZoneResults.tsx
@@ -8,6 +8,7 @@ import {screenReaderPause} from '../components/accessible-text';
 import {MapPointPin} from '../assets/svg/icons/places';
 import {TariffZoneSearchTexts, useTranslation} from '../translations';
 import {TariffZone} from '../reference-data/types';
+import {getNameInLanguage} from '../api/utils';
 
 type Props = {
   tariffZones: TariffZone[];
@@ -16,7 +17,7 @@ type Props = {
 
 const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
   const styles = useThemeStyles();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
@@ -33,7 +34,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                 accessibilityLabel={
                   t(
                     TariffZoneSearchTexts.zones.item.a11yLabel(
-                      tariffZone.name.value,
+                      getNameInLanguage(tariffZone, language),
                     ),
                   ) + screenReaderPause
                 }
@@ -48,7 +49,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                 </View>
                 <View style={styles.nameContainer}>
                   <ThemeText style={styles.nameText}>
-                    {tariffZone.name.value}
+                    getNameInLanguage(tariffZone, language)
                   </ThemeText>
                 </View>
               </TouchableOpacity>

--- a/src/tariff-zone-search/TariffZoneResults.tsx
+++ b/src/tariff-zone-search/TariffZoneResults.tsx
@@ -8,7 +8,7 @@ import {screenReaderPause} from '../components/accessible-text';
 import {MapPointPin} from '../assets/svg/icons/places';
 import {TariffZoneSearchTexts, useTranslation} from '../translations';
 import {TariffZone} from '../reference-data/types';
-import {getNameInLanguage} from '../api/utils';
+import {getReferenceDataName} from '../reference-data/utils';
 
 type Props = {
   tariffZones: TariffZone[];
@@ -34,7 +34,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                 accessibilityLabel={
                   t(
                     TariffZoneSearchTexts.zones.item.a11yLabel(
-                      getNameInLanguage(tariffZone, language),
+                      getReferenceDataName(tariffZone, language),
                     ),
                   ) + screenReaderPause
                 }
@@ -49,7 +49,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                 </View>
                 <View style={styles.nameContainer}>
                   <ThemeText style={styles.nameText}>
-                    getNameInLanguage(tariffZone, language)
+                    getReferenceDataName(tariffZone, language)
                   </ThemeText>
                 </View>
               </TouchableOpacity>

--- a/src/tariff-zone-search/VenueResults.tsx
+++ b/src/tariff-zone-search/VenueResults.tsx
@@ -8,6 +8,7 @@ import {TariffZoneSearchTexts, useTranslation} from '../translations';
 import {Location} from '../favorites/types';
 import LocationIcon from '../components/location-icon';
 import {TariffZone} from '../reference-data/types';
+import {getNameInLanguage} from '../api/utils';
 
 export type LocationAndTariffZone = {
   location: Location;
@@ -21,7 +22,7 @@ type Props = {
 
 const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
   const styles = useThemeStyles();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
@@ -39,7 +40,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
                   t(
                     TariffZoneSearchTexts.results.item.a11yLabel(
                       location.name,
-                      tariffZone.name.value,
+                      getNameInLanguage(tariffZone, language),
                     ),
                   ) + screenReaderPause
                 }
@@ -65,7 +66,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
                   <ThemeText type={'lead'}>
                     {t(
                       TariffZoneSearchTexts.results.item.zoneLabel(
-                        tariffZone.name.value,
+                        getNameInLanguage(tariffZone, language),
                       ),
                     )}
                   </ThemeText>

--- a/src/tariff-zone-search/VenueResults.tsx
+++ b/src/tariff-zone-search/VenueResults.tsx
@@ -8,7 +8,7 @@ import {TariffZoneSearchTexts, useTranslation} from '../translations';
 import {Location} from '../favorites/types';
 import LocationIcon from '../components/location-icon';
 import {TariffZone} from '../reference-data/types';
-import {getNameInLanguage} from '../api/utils';
+import {getReferenceDataName} from '../reference-data/utils';
 
 export type LocationAndTariffZone = {
   location: Location;
@@ -40,7 +40,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
                   t(
                     TariffZoneSearchTexts.results.item.a11yLabel(
                       location.name,
-                      getNameInLanguage(tariffZone, language),
+                      getReferenceDataName(tariffZone, language),
                     ),
                   ) + screenReaderPause
                 }
@@ -66,7 +66,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
                   <ThemeText type={'lead'}>
                     {t(
                       TariffZoneSearchTexts.results.item.zoneLabel(
-                        getNameInLanguage(tariffZone, language),
+                        getReferenceDataName(tariffZone, language),
                       ),
                     )}
                   </ThemeText>

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -20,11 +20,15 @@ const PurchaseConfirmationTexts = {
   },
   validityTexts: {
     zone: {
-      single: (zoneName: string) => _(`Gyldig i sone ${zoneName}`),
+      single: (zoneName: string) =>
+        _(`Gyldig i sone ${zoneName}`, `Valid in zone ${zoneName}`),
       multiple: (zoneNameFrom: string, zoneNameTo: string) =>
-        _(`Gyldig fra sone ${zoneNameFrom} til sone ${zoneNameTo}`),
+        _(
+          `Gyldig fra sone ${zoneNameFrom} til sone ${zoneNameTo}`,
+          `Valid from zone ${zoneNameFrom} to zone ${zoneNameTo}`,
+        ),
     },
-    startTime: _('Gyldig fra kjøpstidspunkt'),
+    startTime: _('Gyldig fra kjøpstidspunkt', `Valid from time of purchase`),
   },
   totalCost: {
     title: _('Totalt', 'Total'),
@@ -33,8 +37,12 @@ const PurchaseConfirmationTexts = {
   infoText: {
     part1: _(
       'Denne billetten blir gyldig med en gang kjøpet blir gjennomført.',
+      'This ticket will be valid once the purchase is completed.',
     ),
-    // part2: _('Du kan angre kjøpet i 2 minutter.'),
+    // part2: _(
+    //   'Du kan angre kjøpet i 2 minutter.',
+    //   'You can undo the purchase during the first 2 minutes'
+    // ),
   },
   paymentButtonVipps: {
     text: _('Betal med Vipps', 'Pay by Vipps service'),

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -2,10 +2,10 @@ import {translation as _} from '../../commons';
 
 const PurchaseOverviewTexts = {
   header: {
-    title: _('Kjøp ny billett'),
+    title: _('Kjøp ny billett', 'Buy new ticket'),
     leftButton: {
-      text: _('Avbryt'),
-      a11yLabel: _('Avbryt kjøpsprosessen'),
+      text: _('Avbryt', 'Cancel'),
+      a11yLabel: _('Avbryt kjøpsprosessen', 'Cancel the purchase process'),
     },
   },
   errorMessageBox: {
@@ -19,7 +19,7 @@ const PurchaseOverviewTexts = {
       'Unable to book a ticket',
     ),
   },
-  startTime: _('Oppstart nå'),
+  startTime: _('Oppstart nå', 'Valid from now'),
   travellers: {
     travellersCount: (count: number) => _(`${count} reisende`),
     a11yHint: _('Aktivér for å velge reisende'),

--- a/src/translations/screens/subscreens/Travellers.ts
+++ b/src/translations/screens/subscreens/Travellers.ts
@@ -9,9 +9,6 @@ const TravellersTexts = {
       a11yLabel: _('Avbryt kjøpsprosessen', 'Cancel purchase'),
     },
   },
-  travellerCounter: {
-    text: (u: UserProfileWithCount) => _(u.name.value),
-  },
   primaryButton: {
     text: _('Bekreft valg', 'Confirm choice'),
     a11yHint: _(


### PR DESCRIPTION
The reference data (UserProfiles, TariffZones, PreassignedFareProducts)
format support multiple languages by providing names and other texts in
a type which has a field 'lang' specifying language and a field 'value'
containing the text in that language. In our code this is typed as a
'LanguageAndText'.

This commit add utility functions for selecting the correct text based
on the current language.