### PR TITLE
feat: Adds pagination and date to service journey/departure details

### DIFF
--- a/src/components/disappearing-header/content.tsx
+++ b/src/components/disappearing-header/content.tsx
@@ -1,0 +1,159 @@
+import {useScrollToTop} from '@react-navigation/native';
+import React, {PropsWithChildren, useCallback, useEffect, useRef} from 'react';
+import {
+  Animated,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Platform,
+  RefreshControl,
+  ScrollView,
+  View,
+} from 'react-native';
+import {StyleSheet, useTheme} from '../../theme';
+import throttle from '../../utils/throttle';
+import {useLayout} from '../../utils/use-layout';
+
+type Props = PropsWithChildren<{
+  header: React.ReactNode;
+  onRefresh?(): void;
+  isRefreshing?: boolean;
+
+  onEndReached?(e: NativeScrollEvent): void;
+  onEndReachedThreshold?: number;
+}>;
+
+type Scrollable = {
+  scrollTo(opts: {y: number}): void;
+};
+
+export default function ContentWithDisappearingHeader({
+  header,
+  children,
+  isRefreshing = false,
+  onRefresh,
+
+  onEndReached,
+  onEndReachedThreshold = 10,
+}: Props) {
+  const {
+    contentHeight,
+    onHeaderContentLayout,
+  } = useCalculateHeaderContentHeight();
+  const contentHeightRef = React.useRef(contentHeight);
+  const scrollableContentRef = React.useRef<ScrollView>(null);
+  useScrollToTop(
+    React.useRef<Scrollable>({
+      scrollTo: () =>
+        scrollableContentRef.current?.scrollTo({y: contentHeightRef.current}),
+    }),
+  );
+
+  useEffect(() => {
+    contentHeightRef.current = contentHeight;
+  }, [contentHeight]);
+
+  const styles = useThemeStyles();
+  const {theme} = useTheme();
+  const scrollYRef = useRef(new Animated.Value(0)).current;
+
+  const headerTranslate = scrollYRef.interpolate({
+    inputRange: [-contentHeight, contentHeight],
+    outputRange: [0, -contentHeight],
+    extrapolate: 'clamp',
+  });
+
+  const endReachListener = useCallback(
+    throttle((e: NativeScrollEvent) => {
+      if (!onEndReached) return;
+      if (!isRefreshing && hasReachedEnd(e, onEndReachedThreshold)) {
+        onEndReached(e);
+      }
+    }, 400),
+    [isRefreshing, onEndReached, onEndReachedThreshold],
+  );
+
+  const onScrolling = useCallback(
+    (e: NativeScrollEvent) => {
+      endReachListener(e);
+    },
+    [endReachListener],
+  );
+
+  return (
+    <View style={styles.content}>
+      <Animated.View
+        style={[styles.header, {transform: [{translateY: headerTranslate}]}]}
+      >
+        <View onLayout={onHeaderContentLayout}>{header}</View>
+      </Animated.View>
+
+      <Animated.ScrollView
+        ref={scrollableContentRef}
+        scrollEventThrottle={10}
+        refreshControl={
+          onRefresh && (
+            <RefreshControl
+              refreshing={isRefreshing}
+              onRefresh={onRefresh}
+              progressViewOffset={contentHeight}
+              tintColor={theme.text.colors.primary}
+            />
+          )
+        }
+        onScroll={Animated.event(
+          [{nativeEvent: {contentOffset: {y: scrollYRef}}}],
+          {
+            useNativeDriver: true,
+            listener: (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+              onScrolling(e.nativeEvent);
+            },
+          },
+        )}
+        contentContainerStyle={{
+          paddingTop: Platform.OS === 'ios' ? 0 : contentHeight,
+        }}
+        contentInset={{top: contentHeight}}
+        contentOffset={{x: 0, y: -contentHeight}}
+        automaticallyAdjustContentInsets={false}
+      >
+        {children}
+      </Animated.ScrollView>
+    </View>
+  );
+}
+
+const hasReachedEnd = (
+  {layoutMeasurement, contentOffset, contentSize}: NativeScrollEvent,
+  paddingThreshold: number,
+) => {
+  return (
+    layoutMeasurement.height + contentOffset.y >=
+    contentSize.height - paddingThreshold
+  );
+};
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  content: {
+    flex: 1,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    overflow: 'hidden',
+    zIndex: 2,
+    elevation: 4,
+    justifyContent: 'space-between',
+  },
+}));
+
+function useCalculateHeaderContentHeight() {
+  const {onLayout: onHeaderContentLayout, height: contentHeight} = useLayout();
+  return {
+    contentHeight,
+    onHeaderContentLayout,
+  };
+}

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -7,18 +7,20 @@ import {fullDateTime} from '../../utils/date';
 import Button from '../button';
 import ThemeText from '../text';
 
