### PR TITLE
fix: screen height is too big when fontScale is less than 1

### DIFF
--- a/src/utils/navigation.tsx
+++ b/src/utils/navigation.tsx
@@ -22,11 +22,14 @@ export const useBottomNavigationStyles = () => {
   const fontScale = useFontScale();
   const {bottom} = useSafeAreaInsets();
 
+  // Prevent fontScale from affecting tab bar height when it is less than 1
+  const fontScaleFactor = fontScale < 1 ? 1 : fontScale;
+
   const adjustedBottom =
     Platform.OS == 'android' ? bottom + ANDROID_BOTTOM_PADDING : bottom;
 
   return {
-    minHeight: DEFAULT_TABBAR_HEIGHT * fontScale + adjustedBottom,
+    minHeight: DEFAULT_TABBAR_HEIGHT * fontScaleFactor + adjustedBottom,
     paddingBottom: adjustedBottom,
   };
 };


### PR DESCRIPTION
Teksstørrelsen som brukes i beregning av høyde på navbar er begrenset til å ikke være mindre enn 1. Dette forhindrer nedre del av skjerm å bli skjult.

<!-- Fixed `minHeight` of `useBottomNavigationStyles` to prevent the lower part of screens from being hidden when fontScale is set to less than default -->

Før/etter:
<img width="1095" alt="Screenshot 2021-08-09 at 11 01 56" src="https://user-images.githubusercontent.com/1774972/128682673-c365400a-902e-4a08-a04e-947d0dd61e07.png">

fixes #1425
