### PR TITLE
fix: add check for `quayId` in `addFavoriteDeparture`

### DIFF
--- a/src/favorites/FavoritesContext.tsx
+++ b/src/favorites/FavoritesContext.tsx
@@ -70,13 +70,15 @@ const FavoritesContextProvider: React.FC = ({children}) => {
     /**
      * Add favorite departure. If adding a favorite for the complete line
      * number, the existing favorites for specific line names on that line
-     * number will be removed.
+     * number on the same quay will be removed.
      */
     async addFavoriteDeparture(favoriteDeparture: FavoriteDeparture) {
       if (!favoriteDeparture.lineName) {
         const favoritesExisting = await departures.getFavorites();
         const favoritesFiltered = favoritesExisting.filter(
-          (f) => f.lineId !== favoriteDeparture.lineId,
+          (f) =>
+            f.lineId !== favoriteDeparture.lineId ||
+            f.quayId !== favoriteDeparture.quayId,
         );
         await departures.setFavorites(favoritesFiltered);
       }


### PR DESCRIPTION
Når brukeren legger alle versjoner av en linje til favoritter, slettes eksisterende favoritter med samme linjenummer. Her manglet en sjekk for om de eksisterende favorittene var på samme quay. 

Ved å kun filtrere bort favoritter har både samme `lineId` og `quayId`, fungerer dette som det skal. 

https://user-images.githubusercontent.com/1774972/129033511-b7bd92c7-3a21-4315-a141-e8e6b63f554e.mp4

fixes #1445 