### PR TITLE
feat: updated phone number with prefix input

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lodash.pickby": "^4.6.0",
     "lodash.sortby": "^4.7.0",
     "marked": "^3.0.2",
+    "phone": "^3.1.8",
     "qrcode": "^1.4.4",
     "query-string": "^7.0.1",
     "react": "16.13.1",

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import {
   AccessibilityProps,
   AccessibilityRole,
@@ -17,6 +17,7 @@ import FixedSwitch from '../switch';
 
 export type ActionModes = 'check' | 'toggle' | 'heading-expand';
 export type ActionItemProps = SectionItem<{
+  children: JSX.Element | undefined;
   text: string;
   onPress?(checked: boolean): void;
   checked?: boolean;
@@ -24,6 +25,7 @@ export type ActionItemProps = SectionItem<{
   accessibility?: AccessibilityProps;
 }>;
 export default function ActionItem({
+  children,
   text,
   onPress,
   mode = 'check',
@@ -60,14 +62,18 @@ export default function ActionItem({
       }}
       {...accessibility}
     >
-      <ThemeText
-        type={
-          mode === 'heading-expand' ? 'body__primary--bold' : 'body__primary'
-        }
-        style={contentContainer}
-      >
-        {text}
-      </ThemeText>
+      {children ? (
+        children
+      ) : (
+        <ThemeText
+          type={
+            mode === 'heading-expand' ? 'body__primary--bold' : 'body__primary'
+          }
+          style={contentContainer}
+        >
+          {text}
+        </ThemeText>
+      )}
       <ActionModeIcon mode={mode} checked={checked} />
     </TouchableOpacity>
   );

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -17,7 +17,7 @@ import FixedSwitch from '../switch';
 
 export type ActionModes = 'check' | 'toggle' | 'heading-expand';
 export type ActionItemProps = SectionItem<{
-  children: JSX.Element | undefined;
+  children?: JSX.Element;
   text: string;
   onPress?(checked: boolean): void;
   checked?: boolean;

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   AccessibilityProps,
   AccessibilityRole,
@@ -17,7 +17,6 @@ import FixedSwitch from '../switch';
 
 export type ActionModes = 'check' | 'toggle' | 'heading-expand';
 export type ActionItemProps = SectionItem<{
-  children?: JSX.Element;
   text: string;
   onPress?(checked: boolean): void;
   checked?: boolean;
@@ -25,7 +24,6 @@ export type ActionItemProps = SectionItem<{
   accessibility?: AccessibilityProps;
 }>;
 export default function ActionItem({
-  children,
   text,
   onPress,
   mode = 'check',
@@ -62,18 +60,14 @@ export default function ActionItem({
       }}
       {...accessibility}
     >
-      {children ? (
-        children
-      ) : (
-        <ThemeText
-          type={
-            mode === 'heading-expand' ? 'body__primary--bold' : 'body__primary'
-          }
-          style={contentContainer}
-        >
-          {text}
-        </ThemeText>
-      )}
+      <ThemeText
+        type={
+          mode === 'heading-expand' ? 'body__primary--bold' : 'body__primary'
+        }
+        style={contentContainer}
+      >
+        {text}
+      </ThemeText>
       <ActionModeIcon mode={mode} checked={checked} />
     </TouchableOpacity>
   );

--- a/src/components/sections/generic-clickable-item.tsx
+++ b/src/components/sections/generic-clickable-item.tsx
@@ -1,0 +1,28 @@
+import React, {PropsWithChildren} from 'react';
+import {AccessibilityProps, View} from 'react-native';
+import {TouchableOpacity} from 'react-native';
+import {SectionItem, useSectionItem, useSectionStyle} from './section-utils';
+
+export type GenericClickableItemProps = PropsWithChildren<
+  SectionItem<{
+    accessibility?: AccessibilityProps;
+    onPress?(): void;
+  }>
+>;
+export default function GenericClickableItem({
+  children,
+  accessibility,
+  onPress,
+  ...props
+}: GenericClickableItemProps) {
+  const {topContainer} = useSectionItem(props);
+  const style = useSectionStyle();
+
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <View style={topContainer} {...accessibility}>
+        {children}
+      </View>
+    </TouchableOpacity>
+  );
+}

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -14,6 +14,7 @@ export {default as FavoriteDepartureItem} from './favorite-departure-item';
 export {default as TimeInputItem} from './time-input';
 export {default as DateInputItem} from './date-input';
 export {default as TextInput} from './text-input';
+export {default as PhoneInput} from './phone-input';
 export {default as LocationInput} from './location-input';
 export {default as ButtonInput} from './button-input';
 export {default as CounterInput} from './counter-input';

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -7,6 +7,7 @@ export {default as LinkItem} from './link-item';
 export {default as HeaderItem} from './header-item';
 export {default as ActionItem} from './action-item';
 export {default as GenericItem} from './generic-item';
+export {default as GenericClickableItem} from './generic-clickable-item';
 export {default as FavoriteItem} from './favorite-item';
 export {default as FavoriteDepartureItem} from './favorite-departure-item';
 

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -171,6 +171,10 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
               <TouchableOpacity
                 style={styles.prefix}
                 onPress={onOpenPrefixSelection}
+                accessibilityRole="button"
+                accessibilityLabel={t(
+                  SectionTexts.phoneInput.a11yLabel(prefix),
+                )}
               >
                 <ThemeText>+{prefix}</ThemeText>
                 <ThemeIcon

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -131,11 +131,20 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
       <ScrollView style={styles.prefixList}>
         <Sections.Section>
           {prefixes.map((country) => (
-            <Sections.LinkItem
+            <Sections.ActionItem
               key={country.country_code + country.country_name}
               text={'+' + country.country_code + ' ' + country.country_name}
               onPress={() => onSelectPrefix(country.country_code)}
-            ></Sections.LinkItem>
+            >
+              <View style={styles.countryItem}>
+                <ThemeText style={styles.countryCode}>
+                  {'+' + country.country_code + ' '}
+                </ThemeText>
+                <ThemeText style={styles.countryName}>
+                  {country.country_name}
+                </ThemeText>
+              </View>
+            </Sections.ActionItem>
           ))}
         </Sections.Section>
       </ScrollView>
@@ -242,5 +251,15 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
   },
   prefixList: {
     maxHeight: 300,
+    borderRadius: theme.border.radius.regular,
+  },
+  countryItem: {
+    flexDirection: 'row',
+  },
+  countryCode: {
+    minWidth: '17%',
+  },
+  countryName: {
+    width: '83%',
   },
 }));

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -129,28 +129,6 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
       })
       .sort((a, b) => (a.country_name > b.country_name ? 1 : -1));
 
