### PR TITLE
fix: past departures no longer causes disabled buttons

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -235,7 +235,6 @@ function DepartureTimeItem({departure, onPress}: DepartureTimeItemProps) {
     return null;
   }
 
-  const inPast = isInThePast(departure.time);
   const timeWithRealtimePrefix = departure.realtime
     ? time
     : t(dictionary.missingRealTimePrefix) + ' ' + time;
@@ -248,7 +247,6 @@ function DepartureTimeItem({departure, onPress}: DepartureTimeItemProps) {
       onPress={() => onPress(departure)}
       text={timeWithRealtimePrefix}
       style={styles.departure}
-      disabled={inPast}
       textStyle={styles.departureText}
       icon={hasSituations(departure) ? Warning : undefined}
       iconPosition="right"


### PR DESCRIPTION
Avganger som nettopp har passert fører ikke lengre til at avgangen blir "grået ut", slik at tekst er mer leselig, og det er mulig å trykke på avganger som uansett er synlig.

**Før:**
![Screenshot 2021-08-09 at 14 26 41](https://user-images.githubusercontent.com/1774972/128706003-4f72d446-c0d7-4033-ade0-58c9ac1f4221.png)


**Etter:** (Avgangen vil alltid se slik ut frem til den forsvinner)
![Screenshot 2021-08-09 at 14 26 53](https://user-images.githubusercontent.com/1774972/128705950-9653ef32-304b-4776-b71e-d01676725311.png)




fixes #1392