### PR TITLE
feat: adds ability to fetch departures from the future

### DIFF
--- a/src/api/departures/departure-group.ts
+++ b/src/api/departures/departure-group.ts
@@ -19,7 +19,7 @@ export type DepartureGroupsPayload = {
 };
 
 export type DepartureGroupsQuery = CursoredQuery<{
-  startTime: Date;
+  startTime: string;
   limitPerLine: number;
 }>;
 

--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -13,7 +13,7 @@ import {StopPlaceGroup} from './types';
 
 export type DeparturesInputQuery = {
   numberOfDepartures: number; // Number of departures to fetch per quay.
-  startTime: Date;
+  startTime: string;
 };
 export type DepartureQuery = Partial<PaginationInput> & DeparturesInputQuery;
 
@@ -23,7 +23,7 @@ export async function getDepartures(
   opts?: AxiosRequestConfig,
 ): Promise<DeparturesMetadata> {
   const {numberOfDepartures, pageOffset = 0, pageSize = 2} = query;
-  const startTime = query.startTime.toISOString();
+  const startTime = query.startTime;
   let url = `bff/v1/departures-from-location-paging?limit=${numberOfDepartures}&pageSize=${pageSize}&pageOffset=${pageOffset}&startTime=${startTime}`;
   const response = await client.post<DeparturesMetadata>(url, location, opts);
   return response.data;
@@ -35,7 +35,7 @@ export async function getRealtimeDeparture(
   opts?: AxiosRequestConfig,
 ): Promise<DeparturesRealtimeData> {
   const quayIds = flatMap(stops, (s) => s.quays.map((q) => q.quay.id));
-  const startTime = query.startTime.toISOString();
+  const startTime = query.startTime;
 
   const params = build({
     quayIds,

--- a/src/screens/Assistant/journey-date-picker/index.tsx
+++ b/src/screens/Assistant/journey-date-picker/index.tsx
@@ -1,12 +1,12 @@
 import Button from '@atb/components/button';
-import ScreenHeader from '@atb/components/screen-header';
+import FullScreenHeader from '@atb/components/screen-header/full-header';
 import {
   DateInputItem,
   RadioSection,
   Section,
   TimeInputItem,
 } from '@atb/components/sections';
-import {StyleSheet, useTheme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {
   JourneyDatePickerTexts,
   TranslateFunction,
@@ -20,8 +20,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import React, {useRef, useState} from 'react';
-import {ScrollView} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import {ScrollView, View} from 'react-native';
 import {AssistantParams} from '..';
 
 export type DateTimePickerParams = {
@@ -50,7 +49,6 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
 }) => {
   const {t, language, locale} = useTranslation();
   const styles = useStyles();
-  const {theme} = useTheme();
   const dateItems = Array.from(DateOptions);
 
   const {callerRouteName, callerRouteParam, searchTime} = route.params;
@@ -72,8 +70,8 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
   const [option, setOption] = useState<DateOptionType>(searchTime.option);
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
-      <ScreenHeader
+    <View style={styles.container}>
+      <FullScreenHeader
         title={t(JourneyDatePickerTexts.header.title)}
         leftButton={{type: 'back'}}
       />
@@ -101,7 +99,7 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
           text={t(JourneyDatePickerTexts.searchButton.text)}
         ></Button>
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -1,13 +1,12 @@
 import {ErrorType} from '@atb/api/utils';
 import {CurrentLocationArrow} from '@atb/assets/svg/icons/places';
-import AccessibleText, {
-  screenReaderPause,
-} from '@atb/components/accessible-text';
+import AccessibleText from '@atb/components/accessible-text';
+import Button from '@atb/components/button';
 import SimpleDisappearingHeader from '@atb/components/disappearing-header/simple';
 import ScreenReaderAnnouncement from '@atb/components/screen-reader-announcement';
 import {ActionItem, LocationInput, Section} from '@atb/components/sections';
 import ThemeIcon from '@atb/components/theme-icon';
-import FavoriteChips from '@atb/favorite-chips';
+import DeparturesList from '@atb/departure-list/DeparturesList';
 import {Location, LocationWithMetadata} from '@atb/favorites/types';
 import {useReverseGeocoder} from '@atb/geocoder';
 import {
@@ -16,23 +15,28 @@ import {
 } from '@atb/GeolocationContext';
 import {useOnlySingleLocation} from '@atb/location-search';
 import {RootStackParamList} from '@atb/navigation';
-import {StyleSheet, useTheme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
+import {ThemeColor} from '@atb/theme/colors';
 import {
-  AssistantTexts,
-  dictionary,
+  Language,
   NearbyTexts,
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
+import {
+  formatToLongDateTime,
+  formatToShortDateTimeWithoutYear,
+  formatToSimpleDate,
+} from '@atb/utils/date';
+import {TFunc} from '@leile/lobo-t';
 import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {NearbyStackParams} from '.';
 import Loading from '../Loading';
-import DeparturesList from '@atb/departure-list/DeparturesList';
+import {SearchTime, useSearchTimeValue} from './departure-date-picker';
 import {useDepartureData} from './state';
-import {ThemeColor} from '@atb/theme/colors';
 
 const themeColor: ThemeColor = 'background_gray';
 
@@ -100,14 +104,21 @@ const NearbyOverview: React.FC<Props> = ({
   const [loadAnnouncement, setLoadAnnouncement] = useState<string>('');
   const styles = useNearbyStyles();
 
+  const searchTime = useSearchTimeValue('searchTime', {
+    option: 'now',
+    date: new Date().toISOString(),
+  });
+
   const currentSearchLocation = useMemo<LocationWithMetadata | undefined>(
     () => currentLocation && {...currentLocation, resultType: 'geolocation'},
     [currentLocation],
   );
   const fromLocation = searchedFromLocation ?? currentSearchLocation;
   const updatingLocation = !fromLocation && hasLocationPermission;
+
   const {state, refresh, loadMore, toggleShowFavorites} = useDepartureData(
     fromLocation,
+    searchTime?.option !== 'now' ? searchTime.date : undefined,
   );
   const {
     data,
@@ -116,12 +127,13 @@ const NearbyOverview: React.FC<Props> = ({
     isFetchingMore,
     error,
     showOnlyFavorites,
+    queryInput,
   } = state;
 
   const isInitialScreen = data == null && !isLoading && !error;
   const activateScroll = !isInitialScreen || !!error;
 
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const onScrollViewEndReached = () => data?.length && loadMore();
 
@@ -132,12 +144,6 @@ const NearbyOverview: React.FC<Props> = ({
       callerRouteParam: 'location',
       initialLocation: fromLocation,
     });
-
-  const fullLocation = (selectedLocation: LocationWithMetadata) => {
-    navigation.setParams({
-      location: selectedLocation,
-    });
-  };
 
   function setCurrentLocationAsFrom() {
     navigation.setParams({
@@ -183,9 +189,11 @@ const NearbyOverview: React.FC<Props> = ({
         <Header
           fromLocation={fromLocation}
           updatingLocation={updatingLocation}
-          fullLocation={fullLocation}
           openLocationSearch={openLocationSearch}
           setCurrentLocationOrRequest={setCurrentLocationOrRequest}
+          navigation={navigation}
+          searchTime={searchTime}
+          timeOfLastSearch={queryInput.startTime}
         />
       }
       headerTitle={t(NearbyTexts.header.title)}
@@ -197,7 +205,12 @@ const NearbyOverview: React.FC<Props> = ({
           type={'body__primary--bold'}
           color={themeColor}
         >
-          {fromLocation?.name}
+          {getHeaderAlternativeTitle(
+            fromLocation?.name ?? '',
+            searchTime,
+            t,
+            language,
+          )}
         </AccessibleText>
       }
       onEndReached={onScrollViewEndReached}
@@ -237,7 +250,9 @@ type HeaderProps = {
   fromLocation?: LocationWithMetadata;
   openLocationSearch: () => void;
   setCurrentLocationOrRequest(): Promise<void>;
-  fullLocation(selectedLocation: LocationWithMetadata): void;
+  navigation: NearbyScreenNavigationProp;
+  timeOfLastSearch: string;
+  searchTime: SearchTime;
 };
 
 const Header = React.memo(function Header({
@@ -245,10 +260,20 @@ const Header = React.memo(function Header({
   fromLocation,
   openLocationSearch,
   setCurrentLocationOrRequest,
-  fullLocation,
+  navigation,
+  timeOfLastSearch,
+  searchTime,
 }: HeaderProps) {
-  const {t} = useTranslation();
-  const {theme} = useTheme();
+  const {t, language} = useTranslation();
+  const styles = useNearbyStyles();
+
+  const onSearchTimePress = useCallback(function onSearchTimePress() {
+    navigation.navigate('DateTimePicker', {
+      callerRouteName: 'NearbyRoot',
+      callerRouteParam: 'searchTime',
+      searchTime,
+    });
+  }, []);
 
   return (
     <>
@@ -270,25 +295,14 @@ const Header = React.memo(function Header({
           }}
         />
       </Section>
-      <FavoriteChips
-        key="favoriteChips"
-        chipTypes={['favorites']}
-        onSelectLocation={fullLocation}
-        containerStyle={{
-          marginTop: theme.spacings.xSmall,
-          marginBottom: theme.spacings.medium,
-        }}
-        contentContainerStyle={{
-          // @TODO Find solution for not hardcoding this. e.g. do proper math
-          paddingLeft: theme.spacings.medium,
-          paddingRight: theme.spacings.medium / 2,
-        }}
-        chipActionHint={
-          t(AssistantTexts.favorites.favoriteChip.a11yHint) +
-          t(dictionary.fromPlace) +
-          screenReaderPause
-        }
-      />
+      <View style={styles.paddedContainer} key="dateInput">
+        <Button
+          text={getSearchTimeLabel(searchTime, timeOfLastSearch, t, language)}
+          accessibilityHint={t(NearbyTexts.dateInput.a11yHint)}
+          color="secondary_3"
+          onPress={onSearchTimePress}
+        />
+      </View>
     </>
   );
 });
@@ -296,6 +310,10 @@ const useNearbyStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     paddingTop: theme.spacings.medium,
     paddingHorizontal: theme.spacings.medium,
+  },
+  paddedContainer: {
+    marginHorizontal: theme.spacings.medium,
+    paddingBottom: theme.spacings.medium,
   },
 }));
 
@@ -309,5 +327,39 @@ function translateErrorType(
       return t(NearbyTexts.messages.networkError);
     default:
       return t(NearbyTexts.messages.defaultFetchError);
+  }
+}
+
+function getSearchTimeLabel(
+  searchTime: SearchTime,
+  timeOfLastSearch: string,
+  t: TFunc<typeof Language>,
+  language: Language,
+) {
+  const date = searchTime.option === 'now' ? timeOfLastSearch : searchTime.date;
+  const time = formatToLongDateTime(date, language);
+
+  switch (searchTime.option) {
+    case 'now':
+      return t(NearbyTexts.dateInput.departureNow(time));
+    case 'departure':
+      return t(NearbyTexts.dateInput.departure(time));
+  }
+  return time;
+}
+
+function getHeaderAlternativeTitle(
+  locationName: string,
+  searchTime: SearchTime,
+  t: TFunc<typeof Language>,
+  language: Language,
+) {
+  const time = formatToShortDateTimeWithoutYear(searchTime.date, language);
+
+  switch (searchTime.option) {
+    case 'now':
+      return locationName;
+    default:
+      return t(NearbyTexts.header.departureFuture(locationName, time));
   }
 }

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -145,6 +145,17 @@ const NearbyOverview: React.FC<Props> = ({
       initialLocation: fromLocation,
     });
 
+  const onSearchTimePress = useCallback(
+    function onSearchTimePress() {
+      navigation.navigate('DateTimePicker', {
+        callerRouteName: 'NearbyRoot',
+        callerRouteParam: 'searchTime',
+        searchTime,
+      });
+    },
+    [searchTime],
+  );
+
   function setCurrentLocationAsFrom() {
     navigation.setParams({
       location: currentLocation && {
@@ -191,7 +202,7 @@ const NearbyOverview: React.FC<Props> = ({
           updatingLocation={updatingLocation}
           openLocationSearch={openLocationSearch}
           setCurrentLocationOrRequest={setCurrentLocationOrRequest}
-          navigation={navigation}
+          onSearchTimePress={onSearchTimePress}
           searchTime={searchTime}
           timeOfLastSearch={queryInput.startTime}
         />
@@ -250,7 +261,7 @@ type HeaderProps = {
   fromLocation?: LocationWithMetadata;
   openLocationSearch: () => void;
   setCurrentLocationOrRequest(): Promise<void>;
-  navigation: NearbyScreenNavigationProp;
+  onSearchTimePress: () => void;
   timeOfLastSearch: string;
   searchTime: SearchTime;
 };
@@ -260,20 +271,12 @@ const Header = React.memo(function Header({
   fromLocation,
   openLocationSearch,
   setCurrentLocationOrRequest,
-  navigation,
+  onSearchTimePress,
   timeOfLastSearch,
   searchTime,
 }: HeaderProps) {
   const {t, language} = useTranslation();
   const styles = useNearbyStyles();
-
-  const onSearchTimePress = useCallback(function onSearchTimePress() {
-    navigation.navigate('DateTimePicker', {
-      callerRouteName: 'NearbyRoot',
-      callerRouteParam: 'searchTime',
-      searchTime,
-    });
-  }, []);
 
   return (
     <>

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -26,7 +26,6 @@ import {
 import {
   formatToLongDateTime,
   formatToShortDateTimeWithoutYear,
-  formatToSimpleDate,
 } from '@atb/utils/date';
 import {TFunc} from '@leile/lobo-t';
 import {CompositeNavigationProp, RouteProp} from '@react-navigation/native';

--- a/src/screens/Nearby/departure-date-picker/index.tsx
+++ b/src/screens/Nearby/departure-date-picker/index.tsx
@@ -6,7 +6,7 @@ import {
   Section,
   TimeInputItem,
 } from '@atb/components/sections';
-import {StyleSheet, useTheme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {
   DepartureDatePickerTexts,
   TranslateFunction,

--- a/src/screens/Nearby/departure-date-picker/index.tsx
+++ b/src/screens/Nearby/departure-date-picker/index.tsx
@@ -1,5 +1,5 @@
 import Button from '@atb/components/button';
-import ScreenHeader from '@atb/components/screen-header';
+import FullScreenHeader from '@atb/components/screen-header/full-header';
 import {
   DateInputItem,
   RadioSection,
@@ -20,8 +20,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import React, {useRef, useState} from 'react';
-import {ScrollView} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import {ScrollView, View} from 'react-native';
 import {NearbyStackParams} from '..';
 
 export type DateTimePickerParams = {
@@ -71,8 +70,8 @@ const DepartureDatePicker: React.FC<DepartureDatePickerProps> = ({
   const [option, setOption] = useState<DateOptionType>(searchTime.option);
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
-      <ScreenHeader
+    <View style={styles.container}>
+      <FullScreenHeader
         title={t(DepartureDatePickerTexts.header.title)}
         leftButton={{type: 'back'}}
       />
@@ -100,7 +99,7 @@ const DepartureDatePicker: React.FC<DepartureDatePickerProps> = ({
           text={t(DepartureDatePickerTexts.searchButton.text)}
         />
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/screens/Nearby/index.tsx
+++ b/src/screens/Nearby/index.tsx
@@ -2,11 +2,15 @@ import {NavigatorScreenParams} from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import React from 'react';
 import TripDetailsRoot, {DetailsStackParams} from '../TripDetails';
+import DepartureDatePicker, {
+  DateTimePickerParams,
+} from './departure-date-picker';
 import NearbyRoot, {NearbyScreenParams, NearbyScreenProp} from './Nearby';
 
 export type NearbyStackParams = {
   NearbyRoot: NearbyScreenParams;
   TripDetails: NavigatorScreenParams<DetailsStackParams>;
+  DateTimePicker: DateTimePickerParams;
 };
 
 const Stack = createStackNavigator<NearbyStackParams>();
@@ -27,6 +31,7 @@ const NearbyScreen = ({route}: NearbyScreenRootProps) => {
         initialParams={route.params}
       />
       <Stack.Screen name="TripDetails" component={TripDetailsRoot} />
+      <Stack.Screen name="DateTimePicker" component={DepartureDatePicker} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/Nearby/state.ts
+++ b/src/screens/Nearby/state.ts
@@ -44,7 +44,7 @@ export type DepartureDataState = {
 
 const initialQueryInput: DepartureGroupsQuery = {
   limitPerLine: DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW,
-  startTime: new Date(),
+  startTime: new Date().toISOString(),
 };
 const initialState: DepartureDataState = {
   data: null,
@@ -65,6 +65,7 @@ type DepartureDataActions =
   | {
       type: 'LOAD_INITIAL_DEPARTURES';
       location?: Location;
+      startTime?: string;
       favoriteDepartures?: UserFavoriteDepartures;
     }
   | {
@@ -115,7 +116,7 @@ const reducer: ReducerWithSideEffects<
       // is a fresh fetch. We should fetch tha latest information.
       const queryInput: DepartureGroupsQuery = {
         limitPerLine: DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW,
-        startTime: new Date(),
+        startTime: action.startTime ?? new Date().toISOString(),
       };
 
       return UpdateWithSideEffect<DepartureDataState, DepartureDataActions>(
@@ -307,6 +308,7 @@ const reducer: ReducerWithSideEffects<
  */
 export function useDepartureData(
   location?: Location,
+  startTime?: string,
   updateFrequencyInSeconds: number = 30,
   tickRateInSeconds: number = 10,
 ) {
@@ -316,8 +318,13 @@ export function useDepartureData(
 
   const refresh = useCallback(
     () =>
-      dispatch({type: 'LOAD_INITIAL_DEPARTURES', location, favoriteDepartures}),
-    [location?.id, favoriteDepartures],
+      dispatch({
+        type: 'LOAD_INITIAL_DEPARTURES',
+        location,
+        startTime,
+        favoriteDepartures,
+      }),
+    [location?.id, favoriteDepartures, startTime],
   );
 
   const loadMore = useCallback(
@@ -332,7 +339,7 @@ export function useDepartureData(
     [location?.id, favoriteDepartures],
   );
 
-  useEffect(refresh, [location?.id]);
+  useEffect(refresh, [location?.id, startTime]);
   useEffect(() => {
     if (!state.tick) {
       return;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -44,5 +44,6 @@ export {default as UserProfileSettingsTexts} from './screens/subscreens/UserProf
 export {default as LoginTexts} from './screens/subscreens/Login';
 export {default as dictionary} from './dictionary';
 export {default as JourneyDatePickerTexts} from './screens/subscreens/JourneyDatePicker';
+export {default as DepartureDatePickerTexts} from './screens/subscreens/DepartureDatePicker';
 export {default as TravelDateTexts} from './screens/subscreens/TravelDate';
 export {default as InformationTexts} from './screens/subscreens/Information';

--- a/src/translations/screens/Nearby.ts
+++ b/src/translations/screens/Nearby.ts
@@ -9,6 +9,8 @@ const NearbyTexts = {
     logo: {
       a11yLabel: _('Gå til startskjerm', 'Back to start screen'),
     },
+    departureFuture: (name: string, time: string) =>
+      _(`${name} (${time})`, `${name} (${time})`),
   },
   search: {
     label: _('Fra', 'From'),
@@ -33,6 +35,16 @@ const NearbyTexts = {
       a11yLabel: _('Bruk min posisjon', 'Use my current location'),
     },
     updatingLocation: _('Oppdaterer posisjon', 'Updating current location'),
+  },
+  dateInput: {
+    departureNow: (time: string) =>
+      _(`Avganger nå (${time})`, `Departing now (${time})`),
+    departure: (time: string) =>
+      _(`Avganger fra ${time}`, `Departures from ${time}`),
+    a11yHint: _(
+      'Aktivér for å endre avgangstidspunkt',
+      'Activate to change time of departures',
+    ),
   },
   messages: {
     networkError: _(

--- a/src/translations/screens/subscreens/DepartureDatePicker.ts
+++ b/src/translations/screens/subscreens/DepartureDatePicker.ts
@@ -1,0 +1,17 @@
+import {translation as _} from '../../commons';
+const DepartureDatePickerTexts = {
+  header: {
+    title: _('Velg dato og tidspunkt', 'Select date and time'),
+    leftButton: {
+      a11yLabel: _('Gå tilbake', 'Go back'),
+    },
+  },
+  options: {
+    now: _('Nå', 'Now'),
+    future: _('Spesifiser tid', 'Specify time'),
+  },
+  searchButton: {
+    text: _('Se avganger', 'See departures'),
+  },
+};
+export default DepartureDatePickerTexts;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -140,6 +140,17 @@ export function formatToLongDateTime(
   return format(parsed, 'PPp', {locale: languageToLocale(language)});
 }
 
+export function formatToShortDateTimeWithoutYear(
+  isoDate: string | Date,
+  language: Language,
+) {
+  const parsed = parseIfNeeded(isoDate);
+  if (isSameDay(parsed, new Date())) {
+    return formatToClock(parsed, language);
+  }
+  return format(parsed, 'dd.MM, HH:mm', {locale: languageToLocale(language)});
+}
+
 export function fullDateTime(isoDate: string | Date, language: Language) {
   const parsed = parseIfNeeded(isoDate);
   return format(parsed, 'PPp', {locale: languageToLocale(language)});


### PR DESCRIPTION
Bytter ut favorittsteder i Avganger-visningen til å kunne hente ut avganger frem i tid.

## Verifiser/Akseptansekriterier/QA

- [ ] Se at dato er rett i overskrift og på knapp
- [ ] Se at sanntid oppdateres når satt frem i tid.
- [ ] Se at pull down to refresh ivaretar dato
- [ ] Se at pull down to refresh ivaretar "nå" om valgt.
- [ ] Se at dato sendt inn er prefilled når man åpner datovelger på nytt.


![Screenshot 2021-07-08 at 09 47 57](https://user-images.githubusercontent.com/606374/124883515-b0111300-dfd1-11eb-918d-d487ffd7738d.png)
![Screenshot 2021-07-08 at 09 47 42](https://user-images.githubusercontent.com/606374/124883523-b1dad680-dfd1-11eb-9a0e-04dd84d98865.png)