-    const prefixList = (
-      <ScrollView style={styles.prefixList} ref={prefixListRef}>
-        <Sections.Section>
-          {prefixes.map((country) => (
-            <Sections.ActionItem
-              key={country.country_code + country.country_name}
-              text={'+' + country.country_code + ' ' + country.country_name}
-              onPress={() => onSelectPrefix(country.country_code)}
-            >
-              <View style={styles.countryItem}>
-                <ThemeText style={styles.countryCode}>
-                  {'+' + country.country_code + ' '}
-                </ThemeText>
-                <ThemeText style={styles.countryName}>
-                  {country.country_name}
-                </ThemeText>
-              </View>
-            </Sections.ActionItem>
-          ))}
-        </Sections.Section>
-      </ScrollView>
-    );
     return (
       <View>
         <View
@@ -210,7 +188,27 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
             ) : null}
           </View>
         </View>
-        {isSelectingPrefix && prefixList}
+        {isSelectingPrefix && (
+          <ScrollView style={styles.prefixList} ref={prefixListRef}>
+            <Sections.Section>
+              {prefixes.map((country) => (
+                <Sections.GenericClickableItem
+                  key={country.country_code + country.country_name}
+                  onPress={() => onSelectPrefix(country.country_code)}
+                >
+                  <View style={styles.countryItem}>
+                    <ThemeText style={styles.countryCode}>
+                      {'+' + country.country_code + ' '}
+                    </ThemeText>
+                    <ThemeText style={styles.countryName}>
+                      {country.country_name}
+                    </ThemeText>
+                  </View>
+                </Sections.GenericClickableItem>
+              ))}
+            </Sections.Section>
+          </ScrollView>
+        )}
       </View>
     );
   },

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -22,6 +22,7 @@ import {Expand, ExpandLess} from '@atb/assets/svg/icons/navigation';
 import {ScrollView} from 'react-native-gesture-handler';
 import {countryPhoneData} from 'phone';
 import * as Sections from '@atb/components/sections';
