### PR TITLE
fix: Wrong color on tiny message box

### DIFF
--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -105,7 +105,9 @@ export const TinyMessageBox: React.FC<TinyMessageProps> = ({
   return (
     <View style={[styles.container, colorStyle]}>
       {message ? (
-        <ThemeText style={styles.text}>{message}</ThemeText>
+        <ThemeText style={{...styles.text, color: colorStyle.color}}>
+          {message}
+        </ThemeText>
       ) : (
         {children}
       )}


### PR DESCRIPTION
Now use the text color appropriate for the tiny message box theme type.