-type PaginationProps = ViewProps & {
+type PaginatedDetailsHeader = ViewProps & {
   page: number;
   totalPages: number;
   onNavigate(newPage: number): void;
+  showPagination?: boolean;
   currentDate?: string | Date;
 };
-const Pagination: React.FC<PaginationProps> = ({
+const PaginatedDetailsHeader: React.FC<PaginatedDetailsHeader> = ({
   page,
   totalPages,
   onNavigate,
   style,
   currentDate,
+  showPagination = true,
 }) => {
   const styles = usePaginateStyles();
   const {t, language} = useTranslation();
@@ -26,42 +28,44 @@ const Pagination: React.FC<PaginationProps> = ({
   const hasNext = page < totalPages;
 
   return (
-    <View style={style}>
-      <View style={styles.container}>
-        <View style={styles.buttonLeft}>
-          <Button
-            type="compact"
-            mode="tertiary"
-            disabled={!hasPrevious}
-            iconPosition="left"
-            icon={ArrowLeft}
-            onPress={() => onNavigate(page - 1)}
-            text={t(PaginationTexts.previous.label)}
-            accessibilityHint={t(PaginationTexts.previous.a11yHint)}
-          />
-        </View>
+    <View style={[styles.wrapper, style]}>
+      {showPagination && (
+        <View style={styles.container}>
+          <View style={styles.buttonLeft}>
+            <Button
+              type="compact"
+              mode="tertiary"
+              disabled={!hasPrevious}
+              iconPosition="left"
+              icon={ArrowLeft}
+              onPress={() => onNavigate(page - 1)}
+              text={t(PaginationTexts.previous.label)}
+              accessibilityHint={t(PaginationTexts.previous.a11yHint)}
+            />
+          </View>
 
-        <ThemeText
-          accessible={true}
-          accessibilityLabel={t(
-            PaginationTexts.current.a11yLabel(page, totalPages),
-          )}
-        >
-          {t(PaginationTexts.current.label(page, totalPages))}
-        </ThemeText>
-        <View style={styles.buttonRight}>
-          <Button
-            type="compact"
-            mode="tertiary"
-            disabled={!hasNext}
-            iconPosition="right"
-            icon={ArrowRight}
-            onPress={() => onNavigate(page + 1)}
-            text={t(PaginationTexts.next.label)}
-            accessibilityHint={t(PaginationTexts.next.a11yHint)}
-          />
+          <ThemeText
+            accessible={true}
+            accessibilityLabel={t(
+              PaginationTexts.current.a11yLabel(page, totalPages),
+            )}
+          >
+            {t(PaginationTexts.current.label(page, totalPages))}
+          </ThemeText>
+          <View style={styles.buttonRight}>
+            <Button
+              type="compact"
+              mode="tertiary"
+              disabled={!hasNext}
+              iconPosition="right"
+              icon={ArrowRight}
+              onPress={() => onNavigate(page + 1)}
+              text={t(PaginationTexts.next.label)}
+              accessibilityHint={t(PaginationTexts.next.a11yHint)}
+            />
+          </View>
         </View>
-      </View>
+      )}
       {currentDate && (
         <View style={styles.subline}>
           <ThemeText
@@ -86,6 +90,10 @@ const usePaginateStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'center',
     padding: theme.spacings.medium,
   },
+  wrapper: {
+    borderBottomWidth: theme.border.width.slim,
+    borderColor: theme.background.level1,
+  },
   buttonLeft: {
     position: 'absolute',
     zIndex: 2,
@@ -100,6 +108,7 @@ const usePaginateStyles = StyleSheet.createThemeHook((theme) => ({
   },
   subline: {
     alignItems: 'center',
+    paddingBottom: theme.spacings.medium,
   },
 }));
-export default Pagination;
+export default PaginatedDetailsHeader;

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -1,58 +1,81 @@
 import React from 'react';
-import ThemeText from '../text';
 import {View, ViewProps} from 'react-native';
-import Button from '../button';
-import {StyleSheet} from '../../theme';
 import {ArrowLeft, ArrowRight} from '../../assets/svg/icons/navigation';
+import {StyleSheet} from '../../theme';
 import {PaginationTexts, useTranslation} from '../../translations';
+import {fullDateTime} from '../../utils/date';
+import Button from '../button';
+import ThemeText from '../text';
 
 type PaginationProps = ViewProps & {
   page: number;
   totalPages: number;
   onNavigate(newPage: number): void;
+  currentDate?: string | Date;
 };
 const Pagination: React.FC<PaginationProps> = ({
   page,
   totalPages,
   onNavigate,
   style,
+  currentDate,
 }) => {
   const styles = usePaginateStyles();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const hasPrevious = page > 1;
   const hasNext = page < totalPages;
 
   return (
-    <View style={[styles.container, style]}>
-      <Button
-        type="compact"
-        mode="tertiary"
-        disabled={!hasPrevious}
-        iconPosition="left"
-        icon={ArrowLeft}
-        onPress={() => onNavigate(page - 1)}
-        text={t(PaginationTexts.previous.label)}
-        accessibilityHint={t(PaginationTexts.previous.a11yHint)}
-      ></Button>
+    <View style={style}>
+      <View style={styles.container}>
+        <View style={styles.buttonLeft}>
+          <Button
+            type="compact"
+            mode="tertiary"
+            disabled={!hasPrevious}
+            iconPosition="left"
+            icon={ArrowLeft}
+            onPress={() => onNavigate(page - 1)}
+            text={t(PaginationTexts.previous.label)}
+            accessibilityHint={t(PaginationTexts.previous.a11yHint)}
+          />
+        </View>
 
-      <ThemeText
-        accessible={true}
-        accessibilityLabel={t(
-          PaginationTexts.current.a11yLabel(page, totalPages),
-        )}
-      >
-        {t(PaginationTexts.current.label(page, totalPages))}
-      </ThemeText>
-      <Button
-        type="compact"
-        mode="tertiary"
-        disabled={!hasNext}
-        iconPosition="right"
-        icon={ArrowRight}
-        onPress={() => onNavigate(page + 1)}
-        text={t(PaginationTexts.next.label)}
-        accessibilityHint={t(PaginationTexts.next.a11yHint)}
-      ></Button>
+        <ThemeText
+          accessible={true}
+          accessibilityLabel={t(
+            PaginationTexts.current.a11yLabel(page, totalPages),
+          )}
+        >
+          {t(PaginationTexts.current.label(page, totalPages))}
+        </ThemeText>
+        <View style={styles.buttonRight}>
+          <Button
+            type="compact"
+            mode="tertiary"
+            disabled={!hasNext}
+            iconPosition="right"
+            icon={ArrowRight}
+            onPress={() => onNavigate(page + 1)}
+            text={t(PaginationTexts.next.label)}
+            accessibilityHint={t(PaginationTexts.next.a11yHint)}
+          />
+        </View>
+      </View>
+      {currentDate && (
+        <View style={styles.subline}>
+          <ThemeText
+            accessible={true}
+            accessibilityLabel={t(
+              PaginationTexts.date.a11yLabel(
+                fullDateTime(currentDate, language),
+              ),
+            )}
+          >
+            {fullDateTime(currentDate, language)}
+          </ThemeText>
+        </View>
+      )}
     </View>
   );
 };
@@ -60,8 +83,23 @@ const usePaginateStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
     flexDirection: 'row',
+    justifyContent: 'center',
+    padding: theme.spacings.medium,
+  },
+  buttonLeft: {
+    position: 'absolute',
+    zIndex: 2,
+    elevated: 1,
+    left: 1,
+  },
+  buttonRight: {
+    position: 'absolute',
+    zIndex: 2,
+    elevated: 1,
+    right: 0,
+  },
+  subline: {
     alignItems: 'center',
-    justifyContent: 'space-between',
   },
 }));
 export default Pagination;

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -72,21 +72,24 @@ export default function LineItem({
 
   const title = `${group.lineInfo?.lineNumber} ${group.lineInfo?.lineName}`;
 
-  const onPress = (departure: DepartureTime) => {
+  const items = group.departures.map((dep) => ({
+    serviceJourneyId: dep.serviceJourneyId!,
+    date: dep.time,
+    fromQuayId: group.lineInfo?.quayId,
+  }));
+
+  const onPress = (activeItemIndex: number) => {
     navigation.navigate('TripDetails', {
       screen: 'DepartureDetails',
       params: {
-        title,
-        serviceJourneyId: departure.serviceJourneyId!,
-        date: departure.aimedTime,
-        fromQuayId: group.lineInfo?.quayId,
+        activeItemIndex,
+        items,
       },
     });
   };
 
   // we know we have a departure as we've checked hasNoDeparturesOnGroup
   const nextValids = group.departures.filter(isValidDeparture);
-  const firstResult = nextValids[0]!;
 
   return (
     <View style={[topContainer, {padding: 0}]}>
@@ -94,7 +97,7 @@ export default function LineItem({
         <TouchableOpacity
           style={styles.lineHeader}
           containerStyle={contentContainer}
-          onPress={() => onPress(firstResult)}
+          onPress={() => onPress(0)}
           hitSlop={insets.symmetric(12, 0)}
           accessibilityRole="button"
           accessibilityHint={
@@ -128,11 +131,11 @@ export default function LineItem({
         accessibilityElementsHidden
         importantForAccessibility="no-hide-descendants"
       >
-        {group.departures.map((departure) => (
+        {group.departures.map((departure, i) => (
           <DepartureTimeItem
             departure={departure}
             key={departure.serviceJourneyId + departure.aimedTime}
-            onPress={onPress}
+            onPress={() => onPress(i)}
           />
         ))}
       </ScrollView>

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -5,7 +5,6 @@ import {
 } from '@react-navigation/native';
 import React, {useEffect, useState} from 'react';
 import {ActivityIndicator, TouchableOpacity, View} from 'react-native';
-import {ScrollView} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {DetailsStackParams} from '..';
 import {getServiceJourneyMapLegs} from '../../../api/serviceJourney';
@@ -87,8 +86,22 @@ export default function DepartureDetails({navigation, route}: Props) {
     setActiveItem(newPage - 1);
   };
 
-  const content = (
-    <View style={{flex: 1}}>
+  return (
+    <View style={styles.container}>
+      <View style={[styles.header, {paddingTop}]}>
+        <ScreenHeader
+          leftButton={{
+            onPress: () => navigation.goBack(),
+            icon: <ThemeIcon svg={ArrowLeft} />,
+            accessible: true,
+            accessibilityRole: 'button',
+            accessibilityLabel: t(
+              DepartureDetailsTexts.header.leftIcon.a11yLabel,
+            ),
+          }}
+          title={title ?? t(DepartureDetailsTexts.header.notFound)}
+        />
+      </View>
       <ContentWithDisappearingHeader
         header={
           mapData && (
@@ -106,68 +119,49 @@ export default function DepartureDetails({navigation, route}: Props) {
             />
           )
         }
-        // style={styles.scrollView}
-        // contentContainerStyle={styles.scrollView__content}
+        //
       >
-        <PaginatedDetailsHeader
-          page={activeItemIndexState + 1}
-          totalPages={items.length}
-          onNavigate={onPaginactionPress}
-          showPagination={hasMultipleItems}
-          currentDate={activeItem?.date}
-        />
-        <SituationMessages
-          situations={parentSituations}
-          containerStyle={styles.situationsContainer}
-        />
+        <View style={styles.scrollView__content}>
+          <PaginatedDetailsHeader
+            page={activeItemIndexState + 1}
+            totalPages={items.length}
+            onNavigate={onPaginactionPress}
+            showPagination={hasMultipleItems}
+            currentDate={activeItem?.date}
+          />
+          <SituationMessages
+            situations={parentSituations}
+            containerStyle={styles.situationsContainer}
+          />
 
-        {isLoading && (
-          <View>
-            <ActivityIndicator
-              color={defaultFill}
-              style={styles.spinner}
-              animating={true}
-              size="large"
-            />
-            <ScreenReaderAnnouncement
-              message={t(DepartureDetailsTexts.messages.loading)}
-            />
+          {isLoading && (
+            <View>
+              <ActivityIndicator
+                color={defaultFill}
+                style={styles.spinner}
+                animating={true}
+                size="large"
+              />
+              <ScreenReaderAnnouncement
+                message={t(DepartureDetailsTexts.messages.loading)}
+              />
+            </View>
+          )}
+
+          <View style={styles.allGroups}>
+            {mapGroup(callGroups, (name, group) => (
+              <CallGroup
+                key={group[0]?.quay?.id ?? name}
+                calls={group}
+                type={name}
+                mode={mode}
+                subMode={subMode}
+                parentSituations={parentSituations}
+              />
+            ))}
           </View>
-        )}
-
-        <View style={styles.allGroups}>
-          {mapGroup(callGroups, (name, group) => (
-            <CallGroup
-              key={group[0]?.quay?.id ?? name}
-              calls={group}
-              type={name}
-              mode={mode}
-              subMode={subMode}
-              parentSituations={parentSituations}
-            />
-          ))}
         </View>
       </ContentWithDisappearingHeader>
-    </View>
-  );
-
-  return (
-    <View style={styles.container}>
-      <View style={[styles.header, {paddingTop}]}>
-        <ScreenHeader
-          leftButton={{
-            onPress: () => navigation.goBack(),
-            icon: <ThemeIcon svg={ArrowLeft} />,
-            accessible: true,
-            accessibilityRole: 'button',
-            accessibilityLabel: t(
-              DepartureDetailsTexts.header.leftIcon.a11yLabel,
-            ),
-          }}
-          title={title ?? t(DepartureDetailsTexts.header.notFound)}
-        />
-      </View>
-      {content}
     </View>
   );
 }
@@ -352,9 +346,6 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   },
   spinner: {
     paddingTop: theme.spacings.medium,
-  },
-  scrollView: {
-    flex: 1,
   },
   scrollView__content: {
     padding: theme.spacings.medium,

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -14,6 +14,7 @@ import {
   Expand,
   ExpandLess,
 } from '../../../assets/svg/icons/navigation';
+import ContentWithDisappearingHeader from '../../../components/disappearing-header/content';
 import PaginatedDetailsHeader from '../../../components/pagination';
 import ScreenReaderAnnouncement from '../../../components/screen-reader-announcement';
 import ThemeText from '../../../components/text';
@@ -88,24 +89,25 @@ export default function DepartureDetails({navigation, route}: Props) {
 
   const content = (
     <View style={{flex: 1}}>
-      {mapData && (
-        <CompactMap
-          mapLegs={mapData.mapLegs}
-          fromPlace={mapData.start}
-          toPlace={mapData.stop}
-          onExpand={() => {
-            navigation.navigate('DetailsMap', {
-              legs: mapData.mapLegs,
-              fromPlace: mapData.start,
-              toPlace: mapData.stop,
-            });
-          }}
-        />
-      )}
-
-      <ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollView__content}
+      <ContentWithDisappearingHeader
+        header={
+          mapData && (
+            <CompactMap
+              mapLegs={mapData.mapLegs}
+              fromPlace={mapData.start}
+              toPlace={mapData.stop}
+              onExpand={() => {
+                navigation.navigate('DetailsMap', {
+                  legs: mapData.mapLegs,
+                  fromPlace: mapData.start,
+                  toPlace: mapData.stop,
+                });
+              }}
+            />
+          )
+        }
+        // style={styles.scrollView}
+        // contentContainerStyle={styles.scrollView__content}
       >
         <PaginatedDetailsHeader
           page={activeItemIndexState + 1}
@@ -145,7 +147,7 @@ export default function DepartureDetails({navigation, route}: Props) {
             />
           ))}
         </View>
-      </ScrollView>
+      </ContentWithDisappearingHeader>
     </View>
   );
 

--- a/src/screens/TripDetails/DepartureDetails/types.ts
+++ b/src/screens/TripDetails/DepartureDetails/types.ts
@@ -1,0 +1,6 @@
+export type ServiceJourneyDeparture = {
+  serviceJourneyId: string;
+  date: string;
+  fromQuayId?: string;
+  toQuayId?: string;
+};

--- a/src/screens/TripDetails/DepartureDetails/use-departure-data.ts
+++ b/src/screens/TripDetails/DepartureDetails/use-departure-data.ts
@@ -1,0 +1,128 @@
+import {parseISO} from 'date-fns';
+import {useCallback} from 'react';
+import {getDepartures} from '../../../api/serviceJourney';
+import {
+  EstimatedCall,
+  Situation,
+  TransportMode,
+  TransportSubmode,
+} from '../../../sdk';
+import usePollableResource from '../../../utils/use-pollable-resource';
+import {ServiceJourneyDeparture} from './types';
+
+export type DepartureData = {
+  callGroups: CallListGroup;
+  mode?: TransportMode;
+  title?: string;
+  subMode?: TransportSubmode;
+  situations: Situation[];
+};
+
+export type CallListGroup = {
+  passed: EstimatedCall[];
+  trip: EstimatedCall[];
+  after: EstimatedCall[];
+};
+
+export default function useDepartureData(
+  activeItem: ServiceJourneyDeparture,
+  pollingTimeInSeconds: number = 0,
+  disabled?: boolean,
+): [DepartureData, boolean] {
+  const getService = useCallback(
+    async function getServiceJourneyDepartures(): Promise<DepartureData> {
+      const deps = await getDepartures(
+        activeItem.serviceJourneyId,
+        parseISO(activeItem.date),
+      );
+      const callGroups = groupAllCallsByQuaysInLeg(
+        deps,
+        activeItem.fromQuayId,
+        activeItem.toQuayId,
+      );
+      const line = callGroups.trip[0]?.serviceJourney?.journeyPattern?.line;
+      const parentSituation = callGroups.trip[0]?.situations;
+
+      return {
+        mode: line?.transportMode,
+        title: `${line?.publicCode} ${callGroups.trip[0]?.destinationDisplay.frontText}`,
+        subMode: line?.transportSubmode,
+        callGroups,
+        situations: parentSituation,
+      };
+    },
+    [activeItem],
+  );
+
+  const [data, , isLoading] = usePollableResource<DepartureData>(getService, {
+    initialValue: {
+      callGroups: {
+        passed: [],
+        trip: [],
+        after: [],
+      },
+      situations: [],
+    },
+    pollingTimeInSeconds,
+    disabled: disabled || !activeItem,
+  });
+
+  return [data, isLoading];
+}
+
+const onType = (
+  obj: CallListGroup,
+  key: keyof CallListGroup,
+  call: EstimatedCall,
+): CallListGroup => ({
+  ...obj,
+  [key]: obj[key].concat(call),
+});
+function groupAllCallsByQuaysInLeg(
+  calls: EstimatedCall[],
+  fromQuayId?: string,
+  toQuayId?: string,
+): CallListGroup {
+  let isAfterStart = false;
+  let isAfterStop = false;
+
+  if (!fromQuayId && !toQuayId) {
+    return {
+      passed: [],
+      trip: calls,
+      after: [],
+    };
+  }
+
+  return calls.reduce(
+    (obj, call) => {
+      // We are at start quay, update flag
+      if (call.quay?.id === fromQuayId) {
+        isAfterStart = true;
+      }
+
+      if (!isAfterStart && !isAfterStop) {
+        // is the first group
+        obj = onType(obj, 'passed', call);
+      } else if (isAfterStart && !isAfterStop) {
+        // is the current route (between start/stop)
+        obj = onType(obj, 'trip', call);
+      } else {
+        // is quays after stop
+        obj = onType(obj, 'after', call);
+      }
+
+      // We are at stop, update flag
+      if (call.quay?.id === toQuayId) {
+        isAfterStop = true;
+      }
+
+      return obj;
+    },
+    {
+      passed: [],
+      trip: [],
+      after: [],
+    } as CallListGroup,
+  );
+}

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -7,7 +7,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {DetailsStackParams} from '..';
 import {getSingleTripPattern} from '../../../api/trips';
 import {ArrowLeft} from '../../../assets/svg/icons/navigation';
-import Pagination from '../../../components/pagination';
+import PaginatedDetailsHeader from '../../../components/pagination';
 import ThemeIcon from '../../../components/theme-icon';
 import Header from '../../../ScreenHeader';
 import {TripPattern} from '../../../sdk';
@@ -122,7 +122,7 @@ const Details: React.FC<Props> = (props) => {
             />
             <View style={styles.paddedContainer}>
               {tripPatterns.length > 1 && (
-                <Pagination
+                <PaginatedDetailsHeader
                   page={currentIndex + 1}
                   totalPages={tripPatterns.length}
                   onNavigate={navigate}

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -7,6 +7,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {DetailsStackParams} from '..';
 import {getSingleTripPattern} from '../../../api/trips';
 import {ArrowLeft} from '../../../assets/svg/icons/navigation';
+import ContentWithDisappearingHeader from '../../../components/disappearing-header/content';
 import PaginatedDetailsHeader from '../../../components/pagination';
 import ThemeIcon from '../../../components/theme-icon';
 import Header from '../../../ScreenHeader';
@@ -92,21 +93,9 @@ const Details: React.FC<Props> = (props) => {
           title={t(TripDetailsTexts.header.title)}
         />
       </View>
-      <ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollViewContent}
-        bounces={false}
-      >
-        {showActivityIndicator && (
-          <ActivityIndicator
-            style={styles.activityIndicator}
-            color={theme.text.colors.faded}
-            animating={true}
-            size="large"
-          />
-        )}
-        {tripPattern && (
-          <>
+      <ContentWithDisappearingHeader
+        header={
+          tripPattern && (
             <CompactMap
               mapLegs={tripPattern.legs}
               fromPlace={tripPattern.legs[0].fromPlace}
@@ -120,21 +109,32 @@ const Details: React.FC<Props> = (props) => {
                 });
               }}
             />
-            <View style={styles.paddedContainer}>
-              {tripPatterns.length > 1 && (
-                <PaginatedDetailsHeader
-                  page={currentIndex + 1}
-                  totalPages={tripPatterns.length}
-                  onNavigate={navigate}
-                  style={styles.pagination}
-                  currentDate={tripPattern.legs[0]?.expectedStartTime}
-                />
-              )}
-              <Trip tripPattern={tripPattern} error={error} />
-            </View>
-          </>
+          )
+        }
+      >
+        {showActivityIndicator && (
+          <ActivityIndicator
+            style={styles.activityIndicator}
+            color={theme.text.colors.faded}
+            animating={true}
+            size="large"
+          />
         )}
-      </ScrollView>
+        {tripPattern && (
+          <View style={styles.paddedContainer}>
+            {tripPatterns.length > 1 && (
+              <PaginatedDetailsHeader
+                page={currentIndex + 1}
+                totalPages={tripPatterns.length}
+                onNavigate={navigate}
+                style={styles.pagination}
+                currentDate={tripPattern.legs[0]?.expectedStartTime}
+              />
+            )}
+            <Trip tripPattern={tripPattern} error={error} />
+          </View>
+        )}
+      </ContentWithDisappearingHeader>
     </View>
   );
 };

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -16,6 +16,7 @@ import {TripDetailsTexts, useTranslation} from '../../../translations';
 import usePollableResource from '../../../utils/use-pollable-resource';
 import Trip from '../components/Trip';
 import CompactMap from '../Map/CompactMap';
+
 export type DetailsRouteParams = {
   tripPatternId?: string;
   tripPatterns?: TripPattern[];
@@ -126,7 +127,8 @@ const Details: React.FC<Props> = (props) => {
                   totalPages={tripPatterns.length}
                   onNavigate={navigate}
                   style={styles.pagination}
-                ></Pagination>
+                  currentDate={tripPattern.legs[0]?.expectedStartTime}
+                />
               )}
               <Trip tripPattern={tripPattern} error={error} />
             </View>

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -2,7 +2,6 @@ import {NavigationProp, RouteProp, useIsFocused} from '@react-navigation/core';
 import Axios, {AxiosError} from 'axios';
 import React, {useCallback, useEffect, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
-import {ScrollView} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {DetailsStackParams} from '..';
 import {getSingleTripPattern} from '../../../api/trips';
@@ -167,9 +166,6 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.background.header,
   },
   container: {
-    flex: 1,
-  },
-  scrollView: {
     flex: 1,
     backgroundColor: theme.background.level0,
   },

--- a/src/screens/TripDetails/components/Trip.tsx
+++ b/src/screens/TripDetails/components/Trip.tsx
@@ -1,7 +1,6 @@
 import {AxiosError} from 'axios';
 import React, {useEffect, useState} from 'react';
 import {View} from 'react-native';
-import ScreenReaderAnnouncement from '../../../components/screen-reader-announcement';
 import {Leg, TripPattern} from '../../../sdk';
 import {StyleSheet} from '../../../theme';
 import {secondsBetween} from '../../../utils/date';
@@ -32,7 +31,6 @@ const Trip: React.FC<TripProps> = ({tripPattern, error}) => {
 
   return (
     <>
-      <View style={styles.line} />
       <TripMessages
         error={error}
         shortTime={shortTime}
@@ -58,7 +56,6 @@ const Trip: React.FC<TripProps> = ({tripPattern, error}) => {
             );
           })}
       </View>
-      <View style={styles.line} />
       <Summary {...tripPattern} />
     </>
   );
@@ -95,11 +92,6 @@ function legWaitDetails(index: number, legs: Leg[]): WaitDetails | undefined {
   return {waitAfter, waitSeconds};
 }
 const useStyle = StyleSheet.createThemeHook((theme) => ({
-  line: {
-    flex: 1,
-    height: theme.border.width.slim,
-    backgroundColor: theme.background.level1,
-  },
   message: {
     marginTop: theme.spacings.medium,
   },

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -1,36 +1,36 @@
-import React from 'react';
-import {Leg, Place} from '../../../sdk';
-import {View} from 'react-native';
-import ThemeText from '../../../components/text';
-import {StyleSheet} from '../../../theme';
-import {formatToClock, secondsToDuration} from '../../../utils/date';
-import {
-  getLineName,
-  getQuayName,
-  getTranslatedModeName,
-} from '../../../utils/transportation-names';
-import TransportationIcon from '../../../components/transportation-icon';
-import {transportationColor} from '../../../utils/transportation-color';
 import {useNavigation} from '@react-navigation/core';
-import {DetailScreenNavigationProp} from '../Details';
+import React from 'react';
+import {View} from 'react-native';
+import {Info, Warning} from '../../../assets/svg/situations';
+import AccessibleText, {
+  screenReaderPause,
+} from '../../../components/accessible-text';
+import ThemeText from '../../../components/text';
+import TransportationIcon from '../../../components/transportation-icon';
 import {TinyMessageBox} from '../../../message-box';
-import {Warning, Info} from '../../../assets/svg/situations';
+import {Leg, Place} from '../../../sdk';
 import SituationMessages from '../../../situations';
-import Time from './Time';
-import TripLegDecoration from './TripLegDecoration';
-import {significantWaitTime, significantWalkTime} from '../Details/utils';
-import TripRow from './TripRow';
-import WaitSection, {WaitDetails} from './WaitSection';
+import {StyleSheet} from '../../../theme';
 import {
   Language,
   TranslatedString,
   TripDetailsTexts,
   useTranslation,
 } from '../../../translations';
-import AccessibleText, {
-  screenReaderPause,
-} from '../../../components/accessible-text';
+import {formatToClock, secondsToDuration} from '../../../utils/date';
+import {transportationColor} from '../../../utils/transportation-color';
+import {
+  getLineName,
+  getQuayName,
+  getTranslatedModeName,
+} from '../../../utils/transportation-names';
+import {DetailScreenNavigationProp} from '../Details';
+import {significantWaitTime, significantWalkTime} from '../Details/utils';
 import {getTimeRepresentationType, TimeValues} from '../utils';
+import Time from './Time';
+import TripLegDecoration from './TripLegDecoration';
+import TripRow from './TripRow';
+import WaitSection, {WaitDetails} from './WaitSection';
 
 type TripSectionProps = {
   isLast?: boolean;
@@ -166,11 +166,14 @@ const IntermediateInfo: React.FC<TripSectionProps> = (leg) => {
   const navigation = useNavigation<DetailScreenNavigationProp>();
   const navigateToDetails = () =>
     navigation.navigate('DepartureDetails', {
-      title: getLineName(leg),
-      serviceJourneyId: leg.serviceJourney.id,
-      date: leg.expectedStartTime,
-      fromQuayId: leg.fromPlace.quay?.id,
-      toQuayId: leg.toPlace.quay?.id,
+      items: [
+        {
+          serviceJourneyId: leg.serviceJourney.id,
+          date: leg.expectedStartTime,
+          fromQuayId: leg.fromPlace.quay?.id,
+          toQuayId: leg.toPlace.quay?.id,
+        },
+      ],
     });
 
   const numberOfIntermediateCalls = leg.intermediateEstimatedCalls.length;

--- a/src/screens/TripDetails/components/TripSummary.tsx
+++ b/src/screens/TripDetails/components/TripSummary.tsx
@@ -51,6 +51,8 @@ const Summary: React.FC<TripPattern> = ({walkDistance, duration}) => {
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   summary: {
     marginVertical: theme.spacings.medium,
+    borderTopWidth: theme.border.width.slim,
+    borderColor: theme.background.level1,
   },
   summaryDetail: {
     padding: theme.spacings.medium,

--- a/src/translations/components/Pagination.ts
+++ b/src/translations/components/Pagination.ts
@@ -13,9 +13,16 @@ const Pagination = {
     a11yHint: _('Aktivér for å vise neste side', 'Activate to show next page'),
   },
   current: {
-    label: (current: number, total: number) => _(`${current} av ${total}`),
+    label: (current: number, total: number) =>
+      _(`${current} av ${total}`, `${current} of ${total}`),
     a11yLabel: (current: number, total: number) =>
-      _(`Viser ${current} av totalt ${total} sider`),
+      _(
+        `Viser ${current} av totalt ${total} sider`,
+        `Showing ${current} of ${total} pages`,
+      ),
+  },
+  date: {
+    a11yLabel: (date: string) => _(`${date}`, `${date}`),
   },
 };
 export default Pagination;

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -2,6 +2,7 @@ import {translation as _} from '../../commons';
 const DepartureDetailsTexts = {
   header: {
     title: (departureName: string) => _(departureName),
+    notFound: _('Ikke funnet', 'Not found'),
     leftIcon: {
       a11yLabel: _('Gå tilbake', 'Go back'),
     },

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -136,6 +136,11 @@ export function formatToLongDateTime(
   return format(parsed, 'PPp', {locale: languageToLocale(language)});
 }
 
+export function fullDateTime(isoDate: string | Date, language: Language) {
+  const parsed = parseIfNeeded(isoDate);
+  return format(parsed, 'PPp', {locale: languageToLocale(language)});
+}
+
 export {isSameDay};
 
 export function formatToSimpleDate(date: Date, language: Language) {

--- a/src/utils/use-is-loading.ts
+++ b/src/utils/use-is-loading.ts
@@ -1,0 +1,34 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * A specialized useState hook for doing isLoading messages. This delays
+ * setting flag as true for `delayTimeInMs`. This is to avoid unnecessary loading indicators.
+ *
+ * @param {boolean} initialState initial flag, true if loading false otherwise.
+ * @param {number} [delayTimeInMs=400] milliseconds to delay before setting flag to true
+ * @returns {[boolean, React.Dispatch<React.SetStateAction<boolean>>]} usual useState return
+ */
+export default function useIsLoading(
+  initialState: boolean,
+  delayTimeInMs: number = 400,
+): [boolean, React.Dispatch<React.SetStateAction<boolean>>] {
+  const [isLoading, setIsLoading] = useState(initialState);
+  const [isLoadingInternal, setIsLoadingInternal] = useState(initialState);
+
+  useEffect(() => {
+    if (!isLoadingInternal) {
+      setIsLoading(isLoadingInternal);
+      return;
+    }
+
+    const timer = setTimeout(
+      () => setIsLoading(isLoadingInternal),
+      delayTimeInMs,
+    );
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isLoadingInternal]);
+
+  return [isLoading, setIsLoadingInternal];
+}

--- a/src/utils/use-pollable-resource.ts
+++ b/src/utils/use-pollable-resource.ts
@@ -1,6 +1,7 @@
 import {useState, useCallback, useEffect} from 'react';
 import {useIsFocused} from '@react-navigation/native';
 import useInterval from './use-interval';
+import useDebounce from './useDebounce';
 
 type PollableResourceOptions<T, E> = {
   initialValue: T;
@@ -25,7 +26,8 @@ export default function usePollableResource<T, E extends Error = Error>(
 ): [T, () => Promise<void>, boolean, E?] {
   const {initialValue, pollingTimeInSeconds = 30, disabled, filterError} = opts;
 
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoadingInternal, setIsLoading] = useState<boolean>(false);
+  const isLoading = useDebounce(isLoadingInternal, 500);
   const [error, setError] = useState<E | undefined>(undefined);
   const [state, setState] = useState<T>(initialValue);
   const pollTime = pollingTimeInSeconds * 1000;

--- a/src/utils/use-pollable-resource.ts
+++ b/src/utils/use-pollable-resource.ts
@@ -2,6 +2,7 @@ import {useState, useCallback, useEffect} from 'react';
 import {useIsFocused} from '@react-navigation/native';
 import useInterval from './use-interval';
 import useDebounce from './useDebounce';
+import useIsLoading from './use-is-loading';
 
 type PollableResourceOptions<T, E> = {
   initialValue: T;
@@ -24,10 +25,8 @@ export default function usePollableResource<T, E extends Error = Error>(
   callback: () => Promise<T>,
   opts: PollableResourceOptions<T, E>,
 ): [T, () => Promise<void>, boolean, E?] {
-  const {initialValue, pollingTimeInSeconds = 30, disabled, filterError} = opts;
-
-  const [isLoadingInternal, setIsLoading] = useState<boolean>(false);
-  const isLoading = useDebounce(isLoadingInternal, 500);
+  const {initialValue, pollingTimeInSeconds = 30, filterError} = opts;
+  const [isLoading, setIsLoading] = useIsLoading(false);
   const [error, setError] = useState<E | undefined>(undefined);
   const [state, setState] = useState<T>(initialValue);
   const pollTime = pollingTimeInSeconds * 1000;


### PR DESCRIPTION
This adds pagination and date metadata to departure details view.

- Unifies behavior/design for trip pattern details and service journey/departure details.
- Adds disappearing map on scroll.
- Adds pagination for service journey/departure details
- Delays loading indicator 400 ms to avoid it showing too often.


## Examples

<img width="342" alt="Screenshot 2021-01-27 at 15 23 19" src="https://user-images.githubusercontent.com/606374/106004519-97f8a780-60b3-11eb-91ba-1a61575e0f9e.png">
<img width="333" alt="Screenshot 2021-01-27 at 15 23 49" src="https://user-images.githubusercontent.com/606374/106004599-a941b400-60b3-11eb-8129-9c16fdc29a1c.png">

<img width="334" alt="Screenshot 2021-01-27 at 15 23 32" src="https://user-images.githubusercontent.com/606374/106004559-9f1fb580-60b3-11eb-9020-2f09a927ecd5.png">


## Demo new scroll behavior for details view


https://user-images.githubusercontent.com/606374/106045112-deb0c680-60e0-11eb-915d-af69434e2257.mov



Closing #879 