### PR TITLE
fix: add missing translations for noResultReasons

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -57,7 +57,7 @@ import FadeBetween from './FadeBetween';
 import {SearchTime, useSearchTimeValue} from './journey-date-picker';
 import NewsBanner from './NewsBanner';
 import Results from './Results';
-import {NoResultReason, SearchStateType} from './types';
+import {SearchStateType} from './types';
 import {ThemeColor} from '@atb/theme/colors';
 
 const themeColor: ThemeColor = 'background_gray';
@@ -370,7 +370,7 @@ const Assistant: React.FC<Props> = ({
       </ThemeText>
     </View>
   );
-  const noResultReasons = computeNoResultReasons(searchTime, from, to);
+  const noResultReasons = computeNoResultReasons(t, searchTime, from, to);
 
   const onPressed = useCallback(
     (tripPatternId, tripPatterns, startIndex) =>
@@ -486,17 +486,20 @@ type SearchForLocations = {
 };
 
 function computeNoResultReasons(
+  t: TFunc<typeof Language>,
   date?: SearchTime,
   from?: Location,
   to?: Location,
-): NoResultReason[] {
+): String[] {
   let reasons = [];
 
   if (!!from && !!to) {
     if (locationsAreEqual(from, to)) {
-      reasons.push(NoResultReason.IdenticalLocations);
+      reasons.push(
+        t(AssistantTexts.searchState.noResultReason.IdenticalLocations),
+      );
     } else if (distanceInMetres(from, to) < LOCATIONS_REALLY_CLOSE_THRESHOLD) {
-      reasons.push(NoResultReason.CloseLocations);
+      reasons.push(t(AssistantTexts.searchState.noResultReason.CloseLocations));
     }
   }
 
@@ -505,8 +508,8 @@ function computeNoResultReasons(
   if (isPastDate) {
     const isArrival = date?.option === 'arrival';
     const dateReason = isArrival
-      ? NoResultReason.PastArrivalTime
-      : NoResultReason.PastDepartureTime;
+      ? t(AssistantTexts.searchState.noResultReason.PastArrivalTime)
+      : t(AssistantTexts.searchState.noResultReason.PastDepartureTime);
     reasons.push(dateReason);
   }
   return reasons;

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -10,14 +10,13 @@ import {isSeveralDays} from '@atb/utils/date';
 import React, {Fragment, useEffect, useMemo, useState} from 'react';
 import {Text, View} from 'react-native';
 import ResultItem from './ResultItem';
-import {NoResultReason} from './types';
 
 type Props = {
   tripPatterns: TripPattern[] | null;
   showEmptyScreen: boolean;
   isEmptyResult: boolean;
   isSearching: boolean;
-  resultReasons: NoResultReason[];
+  resultReasons: String[];
   onDetailsPressed(
     tripPatternId?: string,
     tripPatterns?: TripPattern[],

--- a/src/screens/Assistant/types.tsx
+++ b/src/screens/Assistant/types.tsx
@@ -1,10 +1,3 @@
-export enum NoResultReason {
-  Unspecified,
-  IdenticalLocations = 'Fra- og til-sted er identiske',
-  CloseLocations = 'Det er veldig kort avstand mellom fra- og til-sted',
-  PastArrivalTime = 'Ankomsttid har passert',
-  PastDepartureTime = 'Avreisetid har passert',
-}
 export type SearchStateType =
   | 'idle'
   | 'searching'

--- a/src/translations/screens/Assistant.ts
+++ b/src/translations/screens/Assistant.ts
@@ -63,6 +63,21 @@ const AssistantTexts = {
       'Fikk ingen søkeresultater',
       'We could not find any search results',
     ),
+    noResultReason: {
+      IdenticalLocations: _(
+        'Fra- og til-sted er identiske',
+        'From- and to-place are identical',
+      ),
+      CloseLocations: _(
+        'Det er veldig kort avstand mellom fra- og til-sted',
+        'The distance between to- and from-place is very short',
+      ),
+      PastArrivalTime: _('Ankomsttid har passert', 'Arrival time has passed'),
+      PastDepartureTime: _(
+        'Avreisetid har passert',
+        'Departure time has passed',
+      ),
+    },
   },
   results: {
     error: {
@@ -78,7 +93,7 @@ const AssistantTexts = {
     info: {
       emptyResult: _(
         'Vi fant dessverre ingen reiseruter som passer til ditt søk.',
-        'We could not find any travel routes matching your search criteria',
+        'We could not find any travel routes matching your search criteria.',
       ),
       reasonsTitle: _('Mulige årsaker: ', 'Possible causes:'),
       genericHint: _(


### PR DESCRIPTION
Noen oversettelser mangler på engelsk for `NoResultReason` i feilmeldingen når man ikke får resultater i reisesøk. Byttet ut en enum i `src/screens/Assistant/types.tsx` med oversettelser i `src/translations/screens/Assistant.ts`. 

Usikker på om å sende `t: TFunc<typeof Language>` som parameter til `computeNoResultReasons` er helt riktig, men det ser ut til å fungere bra.

## Før / etter

![collage](https://user-images.githubusercontent.com/1774972/131839809-f8d91d2d-b986-40cc-957a-bf0fae326e95.png)
