### PR TITLE
fix: Fix header text overlap bug

### DIFF
--- a/src/components/screen-header/animated-header.tsx
+++ b/src/components/screen-header/animated-header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Animated, View, ViewProps} from 'react-native';
+import {Animated, useWindowDimensions, View, ViewProps} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import ThemeText from '../text';
+import ThemeText, {MAX_FONT_SCALE} from '../text';
 import {StyleSheet} from '../../theme';
 import HeaderButton from './HeaderButton';
 import {LeftButtonProps, RightButtonProps} from './index';
@@ -13,7 +13,7 @@ type ScreenHeaderProps = ViewProps & {
   scrollRef?: Animated.Value;
 };
 
-const HEADER_HEIGHT = 20;
+const BASE_HEADER_HEIGHT = 20;
 
 const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
   leftButton,
@@ -25,13 +25,17 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
 }) => {
   const style = useHeaderStyle();
   const insets = useSafeAreaInsets();
+
+  const {fontScale} = useWindowDimensions();
+  const headerHeight = BASE_HEADER_HEIGHT * Math.min(fontScale, MAX_FONT_SCALE);
+
   const titleOffset = scrollRef!.interpolate({
-    inputRange: [0, HEADER_HEIGHT + insets.top],
-    outputRange: [0, -HEADER_HEIGHT],
+    inputRange: [0, headerHeight + insets.top],
+    outputRange: [0, -headerHeight],
     extrapolate: 'clamp',
   });
 
-  const altTitleOffset = Animated.add(titleOffset, HEADER_HEIGHT);
+  const altTitleOffset = Animated.add(titleOffset, headerHeight);
   const leftIcon = leftButton ? <HeaderButton {...leftButton} /> : <View />;
   const rightIcon = rightButton ? <HeaderButton {...rightButton} /> : <View />;
 
@@ -39,7 +43,10 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
     <Animated.View
       style={[
         style.regularContainer,
-        {transform: [{translateY: altTitleOffset}]},
+        {
+          height: headerHeight,
+          transform: [{translateY: altTitleOffset}],
+        },
       ]}
     >
       {alternativeTitleComponent}
@@ -51,7 +58,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
       <View
         accessible={true}
         accessibilityRole="header"
-        style={style.titleContainers}
+        style={[style.titleContainers, {height: headerHeight}]}
       >
         <Animated.View
           style={[
@@ -65,8 +72,10 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
         </Animated.View>
         {altTitle}
       </View>
-      <View style={style.iconContainerLeft}>{leftIcon}</View>
-      <View style={style.iconContainerRight}>{rightIcon}</View>
+      <View style={style.buttonsContainer}>
+        <View>{leftIcon}</View>
+        <View>{rightIcon}</View>
+      </View>
     </View>
   );
 };
@@ -80,23 +89,21 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
     padding: theme.spacings.medium,
     backgroundColor: theme.background.header,
   },
-  iconContainerLeft: {
+  buttonsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     position: 'absolute',
     left: theme.spacings.medium,
-  },
-  iconContainerRight: {
-    position: 'absolute',
-    right: theme.spacings.medium,
+    width: '100%',
   },
   titleContainers: {
-    height: HEADER_HEIGHT,
     flex: 1,
     alignItems: 'stretch',
     overflow: 'hidden',
     marginHorizontal: theme.spacings.medium + 30,
   },
   regularContainer: {
-    height: HEADER_HEIGHT,
     flex: 1,
     left: 0,
     right: 0,

--- a/src/components/screen-header/index.tsx
+++ b/src/components/screen-header/index.tsx
@@ -1,6 +1,11 @@
-import {View, ViewStyle} from 'react-native';
-import React from 'react';
-import {StyleSheet} from '../../theme';
+import {
+  LayoutChangeEvent,
+  LayoutRectangle,
+  View,
+  ViewStyle,
+} from 'react-native';
+import React, {useMemo, useState} from 'react';
+import {StyleSheet, useTheme} from '../../theme';
 import HeaderButton, {ButtonModes, HeaderButtonProps} from './HeaderButton';
 import ThemeText from '../text';
 
@@ -26,34 +31,100 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   style,
 }) => {
   const css = useHeaderStyle();
+  const {theme} = useTheme();
+  const {buttonsHeight, buttonsTopOffset, setLayoutFor} = useHeaderLayouts();
 
   const leftIcon = leftButton ? <HeaderButton {...leftButton} /> : <View />;
   const rightIcon = rightButton ? <HeaderButton {...rightButton} /> : <View />;
 
   return (
     <View style={[css.container, style]}>
-      <View accessible={true} accessibilityRole="header">
-        <ThemeText type="paragraphHeadline">{title}</ThemeText>
+      <View
+        accessible={true}
+        accessibilityRole="header"
+        style={[
+          css.headerTitle,
+          {
+            // Make space for absolute positioned buttons in case they are offset below title
+            marginBottom: buttonsTopOffset,
+          },
+        ]}
+        onLayout={setLayoutFor('container')}
+      >
+        <ThemeText onLayout={setLayoutFor('title')} type="paragraphHeadline">
+          {title}
+        </ThemeText>
       </View>
-      <View style={css.iconContainerLeft}>{leftIcon}</View>
-      <View style={css.iconContainerRight}>{rightIcon}</View>
+      <View
+        style={[
+          css.buttons,
+          {
+            top: theme.spacings.medium + buttonsTopOffset,
+            height: buttonsHeight,
+          },
+        ]}
+      >
+        <View onLayout={setLayoutFor('leftButton')}>{leftIcon}</View>
+        <View onLayout={setLayoutFor('rightButton')}>{rightIcon}</View>
+      </View>
     </View>
   );
 };
 export default ScreenHeader;
