### PR TITLE
feat: Not force refresh id token on login

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -121,7 +121,7 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
   useEffect(() => {
     (async function () {
       if (state.user) {
-        const idToken = await state.user.getIdTokenResult(true);
+        const idToken = await state.user.getIdTokenResult();
         const abtCustomerId = idToken.claims['sub'];
         dispatch({type: 'SET_ABT_CUSTOMER_ID', abtCustomerId});
       }


### PR DESCRIPTION
It is not necessary to force refresh id token on login anymore as no
custom claims is used for setting up the firestore fare contract
subscription. This will also give slightly better handling of missing
internet connection on startup as the app can use cached token.