### PR TITLE
feat: Improvements to zone selection after testing

### DIFF
--- a/src/components/sections/button-input.tsx
+++ b/src/components/sections/button-input.tsx
@@ -21,6 +21,7 @@ export type ButtonInputProps = SectionItem<{
   iconAccessibility?: AccessibilityProps;
   placeholder?: string;
   value?: string | JSX.Element;
+  highlighted?: boolean;
   icon?: NavigationIconTypes | JSX.Element;
   containerStyle?: ViewStyle;
 }> &
@@ -31,6 +32,7 @@ export default function ButtonInput({
   value,
   placeholder,
   label,
+  highlighted,
 
   icon,
   onIconPress,
@@ -72,7 +74,10 @@ export default function ButtonInput({
 
   const valueEl =
     isStringText(value) || !value ? (
-      <ThemeText type="body__primary" style={!value && styles.faded}>
+      <ThemeText
+        type={value && highlighted ? 'body__primary--bold' : 'body__primary'}
+        style={!value && styles.faded}
+      >
         {value ?? placeholder}
       </ThemeText>
     ) : (

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -181,7 +181,11 @@ const destinationPickerValue = (
       ),
     );
   } else if (fromTariffZone.id === toTariffZone.id && !toTariffZone.venueName) {
-    return t(TariffZonesTexts.location.destinationPicker.value.noVenueSameZone);
+    return t(
+      TariffZonesTexts.location.destinationPicker.value.noVenueSameZone(
+        getReferenceDataName(toTariffZone, language),
+      ),
+    );
   } else if (toTariffZone.venueName) {
     return t(
       TariffZonesTexts.location.departurePicker.value.withVenue(
@@ -347,6 +351,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
                 <ThemeIcon svg={CurrentLocationArrow} />
               ) : undefined
             }
+            highlighted={selectedZones.selectNext === 'from'}
           />
           <ButtonInput
             label={t(TariffZonesTexts.location.destinationPicker.label)}
@@ -370,6 +375,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
                 <ThemeIcon svg={CurrentLocationArrow} />
               ) : undefined
             }
+            highlighted={selectedZones.selectNext === 'to'}
           />
         </Section>
       </View>
@@ -423,12 +429,11 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
                     // Mapbox Expression syntax
                     'case',
                     ['==', selectedZones.from.id, ['id']],
-                    colors.secondary.red_500,
+                    theme.status.valid.bg.backgroundColor,
                     ['==', selectedZones.to.id, ['id']],
-                    colors.secondary.blue_500,
+                    theme.status.info.bg.backgroundColor,
                     'transparent',
                   ],
-                  fillOpacity: 0.2,
                 }}
               />
               <MapboxGL.LineLayer

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -8,10 +8,7 @@ const TariffZonesTexts = {
     a11yLabelPrefix: _(`Sonevalget er`, `The zone selection is`),
     text: {
       singleZone: (zoneName: string) =>
-        _(
-          `Reise gjennom 1 sone (Sone ${zoneName})`,
-          `Travel through 1 zone (Zone ${zoneName})`,
-        ),
+        _(`Reise i 1 sone (${zoneName})`, `Travel in 1 zone (${zoneName})`),
       multipleZone: (zoneNameFrom: string, zoneNameTo: string) =>
         _(
           `Reise fra sone ${zoneNameFrom} til sone ${zoneNameTo}`,
@@ -54,7 +51,8 @@ const TariffZonesTexts = {
       value: {
         noVenue: (zoneName: string) =>
           _(`Sone ${zoneName}`, `Zone ${zoneName}`),
-        noVenueSameZone: _(`Samme sone`, `Same zone`),
+        noVenueSameZone: (zoneName: string) =>
+          _(`Samme sone (${zoneName})`, `Same zone (${zoneName})`),
         withVenue: (zoneName: string, venueName: string) =>
           _(
             `Sone ${zoneName} (${venueName})`,


### PR DESCRIPTION
- Use blue/green colors for selected zones in map as using red color
  could have unwanted connotations.
- The zone up for selection on next click is marked with bold text.
- Some text improvements.