+import useFocusOnLoad from '@atb/utils/use-focus-on-load';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 
@@ -58,6 +59,7 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
     const {t} = useTranslation();
     const myRef = useRef<InternalTextInput>(null);
     const combinedRef = composeRefs<InternalTextInput>(forwardedRef, myRef);
+    const prefixListRef = useFocusOnLoad();
 
     function accessibilityEscapeKeyboard() {
       setTimeout(
@@ -128,7 +130,7 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
       .sort((a, b) => (a.country_name > b.country_name ? 1 : -1));
 
     const prefixList = (
-      <ScrollView style={styles.prefixList}>
+      <ScrollView style={styles.prefixList} ref={prefixListRef}>
         <Sections.Section>
           {prefixes.map((country) => (
             <Sections.ActionItem

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -1,0 +1,220 @@
+import React, {forwardRef, useRef, useState} from 'react';
+import {
+  AccessibilityInfo,
+  ListViewComponent,
+  NativeSyntheticEvent,
+  Platform,
+  TextInput as InternalTextInput,
+  TextInputFocusEventData,
+  TextInputProps as InternalTextInputProps,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {Close} from '@atb/assets/svg/icons/actions';
+import {StyleSheet, useTheme} from '@atb/theme';
+import insets from '@atb/utils/insets';
+import ThemeText, {MAX_FONT_SCALE} from '@atb/components/text';
+import ThemeIcon from '@atb/components/theme-icon';
+import {SectionItem, useSectionItem} from './section-utils';
+import {SectionTexts, useTranslation} from '@atb/translations';
+import composeRefs from '@seznam/compose-react-refs';
+import {
+  ArrowRight,
+  ArrowUpLeft,
+  Expand,
+  ExpandLess,
+} from '@atb/assets/svg/icons/navigation';
+import {ScrollView} from 'react-native-gesture-handler';
+import {phone, countryPhoneData} from 'phone';
+
+type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
+
+type TextProps = SectionItem<
+  InternalTextInputProps & {
+    label: string;
+    prefix: boolean;
+    showClear?: boolean;
+    onClear?: () => void;
+  }
+>;
+
+const PhoneInput = forwardRef<InternalTextInput, TextProps>(
+  (
+    {label, prefix, onFocus, onBlur, showClear, onClear, style, ...props},
+    forwardedRef,
+  ) => {
+    const {topContainer, spacing, contentContainer} = useSectionItem(props);
+    const {theme, themeName} = useTheme();
+    const styles = useInputStyle(theme, themeName);
+    const [isFocused, setIsFocused] = useState(Boolean(props?.autoFocus));
+    const [isSelectingPrefix, setIsSelectingPrefix] = useState(false);
+    const {t} = useTranslation();
+    const myRef = useRef<InternalTextInput>(null);
+    const combinedRef = composeRefs<InternalTextInput>(forwardedRef, myRef);
+
+    function accessibilityEscapeKeyboard() {
+      setTimeout(
+        () =>
+          AccessibilityInfo.announceForAccessibility(
+            t(SectionTexts.textInput.closeKeyboard),
+          ),
+        50,
+      );
+      myRef.current?.blur();
+    }
+
+    const onFocusEvent = (e: FocusEvent) => {
+      setIsFocused(true);
+      onFocus?.(e);
+    };
+
+    const onBlurEvent = (e: FocusEvent) => {
+      setIsFocused(false);
+      onBlur?.(e);
+    };
+
+    const onClearEvent = () => {
+      if (onClear) onClear();
+      else if (props.onChangeText) props.onChangeText('');
+    };
+
+    const borderColor = !isFocused
+      ? undefined
+      : {borderColor: theme.border.focus};
+
+    const padding = {
+      // There are some oddities with handling padding
+      // on Android and fonts: https://codeburst.io/react-native-quirks-2fb1ae0bbf80
+      paddingBottom: spacing - Platform.select({android: 4, default: 0}),
+      paddingTop: spacing - Platform.select({android: 5, default: 0}),
+    };
+
+    // Remove padding from topContainerStyle
+    const {padding: _dropThis, ...topContainerStyle} = topContainer;
+    const containerPadding = {
+      paddingHorizontal: spacing,
+    };
+
+    const onPrefixSelection = () => {
+      setIsSelectingPrefix(!isSelectingPrefix);
+    };
+
+    const prefixes = countryPhoneData
+      .filter((country) => {
+        switch (country.country_code) {
+          case '1':
+            // Filter out non-US +1 prefixes
+            return country.country_name === 'United States';
+          case '47':
+            // Filter out Svalbard / Jan Mayen
+            return country.country_name === 'Norway';
+          default:
+            return true;
+        }
+      })
+      .sort((a, b) => (a.country_name > b.country_name ? 1 : -1));
+
+    const prefixList = (
+      <ScrollView>
+        {prefixes.map((country) => (
+          <View key={country.country_code + country.country_name}>
+            <ThemeText>
+              +{country.country_code} {country.country_name}
+            </ThemeText>
+          </View>
+        ))}
+      </ScrollView>
+    );
+    return (
+      <View>
+        <View
+          style={[
+            styles.container,
+            label ? styles.containerMultiline : null,
+            topContainerStyle,
+            containerPadding,
+            borderColor,
+          ]}
+          onAccessibilityEscape={accessibilityEscapeKeyboard}
+        >
+          {label && (
+            <ThemeText type="body__secondary" style={styles.label}>
+              {label}
+            </ThemeText>
+          )}
+          <View style={prefix ? styles.containerInline : null}>
+            {prefix && (
+              <TouchableOpacity
+                style={styles.prefix}
+                onPress={onPrefixSelection}
+              >
+                <ThemeText>+123</ThemeText>
+                <ThemeIcon svg={isSelectingPrefix ? ExpandLess : Expand} />
+              </TouchableOpacity>
+            )}
+            <InternalTextInput
+              ref={combinedRef}
+              style={[styles.input, padding, style]}
+              placeholderTextColor={theme.text.colors.secondary}
+              onFocus={onFocusEvent}
+              onBlur={onBlurEvent}
+              maxFontSizeMultiplier={MAX_FONT_SCALE}
+              {...props}
+            />
+            {showClear ? (
+              <View style={styles.inputClear}>
+                <TouchableOpacity
+                  accessible={true}
+                  accessibilityRole="button"
+                  accessibilityLabel={t(SectionTexts.textInput.clear)}
+                  hitSlop={insets.all(8)}
+                  onPress={onClearEvent}
+                >
+                  <ThemeIcon svg={Close} />
+                </TouchableOpacity>
+              </View>
+            ) : null}
+          </View>
+        </View>
+        {isSelectingPrefix && prefixList}
+      </View>
+    );
+  },
+);
+
+export default PhoneInput;
+
+const useInputStyle = StyleSheet.createTheme((theme) => ({
+  input: {
+    color: theme.text.colors.primary,
+    paddingRight: 40,
+
+    fontSize: theme.typography.body__primary.fontSize,
+  },
+  container: {
+    backgroundColor: theme.colors.background_0.backgroundColor,
+    borderWidth: theme.border.width.slim,
+    borderColor: theme.colors.background_0.backgroundColor,
+  },
+  containerInline: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    // justifyContent: 'space-between',
+  },
+  containerMultiline: {
+    paddingTop: theme.spacings.small,
+  },
+  label: {
+    minWidth: 60 - theme.spacings.medium,
+    paddingRight: theme.spacings.xSmall,
+  },
+  prefix: {
+    flexDirection: 'row',
+  },
+  inputClear: {
+    position: 'absolute',
+    right: 0,
+    bottom: theme.spacings.medium,
+    alignSelf: 'center',
+  },
+}));

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -20,7 +20,7 @@ import {SectionTexts, useTranslation} from '@atb/translations';
 import composeRefs from '@seznam/compose-react-refs';
 import {Expand, ExpandLess} from '@atb/assets/svg/icons/navigation';
 import {ScrollView} from 'react-native-gesture-handler';
-import {phone, countryPhoneData} from 'phone';
+import {countryPhoneData} from 'phone';
 import * as Sections from '@atb/components/sections';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
@@ -28,7 +28,8 @@ type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 type TextProps = SectionItem<
   InternalTextInputProps & {
     label: string;
-    enablePrefix: boolean;
+    prefix: string | undefined;
+    onChangePrefix: (prefix: string) => void;
     showClear?: boolean;
     onClear?: () => void;
   }
@@ -36,7 +37,17 @@ type TextProps = SectionItem<
 
 const PhoneInput = forwardRef<InternalTextInput, TextProps>(
   (
-    {label, enablePrefix, onFocus, onBlur, showClear, onClear, style, ...props},
+    {
+      label,
+      prefix,
+      onChangePrefix,
+      onFocus,
+      onBlur,
+      showClear,
+      onClear,
+      style,
+      ...props
+    },
     forwardedRef,
   ) => {
     const {topContainer, spacing} = useSectionItem(props);
@@ -44,7 +55,6 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
     const styles = useInputStyle(theme, themeName);
     const [isFocused, setIsFocused] = useState(Boolean(props?.autoFocus));
     const [isSelectingPrefix, setIsSelectingPrefix] = useState(false);
-    const [prefix, setPrefix] = useState('47');
     const {t} = useTranslation();
     const myRef = useRef<InternalTextInput>(null);
     const combinedRef = composeRefs<InternalTextInput>(forwardedRef, myRef);
@@ -97,7 +107,7 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
 
     const onSelectPrefix = (country_code: string) => {
       setIsSelectingPrefix(false);
-      setPrefix(country_code);
+      onChangePrefix(country_code);
     };
 
     const onOpenPrefixSelection = () => {
@@ -111,9 +121,6 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
           case '1':
             // Filter out non-US +1 prefixes
             return country.country_name === 'United States';
-          case '47':
-            // Filter out Svalbard / Jan Mayen
-            return country.country_name === 'Norway';
           default:
             return true;
         }
@@ -150,8 +157,8 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
               {label}
             </ThemeText>
           )}
-          <View style={enablePrefix ? styles.containerInline : null}>
-            {enablePrefix && (
+          <View style={prefix ? styles.containerInline : null}>
+            {prefix && (
               <TouchableOpacity
                 style={styles.prefix}
                 onPress={onOpenPrefixSelection}

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -110,11 +110,9 @@ export default function PhoneInput({
             </ThemeText>
           </View>
           <Sections.Section>
-            <Sections.GenericItem>
-              <ThemeText>{t(LoginTexts.phoneInput.input.heading)}</ThemeText>
-            </Sections.GenericItem>
-            <Sections.TextInput
-              label={t(LoginTexts.phoneInput.input.label)}
+            <Sections.PhoneInput
+              label={t(LoginTexts.phoneInput.input.heading)}
+              prefix={true}
               value={phoneNumber}
               onChangeText={setPhoneNumber}
               showClear={true}

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -112,7 +112,7 @@ export default function PhoneInput({
           <Sections.Section>
             <Sections.PhoneInput
               label={t(LoginTexts.phoneInput.input.heading)}
-              prefix={true}
+              enablePrefix={true}
               value={phoneNumber}
               onChangeText={setPhoneNumber}
               showClear={true}

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -51,8 +51,11 @@ export default function PhoneInput({
   };
 
   const isValidPhoneNumber = (number: string) => {
-    const r = phone('+' + prefix + number, phoneValidationParams);
-    return r.isValid;
+    const validationResult = phone(
+      '+' + prefix + number,
+      phoneValidationParams,
+    );
+    return validationResult.isValid;
   };
 
   React.useEffect(

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -39,13 +39,14 @@ export default function PhoneInput({
   const styles = useThemeStyles();
   const {signInWithPhoneNumber} = useAuthState();
   const [phoneNumber, setPhoneNumber] = useState('');
+  const [prefix, setPrefix] = useState('47');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<PhoneSignInErrorCode>();
   const navigation = useNavigation();
   const focusRef = useFocusOnLoad();
 
   const isValidPhoneNumber = (number: string) => {
-    const r = phone('+47' + number, {strictDetection: true});
+    const r = phone('+' + prefix + number, {strictDetection: true});
     return r.isValid;
   };
 
@@ -59,7 +60,7 @@ export default function PhoneInput({
 
   const onNext = async () => {
     setIsSubmitting(true);
-    const phoneValidation = phone('+47' + phoneNumber);
+    const phoneValidation = phone('+' + prefix + phoneNumber);
     if (!phoneValidation.phoneNumber) {
       setIsSubmitting(false);
       setError('invalid_phone');
@@ -112,9 +113,10 @@ export default function PhoneInput({
           <Sections.Section>
             <Sections.PhoneInput
               label={t(LoginTexts.phoneInput.input.heading)}
-              enablePrefix={true}
               value={phoneNumber}
               onChangeText={setPhoneNumber}
+              prefix={prefix}
+              onChangePrefix={setPrefix}
               showClear={true}
               keyboardType="number-pad"
               placeholder={t(LoginTexts.phoneInput.input.placeholder)}

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -45,8 +45,13 @@ export default function PhoneInput({
   const navigation = useNavigation();
   const focusRef = useFocusOnLoad();
 
+  const phoneValidationParams = {
+    strictDetection: true,
+    validateMobilePrefix: false,
+  };
+
   const isValidPhoneNumber = (number: string) => {
-    const r = phone('+' + prefix + number, {strictDetection: true});
+    const r = phone('+' + prefix + number, phoneValidationParams);
     return r.isValid;
   };
 
@@ -60,7 +65,10 @@ export default function PhoneInput({
 
   const onNext = async () => {
     setIsSubmitting(true);
-    const phoneValidation = phone('+' + prefix + phoneNumber);
+    const phoneValidation = phone(
+      '+' + prefix + phoneNumber,
+      phoneValidationParams,
+    );
     if (!phoneValidation.phoneNumber) {
       setIsSubmitting(false);
       setError('invalid_phone');

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -19,6 +19,7 @@ import {ArrowRight} from '@atb/assets/svg/icons/navigation';
 import {LeftButtonProps, RightButtonProps} from '@atb/components/screen-header';
 import useFocusOnLoad from '@atb/utils/use-focus-on-load';
 import {ThemeColor} from '@atb/theme/colors';
+import phone from 'phone';
 
 const themeColor: ThemeColor = 'background_gray';
 
@@ -43,9 +44,10 @@ export default function PhoneInput({
   const navigation = useNavigation();
   const focusRef = useFocusOnLoad();
 
-  // Remove whitespaces from phone number
-  const setCleanPhoneNumber = (number: string) =>
-    setPhoneNumber(number.replace(/\s+/g, ''));
+  const isValidPhoneNumber = (number: string) => {
+    const r = phone('+47' + number, {strictDetection: true});
+    return r.isValid;
+  };
 
   React.useEffect(
     () =>
@@ -57,10 +59,16 @@ export default function PhoneInput({
 
   const onNext = async () => {
     setIsSubmitting(true);
+    const phoneValidation = phone('+47' + phoneNumber);
+    if (!phoneValidation.phoneNumber) {
+      setIsSubmitting(false);
+      setError('invalid_phone');
+      return;
+    }
     const errorCode = await signInWithPhoneNumber(phoneNumber);
     if (!errorCode) {
       setError(undefined);
-      doAfterLogin(phoneNumber);
+      doAfterLogin(phoneValidation.phoneNumber);
     } else {
       setIsSubmitting(false);
       setError(errorCode);
@@ -108,7 +116,7 @@ export default function PhoneInput({
             <Sections.TextInput
               label={t(LoginTexts.phoneInput.input.label)}
               value={phoneNumber}
-              onChangeText={setCleanPhoneNumber}
+              onChangeText={setPhoneNumber}
               showClear={true}
               keyboardType="number-pad"
               placeholder={t(LoginTexts.phoneInput.input.placeholder)}
@@ -138,7 +146,7 @@ export default function PhoneInput({
                 color={'primary_2'}
                 onPress={onNext}
                 text={t(LoginTexts.phoneInput.mainButton)}
-                disabled={phoneNumber.length !== 8}
+                disabled={!isValidPhoneNumber(phoneNumber)}
                 icon={ArrowRight}
                 iconPosition="right"
               />

--- a/src/translations/components/Section.ts
+++ b/src/translations/components/Section.ts
@@ -26,6 +26,13 @@ const SectionTexts = {
     clear: _('Tøm redigeringsfelt', 'Clear input'),
     closeKeyboard: _('Lukker tastatur', 'Closing keyboard'),
   },
+  phoneInput: {
+    a11yLabel: (prefix: string) =>
+      _(
+        '+' + prefix + '. Velg for å forandre mobilnummer prefiks.',
+        '+' + prefix + '. Select to edit phone number prefix.',
+      ),
+  },
   counterInput: {
     decreaseButton: {
       a11yLabel: (text: string) =>

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -3,7 +3,7 @@ const LoginTexts = {
   onboarding: {
     title: _(
       'Nå kan du kjøpe periodebilletter!',
-      'Seasonal tickets – available now!',
+      'Period tickets – available now!',
     ),
     description: _(
       'Når du logger inn kan du kjøpe periodebilletter på 7, 30 eller 180 dagers varighet.',

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -28,7 +28,7 @@ const LoginTexts = {
       label: _('+47', '+47'),
       placeholder: _('Skriv inn ditt telefonnummer', 'Type your mobile number'),
     },
-    mainButton: _('Send engangskode', 'Send new one-time code'),
+    mainButton: _('Send engangskode', 'Send one-time code'),
     errors: {
       invalid_phone: _(
         'Er du sikker på at telefonnummeret er korrekt?',
@@ -52,7 +52,7 @@ const LoginTexts = {
       placeholder: _('Skriv inn engangskoden', 'Enter your one-time code'),
     },
     mainButton: _('Logg inn', 'Log in'),
-    resendButton: _('Send engangskode på nytt', 'Request one-time code'),
+    resendButton: _('Send engangskode på nytt', 'Request new one-time code'),
     errors: {
       invalid_phone: _(
         'Er du sikker på at telefonnummeret er korrekt?',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7991,6 +7991,11 @@ phin@^2.9.1:
   resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
   integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
 
+phone@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/phone/-/phone-3.1.8.tgz#6e348512539c9df81bf07fddb3ed3e2ec7e0c66e"
+  integrity sha512-eyneQKbBwhy6PLYgkioO4CcocMUrFHh4WEfYl1A3PpiQK9tiP0ABKU4yhs7F1URKDbp+oeI8rbJU0+8uMgWfBQ==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"


### PR DESCRIPTION
Ny mobilnummer-input-felt med landskode / prefiks velger, som gjør det mulig å bruke internasjonale mobilnummer ved innlogging. 

Noen punker om hvordan det er implementert:

- Rammeverket https://github.com/AfterShip/phone blir brukt for å validere riktig lengde av mobilnummer. Det er også mulig å sjekke at de første sifferene er mobilnummer, men dette er slått av, og håndteres heller i backend. 
- Kun engelsk oversettelse av land/regioner er lagt inn nå.
- Mange av `+1` regionene har blitt filtrert ut (f.eks. British Virgin Islands), siden disse vil fungere ved å velge "+1 United States". Der er fortsatt noen duplikater for landskoder, men (eks. Åland Islands), men tenker det er greit å ha med.
- ~PRen oppdaterer også komponenten `ActionItem`, og gir den en optional parameter `children`, som gjør det mulig å tilpasse innhold utover rent tekstinnhold. Se 19b9d09e70de3d3877f02853f298260d12f3cd2c~
- Liten oppdatering av oversettelse etter tilbakemelding fra @cbrevik a7fac8faef86bb36782edf9041e09fdd972db4a8

Todo:

- [x] Trenger noe input på hvordan gjøre input-feltet universelt utformet

https://user-images.githubusercontent.com/1774972/134161354-09678d16-a8a9-420e-9743-24027f9b5811.mp4

UU demo:

https://user-images.githubusercontent.com/1774972/134304876-675d8c84-4509-4cb3-834e-dcfee2d9f76f.MOV

resolves #1559 
