### PR TITLE
fix: set focus on load for Nearby screen header

### DIFF
--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -202,7 +202,7 @@ const NearbyOverview: React.FC<Props> = ({
       }
       onEndReached={onScrollViewEndReached}
       alertContext={'travel'}
-      setFocusOnLoad={false}
+      setFocusOnLoad={true}
     >
       <ScreenReaderAnnouncement message={loadAnnouncement} />
 


### PR DESCRIPTION
fixes #1182 