### PR TITLE
feat: Lower severity for Network Errors

### DIFF
--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -70,6 +70,7 @@ const RemoteConfigContextProvider: React.FC = ({children}) => {
       ) {
         Bugsnag.notify(e, function (event) {
           event.addMetadata('metadata', {userInfo});
+          event.severity = 'info';
         });
       }
     }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -117,6 +117,7 @@ function responseErrorHandler(error: AxiosError) {
         const errorMetadata = getAxiosErrorMetadata(error);
         Bugsnag.notify(error, (event) => {
           event.addMetadata('api', {...errorMetadata});
+          event.severity = 'info';
         });
       }
       break;


### PR DESCRIPTION
The idea is that Bugsnag Errors with severity 'info' does not need
Github Issues to be created.