### PR TITLE
fix: flex layout supporting shorter screens

### DIFF
--- a/src/screens/Onboarding/components/Illustration.tsx
+++ b/src/screens/Onboarding/components/Illustration.tsx
@@ -15,9 +15,10 @@ const Illustration: React.FC<IllustrationProps> = ({Svg}) => {
 };
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   svgContainer: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.background.level1,
     width: '100%',
     maxHeight: '50%',
+    flexShrink: 1,
   },
 }));
 export default Illustration;

--- a/src/screens/Onboarding/components/NavigationControls.tsx
+++ b/src/screens/Onboarding/components/NavigationControls.tsx
@@ -47,7 +47,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   navigationContainer: {
     width: '100%',
     padding: theme.spacings.xLarge,
-    minHeight: 170,
   },
   bulletContainer: {
     flexDirection: 'row',

--- a/src/screens/Onboarding/components/StepContainer.tsx
+++ b/src/screens/Onboarding/components/StepContainer.tsx
@@ -8,27 +8,19 @@ const StepOuterContainer: React.FC = ({children}) => {
   const styles = useStyles();
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView contentContainerStyle={styles.contentContainer}>
-        <View style={styles.innerContainer}>{children}</View>
-      </ScrollView>
+      <View style={styles.innerContainer}>{children}</View>
     </SafeAreaView>
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.background.level1,
     flex: 1,
-    alignItems: 'center',
-  },
-  contentContainer: {
-    flexGrow: 1,
   },
   innerContainer: {
-    flex: 1,
-    alignItems: 'center',
-    maxWidth: 500,
     justifyContent: 'space-between',
+    flex: 1,
   },
 }));
 export default StepOuterContainer;

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -67,20 +67,18 @@ const StepOne: React.FC<StepProps> = ({navigation}) => {
     navigation.push('StepTwo');
   };
   return (
-    <>
+    <StepOuterContainer>
       <Illustration Svg={Onboarding1} />
-      <StepOuterContainer>
-        <View style={styles.textContainer} accessible={true}>
-          <ThemeText style={[styles.title, styles.text]}>
-            {t(OnboardingTexts.step1.title)}
-          </ThemeText>
-          <ThemeText style={styles.text}>
-            {t(OnboardingTexts.step1.description)}
-          </ThemeText>
-        </View>
-        <NavigationControls currentPage={1} onNavigate={onNavigate} />
-      </StepOuterContainer>
-    </>
+      <View style={styles.textContainer} accessible={true}>
+        <ThemeText style={[styles.title, styles.text]}>
+          {t(OnboardingTexts.step1.title)}
+        </ThemeText>
+        <ThemeText style={styles.text}>
+          {t(OnboardingTexts.step1.description)}
+        </ThemeText>
+      </View>
+      <NavigationControls currentPage={1} onNavigate={onNavigate} />
+    </StepOuterContainer>
   );
 };
 const StepTwo: React.FC<StepProps> = ({navigation}) => {
@@ -90,20 +88,18 @@ const StepTwo: React.FC<StepProps> = ({navigation}) => {
     navigation.push('StepThree');
   };
   return (
-    <>
+    <StepOuterContainer>
       <Illustration Svg={Onboarding2} />
-      <StepOuterContainer>
-        <View style={styles.textContainer} accessible={true}>
-          <ThemeText style={[styles.title, styles.text]}>
-            {t(OnboardingTexts.step2.title)}
-          </ThemeText>
-          <ThemeText style={styles.text}>
-            {t(OnboardingTexts.step2.description)}
-          </ThemeText>
-        </View>
-        <NavigationControls currentPage={2} onNavigate={onNavigate} />
-      </StepOuterContainer>
-    </>
+      <View style={styles.textContainer} accessible={true}>
+        <ThemeText style={[styles.title, styles.text]}>
+          {t(OnboardingTexts.step2.title)}
+        </ThemeText>
+        <ThemeText style={styles.text}>
+          {t(OnboardingTexts.step2.description)}
+        </ThemeText>
+      </View>
+      <NavigationControls currentPage={2} onNavigate={onNavigate} />
+    </StepOuterContainer>
   );
 };
 const StepThree: React.FC<StepProps> = () => {
@@ -123,43 +119,43 @@ const StepThree: React.FC<StepProps> = () => {
     setRequestedOnce(true);
   }
   return (
-    <>
+    <StepOuterContainer>
       <Illustration Svg={Onboarding3} />
-      <StepOuterContainer>
-        <View style={styles.textContainer} accessible={true}>
-          <ThemeText style={[styles.title, styles.text]}>
-            {t(OnboardingTexts.step3.title)}
-          </ThemeText>
-          <ThemeText style={styles.text}>
-            {t(OnboardingTexts.step3.description)}
-          </ThemeText>
-        </View>
-        <NavigationControls
-          currentPage={3}
-          onNavigate={onRequestPermission}
-          title={t(OnboardingTexts.navigation.complete)}
-          arrow={false}
+      <View style={styles.textContainer} accessible={true}>
+        <ThemeText style={[styles.title, styles.text]}>
+          {t(OnboardingTexts.step3.title)}
+        </ThemeText>
+        <ThemeText style={styles.text}>
+          {t(OnboardingTexts.step3.description)}
+        </ThemeText>
+      </View>
+      <NavigationControls
+        currentPage={3}
+        onNavigate={onRequestPermission}
+        title={t(OnboardingTexts.navigation.complete)}
+        arrow={false}
+      >
+        <TouchableOpacity
+          accessibilityRole="link"
+          accessibilityHint={t(OnboardingTexts.step3.privacyLink.a11yHint)}
+          onPress={() =>
+            Linking.openURL(PRIVACY_POLICY_URL ?? 'https://www.atb.no')
+          }
         >
-          <TouchableOpacity
-            accessibilityRole="link"
-            accessibilityHint={t(OnboardingTexts.step3.privacyLink.a11yHint)}
-            onPress={() =>
-              Linking.openURL(PRIVACY_POLICY_URL ?? 'https://www.atb.no')
-            }
-          >
-            <ThemeText type="body" style={[styles.text, styles.privacyPolicy]}>
-              {t(OnboardingTexts.step3.privacyLink.text)}
-            </ThemeText>
-          </TouchableOpacity>
-        </NavigationControls>
-      </StepOuterContainer>
-    </>
+          <ThemeText type="body" style={[styles.text, styles.privacyPolicy]}>
+            {t(OnboardingTexts.step3.privacyLink.text)}
+          </ThemeText>
+        </TouchableOpacity>
+      </NavigationControls>
+    </StepOuterContainer>
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme, themeName) => ({
   textContainer: {
     padding: theme.spacings.xLarge,
+    paddingTop: 0,
+    paddingBottom: 0,
   },
   title: {
     fontWeight: 'bold',


### PR DESCRIPTION
### Observation
The onboarding screens do not behave well on shorter screens, spesifically androids, eg. nexus 4.
The screens implement a scroll view for text info and step navigation, resulting in step navigation being pushed out of the screen with no visible cue (e.g. scroll bar) to guide the user forward.
### fix
re-implent views with working flex-layout, shrinking the illustration to make space for text and navigation when vertical space is limited.
