### PR TITLE
feat: UU hide intercom from screen reader

### DIFF
--- a/src/chat/ContactSheet.tsx
+++ b/src/chat/ContactSheet.tsx
@@ -16,6 +16,7 @@ import {Support, Chat, ChatUnread} from '@atb/assets/svg/icons/actions';
 import useChatUnreadCount from './use-chat-unread-count';
 import Intercom from 'react-native-intercom';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {screenReaderHidden} from '@atb/utils/accessibility';
 
 type Props = {
   close: () => void;
@@ -62,7 +63,7 @@ const ContactSheet = forwardRef<View, Props>(({close}, focusRef) => {
         />
 
         {enable_intercom ? (
-          <>
+          <View {...screenReaderHidden}>
             <View style={styles.descriptionSection}>
               <ThemeText type="body__secondary" color="secondary">
                 {t(ContactSheetTexts.intercom.title)}
@@ -89,7 +90,7 @@ const ContactSheet = forwardRef<View, Props>(({close}, focusRef) => {
                 )
               }
             />
-          </>
+          </View>
         ) : undefined}
       </FullScreenFooter>
     </BottomSheetContainer>

--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -33,8 +33,6 @@ export default function useChatIcon(
       </View>
     ),
     onPress: () => openContactSheet(),
-    importantForAccessibility: 'no-hide-descendants', // Android
-    accessibilityElementsHidden: true, // iOS
   };
 }
 


### PR DESCRIPTION
Flyttet `accessibilityElementsHidden` og `accessibilityElementsHidden` til intercom info på ContactSheet, slik at ContactSheet er tilgjengelig og gir mulighet til å kontakte kundeservice, samtidig som det skjuler Intercom.