### PR TITLE
fix: Handle ticket created before reservation

### DIFF
--- a/src/tickets/TicketContext.tsx
+++ b/src/tickets/TicketContext.tsx
@@ -69,6 +69,14 @@ const ticketReducer: TicketReducer = (
       };
     }
     case 'ADD_RESERVATION': {
+      const fareContractAlreadyCreated = prevState.fareContracts.some(
+        (f) => f.orderId === action.reservation.reservation.order_id,
+      );
+
+      if (fareContractAlreadyCreated) {
+        return prevState;
+      }
+
       return {
         ...prevState,
         activeReservations: [


### PR DESCRIPTION
There was a bug where some customers ended up with haveing both an
active reservation and active ticket with the same order id. This was
(probably) because of a race condition where the reservation was created
after the ticket was created, and thus never "cleaned up".