### PR TITLE
fix: Don't lock focus after navigation

### DIFF
--- a/src/components/screen-header/animated-header.tsx
+++ b/src/components/screen-header/animated-header.tsx
@@ -65,11 +65,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
 
   return (
     <View style={style.container} {...props}>
-      <View
-        accessible={true}
-        accessibilityRole="header"
-        style={[style.titleContainers, {height: headerHeight}]}
-      >
+      <View style={[style.titleContainers, {height: headerHeight}]}>
         <Animated.View
           style={[
             style.regularContainer,


### PR DESCRIPTION
Resolves #1153

Kjent "feil" på bakgrunn av denne endringen er at "alternativ tittel" leses opp rett etter header. Skal se på om den kan gjemmes i en separat PR. Ikke blocking slik jeg ser det.