### PR TITLE
feat: Set background color for React navigation

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -20,6 +20,7 @@ import {
   NavigationContainerRef,
   NavigatorScreenParams,
   useLinking,
+  DefaultTheme,
 } from '@react-navigation/native';
 import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 import React, {useEffect, useRef} from 'react';
@@ -70,6 +71,14 @@ const NavigationRoot = () => {
     ? theme.colors.background_gray.backgroundColor
     : theme.colors.primary_2.backgroundColor;
 
+  const ReactNavigationTheme = {
+    ...DefaultTheme,
+    colors: {
+      ...DefaultTheme.colors,
+      background: theme.colors.background_1.backgroundColor,
+    },
+  };
+
   return (
     <>
       <StatusBar
@@ -78,7 +87,11 @@ const NavigationRoot = () => {
         backgroundColor={statusBarColor}
       />
       <Host>
-        <NavigationContainer ref={ref} onStateChange={trackNavigation}>
+        <NavigationContainer
+          ref={ref}
+          onStateChange={trackNavigation}
+          theme={ReactNavigationTheme}
+        >
           <Stack.Navigator
             mode={isLoading || !onboarded ? 'card' : 'modal'}
             screenOptions={{headerShown: false}}


### PR DESCRIPTION
During transitions the generic white background from React naviation
some times "leaked" through, giving a noticable flash to the user,
especially in dark mode. We got report from a user in Intercom that
this was unpleasant.

The best fix would be to remove these "leaks" of the background color
all together, but I could not find a good solution for this. As such
this was fixed by setting the background color for React navigation to
be 'background_1' from the AtB theme. This makes the background light
gray in light mode and dark gray in dark mode, making the background
leek less unpleasant.