### PR TITLE
fix: #1497 testing results

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1008,7 +1008,7 @@ SPEC CHECKSUMS:
   Intercom: 5d8058e3476ab6b0350dea165338164364eb1acb
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  Mapbox-iOS-SDK: 6a67397df2bcafe5d2851604192aa8de6f8d6c89
+  Mapbox-iOS-SDK: 2563ed87ead6ec08f1c2090873977b8a7be335a8
   MapboxMobileEvents: 36ff53b135aac486eed94b61f813c7967a0c2c6f
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -37,6 +37,7 @@ export default function AnimatedBottomSheet({
             translateY,
           },
         ],
+        maxHeight: height,
       }}
       onLayout={onLayout}
     >
@@ -49,7 +50,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   bottomSheet: {
     backgroundColor: theme.colors.background_2.backgroundColor,
     width: '100%',
-    maxHeight: Dimensions.get('screen').height,
     position: 'absolute',
     bottom: 0,
     borderTopLeftRadius: theme.border.radius.regular,

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -1,4 +1,9 @@
-import {Animated, LayoutChangeEvent, useWindowDimensions} from 'react-native';
+import {
+  Animated,
+  Dimensions,
+  LayoutChangeEvent,
+  useWindowDimensions,
+} from 'react-native';
 import React, {ReactNode, useMemo} from 'react';
 import {StyleSheet} from '@atb/theme';
 
@@ -44,6 +49,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   bottomSheet: {
     backgroundColor: theme.colors.background_2.backgroundColor,
     width: '100%',
+    maxHeight: Dimensions.get('screen').height,
     position: 'absolute',
     bottom: 0,
     borderTopLeftRadius: theme.border.radius.regular,

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -199,6 +199,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
             selectPaymentOption(option);
             close();
           }}
+          close={close}
           previousPaymentMethod={previousPaymentMethod}
         ></SelectPaymentMethod>
       );

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -4,7 +4,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
-  Dimensions,
+  useWindowDimensions,
 } from 'react-native';
 import {Vipps} from '@atb/assets/svg/icons/ticketing';
 import {StyleSheet, useTheme} from '@atb/theme';
