### PR TITLE
fix: fixes inaccessible presses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
       'warn',
       {
         SafeAreaView: 'react-native-safe-area-context',
+        TouchableOpacity: 'react-native',
       },
     ],
   },

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -4,7 +4,6 @@ import {Duration, WalkingPerson} from '@atb/assets/svg/icons/transportation';
 import AccessibleText, {
   screenReaderPause,
 } from '@atb/components/accessible-text';
-import Button from '@atb/components/button';
 import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
 import TransportationIcon from '@atb/components/transportation-icon';
@@ -30,8 +29,13 @@ import insets from '@atb/utils/insets';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {LegMode} from '@entur/sdk';
 import React from 'react';
-import {AccessibilityProps, View, ViewStyle} from 'react-native';
-import {ScrollView, TouchableOpacity} from 'react-native-gesture-handler';
+import {
+  AccessibilityProps,
+  View,
+  ViewStyle,
+  TouchableOpacity,
+} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
 
 type ResultItemProps = {
   tripPattern: TripPattern;

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -95,8 +95,7 @@ export default function LineItem({
     <View style={[topContainer, {padding: 0}]}>
       <View style={[topContainer, sectionStyle.spaceBetween]}>
         <TouchableOpacity
-          style={styles.lineHeader}
-          containerStyle={contentContainer}
+          style={[styles.lineHeader, contentContainer]}
           onPress={() => onPress(0)}
           hitSlop={insets.symmetric(12, 0)}
           accessibilityRole="button"

--- a/src/screens/Nearby/section-items/line.tsx
+++ b/src/screens/Nearby/section-items/line.tsx
@@ -42,8 +42,8 @@ import {
   AccessibilityProps,
   ScrollView,
   View,
+  TouchableOpacity,
 } from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
 import {NearbyScreenNavigationProp} from '../Nearby';
 import {hasNoDeparturesOnGroup, isValidDeparture} from '../utils';
 

--- a/src/screens/Nearby/section-items/more.tsx
+++ b/src/screens/Nearby/section-items/more.tsx
@@ -8,8 +8,7 @@ import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
 import {StyleSheet} from '@atb/theme';
 import React from 'react';
-import {AccessibilityProps, View} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {AccessibilityProps, View, TouchableOpacity} from 'react-native';
 
 export type MoreItemProps = SectionItem<{
   text: string;

--- a/src/screens/TripDetails/components/TripRow.tsx
+++ b/src/screens/TripDetails/components/TripRow.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {View, ViewProps} from 'react-native';
-import {TouchableOpacity} from 'react-native-gesture-handler';
+import {View, ViewProps, TouchableOpacity} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 
 type TripRowProps = {


### PR DESCRIPTION
An issue with using TouchableOpacity from `react-native-gesture-handler` as it is inaccessible. Add avoid import to eslint rule and fix instances of this occurring today.

This should fix issue with screen reader