### PR TITLE
feat: Add underline for resend code button

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -62,7 +62,6 @@ export type ButtonProps = {
   textStyle?: StyleProp<TextStyle>;
   icon?: React.ElementType<{fill: string}>;
   iconPosition?: 'left' | 'right';
-  textType?: TextNames;
 } & ButtonTypeAwareProps &
   TouchableOpacityProps;
 
@@ -81,7 +80,6 @@ const Button: React.FC<ButtonProps> = ({
   viewContainerStyle,
   textContainerStyle,
   textStyle,
-  textType,
   ...props
 }) => {
   const modeData = DefaultModeStyles[mode];
@@ -162,7 +160,7 @@ const Button: React.FC<ButtonProps> = ({
         {text && (
           <View style={[textContainer, textContainerStyle]}>
             <ThemeText
-              type={textType ?? 'paragraphHeadline'}
+              type={mode === 'tertiary' ? 'body' : 'paragraphHeadline'}
               style={[styleText, textStyle]}
             >
               {text}

--- a/src/screens/Profile/Login/ConfirmCode.tsx
+++ b/src/screens/Profile/Login/ConfirmCode.tsx
@@ -2,7 +2,7 @@ import FullScreenHeader from '@atb/components/screen-header/full-header';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {LoginTexts, useTranslation} from '@atb/translations';
 import React, {useState} from 'react';
-import {ActivityIndicator, View} from 'react-native';
+import {ActivityIndicator, TouchableOpacity, View} from 'react-native';
 import {LoginRootParams} from './';
 import * as Sections from '@atb/components/sections';
 import Button from '@atb/components/button';
@@ -109,13 +109,14 @@ export default function ConfirmCode({navigation, route}: ConfirmCodeProps) {
                 text={t(LoginTexts.confirmCode.mainButton)}
                 disabled={!code}
               />
-              <Button
-                color={'primary_2'}
-                mode={'tertiary'}
-                textType="body"
+              <TouchableOpacity
+                style={styles.resendButton}
                 onPress={onResendCode}
-                text={t(LoginTexts.confirmCode.resendButton)}
-              />
+              >
+                <ThemeText style={{textAlign: 'center'}} type="body__link">
+                  {t(LoginTexts.confirmCode.resendButton)}
+                </ThemeText>
+              </TouchableOpacity>
             </>
           )}
         </View>
@@ -137,5 +138,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   },
   buttonView: {
     marginTop: theme.spacings.medium,
+  },
+  resendButton: {
+    marginTop: theme.spacings.medium,
+    padding: theme.spacings.medium,
   },
 }));

--- a/src/screens/Profile/Login/ConfirmCode.tsx
+++ b/src/screens/Profile/Login/ConfirmCode.tsx
@@ -113,7 +113,7 @@ export default function ConfirmCode({navigation, route}: ConfirmCodeProps) {
                 style={styles.resendButton}
                 onPress={onResendCode}
               >
-                <ThemeText style={{textAlign: 'center'}} type="body__link">
+                <ThemeText style={styles.resendButtonText} type="body__link">
                   {t(LoginTexts.confirmCode.resendButton)}
                 </ThemeText>
               </TouchableOpacity>
@@ -143,4 +143,5 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     marginTop: theme.spacings.medium,
     padding: theme.spacings.medium,
   },
+  resendButtonText: {textAlign: 'center'},
 }));


### PR DESCRIPTION
Added the underline by using TouchableOpacity and ThemeText instead of
using button. Modifying button by specifying text type, or adding a mode
"link" would have given more reusability, but this would be adding modes
that is outside the design system.

Also removed the possibility to specify text types for buttons. The text
types should be whatever was intended for that button mode in the design
system.