@@ -90,6 +90,8 @@ const SelectPaymentMethod: React.FC<Props> = ({
 
   const {user} = useAuthState();
 
+  const {height} = useWindowDimensions();
+
   const [selectedOption, setSelectedOption] = useState<
     PaymentMethod | undefined
   >(getSelectedPaymentMethod(previousPaymentMethod));
@@ -160,7 +162,9 @@ const SelectPaymentMethod: React.FC<Props> = ({
       </View>
       {loadingRemoteOption ? <ActivityIndicator /> : null}
       <FlatList
-        style={styles.listMaxHeight}
+        style={{
+          maxHeight: height * (2 / 3),
+        }}
         data={options}
         keyExtractor={(item) =>
           `${item.paymentType}_${
@@ -387,22 +391,22 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   column: {flex: 1, flexDirection: 'column'},
   card: {
-    marginVertical: 6,
-    borderRadius: 8,
+    marginVertical: theme.spacings.xSmall,
+    borderRadius: theme.border.radius.regular,
     backgroundColor: theme.colors.background_0.backgroundColor,
   },
   saveOptionSection: {paddingHorizontal: 24, paddingBottom: 24},
   container: {
     flex: 1,
     backgroundColor: theme.colors.background_2.backgroundColor,
-    paddingHorizontal: 12,
+    paddingHorizontal: theme.spacings.medium,
   },
   rowJustifyEnd: {flex: 1, flexDirection: 'row', justifyContent: 'flex-end'},
   paymentOption: {
     flex: 1,
     flexDirection: 'column',
-    padding: 24,
-    borderRadius: 8,
+    padding: theme.spacings.xLarge,
+    borderRadius: theme.border.radius.regular,
   },
   centerRow: {
     flex: 1,
@@ -416,11 +420,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.colors.background_0.backgroundColor,
   },
   radio: {
-    marginRight: 12,
+    marginRight: theme.spacings.medium,
     height: 24,
     width: 24,
     borderRadius: 12,
-    borderWidth: 2,
+    borderWidth: theme.border.width.medium,
     borderColor: theme.colors.primary_2.backgroundColor,
     alignItems: 'center',
     justifyContent: 'center',
@@ -432,7 +436,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.colors.background_0.backgroundColor,
   },
   saveCheckbox: {
-    marginRight: 12,
+    marginRight: theme.spacings.medium,
     height: 24,
     width: 24,
     borderRadius: 4,
@@ -451,7 +455,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
-    paddingTop: 6,
+    paddingTop: theme.spacings.small,
   },
   masked: {
     opacity: 0.6,
@@ -459,17 +463,13 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingLeft: 36,
   },
   confirmButtonMargin: {
-    marginTop: 6,
-  },
-  listMaxHeight: {
-    maxHeight:
-      Dimensions.get('screen').height - Dimensions.get('screen').height / 3,
+    marginTop: theme.spacings.small,
   },
   maskedPanPadding: {
-    paddingLeft: 8,
+    paddingLeft: theme.spacings.small,
   },
   saveOptionTextPadding: {
-    paddingTop: 18,
+    paddingTop: theme.spacings.medium,
     opacity: 0.6,
   },
 }));

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -264,17 +264,8 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
 
   function getExpireDate(iso: string): string {
     let date = parseISO(iso);
-    if (date.getDate() === 1) {
-      let sinceEpoc = date.getTime();
-      sinceEpoc = sinceEpoc - 86400000;
-      date = new Date(sinceEpoc);
-    }
     let year = date.getFullYear();
     let month = date.getMonth();
-    if (month === 0) {
-      month = 12;
-      year--;
-    }
     return `${month < 10 ? '0' + month : month}/${year.toString().slice(2, 4)}`;
   }
 

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -138,16 +138,14 @@ const SelectPaymentMethod: React.FC<Props> = ({
   }, [previousPaymentMethod]);
 
   return (
-    <SafeAreaView style={[styles.container]}>
-      <View style={{flex: 1, flexDirection: 'row'}}>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.row}>
         <View style={styles.heading}>
           <ThemeText type="heading__title">
             {t(SelectPaymentMethodTexts.header.text)}
           </ThemeText>
         </View>
-        <View
-          style={{flex: 1, flexDirection: 'row', justifyContent: 'flex-end'}}
-        >
+        <View style={styles.rowJustifyEnd}>
           <TouchableOpacity
             onPress={close}
             accessibilityHint={t(
@@ -162,11 +160,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
       </View>
       {loadingRemoteOption ? <ActivityIndicator /> : null}
       <FlatList
-        style={{
-          maxHeight:
-            Dimensions.get('screen').height -
-            Dimensions.get('screen').height / 3,
-        }}
+        style={styles.listMaxHeight}
         data={options}
         keyExtractor={(item) =>
           `${item.paymentType}_${
@@ -200,9 +194,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
         }}
       ></FlatList>
       <Button
-        style={{
-          marginTop: 6,
-        }}
+        style={styles.confirmButtonMargin}
         color="primary_2"
         text={t(SelectPaymentMethodTexts.confirm_button.text)}
         accessibilityHint={t(SelectPaymentMethodTexts.confirm_button.a11yhint)}
@@ -255,14 +247,14 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
       case PaymentType.MasterCard:
         return {
           icon: <MasterCardLogo />,
-          text: t(PurchaseConfirmationTexts.payWithMasterCard.text),
-          a11y: t(PurchaseConfirmationTexts.payWithMasterCard.a11yHint),
+          text: t(PurchaseConfirmationTexts.paymentButtonCardMC.text),
+          a11y: t(PurchaseConfirmationTexts.paymentButtonCardMC.a11yHint),
         };
       case PaymentType.VISA:
         return {
           icon: <VisaLogo />,
-          text: t(PurchaseConfirmationTexts.payWithVisa.text),
-          a11y: t(PurchaseConfirmationTexts.payWithVisa.a11yHint),
+          text: t(PurchaseConfirmationTexts.paymentButtonCardVisa.text),
+          a11y: t(PurchaseConfirmationTexts.paymentButtonCardVisa.a11yHint),
         };
     }
   }
@@ -300,62 +292,55 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
   const info = getPaymentInfo(option.paymentType);
 
   return (
-    <TouchableOpacity
-      style={styles.paymentOption}
-      onPress={select}
-      accessibilityHint={info.a11y}
-    >
-      <View style={styles.centerRow}>
-        <View style={styles.centerRow}>
-          <RadioView checked={selected} />
-          <ThemeText>{info.text}</ThemeText>
-          {option.savedType === 'recurring' ? (
-            <ThemeText
-              style={{
-                paddingLeft: 8,
-              }}
-            >
-              **** {`${option.recurringCard.masked_pan}`}
-            </ThemeText>
+    <View style={styles.card}>
+      <TouchableOpacity
+        style={[styles.paymentOption, styles.centerRow]}
+        onPress={select}
+        accessibilityHint={info.a11y}
+      >
+        <View style={styles.column}>
+          <View style={styles.row}>
+            <View style={styles.centerRow}>
+              <RadioView checked={selected} />
+              <ThemeText>{info.text}</ThemeText>
+              {option.savedType === 'recurring' ? (
+                <ThemeText style={styles.maskedPanPadding}>
+                  **** {`${option.recurringCard.masked_pan}`}
+                </ThemeText>
+              ) : null}
+            </View>
+            {info.icon}
+          </View>
+          {option.savedType === 'recurring' &&
+          option.recurringCard.expires_at ? (
+            <View>
+              <ThemeText style={styles.masked}>
+                {getExpireDate(option.recurringCard.expires_at)}
+              </ThemeText>
+            </View>
           ) : null}
         </View>
-        {option.savedType === 'recurring' ||
-        option.paymentType === PaymentType.Vipps
-          ? info.icon
-          : null}
-      </View>
+      </TouchableOpacity>
       {selected &&
       user?.phoneNumber &&
       option.savedType === 'normal' &&
       option.paymentType !== PaymentType.Vipps ? (
-        <View>
-          <ThemeText
-            style={{
-              paddingTop: 18,
-              opacity: 0.6,
-            }}
-          >
+        <TouchableOpacity
+          onPress={() => {
+            setSave(!save);
+          }}
+          style={styles.saveOptionSection}
+        >
+          <ThemeText style={styles.saveOptionTextPadding}>
             {t(SelectPaymentMethodTexts.save_payment_option_description.text)}
           </ThemeText>
-          <TouchableOpacity
-            style={styles.saveButton}
-            onPress={() => {
-              setSave(!save);
-            }}
-          >
+          <View style={styles.saveButton}>
             <SavedCheckbox checked={save} />
             <ThemeText>{t(SelectPaymentMethodTexts.save_card.text)}</ThemeText>
-          </TouchableOpacity>
-        </View>
+          </View>
+        </TouchableOpacity>
       ) : null}
-      {option.savedType === 'recurring' && option.recurringCard.expires_at ? (
-        <View>
-          <ThemeText style={styles.masked}>
-            {getExpireDate(option.recurringCard.expires_at)}
-          </ThemeText>
-        </View>
-      ) : null}
-    </TouchableOpacity>
+    </View>
   );
 };
 
@@ -393,21 +378,30 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   heading: {
     flex: 1,
     flexDirection: 'row',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     paddingBottom: 24,
   },
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  column: {flex: 1, flexDirection: 'column'},
+  card: {
+    marginVertical: 6,
+    borderRadius: 8,
+    backgroundColor: theme.colors.background_0.backgroundColor,
+  },
+  saveOptionSection: {paddingHorizontal: 24, paddingBottom: 24},
   container: {
     flex: 1,
-    //maxHeight: Dimensions.get('screen').height - 60,
     backgroundColor: theme.colors.background_2.backgroundColor,
     paddingHorizontal: 12,
   },
+  rowJustifyEnd: {flex: 1, flexDirection: 'row', justifyContent: 'flex-end'},
   paymentOption: {
     flex: 1,
     flexDirection: 'column',
-    marginVertical: 6,
     padding: 24,
-    backgroundColor: theme.colors.background_0.backgroundColor,
     borderRadius: 8,
   },
   centerRow: {
@@ -463,6 +457,20 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     opacity: 0.6,
     paddingTop: 18,
     paddingLeft: 36,
+  },
+  confirmButtonMargin: {
+    marginTop: 6,
+  },
+  listMaxHeight: {
+    maxHeight:
+      Dimensions.get('screen').height - Dimensions.get('screen').height / 3,
+  },
+  maskedPanPadding: {
+    paddingLeft: 8,
+  },
+  saveOptionTextPadding: {
+    paddingTop: 18,
+    opacity: 0.6,
   },
 }));
 

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -379,7 +379,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'flex-start',
-    paddingBottom: 24,
+    paddingBottom: theme.spacings.xLarge,
   },
   row: {
     flex: 1,

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -4,12 +4,17 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  Dimensions,
 } from 'react-native';
 import {Vipps} from '@atb/assets/svg/icons/ticketing';
 import {StyleSheet, useTheme} from '@atb/theme';
 import Button from '@atb/components/button';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {PurchaseConfirmationTexts, useTranslation} from '@atb/translations';
