### PR TITLE
fix: Correct CocoaPods-version in Github Actions

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Generate icons
         if: steps.ipa-cache.outputs.cache-hit != 'true'
         run: brew install imagemagick && yarn app-icon generate -i icon.qa.png --platforms=ios
+      - name: Install appropriate CocoaPods-version
+        if: steps.ipa-cache.outputs.cache-hit != 'true'
+        run: gem uninstall cocoapods --all --executables && gem install cocoapods -v 1.10.1 --no-document
       - name: Run fastlane build
         if: steps.ipa-cache.outputs.cache-hit != 'true'
         run: fastlane ios build

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -49,6 +49,8 @@ jobs:
           MATCH_TYPE: 'appstore'
       - name: Generate icons
         run: brew install imagemagick && yarn app-icon generate -i icon.png --platforms=ios
+      - name: Install appropriate CocoaPods-version
+        run: gem uninstall cocoapods --all --executables && gem install cocoapods -v 1.10.1 --no-document
       - name: Run fastlane build
         run: fastlane ios build
         env:


### PR DESCRIPTION
iOS build failing currently, I believe it is related to v1.9.3 being installed by default on Github Actions, trying to remedy this