### PR TITLE
feat: Tickets are shown on the correct tab

### DIFF
--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -3,11 +3,18 @@ import Button from '@atb/components/button';
 import {RootStackParamList} from '@atb/navigation';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {useTicketState} from '@atb/tickets';
+import {
+  FareContract,
+  FareContractState,
+  filterActiveFareContracts,
+  filterExpiredFareContracts,
+  isPreactivatedTicket,
+  useTicketState,
+} from '@atb/tickets';
 import {TicketsTexts, useTranslation} from '@atb/translations';
 import useInterval from '@atb/utils/use-interval';
 import {StackNavigationProp} from '@react-navigation/stack';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {View} from 'react-native';
 import RecentTicketsScrollView from './RecentTicketsScrollView';
 import TicketsScrollView from './TicketsScrollView';
@@ -110,10 +117,12 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
 export const ActiveTickets: React.FC<Props> = () => {
   const {
     activeReservations,
-    activeFareContracts,
+    fareContracts,
     isRefreshingTickets,
     refreshTickets,
   } = useTicketState();
+
+  const activeFareContracts = filterActiveFareContracts(fareContracts);
 
   const [now, setNow] = useState<number>(Date.now());
   useInterval(() => setNow(Date.now()), 2500);
@@ -135,11 +144,9 @@ export const ActiveTickets: React.FC<Props> = () => {
 };
 
 export const ExpiredTickets: React.FC<Props> = () => {
-  const {
-    expiredFareContracts,
-    isRefreshingTickets,
-    refreshTickets,
-  } = useTicketState();
+  const {fareContracts, isRefreshingTickets, refreshTickets} = useTicketState();
+
+  const expiredFareContracts = filterExpiredFareContracts(fareContracts);
 
   const [now, setNow] = useState<number>(Date.now());
   useInterval(() => setNow(Date.now()), 2500);

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -4,17 +4,14 @@ import {RootStackParamList} from '@atb/navigation';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
-  FareContract,
-  FareContractState,
   filterActiveFareContracts,
   filterExpiredFareContracts,
-  isPreactivatedTicket,
   useTicketState,
 } from '@atb/tickets';
 import {TicketsTexts, useTranslation} from '@atb/translations';
 import useInterval from '@atb/utils/use-interval';
 import {StackNavigationProp} from '@react-navigation/stack';
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import {View} from 'react-native';
 import RecentTicketsScrollView from './RecentTicketsScrollView';
 import TicketsScrollView from './TicketsScrollView';

--- a/src/screens/Ticketing/Tickets/index.tsx
+++ b/src/screens/Ticketing/Tickets/index.tsx
@@ -1,6 +1,6 @@
 import Header from '@atb/components/screen-header';
 import {StyleSheet} from '@atb/theme';
-import {useTicketState} from '@atb/tickets';
+import {filterActiveFareContracts, useTicketState} from '@atb/tickets';
 import {TicketsTexts, useTranslation} from '@atb/translations';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import React, {useMemo} from 'react';
@@ -32,7 +32,8 @@ export default function TicketTabs() {
     [top],
   );
 
-  const {activeFareContracts} = useTicketState();
+  const {fareContracts} = useTicketState();
+  const activeFareContracts = filterActiveFareContracts(fareContracts);
   const initialRoute = activeFareContracts.length
     ? ActiveTicketsScreenName
     : BuyTicketsScreenName;

--- a/src/tickets/TicketContext.tsx
+++ b/src/tickets/TicketContext.tsx
@@ -10,11 +10,7 @@ import firestore, {
   FirebaseFirestoreTypes,
 } from '@react-native-firebase/firestore';
 import {useAuthState} from '../auth';
-import {
-  ActiveReservation,
-  FareContract,
-  PaymentStatus,
-} from './types';
+import {ActiveReservation, FareContract, PaymentStatus} from './types';
 import {getPayment} from './api';
 
 type TicketReducerState = {

--- a/src/tickets/TicketContext.tsx
+++ b/src/tickets/TicketContext.tsx
@@ -13,11 +13,9 @@ import {useAuthState} from '../auth';
 import {
   ActiveReservation,
   FareContract,
-  FareContractState,
   PaymentStatus,
 } from './types';
 import {getPayment} from './api';
-import {isPreactivatedTicket} from './utils';
 
 type TicketReducerState = {
   fareContracts: FareContract[];
@@ -95,8 +93,7 @@ const ticketReducer: TicketReducer = (
 type TicketState = {
   addReservation: (reservation: ActiveReservation) => void;
   refreshTickets: () => void;
-  activeFareContracts: FareContract[];
-  expiredFareContracts: FareContract[];
+  fareContracts: FareContract[];
   findFareContractByOrderId: (id: string) => FareContract | undefined;
 } & Pick<TicketReducerState, 'activeReservations' | 'isRefreshingTickets'>;
 
@@ -204,8 +201,6 @@ const TicketContextProvider: React.FC = ({children}) => {
         activeReservations,
         refreshTickets,
         addReservation,
-        activeFareContracts: getActive(state.fareContracts),
-        expiredFareContracts: getExpired(state.fareContracts),
         findFareContractByOrderId: (orderId) =>
           state.fareContracts.find((fc) => fc.orderId === orderId),
       }}
@@ -214,38 +209,6 @@ const TicketContextProvider: React.FC = ({children}) => {
     </TicketContext.Provider>
   );
 };
-
-// const byExpiryComparator = (a: FareContract, b: FareContract): number => {
-//   return b.usage_valid_to - a.usage_valid_to;
-// };
-
-function getActive(fareContracts: FareContract[]) {
-  const isValidNow = (f: FareContract): boolean => {
-    const firstTravelRight = f.travelRights?.[0];
-    if (isPreactivatedTicket(firstTravelRight)) {
-      return firstTravelRight.endDateTime.toMillis() > Date.now();
-    }
-    return false;
-  };
-  const isActivated = (f: FareContract) =>
-    f.state === FareContractState.Activated;
-  return fareContracts.filter(isValidNow).filter(isActivated);
-}
-
-function getExpired(fareContracts: FareContract[]) {
-  const isExpired = (f: FareContract): boolean => {
-    const firstTravelRight = f.travelRights?.[0];
-    if (isPreactivatedTicket(firstTravelRight)) {
-      return !(firstTravelRight.endDateTime.toMillis() > Date.now());
-    }
-    return false;
-  };
-  const isRefunded = (f: FareContract) =>
-    f.state === FareContractState.Refunded;
-  const isExpiredOrRefunded = (f: FareContract) =>
-    isExpired(f) || isRefunded(f);
-  return fareContracts.filter(isExpiredOrRefunded);
-}
 
 function isHandledPaymentStatus(status: PaymentStatus | undefined): boolean {
   switch (status) {

--- a/src/tickets/utils.ts
+++ b/src/tickets/utils.ts
@@ -1,4 +1,9 @@
-import {PreactivatedTicket, TravelRight} from './types';
+import {
+  FareContract,
+  FareContractState,
+  PreactivatedTicket,
+  TravelRight,
+} from './types';
 
 export function isPreactivatedTicket(
   travelRight: TravelRight | undefined,
@@ -8,3 +13,31 @@ export function isPreactivatedTicket(
     travelRight?.type === 'PreActivatedPeriodTicket'
   );
 }
+
+export const filterActiveFareContracts = (fareContracts: FareContract[]) => {
+  const isValidNow = (f: FareContract): boolean => {
+    const firstTravelRight = f.travelRights?.[0];
+    if (isPreactivatedTicket(firstTravelRight)) {
+      return firstTravelRight.endDateTime.toMillis() > Date.now();
+    }
+    return false;
+  };
+  const isActivated = (f: FareContract) =>
+    f.state === FareContractState.Activated;
+  return fareContracts.filter(isValidNow).filter(isActivated);
+};
+
+export const filterExpiredFareContracts = (fareContracts: FareContract[]) => {
+  const isExpired = (f: FareContract): boolean => {
+    const firstTravelRight = f.travelRights?.[0];
+    if (isPreactivatedTicket(firstTravelRight)) {
+      return !(firstTravelRight.endDateTime.toMillis() > Date.now());
+    }
+    return false;
+  };
+  const isRefunded = (f: FareContract) =>
+    f.state === FareContractState.Refunded;
+  const isExpiredOrRefunded = (f: FareContract) =>
+    isExpired(f) || isRefunded(f);
+  return fareContracts.filter(isExpiredOrRefunded);
+};


### PR DESCRIPTION
Earlier active tickets that expired was "hanging around" on the active
tab until the view was remounted. With this change the tickets are
rendered on their correct tab, and changing tab just as it expires.