### PR TITLE
fix: time selector on departures hidden by keyboard on ios

### DIFF
--- a/src/screens/Nearby/DepartureTimeSheet.tsx
+++ b/src/screens/Nearby/DepartureTimeSheet.tsx
@@ -5,8 +5,8 @@ import {
   ScreenHeaderTexts,
   useTranslation,
 } from '@atb/translations';
-import React, {forwardRef} from 'react';
-import {ScrollView, View} from 'react-native';
+import React, {forwardRef, useEffect} from 'react';
+import {ScrollView, View, Keyboard, KeyboardEvent} from 'react-native';
 import FullScreenFooter from '@atb/components/screen-footer/full-footer';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
@@ -48,6 +48,8 @@ const DepartureTimeSheet = forwardRef<ScrollView, Props>(
       close();
     };
 
+    const keyboardHeight = useKeyboard();
+
     return (
       <BottomSheetContainer>
         <ScreenHeaderWithoutNavigation
@@ -63,6 +65,7 @@ const DepartureTimeSheet = forwardRef<ScrollView, Props>(
 
         <ScrollView
           contentContainerStyle={styles.contentContainer}
+          style={{paddingBottom: keyboardHeight}}
           ref={focusRef}
         >
           <Section withBottomPadding>
@@ -94,5 +97,28 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
   };
 });
+
+export const useKeyboard = () => {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  function onKeyboardWillShow(e: KeyboardEvent) {
+    setKeyboardHeight(e.endCoordinates.height);
+  }
+
+  function onKeyboardWillHide() {
+    setKeyboardHeight(0);
+  }
+
+  useEffect(() => {
+    Keyboard.addListener('keyboardWillShow', onKeyboardWillShow);
+    Keyboard.addListener('keyboardWillHide', onKeyboardWillHide);
+    return () => {
+      Keyboard.removeListener('onKeyboardWillShow', onKeyboardWillShow);
+      Keyboard.removeListener('keyboardWillHide', onKeyboardWillHide);
+    };
+  }, []);
+
+  return keyboardHeight;
+};
 
 export default DepartureTimeSheet;

--- a/src/screens/Nearby/DepartureTimeSheet.tsx
+++ b/src/screens/Nearby/DepartureTimeSheet.tsx
@@ -5,8 +5,8 @@ import {
   ScreenHeaderTexts,
   useTranslation,
 } from '@atb/translations';
-import React, {forwardRef, useEffect} from 'react';
-import {ScrollView, View, Keyboard, KeyboardEvent} from 'react-native';
+import React, {forwardRef, useState} from 'react';
+import {ScrollView, View} from 'react-native';
 import FullScreenFooter from '@atb/components/screen-footer/full-footer';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
@@ -16,7 +16,7 @@ import {NearbyStackParams} from '.';
 import {dateWithReplacedTime, formatLocaleTime} from '@atb/utils/date';
 import {SearchTime} from '@atb/screens/Nearby/Nearby';
 import {Confirm} from '@atb/assets/svg/icons/actions';
-import {useState} from 'react';
+import useKeyboardHeight from '@atb/utils/use-keyboard-height';
 
 type Props = {
   close: () => void;
@@ -48,7 +48,7 @@ const DepartureTimeSheet = forwardRef<ScrollView, Props>(
       close();
     };
 
-    const keyboardHeight = useKeyboard();
+    const keyboardHeight = useKeyboardHeight();
 
     return (
       <BottomSheetContainer>
@@ -97,28 +97,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
   };
 });
-
-export const useKeyboard = () => {
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-
-  function onKeyboardWillShow(e: KeyboardEvent) {
-    setKeyboardHeight(e.endCoordinates.height);
-  }
-
-  function onKeyboardWillHide() {
-    setKeyboardHeight(0);
-  }
-
-  useEffect(() => {
-    Keyboard.addListener('keyboardWillShow', onKeyboardWillShow);
-    Keyboard.addListener('keyboardWillHide', onKeyboardWillHide);
-    return () => {
-      Keyboard.removeListener('onKeyboardWillShow', onKeyboardWillShow);
-      Keyboard.removeListener('keyboardWillHide', onKeyboardWillHide);
-    };
-  }, []);
-
-  return keyboardHeight;
-};
 
 export default DepartureTimeSheet;

--- a/src/utils/use-keyboard-height.ts
+++ b/src/utils/use-keyboard-height.ts
@@ -1,0 +1,25 @@
+import {useState, useEffect} from 'react';
+import {Keyboard, KeyboardEvent} from 'react-native';
+
+export default function useKeyboardHeight() {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  function onKeyboardWillShow(e: KeyboardEvent) {
+    setKeyboardHeight(e.endCoordinates.height);
+  }
+
+  function onKeyboardWillHide() {
+    setKeyboardHeight(0);
+  }
+
+  useEffect(() => {
+    Keyboard.addListener('keyboardWillShow', onKeyboardWillShow);
+    Keyboard.addListener('keyboardWillHide', onKeyboardWillHide);
+    return () => {
+      Keyboard.removeListener('onKeyboardWillShow', onKeyboardWillShow);
+      Keyboard.removeListener('keyboardWillHide', onKeyboardWillHide);
+    };
+  }, []);
+
+  return keyboardHeight;
+}


### PR DESCRIPTION
Forsøk på å fikse at tastatur på iOS skjuler tidsvelgeren på avganger. Når tastatur lastes legges det til en padding under innhold tilsvarende størrelse på tastatur. 

https://user-images.githubusercontent.com/1774972/130027165-f6ad697f-16bc-4786-88d2-3ab9024c92a7.mp4

fixes #1492 