### PR TITLE
fix: Refactor fixed Switch into own component for reuse

### DIFF
--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from 'react';
 import {
   AccessibilityProps,
   AccessibilityRole,
-  Switch,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -14,6 +13,7 @@ import ThemeIcon from '@atb/components/theme-icon';
 import NavigationIcon from '@atb/components/theme-icon/navigation-icon';
 import {useSectionItem, SectionItem, useSectionStyle} from './section-utils';
 import InternalLabeledItem from './internals/internal-labeled-item';
+import FixedSwitch from '../switch';
 
 export type ActionModes = 'check' | 'toggle' | 'heading-expand';
 export type ActionItemProps = SectionItem<{
@@ -33,47 +33,18 @@ export default function ActionItem({
 }: ActionItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
   const style = useSectionStyle();
-  const [checkedState, setCheckedState] = useState(checked);
-
-  function useDelay(ms: number) {
-    const [gate, setGate] = useState(false);
-    useEffect(() => {
-      setTimeout(() => {
-        setGate(true);
-      }, ms);
-    });
-    return gate;
-  }
-
-  // Preserve outside changes
-  useEffect(() => {
-    setCheckedState(checked);
-  }, [checked]);
-
-  // A bug in RN borks Switch animations when Switch is used inside react navigation
-  // A small delay to render seems to mitigate the bug
-  const delayRender = useDelay(10);
 
   if (mode === 'toggle') {
     return (
-      <>
-        {delayRender && (
-          <InternalLabeledItem label={text} accessibleLabel={false} {...props}>
-            <Switch
-              value={checkedState}
-              onValueChange={(value) => handleValueChange(value)}
-              accessibilityLabel={text}
-              {...accessibility}
-            />
-          </InternalLabeledItem>
-        )}
-      </>
+      <InternalLabeledItem label={text} accessibleLabel={false} {...props}>
+        <FixedSwitch
+          value={checked}
+          onValueChange={(value) => onPress?.(value)}
+          accessibilityLabel={text}
+          {...accessibility}
+        />
+      </InternalLabeledItem>
     );
-  }
-
-  function handleValueChange(value: boolean) {
-    setCheckedState(value);
-    onPress?.(value);
   }
 
   const role: AccessibilityRole = mode === 'check' ? 'radio' : 'switch';

--- a/src/components/switch/index.tsx
+++ b/src/components/switch/index.tsx
@@ -1,4 +1,4 @@
-import useGate from '@atb/utils/use-gate';
+import useDelayGate from '@atb/utils/use-delay-gate';
 import React, {useEffect, useState} from 'react';
 import {Switch, SwitchProps} from 'react-native';
 
@@ -22,7 +22,7 @@ export default function FixedSwitch({
     setChecked(value);
   }, [value]);
 
-  const delayRender = useGate(10);
+  const delayRender = useDelayGate(10);
 
   return delayRender ? (
     <Switch

--- a/src/components/switch/index.tsx
+++ b/src/components/switch/index.tsx
@@ -1,0 +1,34 @@
+import useGate from '@atb/utils/use-gate';
+import React, {useEffect, useState} from 'react';
+import {Switch, SwitchProps} from 'react-native';
+
+// A bug in RN borks Switch animations when Switch is used inside react navigation
+// for Android. A small delay to render and setting value through state
+// seems to mitigate the bug
+export default function FixedSwitch({
+  value,
+  onValueChange,
+  ...props
+}: SwitchProps) {
+  const [checked, setChecked] = useState(value);
+
+  // Preserve outside changes
+  function handleValueChange(value: boolean) {
+    setChecked(value);
+    onValueChange?.(value);
+  }
+
+  useEffect(() => {
+    setChecked(value);
+  }, [value]);
+
+  const delayRender = useGate(10);
+
+  return delayRender ? (
+    <Switch
+      {...props}
+      value={checked}
+      onValueChange={(value) => handleValueChange(value)}
+    />
+  ) : null;
+}

--- a/src/utils/use-delay-gate.ts
+++ b/src/utils/use-delay-gate.ts
@@ -1,7 +1,7 @@
 import {useState, useEffect} from 'react';
 
 /** Returns false at first, then true after a set time */
-export default function useGate(delayMs: number): boolean {
+export default function useDelayGate(delayMs: number): boolean {
   const [gate, setGate] = useState(false);
   useEffect(() => {
     setTimeout(() => {

--- a/src/utils/use-gate.ts
+++ b/src/utils/use-gate.ts
@@ -1,0 +1,12 @@
+import {useState, useEffect} from 'react';
+
+/** Returns false at first, then true after a set time */
+export default function useGate(delayMs: number): boolean {
+  const [gate, setGate] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      setGate(true);
+    }, delayMs);
+  });
+  return gate;
+}


### PR DESCRIPTION
@monopoint kjempebra catch på fixen her! Jeg tenkte vi kunne flytte den fiksen til en egen component slik at den potensielt kan brukes andre plasser også hvis det behovet oppstår?