### PR TITLE
feat: Blur TextInput on escape gesture (iOS)

### DIFF
--- a/src/components/sections/text-input.tsx
+++ b/src/components/sections/text-input.tsx
@@ -1,5 +1,6 @@
-import React, {forwardRef, useState} from 'react';
+import React, {forwardRef, useRef, useState} from 'react';
 import {
+  AccessibilityInfo,
   NativeSyntheticEvent,
   Platform,
   TextInput as InternalTextInput,
@@ -15,6 +16,7 @@ import ThemeText, {MAX_FONT_SCALE} from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
 import {SectionItem, useSectionItem} from './section-utils';
 import {SectionTexts, useTranslation} from '@atb/translations';
+import composeRefs from '@seznam/compose-react-refs';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 
@@ -39,13 +41,26 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
       style,
       ...props
     },
-    ref,
+    forwardedRef,
   ) => {
     const {topContainer, spacing, contentContainer} = useSectionItem(props);
     const {theme, themeName} = useTheme();
     const styles = useInputStyle(theme, themeName);
     const [isFocused, setIsFocused] = useState(Boolean(props?.autoFocus));
     const {t} = useTranslation();
+    const myRef = useRef<InternalTextInput>(null);
+    const combinedRef = composeRefs<InternalTextInput>(forwardedRef, myRef);
+
+    function accessibilityEscapeKeyboard() {
+      setTimeout(
+        () =>
+          AccessibilityInfo.announceForAccessibility(
+            t(SectionTexts.textInput.closeKeyboard),
+          ),
+        50,
+      );
+      myRef.current?.blur();
+    }
 
     const onFocusEvent = (e: FocusEvent) => {
       setIsFocused(true);
@@ -88,12 +103,13 @@ const TextInput = forwardRef<InternalTextInput, TextProps>(
           containerPadding,
           borderColor,
         ]}
+        onAccessibilityEscape={accessibilityEscapeKeyboard}
       >
         <ThemeText type="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
         <InternalTextInput
-          ref={ref}
+          ref={combinedRef}
           style={[
             styles.input,
             inlineLabel ? contentContainer : undefined,

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -89,6 +89,7 @@ const LocationSearch: React.FC<Props> = ({
       <FullScreenHeader
         title={t(LocationSearchTexts.header.title)}
         leftButton={{type: 'close'}}
+        setFocusOnLoad={false}
       />
 
       <LocationSearchContent

--- a/src/translations/components/Section.ts
+++ b/src/translations/components/Section.ts
@@ -27,6 +27,7 @@ const SectionTexts = {
   },
   textInput: {
     clear: _('Tøm redigeringsfelt', 'Clear input'),
+    closeKeyboard: _('Lukker tastatur', 'Closing keyboard'),
   },
   counterInput: {
     decreaseButton: {


### PR DESCRIPTION
Resolves #1181

Kjører `blur` på input-feltet ved escape-gesture. Dette vil også skje selv om input ikke er focused, så hvis vi skal ha flere actions på escape må vi i framtiden håndtere noe bedre i view-hiarchy her. Altså f. eks. "navigate back" hvis input ikke er focused. La også til at header ikke skulle fokuseres først i søk-modalen, som betyr at input fokuseres først.