### PR TITLE
fix: bottom navigation styling

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -52,7 +52,10 @@ const NavigationRoot = () => {
           backgroundColor: theme.colors.background_0.backgroundColor,
           ...useBottomNavigationStyles(),
         },
-        labelStyle: {fontSize: 14, lineHeight: 14},
+        labelStyle: {
+          fontSize: theme.typography.body__primary.fontSize.valueOf(),
+          lineHeight: theme.typography.body__primary.fontSize.valueOf(),
+        },
       }}
       initialRouteName={settingToRouteName(startScreen)}
     >

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -52,6 +52,7 @@ const NavigationRoot = () => {
           backgroundColor: theme.colors.background_0.backgroundColor,
           ...useBottomNavigationStyles(),
         },
+        labelStyle: {fontSize: 14, lineHeight: 14},
       }}
       initialRouteName={settingToRouteName(startScreen)}
     >
@@ -82,11 +83,7 @@ const NavigationRoot = () => {
 export default NavigationRoot;
 
 type TabSettings = {
-  tabBarLabel(props: {
-    focused: boolean;
-    color: string;
-    position: LabelPosition;
-  }): JSX.Element;
+  tabBarLabel: string;
   tabBarIcon(props: {
     focused: boolean;
     color: string;
@@ -99,14 +96,7 @@ function tabSettings(
   Icon: (svg: SvgProps) => JSX.Element,
 ): TabSettings {
   return {
-    tabBarLabel: ({color}) => (
-      <ThemeText
-        type="body__secondary"
-        style={{color, textAlign: 'center', lineHeight: 14}}
-      >
-        {tabBarLabel}
-      </ThemeText>
-    ),
+    tabBarLabel: tabBarLabel,
     tabBarIcon: ({color}) => <ThemeIcon svg={Icon} fill={color} />,
   };
 }

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -53,8 +53,8 @@ const NavigationRoot = () => {
           ...useBottomNavigationStyles(),
         },
         labelStyle: {
-          fontSize: theme.typography.body__primary.fontSize.valueOf(),
-          lineHeight: theme.typography.body__primary.fontSize.valueOf(),
+          fontSize: theme.typography.body__secondary.fontSize.valueOf(),
+          lineHeight: theme.typography.body__secondary.fontSize.valueOf(),
         },
       }}
       initialRouteName={settingToRouteName(startScreen)}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -23,6 +23,7 @@ import {NavigatorScreenParams, ParamListBase} from '@react-navigation/native';
 import React from 'react';
 import {SvgProps} from 'react-native-svg';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
+import {useFontScaleClamp} from '@atb/utils/use-font-scale';
 
 type SubNavigator<T extends ParamListBase> = {
   [K in keyof T]: {screen: K; initial?: boolean; params?: T[K]};
@@ -43,6 +44,9 @@ const NavigationRoot = () => {
   const {theme} = useTheme();
   const {t} = useTranslation();
   const {startScreen} = usePreferenceItems();
+
+  const fontScaleClamp = useFontScaleClamp();
+
   return (
     <Tab.Navigator
       tabBarOptions={{
@@ -53,8 +57,12 @@ const NavigationRoot = () => {
           ...useBottomNavigationStyles(),
         },
         labelStyle: {
-          fontSize: theme.typography.body__secondary.fontSize.valueOf(),
-          lineHeight: theme.typography.body__secondary.lineHeight.valueOf(),
+          fontSize:
+            fontScaleClamp *
+            theme.typography.body__secondary.fontSize.valueOf(),
+          lineHeight:
+            fontScaleClamp *
+            theme.typography.body__secondary.fontSize.valueOf(),
         },
       }}
       initialRouteName={settingToRouteName(startScreen)}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -54,7 +54,7 @@ const NavigationRoot = () => {
         },
         labelStyle: {
           fontSize: theme.typography.body__secondary.fontSize.valueOf(),
-          lineHeight: theme.typography.body__secondary.fontSize.valueOf(),
+          lineHeight: theme.typography.body__secondary.lineHeight.valueOf(),
         },
       }}
       initialRouteName={settingToRouteName(startScreen)}

--- a/src/utils/use-font-scale.ts
+++ b/src/utils/use-font-scale.ts
@@ -5,3 +5,11 @@ export default function useFontScale() {
   const {fontScale} = useWindowDimensions();
   return Math.min(fontScale, MAX_FONT_SCALE);
 }
+
+export function useFontScaleClamp(): number {
+  const {fontScale} = useWindowDimensions();
+  if (fontScale > MAX_FONT_SCALE) {
+    return MAX_FONT_SCALE / fontScale;
+  }
+  return 1;
+}


### PR DESCRIPTION
custum text-komponent får issues på tablets.
Det er anbefalt å ikke implementere custom textView-komponenter hvis det ikke er helt nødvendig, og her ser det ikke ut som det er helt nødvendig siden themeing settes på parent.