### PR TITLE
feat: Feature toggle for login and period ticket

### DIFF
--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -20,6 +20,8 @@ export type RemoteConfigContextState = Pick<
   | 'enable_i18n'
   | 'enable_creditcard'
   | 'enable_recent_tickets'
+  | 'enable_login'
+  | 'enable_period_tickets'
   | 'must_upgrade_ticketing'
   | 'news_enabled'
   | 'news_text'

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -12,6 +12,8 @@ export type RemoteConfig = {
   enable_i18n: boolean;
   enable_creditcard: boolean;
   enable_recent_tickets: boolean;
+  enable_login: boolean;
+  enable_period_tickets: boolean;
   must_upgrade_ticketing: boolean;
   news_enabled: boolean;
   news_text: string;
@@ -29,6 +31,8 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_i18n: false,
   enable_creditcard: false,
   enable_recent_tickets: false,
+  enable_login: false,
+  enable_period_tickets: false,
   must_upgrade_ticketing: false,
   news_enabled: false,
   news_text: '',
@@ -53,6 +57,11 @@ export function getConfig(): RemoteConfig {
   const enable_recent_tickets =
     values['enable_recent_tickets']?.asBoolean() ??
     defaultRemoteConfig.enable_recent_tickets;
+  const enable_login =
+    values['enable_login']?.asBoolean() ?? defaultRemoteConfig.enable_login;
+  const enable_period_tickets =
+    values['enable_period_tickets']?.asBoolean() ??
+    defaultRemoteConfig.enable_period_tickets;
   const must_upgrade_ticketing =
     values['must_upgrade_ticketing']?.asBoolean() ?? false;
   const news_enabled = values['news_enabled']?.asBoolean() ?? false;
@@ -74,6 +83,8 @@ export function getConfig(): RemoteConfig {
     enable_i18n,
     enable_creditcard,
     enable_recent_tickets,
+    enable_login,
+    enable_period_tickets,
     must_upgrade_ticketing,
     news_enabled,
     news_text,

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -30,7 +30,7 @@ type ProfileScreenProps = {
 };
 
 export default function ProfileHome({navigation}: ProfileScreenProps) {
-  const {enable_i18n} = useRemoteConfig();
+  const {enable_i18n, enable_login} = useRemoteConfig();
   const style = useProfileHomeStyle();
   const {t} = useTranslation();
   const {authenticationType, signOut, user} = useAuthState();
@@ -43,41 +43,43 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
         rightButton={{type: 'chat'}}
       />
 
-      <ScrollView>
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderItem
-            text={t(ProfileTexts.sections.account.heading)}
-          />
-          {authenticationType !== 'phone' && (
-            <Sections.LinkItem
-              text={t(ProfileTexts.sections.account.linkItems.login.label)}
-              onPress={() =>
-                navigation.navigate('Login', {
-                  screen: 'PhoneInput',
-                  params: {
-                    afterLogin: {routeName: 'ProfileHome'},
-                  },
-                })
-              }
+      <ScrollView style={style.scrollView}>
+        {enable_login && (
+          <Sections.Section withPadding>
+            <Sections.HeaderItem
+              text={t(ProfileTexts.sections.account.heading)}
             />
-          )}
-          {authenticationType === 'phone' && (
-            <Sections.GenericItem>
-              <ThemeText>{user?.phoneNumber}</ThemeText>
-            </Sections.GenericItem>
-          )}
-          {authenticationType === 'phone' && (
-            <Sections.LinkItem
-              text={t(ProfileTexts.sections.account.linkItems.logout.label)}
-              onPress={signOut}
-            />
-          )}
-          {__DEV__ && (
-            <Sections.GenericItem>
-              <ThemeText>SignedInState: {authenticationType}</ThemeText>
-            </Sections.GenericItem>
-          )}
-        </Sections.Section>
+            {authenticationType !== 'phone' && (
+              <Sections.LinkItem
+                text={t(ProfileTexts.sections.account.linkItems.login.label)}
+                onPress={() =>
+                  navigation.navigate('Login', {
+                    screen: 'PhoneInput',
+                    params: {
+                      afterLogin: {routeName: 'ProfileHome'},
+                    },
+                  })
+                }
+              />
+            )}
+            {authenticationType === 'phone' && (
+              <Sections.GenericItem>
+                <ThemeText>{user?.phoneNumber}</ThemeText>
+              </Sections.GenericItem>
+            )}
+            {authenticationType === 'phone' && (
+              <Sections.LinkItem
+                text={t(ProfileTexts.sections.account.linkItems.logout.label)}
+                onPress={signOut}
+              />
+            )}
+            {__DEV__ && (
+              <Sections.GenericItem>
+                <ThemeText>SignedInState: {authenticationType}</ThemeText>
+              </Sections.GenericItem>
+            )}
+          </Sections.Section>
+        )}
 
         <Sections.Section withPadding>
           <Sections.HeaderItem
@@ -148,5 +150,8 @@ const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
     backgroundColor: theme.background.level1,
     flex: 1,
+  },
+  scrollView: {
+    marginTop: theme.spacings.medium,
   },
 }));

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -26,7 +26,12 @@ type Props = {
 export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {must_upgrade_ticketing, enable_recent_tickets} = useRemoteConfig();
+  const {
+    must_upgrade_ticketing,
+    enable_recent_tickets,
+    enable_login,
+    enable_period_tickets,
+  } = useRemoteConfig();
   const {abtCustomerId, authenticationType} = useAuthState();
   const {t} = useTranslation();
 
@@ -44,7 +49,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   };
 
   const onBuyPeriodTicket = () => {
-    if (authenticationType === 'phone') {
+    if (authenticationType === 'phone' || !enable_login) {
       navigation.navigate('TicketPurchase', {
         screen: 'PurchaseOverview',
         params: {
@@ -82,17 +87,19 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
               TicketsTexts.buyTicketsTab.button.single.a11yHint,
             )}
             onPress={onBuySingleTicket}
-            viewContainerStyle={styles.buySingleTicketButton}
           />
-          <Button
-            mode="primary"
-            color="primary_2"
-            text={t(TicketsTexts.buyTicketsTab.button.period.text)}
-            accessibilityHint={t(
-              TicketsTexts.buyTicketsTab.button.period.a11yHint,
-            )}
-            onPress={onBuyPeriodTicket}
-          />
+          {enable_period_tickets && (
+            <Button
+              mode="primary"
+              color="primary_2"
+              text={t(TicketsTexts.buyTicketsTab.button.period.text)}
+              accessibilityHint={t(
+                TicketsTexts.buyTicketsTab.button.period.a11yHint,
+              )}
+              onPress={onBuyPeriodTicket}
+              viewContainerStyle={styles.buyPeriodTicketButton}
+            />
+          )}
         </View>
       )}
     </View>
@@ -156,7 +163,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     backgroundColor: theme.background.level1,
   },
-  buySingleTicketButton: {
-    marginVertical: theme.spacings.medium,
+  buyPeriodTicketButton: {
+    marginTop: theme.spacings.medium,
   },
 }));


### PR DESCRIPTION
Created two feature toggles, one for login functionality, and one for
enabling purchase of period tickets.

- If both toggles are enabled there is login functionality under
  "Mitt AtB", and the user will be prompted to login if he tries to buy
  period tickets.
- If only login toggle is enabled the login functionality is present
  under "Mitt AtB", but there is no buy button for period tickets.
- If only toggle for period ticket is enabled then no login
  functionality will be present under "Mitt AtB". The buy button for
  period tickets will be available, and will not open a login prompt
  before ticket purchase.