### PR TITLE
fix: Emoji popup crashing on some Android versions

### DIFF
--- a/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
+++ b/src/screens/Profile/AddEditFavorite/EmojiPopup.tsx
@@ -181,7 +181,7 @@ const EmojiCategory: React.FC<EmojiCategory> = ({
         {categoryText}
       </ThemeText>
       <View style={styles.categoryInner}>
-        {emojis.map((e: string) => (
+        {emojis?.map((e: string) => (
           <ThemeText style={style} key={e} onPress={() => onEmojiSelected(e)}>
             {e}
           </ThemeText>


### PR DESCRIPTION
The .map function throws error since the emojis are undefined. I have
not used time on looking into why the emojis are undefined, just quick
fixed this to make the app not crash.