### PR TITLE
fix: padding for profile home screen

### DIFF
--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -44,7 +44,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
         rightButton={{type: 'chat'}}
       />
 
-      <ScrollView style={style.scrollView}>
+      <ScrollView contentContainerStyle={style.scrollView}>
         {enable_login && (
           <Sections.Section withPadding>
             <Sections.HeaderItem


### PR DESCRIPTION
Before:

<img width="607" alt="Screenshot 2021-03-24 at 20 50 09" src="https://user-images.githubusercontent.com/606374/112374641-a4c7ff00-8ce2-11eb-9d42-247155ff1f60.png">

After:

<img width="607" alt="Screenshot 2021-03-24 at 20 50 34" src="https://user-images.githubusercontent.com/606374/112374657-aa254980-8ce2-11eb-8686-58ab12b8b28e.png">
