### PR TITLE
fix: enable/disable ticketing snapshot listeners

### DIFF
--- a/src/tickets/TicketContext.tsx
+++ b/src/tickets/TicketContext.tsx
@@ -143,7 +143,7 @@ const TicketContextProvider: React.FC = ({children}) => {
       // Stop listening for updates when no longer required
       return () => subscriber();
     }
-  }, [user, abtCustomerId]);
+  }, [user, abtCustomerId, enable_ticketing]);
 
   const refreshTickets = () => {};
 


### PR DESCRIPTION
Ticketing Context sin useEffect mangler enable_ticketing som dependency som kan føre til at dersom enable ticketing går fra false til true ila appens levetid så vil vi ikke legge på en lytter på Firebases onSnapshot. I praksis kan det slå ut med at om remoteconfig feiler og default enable_ticketing = false, så vil vi ikke kunne legge på en ny lytter når config en gang blir hentet.

Ytterste konsekvens kan være at billetter ikke dukker opp som forventet.