### PR TITLE
fix: issue with wrapping section items

### DIFF
--- a/src/components/sections/generic-item.tsx
+++ b/src/components/sections/generic-item.tsx
@@ -18,7 +18,7 @@ export default function GenericItem({
   return (
     <View style={topContainer} {...accessibility}>
       {Children.map(children, (child) => (
-        <View style={[style.spaceBetween, contentContainer]}>{child}</View>
+        <View style={style.spaceBetween}>{child}</View>
       ))}
     </View>
   );

--- a/src/components/sections/internals/internal-labeled-item.tsx
+++ b/src/components/sections/internals/internal-labeled-item.tsx
@@ -40,6 +40,8 @@ const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   label: {
     // @TODO Find a better way to do this.
     minWidth: 60 - theme.spacings.medium,
+    flex: 1,
+    flexWrap: 'wrap',
   },
   content: {
     // flexGrow: 1,

--- a/src/components/sections/link-item.tsx
+++ b/src/components/sections/link-item.tsx
@@ -46,8 +46,8 @@ export default function LinkItem({
       style={topContainer}
       {...accessibility}
     >
-      <View style={[style.spaceBetween, contentContainer, disabledStyle]}>
-        <ThemeText style={linkItemStyle.text}>{text}</ThemeText>
+      <View style={[style.spaceBetween, disabledStyle]}>
+        <ThemeText style={contentContainer}>{text}</ThemeText>
         {iconEl}
       </View>
       {subtitle && (
@@ -61,5 +61,4 @@ export default function LinkItem({
 
 const useStyles = StyleSheet.createThemeHook(() => ({
   disabled: {opacity: 0.2},
-  text: {flex: 1},
 }));

--- a/src/components/sections/section-utils/use-section-item.ts
+++ b/src/components/sections/section-utils/use-section-item.ts
@@ -38,7 +38,7 @@ export default function useSectionItem({
     backgroundColor: transparent ? undefined : theme.background.level0,
   };
   const contentContainer: ViewStyle = {
-    flexGrow: isInline ? undefined : 1,
+    flex: isInline ? undefined : 1,
   };
 
   return {

--- a/src/components/sections/text-input.tsx
+++ b/src/components/sections/text-input.tsx
@@ -14,6 +14,7 @@ import insets from '@atb/utils/insets';
 import ThemeText, {MAX_FONT_SCALE} from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
 import {SectionItem, useSectionItem} from './section-utils';
+import {SectionTexts, useTranslation} from '@atb/translations';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 
@@ -44,6 +45,7 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
     const {theme, themeName} = useTheme();
     const styles = useInputStyle(theme, themeName);
     const [isFocused, setIsFocused] = useState(Boolean(props?.autoFocus));
+    const {t} = useTranslation();
 
     const onFocusEvent = (e: FocusEvent) => {
       setIsFocused(true);
@@ -92,7 +94,12 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
         </ThemeText>
         <InternalTextInput
           ref={ref}
-          style={[styles.input, contentContainer, padding, style]}
+          style={[
+            styles.input,
+            inlineLabel ? contentContainer : undefined,
+            padding,
+            style,
+          ]}
           placeholderTextColor={theme.text.colors.secondary}
           onFocus={onFocusEvent}
           onBlur={onBlurEvent}
@@ -104,7 +111,7 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
             <TouchableOpacity
               accessible={true}
               accessibilityRole="button"
-              accessibilityLabel="Tøm redigeringsfelt"
+              accessibilityLabel={t(SectionTexts.textInput.clear)}
               hitSlop={insets.all(8)}
               onPress={onClearEvent}
             >
@@ -145,7 +152,8 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
   inputClear: {
     position: 'absolute',
     right: theme.spacings.medium,
-    bottom: theme.spacings.medium,
+    // Not ideal but position X better centered when position absolute.
+    bottom: theme.spacings.medium + 3,
     alignSelf: 'center',
   },
 }));

--- a/src/components/sections/text-input.tsx
+++ b/src/components/sections/text-input.tsx
@@ -152,8 +152,7 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
   inputClear: {
     position: 'absolute',
     right: theme.spacings.medium,
-    // Not ideal but position X better centered when position absolute.
-    bottom: theme.spacings.medium + 3,
+    bottom: theme.spacings.medium,
     alignSelf: 'center',
   },
 }));

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -117,7 +117,7 @@ export default function LineItem({
               subMode={group.lineInfo?.transportSubmode}
             />
           </View>
-          <ThemeText>{title}</ThemeText>
+          <ThemeText style={{flex: 1}}>{title}</ThemeText>
         </TouchableOpacity>
         <ToggleFavoriteDepartureButton
           line={group.lineInfo}

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -1,4 +1,4 @@
-import {Delete} from '@atb/assets/svg/icons/actions';
+import {Delete, Edit} from '@atb/assets/svg/icons/actions';
 import {Check} from '@atb/assets/svg/icons/status';
 import {BlankTicket} from '@atb/assets/svg/icons/ticketing';
 import Button, {ButtonGroup} from '@atb/components/button';
@@ -107,7 +107,64 @@ export default function DesignSystem() {
           />
           <Button text="Press me" onPress={presser} type="inline" />
           <Button text="Press me" onPress={presser} type="compact" />
+          <Button
+            text="Press me"
+            onPress={presser}
+            type="compact"
+            icon={Delete}
+            iconPosition="right"
+          />
         </ButtonGroup>
+
+        <Sections.Section withPadding withTopPadding>
+          <Sections.ActionItem
+            text="Some very long text over here which goes over multiple lines"
+            mode="check"
+            checked
+          />
+          <Sections.ActionItem text="Some short text" mode="toggle" />
+          <Sections.ActionItem
+            text="Some short text"
+            mode="check"
+            checked
+            type="compact"
+          />
+        </Sections.Section>
+
+        <Sections.Section withPadding withTopPadding>
+          <Sections.LocationInput
+            label="Label"
+            placeholder="My very long placeholder over here. Yes over multiple lines"
+            onPress={() => {}}
+          />
+          <Sections.LocationInput
+            label="Label"
+            placeholder="Short"
+            onPress={() => {}}
+            type="compact"
+          />
+        </Sections.Section>
+
+        <Sections.Section withPadding withTopPadding>
+          <Sections.ButtonInput
+            label="Label"
+            placeholder="My very long placeholder over here. Yes over multiple lines"
+            onPress={() => {}}
+            icon="arrow-left"
+          />
+
+          <Sections.LinkItem
+            text="Some longer text"
+            onPress={() => {}}
+            disabled
+            icon={<ThemeIcon svg={Edit} />}
+          />
+          <Sections.LinkItem
+            text="Some longer text"
+            onPress={() => {}}
+            icon={<ThemeIcon svg={Edit} />}
+          />
+        </Sections.Section>
 
         <Sections.Section withPadding withTopPadding>
           <Sections.HeaderItem text="Texts" />

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -167,6 +167,28 @@ export default function DesignSystem() {
         </Sections.Section>
 
         <Sections.Section withPadding withTopPadding>
+          <Sections.TextInput
+            label="Input"
+            placeholder="My very long placeholder over here. Yes over multiple lines"
+            onChangeText={() => {}}
+            keyboardType="phone-pad"
+            textContentType="oneTimeCode"
+            showClear={true}
+            inlineLabel={false}
+          />
+
+          <Sections.TextInput
+            label="Input"
+            placeholder="Short placeholder"
+            onChangeText={() => {}}
+            keyboardType="phone-pad"
+            textContentType="oneTimeCode"
+            showClear={true}
+            inlineLabel={false}
+          />
+        </Sections.Section>
+
+        <Sections.Section withPadding withTopPadding>
           <Sections.HeaderItem text="Texts" />
 
           <Sections.GenericItem>

--- a/src/translations/components/Section.ts
+++ b/src/translations/components/Section.ts
@@ -25,6 +25,9 @@ const SectionTexts = {
       },
     },
   },
+  textInput: {
+    clear: _('Tøm redigeringsfelt', 'Clear input'),
+  },
   counterInput: {
     decreaseButton: {
       a11yLabel: _('Reduser antall', 'Reduce quantity'),


### PR DESCRIPTION
Fixes #983

This sets general flex on section base items. Can introduce some regressions but it should also fix text overflowing for every section item.

@gorandalum Could you check Ticketing?

![Screenshot 2021-03-09 at 14 34 46](https://user-images.githubusercontent.com/606374/110481122-83162780-80e7-11eb-8328-859b7dc92f4d.png)

![Screenshot 2021-03-09 at 14 35 12](https://user-images.githubusercontent.com/606374/110481109-814c6400-80e7-11eb-8f7a-d7554223eeb8.png)
