### PR TITLE
fix: Button text centered with icon

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -129,8 +129,7 @@ const Button: React.FC<ButtonProps> = ({
   const textContainer: TextStyle = {
     flex: isInline ? undefined : 1,
     alignItems: 'center',
-    marginLeft: leftIconSpacing,
-    marginRight: rightIconSpacing,
+    marginHorizontal: Icon ? theme.spacings.xLarge : 0,
   };
   const iconContainer: ViewStyle = isInline
     ? {


### PR DESCRIPTION
The Button component had two minor bugs when used with icon:
- The text was not completely centered on the button
- Long texts overlapped the icon

With this fix a horizontal margin is added to both sides when an icon is
present, making the text remain centered. Also this margin is now set to
xLarge (24), which makes it greater than the icon size (20), thus
hindering overlap.