+import {
+  PurchaseConfirmationTexts,
+  ScreenHeaderTexts,
+  useTranslation,
+} from '@atb/translations';
 import {useState, useEffect} from 'react';
 import {ArrowRight} from '@atb/assets/svg/icons/navigation';
 import {SavedPaymentOption} from '@atb/preferences';
@@ -25,6 +30,7 @@ import {useAuthState} from '@atb/auth';
 
 type Props = {
   onSelect: (value: PaymentMethod) => void;
+  close: () => void;
   previousPaymentMethod?: SavedPaymentOption;
 };
 
@@ -74,6 +80,7 @@ function isRecurring(
 const SelectPaymentMethod: React.FC<Props> = ({
   onSelect,
   previousPaymentMethod,
+  close,
 }) => {
   const {t} = useTranslation();
 
@@ -131,14 +138,35 @@ const SelectPaymentMethod: React.FC<Props> = ({
   }, [previousPaymentMethod]);
 
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.heading}>
-        <ThemeText type="heading__title">
-          {t(SelectPaymentMethodTexts.header.text)}
-        </ThemeText>
+    <SafeAreaView style={[styles.container]}>
+      <View style={{flex: 1, flexDirection: 'row'}}>
+        <View style={styles.heading}>
+          <ThemeText type="heading__title">
+            {t(SelectPaymentMethodTexts.header.text)}
+          </ThemeText>
+        </View>
+        <View
+          style={{flex: 1, flexDirection: 'row', justifyContent: 'flex-end'}}
+        >
+          <TouchableOpacity
+            onPress={close}
+            accessibilityHint={t(
+              ScreenHeaderTexts.headerButton.cancel.a11yHint,
+            )}
+          >
+            <ThemeText>
+              {t(ScreenHeaderTexts.headerButton.cancel.text)}
+            </ThemeText>
+          </TouchableOpacity>
+        </View>
       </View>
       {loadingRemoteOption ? <ActivityIndicator /> : null}
       <FlatList
+        style={{
+          maxHeight:
+            Dimensions.get('screen').height -
+            Dimensions.get('screen').height / 3,
+        }}
         data={options}
         keyExtractor={(item) =>
           `${item.paymentType}_${
@@ -370,6 +398,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   container: {
     flex: 1,
+    //maxHeight: Dimensions.get('screen').height - 60,
     backgroundColor: theme.colors.background_2.backgroundColor,
     paddingHorizontal: 12,
   },


### PR DESCRIPTION
> Uten innlogging
> 
>     Med VoiceOver så leser valgmodul opp "Betal med ... - aktiver for å betale med ..." uavhengig av om denne allerede er valgt.
>     Markering av en betalingsmåte gir ingen feedback på hverken VoiceOver eller TalkBack at denne er valgt.
>     Android 7.0 / Talkback: Fra billettkjøp, velger jeg "Velg betalingsmåte". Header "Velg betalingsmåte" blir ikke lest opp.
> 
> Med innlogging
> 
>     Med både VoiceOver og TalkBack så er det ikke alltid header kommer i fokus. Kan være avhengig av om jeg har vært "inne der før" og gjort en betaling.
>     Med VoiceOver så får jeg ikke markert lagre-kort-checkbox. Sveip til høyre og venstre veksler kun mellom betalingsmåtene og kommer ikke innom lagre-kort-checkbox (dette skjer ikke med TalkBack).
>     Med VoiceOver så får jeg ikke markert lagre-kort-checkbox. Ikke med enkelttrykk eller dobbelttrykk. Henger sammen med observasjon over (dette skjer ikke med TalkBack)?
>     Med TalkBack så er det ingen hørbar feedback når lagre-kort-checkbox velges

Dette er det jeg har prøvd å ordne opp i 😊