### PR TITLE
chore: Add quick-copy link to Firestore for user

### DIFF
--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -44,7 +44,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
   const style = useProfileHomeStyle();
   const {clearHistory} = useSearchHistory();
   const {t} = useTranslation();
-  const {authenticationType, signOut, user} = useAuthState();
+  const {authenticationType, signOut, user, abtCustomerId} = useAuthState();
   const config = useLocalConfig();
 
   const {fareContracts} = useTicketState();
@@ -59,6 +59,13 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
 
   function copyInstallId() {
     if (config?.installId) setClipboard(config.installId);
+  }
+
+  function copyFirestoreLink() {
+    if (abtCustomerId)
+      setClipboard(
+        `https://console.firebase.google.com/u/1/project/atb-mobility-platform-staging/firestore/data/~2Fcustomers~2F${abtCustomerId}`,
+      );
   }
 
   return (
@@ -245,6 +252,11 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               onPress={() => {
                 appDispatch({type: 'RESTART_ONBOARDING'});
               }}
+            />
+            <Sections.LinkItem
+              text="Copy link to customer in Firestore (staging)"
+              icon="arrow-upleft"
+              onPress={() => copyFirestoreLink()}
             />
           </Sections.Section>
         )}


### PR DESCRIPTION
Så det er enklere å gå til kunden i Firestore ved debugging. Fant ingen gode "copy" ikoner i katalogen vår, så ble bare en random pil.

![image](https://user-images.githubusercontent.com/4932625/136914967-127fb9b2-6a8f-44e1-9830-8f3f08f1a097.png)
