### PR TITLE
feat: Handle focus on bottom sheet close

### DIFF
--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -27,8 +27,11 @@ type BottomSheetContentFunction = (
 ) => ReactNode;
 
 type BottomSheetState = {
-  open: (contentFunction: BottomSheetContentFunction) => void;
-  close: () => void;
+  open: (
+    contentFunction: BottomSheetContentFunction,
+    /** Optional ref to component which should be focused on sheet close */
+    closeRef?: RefObject<any>,
+  ) => void;
 };
 
 const BottomSheetContext = createContext<BottomSheetState | undefined>(
@@ -45,6 +48,7 @@ const BottomSheetProvider: React.FC = ({children}) => {
 
   const animatedOffset = useMemo(() => new Animated.Value(0), []);
   const focusRef = useRef(null);
+  const [closeRef, setCloseRef] = useState<RefObject<any> | undefined>();
 
   useEffect(
     () => () =>
@@ -60,12 +64,17 @@ const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
+    if (closeRef) {
+      setTimeout(() => giveFocus(closeRef), 200);
+    }
   };
 
   const open = (
     contentFunction: (close: () => void, focusRef: RefObject<any>) => ReactNode,
+    closeRef?: RefObject<any>,
   ) => {
     setContentFunction(() => contentFunction);
+    setCloseRef(closeRef);
     setIsOpen(true);
     setTimeout(() => giveFocus(focusRef), 200);
   };
@@ -108,7 +117,6 @@ const BottomSheetProvider: React.FC = ({children}) => {
 
   const state = {
     open,
-    close,
   };
 
   return (

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -37,7 +37,7 @@ import {
 import insets from '@atb/utils/insets';
 import {TFunc} from '@leile/lobo-t';
 import {useNavigation} from '@react-navigation/native';
-import React from 'react';
+import React, {useRef} from 'react';
 import {
   AccessibilityInfo,
   AccessibilityProps,
@@ -296,6 +296,7 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
   } = useFavorites();
   const {t} = useTranslation();
   const styles = useItemStyles();
+  const closeRef = useRef(null);
 
   const {open: openBottomSheet} = useBottomSheet();
 
@@ -312,14 +313,17 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
         t(NearbyTexts.results.lines.favorite.message.removed),
       );
     } else {
-      openBottomSheet((close, focusRef) => (
-        <FavoriteDialogSheet
-          line={line}
-          addFavorite={addFavorite}
-          close={close}
-          ref={focusRef}
-        />
-      ));
+      openBottomSheet(
+        (close, focusRef) => (
+          <FavoriteDialogSheet
+            line={line}
+            addFavorite={addFavorite}
+            close={close}
+            ref={focusRef}
+          />
+        ),
+        closeRef,
+      );
     }
   };
 
@@ -355,6 +359,7 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
       );
   return (
     <TouchableOpacity
+      ref={closeRef}
       onPress={onFavoritePress}
       accessibilityRole="checkbox"
       accessibilityState={{checked: !!existingFavorite}}


### PR DESCRIPTION
Basert på kommentar fra Tor på #1260:
> markerer favoritt og velger alle variasjoner av en linje, så flyttes fokus til Avganger nede på menyen. Upraktisk hvis man da sveiper til siden for å kunne markere f.ex Vis kun mine favoritter.

Bør testes på Android, og også at det ikke gir noen regresjoner for det å åpne bottom sheet under billettkjøp.
