### PR TITLE
fix: Flickering header button text

### DIFF
--- a/src/components/screen-header/index.tsx
+++ b/src/components/screen-header/index.tsx
@@ -113,7 +113,12 @@ const useHeaderLayouts = () => {
       return false;
     }
 
-    const widestButtonWidth = Math.max(leftButton.width, rightButton.height);
+    const leftButtonVisibleWidth = leftButton.height ? leftButton.width : 0;
+    const rightButtonVisibleWidth = rightButton.height ? rightButton.width : 0;
+    const widestButtonWidth = Math.max(
+      leftButtonVisibleWidth,
+      rightButtonVisibleWidth,
+    );
     const buttonsAndTitleWidth = title.width + widestButtonWidth * 2;
     const containerWidth = container.width;
     return buttonsAndTitleWidth > containerWidth - 10;


### PR DESCRIPTION
On Android the header buttons sometimes flickered below the header title
for a single render. This was because for the first onLayout event the
button width was full screen width, event though the height of 0 made it
not visible yet.