### PR TITLE
fix: adds custom lint rules to avoid simple mistakes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+rulesDirPlugin.RULES_DIR = 'eslint-rules/';
+
 module.exports = {
   env: {
     es6: true,
@@ -8,7 +11,7 @@ module.exports = {
   root: true,
   extends: ['plugin:prettier/recommended', 'prettier/react'],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'react-hooks', 'react-native'],
+  plugins: ['@typescript-eslint', 'react-hooks', 'react-native', 'rulesdir'],
   rules: {
     // eslint
     'no-console': [1, {allow: ['warn', 'error']}],
@@ -22,5 +25,7 @@ module.exports = {
     'react-native/no-raw-text': [2, {skip: 'ThemeText'}], // rather early error than JS bundle crash
     'react-native/no-single-element-style-arrays': 1,
     'react-native/no-unused-styles': 1,
+
+    'rulesdir/translations-warning': 'warn',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,12 @@ module.exports = {
     'react-native/no-unused-styles': 1,
 
     'rulesdir/translations-warning': 'warn',
+    'rulesdir/avoid-imports': [
+      'warn',
+      {
+        '@react-navigation/core': '@react-navigation/native',
+      },
+    ],
     'rulesdir/import-warning': [
       'warn',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,11 @@ module.exports = {
     'react-native/no-unused-styles': 1,
 
     'rulesdir/translations-warning': 'warn',
+    'rulesdir/import-warning': [
+      'warn',
+      {
+        SafeAreaView: 'react-native-safe-area-context',
+      },
+    ],
   },
 };

--- a/eslint-rules/avoid-imports.js
+++ b/eslint-rules/avoid-imports.js
@@ -1,0 +1,98 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+
+    messages: {
+      avoidableModuleWithAlternative:
+        'Package {{ actualModule }} should be avoided. Use {{ suggestedModule }} instead.',
+      avoidableModule: 'Package {{ actualModule }} should be avoided.',
+    },
+
+    schema: [
+      {
+        anyOf: [
+          {
+            type: 'object',
+            additionalProperties: {
+              type: 'string',
+            },
+          },
+          {
+            type: 'array',
+            items: {
+              anyOf: [
+                {type: 'string'},
+                {
+                  type: 'object',
+                  additionalProperties: {
+                    type: 'string',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  create: function (context) {
+    const [config] = context.options;
+    const avoidables = avoidableModules(config);
+
+    return {
+      ImportDeclaration(node) {
+        const fullModule = node.source.value;
+        const actualModule = avoidables.find((m) => fullModule.startsWith(m));
+        if (!actualModule) {
+          return;
+        }
+
+        const suggestedModule = findSuggestedModule(config, actualModule);
+        const data = {
+          actualModule,
+          suggestedModule,
+        };
+        context.report({
+          node,
+          messageId: suggestedModule
+            ? 'avoidableModuleWithAlternative'
+            : 'avoidableModule',
+          data,
+          fix: suggestedModule
+            ? function (fixer) {
+                const replaced = node.source.raw.replace(
+                  actualModule,
+                  suggestedModule,
+                );
+                return fixer.replaceText(node.source, replaced);
+              }
+            : undefined,
+        });
+      },
+    };
+  },
+};
+
+function avoidableModules(mappings) {
+  if (Array.isArray(mappings)) {
+    return mappings.flatMap(stringOrKeys);
+  }
+  return stringOrKeys(mappings);
+}
+function stringOrKeys(item) {
+  if (typeof item === 'string') {
+    return item;
+  }
+  return Object.keys(item);
+}
+
+function findSuggestedModule(mappings, name) {
+  if (!Array.isArray(mappings)) {
+    return mappings[name];
+  }
+  for (let item of mappings) {
+    if (typeof item === 'string') continue;
+    if (item[name]) return item[name];
+  }
+}

--- a/eslint-rules/import-warning.js
+++ b/eslint-rules/import-warning.js
@@ -1,0 +1,42 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+        },
+      },
+    ],
+  },
+  create: function (context) {
+    const [mappings] = context.options;
+
+    return {
+      ImportDeclaration(node) {
+        const actualModule = node.source.value;
+        for (let specifierNode of node.specifiers) {
+          const identifier = specifierNode.local.name;
+          const preferredModule = mappings[identifier];
+          if (!preferredModule) continue;
+
+          if (preferredModule !== actualModule) {
+            context.report({
+              node: specifierNode,
+              message:
+                '{{ identifier }} should be importet from {{ preferredModule }} not {{ actualModule }}',
+              data: {
+                identifier,
+                preferredModule,
+                actualModule,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,7 @@
+const translationsWarning = require('./translations-warning');
+
+module.exports = {
+  rules: {
+    ['translations-warning']: translationsWarning,
+  },
+};

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,9 +1,11 @@
 const translationsWarning = require('./translations-warning');
 const importWarning = require('./import-warning');
+const avoidImports = require('./avoid-imports');
 
 module.exports = {
   rules: {
     ['translations-warning']: translationsWarning,
     ['import-warning']: importWarning,
+    ['avoid-imports']: avoidImports,
   },
 };

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,7 +1,9 @@
 const translationsWarning = require('./translations-warning');
+const importWarning = require('./import-warning');
 
 module.exports = {
   rules: {
     ['translations-warning']: translationsWarning,
+    ['import-warning']: importWarning,
   },
 };

--- a/eslint-rules/translations-warning.js
+++ b/eslint-rules/translations-warning.js
@@ -1,0 +1,80 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+  },
+  create: function (context) {
+    const config = {
+      translateFunctionIdentifier: 't',
+      translateModulePrefix: '@atb/translations',
+    };
+
+    const objectify = (names) =>
+      names.reduce((obj, n) => ({...obj, [n]: true}), {});
+    const NOT_TRANSLATION_SPECIFIERS = objectify([
+      'Language',
+      'DEFAULT_LANGUAGE',
+      'lobot',
+      'useTranslation',
+      'appLanguages',
+      'translation',
+    ]);
+
+    let identifiers = {};
+
+    return {
+      ImportDeclaration(node) {
+        if (!node.source.value.startsWith(config.translateModulePrefix)) return;
+        for (let s of node.specifiers) {
+          const identifier = s.local.name;
+          if (NOT_TRANSLATION_SPECIFIERS.hasOwnProperty(identifier)) continue;
+          identifiers[identifier] = true;
+        }
+      },
+      Identifier(node) {
+        if (!identifiers.hasOwnProperty(node.name)) return;
+        const validParent = parentCallExpressionWithIdentifier(
+          node.parent,
+          config.translateFunctionIdentifier,
+        );
+        if (node.parent.type !== 'MemberExpression' || validParent) {
+          return;
+        }
+        const name = translationTextFullName(node.parent);
+
+        context.report({
+          node,
+          message:
+            'Expected {{ identifier }} to be argument of translate function {{ translateFunction }}',
+          data: {
+            identifier: name,
+            translateFunction: config.translateFunctionIdentifier,
+          },
+        });
+      },
+    };
+  },
+};
+
+function parentCallExpressionWithIdentifier(node, identifier) {
+  if (!node) return false;
+  if (
+    node.type === 'CallExpression' &&
+    node.callee &&
+    node.callee.name === identifier
+  ) {
+    return node;
+  }
+  return parentCallExpressionWithIdentifier(node.parent, identifier);
+}
+
+function translationTextFullName(node) {
+  const base = node.object.name;
+  const prop = node.property.name;
+  return `${base}.${prop}.${onlyProperties(node.parent)}`.slice(0, -1);
+}
+function onlyProperties(node) {
+  if (node.type !== 'MemberExpression' || !node.property) return '';
+  if (!node.property || !node.property.name) return '';
+  return `${node.property.name}.${onlyProperties(node.parent)}`;
+}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-react-native": "3.8.1",
+    "eslint-plugin-rulesdir": "^0.1.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.65.0",
     "patch-package": "^6.2.2",

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -352,29 +352,46 @@ function LineDisplayName({leg, style}: {leg: Leg; style?: ViewStyle}) {
 
 const tripSummary = (tripPattern: TripPattern, t: TranslateFunction) => {
   const nonFootLegs = tripPattern.legs.filter((l) => l.mode !== 'foot') ?? [];
-  const screenreaderText = AssistantTexts.results.resultItem.journeySummary;
-
   return `
     ${
       !nonFootLegs.length
-        ? t(screenreaderText.legsDescription.footLegsOnly)
+        ? t(
+            AssistantTexts.results.resultItem.journeySummary.legsDescription
+              .footLegsOnly,
+          )
         : nonFootLegs.length === 1
-        ? t(screenreaderText.legsDescription.noSwitching)
+        ? t(
+            AssistantTexts.results.resultItem.journeySummary.legsDescription
+              .noSwitching,
+          )
         : nonFootLegs.length === 2
-        ? t(screenreaderText.legsDescription.oneSwitch)
-        : t(screenreaderText.legsDescription.someSwitches(nonFootLegs.length))
+        ? t(
+            AssistantTexts.results.resultItem.journeySummary.legsDescription
+              .oneSwitch,
+          )
+        : t(
+            AssistantTexts.results.resultItem.journeySummary.legsDescription.someSwitches(
+              nonFootLegs.length,
+            ),
+          )
     }. ${screenReaderPause}
     ${nonFootLegs
       ?.map((l) => {
         return `${t(getTranslatedModeName(l.mode))} ${
           l.line
-            ? t(screenreaderText.prefixedLineNumber(l.line.publicCode))
+            ? t(
+                AssistantTexts.results.resultItem.journeySummary.prefixedLineNumber(
+                  l.line.publicCode,
+                ),
+              )
             : ''
         }`;
       })
       .join(', ')} ${screenReaderPause}
       ${t(
-        screenreaderText.totalWalkDistance(tripPattern.walkDistance.toFixed(0)),
+        AssistantTexts.results.resultItem.journeySummary.totalWalkDistance(
+          tripPattern.walkDistance.toFixed(0),
+        ),
       )}  ${screenReaderPause}
      
 

--- a/src/screens/Assistant/journey-date-picker/index.tsx
+++ b/src/screens/Assistant/journey-date-picker/index.tsx
@@ -18,7 +18,7 @@ import {
   ParamListBase,
   RouteProp,
   useRoute,
-} from '@react-navigation/core';
+} from '@react-navigation/native';
 import React, {useRef, useState} from 'react';
 import {ScrollView} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';

--- a/src/screens/Assistant/journey-date-picker/index.tsx
+++ b/src/screens/Assistant/journey-date-picker/index.tsx
@@ -7,7 +7,11 @@ import {
   TimeInputItem,
 } from '@atb/components/sections';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {JourneyDatePickerTexts, useTranslation} from '@atb/translations';
+import {
+  JourneyDatePickerTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import {dateWithReplacedTime, formatLocaleTime} from '@atb/utils/date';
 import {
   NavigationProp,
@@ -84,7 +88,7 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
           items={dateItems}
           withBottomPadding
           onSelect={setOption}
-          itemToText={(s: DateOptionType) => t(getDateOptionText(s))}
+          itemToText={(s: DateOptionType) => getDateOptionText(s, t)}
         />
 
         {option !== 'now' && (
@@ -117,15 +121,18 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-const getDateOptionText = (dateOption: DateOptionType) => {
+const getDateOptionText = (
+  dateOption: DateOptionType,
+  t: TranslateFunction,
+) => {
   switch (dateOption) {
     case 'now':
-      return JourneyDatePickerTexts.options.now;
+      return t(JourneyDatePickerTexts.options.now);
     case 'arrival':
-      return JourneyDatePickerTexts.options.arrival;
+      return t(JourneyDatePickerTexts.options.arrival);
     case 'departure':
     default:
-      return JourneyDatePickerTexts.options.departure;
+      return t(JourneyDatePickerTexts.options.departure);
   }
 };
 export default JourneyDatePicker;

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -22,8 +22,9 @@ import {
   dictionary,
   NearbyTexts,
   TranslatedString,
+  TranslateFunction,
   useTranslation,
-} from '@atb/translations/';
+} from '@atb/translations';
 import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React, {useEffect, useMemo, useState} from 'react';
@@ -220,7 +221,7 @@ const NearbyOverview: React.FC<Props> = ({
         isFetchingMore={isFetchingMore && !isLoading}
         isLoading={isLoading}
         isInitialScreen={isInitialScreen}
-        error={error ? t(translateErrorType(error.type)) : undefined}
+        error={error ? translateErrorType(error.type, t) : undefined}
       />
     </SimpleDisappearingHeader>
   );
@@ -293,12 +294,15 @@ const useNearbyStyles = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-function translateErrorType(errorType: ErrorType): TranslatedString {
+function translateErrorType(
+  errorType: ErrorType,
+  t: TranslateFunction,
+): string {
   switch (errorType) {
     case 'network-error':
     case 'timeout':
-      return NearbyTexts.messages.networkError;
+      return t(NearbyTexts.messages.networkError);
     default:
-      return NearbyTexts.messages.defaultFetchError;
+      return t(NearbyTexts.messages.defaultFetchError);
   }
 }

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -324,18 +324,17 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
   };
 
   const Icon = favorite ? SvgFavoriteFill : SvgFavorite;
-  const label =
+  const label = t(
     NearbyTexts.results.lines.favorite[
       !favorite ? 'addFavorite' : 'removeFavorite'
-    ];
+    ](`${line.lineNumber} ${line.lineName}`, stop.name),
+  );
   return (
     <TouchableOpacity
       onPress={onPress}
       accessibilityRole="checkbox"
       accessibilityState={{checked: !!favorite}}
-      accessibilityLabel={t(
-        label(`${line.lineNumber} ${line.lineName}`, stop.name),
-      )}
+      accessibilityLabel={label}
       hitSlop={insets.symmetric(14, 8)}
       style={styles.favoriteButton}
     >

--- a/src/screens/Onboarding/components/StepContainer.tsx
+++ b/src/screens/Onboarding/components/StepContainer.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import {SafeAreaView, View} from 'react-native';
+import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {ScrollView} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
 const StepOuterContainer: React.FC = ({children}) => {
   const styles = useStyles();
   return (

--- a/src/screens/Profile/SelectStartScreen/index.tsx
+++ b/src/screens/Profile/SelectStartScreen/index.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
-import {ScrollView} from 'react-native-gesture-handler';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import ScreenHeader from '@atb/components/screen-header';
 import {RadioSection} from '@atb/components/sections';
 import {
   Preference_ScreenAlternatives,
@@ -10,20 +8,25 @@ import {
 import {StyleSheet, Theme} from '@atb/theme';
 import {
   SelectStartScreenTexts,
+  TranslateFunction,
   useTranslation,
-  TranslatedString,
 } from '@atb/translations';
-import ScreenHeader from '@atb/components/screen-header';
+import React from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 const identity = (s: string) => s;
-function toName(alt: Preference_ScreenAlternatives): TranslatedString {
+function toName(
+  alt: Preference_ScreenAlternatives,
+  t: TranslateFunction,
+): string {
   switch (alt) {
     case 'assistant':
-      return SelectStartScreenTexts.options.assistant;
+      return t(SelectStartScreenTexts.options.assistant);
     case 'departures':
-      return SelectStartScreenTexts.options.departures;
+      return t(SelectStartScreenTexts.options.departures);
     case 'ticketing':
-      return SelectStartScreenTexts.options.ticketing;
+      return t(SelectStartScreenTexts.options.ticketing);
   }
 }
 
@@ -49,7 +52,7 @@ export default function SelectStartScreen() {
           withTopPadding
           items={items}
           keyExtractor={identity}
-          itemToText={(alt) => t(toName(alt))}
+          itemToText={(alt) => toName(alt, t)}
           selected={startScreen ?? items[0]}
           onSelect={(startScreen) => setPreference({startScreen})}
         />

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -147,7 +147,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             icon={<ThemeIcon svg={Edit} />}
           />
           <Sections.LinkItem
-            text={t(tariffZonesSummary(fromTariffZone, toTariffZone, language))}
+            text={tariffZonesSummary(fromTariffZone, toTariffZone, language, t)}
             onPress={() => {
               navigation.push('TariffZones', {
                 fromTariffZone,

--- a/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
@@ -5,7 +5,11 @@ import MessageBox from '@atb/message-box';
 import {DismissableStackNavigationProp} from '@atb/navigation/createDismissableStackNavigator';
 import {StyleSheet} from '@atb/theme';
 import {ReserveOffer, TicketReservation, useTicketState} from '@atb/tickets';
-import {PaymentCreditCardTexts, useTranslation} from '@atb/translations';
+import {
+  PaymentCreditCardTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import {MaterialTopTabNavigationProp} from '@react-navigation/material-top-tabs';
 import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';
 import React, {useState} from 'react';
@@ -93,13 +97,13 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
       </View>
       {loadingState && (
         <View style={styles.center}>
-          <Processing message={t(translateLoadingMessage(loadingState))} />
+          <Processing message={translateLoadingMessage(loadingState, t)} />
         </View>
       )}
       {!!error && (
         <View style={styles.center}>
           <MessageBox
-            message={t(translateError(error.context, error.type))}
+            message={translateError(error.context, error.type, t)}
             type="error"
             containerStyle={styles.messageBox}
           />
@@ -122,25 +126,32 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
   );
 };
 
-const translateLoadingMessage = (loadingState: LoadingState) => {
+const translateLoadingMessage = (
+  loadingState: LoadingState,
+  t: TranslateFunction,
+) => {
   switch (loadingState) {
     case 'reserving-offer':
-      return PaymentCreditCardTexts.stateMessages.reserving;
+      return t(PaymentCreditCardTexts.stateMessages.reserving);
     case 'loading-terminal':
-      return PaymentCreditCardTexts.stateMessages.loading;
+      return t(PaymentCreditCardTexts.stateMessages.loading);
     case 'processing-payment':
-      return PaymentCreditCardTexts.stateMessages.processing;
+      return t(PaymentCreditCardTexts.stateMessages.processing);
   }
 };
 
-const translateError = (errorContext: ErrorContext, errorType: ErrorType) => {
+const translateError = (
+  errorContext: ErrorContext,
+  errorType: ErrorType,
+  t: TranslateFunction,
+) => {
   switch (errorContext) {
     case 'terminal-loading':
-      return PaymentCreditCardTexts.errorMessages.loading;
+      return t(PaymentCreditCardTexts.errorMessages.loading);
     case 'reservation':
-      return PaymentCreditCardTexts.errorMessages.reservation;
+      return t(PaymentCreditCardTexts.errorMessages.reservation);
     case 'capture':
-      return PaymentCreditCardTexts.errorMessages.capture;
+      return t(PaymentCreditCardTexts.errorMessages.capture);
   }
 };
 

--- a/src/screens/Ticketing/Purchase/Payment/Vipps/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/Vipps/index.tsx
@@ -5,7 +5,11 @@ import MessageBox from '@atb/message-box';
 import {DismissableStackNavigationProp} from '@atb/navigation/createDismissableStackNavigator';
 import {StyleSheet} from '@atb/theme';
 import {ReserveOffer, TicketReservation, useTicketState} from '@atb/tickets';
-import {PaymentVippsTexts, useTranslation} from '@atb/translations';
+import {
+  PaymentVippsTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import {MaterialTopTabNavigationProp} from '@react-navigation/material-top-tabs';
 import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';
 import React from 'react';
@@ -70,7 +74,7 @@ export default function VippsPayment({
       <View style={styles.content}>
         {!error &&
           (state === 'reserving-offer' || state === 'offer-reserved' ? (
-            <Processing message={t(translateStateMessage(state))} />
+            <Processing message={translateStateMessage(state, t)} />
           ) : (
             <Button
               text={t(PaymentVippsTexts.buttons.goToVipps)}
@@ -81,7 +85,7 @@ export default function VippsPayment({
         {!!error && (
           <>
             <MessageBox
-              message={t(translateError(error.context, error.type))}
+              message={translateError(error.context, error.type, t)}
               type="error"
               containerStyle={styles.messageBox}
             />
@@ -105,22 +109,26 @@ export default function VippsPayment({
   );
 }
 
-const translateError = (errorContext: ErrorContext, errorType: ErrorType) => {
+const translateError = (
+  errorContext: ErrorContext,
+  errorType: ErrorType,
+  t: TranslateFunction,
+) => {
   switch (errorContext) {
     case 'open-vipps-url':
-      return PaymentVippsTexts.errorMessages.openVipps;
+      return t(PaymentVippsTexts.errorMessages.openVipps);
     case 'reserve-offer':
-      return PaymentVippsTexts.errorMessages.reserveOffer;
+      return t(PaymentVippsTexts.errorMessages.reserveOffer);
   }
 };
 
-const translateStateMessage = (loadingState: State) => {
+const translateStateMessage = (loadingState: State, t: TranslateFunction) => {
   switch (loadingState) {
     case 'reserving-offer':
-      return PaymentVippsTexts.stateMessages.reserving;
+      return t(PaymentVippsTexts.stateMessages.reserving);
     case 'offer-reserved':
     default:
-      return PaymentVippsTexts.stateMessages.reserved;
+      return t(PaymentVippsTexts.stateMessages.reserved);
   }
 };
 

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -18,7 +18,12 @@ import {getReferenceDataName} from '@atb/reference-data/utils';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {StyleSheet, useTheme} from '@atb/theme';
 import colors from '@atb/theme/colors';
-import {Language, TariffZonesTexts, useTranslation} from '@atb/translations';
+import {
+  Language,
+  TariffZonesTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import MapboxGL, {
   OnPressEvent,
   RegionPayload,
@@ -80,15 +85,20 @@ export const tariffZonesSummary = (
   fromTariffZone: TariffZoneWithMetadata,
   toTariffZone: TariffZoneWithMetadata,
   language: Language,
+  t: TranslateFunction,
 ) => {
   if (fromTariffZone.id === toTariffZone.id) {
-    return TariffZonesTexts.zoneSummary.text.singleZone(
-      getReferenceDataName(fromTariffZone, language),
+    return t(
+      TariffZonesTexts.zoneSummary.text.singleZone(
+        getReferenceDataName(fromTariffZone, language),
+      ),
     );
   } else {
-    return TariffZonesTexts.zoneSummary.text.multipleZone(
-      getReferenceDataName(fromTariffZone, language),
-      getReferenceDataName(toTariffZone, language),
+    return t(
+      TariffZonesTexts.zoneSummary.text.multipleZone(
+        getReferenceDataName(fromTariffZone, language),
+        getReferenceDataName(toTariffZone, language),
+      ),
     );
   }
 };
@@ -96,15 +106,20 @@ export const tariffZonesSummary = (
 const departurePickerAccessibilityLabel = (
   fromTariffZone: TariffZoneWithMetadata,
   language: Language,
-) => {
+  t: TranslateFunction,
+): string => {
   if (fromTariffZone.venueName)
-    return TariffZonesTexts.location.departurePicker.a11yLabel.withVenue(
-      getReferenceDataName(fromTariffZone, language),
-      fromTariffZone.venueName,
+    return t(
+      TariffZonesTexts.location.departurePicker.a11yLabel.withVenue(
+        getReferenceDataName(fromTariffZone, language),
+        fromTariffZone.venueName,
+      ),
     );
   else {
-    return TariffZonesTexts.location.departurePicker.a11yLabel.noVenue(
-      getReferenceDataName(fromTariffZone, language),
+    return t(
+      TariffZonesTexts.location.departurePicker.a11yLabel.noVenue(
+        getReferenceDataName(fromTariffZone, language),
+      ),
     );
   }
 };
@@ -112,15 +127,20 @@ const departurePickerAccessibilityLabel = (
 const destinationPickerAccessibilityLabel = (
   toTariffZone: TariffZoneWithMetadata,
   language: Language,
-) => {
+  t: TranslateFunction,
+): string => {
   if (toTariffZone.venueName)
-    return TariffZonesTexts.location.destinationPicker.a11yLabel.withVenue(
-      getReferenceDataName(toTariffZone, language),
-      toTariffZone.venueName,
+    return t(
+      TariffZonesTexts.location.destinationPicker.a11yLabel.withVenue(
+        getReferenceDataName(toTariffZone, language),
+        toTariffZone.venueName,
+      ),
     );
   else {
-    return TariffZonesTexts.location.destinationPicker.a11yLabel.noVenue(
-      getReferenceDataName(toTariffZone, language),
+    return t(
+      TariffZonesTexts.location.destinationPicker.a11yLabel.noVenue(
+        getReferenceDataName(toTariffZone, language),
+      ),
     );
   }
 };
@@ -128,15 +148,20 @@ const destinationPickerAccessibilityLabel = (
 const departurePickerValue = (
   fromTariffZone: TariffZoneWithMetadata,
   language: Language,
-) => {
+  t: TranslateFunction,
+): string => {
   if (fromTariffZone.venueName)
-    return TariffZonesTexts.location.departurePicker.value.withVenue(
-      getReferenceDataName(fromTariffZone, language),
-      fromTariffZone.venueName,
+    return t(
+      TariffZonesTexts.location.departurePicker.value.withVenue(
+        getReferenceDataName(fromTariffZone, language),
+        fromTariffZone.venueName,
+      ),
     );
   else {
-    return TariffZonesTexts.location.departurePicker.value.noVenue(
-      getReferenceDataName(fromTariffZone, language),
+    return t(
+      TariffZonesTexts.location.departurePicker.value.noVenue(
+        getReferenceDataName(fromTariffZone, language),
+      ),
     );
   }
 };
@@ -145,21 +170,28 @@ const destinationPickerValue = (
   fromTariffZone: TariffZoneWithMetadata,
   toTariffZone: TariffZoneWithMetadata,
   language: Language,
-) => {
+  t: TranslateFunction,
+): string => {
   if (fromTariffZone.id === toTariffZone.id && toTariffZone.venueName) {
-    return TariffZonesTexts.location.destinationPicker.value.withVenueSameZone(
-      toTariffZone.venueName,
+    return t(
+      TariffZonesTexts.location.destinationPicker.value.withVenueSameZone(
+        toTariffZone.venueName,
+      ),
     );
   } else if (fromTariffZone.id === toTariffZone.id && !toTariffZone.venueName) {
-    return TariffZonesTexts.location.destinationPicker.value.noVenueSameZone;
+    return t(TariffZonesTexts.location.destinationPicker.value.noVenueSameZone);
   } else if (toTariffZone.venueName) {
-    return TariffZonesTexts.location.departurePicker.value.withVenue(
-      getReferenceDataName(toTariffZone, language),
-      toTariffZone.venueName,
+    return t(
+      TariffZonesTexts.location.departurePicker.value.withVenue(
+        getReferenceDataName(toTariffZone, language),
+        toTariffZone.venueName,
+      ),
     );
   } else {
-    return TariffZonesTexts.location.departurePicker.value.noVenue(
-      getReferenceDataName(toTariffZone, language),
+    return t(
+      TariffZonesTexts.location.departurePicker.value.noVenue(
+        getReferenceDataName(toTariffZone, language),
+      ),
     );
   }
 };
@@ -297,9 +329,11 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
         <Section withPadding>
           <ButtonInput
             label={t(TariffZonesTexts.location.departurePicker.label)}
-            value={t(departurePickerValue(selectedZones.from, language))}
-            accessibilityLabel={t(
-              departurePickerAccessibilityLabel(selectedZones.from, language),
+            value={departurePickerValue(selectedZones.from, language, t)}
+            accessibilityLabel={departurePickerAccessibilityLabel(
+              selectedZones.from,
+              language,
+              t,
             )}
             accessibilityHint={t(
               TariffZonesTexts.location.departurePicker.a11yHint,
@@ -313,15 +347,16 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
           />
           <ButtonInput
             label={t(TariffZonesTexts.location.destinationPicker.label)}
-            value={t(
-              destinationPickerValue(
-                selectedZones.from,
-                selectedZones.to,
-                language,
-              ),
+            value={destinationPickerValue(
+              selectedZones.from,
+              selectedZones.to,
+              language,
+              t,
             )}
-            accessibilityLabel={t(
-              destinationPickerAccessibilityLabel(selectedZones.from, language),
+            accessibilityLabel={destinationPickerAccessibilityLabel(
+              selectedZones.from,
+              language,
+              t,
             )}
             accessibilityHint={t(
               TariffZonesTexts.location.departurePicker.a11yHint,

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -86,7 +86,7 @@ export const tariffZonesSummary = (
   toTariffZone: TariffZoneWithMetadata,
   language: Language,
   t: TranslateFunction,
-) => {
+): string => {
   if (fromTariffZone.id === toTariffZone.id) {
     return t(
       TariffZonesTexts.zoneSummary.text.singleZone(

--- a/src/screens/TripDetails/components/TripMessages.tsx
+++ b/src/screens/TripDetails/components/TripMessages.tsx
@@ -2,7 +2,7 @@ import {getAxiosErrorType} from '@atb/api/utils';
 import ScreenReaderAnnouncement from '@atb/components/screen-reader-announcement';
 import MessageBox from '@atb/message-box';
 import {
-  TranslatedString,
+  TranslateFunction,
   TripDetailsTexts,
   useTranslation,
 } from '@atb/translations';
@@ -32,25 +32,25 @@ const TripMessages: React.FC<TripMessagesProps> = ({
       )}
       {error && (
         <>
-          <ScreenReaderAnnouncement message={t(translatedError(error))} />
+          <ScreenReaderAnnouncement message={translatedError(error, t)} />
           <MessageBox
             containerStyle={messageStyle}
             type="warning"
-            message={t(translatedError(error))}
+            message={translatedError(error, t)}
           />
         </>
       )}
     </>
   );
 };
-function translatedError(error: AxiosError): TranslatedString {
+function translatedError(error: AxiosError, t: TranslateFunction): string {
   const errorType = getAxiosErrorType(error);
   switch (errorType) {
     case 'network-error':
     case 'timeout':
-      return TripDetailsTexts.messages.errorNetwork;
+      return t(TripDetailsTexts.messages.errorNetwork);
     default:
-      return TripDetailsTexts.messages.errorDefault;
+      return t(TripDetailsTexts.messages.errorDefault);
   }
 }
 export default TripMessages;

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -11,6 +11,7 @@ import {StyleSheet} from '@atb/theme';
 import {
   Language,
   TranslatedString,
+  TranslateFunction,
   TripDetailsTexts,
   useTranslation,
 } from '@atb/translations';
@@ -79,13 +80,12 @@ const TripSection: React.FC<TripSectionProps> = ({
         {showFrom && (
           <TripRow
             alignChildren="flex-start"
-            accessibilityLabel={t(
-              getStopRowA11yTranslated(
-                'start',
-                getPlaceName(leg.fromPlace),
-                startTimes,
-                language,
-              ),
+            accessibilityLabel={getStopRowA11yTranslated(
+              'start',
+              getPlaceName(leg.fromPlace),
+              startTimes,
+              language,
+              t,
             )}
             rowLabel={<Time {...startTimes} />}
           >
@@ -135,13 +135,12 @@ const TripSection: React.FC<TripSectionProps> = ({
         {showTo && (
           <TripRow
             alignChildren="flex-end"
-            accessibilityLabel={t(
-              getStopRowA11yTranslated(
-                'end',
-                getPlaceName(leg.toPlace),
-                endTimes,
-                language,
-              ),
+            accessibilityLabel={getStopRowA11yTranslated(
+              'end',
+              getPlaceName(leg.toPlace),
+              endTimes,
+              language,
+              t,
             )}
             rowLabel={<Time {...endTimes} />}
           >
@@ -253,20 +252,32 @@ function getStopRowA11yTranslated(
   placeName: string,
   values: TimeValues,
   language: Language,
-): TranslatedString {
-  const a11yLabels = TripDetailsTexts.trip.leg[key].a11yLabel;
-
+  t: TranslateFunction,
+): string {
   const timeType = getTimeRepresentationType(values);
   const time = formatToClock(values.expectedTime ?? values.aimedTime, language);
   const aimedTime = formatToClock(values.aimedTime, language);
 
   switch (timeType) {
     case 'no-realtime':
-      return a11yLabels.noRealTime(placeName, aimedTime);
+      return t(
+        TripDetailsTexts.trip.leg[key].a11yLabel.noRealTime(
+          placeName,
+          aimedTime,
+        ),
+      );
     case 'no-significant-difference':
-      return a11yLabels.singularTime(placeName, time);
+      return t(
+        TripDetailsTexts.trip.leg[key].a11yLabel.singularTime(placeName, time),
+      );
     case 'significant-difference':
-      return a11yLabels.realAndAimed(placeName, time, aimedTime);
+      return t(
+        TripDetailsTexts.trip.leg[key].a11yLabel.realAndAimed(
+          placeName,
+          time,
+          aimedTime,
+        ),
+      );
   }
 }
 

--- a/src/screens/TripDetails/components/TripSummary.tsx
+++ b/src/screens/TripDetails/components/TripSummary.tsx
@@ -12,7 +12,6 @@ const Summary: React.FC<TripPattern> = ({walkDistance, duration}) => {
   const styles = useStyle();
   const {t, language} = useTranslation();
   const time = secondsToDuration(duration, language);
-  const summaryTexts = TripDetailsTexts.trip.summary;
   const readableDistance = walkDistance.toFixed();
   return (
     <View style={styles.summary}>
@@ -25,9 +24,11 @@ const Summary: React.FC<TripPattern> = ({walkDistance, duration}) => {
         <ThemeText
           color="secondary"
           accessible={true}
-          accessibilityLabel={t(summaryTexts.travelTime.a11yLabel(time))}
+          accessibilityLabel={t(
+            TripDetailsTexts.trip.summary.travelTime.a11yLabel(time),
+          )}
         >
-          {t(summaryTexts.travelTime.label(time))}
+          {t(TripDetailsTexts.trip.summary.travelTime.label(time))}
         </ThemeText>
       </View>
       <View style={styles.summaryDetail}>
@@ -40,10 +41,14 @@ const Summary: React.FC<TripPattern> = ({walkDistance, duration}) => {
           color="secondary"
           accessible={true}
           accessibilityLabel={t(
-            summaryTexts.walkDistance.a11yLabel(readableDistance),
+            TripDetailsTexts.trip.summary.walkDistance.a11yLabel(
+              readableDistance,
+            ),
           )}
         >
-          {t(summaryTexts.walkDistance.label(readableDistance))}
+          {t(
+            TripDetailsTexts.trip.summary.walkDistance.label(readableDistance),
+          )}
         </ThemeText>
       </View>
     </View>

--- a/src/screens/TripDetails/components/WaitSection.tsx
+++ b/src/screens/TripDetails/components/WaitSection.tsx
@@ -20,7 +20,6 @@ export type WaitDetails = {
 const WaitSection: React.FC<WaitDetails> = (wait) => {
   const style = useSectionStyles();
   const {t, language} = useTranslation();
-  const WaitTexts = TripDetailsTexts.trip.leg.wait;
   const waitTime = secondsToDuration(wait.waitSeconds, language);
   const shortWait = timeIsShort(wait.waitSeconds);
   const iconColor = useTransportationColor();
@@ -32,13 +31,13 @@ const WaitSection: React.FC<WaitDetails> = (wait) => {
         <TripRow rowLabel={<Info />}>
           <TinyMessageBox
             type="info"
-            message={t(WaitTexts.messages.shortTime)}
+            message={t(TripDetailsTexts.trip.leg.wait.messages.shortTime)}
           />
         </TripRow>
       )}
       <TripRow rowLabel={<Wait />}>
         <ThemeText type="lead" color="secondary">
-          {t(WaitTexts.label(waitTime))}
+          {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
         </ThemeText>
       </TripRow>
     </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4276,6 +4276,11 @@ eslint-plugin-react-native@3.8.1:
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 
+eslint-plugin-rulesdir@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz#ad144d7e98464fda82963eff3fab331aecb2bf08"
+  integrity sha1-rRRNfphGT9qClj7/P6szGuyyvwg=
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
This adds 3 custom linting rules to make some implicit project knowledge explicit. Namely:

1. We should always use `@react-navigation/native` instead of `@react-navigation/core`. Both work but native is more performant and is best practice. VSCode often suggests `/core`. This lint rule gives a warning when not using `/native` and provides autofix.
1. We should always use `SafeAreaView` from `react-native-safe-area-context` instead of `react-native`. SafeAreaView from react-native calculates padding wrong currently (at least for our use case). 
1. Texts from `/translate` modules should always be wrapped in `t` function provided from `@leile/lobo-t`. This is a naive implementation that doesn't actually check if given identifier `t` is from the correct function. Also the AST traversing is simple and does not account for storing result in variables. This could be done, but ROI etc.