### PR TITLE
chore: New release process for TestFlight/Alpha

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -1,11 +1,11 @@
 # Managing new releases
 
-Currently we setup deploy through AppCenter directly and build on two branches:
+Currently we distribute builds through AppCenter, but build on Github with Github Actions. We target a single branch, `master`, and build for two different environments:
 
-- `master` - Continous integrated and distributed to test devices and development team. Also where we do most of our [QA](https://github.com/AtB-AS/org/blob/master/guides/workflow-and-qa-progress-apps.md).
-- `alpha-release` - Periodic manually built and distributed to internal people on the "alpha" release plan (Test Flight for iOS and alpha store on Google Play Store).
+- `staging` - Continous integrated and distributed to test devices and development team. Also where we do most of our [QA](https://github.com/AtB-AS/org/blob/master/guides/workflow-and-qa-progress-apps.md).
+- `store` - Periodic manually triggered by Github-releases, and distributed to internal testers on the "alpha" release plan (TestFlight for iOS and Alpha-channel on Google Play Store). When a `store` build is ready for Production-channels, we promote the builds inside the respective store-pages (Github is not involved).
 
-For `master` we just merge new changes through Pull Requests and feature branches with squash and rebase. But if we really want to test larger concepts and features, we should distribute to the internal testing team through the alpha channel. For this we make changes as a "sync pull request" to `alpha-release`. This is what this script solves.
+Whenever a new change is merged to `master`, through Pull Requests or similar, we build a QA-version for the `staging` environment. When we're getting ready to distribute to our Production-channels, and we want to test larger concepts and features, we will build for our `store` environment and distribute to the internal testing team through the store alpha channels (TestFlight/Alpha). For this we make create releases on Github which triggers alpha-channel builds. This is what this script solves.
 
 ### Requirements
 
@@ -16,10 +16,11 @@ For `master` we just merge new changes through Pull Requests and feature branche
 
 1. Do continuous changes on master through PR
 1. When you want to do an alpha release, run the following on the `master` branch (from project root): `yarn release-draft`
-1. Revise and review PR on Github, making sure all checks pass.
+1. Revise and review the release draft on Github
+1. Publish the release when you want to trigger the `store` build and distribute to our alpha-channels
 
 Running this script does the following:
 
 1. Find the last commit of the previous alpha release
 1. Generate changelog [using conventional changelog](https://github.com/conventional-changelog/conventional-changelog) for all changes from now to previous release (see step 1)
-1. Create PR from `master` to `alpha-release`.
+1. Create a draft release on Github

--- a/tools/release/changelog.config.js
+++ b/tools/release/changelog.config.js
@@ -1,14 +1,14 @@
 const {execSync} = require('child_process');
 
-const latestAlphaReleaseTag = execSync(
-  `git tag --sort=committerdate | grep -E '^alpha-.*'  | tail -1`,
+const latestReleaseTag = execSync(
+  `git tag --sort=creatordate |  grep -E '(^alpha-.*)|(^v.*)' | tail -1`,
 )
   .toString('utf-8')
   .trim();
 
 module.exports = {
   gitRawCommitsOpts: {
-    from: latestAlphaReleaseTag,
+    from: latestReleaseTag,
     to: 'HEAD',
   },
 };

--- a/tools/release/release-draft.sh
+++ b/tools/release/release-draft.sh
@@ -4,19 +4,28 @@ if [[ "$branch" != "master" ]]; then
   exit 1;
 fi
 
-read -p "This will create a Pull Request on Github, are you sure you want to do release? (n/Y) " -n 1 -r
+read -p "What do you want the release tag to be? The usual format is v1.x, for example v1.5. Can also suffix with -rc or similar:
+" -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^v[0-9]+\.[0-9]+.*$ ]]
+then
+  echo "The format has to start with 'v1.x' "
+  exit 0;
+fi
+releaseVersion=$REPLY
+
+read -p "This will create a draft release $releaseVersion on Github, are you sure you want to do release? (n/Y) " -n 1 -r
 echo    # (optional) move to a new line
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
   exit 0;
 fi
 
-
 echo 'Gathering commits and creating changelog'
 message=`yarn --silent conventional-changelog -p angular -n ./tools/release/changelog.config.js`
 
 if [ $? -eq 0 ]; then
-  gh pr create -B alpha-release -b "$message" -t 'chore: [Sync] New release to alpha channel'
+  gh release create $releaseVersion --draft --title "$releaseVersion release draft" --notes "$message" 
 else
   echo 'Could not create changelog'
   exit 1;


### PR DESCRIPTION
New release script for Github releases instead of Alpha-channel PR.