### PR TITLE
fix: Fix language prioritizing and default to no if enable_i18n is false

### DIFF
--- a/src/translations/LanguageContext.tsx
+++ b/src/translations/LanguageContext.tsx
@@ -36,9 +36,13 @@ function useLanguage() {
 
   useEffect(() => {
     if (useSystemLanguage) {
+      // Get preferred locale from system settings.
+      // If no system settings match our languages we select
+      // English as it is more likely they know english than Norwegian.
+      // If locale is undefined we don't support any of the system languages.
       const language = locale
         ? getAsAppLanguage(locale.languageCode)
-        : DEFAULT_LANGUAGE;
+        : Language.English;
       setCurrentLanguage(language);
     } else {
       const newLanguage = getAsAppLanguage(
@@ -53,11 +57,16 @@ function useLanguage() {
 
 function preferredLocale(): RNLocalize.Locale | undefined {
   const preferredSystemLocales = RNLocalize.getLocales();
-  const locale = preferredSystemLocales.find(
-    (l) => !!getAsAppLanguage(l.languageCode),
-  );
+  const locale = preferredSystemLocales.find(isAppLanguage);
   return locale;
 }
+function isAppLanguage(arg?: RNLocalize.Locale): boolean {
+  return (
+    arg?.languageCode == Language.English ||
+    arg?.languageCode == Language.Norwegian
+  );
+}
+
 function getAsAppLanguage(arg?: string): Language {
   if (arg == Language.English) {
     return Language.English;

--- a/src/translations/commons.ts
+++ b/src/translations/commons.ts
@@ -8,7 +8,7 @@ export enum Language {
 }
 export const appLanguages = ['nb', 'en'] as const;
 
-export const DEFAULT_LANGUAGE = Language.English;
+export const DEFAULT_LANGUAGE = Language.Norwegian;
 export type TranslatedString = Translatable<typeof Language, string>;
 
 export const lobot = initLobot<typeof Language>(DEFAULT_LANGUAGE);


### PR DESCRIPTION
There is an issue with the language selection when feature toggle is disabled where it defaults to English. That kind of defeat the purpose of the feature toggle as a safety mechanism to enforce "old" way to show things. This PR fixes that.

This PR also fixes what seems to be a small error in handling default system languages where it now looks to just select the _most_ preferred language or English.