+
 const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
     padding: theme.spacings.medium,
   },
-  iconContainerLeft: {
+  headerTitle: {alignItems: 'center'},
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     position: 'absolute',
     left: theme.spacings.medium,
-  },
-  iconContainerRight: {
-    position: 'absolute',
-    right: theme.spacings.medium,
+    width: '100%',
   },
 }));
+
+type HeaderLayouts = {
+  container?: LayoutRectangle;
+  title?: LayoutRectangle;
+  leftButton?: LayoutRectangle;
+  rightButton?: LayoutRectangle;
+};
+
+/**
+ * Hook for deciding buttons top offset and height, based on the layout of the
+ * header components. If one of the left or right button overlaps with the
+ * header title, the buttons should be rendered below the header title.
+ */
+const useHeaderLayouts = () => {
+  const [headerLayouts, setHeaderLayouts] = useState<HeaderLayouts>({});
+  const setLayoutFor = (element: keyof HeaderLayouts) => ({
+    nativeEvent: {layout},
+  }: LayoutChangeEvent) => {
+    setHeaderLayouts((prev) => ({...prev, [element]: layout}));
+  };
+
+  const buttonsOnOwnLine = useMemo(() => {
+    const {container, title, leftButton, rightButton} = headerLayouts;
+    if (!container || !title || !leftButton || !rightButton) {
+      return false;
+    }
+
+    const widestButtonWidth = Math.max(leftButton.width, rightButton.height);
+    const buttonsAndTitleWidth = title.width + widestButtonWidth * 2;
+    const containerWidth = container.width;
+    return buttonsAndTitleWidth > containerWidth - 10;
+  }, [headerLayouts]);
+
+  const buttonsHeight = headerLayouts.container?.height || 0;
+  const buttonsTopOffset = buttonsOnOwnLine ? buttonsHeight : 0;
+
+  return {
+    buttonsTopOffset,
+    buttonsHeight,
+    setLayoutFor,
+  };
+};

--- a/src/components/sections/text-input.tsx
+++ b/src/components/sections/text-input.tsx
@@ -11,7 +11,7 @@ import {
 import {Close} from '../../assets/svg/icons/actions';
 import {StyleSheet, useTheme} from '../../theme';
 import insets from '../../utils/insets';
-import ThemeText from '../text';
+import ThemeText, {MAX_FONT_SCALE} from '../text';
 import ThemeIcon from '../theme-icon';
 import {SectionItem, useSectionItem} from './section-utils';
 
@@ -77,7 +77,7 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
           placeholderTextColor={theme.text.colors.faded}
           onFocus={onFocusEvent}
           onBlur={onBlurEvent}
-          maxFontSizeMultiplier={2}
+          maxFontSizeMultiplier={MAX_FONT_SCALE}
           {...props}
         />
         {showClear ? (

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -3,6 +3,8 @@ import {Text, TextProps} from 'react-native';
 import {TextColors, TextNames} from '../../theme/colors';
 import {useTheme} from '../../theme';
 
+export const MAX_FONT_SCALE = 2;
+
 export type ThemeTextProps = TextProps & {
   type?: TextNames;
   color?: TextColors;
@@ -23,7 +25,11 @@ const ThemeText: React.FC<ThemeTextProps> = ({
   };
 
   return (
-    <Text style={[typeStyle, style]} maxFontSizeMultiplier={2} {...props}>
+    <Text
+      style={[typeStyle, style]}
+      maxFontSizeMultiplier={MAX_FONT_SCALE}
+      {...props}
+    >
       {children}
     </Text>
   );

--- a/src/utils/navigation.tsx
+++ b/src/utils/navigation.tsx
@@ -8,6 +8,7 @@ import {
   Preference_ScreenAlternatives,
   usePreferenceItems,
 } from '../preferences';
+import {MAX_FONT_SCALE} from '../components/text';
 
 // This is code from react-navigation, for regular tab bar
 // (not compact). Should be a better way to set this or
@@ -15,7 +16,7 @@ import {
 const DEFAULT_TABBAR_HEIGHT = 44;
 
 export const useBottomNavigationStyles = (
-  maxScale: number = 2,
+  maxScale: number = MAX_FONT_SCALE,
 ): {minHeight: number} => {
   const {fontScale} = useWindowDimensions();
   const {bottom} = useSafeAreaInsets();


### PR DESCRIPTION
The combination of a long header title and large accessibility font
size made the title text overlap with the left button text. With this
change, the left button and right button will be rendered below the
header title if they are to wide to be on the same line.

Tried adding the same logic for the animated header, but decided not to
invest the necessary time for making it work. The animated header, and
its usage in the disappearing header, is quite complex, and changes
there can be error-prone. Instead used a simpler solution with
fontscale, but the buttons will as of now not render below the title on
the animated header.