### PR TITLE
fix: wrong header when returning to home from search

### DIFF
--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -47,6 +47,7 @@ type Props = {
   useScroll?: boolean;
   headerTitle: React.ReactNode;
   alternativeTitleComponent?: React.ReactNode;
+  showAlterntativeTitle?: Boolean;
 
   headerMargin?: number;
 
@@ -87,6 +88,7 @@ const DisappearingHeader: React.FC<Props> = ({
 
   headerTitle,
   alternativeTitleComponent,
+  showAlterntativeTitle,
 
   onEndReached,
   onEndReachedThreshold = 10,
@@ -201,6 +203,7 @@ const DisappearingHeader: React.FC<Props> = ({
             title={headerTitle}
             rightButton={{type: 'chat', color: themeColor}}
             alternativeTitleComponent={alternativeTitleComponent}
+            showAlternativeTitle={showAlterntativeTitle && !isAnimating}
             scrollRef={scrollYRef}
             leftButton={leftButton}
           />

--- a/src/components/screen-header/animated-header.tsx
+++ b/src/components/screen-header/animated-header.tsx
@@ -14,6 +14,7 @@ type ScreenHeaderProps = ViewProps & {
   rightButton?: RightButtonProps;
   title: React.ReactNode;
   alternativeTitleComponent?: React.ReactNode;
+  showAlternativeTitle?: Boolean;
   scrollRef?: Animated.Value;
   setFocusOnLoad?: boolean;
 };
@@ -27,6 +28,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
   rightButton,
   title,
   alternativeTitleComponent,
+  showAlternativeTitle,
   scrollRef,
   setFocusOnLoad,
   ...props
@@ -37,13 +39,16 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
   const fontScale = useFontScale();
   const headerHeight = BASE_HEADER_HEIGHT * fontScale;
 
-  const titleOffset = scrollRef!.interpolate({
-    inputRange: [0, headerHeight + insets.top],
-    outputRange: [0, -headerHeight],
-    extrapolate: 'clamp',
-  });
+  const titleOffset = showAlternativeTitle
+    ? scrollRef!.interpolate({
+        inputRange: [0, headerHeight + insets.top],
+        outputRange: [0, -headerHeight],
+        extrapolate: 'clamp',
+      })
+    : 0;
 
   const altTitleOffset = Animated.add(titleOffset, headerHeight);
+  const altTitleVisibility = showAlternativeTitle ? 'flex' : 'none';
   const leftIcon = leftButton ? <HeaderButton {...leftButton} /> : <View />;
   const rightIcon = rightButton ? <HeaderButton {...rightButton} /> : <View />;
 
@@ -54,6 +59,7 @@ const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
         {
           height: headerHeight,
           transform: [{translateY: altTitleOffset}],
+          display: altTitleVisibility,
         },
       ]}
     >

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -419,6 +419,7 @@ const Assistant: React.FC<Props> = ({
       headerMargin={24}
       isFullHeight={isHeaderFullHeight}
       alternativeTitleComponent={altHeaderComp}
+      showAlterntativeTitle={Boolean(from && to)}
       leftButton={{
         type: 'home',
         color: themeColor,


### PR DESCRIPTION
Se issue #1502 for demo av problemet.

DisappearingHeader har nå en `showAlterntativeTitle` attributt, som deaktiverer `alternativeTitleComponent` når den er false. 

Den er nå satt til å være false

1. så lenge `from` og `to` ikke er definert
2. mens DisappearingHeader animerer, for å unngå at [alternativ tittel vises mens søk blir gjort.](https://user-images.githubusercontent.com/1774972/131834700-27e85e86-d70e-4214-bbb0-b0eb0c08d1eb.mov
)

https://user-images.githubusercontent.com/1774972/131834981-c9a2f32d-c235-4044-ab02-3a8ab89ac493.mov

fixes #1502 