### PR TITLE
fix: Make confirmation screen scrollable

### DIFF
--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ActivityIndicator, View} from 'react-native';
+import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {RouteProp} from '@react-navigation/native';
 import {TicketingStackParams} from '../';
 import Header from '../../../../ScreenHeader';
@@ -116,7 +116,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
         style={styles.header}
       />
 
-      <View style={styles.ticketInfoSection}>
+      <ScrollView style={styles.ticketInfoSection}>
         <View>
           {error && (
             <MessageBox
@@ -244,7 +244,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
             />
           )}
         </View>
-      </View>
+      </ScrollView>
     </View>
   );
 };


### PR DESCRIPTION
Users were unable to pay if they used enlarged text and selected
multiple traveller types, as the payment button came below the screen
view, and they were not able to scroll.

I won't be surprised if this also is the case on other screens. Maybe we
could create a View-component which enforced this layout somehow:
-- Header (with safe area top)
-- ScrollView
-- Footer (optional, with safe area bottom)