### PR TITLE
fix: Fixed issue where expiredate 12/xx is represented as 00/xx+1

### DIFF
--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -290,6 +290,10 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
     let date = parseISO(iso);
     let year = date.getFullYear();
     let month = date.getMonth();
+    if (month === 0) {
+      month = 12;
+      year--;
+    }
     return `${month < 10 ? '0' + month : month}/${year.toString().slice(2, 4)}`;
   }
 


### PR DESCRIPTION
If the expiredate for a card was set to 12/xx the app would show 00/xx+1. This is now resolved.