### PR TITLE
feat: adds recently searched journeys to location search and ability to clear history. Closes #673 

### DIFF
--- a/src/components/sections/header-item.tsx
+++ b/src/components/sections/header-item.tsx
@@ -1,7 +1,7 @@
+import ThemeText from '@atb/components/text';
 import React from 'react';
 import {View} from 'react-native';
-import ThemeText from '@atb/components/text';
-import {useSectionItem, SectionItem, useSectionStyle} from './section-utils';
+import {SectionItem, useSectionItem} from './section-utils';
 
 export type HeaderItemProps = SectionItem<{
   text: string;
@@ -15,7 +15,6 @@ export default function HeaderItem({
   ...props
 }: HeaderItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
-  const style = useSectionStyle();
 
   return (
     <View style={topContainer}>

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -13,6 +13,9 @@ type JourneyHistoryProps = {
   onSelect: (journey: JourneySearchHistoryEntry) => void;
 };
 
+// @TODO Could be configurable at some point.
+const DEFAULT_HISTORY_LIMIT = 3;
+
 export default function JourneyHistory({onSelect}: JourneyHistoryProps) {
   const {t} = useTranslation();
   const {journeyHistory} = useSearchHistory();
@@ -31,23 +34,26 @@ export default function JourneyHistory({onSelect}: JourneyHistoryProps) {
         mode="subheading"
       />
       <View>
-        {journeyHistory.map(mapToVisibleSearchResult).map((searchResult) => (
-          <TouchableOpacity
-            accessible={true}
-            accessibilityLabel={searchResult.text + screenReaderPause}
-            accessibilityHint={t(
-              LocationSearchTexts.journeySearch.result.a11yHint,
-            )}
-            accessibilityRole="button"
-            onPress={() => onSelect(searchResult.selectable)}
-          >
-            <GenericItem transparent>
-              <ThemeText type="paragraphHeadline">
-                {searchResult.text}
-              </ThemeText>
-            </GenericItem>
-          </TouchableOpacity>
-        ))}
+        {journeyHistory
+          .slice(0, DEFAULT_HISTORY_LIMIT)
+          .map(mapToVisibleSearchResult)
+          .map((searchResult) => (
+            <TouchableOpacity
+              accessible={true}
+              accessibilityLabel={searchResult.text + screenReaderPause}
+              accessibilityHint={t(
+                LocationSearchTexts.journeySearch.result.a11yHint,
+              )}
+              accessibilityRole="button"
+              onPress={() => onSelect(searchResult.selectable)}
+            >
+              <GenericItem transparent>
+                <ThemeText type="paragraphHeadline">
+                  {searchResult.text}
+                </ThemeText>
+              </GenericItem>
+            </TouchableOpacity>
+          ))}
       </View>
     </SectionGroup>
   );

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -40,7 +40,14 @@ export default function JourneyHistory({onSelect}: JourneyHistoryProps) {
           .map((searchResult) => (
             <TouchableOpacity
               accessible={true}
-              accessibilityLabel={searchResult.text + screenReaderPause}
+              accessibilityLabel={
+                t(
+                  LocationSearchTexts.journeySearch.result.a11yLabel(
+                    searchResult.fromName,
+                    searchResult.toName,
+                  ),
+                ) + screenReaderPause
+              }
               accessibilityHint={t(
                 LocationSearchTexts.journeySearch.result.a11yHint,
               )}
@@ -64,6 +71,8 @@ function mapToVisibleSearchResult(entry: JourneySearchHistoryEntry) {
   return {
     key: `${from.id}-${to.id}`,
     selectable: entry,
+    fromName: from.name,
+    toName: to.name,
     text: `${from.name} - ${to.name}`,
   };
 }

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -43,6 +43,7 @@ export default function JourneyHistory({
           .map((searchResult) => (
             <TouchableOpacity
               accessible={true}
+              key={searchResult.key}
               accessibilityLabel={
                 t(
                   LocationSearchTexts.journeySearch.result.a11yLabel(

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -1,0 +1,63 @@
+import {GenericItem, HeaderItem} from '@atb/components/sections';
+import SectionGroup from '@atb/components/sections/section';
+import {useSearchHistory} from '@atb/search-history';
+import {JourneySearchHistoryEntry} from '@atb/search-history/types';
+import {LocationSearchTexts, useTranslation} from '@atb/translations';
+import React from 'react';
+import {TouchableOpacity, View} from 'react-native';
+import {screenReaderPause} from '../components/accessible-text';
+import ThemeText from '../components/text';
+import insets from '../utils/insets';
+
+type JourneyHistoryProps = {
+  onSelect: (journey: JourneySearchHistoryEntry) => void;
+};
+
+export default function JourneyHistory({onSelect}: JourneyHistoryProps) {
+  const {t} = useTranslation();
+  const {journeyHistory} = useSearchHistory();
+
+  if (!journeyHistory.length) {
+    return null;
+  }
+
+  return (
+    <SectionGroup withTopPadding withBottomPadding>
+      <HeaderItem
+        transparent
+        text={t(
+          LocationSearchTexts.journeySearch.previousJourneyResults.heading,
+        )}
+        mode="subheading"
+      />
+      <View>
+        {journeyHistory.map(mapToVisibleSearchResult).map((searchResult) => (
+          <TouchableOpacity
+            accessible={true}
+            accessibilityLabel={searchResult.text + screenReaderPause}
+            accessibilityHint={t(
+              LocationSearchTexts.journeySearch.result.a11yHint,
+            )}
+            accessibilityRole="button"
+            onPress={() => onSelect(searchResult.selectable)}
+          >
+            <GenericItem transparent>
+              <ThemeText type="paragraphHeadline">
+                {searchResult.text}
+              </ThemeText>
+            </GenericItem>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </SectionGroup>
+  );
+}
+
+function mapToVisibleSearchResult(entry: JourneySearchHistoryEntry) {
+  const [from, to] = entry;
+  return {
+    key: `${from.id}-${to.id}`,
+    selectable: entry,
+    text: `${from.name} - ${to.name}`,
+  };
+}

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -1,24 +1,27 @@
 import {GenericItem, HeaderItem} from '@atb/components/sections';
 import SectionGroup from '@atb/components/sections/section';
-import {useSearchHistory} from '@atb/search-history';
 import {JourneySearchHistoryEntry} from '@atb/search-history/types';
 import {LocationSearchTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {TouchableOpacity, View} from 'react-native';
 import {screenReaderPause} from '../components/accessible-text';
 import ThemeText from '../components/text';
-import insets from '../utils/insets';
+import {useFilteredJourneySearch} from './utils';
 
 type JourneyHistoryProps = {
+  searchText?: string;
   onSelect: (journey: JourneySearchHistoryEntry) => void;
 };
 
 // @TODO Could be configurable at some point.
 const DEFAULT_HISTORY_LIMIT = 3;
 
-export default function JourneyHistory({onSelect}: JourneyHistoryProps) {
+export default function JourneyHistory({
+  searchText,
+  onSelect,
+}: JourneyHistoryProps) {
   const {t} = useTranslation();
-  const {journeyHistory} = useSearchHistory();
+  const journeyHistory = useFilteredJourneySearch(searchText);
 
   if (!journeyHistory.length) {
     return null;

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -30,6 +30,7 @@ import {LocationSearchNavigationProp} from './';
 import LocationResults from './LocationResults';
 import {LocationSearchResult} from './types';
 import useDebounce from './useDebounce';
+import JourneyHistory from './JourneyHistory';
 export type Props = {
   navigation: LocationSearchNavigationProp;
   route: RouteProp<RootStackParamList, 'LocationSearch'>;
@@ -238,6 +239,9 @@ export function LocationSearchContent({
           keyboardShouldPersistTaps="handled"
           onScrollBeginDrag={() => Keyboard.dismiss()}
         >
+          {includeHistory && !hasResults && (
+            <JourneyHistory onSelect={() => {}} />
+          )}
           {includeHistory && hasPreviousResults && (
             <LocationResults
               title={t(LocationSearchTexts.results.previousResults.heading)}

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -112,6 +112,7 @@ type LocationSearchContentProps = {
   onMapSelection?(): void;
   onlyAtbVenues?: boolean;
   includeHistory?: boolean;
+  includeJourneyHistory?: boolean;
 };
 
 export function LocationSearchContent({
@@ -123,6 +124,7 @@ export function LocationSearchContent({
   onMapSelection,
   onlyAtbVenues = false,
   includeHistory = true,
+  includeJourneyHistory = false,
 }: LocationSearchContentProps) {
   const styles = useThemeStyles();
   const {favorites} = useFavorites();
@@ -239,7 +241,7 @@ export function LocationSearchContent({
           keyboardShouldPersistTaps="handled"
           onScrollBeginDrag={() => Keyboard.dismiss()}
         >
-          {includeHistory && !hasResults && (
+          {includeJourneyHistory && !hasResults && (
             <JourneyHistory onSelect={() => {}} />
           )}
           {includeHistory && hasPreviousResults && (

--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -1,23 +1,24 @@
-import React, {useRef} from 'react';
-import {
-  createStackNavigator,
-  StackNavigationProp,
-  TransitionPresets,
-} from '@react-navigation/stack';
-import LocationSearch, {
-  RouteParams as LocationSearchRouteParams,
-} from './LocationSearch';
-import MapSelection, {
-  RouteParams as MapSelectionRouteParams,
-} from './map-selection';
 import {
   CompositeNavigationProp,
   ParamListBase,
   RouteProp,
   useRoute,
 } from '@react-navigation/native';
+import {
+  createStackNavigator,
+  StackNavigationProp,
+  TransitionPresets,
+} from '@react-navigation/stack';
+import React, {useRef} from 'react';
+import {Location} from '../favorites/types';
 import {RootStackParamList} from '../navigation';
-import {Location, LocationWithMetadata} from '../favorites/types';
+import LocationSearch, {
+  RouteParams as LocationSearchRouteParams,
+} from './LocationSearch';
+import MapSelection, {
+  RouteParams as MapSelectionRouteParams,
+} from './map-selection';
+import {SelectableLocationData} from './types';
 
 export type LocationSearchStackParams = {
   LocationSearch: LocationSearchRouteParams;
@@ -64,11 +65,11 @@ export function useLocationSearchValue<
 >(
   callerRouteParam: keyof T['params'],
   defaultLocation?: Location,
-): LocationWithMetadata | undefined {
+): SelectableLocationData | undefined {
   const route = useRoute<T>();
   const firstTimeRef = useRef(true);
   const [location, setLocation] = React.useState<
-    LocationWithMetadata | undefined
+    SelectableLocationData | undefined
   >(defaultLocation && {...defaultLocation, resultType: 'search'});
 
   React.useEffect(() => {

--- a/src/location-search/index.tsx
+++ b/src/location-search/index.tsx
@@ -10,7 +10,7 @@ import {
   TransitionPresets,
 } from '@react-navigation/stack';
 import React, {useRef} from 'react';
-import {Location} from '../favorites/types';
+import {Location, LocationWithMetadata} from '../favorites/types';
 import {RootStackParamList} from '../navigation';
 import LocationSearch, {
   RouteParams as LocationSearchRouteParams,
@@ -84,4 +84,24 @@ export function useLocationSearchValue<
   }, [route.params?.[callerRouteParam]]);
 
   return location;
+}
+
+export function useOnlySingleLocation<
+  T extends RouteProp<any, any> & {params: ParamListBase}
+>(
+  callerRouteParam: keyof T['params'],
+  defaultLocation?: Location,
+): LocationWithMetadata | undefined {
+  const selectable = useLocationSearchValue(callerRouteParam, defaultLocation);
+
+  if (!selectable) return undefined;
+  switch (selectable.resultType) {
+    case 'journey': {
+      return {
+        resultType: 'search',
+        ...selectable.journeyData[0],
+      };
+    }
+  }
+  return selectable;
 }

--- a/src/location-search/types.ts
+++ b/src/location-search/types.ts
@@ -1,6 +1,18 @@
-import {Location, StoredLocationFavorite} from '../favorites/types';
+import {JourneySearchHistoryEntry} from '@atb/search-history/types';
+import {
+  Location,
+  LocationWithMetadata,
+  StoredLocationFavorite,
+} from '../favorites/types';
 
 export type LocationSearchResult = {
   location: Location;
   favoriteInfo?: Omit<StoredLocationFavorite, 'location'>;
 };
+
+export type SelectableLocationData =
+  | LocationWithMetadata
+  | {
+      resultType: 'journey';
+      journeyData: JourneySearchHistoryEntry;
+    };

--- a/src/location-search/utils.ts
+++ b/src/location-search/utils.ts
@@ -1,0 +1,67 @@
+import {Location, UserFavorites} from '@atb/favorites/types';
+import {useSearchHistory} from '@atb/search-history';
+import {LocationSearchResult} from './types';
+
+export function useFilteredJourneySearch(searchText?: string) {
+  const {journeyHistory} = useSearchHistory();
+
+  if (!searchText) {
+    return journeyHistory;
+  }
+
+  return journeyHistory.filter(
+    ([a, b]) => matchLocation(searchText, a) || matchLocation(searchText, b),
+  );
+}
+
+export const filterPreviousLocations = (
+  searchText: string,
+  previousLocations: Location[],
+  favorites?: UserFavorites,
+  onlyAtbVenues: boolean = false,
+): LocationSearchResult[] => {
+  const mappedHistory: LocationSearchResult[] =
+    previousLocations
+      ?.map((location) => ({
+        location,
+      }))
+      .filter(
+        (location) => !onlyAtbVenues || location.location.layer == 'venue',
+      ) ?? [];
+
+  if (!searchText) {
+    return mappedHistory;
+  }
+
+  const filteredFavorites: LocationSearchResult[] = (favorites ?? [])
+    .filter(
+      (favorite) =>
+        (matchText(searchText, favorite.location?.name) ||
+          matchText(searchText, favorite.name)) &&
+        (!onlyAtbVenues || favorite.location.layer == 'venue'),
+    )
+    .map(({location, ...favoriteInfo}) => ({
+      location,
+      favoriteInfo,
+    }));
+
+  return filteredFavorites.concat(
+    mappedHistory.filter((l) => matchText(l.location.name)),
+  );
+};
+
+const matchText = (searchText: string, text?: string) =>
+  text?.toLowerCase()?.startsWith(searchText.toLowerCase());
+const matchLocation = (searchText: string, location: Location) =>
+  matchText(searchText, location.name);
+
+export const filterCurrentLocation = (
+  locations: Location[] | null,
+  previousLocations: LocationSearchResult[] | null,
+): LocationSearchResult[] => {
+  if (!previousLocations?.length || !locations)
+    return locations?.map((location) => ({location})) ?? [];
+  return locations
+    .filter((l) => !previousLocations.some((pl) => pl.location.id === l.id))
+    .map((location) => ({location}));
+};

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -24,6 +24,7 @@ import {
 import {useLocationSearchValue} from '@atb/location-search';
 import {RootStackParamList} from '@atb/navigation';
 import {TripPattern} from '@atb/sdk';
+import {useSearchHistory} from '@atb/search-history';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
   AssistantTexts,
@@ -570,6 +571,7 @@ function useTripPatterns(
   const [tripPatterns, setTripPatterns] = useState<TripPattern[] | null>(null);
   const [errorType, setErrorType] = useState<ErrorType>();
   const [searchState, setSearchState] = useState<SearchStateType>('idle');
+  const {addJourneySearchEntry} = useSearchHistory();
 
   const clearPatterns = () => setTripPatterns(null);
   const reload = useCallback(() => {
@@ -592,6 +594,11 @@ function useTripPatterns(
           toLocation: translateLocation(toLocation),
           searchDate: searchDate,
         });
+
+        try {
+          // Fire and forget add journey search entry
+          await addJourneySearchEntry([fromLocation, toLocation]);
+        } catch (e) {}
 
         const response = await searchTrip(
           fromLocation,

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -14,7 +14,10 @@ import {
   RequestPermissionFn,
   useGeolocationState,
 } from '@atb/GeolocationContext';
-import {useLocationSearchValue} from '@atb/location-search';
+import {
+  useLocationSearchValue,
+  useOnlySingleLocation,
+} from '@atb/location-search';
 import {RootStackParamList} from '@atb/navigation';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
@@ -92,7 +95,7 @@ const NearbyOverview: React.FC<Props> = ({
   hasLocationPermission,
   navigation,
 }) => {
-  const searchedFromLocation = useLocationSearchValue<NearbyScreenProp>(
+  const searchedFromLocation = useOnlySingleLocation<NearbyScreenProp>(
     'location',
   );
   const [loadAnnouncement, setLoadAnnouncement] = useState<string>('');

--- a/src/screens/Profile/AddEditFavorite/AddForm.tsx
+++ b/src/screens/Profile/AddEditFavorite/AddForm.tsx
@@ -2,6 +2,7 @@ import SvgConfirm from '@atb/assets/svg/icons/actions/Confirm';
 import SvgDelete from '@atb/assets/svg/icons/actions/Delete';
 import {MapPointPin} from '@atb/assets/svg/icons/places';
 import Button, {ButtonGroup} from '@atb/components/button';
+import MessageBox from '@atb/components/message-box';
 import ScreenHeader from '@atb/components/screen-header';
 import ScreenReaderAnnouncement from '@atb/components/screen-reader-announcement';
 import * as Sections from '@atb/components/sections';
@@ -9,8 +10,7 @@ import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
 import {useFavorites} from '@atb/favorites';
 import {StoredLocationFavorite} from '@atb/favorites/types';
-import {useLocationSearchValue} from '@atb/location-search';
-import MessageBox from '@atb/components/message-box';
+import {useOnlySingleLocation} from '@atb/location-search';
 import {RootStackParamList} from '@atb/navigation';
 import {StyleSheet, Theme} from '@atb/theme';
 import {AddEditFavoriteTexts, useTranslation} from '@atb/translations';
@@ -62,7 +62,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
   );
   const [emoji, setEmoji] = useState<string | undefined>(editItem?.emoji);
   const [name, setName] = useState<string>(editItem?.name ?? '');
-  const location = useLocationSearchValue<AddEditScreenRouteProp>(
+  const location = useOnlySingleLocation<AddEditScreenRouteProp>(
     'searchLocation',
     editItem?.location,
   );

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -1,19 +1,19 @@
 import {useAuthState} from '@atb/auth';
 import FullScreenHeader from '@atb/components/screen-header/full-header';
 import * as Sections from '@atb/components/sections';
-import {TabNavigatorParams} from '@atb/navigation/TabNavigator';
+import ThemeText from '@atb/components/text';
+import {RootStackParamList} from '@atb/navigation';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useSearchHistory} from '@atb/search-history';
 import {StyleSheet, Theme} from '@atb/theme';
 import {ProfileTexts, useTranslation} from '@atb/translations';
 import {PRIVACY_POLICY_URL} from '@env';
 import {CompositeNavigationProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import React from 'react';
-import {Linking, View} from 'react-native';
+import {Alert, Linking, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {ProfileStackParams} from '..';
-import ThemeText from '@atb/components/text';
-import {RootStackParamList} from '@atb/navigation';
 
 export type ProfileScreenNavigationProp = StackNavigationProp<
   ProfileStackParams,
@@ -32,6 +32,7 @@ type ProfileScreenProps = {
 export default function ProfileHome({navigation}: ProfileScreenProps) {
   const {enable_i18n, enable_login} = useRemoteConfig();
   const style = useProfileHomeStyle();
+  const {history, clearSearchHistory} = useSearchHistory();
   const {t} = useTranslation();
   const {authenticationType, signOut, user} = useAuthState();
 
@@ -128,6 +129,39 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             }}
             onPress={() =>
               Linking.openURL(PRIVACY_POLICY_URL ?? 'https://www.atb.no')
+            }
+          />
+          <Sections.LinkItem
+            text={t(ProfileTexts.sections.privacy.linkItems.clearHistory.label)}
+            accessibility={{
+              accessibilityHint: t(
+                ProfileTexts.sections.privacy.linkItems.clearHistory.a11yHint,
+              ),
+            }}
+            onPress={() =>
+              Alert.alert(
+                t(ProfileTexts.sections.privacy.linkItems.clearHistory.confirm),
+                undefined,
+                [
+                  {
+                    text: t(
+                      ProfileTexts.sections.privacy.linkItems.clearHistory.alert
+                        .cancel,
+                    ),
+                    style: 'cancel',
+                  },
+                  {
+                    text: t(
+                      ProfileTexts.sections.privacy.linkItems.clearHistory.alert
+                        .confirm,
+                    ),
+                    style: 'destructive',
+                    onPress: async () => {
+                      await clearSearchHistory();
+                    },
+                  },
+                ],
+              )
             }
           />
         </Sections.Section>

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -32,7 +32,7 @@ type ProfileScreenProps = {
 export default function ProfileHome({navigation}: ProfileScreenProps) {
   const {enable_i18n, enable_login} = useRemoteConfig();
   const style = useProfileHomeStyle();
-  const {history, clearSearchHistory} = useSearchHistory();
+  const {clearHistory} = useSearchHistory();
   const {t} = useTranslation();
   const {authenticationType, signOut, user} = useAuthState();
 
@@ -157,7 +157,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                     ),
                     style: 'destructive',
                     onPress: async () => {
-                      await clearSearchHistory();
+                      await clearHistory();
                     },
                   },
                 ],

--- a/src/search-history/index.tsx
+++ b/src/search-history/index.tsx
@@ -38,14 +38,12 @@ const SearchHistoryContextProvider: React.FC = ({children}) => {
   const contextValue: SearchHistoryContextState = {
     history,
     async addSearchEntry(searchEntry: SearchHistoryEntry) {
-      console.log('adding entry:', searchEntry.name);
       const history = await searchStore.addEntry(searchEntry);
       setSearchHistory(history);
     },
 
     journeyHistory,
     async addJourneySearchEntry(searchEntry: JourneySearchHistoryEntry) {
-      console.log('adding journey entry:', searchEntry[0].name);
       setJourneySearchHistory(await journeyStore.addEntry(searchEntry));
     },
 

--- a/src/search-history/index.tsx
+++ b/src/search-history/index.tsx
@@ -10,11 +10,11 @@ import {
 type SearchHistoryContextState = {
   history: SearchHistory;
   addSearchEntry(searchEntry: SearchHistoryEntry): Promise<void>;
-  clearSearchHistory(): Promise<void>;
 
   journeyHistory: JourneySearchHistory;
   addJourneySearchEntry(searchEntry: JourneySearchHistoryEntry): Promise<void>;
-  clearJourneySearchHistory(): Promise<void>;
+
+  clearHistory(): Promise<void>;
 };
 const SearchHistoryContext = createContext<
   SearchHistoryContextState | undefined
@@ -38,19 +38,19 @@ const SearchHistoryContextProvider: React.FC = ({children}) => {
   const contextValue: SearchHistoryContextState = {
     history,
     async addSearchEntry(searchEntry: SearchHistoryEntry) {
+      console.log('adding entry:', searchEntry.name);
       const history = await searchStore.addEntry(searchEntry);
-      setSearchHistory(history);
-    },
-    async clearSearchHistory() {
-      const history = await searchStore.clear();
       setSearchHistory(history);
     },
 
     journeyHistory,
     async addJourneySearchEntry(searchEntry: JourneySearchHistoryEntry) {
+      console.log('adding journey entry:', searchEntry[0].name);
       setJourneySearchHistory(await journeyStore.addEntry(searchEntry));
     },
-    async clearJourneySearchHistory() {
+
+    async clearHistory() {
+      setSearchHistory(await searchStore.clear());
       setJourneySearchHistory(await journeyStore.clear());
     },
   };

--- a/src/search-history/index.tsx
+++ b/src/search-history/index.tsx
@@ -1,15 +1,20 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
-import {SearchHistoryEntry, SearchHistory} from './types';
+import {searchStore, journeyStore} from './storage';
 import {
-  clearSearchHistory,
-  addSearchEntry as storage_addSearchEntry,
-  getSearchHistory,
-} from './storage';
+  JourneySearchHistory,
+  JourneySearchHistoryEntry,
+  SearchHistory,
+  SearchHistoryEntry,
+} from './types';
 
 type SearchHistoryContextState = {
   history: SearchHistory;
   addSearchEntry(searchEntry: SearchHistoryEntry): Promise<void>;
   clearSearchHistory(): Promise<void>;
+
+  journeyHistory: JourneySearchHistory;
+  addJourneySearchEntry(searchEntry: JourneySearchHistoryEntry): Promise<void>;
+  clearJourneySearchHistory(): Promise<void>;
 };
 const SearchHistoryContext = createContext<
   SearchHistoryContextState | undefined
@@ -17,9 +22,13 @@ const SearchHistoryContext = createContext<
 
 const SearchHistoryContextProvider: React.FC = ({children}) => {
   const [history, setSearchHistory] = useState<SearchHistory>([]);
+  const [journeyHistory, setJourneySearchHistory] = useState<
+    JourneySearchHistoryEntry[]
+  >([]);
+
   async function populateSearchHistory() {
-    const history = await getSearchHistory();
-    setSearchHistory(history ?? []);
+    setSearchHistory(await searchStore.getHistory());
+    setJourneySearchHistory(await journeyStore.getHistory());
   }
 
   useEffect(() => {
@@ -29,12 +38,20 @@ const SearchHistoryContextProvider: React.FC = ({children}) => {
   const contextValue: SearchHistoryContextState = {
     history,
     async addSearchEntry(searchEntry: SearchHistoryEntry) {
-      const history = await storage_addSearchEntry(searchEntry);
+      const history = await searchStore.addEntry(searchEntry);
       setSearchHistory(history);
     },
     async clearSearchHistory() {
-      const history = await clearSearchHistory();
+      const history = await searchStore.clear();
       setSearchHistory(history);
+    },
+
+    journeyHistory,
+    async addJourneySearchEntry(searchEntry: JourneySearchHistoryEntry) {
+      setJourneySearchHistory(await journeyStore.addEntry(searchEntry));
+    },
+    async clearJourneySearchHistory() {
+      setJourneySearchHistory(await journeyStore.clear());
     },
   };
 

--- a/src/search-history/storage.ts
+++ b/src/search-history/storage.ts
@@ -5,9 +5,6 @@ import {JourneySearchHistoryEntry, SearchHistoryEntry} from './types';
 // but in the future with external storage, this
 const HISTORY_LIMIT = 10;
 
-export const STORAGE_KEY = '@ATB_search-history';
-export const JOURNEY_STORAGE_KEY = '@ATB_journey_search-history';
-
 class HistoryStore<T = SearchHistoryEntry | JourneySearchHistoryEntry> {
   private key: StorageModelTypes;
   private eqaulityComparator: (a: T, b: T) => boolean;
@@ -51,7 +48,7 @@ class HistoryStore<T = SearchHistoryEntry | JourneySearchHistoryEntry> {
   }
 
   private async setSearchHistory(completeHistory: T[]): Promise<T[]> {
-    await storage.set(STORAGE_KEY, JSON.stringify(completeHistory));
+    await storage.set(this.key, JSON.stringify(completeHistory));
     return completeHistory;
   }
 
@@ -59,6 +56,9 @@ class HistoryStore<T = SearchHistoryEntry | JourneySearchHistoryEntry> {
     return history.filter((item) => !this.eqaulityComparator(item, entry));
   }
 }
+
+export const STORAGE_KEY = '@ATB_search-history';
+export const JOURNEY_STORAGE_KEY = '@ATB_journey_search-history';
 
 export const searchStore = new HistoryStore<SearchHistoryEntry>(
   STORAGE_KEY,

--- a/src/search-history/storage.ts
+++ b/src/search-history/storage.ts
@@ -1,49 +1,77 @@
-import storage from '../storage';
-import {SearchHistory, SearchHistoryEntry} from './types';
+import storage, {StorageModelTypes} from '../storage';
+import {JourneySearchHistoryEntry, SearchHistoryEntry} from './types';
 
 // @TODO Should be configurable. Also now used to limit store,
 // but in the future with external storage, this
 const HISTORY_LIMIT = 10;
 
-const STORAGE_KEY = '@ATB_search-history';
+export const STORAGE_KEY = '@ATB_search-history';
+export const JOURNEY_STORAGE_KEY = '@ATB_journey_search-history';
 
-export async function getSearchHistory(): Promise<SearchHistory> {
-  const searchHistory = await storage.get(STORAGE_KEY);
-  if (!searchHistory) return [];
-  let data = (searchHistory ? JSON.parse(searchHistory) : []) as SearchHistory;
-  return data;
-}
+class HistoryStore<T = SearchHistoryEntry | JourneySearchHistoryEntry> {
+  private key: StorageModelTypes;
+  private eqaulityComparator: (a: T, b: T) => boolean;
 
-async function setSearchHistory(
-  completeHistory: SearchHistory,
-): Promise<SearchHistory> {
-  await storage.set(STORAGE_KEY, JSON.stringify(completeHistory));
-  return completeHistory;
-}
-
-export async function addSearchEntry(
-  searchEntry: SearchHistoryEntry,
-): Promise<SearchHistory> {
-  let searchHistory = (await getSearchHistory()) ?? [];
-  searchHistory = [searchEntry].concat(
-    removeExistingEntry(searchHistory, searchEntry),
-  );
-
-  // Keeping search history down in storage to prevent it from
-  // beeing too large. Current size limit is 6 MB (by default).
-  if (searchHistory.length > HISTORY_LIMIT) {
-    searchHistory.pop();
+  constructor(
+    key: StorageModelTypes,
+    eqaulityComparator: (a: T, b: T) => boolean,
+  ) {
+    this.key = key;
+    this.eqaulityComparator = eqaulityComparator;
   }
-  return await setSearchHistory(searchHistory);
+
+  async getHistory(): Promise<T[]> {
+    const searchHistory = await storage.get(this.key);
+    if (!searchHistory) return [];
+    try {
+      const parsed = JSON.parse(searchHistory);
+      if (!parsed || !Array.isArray(parsed)) return [];
+      return parsed as T[];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  async addEntry(searchEntry: T): Promise<T[]> {
+    let searchHistory = await this.getHistory();
+    searchHistory = [searchEntry].concat(
+      this.removeExisting(searchHistory, searchEntry),
+    );
+
+    // Keeping search history down in storage to prevent it from
+    // beeing too large. Current size limit is 6 MB (by default).
+    if (searchHistory.length > HISTORY_LIMIT) {
+      searchHistory.pop();
+    }
+    return await this.setSearchHistory(searchHistory);
+  }
+
+  async clear(): Promise<T[]> {
+    return await this.setSearchHistory([]);
+  }
+
+  private async setSearchHistory(completeHistory: T[]): Promise<T[]> {
+    await storage.set(STORAGE_KEY, JSON.stringify(completeHistory));
+    return completeHistory;
+  }
+
+  private removeExisting(history: T[], entry: T) {
+    return history.filter((item) => !this.eqaulityComparator(item, entry));
+  }
 }
 
-export async function clearSearchHistory(): Promise<SearchHistory> {
-  return await setSearchHistory([]);
-}
+export const searchStore = new HistoryStore<SearchHistoryEntry>(
+  STORAGE_KEY,
+  (a, b) => a.id === b.id,
+);
 
-function removeExistingEntry(
-  history: SearchHistory,
-  entry: SearchHistoryEntry,
-) {
-  return history.filter((item) => item.id !== entry.id);
-}
+const equals = <T>(a: T[], b: T[]) =>
+  a.length === b.length && a.every((v, i) => v === b[i]);
+export const journeyStore = new HistoryStore<JourneySearchHistoryEntry>(
+  JOURNEY_STORAGE_KEY,
+  (a, b) =>
+    equals(
+      a.map((i) => i.id),
+      b.map((i) => i.id),
+    ),
+);

--- a/src/search-history/types.d.ts
+++ b/src/search-history/types.d.ts
@@ -2,3 +2,6 @@ import {Location} from '../favorites/types';
 
 export type SearchHistoryEntry = Location;
 export type SearchHistory = SearchHistoryEntry[];
+
+export type JourneySearchHistoryEntry = [Location, Location];
+export type JourneySearchHistory = JourneySearchHistoryEntry[];

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -10,6 +10,7 @@ export type StorageModel = {
   customer_id: string;
   onboarded: string;
   '@ATB_search-history': string;
+  '@ATB_journey_search-history': string;
 };
 
 export type StorageModelTypes = keyof StorageModel;

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -51,6 +51,21 @@ const ProfileTexts = {
             'Activate to read our privacy statement (external content)',
           ),
         },
+        clearHistory: {
+          label: _('Tøm søkehistorikk', 'Clear search history'),
+          a11yHint: _(
+            'Aktivér for å tømme tidligere søk',
+            'Activate to clear previous searches',
+          ),
+          confirm: _(
+            'Dette vil fjerne søkehistorikk.',
+            'This will permanently clear search history.',
+          ),
+          alert: {
+            cancel: _('Avbryt', 'Cancel'),
+            confirm: _('Tøm historikk', 'Clear history'),
+          },
+        },
       },
     },
   },

--- a/src/translations/screens/subscreens/LocationSearch.ts
+++ b/src/translations/screens/subscreens/LocationSearch.ts
@@ -23,6 +23,11 @@ const LocationSearchTexts = {
       heading: _('Siste reisesøk', 'Most recent journeys'),
     },
     result: {
+      a11yLabel: (fromName: string, toName: string) =>
+        _(
+          `Reise fra ${fromName} til ${toName}.`,
+          `Journey from ${fromName} to ${toName}.`,
+        ),
       a11yHint: _(
         'Aktivér for å søke etter reiser for dette resultatet.',
         'Activate to search for trips for these locations.',

--- a/src/translations/screens/subscreens/LocationSearch.ts
+++ b/src/translations/screens/subscreens/LocationSearch.ts
@@ -18,6 +18,17 @@ const LocationSearchTexts = {
       heading: _('Søkeresultater', 'Search results'),
     },
   },
+  journeySearch: {
+    previousJourneyResults: {
+      heading: _('Siste reisesøk', 'Most recent journeys'),
+    },
+    result: {
+      a11yHint: _(
+        'Aktivér for å søke etter reiser for dette resultatet.',
+        'Activate to search for trips for these locations.',
+      ),
+    },
+  },
   messages: {
     networkError: _(
       'Hei, er du på nett? Vi kan ikke søke siden nettforbindelsen din mangler eller er ustabil.',


### PR DESCRIPTION
Closes #673

This PR adds the ability to re-use previous journey searches.

With this, I also added the ability to clear search history as a part of privacy. I feel this is more important now with actual journey searches, even though it is still only stored locally. (I also needed it for testing).



### Example screen shots

<img width="513" alt="Screenshot 2021-03-17 at 22 47 10" src="https://user-images.githubusercontent.com/606374/111543258-164bfe80-8773-11eb-94d3-ae7401bef43e.png">
<img width="510" alt="Screenshot 2021-03-17 at 22 47 06" src="https://user-images.githubusercontent.com/606374/111543262-1815c200-8773-11eb-8be9-cacf148c22f3.png">t of
<img width="539" alt="Screenshot 2021-03-17 at 22 46 46" src="https://user-images.githubusercontent.com/606374/111543263-18ae5880-8773-11eb-880d-454111a1d112.png">
