### PR TITLE
fix: modal transitions for android

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -21,7 +21,7 @@ import {
   NavigatorScreenParams,
   useLinking,
 } from '@react-navigation/native';
-import {createStackNavigator} from '@react-navigation/stack';
+import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 import React, {useEffect, useRef} from 'react';
 import {StatusBar} from 'react-native';
 import {Host} from 'react-native-portalize';
@@ -85,43 +85,21 @@ const NavigationRoot = () => {
                 <Stack.Screen
                   name="LocationSearch"
                   component={LocationSearch}
-                  options={{
-                    transitionSpec: {
-                      open: transitionSpec,
-                      close: transitionSpec,
-                    },
-                  }}
+                  options={{...TransitionPresets.ModalSlideFromBottomIOS}}
                 />
                 <Stack.Screen
                   name="TicketPurchase"
                   component={TicketPurchase}
-                  options={{
-                    transitionSpec: {
-                      open: transitionSpec,
-                      close: transitionSpec,
-                    },
-                  }}
                 />
                 <Stack.Screen
                   name="TicketModal"
                   component={TicketModalScreen}
-                  options={{
-                    transitionSpec: {
-                      open: transitionSpec,
-                      close: transitionSpec,
-                    },
-                  }}
                 />
 
                 <Stack.Screen
                   name="AddEditFavorite"
                   component={AddEditFavorite}
-                  options={{
-                    transitionSpec: {
-                      open: transitionSpec,
-                      close: transitionSpec,
-                    },
-                  }}
+                  options={{...TransitionPresets.ModalSlideFromBottomIOS}}
                 />
                 <Stack.Screen
                   name="SortableFavoriteList"
@@ -129,10 +107,6 @@ const NavigationRoot = () => {
                   options={{
                     gestureResponseDistance: {
                       vertical: 100,
-                    },
-                    transitionSpec: {
-                      open: transitionSpec,
-                      close: transitionSpec,
                     },
                   }}
                 />

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -85,7 +85,7 @@ const NavigationRoot = () => {
                 <Stack.Screen
                   name="LocationSearch"
                   component={LocationSearch}
-                  options={{...TransitionPresets.ModalSlideFromBottomIOS}}
+                  options={TransitionPresets.ModalSlideFromBottomIOS}
                 />
                 <Stack.Screen
                   name="TicketPurchase"
@@ -99,7 +99,7 @@ const NavigationRoot = () => {
                 <Stack.Screen
                   name="AddEditFavorite"
                   component={AddEditFavorite}
-                  options={{...TransitionPresets.ModalSlideFromBottomIOS}}
+                  options={TransitionPresets.ModalSlideFromBottomIOS}
                 />
                 <Stack.Screen
                   name="SortableFavoriteList"
@@ -107,6 +107,10 @@ const NavigationRoot = () => {
                   options={{
                     gestureResponseDistance: {
                       vertical: 100,
+                    },
+                    transitionSpec: {
+                      open: transitionSpec,
+                      close: transitionSpec,
                     },
                   }}
                 />

--- a/src/screens/Profile/index.tsx
+++ b/src/screens/Profile/index.tsx
@@ -1,4 +1,4 @@
-import {createStackNavigator} from '@react-navigation/stack';
+import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 import React from 'react';
 import Login from './Login';
 import Appearance from './Appearance';
@@ -25,7 +25,10 @@ export default function ProfileScreen() {
   return (
     <Stack.Navigator
       initialRouteName="ProfileHome"
-      screenOptions={{headerShown: false}}
+      screenOptions={{
+        ...TransitionPresets.SlideFromRightIOS,
+        headerShown: false,
+      }}
     >
       <Stack.Screen name="ProfileHome" component={ProfileHome} />
       <Stack.Screen name="FavoriteList" component={FavoriteList} />


### PR DESCRIPTION
Modal transitions default to scale animation on android and are not consistent with design intentions.
By explicitly using slidefromBottom transitions from IOS on the Assistant screen and slidefromRight transitions on Profile screen we get consistent transitions that are in line with the design.

The disappearing header has its own problems and are handled elsewhere.
Some modals still use scale on Android when they are not out of line with the design (tickets, maps etc)