### PR TITLE
feat: Add product selection screen

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -116,8 +116,12 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
         <Sections.Section>
           <Sections.LinkItem
             text={getReferenceDataName(preassignedFareProduct, language)}
-            onPress={() => {}}
-            disabled={true}
+            onPress={() => {
+              navigation.push('Product', {
+                preassignedFareProductId: preassignedFareProduct.id,
+              });
+            }}
+            disabled={preassignedFareProducts.length <= 1}
             icon={<ThemeIcon svg={Edit} />}
           />
           <Sections.LinkItem

--- a/src/screens/Ticketing/Purchase/Product/index.tsx
+++ b/src/screens/Ticketing/Purchase/Product/index.tsx
@@ -59,7 +59,7 @@ const Product: React.FC<{
         }}
       />
 
-      <ScrollView style={styles.travellerCounters}>
+      <ScrollView style={styles.productsSection}>
         <Sections.Section>
           <Sections.RadioSection<PreassignedFareProduct>
             items={preassignedFareProducts}
@@ -98,7 +98,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     backgroundColor: theme.background.level2,
   },
-  travellerCounters: {
+  productsSection: {
     margin: theme.spacings.medium,
   },
   saveButton: {

--- a/src/screens/Ticketing/Purchase/Product/index.tsx
+++ b/src/screens/Ticketing/Purchase/Product/index.tsx
@@ -1,0 +1,109 @@
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import {RouteProp} from '@react-navigation/native';
+import {TicketingStackParams} from '../';
+import Header from '../../../../ScreenHeader';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {StyleSheet, useTheme} from '../../../../theme';
+import {DismissableStackNavigationProp} from '../../../../navigation/createDismissableStackNavigator';
+import * as Sections from '../../../../components/sections';
+import {ScrollView} from 'react-native-gesture-handler';
+import {ProductTexts, useTranslation} from '../../../../translations';
+import Button from '../../../../components/button';
+import {getReferenceDataName} from '../../../../reference-data/utils';
+import {useRemoteConfig} from '../../../../RemoteConfigContext';
+import ThemeText from '../../../../components/text';
+import {PreassignedFareProduct} from '../../../../reference-data/types';
+
+export type ProductRouteParams = {
+  preassignedFareProductId: string;
+};
+
+type ProductNavigationProp = DismissableStackNavigationProp<
+  TicketingStackParams,
+  'Product'
+>;
+
+type ProductRouteProp = RouteProp<TicketingStackParams, 'Product'>;
+
+const Product: React.FC<{
+  navigation: ProductNavigationProp;
+  route: ProductRouteProp;
+}> = ({navigation, route: {params}}) => {
+  const styles = useStyles();
+  const {theme} = useTheme();
+  const {t, language} = useTranslation();
+
+  const {
+    preassigned_fare_products: preassignedFareProducts,
+  } = useRemoteConfig();
+
+  const findProduct = (id: string) =>
+    preassignedFareProducts.find((p) => p.id === id);
+
+  const [selectedProduct, setSelectedProduct] = useState(
+    findProduct(params.preassignedFareProductId),
+  );
+
+  const {top: safeAreaTop, bottom: safeAreBottom} = useSafeAreaInsets();
+
+  return (
+    <View style={[styles.container, {paddingTop: safeAreaTop}]}>
+      <Header
+        title={t(ProductTexts.header.title)}
+        leftButton={{
+          accessible: true,
+          accessibilityRole: 'button',
+          icon: <ThemeText>{t(ProductTexts.header.leftButton)}</ThemeText>,
+          onPress: () => navigation.goBack(),
+        }}
+      />
+
+      <ScrollView style={styles.travellerCounters}>
+        <Sections.Section>
+          <Sections.RadioSection<PreassignedFareProduct>
+            items={preassignedFareProducts}
+            itemToText={(p) => getReferenceDataName(p, language)}
+            keyExtractor={(p) => p.id}
+            onSelect={setSelectedProduct}
+            selected={selectedProduct}
+          />
+        </Sections.Section>
+      </ScrollView>
+
+      <View
+        style={[
+          styles.saveButton,
+          {
+            paddingBottom: Math.max(safeAreBottom, theme.spacings.medium),
+          },
+        ]}
+      >
+        <Button
+          mode="primary"
+          text={t(ProductTexts.primaryButton.text)}
+          onPress={() => {
+            navigation.navigate('PurchaseOverview', {
+              preassignedFareProduct: selectedProduct,
+            });
+          }}
+        />
+      </View>
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.background.level2,
+  },
+  travellerCounters: {
+    margin: theme.spacings.medium,
+  },
+  saveButton: {
+    marginHorizontal: theme.spacings.medium,
+  },
+}));
+
+export default Product;

