### PR TITLE
refactor: Setter funksjoner som memoed og fikser potensiell anonym innlogging bug

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -93,17 +93,20 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
   const [state, dispatch] = useReducer(authReducer, initialReducerState);
   const {language} = useTranslation();
 
-  async function confirmCode(code: string) {
-    try {
-      await state.confirmationHandler?.confirm(code);
-    } catch (error) {
-      if (error.code === ERROR_INVALID_CONFIRMATION_CODE) {
-        return 'invalid_code';
+  const confirmCode = useCallback(
+    async function confirmCode(code: string) {
+      try {
+        await state.confirmationHandler?.confirm(code);
+      } catch (error) {
+        if (error.code === ERROR_INVALID_CONFIRMATION_CODE) {
+          return 'invalid_code';
+        }
+        console.warn(error);
+        return 'unknown_error';
       }
-      console.warn(error);
-      return 'unknown_error';
-    }
-  }
+    },
+    [state.confirmationHandler],
+  );
 
   useEffect(() => {
     if (language) auth().setLanguageCode(language);
@@ -134,20 +137,23 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
     return subscriber;
   }, [onUserChanged]);
 
-  async function signInWithPhoneNumber(phoneNumber: string) {
-    try {
-      const confirmationHandler = await auth().signInWithPhoneNumber(
-        '+47' + phoneNumber,
-      );
-      dispatch({type: 'SIGN_IN_INITIATED', confirmationHandler});
-    } catch (error) {
-      if (error.code === ERROR_INVALID_PHONE_NUMBER) {
-        return 'invalid_phone';
+  const signInWithPhoneNumber = useCallback(
+    async function signInWithPhoneNumber(phoneNumber: string) {
+      try {
+        const confirmationHandler = await auth().signInWithPhoneNumber(
+          '+47' + phoneNumber,
+        );
+        dispatch({type: 'SIGN_IN_INITIATED', confirmationHandler});
+      } catch (error) {
+        if (error.code === ERROR_INVALID_PHONE_NUMBER) {
+          return 'invalid_phone';
+        }
+        console.warn(error);
+        return 'unknown_error';
       }
-      console.warn(error);
-      return 'unknown_error';
-    }
-  }
+    },
+    [],
+  );
 
   const signInAnonymously = useCallback(async function () {
     await auth().signInAnonymously();

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -162,7 +162,7 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
     if (state.isAuthConnectionInitialized && !state.user) {
       signInAnonymously();
     }
-  }, [state.isAuthConnectionInitialized]);
+  }, [state.isAuthConnectionInitialized, state.user?.uid]);
 
   return (
     <AuthContext.Provider

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,6 +1,0 @@
-import {FirebaseAuthTypes} from '@react-native-firebase/auth';
-
-export async function getAbtCustomerId(user: FirebaseAuthTypes.User) {
-  const idTokenResult = await user.getIdTokenResult();
-  return idTokenResult.claims['abt_id'];
-}


### PR DESCRIPTION
Kan se ut som det er en bitteliten sjanse for feil med innlogging til anonym her i rette omstendigheter, selv om det burde fungere som regel via signout -> så signin anon.

Gjør funksjoner signing/confirm om til useCallbacks for litt optimalisering og sletter ubrukt kode.