### PR TITLE
feat: Use RemoteConfig as source for allowed users

### DIFF
--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -14,6 +14,9 @@ export type PreassignedFareProduct = {
   alternativeNames: LanguageAndText[];
   version: string;
   type: PreassignedFareProductType;
+  limitations: {
+    userProfileRefs: string[];
+  };
 };
 
 export type UserProfile = {

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -56,17 +56,13 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
   const preassignedFareProduct =
     params.preassignedFareProduct ?? selectableProducts[0];
 
-  const {userProfilesWhiteList, travelDateSelectionEnabled} = getPurchaseFlow(
-    preassignedFareProduct,
-  );
+  const {travelDateSelectionEnabled} = getPurchaseFlow(preassignedFareProduct);
 
   const defaultUserProfilesWithCount = useMemo(
     () =>
       userProfiles
-        .filter(
-          (u) =>
-            !userProfilesWhiteList ||
-            userProfilesWhiteList.includes(u.userTypeString),
+        .filter((u) =>
+          preassignedFareProduct.limitations.userProfileRefs.includes(u.id),
         )
         .map((u, i) => ({
           ...u,

--- a/src/screens/Ticketing/Purchase/utils.ts
+++ b/src/screens/Ticketing/Purchase/utils.ts
@@ -12,14 +12,6 @@ export type PurchaseFlow = {
    * ticket.
    */
   travelDateSelectionEnabled: boolean;
-
-  /**
-   * An optional user profile white list containing the userTypeString of the
-   * user profiles that should be allowed. If no whitelist is defined, then all
-   * user profiles should be selectable. This should preferably later be
-   * modelled into the reference data with Entur as the source.
-   */
-  userProfilesWhiteList?: string[];
 };
 
 export const getPurchaseFlow = (
@@ -29,7 +21,6 @@ export const getPurchaseFlow = (
     return {
       travellerSelectionMode: 'single',
       travelDateSelectionEnabled: true,
-      userProfilesWhiteList: ['ADULT', 'SENIOR', 'CHILD', 'STUDENT'],
     };
   } else {
     return {


### PR DESCRIPTION
The allowed user profiles was hardcoded in the app, but with this change
it is retrieved from RemoteConfig. The values in RemoteConfig is
populated from Entur.