### PR TITLE
fix: include prefix when calling `signInWithPhoneNumber`

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -150,7 +150,7 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
     async function signInWithPhoneNumber(phoneNumber: string) {
       try {
         const confirmationHandler = await auth().signInWithPhoneNumber(
-          '+47' + phoneNumber,
+          phoneNumber,
         );
         dispatch({type: 'SIGN_IN_INITIATED', confirmationHandler});
       } catch (error) {

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -147,10 +147,10 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
   }, [onUserChanged]);
 
   const signInWithPhoneNumber = useCallback(
-    async function signInWithPhoneNumber(phoneNumber: string) {
+    async function signInWithPhoneNumber(phoneNumberWithPrefix: string) {
       try {
         const confirmationHandler = await auth().signInWithPhoneNumber(
-          phoneNumber,
+          phoneNumberWithPrefix,
         );
         dispatch({type: 'SIGN_IN_INITIATED', confirmationHandler});
       } catch (error) {

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -75,7 +75,7 @@ export default function PhoneInput({
       setError('invalid_phone');
       return;
     }
-    const errorCode = await signInWithPhoneNumber(phoneNumber);
+    const errorCode = await signInWithPhoneNumber(phoneValidation.phoneNumber);
     if (!errorCode) {
       setError(undefined);
       doAfterLogin(phoneValidation.phoneNumber);


### PR DESCRIPTION
@tormoseng oppdaget en feil med at prefiks ikke kom med i kallet til `singInWithPhoneNumber`, og at `+47` fortsatt blir hardkodet inn i starten av alle mobilnummer når man prøver å logge inn.