### PR TITLE
fix: improve SelectPaymentMethod sheet consistency

### DIFF
--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -424,7 +424,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     borderRadius: theme.border.radius.regular,
     backgroundColor: theme.colors.background_0.backgroundColor,
   },
-  saveOptionSection: {paddingHorizontal: 24, paddingBottom: 24},
+  saveOptionSection: {
+    paddingHorizontal: theme.spacings.xLarge,
+    paddingBottom: theme.spacings.xLarge,
+  },
   container: {
     flex: 1,
     backgroundColor: theme.colors.background_2.backgroundColor,


### PR DESCRIPTION
Denne PRen wrapper SelectPaymentMethod i en BottomSheetContainer og gjør den konsistent med andre bottom sheets i appen.

Fikser også en bug hvor lagret betalingsmåte ble duplisert etter reload (3a87768863d082133c58fe8aea3f41e19770b5b8).

fixes AtB-AS/kundevendt#456 