### PR TITLE
fix: Make 'x' on confirm code input work

### DIFF
--- a/src/screens/Profile/Login/ConfirmCode.tsx
+++ b/src/screens/Profile/Login/ConfirmCode.tsx
@@ -86,6 +86,7 @@ export default function ConfirmCode({navigation, route}: ConfirmCodeProps) {
             textContentType="oneTimeCode"
             showClear={true}
             inlineLabel={false}
+            value={code}
           />
         </Sections.Section>
         <View style={styles.buttonView}>


### PR DESCRIPTION
The destructive 'x' button for clearing did not work as the input field
was not fully managed by the component state code.