### PR TITLE
fix: hide `SimpleTicket` details on `ActiveTicketPrompt` screen

### DIFF
--- a/src/login/ActiveTicketPrompt.tsx
+++ b/src/login/ActiveTicketPrompt.tsx
@@ -68,12 +68,7 @@ export default function ActiveTicketPrompt({
           <SimpleTicket
             fareContract={fareContracts[0]}
             now={now}
-            onPressDetails={() =>
-              navigation.navigate('TicketModal', {
-                screen: 'TicketDetails',
-                params: {orderId: fareContracts[0].orderId},
-              })
-            }
+            hideDetails={true}
           />
         </View>
         <Button

--- a/src/screens/Ticketing/Ticket/index.tsx
+++ b/src/screens/Ticketing/Ticket/index.tsx
@@ -11,12 +11,14 @@ import {getValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
 type Props = {
   fareContract: FareContract;
   now: number;
-  onPressDetails: () => void;
+  hideDetails?: boolean;
+  onPressDetails?: () => void;
 };
 
 const SimpleTicket: React.FC<Props> = ({
   fareContract: fc,
   now,
+  hideDetails,
   onPressDetails,
 }) => {
   const {t} = useTranslation();
@@ -48,14 +50,16 @@ const SimpleTicket: React.FC<Props> = ({
             status={validityStatus}
           />
         </Sections.GenericItem>
-        <Sections.LinkItem
-          text={t(
-            validityStatus === 'valid'
-              ? TicketTexts.detailsLink.valid
-              : TicketTexts.detailsLink.notValid,
-          )}
-          onPress={onPressDetails}
-        />
+        {!hideDetails && (
+          <Sections.LinkItem
+            text={t(
+              validityStatus === 'valid'
+                ? TicketTexts.detailsLink.valid
+                : TicketTexts.detailsLink.notValid,
+            )}
+            onPress={onPressDetails}
+          />
+        )}
       </Sections.Section>
     );
   } else {


### PR DESCRIPTION
Oppdaterer `SimpleTicket` til å ikke støtte billettkontroll i `ActiveTicketPrompt` skjermbildet, siden dette sikkert er uventet funksjonalitet for de fleste :)

Før/etter: (Se "Show details / inspections"-knappen)

![collage](https://user-images.githubusercontent.com/1774972/135087948-f6d2d714-8c24-4de3-9a55-c6aa0a366f37.png)
