### PR TITLE
feat: Default tariff zone from location

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@react-navigation/native": "^5.7.6",
     "@react-navigation/stack": "^5.9.3",
     "@seznam/compose-react-refs": "^1.0.4",
+    "@turf/boolean-point-in-polygon": "^6.3.0",
     "@turf/centroid": "^6.3.0",
     "@types/lodash.sortby": "^4.7.6",
     "@types/mapbox__polyline": "^1.0.1",

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -21,6 +21,9 @@ import {
 import {useRemoteConfig} from '../../../../RemoteConfigContext';
 import {UserProfileWithCount} from '../Travellers/use-user-count-state';
 import {getReferenceDataName} from '../../../../reference-data/utils';
+import {TariffZone} from '../../../../reference-data/types';
+import {useGeolocationState} from '../../../../GeolocationContext';
+import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
 
 export type OverviewProps = {
   navigation: DismissableStackNavigationProp<
@@ -57,13 +60,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
   const userProfilesWithCount =
     params.userProfilesWithCount ?? defaultUserProfilesWithCount;
 
-  const defaultTariffZone: TariffZoneWithMetadata = useMemo(
-    () => ({
-      ...tariffZones[0],
-      resultType: 'zone',
-    }),
-    [tariffZones],
-  );
+  const defaultTariffZone = useDefaultTariffZone(tariffZones);
   const {
     fromTariffZone = defaultTariffZone,
     toTariffZone = defaultTariffZone,
@@ -191,6 +188,31 @@ const createTravellersText = (
       .map((u) => `${u.count} ${getReferenceDataName(u, language)}`)
       .join(', ');
   }
+};
+
+/**
+ * Get the default tariff zone, either based on current location or else the
+ * first tariff zone in the provided tariff zones list.
+ */
+const useDefaultTariffZone = (
+  tariffZones: TariffZone[],
+): TariffZoneWithMetadata => {
+  const {location} = useGeolocationState();
+  const tariffZoneFromLocation = useMemo(() => {
+    if (location) {
+      const {longitude, latitude} = location.coords;
+      return tariffZones.find((t) =>
+        turfBooleanPointInPolygon([longitude, latitude], t.geometry),
+      );
+    }
+  }, [tariffZones, location]);
+  return useMemo<TariffZoneWithMetadata>(
+    () =>
+      tariffZoneFromLocation
+        ? {...tariffZoneFromLocation, resultType: 'geolocation'}
+        : {...tariffZones[0], resultType: 'zone'},
+    [tariffZones, tariffZoneFromLocation],
+  );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,6 +1849,14 @@
     "@turf/helpers" "6.x"
     "@turf/invariant" "6.x"
 
+"@turf/boolean-point-in-polygon@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.3.0.tgz#784952a36c64119e90fbe94650245da62ecd8fc2"
+  integrity sha512-NqFSsoE6OwhDK19IllDQRhEQEkF7UVEOlqH9vgS1fGg4T6NcyKvACJs05c9457tL7QSbV9ZS53f2qiLneFL+qg==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
 "@turf/centroid@^6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-6.3.0.tgz#e86611e1e171fb0a38ade30453351a00e04956a3"
@@ -1889,6 +1897,13 @@
   integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
   dependencies:
     "@turf/helpers" "6.x"
+
+"@turf/invariant@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.3.0.tgz#04a22b26c5503146c03fa6198176b72bd591eadf"
+  integrity sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
 
 "@turf/length@>= 4.6.0 <7.0.0":
   version "6.0.2"


### PR DESCRIPTION
If the user is sharing his location, and the location in within a
tariff zone, use this tariff zone as the default tariff zone when
purchasing ticket. Else the default tariff zone will be the first tariff
zone in RemoteConfig.

There was talks about letting the user select tariff zone based on his
nearest stops, to reduce the risk of selecting a initial tariff zone
that does not include the actual stop the user will travel from. This
may be implemented later if necessary.