--- a/src/screens/Ticketing/Purchase/index.tsx
+++ b/src/screens/Ticketing/Purchase/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PurchaseOverviewScreen from './Overview';
 import ConfirmationScreen from './Confirmation';
 import TravellersScreen from './Travellers';
+import ProductScreen from './Product';
 import {CreditCard as CreditCardScreen, Vipps as VippsScreen} from './Payment';
 import createDismissableStackNavigator from '../../../navigation/createDismissableStackNavigator';
 import {BuyTicketsScreenName} from '../Tickets';
@@ -18,6 +19,7 @@ import TariffZoneSearch, {
 import transitionSpec from '../../../navigation/transitionSpec';
 import {PreassignedFareProduct} from '../../../reference-data/types';
 import {UserProfileWithCount} from './Travellers/use-user-count-state';
+import {ProductRouteParams} from './Product';
 
 type PurchaseOverviewParams = {
   refreshOffer?: boolean;
@@ -45,6 +47,7 @@ type PaymentParams = {
 
 export type TicketingStackParams = {
   PurchaseOverview: PurchaseOverviewParams;
+  Product: ProductRouteParams;
   Travellers: TravellersParams;
   TariffZones: TariffZonesParams;
   TariffZoneSearch: TariffZoneSearchParams;
@@ -73,6 +76,7 @@ export default function PurchaseStack({route}: TicketPurchaseRootProps) {
         component={PurchaseOverviewScreen}
         initialParams={route.params}
       />
+      <Stack.Screen name="Product" component={ProductScreen} />
       <Stack.Screen name="Travellers" component={TravellersScreen} />
       <Stack.Screen name="TariffZones" component={TariffZones} />
       <Stack.Screen name="Confirmation" component={ConfirmationScreen} />

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -16,6 +16,7 @@ export {default as SectionTexts} from './components/Section';
 export {default as MapTexts} from './components/Map';
 export {default as DateInputTexts} from './components/DateInput';
 export {default as LocationSearchTexts} from './screens/subscreens/LocationSearch';
+export {default as ProductTexts} from './screens/subscreens/Product';
 export {default as TravellersTexts} from './screens/subscreens/Travellers';
 export {default as TariffZonesTexts} from './screens/subscreens/TariffZones';
 export {default as TariffZoneSearchTexts} from './screens/subscreens/TariffZoneSearch';

--- a/src/translations/screens/subscreens/Product.ts
+++ b/src/translations/screens/subscreens/Product.ts
@@ -1,0 +1,12 @@
+import {translation as _} from '../../commons';
+
+const ProductTexts = {
+  header: {
+    title: _('Velg billettype', 'Select ticket type'),
+    leftButton: _('Tilbake', 'Back'),
+  },
+  primaryButton: {
+    text: _('Lagre billettype', 'Confirm ticket type'),
+  },
+};
+export default ProductTexts;


### PR DESCRIPTION
If more than one preassigned fare product is defined in RemoteConfig,
the user will be able to go to the product selection screen for
selecting product. In the overview screen the first product will still
be selected as default product.

The old app code also selected the first product in RemoteConfig as
default, and never allowed the user to change the product. To keep the
old app functioning as is, the 'Enkeltbillett buss/trikk' product must
be kept as the first product defined in the list from RemoteConfig.