### PR TITLE
feat: Screen reader improvements at ticket details

### DIFF
--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -13,6 +13,7 @@ import TicketInfo from '../TicketInfo';
 import ValidityHeader from '../ValidityHeader';
 import ValidityLine from '../ValidityLine';
 import {getValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
+import {screenReaderPause} from '@atb/components/accessible-text';
 
 type Props = {
   fareContract: FareContract;
@@ -34,6 +35,8 @@ const DetailsContent: React.FC<Props> = ({
     const validFrom = firstTravelRight.startDateTime.toMillis();
     const validTo = firstTravelRight.endDateTime.toMillis();
     const validityStatus = getValidityStatus(now, validFrom, validTo, fc.state);
+
+    const orderIdText = t(TicketTexts.details.orderId(fc.orderId));
 
     return (
       <Sections.Section withBottomPadding>
@@ -57,7 +60,9 @@ const DetailsContent: React.FC<Props> = ({
         </Sections.GenericItem>
         <Sections.GenericItem>
           <View accessible={true}>
-            <ThemeText>{t(TicketTexts.details.orderId(fc.orderId))}</ThemeText>
+            <ThemeText accessibilityLabel={`${orderIdText},`}>
+              {orderIdText}
+            </ThemeText>
             <ThemeText type="body__secondary" color="secondary">
               {t(
                 TicketTexts.details.purchaseTime(

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -20,6 +20,7 @@ import {BusSide, Wait} from '@atb/assets/svg/icons/transportation';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 import {ValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
 import {AddTicket, InvalidTicket} from '@atb/assets/svg/icons/ticketing';
+import {screenReaderPause} from '@atb/components/accessible-text';
 
 type TicketInfoProps = {
   travelRights: PreactivatedTicket[];
@@ -88,23 +89,48 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
+
+  const productName = preassignedFareProduct
+    ? getReferenceDataName(preassignedFareProduct, language)
+    : undefined;
+
+  const tariffZoneSummary =
+    fromTariffZone && toTariffZone
+      ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
+      : undefined;
+
+  const userProfileCountAndName = (u: UserProfileWithCount) =>
+    `${u.count} ${getReferenceDataName(u, language)}`;
+
   return (
     <View style={styles.textsContainer} accessible={true}>
       <View>
         {userProfilesWithCount.map((u) => (
-          <ThemeText type="body__primary--bold" key={u.id}>{`${
-            u.count
-          } ${getReferenceDataName(u, language)}`}</ThemeText>
+          <ThemeText
+            type="body__primary--bold"
+            key={u.id}
+            accessibilityLabel={userProfileCountAndName(u) + screenReaderPause}
+          >
+            {userProfileCountAndName(u)}
+          </ThemeText>
         ))}
       </View>
-      {preassignedFareProduct && (
-        <ThemeText type="body__secondary" style={styles.product}>
-          {getReferenceDataName(preassignedFareProduct, language)}
+      {productName && (
+        <ThemeText
+          type="body__secondary"
+          style={styles.product}
+          accessibilityLabel={productName + screenReaderPause}
+        >
+          {productName}
         </ThemeText>
       )}
-      {fromTariffZone && toTariffZone && (
-        <ThemeText type="body__secondary" style={styles.zones}>
-          {tariffZonesSummary(fromTariffZone, toTariffZone, language, t)}
+      {tariffZoneSummary && (
+        <ThemeText
+          type="body__secondary"
+          style={styles.zones}
+          accessibilityLabel={tariffZoneSummary + screenReaderPause}
+        >
+          {tariffZoneSummary}
         </ThemeText>
       )}
     </View>


### PR DESCRIPTION
The texts in the ticket details screen were read a little too fast with
no breaks between the lines. This was fixed by adding accessibility
labels with screen reader pauses.