### PR TITLE
fix: double space after missingRealTimePrefix

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -237,7 +237,7 @@ function DepartureTimeItem({departure, onPress}: DepartureTimeItemProps) {
 
   const timeWithRealtimePrefix = departure.realtime
     ? time
-    : t(dictionary.missingRealTimePrefix) + ' ' + time;
+    : t(dictionary.missingRealTimePrefix) + time;
 
   return (
     <Button

--- a/src/screens/TripDetails/components/Time.tsx
+++ b/src/screens/TripDetails/components/Time.tsx
@@ -34,7 +34,7 @@ const Time: React.FC<TimeValues> = (timeValues) => {
     case 'no-realtime': {
       return (
         <ThemeText>
-          <ThemeText>{t(dictionary.missingRealTimePrefix)} </ThemeText>
+          <ThemeText>{t(dictionary.missingRealTimePrefix)}</ThemeText>
           {scheduled}
         </ThemeText>
       );


### PR DESCRIPTION
Nitpick: Siden translation av missingRealTimePrefix [allerede har en whitespace](https://github.com/AtB-AS/mittatb-app/blob/0fe7872e38b1c60fc3294d1db166e16eb5c09b2a/src/translations/dictionary.ts#L16) (`'ca. '`). Bør der ikke være ekstra mellomrom når det brukes i tekst, siden det fører til litt for lang avstand mellom "ca." og klokkeslett, og gir litt mindre plass til tidspunkt på avganger-skjermen.

## Før/etter:

<img width="449" alt="Screenshot 2021-08-19 at 11 08 21" src="https://user-images.githubusercontent.com/1774972/130044131-a9f36986-93b0-4ea5-aaec-51737d170e7f.png">
<img width="449" alt="Screenshot 2021-08-19 at 11 08 25" src="https://user-images.githubusercontent.com/1774972/130044128-60be67b2-c3b8-4099-928d-4945597754da.png">

<img width="449" alt="Screenshot 2021-08-19 at 11 19 34" src="https://user-images.githubusercontent.com/1774972/130044162-74b171e0-5dde-44b7-846c-52bb14e2ff8d.png">
<img width="449" alt="Screenshot 2021-08-19 at 11 19 37" src="https://user-images.githubusercontent.com/1774972/130044156-f6d259d4-4c44-4e79-9801-418db8a8164f.png">
