### PR TITLE
feat: show warning when user tries to log in with active ticket

### DIFF
--- a/src/login/ActiveTicketPrompt.tsx
+++ b/src/login/ActiveTicketPrompt.tsx
@@ -10,18 +10,9 @@ import {LeftButtonProps, RightButtonProps} from '@atb/components/screen-header';
 import useFocusOnLoad from '@atb/utils/use-focus-on-load';
 import {ThemeColor} from '@atb/theme/colors';
 import {useNavigation} from '@react-navigation/native';
-import {TicketIllustration, Psst} from '@atb/assets/svg/illustrations';
 import {TouchableOpacity} from 'react-native';
-import TicketInfo, {
-  TicketInfoView,
-} from '@atb/screens/Ticketing/Ticket/TicketInfo';
-import {
-  filterActiveFareContracts,
-  isPreactivatedTicket,
-  useTicketState,
-} from '@atb/tickets';
+import {useTicketState} from '@atb/tickets';
 import SimpleTicket from '@atb/screens/Ticketing/Ticket';
-import {getValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
 
 const themeColor: ThemeColor = 'background_gray';
 
@@ -39,21 +30,8 @@ export default function ActiveTicketPrompt({
   const navigation = useNavigation();
   const styles = useThemeStyles();
   const focusRef = useFocusOnLoad();
-  const {fareContracts, isRefreshingTickets, refreshTickets} = useTicketState();
+  const {fareContracts} = useTicketState();
   const [now, setNow] = useState<number>(Date.now());
-
-  // const firstTravelRight = fareContracts[0].travelRights?.[0];
-  // if (isPreactivatedTicket(firstTravelRight)) {
-  //   const {startDateTime, endDateTime} = firstTravelRight;
-  //   const validTo = endDateTime.toMillis();
-  //   const validFrom = startDateTime.toMillis();
-  //   const validityStatus = getValidityStatus(
-  //     now,
-  //     validFrom,
-  //     validTo,
-  //     fareContracts[0].state,
-  //   );
-  // }
 
   const onNext = async () => {
     doAfterSubmit();

--- a/src/login/ActiveTicketPrompt.tsx
+++ b/src/login/ActiveTicketPrompt.tsx
@@ -1,0 +1,171 @@
+import FullScreenHeader from '@atb/components/screen-header/full-header';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {LoginTexts, useTranslation} from '@atb/translations';
+import React, {useState} from 'react';
+import {ScrollView, View} from 'react-native';
+import Button from '@atb/components/button';
+import ThemeText from '@atb/components/text';
+import {ArrowRight} from '@atb/assets/svg/icons/navigation';
+import {LeftButtonProps, RightButtonProps} from '@atb/components/screen-header';
+import useFocusOnLoad from '@atb/utils/use-focus-on-load';
+import {ThemeColor} from '@atb/theme/colors';
+import {useNavigation} from '@react-navigation/native';
+import {TicketIllustration, Psst} from '@atb/assets/svg/illustrations';
+import {TouchableOpacity} from 'react-native';
+import TicketInfo, {
+  TicketInfoView,
+} from '@atb/screens/Ticketing/Ticket/TicketInfo';
+import {
+  filterActiveFareContracts,
+  isPreactivatedTicket,
+  useTicketState,
+} from '@atb/tickets';
+import SimpleTicket from '@atb/screens/Ticketing/Ticket';
+import {getValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
+
+const themeColor: ThemeColor = 'background_gray';
+
+export default function ActiveTicketPrompt({
+  headerLeftButton,
+  doAfterSubmit,
+  headerRightButton,
+}: {
+  loginReason?: string;
+  doAfterSubmit: () => void;
+  headerLeftButton?: LeftButtonProps;
+  headerRightButton?: RightButtonProps;
+}) {
+  const {t} = useTranslation();
+  const navigation = useNavigation();
+  const styles = useThemeStyles();
+  const focusRef = useFocusOnLoad();
+  const {fareContracts, isRefreshingTickets, refreshTickets} = useTicketState();
+  const [now, setNow] = useState<number>(Date.now());
+
+  // const firstTravelRight = fareContracts[0].travelRights?.[0];
+  // if (isPreactivatedTicket(firstTravelRight)) {
+  //   const {startDateTime, endDateTime} = firstTravelRight;
+  //   const validTo = endDateTime.toMillis();
+  //   const validFrom = startDateTime.toMillis();
+  //   const validityStatus = getValidityStatus(
+  //     now,
+  //     validFrom,
+  //     validTo,
+  //     fareContracts[0].state,
+  //   );
+  // }
+
+  const onNext = async () => {
+    doAfterSubmit();
+  };
+
+  return (
+    <View style={styles.container}>
+      <FullScreenHeader
+        leftButton={headerLeftButton}
+        rightButton={headerRightButton}
+        setFocusOnLoad={false}
+        color={themeColor}
+      />
+
+      <ScrollView centerContent={true} contentContainerStyle={styles.mainView}>
+        <View accessible={true} accessibilityRole="header" ref={focusRef}>
+          <ThemeText
+            type={'body__primary--jumbo--bold'}
+            style={styles.title}
+            color={themeColor}
+          >
+            Du har en aktiv billett
+          </ThemeText>
+        </View>
+        <View accessible={true}>
+          <ThemeText
+            style={styles.description}
+            color={themeColor}
+            isMarkdown={true}
+          >
+            Når du logger inn vil dine anonyme billetter **ikke** kunne
+            overføres til din profil. Hvis du ønsker å beholde din aktive
+            billett venter du med innloggingen til billetten har utløpt.
+          </ThemeText>
+        </View>
+        <View style={styles.ticket}>
+          <SimpleTicket
+            fareContract={fareContracts[0]}
+            now={now}
+            onPressDetails={() =>
+              navigation.navigate('TicketModal', {
+                screen: 'TicketDetails',
+                params: {orderId: fareContracts[0].orderId},
+              })
+            }
+          />
+        </View>
+        <Button
+          color={'primary_2'}
+          onPress={navigation.goBack}
+          text={'Logg inn senere'}
+          icon={ArrowRight}
+          iconPosition="right"
+        />
+        <TouchableOpacity
+          style={styles.laterButton}
+          onPress={onNext}
+          accessibilityRole="button"
+        >
+          <ThemeText
+            style={styles.laterButtonText}
+            type="body__primary"
+            color={themeColor}
+          >
+            Jeg vil logge inn likevel
+          </ThemeText>
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+}
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    backgroundColor: theme.colors[themeColor].backgroundColor,
+    flex: 1,
+  },
+  mainView: {
+    padding: theme.spacings.large,
+  },
+  title: {
+    textAlign: 'center',
+    marginVertical: theme.spacings.medium,
+  },
+  loginReason: {
+    marginTop: theme.spacings.medium,
+  },
+  description: {
+    marginVertical: theme.spacings.medium,
+    textAlign: 'center',
+  },
+  errorMessage: {
+    marginBottom: theme.spacings.medium,
+  },
+  ticket: {
+    marginVertical: theme.spacings.large,
+  },
+  illustation: {
+    alignSelf: 'center',
+    marginVertical: theme.spacings.medium,
+  },
+  laterButton: {
+    marginTop: theme.spacings.medium,
+    padding: theme.spacings.medium,
+    marginBottom: theme.spacings.xLarge,
+  },
+  laterButtonText: {textAlign: 'center'},
+  carrotInfo: {
+    margin: theme.spacings.xLarge,
+    marginBottom: theme.spacings.xLarge,
+  },
+  carrotTitle: {
+    marginVertical: theme.spacings.medium,
+  },
+}));

--- a/src/login/ActiveTicketPrompt.tsx
+++ b/src/login/ActiveTicketPrompt.tsx
@@ -75,7 +75,7 @@ export default function ActiveTicketPrompt({
             style={styles.title}
             color={themeColor}
           >
-            Du har en aktiv billett
+            {t(LoginTexts.activeTicketPrompt.title)}
           </ThemeText>
         </View>
         <View accessible={true}>
@@ -84,9 +84,7 @@ export default function ActiveTicketPrompt({
             color={themeColor}
             isMarkdown={true}
           >
-            Når du logger inn vil dine anonyme billetter **ikke** kunne
-            overføres til din profil. Hvis du ønsker å beholde din aktive
-            billett venter du med innloggingen til billetten har utløpt.
+            {t(LoginTexts.activeTicketPrompt.body)}
           </ThemeText>
         </View>
         <View style={styles.ticket}>
@@ -104,7 +102,7 @@ export default function ActiveTicketPrompt({
         <Button
           color={'primary_2'}
           onPress={navigation.goBack}
-          text={'Logg inn senere'}
+          text={t(LoginTexts.activeTicketPrompt.laterButton)}
           icon={ArrowRight}
           iconPosition="right"
         />
@@ -118,7 +116,7 @@ export default function ActiveTicketPrompt({
             type="body__primary"
             color={themeColor}
           >
-            Jeg vil logge inn likevel
+            {t(LoginTexts.activeTicketPrompt.continueButton)}
           </ThemeText>
         </TouchableOpacity>
       </ScrollView>

--- a/src/login/ActiveTicketPrompt.tsx
+++ b/src/login/ActiveTicketPrompt.tsx
@@ -1,5 +1,5 @@
 import FullScreenHeader from '@atb/components/screen-header/full-header';
-import {StyleSheet, useTheme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {LoginTexts, useTranslation} from '@atb/translations';
 import React, {useState} from 'react';
 import {ScrollView, View} from 'react-native';
@@ -21,7 +21,6 @@ export default function ActiveTicketPrompt({
   doAfterSubmit,
   headerRightButton,
 }: {
-  loginReason?: string;
   doAfterSubmit: () => void;
   headerLeftButton?: LeftButtonProps;
   headerRightButton?: RightButtonProps;
@@ -113,9 +112,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   title: {
     textAlign: 'center',
     marginVertical: theme.spacings.medium,
-  },
-  loginReason: {
-    marginTop: theme.spacings.medium,
   },
   description: {
     marginVertical: theme.spacings.medium,

--- a/src/login/LoginOnboarding.tsx
+++ b/src/login/LoginOnboarding.tsx
@@ -112,9 +112,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     textAlign: 'center',
     marginVertical: theme.spacings.medium,
   },
-  loginReason: {
-    marginTop: theme.spacings.medium,
-  },
   description: {
     marginVertical: theme.spacings.medium,
     textAlign: 'center',

--- a/src/login/LoginOnboarding.tsx
+++ b/src/login/LoginOnboarding.tsx
@@ -12,17 +12,16 @@ import {ThemeColor} from '@atb/theme/colors';
 import {useNavigation} from '@react-navigation/native';
 import {TicketIllustration, Psst} from '@atb/assets/svg/illustrations';
 import {TouchableOpacity} from 'react-native';
+import {filterActiveFareContracts, useTicketState} from '@atb/tickets';
 
 const themeColor: ThemeColor = 'background_gray';
 
 export default function LoginOnboarding({
-  loginReason,
   headerLeftButton,
   doAfterSubmit,
   headerRightButton,
 }: {
-  loginReason?: string;
-  doAfterSubmit: () => void;
+  doAfterSubmit: (hasActiveFareContracts: boolean) => void;
   headerLeftButton?: LeftButtonProps;
   headerRightButton?: RightButtonProps;
 }) {
@@ -31,8 +30,10 @@ export default function LoginOnboarding({
   const styles = useThemeStyles();
   const focusRef = useFocusOnLoad();
 
+  const {fareContracts} = useTicketState();
+  const activeFareContracts = filterActiveFareContracts(fareContracts);
   const onNext = async () => {
-    doAfterSubmit();
+    doAfterSubmit(activeFareContracts.length > 0);
   };
 
   return (

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -23,12 +23,10 @@ import {ThemeColor} from '@atb/theme/colors';
 const themeColor: ThemeColor = 'background_gray';
 
 export default function PhoneInput({
-  loginReason,
   doAfterLogin,
   headerLeftButton,
   headerRightButton,
 }: {
-  loginReason?: string;
   doAfterLogin: (phoneNumber: string) => void;
   headerLeftButton?: LeftButtonProps;
   headerRightButton?: RightButtonProps;
@@ -92,11 +90,6 @@ export default function PhoneInput({
             </ThemeText>
           </View>
           <View accessible={true}>
-            {loginReason && (
-              <ThemeText style={styles.loginReason} color={themeColor}>
-                {loginReason}
-              </ThemeText>
-            )}
             <ThemeText style={styles.description} color={themeColor}>
               {t(LoginTexts.phoneInput.description)}
             </ThemeText>
@@ -165,10 +158,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   title: {
     textAlign: 'center',
     marginVertical: theme.spacings.medium,
-  },
-  loginReason: {
-    marginTop: theme.spacings.medium,
-    textAlign: 'center',
   },
   description: {
     marginVertical: theme.spacings.large,

--- a/src/login/in-app/ActiveTicketPrompt.tsx
+++ b/src/login/in-app/ActiveTicketPrompt.tsx
@@ -1,17 +1,12 @@
 import {StackNavigationProp} from '@react-navigation/stack';
 import React from 'react';
 
-import LoginOnboarding from '@atb/login/LoginOnboarding';
 import {RouteProp} from '@react-navigation/native';
 import {LoginInAppStackParams} from '@atb/login/in-app/LoginInAppStack';
 import {AfterLoginParams} from '@atb/login/types';
 import ActiveTicketPrompt from '../ActiveTicketPrompt';
 
 export type ActiveTicketPromptInAppRouteParams = {
-  /**
-   * An optional message to the user why the login is necessary
-   */
-  loginReason?: string;
   afterLogin: AfterLoginParams;
 };
 

--- a/src/login/in-app/ActiveTicketPrompt.tsx
+++ b/src/login/in-app/ActiveTicketPrompt.tsx
@@ -32,6 +32,6 @@ export const ActiveTicketPromptInApp = ({
         afterLogin,
       });
     }}
-    headerLeftButton={{type: 'cancel'}}
+    headerLeftButton={{type: 'back'}}
   />
 );

--- a/src/login/in-app/ActiveTicketPrompt.tsx
+++ b/src/login/in-app/ActiveTicketPrompt.tsx
@@ -2,12 +2,12 @@ import {StackNavigationProp} from '@react-navigation/stack';
 import React from 'react';
 
 import LoginOnboarding from '@atb/login/LoginOnboarding';
-// import LoginOnboarding from '@atb/login/LoginOnboarding';
 import {RouteProp} from '@react-navigation/native';
 import {LoginInAppStackParams} from '@atb/login/in-app/LoginInAppStack';
 import {AfterLoginParams} from '@atb/login/types';
+import ActiveTicketPrompt from '../ActiveTicketPrompt';
 
-export type LoginOnboardingInAppRouteParams = {
+export type ActiveTicketPromptInAppRouteParams = {
   /**
    * An optional message to the user why the login is necessary
    */
@@ -15,29 +15,29 @@ export type LoginOnboardingInAppRouteParams = {
   afterLogin: AfterLoginParams;
 };
 
-type LoginOnboardingInAppRouteProps = RouteProp<
+type ActiveTicketPromptInAppRouteProps = RouteProp<
   LoginInAppStackParams,
-  'PhoneInputInApp'
+  'ActiveTicketPromptInApp'
 >;
 
-export type LoginOnboardingProps = {
+export type ActiveTicketPromptProps = {
   navigation: StackNavigationProp<LoginInAppStackParams>;
-  route: LoginOnboardingInAppRouteProps;
+  route: ActiveTicketPromptInAppRouteProps;
 };
 
-export const LoginOnboardingInApp = ({
+export const ActiveTicketPromptInApp = ({
   navigation,
   route: {
     params: {loginReason, afterLogin},
   },
-}: LoginOnboardingProps) => (
-  <LoginOnboarding
+}: ActiveTicketPromptProps) => (
+  <ActiveTicketPrompt
     loginReason={loginReason}
-    doAfterSubmit={() =>
-      navigation.navigate('PhoneInputInApp', {
+    doAfterSubmit={() => {
+      navigation.navigate('LoginOnboardingInApp', {
         afterLogin,
-      })
-    }
-    headerLeftButton={{type: 'back'}}
+      });
+    }}
+    headerLeftButton={{type: 'cancel'}}
   />
 );

--- a/src/login/in-app/ActiveTicketPrompt.tsx
+++ b/src/login/in-app/ActiveTicketPrompt.tsx
@@ -28,13 +28,12 @@ export type ActiveTicketPromptProps = {
 export const ActiveTicketPromptInApp = ({
   navigation,
   route: {
-    params: {loginReason, afterLogin},
+    params: {afterLogin},
   },
 }: ActiveTicketPromptProps) => (
   <ActiveTicketPrompt
-    loginReason={loginReason}
     doAfterSubmit={() => {
-      navigation.navigate('LoginOnboardingInApp', {
+      navigation.navigate('PhoneInputInApp', {
         afterLogin,
       });
     }}

--- a/src/login/in-app/LoginInAppStack.tsx
+++ b/src/login/in-app/LoginInAppStack.tsx
@@ -8,14 +8,18 @@ import {
   PhoneInputInApp,
   PhoneInputInAppRouteParams,
 } from '@atb/login/in-app/PhoneInputInApp';
-
 import {
   LoginOnboardingInApp,
   LoginOnboardingInAppRouteParams,
 } from '@atb/login/in-app/LoginOnboarding';
+import {
+  ActiveTicketPromptInApp,
+  ActiveTicketPromptInAppRouteParams,
+} from '@atb/login/in-app/ActiveTicketPrompt';
 
 export type LoginInAppStackParams = {
-  LoginOnboarding: LoginOnboardingInAppRouteParams;
+  LoginOnboardingInApp: LoginOnboardingInAppRouteParams;
+  ActiveTicketPromptInApp: ActiveTicketPromptInAppRouteParams;
   PhoneInputInApp: PhoneInputInAppRouteParams;
   ConfirmCodeInApp: ConfirmCodeInAppRouteParams;
 };
@@ -26,9 +30,16 @@ export default function LoginInAppStack() {
   return (
     <Stack.Navigator
       screenOptions={{headerShown: false}}
-      initialRouteName="LoginOnboarding"
+      initialRouteName="ActiveTicketPromptInApp"
     >
-      <Stack.Screen name="LoginOnboarding" component={LoginOnboardingInApp} />
+      <Stack.Screen
+        name="ActiveTicketPromptInApp"
+        component={ActiveTicketPromptInApp}
+      />
+      <Stack.Screen
+        name="LoginOnboardingInApp"
+        component={LoginOnboardingInApp}
+      />
       <Stack.Screen name="PhoneInputInApp" component={PhoneInputInApp} />
       <Stack.Screen name="ConfirmCodeInApp" component={ConfirmCodeInApp} />
     </Stack.Navigator>

--- a/src/login/in-app/LoginOnboarding.tsx
+++ b/src/login/in-app/LoginOnboarding.tsx
@@ -38,6 +38,6 @@ export const LoginOnboardingInApp = ({
         });
       }
     }}
-    headerLeftButton={{type: 'back'}}
+    headerLeftButton={{type: 'cancel'}}
   />
 );

--- a/src/login/in-app/LoginOnboarding.tsx
+++ b/src/login/in-app/LoginOnboarding.tsx
@@ -32,12 +32,17 @@ export const LoginOnboardingInApp = ({
   },
 }: LoginOnboardingProps) => (
   <LoginOnboarding
-    loginReason={loginReason}
-    doAfterSubmit={() =>
-      navigation.navigate('PhoneInputInApp', {
-        afterLogin,
-      })
-    }
+    doAfterSubmit={(hasActiveFareContracts: boolean) => {
+      if (hasActiveFareContracts) {
+        navigation.navigate('ActiveTicketPromptInApp', {
+          afterLogin,
+        });
+      } else {
+        navigation.navigate('PhoneInputInApp', {
+          afterLogin,
+        });
+      }
+    }}
     headerLeftButton={{type: 'back'}}
   />
 );

--- a/src/login/in-app/LoginOnboarding.tsx
+++ b/src/login/in-app/LoginOnboarding.tsx
@@ -2,16 +2,11 @@ import {StackNavigationProp} from '@react-navigation/stack';
 import React from 'react';
 
 import LoginOnboarding from '@atb/login/LoginOnboarding';
-// import LoginOnboarding from '@atb/login/LoginOnboarding';
 import {RouteProp} from '@react-navigation/native';
 import {LoginInAppStackParams} from '@atb/login/in-app/LoginInAppStack';
 import {AfterLoginParams} from '@atb/login/types';
 
 export type LoginOnboardingInAppRouteParams = {
-  /**
-   * An optional message to the user why the login is necessary
-   */
-  loginReason?: string;
   afterLogin: AfterLoginParams;
 };
 
@@ -28,7 +23,7 @@ export type LoginOnboardingProps = {
 export const LoginOnboardingInApp = ({
   navigation,
   route: {
-    params: {loginReason, afterLogin},
+    params: {afterLogin},
   },
 }: LoginOnboardingProps) => (
   <LoginOnboarding

--- a/src/login/in-app/PhoneInputInApp.tsx
+++ b/src/login/in-app/PhoneInputInApp.tsx
@@ -6,10 +6,6 @@ import {LoginInAppStackParams} from '@atb/login/in-app/LoginInAppStack';
 import {AfterLoginParams} from '@atb/login/types';
 
 export type PhoneInputInAppRouteParams = {
-  /**
-   * An optional message to the user why the login is necessary
-   */
-  loginReason?: string;
   afterLogin: AfterLoginParams;
 };
 
@@ -26,11 +22,10 @@ export type PhoneInputInAppProps = {
 export const PhoneInputInApp = ({
   navigation,
   route: {
-    params: {loginReason, afterLogin},
+    params: {afterLogin},
   },
 }: PhoneInputInAppProps) => (
   <PhoneInput
-    loginReason={loginReason}
     doAfterLogin={(phoneNumber: string) =>
       navigation.navigate('ConfirmCodeInApp', {
         afterLogin,

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -39,8 +39,6 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const {abtCustomerId, authenticationType} = useAuthState();
   const {t} = useTranslation();
   const appContext = useAppState();
-  const {fareContracts} = useTicketState();
-  const activeFareContracts = filterActiveFareContracts(fareContracts);
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 
@@ -67,7 +65,6 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
       navigation.navigate('LoginInApp', {
         screen: 'LoginOnboardingInApp',
         params: {
-          loginReason: t(TicketsTexts.buyTicketsTab.loginReason),
           afterLogin: {
             routeName: 'TicketPurchase',
             routeParams: {selectableProductType: 'period'},

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -63,17 +63,6 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
           selectableProductType: 'period',
         },
       });
-    } else if (activeFareContracts.length > 0) {
-      navigation.navigate('LoginInApp', {
-        screen: 'ActiveTicketPromptInApp',
-        params: {
-          loginReason: t(TicketsTexts.buyTicketsTab.loginReason),
-          afterLogin: {
-            routeName: 'TicketPurchase',
-            routeParams: {selectableProductType: 'period'},
-          },
-        },
-      });
     } else {
       navigation.navigate('LoginInApp', {
         screen: 'LoginOnboardingInApp',

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -39,6 +39,8 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const {abtCustomerId, authenticationType} = useAuthState();
   const {t} = useTranslation();
   const appContext = useAppState();
+  const {fareContracts} = useTicketState();
+  const activeFareContracts = filterActiveFareContracts(fareContracts);
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 
@@ -61,9 +63,20 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
           selectableProductType: 'period',
         },
       });
+    } else if (activeFareContracts.length > 0) {
+      navigation.navigate('LoginInApp', {
+        screen: 'ActiveTicketPromptInApp',
+        params: {
+          loginReason: t(TicketsTexts.buyTicketsTab.loginReason),
+          afterLogin: {
+            routeName: 'TicketPurchase',
+            routeParams: {selectableProductType: 'period'},
+          },
+        },
+      });
     } else {
       navigation.navigate('LoginInApp', {
-        screen: 'LoginOnboarding',
+        screen: 'LoginOnboardingInApp',
         params: {
           loginReason: t(TicketsTexts.buyTicketsTab.loginReason),
           afterLogin: {

--- a/src/translations/screens/Tickets.ts
+++ b/src/translations/screens/Tickets.ts
@@ -9,10 +9,6 @@ const TicketsTexts = {
   buyTicketsTab: {
     label: _('Kjøp', 'Buy'),
     a11yLabel: _('Kjøp billetter', 'Buy tickets'),
-    loginReason: _(
-      'For å kjøpe periodebillett må du være logget inn.',
-      'To buy a period ticket you have to be signed in.',
-    ),
     button: {
       single: {
         text: _('Ny enkeltbillett', 'New single ticket'),

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -1,5 +1,14 @@
 import {translation as _} from '../../commons';
 const LoginTexts = {
+  activeTicketPrompt: {
+    title: _('Du har en aktiv billett', 'You have an active ticket'),
+    body: _(
+      'Når du logger inn vil dine anonyme billetter **ikke** kunne overføres til din profil. Hvis du ønsker å beholde din aktive billett venter du med innloggingen til billetten har utløpt.',
+      'When you log in, your anonymous tickets will **not** be transferred to your profile. If you want to keep your active ticket, wait for it to expire before logging in.',
+    ),
+    laterButton: _('Logg inn senere', 'Log in later'),
+    continueButton: _('Jeg vil logge inn likevel', 'I want to log in anyway'),
+  },
   onboarding: {
     title: _(
       'Nå kan du kjøpe periodebilletter!',

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -22,7 +22,7 @@ const LoginTexts = {
     laterButton: _('Jeg vil logge inn senere', 'I want to log in later'),
     carrotTitle: _('Det er lurt å logge inn', 'Smart travellers log in...'),
     carrotBody: _(
-      'Da kan du også lagre betalingskort og etter hvert andre smarte reiseting slik at du enkelt finner dem igjen – selv ved bytte av mobil.',
+      'Da kan du også lagre betalingskort og etterhvert andre smarte reiseting slik at du enkelt finner dem igjen – selv ved bytte av mobil.',
       '...to store payment cards for later use. Soon, login will store personal preferences to your profile so that you can carry them with you when swapping phones.',
     ),
   },

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -1,10 +1,13 @@
 import {translation as _} from '../../commons';
 const LoginTexts = {
   activeTicketPrompt: {
-    title: _('Du har en aktiv billett', 'You have an active ticket'),
+    title: _(
+      'Vent litt, du har en gyldig billett',
+      'Wait a sec – you have a valid ticket',
+    ),
     body: _(
-      'Når du logger inn vil dine anonyme billetter **ikke** kunne overføres til din profil. Hvis du ønsker å beholde din aktive billett venter du med innloggingen til billetten har utløpt.',
-      'When you log in, your anonymous tickets will **not** be transferred to your profile. If you want to keep your active ticket, wait for it to expire before logging in.',
+      'Billetten kan **ikke** overføres til din profil og vil slettes ved innlogging. Dersom du trenger billetten, vent til den er utløpt **før** du logger inn.',
+      'This ticket can **not** be transferred to your profile, and will be deleted upon login. If you need the ticket, wait until it has expired **before** logging in.',
     ),
     laterButton: _('Logg inn senere', 'Log in later'),
     continueButton: _('Jeg vil logge inn likevel', 'I want to log in anyway'),


### PR DESCRIPTION
Lagt til ny skjerm med info til brukere som prøver å logge inn med aktive billetter, `ActiveTicketPrompt`. Fjernet også `loginReason` fra PhoneInput.tsx, siden denne ikke lenger er i bruk (c992fa3727f57c03b447f336fc1c774d0ff5aae4). 

https://user-images.githubusercontent.com/1774972/134673392-afdf499e-c9da-43f1-ab1a-eec82a8c3d47.mp4


Todo:

- [x] Se over ordlyd og oversettelser @magnusolderoesaether :
```jsx
{
title: _(
	'Du har en aktiv billett', 
	'You have an active ticket'
),
body: _(
	'Når du logger inn vil dine anonyme billetter **ikke** kunne overføres til din profil. Hvis du ønsker å beholde din aktive billett venter du med innloggingen til billetten har utløpt.',
	'When you log in, your anonymous tickets will **not** be transferred to your profile. If you want to keep your active ticket, wait for it to expire before logging in.',
),
laterButton: _(
	'Logg inn senere', 
	'Log in later'
),
continueButton: _(
	'Jeg vil logge inn likevel', 
	'I want to log in anyway'
),
}
```

closes #1597 