### PR TITLE
fix: makes entire result item in Assistant pressable

### DIFF
--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -14,48 +14,45 @@ const MapControls: React.FC<Props> = ({zoomIn, zoomOut}) => {
   const styles = useStyles();
   const {t} = useTranslation();
   return (
-    <View>
-      <View style={styles.zoomContainer}>
-        <TouchableOpacity
-          onPress={zoomIn}
-          accessibilityLabel={t(MapTexts.controls.zoomIn.a11yLabel)}
-          accessibilityRole="button"
-        >
-          <View style={styles.zoomInButton}>
-            <ThemeIcon svg={Add} />
-          </View>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={zoomOut}
-          accessibilityLabel={t(MapTexts.controls.zoomOut.a11yLabel)}
-          accessibilityRole="button"
-        >
-          <View style={styles.zoomOutButton}>
-            <ThemeIcon svg={Remove} />
-          </View>
-        </TouchableOpacity>
-      </View>
+    <View style={styles.zoomContainer}>
+      <TouchableOpacity
+        onPress={zoomIn}
+        accessibilityLabel={t(MapTexts.controls.zoomIn.a11yLabel)}
+        accessibilityRole="button"
+      >
+        <View style={styles.zoomInButton}>
+          <ThemeIcon svg={Add} />
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={zoomOut}
+        accessibilityLabel={t(MapTexts.controls.zoomOut.a11yLabel)}
+        accessibilityRole="button"
+      >
+        <View style={styles.zoomOutButton}>
+          <ThemeIcon svg={Remove} />
+        </View>
+      </TouchableOpacity>
     </View>
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   zoomContainer: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.background.level1,
     borderRadius: theme.border.radius.small,
+    alignContent: 'stretch',
     ...shadows,
   },
   zoomInButton: {
-    width: 36,
     height: 36,
     justifyContent: 'center',
     alignItems: 'center',
   },
   zoomOutButton: {
-    width: 36,
     height: 36,
     borderTopColor: theme.border.primary,
-    borderTopWidth: 0.5,
+    borderTopWidth: theme.border.width.slim,
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -394,7 +394,7 @@ export const themes: Themes = {
       ...textTypeStyles,
     },
     border: {
-      primary: colors.text.light,
+      primary: colors.primary.gray_600,
       secondary: colors.text.light,
       focus: colors.secondary.cyan_500,
       info: colors.secondary.cyan_800,


### PR DESCRIPTION
This PR fixes issue with only "Details" being pressable, after several feedbacks and discussions. The latest feedback can be seen at https://app.intercom.com/a/apps/vdemedo2/inbox/inbox/4207849/conversations/159245400004398.

Also, the primary border in dark mode was way too contrasty. Although this is another issue I fixed this in the same go. I can separate this into two different PR-s if necessary, but I was lazy. Sorry!

## Examples
(Attached image of the Map-screen as it also uses border primary style.)

<img width="443" alt="Screenshot 2021-02-26 at 16 18 03" src="https://user-images.githubusercontent.com/606374/109320018-d4a0f580-784f-11eb-91c3-a7e0efee6744.png"> 

<img width="407" alt="Screenshot 2021-02-26 at 16 26 05" src="https://user-images.githubusercontent.com/606374/109320011-d2d73200-784f-11eb-934a-5a7482330abd.png">
