### PR TITLE
feat: Group texts for screen reader

### DIFF
--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -152,6 +152,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
               <Sections.GenericItem>
                 {userProfilesWithCountAndOffer.map((u, i) => (
                   <View
+                    accessible={true}
                     key={u.id}
                     style={[
                       styles.userProfileItem,
@@ -168,7 +169,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                 ))}
               </Sections.GenericItem>
               <Sections.GenericItem>
-                <View>
+                <View accessible={true}>
                   <ThemeText>
                     {getReferenceDataName(preassignedFareProduct, language)}
                   </ThemeText>
@@ -202,7 +203,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
             </Sections.Section>
           </View>
         </View>
-        <View style={styles.totalContainer}>
+        <View style={styles.totalContainer} accessible={true}>
           <View style={styles.totalContainerHeadings}>
             <ThemeText type="body">
               {t(PurchaseConfirmationTexts.totalCost.title)}

--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -56,17 +56,19 @@ const DetailsContent: React.FC<Props> = ({
           />
         </Sections.GenericItem>
         <Sections.GenericItem>
-          <ThemeText>{t(TicketTexts.details.orderId(fc.orderId))}</ThemeText>
-          <ThemeText type="lead" color="secondary">
-            {t(
-              TicketTexts.details.purchaseTime(
-                formatToLongDateTime(
-                  fromUnixTime(fc.created.toMillis() / 1000),
-                  language,
+          <View accessible={true}>
+            <ThemeText>{t(TicketTexts.details.orderId(fc.orderId))}</ThemeText>
+            <ThemeText type="lead" color="secondary">
+              {t(
+                TicketTexts.details.purchaseTime(
+                  formatToLongDateTime(
+                    fromUnixTime(fc.created.toMillis() / 1000),
+                    language,
+                  ),
                 ),
-              ),
-            )}
-          </ThemeText>
+              )}
+            </ThemeText>
+          </View>
         </Sections.GenericItem>
         <Sections.LinkItem
           text={t(TicketTexts.details.askForReceipt)}

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -89,7 +89,7 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   return (
-    <View style={styles.textsContainer}>
+    <View style={styles.textsContainer} accessible={true}>
       <View>
         {userProfilesWithCount.map((u) => (
           <ThemeText type="paragraphHeadline" key={u.id}>{`${


### PR DESCRIPTION
Setting accessibile true on parent views that contain multiple texts,
making them be read by the screen reader in one go, instead of each text
being selectable.