### PR TITLE
feat: No tariff zone map if screen reader enabled

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -249,15 +249,7 @@ export const createTravelDateText = (
 const useDefaultTariffZone = (
   tariffZones: TariffZone[],
 ): TariffZoneWithMetadata => {
-  const {location} = useGeolocationState();
-  const tariffZoneFromLocation = useMemo(() => {
-    if (location) {
-      const {longitude, latitude} = location.coords;
-      return tariffZones.find((t) =>
-        turfBooleanPointInPolygon([longitude, latitude], t.geometry),
-      );
-    }
-  }, [tariffZones, location]);
+  const tariffZoneFromLocation = useTariffZoneFromLocation(tariffZones);
   return useMemo<TariffZoneWithMetadata>(
     () =>
       tariffZoneFromLocation
@@ -265,6 +257,18 @@ const useDefaultTariffZone = (
         : {...tariffZones[0], resultType: 'zone'},
     [tariffZones, tariffZoneFromLocation],
   );
+};
+
+export const useTariffZoneFromLocation = (tariffZones: TariffZone[]) => {
+  const {location} = useGeolocationState();
+  return useMemo(() => {
+    if (location) {
+      const {longitude, latitude} = location.coords;
+      return tariffZones.find((t) =>
+        turfBooleanPointInPolygon([longitude, latitude], t.geometry),
+      );
+    }
+  }, [tariffZones, location]);
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -35,6 +35,8 @@ import React, {useEffect, useRef, useState} from 'react';
 import {PixelRatio, Platform, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {TicketingStackParams} from '../';
+import useIsScreenReaderEnabled from '@atb/utils/use-is-screen-reader-enabled';
+import TariffZoneResults from '@atb/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults';
 
 type TariffZonesRouteName = 'TariffZones';
 const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
@@ -315,6 +317,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
   const styles = useMapStyles();
   const {t, language} = useTranslation();
   const {theme} = useTheme();
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   const featureCollection = mapZonesToFeatureCollection(tariffZones, language);
 
@@ -371,90 +374,99 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
         </Section>
       </View>
 
-      <MapboxGL.MapView
-        ref={mapViewRef}
-        style={{
-          flex: 1,
-        }}
-        onRegionDidChange={(region) => {
-          setRegionEvent({isMoving: false, region});
-        }}
-        onRegionWillChange={() => {
-          setRegionEvent({isMoving: true, region: regionEvent?.region});
-        }}
-        {...MapViewConfig}
-      >
-        <MapboxGL.ShapeSource
-          id={'tariffZonesShape'}
-          shape={featureCollection}
-          hitbox={{width: 1, height: 1}} // to not be able to hit multiple zones with one click
-          onPress={selectFeature}
-        >
-          <MapboxGL.FillLayer
-            id="tariffZonesFill"
-            style={{
-              fillAntialias: true,
-              fillColor: [
-                // Mapbox Expression syntax
-                'case',
-                ['==', selectedZones.from.id, ['id']],
-                colors.secondary.red_500,
-                ['==', selectedZones.to.id, ['id']],
-                colors.secondary.blue_500,
-                'transparent',
-              ],
-              fillOpacity: 0.2,
-            }}
-          />
-          <MapboxGL.LineLayer
-            id="tariffZonesLine"
-            style={{
-              lineWidth: 1,
-              lineColor: colors.primary.gray_400,
-            }}
-          />
-        </MapboxGL.ShapeSource>
-        {featureCollection.features.map((f) => (
-          <MapboxGL.ShapeSource
-            key={f.id}
-            id={`label-shape-${f.id}`}
-            shape={f.properties!.midPoint}
-          >
-            <MapboxGL.SymbolLayer
-              id={`label-symbol-${f.id}`}
-              style={{
-                textSize: 20,
-                textField: f.properties!.name,
-                textHaloColor: 'white',
-                textHaloWidth: 10,
-              }}
-            />
-          </MapboxGL.ShapeSource>
-        ))}
-        <MapboxGL.Camera
-          ref={mapCameraRef}
-          zoomLevel={6}
-          centerCoordinate={startCoordinates}
-          {...MapCameraConfig}
+      {isScreenReaderEnabled ? (
+        <TariffZoneResults
+          tariffZones={tariffZones}
+          onSelect={(t) => updateSelectedZones(t.id)}
         />
-      </MapboxGL.MapView>
+      ) : (
+        <>
+          <MapboxGL.MapView
+            ref={mapViewRef}
+            style={{
+              flex: 1,
+            }}
+            onRegionDidChange={(region) => {
+              setRegionEvent({isMoving: false, region});
+            }}
+            onRegionWillChange={() => {
+              setRegionEvent({isMoving: true, region: regionEvent?.region});
+            }}
+            {...MapViewConfig}
+          >
+            <MapboxGL.ShapeSource
+              id={'tariffZonesShape'}
+              shape={featureCollection}
+              hitbox={{width: 1, height: 1}} // to not be able to hit multiple zones with one click
+              onPress={selectFeature}
+            >
+              <MapboxGL.FillLayer
+                id="tariffZonesFill"
+                style={{
+                  fillAntialias: true,
+                  fillColor: [
+                    // Mapbox Expression syntax
+                    'case',
+                    ['==', selectedZones.from.id, ['id']],
+                    colors.secondary.red_500,
+                    ['==', selectedZones.to.id, ['id']],
+                    colors.secondary.blue_500,
+                    'transparent',
+                  ],
+                  fillOpacity: 0.2,
+                }}
+              />
+              <MapboxGL.LineLayer
+                id="tariffZonesLine"
+                style={{
+                  lineWidth: 1,
+                  lineColor: colors.primary.gray_400,
+                }}
+              />
+            </MapboxGL.ShapeSource>
+            {featureCollection.features.map((f) => (
+              <MapboxGL.ShapeSource
+                key={f.id}
+                id={`label-shape-${f.id}`}
+                shape={f.properties!.midPoint}
+              >
+                <MapboxGL.SymbolLayer
+                  id={`label-symbol-${f.id}`}
+                  style={{
+                    textSize: 20,
+                    textField: f.properties!.name,
+                    textHaloColor: 'white',
+                    textHaloWidth: 10,
+                  }}
+                />
+              </MapboxGL.ShapeSource>
+            ))}
+            <MapboxGL.Camera
+              ref={mapCameraRef}
+              zoomLevel={6}
+              centerCoordinate={startCoordinates}
+              {...MapCameraConfig}
+            />
+          </MapboxGL.MapView>
 
-      <View style={[styles.bottomControls, {bottom: safeAreaBottom}]}>
-        <View>
-          <View style={styles.mapControls}>
-            <PositionArrow flyToCurrentLocation={flyToCurrentLocation} />
-            <MapControls zoomIn={zoomIn} zoomOut={zoomOut} />
+          <View style={[styles.bottomControls, {bottom: safeAreaBottom}]}>
+            <View>
+              <View style={styles.mapControls}>
+                <PositionArrow flyToCurrentLocation={flyToCurrentLocation} />
+                <MapControls zoomIn={zoomIn} zoomOut={zoomOut} />
+              </View>
+            </View>
+            <View style={styles.saveButton}>
+              <Button
+                onPress={onSave}
+                color="primary_2"
+                text={t(TariffZonesTexts.saveButton.text)}
+                accessibilityHint={t(TariffZonesTexts.saveButton.a11yHint)}
+              />
+            </View>
           </View>
-        </View>
-        <View style={styles.saveButton}>
-          <Button
-            onPress={onSave}
-            color="primary_2"
-            text={t(TariffZonesTexts.saveButton.text)}
-            accessibilityHint={t(TariffZonesTexts.saveButton.a11yHint)}
-          />
-        </View>
-      </View>
+        </>
+      )}
     </View>
   );
 };
@@ -478,7 +490,10 @@ const mapZonesToFeatureCollection = (
 });
 
 const useMapStyles = StyleSheet.createThemeHook((theme) => ({
-  container: {flex: 1},
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background_2.backgroundColor,
+  },
   pinContainer: {
     position: 'absolute',
     top: '50%',

--- a/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
@@ -1,4 +1,4 @@
-import {MapPointPin} from '@atb/assets/svg/icons/places';
+import {CurrentLocationArrow, MapPointPin} from '@atb/assets/svg/icons/places';
 import {screenReaderPause} from '@atb/components/accessible-text';
 import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
@@ -9,6 +9,7 @@ import {TariffZoneSearchTexts, useTranslation} from '@atb/translations';
 import insets from '@atb/utils/insets';
 import React from 'react';
 import {TouchableOpacity, View} from 'react-native';
+import {useTariffZoneFromLocation} from '@atb/screens/Ticketing/Purchase/Overview';
 
 type Props = {
   tariffZones: TariffZone[];
@@ -18,6 +19,7 @@ type Props = {
 const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
   const styles = useThemeStyles();
   const {t, language} = useTranslation();
+  const tariffZoneFromLocation = useTariffZoneFromLocation(tariffZones);
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
@@ -48,10 +50,15 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                   <ThemeIcon svg={MapPointPin} width={20} />
                 </View>
                 <View style={styles.nameContainer}>
-                  <ThemeText style={styles.nameText}>
+                  <ThemeText type={'body__primary--bold'}>
                     {getReferenceDataName(tariffZone, language)}
                   </ThemeText>
                 </View>
+                {tariffZoneFromLocation?.id === tariffZone.id ? (
+                  <View style={styles.currentLocationIcon}>
+                    <ThemeIcon svg={CurrentLocationArrow} />
+                  </View>
+                ) : null}
               </TouchableOpacity>
             </View>
           </View>
@@ -82,10 +89,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
   },
   nameContainer: {
-    marginLeft: 16,
+    marginLeft: theme.spacings.large,
   },
-  nameText: {
-    fontSize: 16,
-    fontWeight: '600',
+  currentLocationIcon: {
+    marginLeft: theme.spacings.small,
   },
 }));

--- a/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
@@ -50,7 +50,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                   <ThemeIcon svg={MapPointPin} width={20} />
                 </View>
                 <View style={styles.nameContainer}>
-                  <ThemeText type={'body__primary--bold'}>
+                  <ThemeText type="body__primary--bold">
                     {getReferenceDataName(tariffZone, language)}
                   </ThemeText>
                 </View>


### PR DESCRIPTION
Disable the tariff zone map selection if screen reader is enabled, as
MapBox crashes with screen reader. Instead show a list of the available
tariff zones.