### PR TITLE
fix: updates to use preassigned_fare_products_v2 from RC

### DIFF
--- a/src/reference-data/defaults.ts
+++ b/src/reference-data/defaults.ts
@@ -1,4 +1,5 @@
 import {
+  DistributionChannel,
   PreassignedFareProduct,
   PreassignedFareProductType,
   TariffZone,
@@ -14,7 +15,11 @@ export const defaultPreassignedFareProducts: PreassignedFareProduct[] = preassig
   makes it extra important to ensure that the product type is correct when
   reviewing the pull requests from the RemoteConfig update job.
    */
-  (p) => ({...p, type: p.type as PreassignedFareProductType}),
+  (p) => ({
+    ...p,
+    type: p.type as PreassignedFareProductType,
+    distributionChannel: p.distributionChannel as DistributionChannel[],
+  }),
 );
 export const defaultTariffZones: TariffZone[] = tariffZones;
 export const defaultUserProfiles: UserProfile[] = userProfiles;

--- a/src/reference-data/preassigned-fare-products.json
+++ b/src/reference-data/preassigned-fare-products.json
@@ -4,6 +4,7 @@
     "version": "ATB:Version:d918f8e3-eb23-4d62-9626-a5cbd02a1dee",
     "type": "single",
     "name": {"lang": "nob", "value": "Enkeltbillett buss/trikk"},
+    "distributionChannel": ["app"],
     "alternativeNames": [
       {"lang": "eng", "value": "Single ticket bus/tram"},
       {"lang": "nno", "value": "Enkeltbillett buss/trikk"}
@@ -24,6 +25,7 @@
     "version": "ATB:Version:12b94a4d-b347-41c9-a6c6-35bc3386d4f4",
     "type": "period",
     "name": {"lang": "nob", "value": "30-dagersbillett"},
+    "distributionChannel": ["app", "web"],
     "alternativeNames": [
       {"lang": "eng", "value": "Monthly pass"},
       {"lang": "nno", "value": "30-dagersbillett"}
@@ -42,6 +44,7 @@
     "version": "ATB:Version:62736d83-3854-4c71-b9f2-d2d9b52997ab",
     "type": "period",
     "name": {"lang": "nob", "value": "180-dagersbillett"},
+    "distributionChannel": ["app", "web"],
     "alternativeNames": [
       {"lang": "eng", "value": "180 days pass"},
       {"lang": "nno", "value": "180-dagersbillett"}

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -7,11 +7,14 @@ export type LanguageAndText = {
 
 export type PreassignedFareProductType = 'single' | 'period';
 
+export type DistributionChannel = 'web' | 'app';
+
 export type PreassignedFareProduct = {
   id: string;
   name: LanguageAndText;
   description?: LanguageAndText;
   alternativeNames: LanguageAndText[];
+  distributionChannel: DistributionChannel[];
   version: string;
   type: PreassignedFareProductType;
   limitations: {

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -87,7 +87,7 @@ export function getConfig(): RemoteConfig {
     values['modes_we_sell_tickets_for']?.asString() ??
     defaultRemoteConfig.modes_we_sell_tickets_for;
   const preassigned_fare_products =
-    values['preassigned_fare_products']?.asString() ??
+    values['preassigned_fare_products_v2']?.asString() ??
     defaultRemoteConfig.preassigned_fare_products;
   const tariff_zones =
     values['tariff_zones']?.asString() ?? defaultRemoteConfig.tariff_zones;


### PR DESCRIPTION
Legger om til å bruke nytt felt i RemoteConfig: `preassigned_fare_products_v2`. 

Se kontekst: https://mittatb.slack.com/archives/CSDA8BGD9/p1623753524064600

Legger til nytt felt som har distributionChannel i fare products. Dette for å kunne spesifisere hva som skal være tilgjengelig i forskjellige miljøer (staging/prod) og klient (web/app).

Her skriver jeg ikke om til å faktisk filtrere ut produkter vi ikke har, men bare går over til ny property på config.