### PR TITLE
feat: Add summary on travellers screen

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -171,13 +171,15 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
   );
 };
 
-const createTravellersText = (
+export const createTravellersText = (
   userProfilesWithCount: UserProfileWithCount[],
   t: TranslateFunction,
   language: Language,
 ) => {
   const chosenUserProfiles = userProfilesWithCount.filter((u) => u.count);
-  if (chosenUserProfiles.length > 2) {
+  if (chosenUserProfiles.length === 0) {
+    return t(PurchaseOverviewTexts.travellers.noTravellers);
+  } else if (chosenUserProfiles.length > 2) {
     const totalCount = chosenUserProfiles.reduce(
       (total, u) => total + u.count,
       0,

--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -12,6 +12,10 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {TravellersTexts, useTranslation} from '../../../../translations';
 import Button from '../../../../components/button';
 import {getReferenceDataName} from '../../../../reference-data/utils';
+import ThemeText from '../../../../components/text';
+import {createTravellersText} from '../Overview';
+import ThemeIcon from '../../../../components/theme-icon';
+import SvgProfile from '../../../../assets/svg/icons/tab-bar/Profile';
 
 export type TravellersProps = {
   navigation: DismissableStackNavigationProp<
@@ -43,6 +47,18 @@ const Travellers: React.FC<TravellersProps> = ({
       />
 
       <ScrollView style={styles.travellerCounters}>
+        <View style={styles.summarySection}>
+          <Sections.Section>
+            <Sections.GenericItem>
+              <View style={styles.summaryItem}>
+                <ThemeIcon style={styles.summaryIcon} svg={SvgProfile} />
+                <ThemeText>
+                  {createTravellersText(userProfilesWithCount, t, language)}
+                </ThemeText>
+              </View>
+            </Sections.GenericItem>
+          </Sections.Section>
+        </View>
         <Sections.Section>
           {userProfilesWithCount.map((u) => (
             <Sections.CounterInput
@@ -87,6 +103,16 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   travellerCounters: {
     margin: theme.spacings.medium,
+  },
+  summarySection: {
+    marginBottom: theme.spacings.medium,
+  },
+  summaryItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  summaryIcon: {
+    marginRight: theme.spacings.medium,
   },
   saveButton: {
     marginHorizontal: theme.spacings.medium,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -13,6 +13,7 @@ const PurchaseOverviewTexts = {
   },
   startTime: _('Oppstart nå', 'Starting now'),
   travellers: {
+    noTravellers: _(`Ingen reisende`, `No travellers`),
     travellersCount: (count: number) =>
       _(`${count} reisende`, `${count} travellers`),
     a11yHint: _(


### PR DESCRIPTION
A summary of the selected travellers was added to the top of the travellers screen. The text follows the same logic as the overview screen, where three or more selected traveller groups gives the text "X travellers" instead of listing every group.

<img width="300" alt="Screenshot 2021-02-12 at 10 19 34" src="https://user-images.githubusercontent.com/675421/107750215-011b2480-6d1c-11eb-884d-f39abd651283.png">
<img width="300" alt="Screenshot 2021-02-12 at 10 19 47" src="https://user-images.githubusercontent.com/675421/107750214-00828e00-6d1c-11eb-94fb-d3c3dcbadd69.png">
<img width="300" alt="Screenshot 2021-02-12 at 10 20 04" src="https://user-images.githubusercontent.com/675421/107750212-feb8ca80-6d1b-11eb-8310-47171a83bbb6.png">