### PR TITLE
refactor: rewrites color definitions to use @atb-as/theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "update-device-profiles": "bundle exec fastlane ios update_devices"
   },
   "dependencies": {
+    "@atb-as/theme": "^1.2.0",
     "@bugsnag/react-native": "^7.6.1",
     "@entur/sdk": "^3.4.0",
     "@leile/lobo-t": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "update-device-profiles": "bundle exec fastlane ios update_devices"
   },
   "dependencies": {
-    "@atb-as/theme": "^1.2.0",
+    "@atb-as/theme": "^1.2.1",
     "@bugsnag/react-native": "^7.6.1",
     "@entur/sdk": "^3.4.0",
     "@leile/lobo-t": "^1.0.5",

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,17 +1,17 @@
+import ThemeText from '@atb/components/text';
+import {StyleSheet, Theme, useTheme} from '@atb/theme';
+import {ContrastColor, defaultTextColors} from '@atb/theme/colors';
+import React, {useRef} from 'react';
 import {
-  TouchableOpacityProps,
-  View,
-  StyleProp,
-  ViewStyle,
-  TouchableOpacity,
-  TextStyle,
   Animated,
   Easing,
+  StyleProp,
+  TextStyle,
+  TouchableOpacity,
+  TouchableOpacityProps,
+  View,
+  ViewStyle,
 } from 'react-native';
-import React, {useRef} from 'react';
-import {StyleSheet, Theme, useTheme} from '@atb/theme';
-import ThemeText from '@atb/components/text';
-import {ContrastColor, TextNames} from '@atb/theme/colors';
 
 export {default as ButtonGroup} from './group';
 
@@ -112,7 +112,7 @@ const Button: React.FC<ButtonProps> = ({
         backgroundColor: 'transparent',
         textColorType: themeName == 'dark' ? 'light' : 'dark',
       } as ContrastColor);
-  const {primary} = theme.text.colorSelection[textColorType];
+  const {primary} = defaultTextColors[textColorType];
 
   const styleContainer: ViewStyle[] = [
     css.button,

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -160,7 +160,9 @@ const Button: React.FC<ButtonProps> = ({
         {text && (
           <View style={[textContainer, textContainerStyle]}>
             <ThemeText
-              type={mode === 'tertiary' ? 'body' : 'paragraphHeadline'}
+              type={
+                mode === 'tertiary' ? 'body__primary' : 'body__primary--bold'
+              }
               style={[styleText, textStyle]}
             >
               {text}

--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -292,7 +292,7 @@ const hasReachedEnd = (
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   screen: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flexGrow: 1,
   },
   alertBoxContainer: {
@@ -333,7 +333,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
   },
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     paddingBottom: 0,
     flexGrow: 1,
   },

--- a/src/components/disappearing-header/simple.tsx
+++ b/src/components/disappearing-header/simple.tsx
@@ -194,7 +194,7 @@ const hasReachedEnd = (
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   screen: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flexGrow: 1,
   },
   alertBoxContainer: {
@@ -225,7 +225,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
   },
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     paddingBottom: 0,
     flexGrow: 1,
   },

--- a/src/components/map/MapControls.tsx
+++ b/src/components/map/MapControls.tsx
@@ -39,7 +39,7 @@ const MapControls: React.FC<Props> = ({zoomIn, zoomOut}) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   zoomContainer: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     borderRadius: theme.border.radius.small,
     alignContent: 'stretch',
     ...shadows,

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -59,7 +59,7 @@ const MessageBox: React.FC<MessageBoxProps> = ({
       {retryFunction && (
         <ThemeText
           style={styles.retryText}
-          type="body__link"
+          type="body__primary--underline"
           onPress={retryFunction}
         >
           {t(MessageBoxTexts.tryAgainButton)}
@@ -131,7 +131,7 @@ const useBoxStyle = StyleSheet.createThemeHook((theme) => ({
   content: {
     flex: 1,
   },
-  text: theme.typography.body,
+  text: theme.typography.body__primary,
   retryText: {
     marginTop: theme.spacings.medium,
   },

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -131,7 +131,7 @@ const useBoxStyle = StyleSheet.createThemeHook((theme) => ({
   content: {
     flex: 1,
   },
-  text: theme.text.body,
+  text: theme.typography.body,
   retryText: {
     marginTop: theme.spacings.medium,
   },

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -58,7 +58,7 @@ const MessageBox: React.FC<MessageBoxProps> = ({
       </ThemeText>
       {retryFunction && (
         <ThemeText
-          style={styles.retryText}
+          style={[styles.retryText, {color: textColor}]}
           type="body__primary--underline"
           onPress={retryFunction}
         >

--- a/src/components/optional-day-header/index.tsx
+++ b/src/components/optional-day-header/index.tsx
@@ -25,7 +25,7 @@ export default function OptionalNextDayLabel({
 
   if ((isFirst && !allSameDay) || !isSameDay(prevDate, departureDate)) {
     return (
-      <ThemeText type="lead" style={style.title}>
+      <ThemeText type="body__secondary" style={style.title}>
         {getHumanizedDepartureDatePrefixed(
           departureDate,
           formatToSimpleDate(departureDate, language),

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -92,7 +92,7 @@ const usePaginateStyles = StyleSheet.createThemeHook((theme) => ({
   },
   wrapper: {
     borderBottomWidth: theme.border.width.slim,
-    borderColor: theme.background.level1,
+    borderColor: theme.colors.background_1.backgroundColor,
   },
   buttonLeft: {
     position: 'absolute',

--- a/src/components/screen-header/animated-header.tsx
+++ b/src/components/screen-header/animated-header.tsx
@@ -67,7 +67,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
           ]}
         >
           <View accessible={true} accessibilityRole="header">
-            <ThemeText type="paragraphHeadline">{title}</ThemeText>
+            <ThemeText type="body__primary--bold">{title}</ThemeText>
           </View>
         </Animated.View>
         {altTitle}

--- a/src/components/screen-header/index.tsx
+++ b/src/components/screen-header/index.tsx
@@ -62,7 +62,7 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = ({
         ]}
         onLayout={setLayoutFor('container')}
       >
-        <ThemeText onLayout={setLayoutFor('title')} type="paragraphHeadline">
+        <ThemeText onLayout={setLayoutFor('title')} type="body__primary--bold">
           {title}
         </ThemeText>
       </View>

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -61,7 +61,9 @@ export default function ActionItem({
       {...accessibility}
     >
       <ThemeText
-        type={mode === 'heading-expand' ? 'paragraphHeadline' : 'body'}
+        type={
+          mode === 'heading-expand' ? 'body__primary--bold' : 'body__primary'
+        }
         style={contentContainer}
       >
         {text}
@@ -93,7 +95,10 @@ function ActionModeIcon({
       const icon = checked ? 'expand-less' : 'expand-more';
       return (
         <View style={style.headerExpandIconGroup}>
-          <ThemeText style={style.headerExpandIconGroup__text} type="lead">
+          <ThemeText
+            style={style.headerExpandIconGroup__text}
+            type="body__secondary"
+          >
             {text}
           </ThemeText>
           <NavigationIcon mode={icon} />

--- a/src/components/sections/button-input.tsx
+++ b/src/components/sections/button-input.tsx
@@ -72,7 +72,7 @@ export default function ButtonInput({
 
   const valueEl =
     isStringText(value) || !value ? (
-      <ThemeText type="body" style={!value && styles.faded}>
+      <ThemeText type="body__primary" style={!value && styles.faded}>
         {value ?? placeholder}
       </ThemeText>
     ) : (
@@ -93,7 +93,7 @@ export default function ButtonInput({
         ]}
         {...props}
       >
-        <ThemeText type="lead" style={styles.label}>
+        <ThemeText type="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
         <View style={[contentContainer, containerStyle]}>{valueEl}</View>

--- a/src/components/sections/button-input.tsx
+++ b/src/components/sections/button-input.tsx
@@ -110,7 +110,7 @@ function isStringText(a: any): a is string {
 
 const useSymbolPickerStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
   },
   wrapper__inline: {
     alignSelf: 'flex-start',

--- a/src/components/sections/counter-input.tsx
+++ b/src/components/sections/counter-input.tsx
@@ -51,7 +51,7 @@ export default function CounterInput({
         <ThemeText
           accessible={false}
           style={counterStyles.countText}
-          type="paragraphHeadline"
+          type="body__primary--bold"
         >
           {count}
         </ThemeText>

--- a/src/components/sections/favorite-departure-item.tsx
+++ b/src/components/sections/favorite-departure-item.tsx
@@ -74,7 +74,7 @@ function FavoriteItemContent({favorite, icon, ...props}: BaseProps) {
         <ThemeText>
           {favorite.lineLineNumber} {favorite.lineName}
         </ThemeText>
-        <ThemeText type="lead" color="secondary">
+        <ThemeText type="body__secondary" color="secondary">
           {t(SectionTexts.favoriteDeparture.from)} {favorite.quayName}{' '}
           {favorite.quayPublicCode ?? ''}
         </ThemeText>

--- a/src/components/sections/header-item.tsx
+++ b/src/components/sections/header-item.tsx
@@ -20,7 +20,7 @@ export default function HeaderItem({
     <View style={topContainer}>
       <ThemeText
         style={contentContainer}
-        type={mode === 'heading' ? 'paragraphHeadline' : 'lead'}
+        type={mode === 'heading' ? 'body__primary--bold' : 'body__secondary'}
       >
         {text}
       </ThemeText>
@@ -28,7 +28,7 @@ export default function HeaderItem({
         <ThemeText
           style={contentContainer}
           color="secondary"
-          type={mode === 'heading' ? 'lead' : 'label'}
+          type={mode === 'heading' ? 'body__secondary' : 'body__tertiary'}
         >
           {subtitle}
         </ThemeText>

--- a/src/components/sections/internals/internal-labeled-item.tsx
+++ b/src/components/sections/internals/internal-labeled-item.tsx
@@ -26,7 +26,7 @@ export default function InternalLabeledItem({
     <View style={[style.spaceBetween, topContainer, wrapperStyle]}>
       <ThemeText
         accessible={accessibleLabel}
-        type="body"
+        type="body__primary"
         style={itemStyle.label}
       >
         {label}

--- a/src/components/sections/link-item.tsx
+++ b/src/components/sections/link-item.tsx
@@ -51,7 +51,7 @@ export default function LinkItem({
         {iconEl}
       </View>
       {subtitle && (
-        <ThemeText color="secondary" type="lead">
+        <ThemeText color="secondary" type="body__secondary">
           {subtitle}
         </ThemeText>
       )}

--- a/src/components/sections/section-utils/use-section-item.ts
+++ b/src/components/sections/section-utils/use-section-item.ts
@@ -35,7 +35,9 @@ export default function useSectionItem({
     padding: spacing,
     alignSelf: isInline ? 'flex-start' : undefined,
     ...mapToBorderRadius(theme, radiusSize, radius),
-    backgroundColor: transparent ? undefined : theme.background.level0,
+    backgroundColor: transparent
+      ? undefined
+      : theme.colors.background_0.backgroundColor,
   };
   const contentContainer: ViewStyle = {
     flex: isInline ? undefined : 1,

--- a/src/components/sections/text-input.tsx
+++ b/src/components/sections/text-input.tsx
@@ -89,7 +89,7 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
           borderColor,
         ]}
       >
-        <ThemeText type="lead" style={styles.label}>
+        <ThemeText type="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
         <InternalTextInput
@@ -131,7 +131,7 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     color: theme.text.colors.primary,
     paddingRight: 40,
 
-    fontSize: theme.typography.body.fontSize,
+    fontSize: theme.typography.body__primary.fontSize,
   },
   container: {
     backgroundColor: theme.colors.background_0.backgroundColor,

--- a/src/components/sections/text-input.tsx
+++ b/src/components/sections/text-input.tsx
@@ -131,12 +131,12 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     color: theme.text.colors.primary,
     paddingRight: 40,
 
-    fontSize: theme.text.body.fontSize,
+    fontSize: theme.typography.body.fontSize,
   },
   container: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     borderWidth: theme.border.width.slim,
-    borderColor: theme.background.level0,
+    borderColor: theme.colors.background_0.backgroundColor,
   },
   containerInline: {
     alignItems: 'center',

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -11,7 +11,7 @@ export type ThemeTextProps = TextProps & {
 };
 
 const ThemeText: React.FC<ThemeTextProps> = ({
-  type: fontType = 'body',
+  type: fontType = 'body__primary',
   color = 'primary',
   style,
   children,

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -20,7 +20,7 @@ const ThemeText: React.FC<ThemeTextProps> = ({
   const {theme} = useTheme();
 
   const typeStyle = {
-    ...theme.text[fontType],
+    ...theme.typography[fontType],
     color: theme.text.colors[color],
   };
 

--- a/src/components/theme-icon/theme-icon.tsx
+++ b/src/components/theme-icon/theme-icon.tsx
@@ -1,11 +1,11 @@
 import {useTheme} from '@atb/theme';
-import {iconSizes, Statuses, TextColor, Theme} from '@atb/theme/colors';
+import {Statuses, TextColor, Theme} from '@atb/theme/colors';
 import {SvgProps} from 'react-native-svg';
 
 type ThemeIconProps = {
   svg(props: SvgProps): JSX.Element;
   colorType?: TextColor | Statuses;
-  size?: keyof typeof iconSizes;
+  size?: keyof Theme['icon']['size'];
 } & SvgProps;
 
 const ThemeIcon = ({

--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -30,7 +30,7 @@ export default function FullScreenErrorView({
       </View>
       <View style={styles.container}>
         <View>
-          <ThemeText type="paragraphHeadline" style={styles.title}>
+          <ThemeText type="body__primary--bold" style={styles.title}>
             Appen krasja - håper du lander mykt!
           </ThemeText>
           <ThemeText style={styles.message}>

--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -62,7 +62,7 @@ export default function FullScreenErrorView({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   safearea: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   svgContainer: {
     aspectRatio: 1,

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -59,7 +59,7 @@ export default function JourneyHistory({
               onPress={() => onSelect(searchResult.selectable)}
             >
               <GenericItem transparent>
-                <ThemeText type="paragraphHeadline">
+                <ThemeText type="body__primary--bold">
                   {searchResult.text}
                 </ThemeText>
               </GenericItem>

--- a/src/location-search/LocationResults.tsx
+++ b/src/location-search/LocationResults.tsx
@@ -28,7 +28,7 @@ const LocationResults: React.FC<Props> = ({
     <>
       {title && (
         <View accessibilityRole="header" style={styles.subHeader}>
-          <ThemeText type="lead">{title}</ThemeText>
+          <ThemeText type="body__secondary">{title}</ThemeText>
         </View>
       )}
       <View>

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -301,7 +301,7 @@ function translateErrorType(
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
     flex: 1,
   },
   header: {

--- a/src/location-search/map-selection/LocationBar.tsx
+++ b/src/location-search/map-selection/LocationBar.tsx
@@ -142,7 +142,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingRight: theme.spacings.small,
     paddingVertical: theme.spacings.small,
     borderRadius: theme.border.radius.regular,
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     flexDirection: 'row',
     flexGrow: 1,
     justifyContent: 'space-between',

--- a/src/location-search/map-selection/LocationBar.tsx
+++ b/src/location-search/map-selection/LocationBar.tsx
@@ -83,8 +83,8 @@ const LocationText: React.FC<{
   const {title, subtitle} = getLocationText(t, location, error);
   return (
     <>
-      <ThemeText type="lead">{title}</ThemeText>
-      <ThemeText type="label">{subtitle}</ThemeText>
+      <ThemeText type="body__secondary">{title}</ThemeText>
+      <ThemeText type="body__tertiary">{subtitle}</ThemeText>
     </>
   );
 };

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -49,7 +49,7 @@ const NavigationRoot = () => {
       tabBarOptions={{
         activeTintColor: theme.colors.primary_3.backgroundColor,
         style: {
-          backgroundColor: theme.background.level0,
+          backgroundColor: theme.colors.background_0.backgroundColor,
           ...useBottomNavigationStyles(),
         },
         labelStyle: {

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -104,7 +104,7 @@ function tabSettings(
   return {
     tabBarLabel: ({color}) => (
       <ThemeText
-        type="lead"
+        type="body__secondary"
         style={{color, textAlign: 'center', lineHeight: 14}}
       >
         {tabBarLabel}

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -323,7 +323,7 @@ const Assistant: React.FC<Props> = ({
   const altHeaderComp = (
     <View accessible={true} onLayout={onAltLayout} style={styles.altTitle}>
       <ThemeText
-        type="paragraphHeadline"
+        type="body__primary--bold"
         style={[
           styles.altTitleText,
           styles.altTitleText__right,
@@ -334,7 +334,7 @@ const Assistant: React.FC<Props> = ({
         {from?.name}
       </ThemeText>
       <ThemeText
-        type="paragraphHeadline"
+        type="body__primary--bold"
         accessibilityLabel="til"
         style={styles.altTitleText}
       >
@@ -342,7 +342,7 @@ const Assistant: React.FC<Props> = ({
         –{' '}
       </ThemeText>
       <ThemeText
-        type="paragraphHeadline"
+        type="body__primary--bold"
         style={[styles.altTitleText, {maxWidth: altWidth / 2}]}
         numberOfLines={1}
       >

--- a/src/screens/Assistant/NewsBanner.tsx
+++ b/src/screens/Assistant/NewsBanner.tsx
@@ -24,12 +24,12 @@ const NewsBanner: React.FC<{} & AccessibilityProps> = ({...props}) => {
 
   return (
     <View style={style.container}>
-      <ThemeText type={'body'} style={style.text}>
+      <ThemeText type={'body__primary'} style={style.text}>
         {news_text}
       </ThemeText>
       {news_link_url ? (
         <TouchableOpacity onPress={() => Linking.openURL(news_link_url)}>
-          <ThemeText type="body__link" style={style.link}>
+          <ThemeText type="body__primary--underline" style={style.link}>
             {news_link_text}
           </ThemeText>
         </TouchableOpacity>

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -69,7 +69,7 @@ const ResultItemHeader: React.FC<{
   return (
     <View style={styles.resultHeader}>
       <ThemeText
-        type="lead"
+        type="body__secondary"
         color="secondary"
         style={styles.resultHeaderLabel}
         accessibilityLabel={t(
@@ -84,7 +84,7 @@ const ResultItemHeader: React.FC<{
       </ThemeText>
       <View style={styles.durationContainer}>
         <AccessibleText
-          type="lead"
+          type="body__secondary"
           color="secondary"
           prefix={t(AssistantTexts.results.resultItem.header.totalDuration)}
         >
@@ -167,7 +167,7 @@ function ResultItemFooter({legs}: {legs: Leg[]}) {
 
   return (
     <View style={styles.resultFooter}>
-      <ThemeText type={'lead'}>
+      <ThemeText type={'body__secondary'}>
         {t(
           AssistantTexts.results.resultItem.footer.fromLabel(
             quayName,
@@ -177,7 +177,7 @@ function ResultItemFooter({legs}: {legs: Leg[]}) {
       </ThemeText>
 
       <View style={styles.detailsTextWrapper}>
-        <ThemeText type="lead">
+        <ThemeText type="body__secondary">
           {t(AssistantTexts.results.resultItem.footer.detailsLabel)}
         </ThemeText>
         <ThemeIcon svg={ArrowRight} style={styles.detailsIcon} />
@@ -319,7 +319,7 @@ const TransportationLeg = ({leg}: {leg: Leg}) => {
           subMode={leg.line?.transportSubmode}
         />
       </View>
-      <ThemeText type="body">
+      <ThemeText type="body__primary">
         <LineDisplayName style={styles.lineDisplayName} leg={leg} />
       </ThemeText>
     </View>

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -188,7 +188,7 @@ function ResultItemFooter({legs}: {legs: Leg[]}) {
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   result: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     borderRadius: theme.border.radius.regular,
     marginTop: theme.spacings.medium,
   },

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -134,5 +134,5 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacings.medium,
     paddingBottom: theme.spacings.medium,
   },
-  infoBoxText: theme.typography.body,
+  infoBoxText: theme.typography.body__primary,
 }));

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -134,5 +134,5 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacings.medium,
     paddingBottom: theme.spacings.medium,
   },
-  infoBoxText: theme.text.body,
+  infoBoxText: theme.typography.body,
 }));

--- a/src/screens/Assistant/journey-date-picker/index.tsx
+++ b/src/screens/Assistant/journey-date-picker/index.tsx
@@ -111,7 +111,7 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   contentContainer: {
     padding: theme.spacings.medium,

--- a/src/screens/Loading/index.tsx
+++ b/src/screens/Loading/index.tsx
@@ -14,7 +14,7 @@ const Loading: React.FC<{text?: string}> = ({text}) => {
         color={theme.text.colors.primary}
       />
       {text ? (
-        <ThemeText type="paragraphHeadline" style={styles.text}>
+        <ThemeText type="body__primary--bold" style={styles.text}>
           {text}
         </ThemeText>
       ) : null}

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -195,7 +195,7 @@ const NearbyOverview: React.FC<Props> = ({
       alternativeTitleComponent={
         <AccessibleText
           prefix={t(NearbyTexts.header.altTitle.a11yPrefix)}
-          type={'paragraphHeadline'}
+          type={'body__primary--bold'}
         >
           {fromLocation?.name}
         </AccessibleText>

--- a/src/screens/Onboarding/components/Illustration.tsx
+++ b/src/screens/Onboarding/components/Illustration.tsx
@@ -15,7 +15,7 @@ const Illustration: React.FC<IllustrationProps> = ({Svg}) => {
 };
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   svgContainer: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     width: '100%',
     maxHeight: '50%',
     flexShrink: 1,

--- a/src/screens/Onboarding/components/StepContainer.tsx
+++ b/src/screens/Onboarding/components/StepContainer.tsx
@@ -15,7 +15,7 @@ const StepOuterContainer: React.FC = ({children}) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
   innerContainer: {

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -142,7 +142,10 @@ const StepThree: React.FC<StepProps> = () => {
             Linking.openURL(PRIVACY_POLICY_URL ?? 'https://www.atb.no')
           }
         >
-          <ThemeText type="body" style={[styles.text, styles.privacyPolicy]}>
+          <ThemeText
+            type="body__primary"
+            style={[styles.text, styles.privacyPolicy]}
+          >
             {t(OnboardingTexts.step3.privacyLink.text)}
           </ThemeText>
         </TouchableOpacity>

--- a/src/screens/Profile/AddEditFavorite/AddForm.tsx
+++ b/src/screens/Profile/AddEditFavorite/AddForm.tsx
@@ -210,7 +210,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
               !emoji ? (
                 <ThemeIcon svg={MapPointPin} />
               ) : (
-                <ThemeText type="body">{emoji}</ThemeText>
+                <ThemeText type="body__primary">{emoji}</ThemeText>
               )
             }
           />

--- a/src/screens/Profile/AddEditFavorite/AddForm.tsx
+++ b/src/screens/Profile/AddEditFavorite/AddForm.tsx
@@ -245,7 +245,7 @@ const useScreenStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     flex: 1,
     alignItems: 'stretch',
     justifyContent: 'center',
-    backgroundColor: theme.background.level3,
+    backgroundColor: theme.colors.background_3.backgroundColor,
   },
   innerContainer: {
     flex: 1,

--- a/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
+++ b/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
@@ -131,7 +131,10 @@ const ClearButton: React.FC<{
   if (!value) return null;
   return (
     <TouchableOpacity onPress={() => onEmojiSelected(null)}>
-      <ThemeText type="body" style={[styles.clearButton, clearButtonStyle]}>
+      <ThemeText
+        type="body__primary"
+        style={[styles.clearButton, clearButtonStyle]}
+      >
         {clearButtonText ?? 'Fjern emoji'}
       </ThemeText>
     </TouchableOpacity>

--- a/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
+++ b/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
@@ -242,7 +242,7 @@ const EmojiPicker = forwardRef<Modalize, Props>(
 );
 const usePickerStyles = StyleSheet.createThemeHook((theme) => ({
   modal: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
   },
 }));
 

--- a/src/screens/Profile/AddEditFavorite/SearchLocation.tsx
+++ b/src/screens/Profile/AddEditFavorite/SearchLocation.tsx
@@ -42,7 +42,7 @@ export default function SearchStopPlace({navigation}: SearchStopPlaceProps) {
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
 }));

--- a/src/screens/Profile/Appearance/index.tsx
+++ b/src/screens/Profile/Appearance/index.tsx
@@ -50,7 +50,7 @@ export default function Appearance() {
 
 const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
 }));

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -133,12 +133,12 @@ export default function DesignSystem() {
 
         <Sections.Section withPadding withTopPadding>
           <Sections.LocationInput
-            label="Label"
+            label="body__tertiary"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onPress={() => {}}
           />
           <Sections.LocationInput
-            label="Label"
+            label="body__tertiary"
             placeholder="Short"
             onPress={() => {}}
             type="compact"
@@ -147,7 +147,7 @@ export default function DesignSystem() {
 
         <Sections.Section withPadding withTopPadding>
           <Sections.ButtonInput
-            label="Label"
+            label="body__tertiary"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onPress={() => {}}
             icon="arrow-left"

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -133,12 +133,12 @@ export default function DesignSystem() {
 
         <Sections.Section withPadding withTopPadding>
           <Sections.LocationInput
-            label="body__tertiary"
+            label="Label"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onPress={() => {}}
           />
           <Sections.LocationInput
-            label="body__tertiary"
+            label="Label"
             placeholder="Short"
             onPress={() => {}}
             type="compact"
@@ -147,7 +147,7 @@ export default function DesignSystem() {
 
         <Sections.Section withPadding withTopPadding>
           <Sections.ButtonInput
-            label="body__tertiary"
+            label="Label"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onPress={() => {}}
             icon="arrow-left"

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -212,7 +212,7 @@ function presser() {
 
 const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
   icons: {

--- a/src/screens/Profile/FavoriteDepartures/index.tsx
+++ b/src/screens/Profile/FavoriteDepartures/index.tsx
@@ -74,7 +74,7 @@ export default function FavoriteDepartures() {
 }
 const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'flex-start',

--- a/src/screens/Profile/FavoriteList/SortFavorites.tsx
+++ b/src/screens/Profile/FavoriteList/SortFavorites.tsx
@@ -115,7 +115,7 @@ export default function SortableFavoriteList({navigation}: ProfileScreenProps) {
 }
 const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level3,
+    backgroundColor: theme.colors.background_3.backgroundColor,
     flex: 1,
   },
   error: {

--- a/src/screens/Profile/FavoriteList/SortableListFallback.tsx
+++ b/src/screens/Profile/FavoriteList/SortableListFallback.tsx
@@ -80,7 +80,7 @@ function Item(props: ItemProps) {
   return (
     <View style={[styles.item, sectionStyles.spaceBetween, topContainer]}>
       <FavoriteIcon favorite={item} />
-      <ThemeText type="body" style={contentContainer}>
+      <ThemeText type="body__primary" style={contentContainer}>
         {name(item)}
       </ThemeText>
       <MoveIcon direction="up" {...props} />

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -91,7 +91,7 @@ export default function FavoriteList({navigation}: ProfileScreenProps) {
 }
 const useProfileStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'flex-start',

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -182,7 +182,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
 
 const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
   scrollView: {

--- a/src/screens/Profile/Language/index.tsx
+++ b/src/screens/Profile/Language/index.tsx
@@ -57,7 +57,7 @@ export default function Language() {
 
 const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
 }));

--- a/src/screens/Profile/Login/ConfirmCode.tsx
+++ b/src/screens/Profile/Login/ConfirmCode.tsx
@@ -114,7 +114,10 @@ export default function ConfirmCode({navigation, route}: ConfirmCodeProps) {
                 style={styles.resendButton}
                 onPress={onResendCode}
               >
-                <ThemeText style={styles.resendButtonText} type="body__link">
+                <ThemeText
+                  style={styles.resendButtonText}
+                  type="body__primary--underline"
+                >
                   {t(LoginTexts.confirmCode.resendButton)}
                 </ThemeText>
               </TouchableOpacity>

--- a/src/screens/Profile/Login/ConfirmCode.tsx
+++ b/src/screens/Profile/Login/ConfirmCode.tsx
@@ -128,7 +128,7 @@ export default function ConfirmCode({navigation, route}: ConfirmCodeProps) {
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
     flex: 1,
   },
   mainView: {

--- a/src/screens/Profile/Login/PhoneInput.tsx
+++ b/src/screens/Profile/Login/PhoneInput.tsx
@@ -119,7 +119,7 @@ export default function PhoneInput({navigation, route}: PhoneInputProps) {
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
     flex: 1,
   },
   mainView: {

--- a/src/screens/Profile/SelectStartScreen/index.tsx
+++ b/src/screens/Profile/SelectStartScreen/index.tsx
@@ -63,7 +63,7 @@ export default function SelectStartScreen() {
 
 const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   container: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
     flex: 1,
   },
 }));

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -174,7 +174,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                   </ThemeText>
                   <ThemeText
                     style={styles.smallTopMargin}
-                    type="lead"
+                    type="body__secondary"
                     color="secondary"
                   >
                     {fromTariffZone.id === toTariffZone.id
@@ -192,7 +192,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                   </ThemeText>
                   <ThemeText
                     style={styles.smallTopMargin}
-                    type="lead"
+                    type="body__secondary"
                     color="secondary"
                   >
                     {createTravelDateText(t, language, travelDate)}
@@ -204,10 +204,10 @@ const Confirmation: React.FC<ConfirmationProps> = ({
         </View>
         <View style={styles.totalContainer}>
           <View style={styles.totalContainerHeadings}>
-            <ThemeText type="body">
+            <ThemeText type="body__primary">
               {t(PurchaseConfirmationTexts.totalCost.title)}
             </ThemeText>
-            <ThemeText type="label" color="secondary">
+            <ThemeText type="body__tertiary" color="secondary">
               {t(
                 PurchaseConfirmationTexts.totalCost.label(
                   vatPercentString,
@@ -218,7 +218,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
           </View>
 
           {!isSearchingOffer ? (
-            <ThemeText type="heroTitle">{totalPrice} kr</ThemeText>
+            <ThemeText type="body__primary--jumbo">{totalPrice} kr</ThemeText>
           ) : (
             <ActivityIndicator
               size={theme.spacings.medium}

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -279,14 +279,14 @@ const Confirmation: React.FC<ConfirmationProps> = ({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   ticketsContainer: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     borderTopEndRadius: theme.border.radius.regular,
     borderTopLeftRadius: theme.border.radius.regular,
     borderBottomWidth: 1,
-    borderBottomColor: theme.background.level1,
+    borderBottomColor: theme.colors.background_1.backgroundColor,
     padding: theme.spacings.medium,
     marginTop: theme.spacings.small,
   },
@@ -308,7 +308,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
     padding: theme.spacings.medium,
     marginVertical: theme.spacings.medium,
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     borderRadius: theme.border.radius.regular,
   },
   totalContainerHeadings: {

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -177,7 +177,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             {isSearchingOffer ? (
               <ActivityIndicator style={styles.totalSection} />
             ) : (
-              <ThemeText style={styles.totalSection} type="paragraphHeadline">
+              <ThemeText style={styles.totalSection} type="body__primary--bold">
                 {t(PurchaseOverviewTexts.totalPrice(totalPrice))}
               </ThemeText>
             )}

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -270,7 +270,7 @@ const useDefaultTariffZone = (
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   errorMessage: {
     marginBottom: theme.spacings.medium,

--- a/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
@@ -156,7 +156,10 @@ const translateError = (
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  container: {flex: 1, backgroundColor: theme.background.level2},
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background_2.backgroundColor,
+  },
   center: {flex: 1, justifyContent: 'center', padding: theme.spacings.medium},
   messageBox: {marginBottom: theme.spacings.small},
   button: {marginBottom: theme.spacings.small},

--- a/src/screens/Ticketing/Purchase/Payment/Processing.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/Processing.tsx
@@ -20,7 +20,7 @@ const Processing: React.FC<{message: string}> = ({message}) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     paddingHorizontal: theme.spacings.medium,
     paddingVertical: theme.spacings.large,
     borderRadius: theme.border.radius.regular,

--- a/src/screens/Ticketing/Purchase/Payment/Vipps/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/Vipps/index.tsx
@@ -136,7 +136,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
     padding: theme.spacings.medium,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   content: {
     flex: 1,

--- a/src/screens/Ticketing/Purchase/Product/index.tsx
+++ b/src/screens/Ticketing/Purchase/Product/index.tsx
@@ -94,7 +94,7 @@ const Product: React.FC<{
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   productsSection: {
     margin: theme.spacings.medium,

--- a/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
@@ -21,7 +21,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
-        <ThemeText type="lead" color="secondary">
+        <ThemeText type="body__secondary" color="secondary">
           {t(TariffZoneSearchTexts.zones.heading)}
         </ThemeText>
       </View>

--- a/src/screens/Ticketing/Purchase/TariffZones/search/VenueResults.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/VenueResults.tsx
@@ -26,7 +26,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
-        <ThemeText type="lead" color="secondary">
+        <ThemeText type="body__secondary" color="secondary">
           {t(TariffZoneSearchTexts.results.heading)}
         </ThemeText>
       </View>
@@ -60,10 +60,10 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
                   />
                 </View>
                 <View style={styles.nameContainer}>
-                  <ThemeText type={'paragraphHeadline'}>
+                  <ThemeText type={'body__primary--bold'}>
                     {location.name}
                   </ThemeText>
-                  <ThemeText type={'lead'}>
+                  <ThemeText type={'body__secondary'}>
                     {t(
                       TariffZoneSearchTexts.results.item.zoneLabel(
                         getReferenceDataName(tariffZone, language),

--- a/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
@@ -209,7 +209,7 @@ function translateErrorType(
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
     flex: 1,
   },
   header: {

--- a/src/screens/Ticketing/Purchase/TravelDate/index.tsx
+++ b/src/screens/Ticketing/Purchase/TravelDate/index.tsx
@@ -96,7 +96,7 @@ const TravelDate: React.FC<{
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   contentContainer: {
     padding: theme.spacings.medium,

--- a/src/screens/Ticketing/Purchase/Travellers/index.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/index.tsx
@@ -101,7 +101,7 @@ const Travellers: React.FC<TravellersProps> = ({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   travellerCounters: {
     margin: theme.spacings.medium,

--- a/src/screens/Ticketing/Splash/InviteModal.tsx
+++ b/src/screens/Ticketing/Splash/InviteModal.tsx
@@ -105,7 +105,7 @@ export default forwardRef<Modalize, Props>(function InviteModal(
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.level3,
+    backgroundColor: theme.colors.background_3.backgroundColor,
     paddingVertical: theme.spacings.large,
     paddingHorizontal: theme.spacings.medium,
   },

--- a/src/screens/Ticketing/Splash/InviteModal.tsx
+++ b/src/screens/Ticketing/Splash/InviteModal.tsx
@@ -65,10 +65,10 @@ export default forwardRef<Modalize, Props>(function InviteModal(
             <ActivityIndicator style={styles.loading} />
           ) : (
             <>
-              <ThemeText type="paragraphHeadline" style={styles.title}>
+              <ThemeText type="body__primary--bold" style={styles.title}>
                 Registrer deg som testpilot for billettkjøp
               </ThemeText>
-              <ThemeText type="body" style={styles.text}>
+              <ThemeText type="body__primary" style={styles.text}>
                 Send oss invitasjonskoden din og bli først ute med å teste
                 billettkjøp direkte fra reiseappen.
               </ThemeText>

--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -57,7 +57,7 @@ const DetailsContent: React.FC<Props> = ({
         </Sections.GenericItem>
         <Sections.GenericItem>
           <ThemeText>{t(TicketTexts.details.orderId(fc.orderId))}</ThemeText>
-          <ThemeText type="lead" color="secondary">
+          <ThemeText type="body__secondary" color="secondary">
             {t(
               TicketTexts.details.purchaseTime(
                 formatToLongDateTime(

--- a/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
@@ -61,11 +61,11 @@ export default function DetailsScreen({navigation, route}: Props) {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   header: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   content: {
     padding: theme.spacings.medium,

--- a/src/screens/Ticketing/Ticket/Details/ReceiptScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/ReceiptScreen.tsx
@@ -124,11 +124,11 @@ function translateStateToMessage(
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   header: {
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   container: {
     flex: 1,
-    backgroundColor: theme.background.level2,
+    backgroundColor: theme.colors.background_2.backgroundColor,
   },
   content: {
     padding: theme.spacings.medium,

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -92,18 +92,18 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
     <View style={styles.textsContainer}>
       <View>
         {userProfilesWithCount.map((u) => (
-          <ThemeText type="paragraphHeadline" key={u.id}>{`${
+          <ThemeText type="body__primary--bold" key={u.id}>{`${
             u.count
           } ${getReferenceDataName(u, language)}`}</ThemeText>
         ))}
       </View>
       {preassignedFareProduct && (
-        <ThemeText type="lead" style={styles.product}>
+        <ThemeText type="body__secondary" style={styles.product}>
           {getReferenceDataName(preassignedFareProduct, language)}
         </ThemeText>
       )}
       {fromTariffZone && toTariffZone && (
-        <ThemeText type="lead" style={styles.zones}>
+        <ThemeText type="body__secondary" style={styles.zones}>
           {tariffZonesSummary(fromTariffZone, toTariffZone, language, t)}
         </ThemeText>
       )}
@@ -140,7 +140,7 @@ const TicketInspectionSymbol = ({
       <>
         {status === 'valid' && (
           <ThemeText
-            type="paragraphHeadline"
+            type="body__primary--bold"
             allowFontScaling={false}
             style={styles.symbolZones}
           >

--- a/src/screens/Ticketing/Ticket/ValidityHeader.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityHeader.tsx
@@ -85,7 +85,7 @@ function validityTimeText(
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   iconContainer: {marginRight: theme.spacings.medium},
   ticketContainer: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     borderRadius: theme.border.radius.regular,
     marginBottom: theme.spacings.medium,
   },

--- a/src/screens/Ticketing/Ticket/ValidityHeader.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityHeader.tsx
@@ -26,7 +26,7 @@ const ValidityHeader: React.FC<{
     <View style={styles.validityHeader}>
       <View style={styles.validityContainer}>
         <ValidityIcon status={status} />
-        <ThemeText style={styles.validityText} type="lead">
+        <ThemeText style={styles.validityText} type="body__secondary">
           {validityTimeText(status, now, validFrom, validTo, t, language)}
         </ThemeText>
       </View>

--- a/src/screens/Ticketing/Ticket/ValidityLine.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityLine.tsx
@@ -48,7 +48,7 @@ const ValidityLine = (props: Props): ReactElement => {
             dashGap={0}
             dashLength={1}
             dashThickness={1}
-            dashColor={theme.background.level1}
+            dashColor={theme.colors.background_1.backgroundColor}
           />
         </View>
       );
@@ -92,7 +92,7 @@ const LineWithVerticalBars = ({
         dashGap={0}
         dashLength={1}
         dashThickness={8}
-        dashColor={theme.background.level1}
+        dashColor={theme.colors.background_1.backgroundColor}
       />
     </View>
   );

--- a/src/screens/Ticketing/Tickets/RecentTicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/RecentTicketsScrollView.tsx
@@ -78,8 +78,8 @@ const RecentTicketsScrollView = () => {
       <LinearGradient
         style={styles.gradient}
         colors={[
-          hexToRgba(theme.background.level1, 0.1),
-          hexToRgba(theme.background.level1, 1),
+          hexToRgba(theme.colors.background_1.backgroundColor, 0.1),
+          hexToRgba(theme.colors.background_1.backgroundColor, 1),
         ]}
         pointerEvents={'none'}
       />

--- a/src/screens/Ticketing/Tickets/TabBar.tsx
+++ b/src/screens/Ticketing/Tickets/TabBar.tsx
@@ -58,7 +58,7 @@ const TicketsTabBar: React.FC<MaterialTopTabBarProps> = ({
               styles.button,
               {
                 backgroundColor: isFocused
-                  ? theme.background.level1
+                  ? theme.colors.background_1.backgroundColor
                   : theme.background.header,
               },
             ]}

--- a/src/screens/Ticketing/Tickets/TabBar.tsx
+++ b/src/screens/Ticketing/Tickets/TabBar.tsx
@@ -63,7 +63,9 @@ const TicketsTabBar: React.FC<MaterialTopTabBarProps> = ({
               },
             ]}
           >
-            <ThemeText type={isFocused ? 'paragraphHeadline' : 'body'}>
+            <ThemeText
+              type={isFocused ? 'body__primary--bold' : 'body__primary'}
+            >
               {label}
             </ThemeText>
           </TouchableOpacity>

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -166,7 +166,7 @@ export const ExpiredTickets: React.FC<Props> = () => {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
   },
   buyPeriodTicketButton: {
     marginTop: theme.spacings.medium,

--- a/src/screens/Ticketing/Tickets/TicketReservation.tsx
+++ b/src/screens/Ticketing/Tickets/TicketReservation.tsx
@@ -85,7 +85,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingVertical: theme.spacings.xSmall,
   },
   ticketContainer: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     borderRadius: theme.border.radius.regular,
     marginBottom: theme.spacings.medium,
   },

--- a/src/screens/Ticketing/Tickets/TicketReservation.tsx
+++ b/src/screens/Ticketing/Tickets/TicketReservation.tsx
@@ -32,7 +32,7 @@ const TicketReservation: React.FC<Props> = ({reservation}) => {
             <View style={styles.iconContainer}>
               <ThemeIcon svg={BlankTicket} />
             </View>
-            <ThemeText type="lead" color="secondary">
+            <ThemeText type="body__secondary" color="secondary">
               {reservation.paymentStatus !== 'CAPTURE'
                 ? t(TicketsTexts.reservation.processing)
                 : t(TicketsTexts.reservation.approved)}

--- a/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
@@ -75,8 +75,8 @@ const TicketsScrollView: React.FC<Props> = ({
       <LinearGradient
         style={{position: 'absolute', bottom: 0, width: '100%', height: 30}}
         colors={[
-          hexToRgba(theme.background.level1, 0.1),
-          hexToRgba(theme.background.level1, 1),
+          hexToRgba(theme.colors.background_1.backgroundColor, 0.1),
+          hexToRgba(theme.colors.background_1.backgroundColor, 1),
         ]}
         pointerEvents={'none'}
       />
@@ -91,7 +91,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     textAlign: 'center',
   },
   gradient: {
-    backgroundColor: theme.background.level1,
+    backgroundColor: theme.colors.background_1.backgroundColor,
   },
 }));
 

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -344,7 +344,7 @@ const useCollapseButtonStyle = StyleSheet.createThemeHook((theme) => ({
 const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
   },
   header: {
     backgroundColor: theme.background.header,
@@ -368,7 +368,7 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
     marginBottom: theme.spacings.small,
   },
   allGroups: {
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
     marginBottom: theme.spacings.xLarge,
   },
   spinner: {

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -163,7 +163,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   },
   container: {
     flex: 1,
-    backgroundColor: theme.background.level0,
+    backgroundColor: theme.colors.background_0.backgroundColor,
   },
   paddedContainer: {
     paddingHorizontal: theme.spacings.medium,

--- a/src/screens/TripDetails/LocationRow.tsx
+++ b/src/screens/TripDetails/LocationRow.tsx
@@ -56,7 +56,7 @@ const LocationRow: React.FC<{
             iconContainerStyle,
             {
               backgroundColor: !dashThroughIcon
-                ? theme.background.level2
+                ? theme.colors.background_2.backgroundColor
                 : 'transparent',
             },
           ]}

--- a/src/screens/TripDetails/LocationRow.tsx
+++ b/src/screens/TripDetails/LocationRow.tsx
@@ -45,7 +45,7 @@ const LocationRow: React.FC<{
             {time}
           </ThemeText>
           {aimedTime && (
-            <ThemeText type="label" style={styles.aimedTime}>
+            <ThemeText type="body__tertiary" style={styles.aimedTime}>
               {aimedTime}
             </ThemeText>
           )}

--- a/src/screens/TripDetails/Map/CompactMap.tsx
+++ b/src/screens/TripDetails/Map/CompactMap.tsx
@@ -120,7 +120,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingVertical: theme.spacings.small,
   },
   toggleText: {
-    textShadowColor: theme.background.level0,
+    textShadowColor: theme.colors.background_0.backgroundColor,
     textShadowOffset: {height: 1, width: 1},
     textShadowRadius: 1,
   },

--- a/src/screens/TripDetails/components/Time.tsx
+++ b/src/screens/TripDetails/components/Time.tsx
@@ -21,7 +21,7 @@ const Time: React.FC<TimeValues> = (timeValues) => {
             {expected}
           </AccessibleText>
           <AccessibleText
-            type="label"
+            type="body__tertiary"
             color="secondary"
             prefix={t(dictionary.travel.time.aimedPrefix)}
             style={{textDecorationLine: 'line-through'}}

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -188,7 +188,7 @@ const IntermediateInfo: React.FC<TripSectionProps> = (leg) => {
         TripDetailsTexts.trip.leg.intermediateStops.a11yHint,
       )}
     >
-      <ThemeText type="lead" color="secondary">
+      <ThemeText type="body__secondary" color="secondary">
         {t(
           TripDetailsTexts.trip.leg.intermediateStops.label(
             numberOfIntermediateCalls,
@@ -214,7 +214,7 @@ const WalkSection: React.FC<TripSectionProps> = (leg) => {
         />
       }
     >
-      <ThemeText type="lead" color="secondary">
+      <ThemeText type="body__secondary" color="secondary">
         {t(
           TripDetailsTexts.trip.leg.walk.label(
             secondsToDuration(leg.duration ?? 0, language),

--- a/src/screens/TripDetails/components/TripSummary.tsx
+++ b/src/screens/TripDetails/components/TripSummary.tsx
@@ -58,7 +58,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   summary: {
     marginVertical: theme.spacings.medium,
     borderTopWidth: theme.border.width.slim,
-    borderColor: theme.background.level1,
+    borderColor: theme.colors.background_1.backgroundColor,
   },
   summaryDetail: {
     padding: theme.spacings.medium,

--- a/src/screens/TripDetails/components/WaitSection.tsx
+++ b/src/screens/TripDetails/components/WaitSection.tsx
@@ -36,7 +36,7 @@ const WaitSection: React.FC<WaitDetails> = (wait) => {
         </TripRow>
       )}
       <TripRow rowLabel={<Wait />}>
-        <ThemeText type="lead" color="secondary">
+        <ThemeText type="body__secondary" color="secondary">
           {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
         </ThemeText>
       </TripRow>

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -9,42 +9,32 @@ import {
   ContrastColor,
   RadiusSizes,
   defaultTextColors,
+  TextNames,
+  createTextTypeStyles,
+  textNames,
 } from '@atb-as/theme';
 
 export default colors;
-export type {Statuses, Mode, TextColor, ContrastColor, RadiusSizes};
-export {defaultTextColors};
+export type {Statuses, Mode, TextColor, ContrastColor, RadiusSizes, TextNames};
+export {defaultTextColors, textNames};
 
-export const textNames = [
-  'body__primary--jumbo',
-  'body__primary--bold',
-  'body__primary',
-  'body__primary--underline',
-  'body__secondary',
-  'body__tertiary',
-] as const;
-
-export type TextNames = typeof textNames[number];
-
-export const textTypeStyles: {[key in TextNames]: TextStyle} = {
-  'body__primary--jumbo': {fontSize: 32, lineHeight: 40},
-  'body__primary--bold': {
-    fontSize: 16,
-    lineHeight: 20,
-    fontWeight: Platform.select({
-      android: 'bold',
-      default: '600',
-    }),
-  },
-  body__primary: {fontSize: 16, lineHeight: 20},
-  'body__primary--underline': {
-    fontSize: 16,
-    lineHeight: 20,
-    textDecorationLine: 'underline',
-  },
-  body__secondary: {fontSize: 14, lineHeight: 20},
-  body__tertiary: {fontSize: 12, lineHeight: 16},
+// Override semibold with bold to avoid Android Roboto bold bug.
+// See ttps://github.com/facebook/react-native/issues/25696
+const fontWeightFix: TextStyle = {
+  fontWeight: Platform.select({
+    android: 'bold',
+    default: '600',
+  }),
 };
+
+const androidOrIos = Platform.OS === 'android' ? 'android' : 'ios';
+export const textTypeStyles = createTextTypeStyles(androidOrIos, {
+  'body__primary--bold': fontWeightFix,
+  'body__secondary--bold': fontWeightFix,
+  heading__component: fontWeightFix,
+  heading__paragraph: fontWeightFix,
+  heading__title: fontWeightFix,
+});
 
 const tripLegDetail = {
   labelWidth: 80,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -12,6 +12,7 @@ import {
   TextNames,
   createTextTypeStyles,
   textNames,
+  backgrounds,
 } from '@atb-as/theme';
 
 export default colors;
@@ -74,9 +75,9 @@ export const themes = createExtendedThemes<AppThemeExtension>({
     statusBarStyle: 'light-content',
 
     background: {
-      header: colors.secondary.cyan_500,
+      header: colors.secondary.blue_900,
       destructive: colors.secondary.red_500,
-      accent: colors.secondary.cyan_500,
+      accent: backgrounds.dark.level1,
     },
 
     typography: textTypeStyles,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -16,26 +16,19 @@ export type {Statuses, Mode, TextColor, ContrastColor, RadiusSizes};
 export {defaultTextColors};
 
 export const textNames = [
-  'heroTitle',
-  'pageTitle',
-  'sectionHeadline',
-  'itemHeadline',
-  'paragraphHeadline',
-  'body',
-  'body__link',
-  'lead',
-  'label',
-  'label__link',
+  'body__primary--jumbo',
+  'body__primary--bold',
+  'body__primary',
+  'body__primary--underline',
+  'body__secondary',
+  'body__tertiary',
 ] as const;
 
 export type TextNames = typeof textNames[number];
 
 export const textTypeStyles: {[key in TextNames]: TextStyle} = {
-  heroTitle: {fontSize: 32, lineHeight: 40},
-  pageTitle: {fontSize: 26, lineHeight: 32},
-  sectionHeadline: {fontSize: 23, lineHeight: 28},
-  itemHeadline: {fontSize: 20, lineHeight: 24},
-  paragraphHeadline: {
+  'body__primary--jumbo': {fontSize: 32, lineHeight: 40},
+  'body__primary--bold': {
     fontSize: 16,
     lineHeight: 20,
     fontWeight: Platform.select({
@@ -43,11 +36,14 @@ export const textTypeStyles: {[key in TextNames]: TextStyle} = {
       default: '600',
     }),
   },
-  body: {fontSize: 16, lineHeight: 20},
-  body__link: {fontSize: 16, lineHeight: 20, textDecorationLine: 'underline'},
-  lead: {fontSize: 14, lineHeight: 20},
-  label: {fontSize: 12, lineHeight: 16},
-  label__link: {fontSize: 12, lineHeight: 16, textDecorationLine: 'underline'},
+  body__primary: {fontSize: 16, lineHeight: 20},
+  'body__primary--underline': {
+    fontSize: 16,
+    lineHeight: 20,
+    textDecorationLine: 'underline',
+  },
+  body__secondary: {fontSize: 14, lineHeight: 20},
+  body__tertiary: {fontSize: 12, lineHeight: 16},
 };
 
 const tripLegDetail = {

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,98 +1,19 @@
-import hexToRgba from 'hex-to-rgba';
 import {Platform, StatusBarProps, TextStyle} from 'react-native';
 
-const backgrounds = {
-  light__level0: '#FFFFFF',
-  light__level1: '#E7E8E9',
-  light__level2: '#DBDDDE',
-  light__level3: '#CFD2D3',
-
-  dark__level0: '#000000',
-  dark__level1: '#111416',
-  dark__level2: '#191E21',
-  dark__level3: '#1E2429',
-};
-
-const colors = {
-  white: '#ffffff',
-  black: '#000000',
-  primary: {
-    // grays
-    gray_50: '#E7E8E9',
-    gray_100: '#F5F5F6',
-    gray_200: '#AFB3B7',
-    gray_300: '#878E92',
-    gray_400: '#5F686E',
-    gray_500: '#37424A',
-    gray_600: '#2C353B',
-    gray_700: '#21282C',
-    gray_800: '#161A1E',
-    gray_900: '#101416',
-    gray_950: '#1B1C1D',
-    // greens
-    green_100: '#E3E6B3',
-    green_200: '#DADE99',
-    green_300: '#C7CE66',
-    green_400: '#B5BD33',
-    green_500: '#A2AD00',
-    green_600: '#828A00',
-    green_700: '#616800',
-    green_800: '#414500',
-    green_900: '#313400',
-  },
-  secondary: {
-    // cyan
-    cyan_100: '#D4F3F6',
-    cyan_200: '#C6EFF3',
-    cyan_300: '#AAE6EC',
-    cyan_400: '#8DDEE6',
-    cyan_500: '#71D6E0',
-    cyan_600: '#5AABB3',
-    cyan_700: '#448086',
-    cyan_800: '#2D565A',
-    cyan_900: '#224043',
-    // i got the blues
-    blue_100: '#B3D8DE',
-    blue_200: '#99CBD3',
-    blue_300: '#66B0BE',
-    blue_400: '#3396A8',
-    blue_500: '#007C92',
-    blue_600: '#006375',
-    blue_700: '#004A58',
-    blue_800: '#00323A',
-    blue_900: '#00252C',
-
-    brown: '#584528',
-
-    orange: '#C75B12',
-
-    yellow_100: '#F7F3B2',
-    yellow_500: '#E4D700',
-
-    red_100: '#E4B8C6',
-    red_400: '#B74166',
-    red_500: '#A51140',
-  },
-  text: {
-    light: '#FFFFFF',
-    dark: '#000000',
-  },
-  other: {
-    orange_500: '#BE5604',
-    ekspressen_500: '#ED6C05',
-    ekspressen_600: '#C75B12',
-  },
-};
+import {
+  colors,
+  createExtendedThemes,
+  Statuses,
+  Mode,
+  TextColor,
+  ContrastColor,
+  RadiusSizes,
+  defaultTextColors,
+} from '@atb-as/theme';
 
 export default colors;
-
-const spacings = {
-  xLarge: 24,
-  large: 20,
-  medium: 12,
-  small: 8,
-  xSmall: 4,
-};
+export type {Statuses, Mode, TextColor, ContrastColor, RadiusSizes};
+export {defaultTextColors};
 
 export const textNames = [
   'heroTitle',
@@ -128,293 +49,53 @@ export const textTypeStyles: {[key in TextNames]: TextStyle} = {
   label: {fontSize: 12, lineHeight: 16},
   label__link: {fontSize: 12, lineHeight: 16, textDecorationLine: 'underline'},
 };
-export const iconSizes = {
-  large: 28,
-  normal: 20,
-  small: 10,
-};
+
 const tripLegDetail = {
   labelWidth: 80,
   decorationContainerWidth: 20,
   decorationLineEndWidth: 12,
   decorationLineWidth: 4,
 };
-const borderRadius = {
-  circle: 20,
-  regular: 8,
-  small: 4,
-} as const;
 
-const borderWidth = {
-  slim: 1,
-  medium: 2,
-};
-
-export type Themes = {
-  light: Theme;
-  dark: Theme;
-};
-export type Mode = keyof Themes;
-
-export type RadiusSizes = keyof typeof borderRadius;
-
-export type TextColor = 'primary' | 'secondary' | 'disabled';
-
-type TextColorType = 'dark' | 'light';
-
-export type ContrastColor = {
-  backgroundColor: string;
-  color: string;
-  textColorType: TextColorType;
-};
-const contrastColor = (
-  backgroundColor: string = colors.white,
-  textColorType: TextColorType = 'dark',
-): ContrastColor => {
-  return {backgroundColor, color: colors.text[textColorType], textColorType};
-};
-type StatusColor = {
-  main: ContrastColor;
-  bg: ContrastColor;
-};
-
-export interface Theme {
+type AppThemeExtension = {
   statusBarStyle: StatusBarProps['barStyle'];
-  spacings: typeof spacings;
   tripLegDetail: typeof tripLegDetail;
-  colors: {
-    background_0: ContrastColor;
-    background_1: ContrastColor;
-    background_2: ContrastColor;
-    background_3: ContrastColor;
-    primary_1: ContrastColor;
-    primary_2: ContrastColor;
-    primary_3: ContrastColor;
-    primary_destructive: ContrastColor;
-    secondary_1: ContrastColor;
-    secondary_2: ContrastColor;
-    secondary_3: ContrastColor;
-    secondary_4: ContrastColor;
-    transport_city: ContrastColor;
-    transport_region: ContrastColor;
-    transport_boat: ContrastColor;
-    transport_train: ContrastColor;
-    transport_airport: ContrastColor;
-    transport_plane: ContrastColor;
-    transport_other: ContrastColor;
-  };
-  status: {
-    valid: StatusColor;
-    info: StatusColor;
-    warning: StatusColor;
-    error: StatusColor;
-  };
+
   background: {
-    level0: string;
-    level1: string;
-    level2: string;
-    level3: string;
     header: string;
     destructive: string;
-    warning: string;
-    error: string;
-    success: string;
-    info: string;
     accent: string;
   };
 
-  text: {
-    colors: typeof defaultTextColors.light;
-    colorSelection: typeof defaultTextColors;
-  } & typeof textTypeStyles;
-
-  border: {
-    primary: string;
-    secondary: string;
-    focus: string;
-    info: string;
-    warning: string;
-    error: string;
-    success: string;
-    radius: typeof borderRadius;
-    width: typeof borderWidth;
-  };
-  icon: {
-    size: typeof iconSizes;
-  };
-}
-
-export type Statuses = keyof Theme['status'];
-
-const defaultTextColors: {
-  [key in TextColorType]: {[key in TextColor]: string};
-} = {
-  dark: {
-    primary: colors.text.dark,
-    secondary: hexToRgba(colors.text.dark, 0.6),
-    disabled: hexToRgba(colors.text.dark, 0.2),
-  },
-  light: {
-    primary: colors.text.light,
-    secondary: hexToRgba(colors.text.light, 0.6),
-    disabled: hexToRgba(colors.text.light, 0.2),
-  },
+  typography: typeof textTypeStyles;
 };
 
-export const themes: Themes = {
+export const themes = createExtendedThemes<AppThemeExtension>({
   light: {
-    spacings: spacings,
-    tripLegDetail: tripLegDetail,
+    tripLegDetail,
     statusBarStyle: 'dark-content',
+
     background: {
-      level0: backgrounds.light__level0,
-      level1: backgrounds.light__level1,
-      level2: backgrounds.light__level2,
-      level3: backgrounds.light__level3,
       header: colors.secondary.cyan_500,
       destructive: colors.secondary.red_500,
-      info: colors.secondary.cyan_100,
-      warning: colors.secondary.yellow_100,
-      error: colors.secondary.red_500,
-      success: hexToRgba(colors.primary.green_500, 0.25),
       accent: colors.secondary.cyan_500,
     },
 
-    colors: {
-      background_0: contrastColor(colors.white, 'dark'),
-      background_1: contrastColor(colors.primary.gray_50, 'dark'),
-      background_2: contrastColor(colors.primary.gray_100, 'dark'),
-      background_3: contrastColor(colors.primary.gray_200, 'dark'),
-      primary_1: contrastColor(colors.primary.green_500, 'dark'),
-      primary_2: contrastColor(colors.secondary.cyan_500, 'dark'),
-      primary_3: contrastColor(colors.secondary.blue_500, 'light'),
-      primary_destructive: contrastColor(colors.secondary.red_500, 'light'),
-      secondary_1: contrastColor(colors.primary.gray_500, 'light'),
-      secondary_2: contrastColor(colors.primary.gray_200, 'dark'),
-      secondary_3: contrastColor(colors.secondary.cyan_200, 'dark'),
-      secondary_4: contrastColor(colors.primary.gray_50, 'dark'),
-
-      transport_city: contrastColor(colors.primary.green_600),
-      transport_region: contrastColor(colors.secondary.blue_500),
-      transport_boat: contrastColor(colors.secondary.cyan_700),
-      transport_train: contrastColor(colors.secondary.red_500),
-      transport_airport: contrastColor(colors.other.ekspressen_600),
-      transport_plane: contrastColor(colors.other.orange_500),
-      transport_other: contrastColor(colors.primary.gray_400),
-    },
-    status: {
-      valid: {
-        main: contrastColor(colors.primary.green_500, 'dark'),
-        bg: contrastColor(hexToRgba(colors.primary.green_500, 0.25), 'dark'),
-      },
-      info: {
-        main: contrastColor(colors.secondary.blue_500, 'light'),
-        bg: contrastColor(hexToRgba(colors.secondary.blue_500, 0.25), 'dark'),
-      },
-      warning: {
-        main: contrastColor(colors.secondary.yellow_500, 'dark'),
-        bg: contrastColor(hexToRgba(colors.secondary.yellow_500, 0.25), 'dark'),
-      },
-      error: {
-        main: contrastColor(colors.secondary.red_500, 'light'),
-        bg: contrastColor(hexToRgba(colors.secondary.red_500, 0.25), 'dark'),
-      },
-    },
-    text: {
-      colors: defaultTextColors['dark'],
-      colorSelection: defaultTextColors,
-      ...textTypeStyles,
-    },
-    border: {
-      primary: colors.primary.gray_50,
-      secondary: colors.text.dark,
-      focus: colors.secondary.blue_500,
-      info: colors.secondary.cyan_500,
-      warning: colors.secondary.yellow_500,
-      error: colors.secondary.red_500,
-      success: colors.primary.green_500,
-      radius: borderRadius,
-      width: borderWidth,
-    },
-    icon: {
-      size: iconSizes,
-    },
+    typography: textTypeStyles,
   },
   dark: {
-    spacings: spacings,
-    tripLegDetail: tripLegDetail,
+    tripLegDetail,
     statusBarStyle: 'light-content',
-    background: {
-      level0: backgrounds.dark__level0,
-      level1: backgrounds.dark__level1,
-      level2: backgrounds.dark__level2,
-      level3: backgrounds.dark__level3,
-      header: colors.secondary.blue_900,
-      destructive: colors.secondary.red_500,
-      warning: colors.primary.green_900,
-      error: colors.secondary.red_500,
-      success: hexToRgba(colors.primary.green_500, 0.25),
-      info: colors.secondary.cyan_900,
-      accent: backgrounds.dark__level1,
-    },
-    colors: {
-      background_0: contrastColor(colors.white, 'dark'),
-      background_1: contrastColor(colors.primary.gray_50, 'dark'),
-      background_2: contrastColor(colors.primary.gray_100, 'dark'),
-      background_3: contrastColor(colors.primary.gray_200, 'dark'),
-      primary_1: contrastColor(colors.primary.green_500, 'dark'),
-      primary_2: contrastColor(colors.secondary.blue_500, 'light'),
-      primary_3: contrastColor(colors.secondary.cyan_500, 'dark'),
-      primary_destructive: contrastColor(colors.secondary.red_500, 'light'),
-      secondary_1: contrastColor(colors.primary.gray_300, 'dark'),
-      secondary_2: contrastColor(colors.primary.gray_500, 'light'),
-      secondary_3: contrastColor(colors.secondary.blue_600, 'light'),
-      secondary_4: contrastColor(colors.primary.gray_600, 'light'),
 
-      transport_city: contrastColor(colors.primary.green_500),
-      transport_region: contrastColor(colors.secondary.blue_500),
-      transport_boat: contrastColor(colors.secondary.cyan_300),
-      transport_train: contrastColor(colors.secondary.red_400),
-      transport_airport: contrastColor(colors.other.ekspressen_500),
-      transport_plane: contrastColor(colors.other.orange_500),
-      transport_other: contrastColor(colors.primary.gray_300),
+    background: {
+      header: colors.secondary.cyan_500,
+      destructive: colors.secondary.red_500,
+      accent: colors.secondary.cyan_500,
     },
-    status: {
-      valid: {
-        main: contrastColor(colors.primary.green_500, 'dark'),
-        bg: contrastColor(hexToRgba(colors.primary.green_500, 0.25), 'light'),
-      },
-      info: {
-        main: contrastColor(colors.secondary.cyan_500, 'dark'),
-        bg: contrastColor(hexToRgba(colors.secondary.cyan_500, 0.25), 'light'),
-      },
-      warning: {
-        main: contrastColor(colors.secondary.yellow_500, 'dark'),
-        bg: contrastColor(hexToRgba(colors.secondary.yellow_500, 0.25), 'dark'),
-      },
-      error: {
-        main: contrastColor(colors.secondary.red_500, 'light'),
-        bg: contrastColor(hexToRgba(colors.secondary.red_500, 0.25), 'dark'),
-      },
-    },
-    text: {
-      colors: defaultTextColors['light'],
-      colorSelection: defaultTextColors,
-      ...textTypeStyles,
-    },
-    border: {
-      primary: colors.primary.gray_600,
-      secondary: colors.text.light,
-      focus: colors.secondary.cyan_500,
-      info: colors.secondary.cyan_800,
-      warning: colors.primary.green_700,
-      error: colors.secondary.red_500,
-      success: colors.primary.green_500,
-      radius: borderRadius,
-      width: borderWidth,
-    },
-    icon: {
-      size: iconSizes,
-    },
+
+    typography: textTypeStyles,
   },
-};
+});
+
+export type Themes = typeof themes;
+export type Theme = Themes['light'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@atb-as/theme@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-1.2.0.tgz#b86e14ee102b1cb2fbf2dc92a7b6542de152a0da"
+  integrity sha512-Xmh01sXQqM7tmVna373vXJpMI2UpX1zELog83N42ly5yv8Y7XXjPeMBSwwxhIoJ56gM/sYJmY5jbGf5aDc15+Q==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^1.0.7"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -9572,6 +9580,11 @@ truncate-utf8-bytes@^1.0.0:
   integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
   dependencies:
     utf8-byte-length "^1.0.1"
+
+ts-deepmerge@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/ts-deepmerge/-/ts-deepmerge-1.0.7.tgz#8931501f750b3fb4d1e564d6753063fa3ed05298"
+  integrity sha512-zJInx1VKRn9S20n80P8/G19Xrov4xtcNFEUH0GwPfIUr24U/bNiw+I1X2RmQsnL2n0KT/7HQ6L5fbDuE7by/zw==
 
 ts-object-utils@0.0.5:
   version "0.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@atb-as/theme@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-1.2.0.tgz#b86e14ee102b1cb2fbf2dc92a7b6542de152a0da"
-  integrity sha512-Xmh01sXQqM7tmVna373vXJpMI2UpX1zELog83N42ly5yv8Y7XXjPeMBSwwxhIoJ56gM/sYJmY5jbGf5aDc15+Q==
+"@atb-as/theme@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-1.2.1.tgz#95cea0e0c3c8cf8363ce13ccc7e3956f4354b76a"
+  integrity sha512-VkfYm5BLidK8Yt76YiomEytk5Sc5G0y+NoCcRIQ50J3w+fzzS+QW0XtlJzbdEUkIkWow3boIeuxf2aqhlzDDAQ==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^1.0.7"


### PR DESCRIPTION
Uses shared styles from `@atb-as/theme` as defined in https://github.com/AtB-AS/design-system.

See the documentation of use for colors and typography: https://github.com/AtB-AS/design-system/tree/main/packages/theme

This PR rewrites ThemeText and Colors to match the new distributed theme module which can be shared by other products.

## TODO

- [x] Rewrite colors
- [x] Rewrite typography names to match new design system names