### PR TITLE
feat: First time setup commands

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -52,9 +52,9 @@ jobs:
         env:
           GPG_KEYSTORE_FILE: ${{ secrets.GPG_KEYSTORE_FILE }}
           GPG_KEYSTORE_PASS: ${{ secrets.GPG_KEYSTORE_PASS }}
-      - name: Generate icons
+      - name: Generate native assets
         if: steps.apk-cache.outputs.cache-hit != 'true'
-        run: brew install imagemagick && yarn icons
+        run: brew install imagemagick && yarn generate-native-assets
       - name: Run fastlane build
         if: steps.apk-cache.outputs.cache-hit != 'true'
         run: fastlane android build

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -57,9 +57,9 @@ jobs:
           FASTLANE_MATCH_URL: ${{ secrets.FASTLANE_MATCH_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_TYPE: "adhoc"
-      - name: Generate icons
+      - name: Generate native assets
         if: steps.ipa-cache.outputs.cache-hit != 'true'
-        run: brew install imagemagick && yarn icons
+        run: brew install imagemagick && yarn generate-native-assets
       - name: Run fastlane build
         if: steps.ipa-cache.outputs.cache-hit != 'true'
         run: fastlane ios build

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -43,8 +43,8 @@ jobs:
         env:
           GPG_KEYSTORE_FILE: ${{ secrets.GPG_KEYSTORE_FILE }}
           GPG_KEYSTORE_PASS: ${{ secrets.GPG_KEYSTORE_PASS }}
-      - name: Generate icons
-        run: brew install imagemagick && yarn icons
+      - name: Generate native assets
+        run: brew install imagemagick && yarn generate-native-assets
       - name: Run fastlane build
         run: fastlane android build
         env:

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -48,8 +48,8 @@ jobs:
           FASTLANE_MATCH_URL: ${{ secrets.FASTLANE_MATCH_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_TYPE: "appstore"
-      - name: Generate icons
-        run: brew install imagemagick && yarn icons
+      - name: Generate native assets
+        run: brew install imagemagick && yarn generate-native-assets
       - name: Run fastlane build
         run: fastlane ios build
         env:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We love feedback and suggestions. The AtB app and service is continously improve
    1. React Native: `yarn`
    1. iOS specific: `cd ios/` and `pod install`
 1. Decrypt sensitive files `git-crypt unlock <path/to/key>` (Key given to internal members)
-1. From root folder run: `sh scripts/override-environment.sh dev <organization>` where organization is either `AtB` or `nfk`, to set root .env for local development and generate all icons and launch screens for iOS and Android
+1. From root folder run: `yarn setup dev <organization>` where organization is either `atb` or `nfk`, to set root .env for local development and generate all icons and launch screens for iOS and Android
 
 
 For external contributors, we need to fix [#35](https://github.com/AtB-AS/mittatb-app/issues/35) before they are able to run the app.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "license": "EUPL-1.2",
   "scripts": {
-    "android-atb": "react-native run-android --appIdSuffix debug",
-    "android-nfk": "react-native run-android --appId no.reisnordland.reis.debug",
+    "android": "sh ./scripts/android/run-android.sh",
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "update-device-profiles": "bundle exec fastlane ios update_devices",
     "clean": "rm -rf node_modules/ **/node_modules/ yarn-error.log",
     "clean:install": "yarn clean && yarn install",
-    "setup": "sh ./setup.sh"
+    "setup": "sh ./setup.sh",
+    "generate-native-assets": "sh ./scripts/generate-native-assets.sh"
   },
   "dependencies": {
     "@atb-as/theme": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "generate-svgs": "yarn generate-svg-mono-icons && yarn generate-svg-color",
     "update-device-profiles": "bundle exec fastlane ios update_devices",
     "clean": "rm -rf node_modules/ **/node_modules/ yarn-error.log",
-    "clean:install": "yarn clean && yarn install"
+    "clean:install": "yarn clean && yarn install",
+    "setup": "sh ./setup.sh"
   },
   "dependencies": {
     "@atb-as/theme": "^3.0.0",

--- a/scripts/android/run-android.sh
+++ b/scripts/android/run-android.sh
@@ -1,0 +1,3 @@
+export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
+
+react-native run-android --appId $ANDROID_APPLICATION_ID

--- a/scripts/generate-native-assets.sh
+++ b/scripts/generate-native-assets.sh
@@ -1,0 +1,7 @@
+export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
+
+echo "Generating app icons"
+yarn icons
+ 
+echo "Generating native bootsplash"
+yarn react-native generate-bootsplash assets/bootsplash_logo_original.png --assets-path=assets/ --background-color=$BOOTSPLASH_BACKGROUND_COLOR

--- a/scripts/override-environment.sh
+++ b/scripts/override-environment.sh
@@ -13,7 +13,7 @@ then
 -nfk"
 
     echo "Example:
-./override-environment.sh store AtB"
+./override-environment.sh store atb"
     exit 1
 else
     APP_ENVIRONMENT=$1
@@ -39,10 +39,4 @@ else
 
     echo "Copying boot splash image to assets/"
     cp $ORG_FOLDER/bootsplash_logo_original.png assets/
-
-    echo "Generating app icons and bootsplash screens"
-    export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
-    yarn icons && yarn react-native generate-bootsplash assets/bootsplash_logo_original.png \
-        --assets-path=assets/ --background-color=$BOOTSPLASH_BACKGROUND_COLOR
-
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,21 @@
+if [ "$#" -ne 2 ]
+then
+    echo "Argument error!"
+    echo "First argument should be the environment name."
+    echo "Available environment names:
+ - dev
+ - prodstaging
+ - staging
+ - store"
+    echo "Second argument should be the app organisation name."
+    echo "Available app variant names:
+-atb
+-nfk"
+
+    echo "Example:
+./setup.sh dev atb"
+    exit 1
+else
+    sh ./scripts/override-environment.sh $1 $2
+    sh ./scripts/generate-native-assets.sh
+fi


### PR DESCRIPTION
Endrer setup commandoen til `yarn setup dev atb` for å forenkle ting, og separerer generering av native assets fra override-environment. Dette bør fikse bygget, samt potensielt gjøre det enklere å "setup" en lokal dev-env.