### PR TITLE
feat: Remove theme overrides for background colors

### DIFF
--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -296,14 +296,14 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flexGrow: 1,
   },
   alertBoxContainer: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   alertBox: {
     marginHorizontal: theme.spacings.medium,
     marginBottom: theme.spacings.medium,
   },
   topBorder: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   bannerContainer: {
     position: 'absolute',
@@ -329,7 +329,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     overflow: 'hidden',
     zIndex: 2,
     elevated: 1,
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
     justifyContent: 'space-between',
   },
   container: {

--- a/src/components/disappearing-header/simple.tsx
+++ b/src/components/disappearing-header/simple.tsx
@@ -136,7 +136,7 @@ const SimpleDisappearingHeader: React.FC<Props> = ({
             leftButton={leftButton}
             setFocusOnLoad={setFocusOnLoad}
           />
-          <View style={{backgroundColor: theme.background.header}}>
+          <View style={styles.alertBoxContainer}>
             <AlertBox alertContext={alertContext} style={styles.alertBox} />
           </View>
         </View>
@@ -203,14 +203,14 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flexGrow: 1,
   },
   alertBoxContainer: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   alertBox: {
     marginHorizontal: theme.spacings.medium,
     marginBottom: theme.spacings.medium,
   },
   topBorder: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
 
   content: {
@@ -226,7 +226,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     overflow: 'hidden',
     zIndex: 2,
     elevated: 1,
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
     justifyContent: 'space-between',
   },
   container: {

--- a/src/components/screen-header/animated-header.tsx
+++ b/src/components/screen-header/animated-header.tsx
@@ -93,7 +93,7 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     padding: theme.spacings.medium,
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   buttonsContainer: {
     flexDirection: 'row',

--- a/src/components/screen-header/full-header.tsx
+++ b/src/components/screen-header/full-header.tsx
@@ -17,6 +17,6 @@ export default function FullScreenHeader(props: ScreenHeaderProps) {
 
 const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
   background: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
 }));

--- a/src/components/sections/favorite-departure-item.tsx
+++ b/src/components/sections/favorite-departure-item.tsx
@@ -79,7 +79,9 @@ function FavoriteItemContent({favorite, icon, ...props}: BaseProps) {
           {favorite.quayPublicCode ?? ''}
         </ThemeText>
       </View>
-      {icon ?? <SvgDelete fill={theme.background.destructive} />}
+      {icon ?? (
+        <SvgDelete fill={theme.colors.primary_destructive.backgroundColor} />
+      )}
     </View>
   );
 }

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -305,7 +305,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
   },
   header: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   withMargin: {
     margin: theme.spacings.medium,

--- a/src/location-search/map-selection/LocationBar.tsx
+++ b/src/location-search/map-selection/LocationBar.tsx
@@ -136,7 +136,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     padding: theme.spacings.medium,
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   innerContainer: {
     paddingRight: theme.spacings.small,

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -69,7 +69,7 @@ const NavigationRoot = () => {
       <StatusBar
         barStyle={theme.statusBarStyle}
         translucent={true}
-        backgroundColor={theme.background.header}
+        backgroundColor={theme.colors.primary_2.backgroundColor}
       />
       <Host>
         <NavigationContainer ref={ref} onStateChange={trackNavigation}>

--- a/src/screens/Loading/index.tsx
+++ b/src/screens/Loading/index.tsx
@@ -24,7 +24,7 @@ const Loading: React.FC<{text?: string}> = ({text}) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    backgroundColor: theme.background.accent,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -327,7 +327,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
 
   return (
     <View style={styles.container}>
-      <View style={{backgroundColor: theme.background.header}}>
+      <View style={styles.headerContainer}>
         <FullScreenHeader
           title={t(TariffZonesTexts.header.title)}
           leftButton={{type: 'back'}}
@@ -513,6 +513,9 @@ const useMapStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background_2.backgroundColor,
+  },
+  headerContainer: {
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   pinContainer: {
     position: 'absolute',

--- a/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
@@ -213,7 +213,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
   },
   header: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   favouriteChips: {
     marginLeft: theme.spacings.medium,

--- a/src/screens/Ticketing/Splash/Info.tsx
+++ b/src/screens/Ticketing/Splash/Info.tsx
@@ -44,7 +44,7 @@ export default function SplashInfo({navigation}: Props) {
           </View>
           <View style={styles.buttonContainer}>
             <Button
-              color="primary_2"
+              color="primary_3"
               onPress={() => navigation.navigate('TicketEnrollment')}
               text={t(TicketSplashTexts.splash.betaButtonLabel)}
               style={styles.button}
@@ -57,7 +57,7 @@ export default function SplashInfo({navigation}: Props) {
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  container: {flex: 1, backgroundColor: theme.background.accent},
+  container: {flex: 1, backgroundColor: theme.colors.primary_2.backgroundColor},
   scrollContainer: {
     flexGrow: 1,
   },
@@ -70,7 +70,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   textContent: {
     paddingHorizontal: theme.spacings.large,
-    backgroundColor: theme.background.accent,
     marginBottom: theme.spacings.xLarge,
     boxShadow: 'inset 0',
   },

--- a/src/screens/Ticketing/Tickets/TabBar.tsx
+++ b/src/screens/Ticketing/Tickets/TabBar.tsx
@@ -59,7 +59,7 @@ const TicketsTabBar: React.FC<MaterialTopTabBarProps> = ({
               {
                 backgroundColor: isFocused
                   ? theme.colors.background_1.backgroundColor
-                  : theme.background.header,
+                  : theme.colors.primary_2.backgroundColor,
               },
             ]}
           >

--- a/src/screens/Ticketing/Tickets/UpgradeSplash.tsx
+++ b/src/screens/Ticketing/Tickets/UpgradeSplash.tsx
@@ -1,5 +1,4 @@
 import {ShinyTicketBanner} from '@atb/assets/svg/illustrations';
-import ThemeText from '@atb/components/text';
 import MessageBox from '@atb/components/message-box';
 import {StyleSheet} from '@atb/theme';
 import {UpgradeSplashTexts, useTranslation} from '@atb/translations';
@@ -20,53 +19,23 @@ export default function UpgradeSplash() {
           height={windowWidth / 2}
         ></ShinyTicketBanner>
       </View>
-      <View style={styles.contentContainer}>
-        <View style={styles.textContent}>
-          <ThemeText style={[styles.text, styles.bold]}>
-            {t(UpgradeSplashTexts.title)}
-          </ThemeText>
-          <MessageBox
-            type="warning"
-            message={t(UpgradeSplashTexts.paragraph1)}
-          />
-        </View>
-      </View>
+      <MessageBox
+        type="warning"
+        title={t(UpgradeSplashTexts.title)}
+        message={t(UpgradeSplashTexts.paragraph1)}
+      />
     </View>
   );
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  container: {flex: 1, backgroundColor: theme.background.accent},
-  scrollContainer: {
-    flexGrow: 1,
-  },
-  contentContainer: {
-    paddingVertical: theme.spacings.xLarge,
+  container: {
     flex: 1,
-    height: '100%',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    backgroundColor: theme.colors.background_1.backgroundColor,
+    padding: theme.spacings.medium,
   },
-  textContent: {
-    paddingHorizontal: theme.spacings.large,
-    backgroundColor: theme.background.accent,
-    marginBottom: theme.spacings.xLarge,
-    boxShadow: 'inset 0',
-  },
-  buttonContainer: {
-    paddingHorizontal: theme.spacings.large,
-    width: '100%',
-    marginBottom: theme.spacings.medium,
-  },
-  text: {
-    textAlign: 'center',
-    marginBottom: theme.spacings.large,
-  },
-  bold: {fontWeight: 'bold'},
   bannerContainer: {
     position: 'absolute',
     bottom: theme.spacings.large,
   },
-  underline: {textDecorationLine: 'underline'},
-  button: {marginBottom: theme.spacings.small},
 }));

--- a/src/screens/Ticketing/Tickets/index.tsx
+++ b/src/screens/Ticketing/Tickets/index.tsx
@@ -71,5 +71,5 @@ export default function TicketTabs() {
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  container: {flex: 1, backgroundColor: theme.background.header},
+  container: {flex: 1, backgroundColor: theme.colors.primary_2.backgroundColor},
 }));

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -366,7 +366,7 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.colors.background_0.backgroundColor,
   },
   header: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   startPlace: {
     marginTop: theme.spacings.large,

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -159,7 +159,7 @@ function useTripPattern(
 }
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   header: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
   },
   container: {
     flex: 1,

--- a/src/screens/TripDetails/QuayDepartures/index.tsx
+++ b/src/screens/TripDetails/QuayDepartures/index.tsx
@@ -66,7 +66,7 @@ export default QuayDepartures;
 
 const useNearbyStyles = StyleSheet.createThemeHook((theme) => ({
   header: {
-    backgroundColor: theme.background.header,
+    backgroundColor: theme.colors.primary_2.backgroundColor,
     zIndex: 2,
   },
   screen: {

--- a/src/screens/TripDetails/components/TripLegDecoration.tsx
+++ b/src/screens/TripDetails/components/TripLegDecoration.tsx
@@ -51,13 +51,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     left:
       theme.tripLegDetail.labelWidth +
       theme.tripLegDetail.decorationContainerWidth / 2,
-    backgroundColor: theme.background.accent,
   },
   decorationMarker: {
     width: theme.tripLegDetail.decorationLineEndWidth,
     left: -theme.tripLegDetail.decorationLineWidth,
     height: theme.tripLegDetail.decorationLineWidth,
-    backgroundColor: theme.background.accent,
   },
   decorationStart: {
     position: 'absolute',

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -48,12 +48,6 @@ type AppThemeExtension = {
   statusBarStyle: StatusBarProps['barStyle'];
   tripLegDetail: typeof tripLegDetail;
 
-  background: {
-    header: string;
-    destructive: string;
-    accent: string;
-  };
-
   typography: typeof textTypeStyles;
 };
 
@@ -62,23 +56,11 @@ export const themes = createExtendedThemes<AppThemeExtension>({
     tripLegDetail,
     statusBarStyle: 'dark-content',
 
-    background: {
-      header: colors.secondary.cyan_500,
-      destructive: colors.secondary.red_500,
-      accent: colors.secondary.cyan_500,
-    },
-
     typography: textTypeStyles,
   },
   dark: {
     tripLegDetail,
     statusBarStyle: 'light-content',
-
-    background: {
-      header: colors.secondary.blue_900,
-      destructive: colors.secondary.red_500,
-      accent: backgrounds.dark.level1,
-    },
 
     typography: textTypeStyles,
   },


### PR DESCRIPTION
After some contemplation I figured that the extra layer with theme
colors did more harm than good, as it removed the tight link between
the app design and the Figma design.