### PR TITLE
fix: typo in `use-keyboard-height`

### DIFF
--- a/src/utils/use-keyboard-height.ts
+++ b/src/utils/use-keyboard-height.ts
@@ -16,7 +16,7 @@ export default function useKeyboardHeight() {
     Keyboard.addListener('keyboardWillShow', onKeyboardWillShow);
     Keyboard.addListener('keyboardWillHide', onKeyboardWillHide);
     return () => {
-      Keyboard.removeListener('onKeyboardWillShow', onKeyboardWillShow);
+      Keyboard.removeListener('keyboardWillShow', onKeyboardWillShow);
       Keyboard.removeListener('keyboardWillHide', onKeyboardWillHide);
     };
   }, []);


### PR DESCRIPTION
Liten typo i use-keyboard-height.ts, som fører til at listener ikke blir fjernet etter bruk.