### PR TITLE
fix: Better formatting of tax amount

### DIFF
--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -10,7 +10,11 @@ import {getReferenceDataName} from '@atb/reference-data/utils';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {ReserveOffer} from '@atb/tickets';
-import {PurchaseConfirmationTexts, useTranslation} from '@atb/translations';
+import {
+  Language,
+  PurchaseConfirmationTexts,
+  useTranslation,
+} from '@atb/translations';
 import {RouteProp} from '@react-navigation/native';
 import {addMinutes} from 'date-fns';
 import React from 'react';
@@ -87,14 +91,33 @@ const Confirmation: React.FC<ConfirmationProps> = ({
   );
 
   const vatAmount = totalPrice * (vatPercent / 100);
-  const vatAmountString = vatAmount.toLocaleString(language, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-  const vatPercentString = vatPercent.toLocaleString(language, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  });
+
+  /*
+  Todo: toLocaleString not working on Android until React Native 0.65. Remove manual
+    handling when RN 0.65 is used.
+  */
+  // const vatAmountString = vatAmount.toLocaleString(language, {
+  //   minimumFractionDigits: 2,
+  //   maximumFractionDigits: 2,
+  // });
+  // const vatPercentString = vatPercent.toLocaleString(language, {
+  //   minimumFractionDigits: 0,
+  //   maximumFractionDigits: 2,
+  // });
+
+  /*
+  Temporary manual handling of decimal number representation. Will use comma/dot
+  based on language, and a maximal of two decimals. Will not round the decimals.
+  */
+  const formatNumberRegexp = /(\d+)\.(\d{0,2})\d*/g;
+  const decimalMark = language === Language.Norwegian ? ',' : '.';
+  const formatNumberReplacement = `$1${decimalMark}$2`;
+  const vatAmountString = vatAmount
+    .toString()
+    .replace(formatNumberRegexp, formatNumberReplacement);
+  const vatPercentString = vatPercent
+    .toString()
+    .replace(formatNumberRegexp, formatNumberReplacement);
 
   async function payWithVipps() {
     if (offerExpirationTime && totalPrice > 0) {

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -25,6 +25,7 @@ import useOfferState from '../Overview/use-offer-state';
 import {UserProfileWithCount} from '../Travellers/use-user-count-state';
 import {createTravelDateText} from '@atb/screens/Ticketing/Purchase/Overview';
 import {formatToLongDateTime} from '@atb/utils/date';
+import {formatDecimalNumber} from '@atb/utils/numbers';
 
 export type RouteParams = {
   preassignedFareProduct: PreassignedFareProduct;
@@ -92,32 +93,8 @@ const Confirmation: React.FC<ConfirmationProps> = ({
 
   const vatAmount = totalPrice * (vatPercent / 100);
 
-  /*
-  Todo: toLocaleString not working on Android until React Native 0.65. Remove manual
-    handling when RN 0.65 is used.
-  */
-  // const vatAmountString = vatAmount.toLocaleString(language, {
-  //   minimumFractionDigits: 2,
-  //   maximumFractionDigits: 2,
-  // });
-  // const vatPercentString = vatPercent.toLocaleString(language, {
-  //   minimumFractionDigits: 0,
-  //   maximumFractionDigits: 2,
-  // });
-
-  /*
-  Temporary manual handling of decimal number representation. Will use comma/dot
-  based on language, and a maximal of two decimals. Will not round the decimals.
-  */
-  const formatNumberRegexp = /(\d+)\.(\d{0,2})\d*/g;
-  const decimalMark = language === Language.Norwegian ? ',' : '.';
-  const formatNumberReplacement = `$1${decimalMark}$2`;
-  const vatAmountString = vatAmount
-    .toString()
-    .replace(formatNumberRegexp, formatNumberReplacement);
-  const vatPercentString = vatPercent
-    .toString()
-    .replace(formatNumberRegexp, formatNumberReplacement);
+  const vatAmountString = formatDecimalNumber(vatAmount, language);
+  const vatPercentString = formatDecimalNumber(vatPercent, language);
 
   async function payWithVipps() {
     if (offerExpirationTime && totalPrice > 0) {

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,0 +1,15 @@
+import {Language} from '@atb/translations';
+
+/*
+Utility method for formatting a decimal number. Will use comma/dot based on
+language, and a maximal of two decimals. Will not round the decimals.
+
+When RN 0.65 is released, this can be replaced by the 'toLocaleString' method,
+which as of now is not working on Android.
+*/
+export const formatDecimalNumber = (str: number, language: Language) => {
+  const formatNumberRegexp = /(\d+)\.(\d{0,2})\d*/g;
+  const decimalMark = language === Language.Norwegian ? ',' : '.';
+  const formatNumberReplacement = `$1${decimalMark}$2`;
+  return str.toString().replace(formatNumberRegexp, formatNumberReplacement);
+};


### PR DESCRIPTION
Method 'toLocaleString' does not work on Android, but will be fixed in
RN 0.65. Added a temporary solution for formatting of tax amount until
we upgrade to RN 0.65.