### PR TITLE
refactor: make inspectable a prop instead of ticket status

### DIFF
--- a/src/screens/Ticketing/Ticket/Carnet/index.tsx
+++ b/src/screens/Ticketing/Ticket/Carnet/index.tsx
@@ -51,19 +51,18 @@ const CarnetTicketInfo: React.FC<Props> = ({
     fareContractValidFrom,
     fareContractValidTo,
     fareContractState,
-    isInspectable,
   );
 
   return (
     <Sections.Section withBottomPadding>
       <Sections.GenericItem>
-        {fareContractValidityStatus !== 'valid' &&
-        fareContractValidityStatus !== 'uninspectable' ? (
+        {fareContractValidityStatus !== 'valid' && isInspectable ? (
           <ValidityHeader
             now={now}
             status={fareContractValidityStatus}
             validFrom={fareContractValidFrom}
             validTo={fareContractValidTo}
+            isInspectable={isInspectable}
           />
         ) : (
           <UsedAccessValidityHeader
@@ -79,6 +78,7 @@ const CarnetTicketInfo: React.FC<Props> = ({
             now={now}
             validFrom={usedAccessValidFrom ?? 0}
             validTo={usedAccessValidTo ?? 0}
+            isInspectable={isInspectable}
           />
         )}
         <TicketInfo
@@ -86,6 +86,7 @@ const CarnetTicketInfo: React.FC<Props> = ({
           // makes no sense to show multiple for carnet travel rights
           travelRights={travelRights.slice(0, 1)}
           status={fareContractValidityStatus}
+          isInspectable={isInspectable}
         />
       </Sections.GenericItem>
       <Sections.GenericItem>

--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -39,13 +39,7 @@ const DetailsContent: React.FC<Props> = ({
       !hasActiveTravelCard &&
       firstTravelRight.type === 'PreActivatedSingleTicket';
 
-    const validityStatus = getValidityStatus(
-      now,
-      validFrom,
-      validTo,
-      fc.state,
-      isInspectable,
-    );
+    const validityStatus = getValidityStatus(now, validFrom, validTo, fc.state);
 
     const orderIdText = t(TicketTexts.details.orderId(fc.orderId));
 
@@ -57,17 +51,20 @@ const DetailsContent: React.FC<Props> = ({
             now={now}
             validFrom={validFrom}
             validTo={validTo}
+            isInspectable={isInspectable}
           />
           <ValidityLine
             status={validityStatus}
             now={now}
             validFrom={validFrom}
             validTo={validTo}
+            isInspectable={isInspectable}
           />
           <TicketInfo
             travelRights={fc.travelRights.filter(isPreactivatedTicket)}
             status={validityStatus}
             hasActiveTravelCard={hasActiveTravelCard}
+            isInspectable={isInspectable}
           />
         </Sections.GenericItem>
         <Sections.GenericItem>
@@ -92,7 +89,7 @@ const DetailsContent: React.FC<Props> = ({
           onPress={onReceiptNavigate}
           accessibility={{accessibilityRole: 'button'}}
         />
-        {validityStatus === 'valid' && qrCodeSvg && (
+        {validityStatus === 'valid' && isInspectable && qrCodeSvg && (
           <Sections.GenericItem>
             <View
               style={styles.qrCode}

--- a/src/screens/Ticketing/Ticket/PreactivatedTicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/PreactivatedTicketInfo.tsx
@@ -14,6 +14,7 @@ type Props = {
   isInspectable: boolean;
   hideDetails?: boolean;
   onPressDetails?: () => void;
+  hasActiveTravelCard: boolean;
 };
 
 const PreactivatedTicketInfo: React.FC<Props> = ({
@@ -23,6 +24,7 @@ const PreactivatedTicketInfo: React.FC<Props> = ({
   isInspectable,
   hideDetails,
   onPressDetails,
+  hasActiveTravelCard,
 }) => {
   const {t} = useTranslation();
 
@@ -35,30 +37,36 @@ const PreactivatedTicketInfo: React.FC<Props> = ({
     validFrom,
     validTo,
     fareContractState,
-    isInspectable,
   );
   return (
     <Sections.Section withBottomPadding>
       <Sections.GenericItem>
         <ValidityHeader
           status={validityStatus}
+          isInspectable={isInspectable}
           now={now}
           validFrom={validFrom}
           validTo={validTo}
         />
         <ValidityLine
           status={validityStatus}
+          isInspectable={isInspectable}
           now={now}
           validFrom={validFrom}
           validTo={validTo}
         />
 
-        <TicketInfo travelRights={travelRights} status={validityStatus} />
+        <TicketInfo
+          travelRights={travelRights}
+          status={validityStatus}
+          isInspectable={isInspectable}
+          hasActiveTravelCard={hasActiveTravelCard}
+        />
       </Sections.GenericItem>
       {!hideDetails && (
         <Sections.LinkItem
           text={t(
-            validityStatus === 'valid'
+            validityStatus === 'valid' && isInspectable
               ? TicketTexts.detailsLink.valid
               : TicketTexts.detailsLink.notValid,
           )}

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -27,12 +27,14 @@ type TicketInfoProps = {
   travelRights: PreactivatedTicket[];
   status: ValidityStatus | 'recent';
   hasActiveTravelCard?: boolean;
+  isInspectable: boolean;
 };
 
 const TicketInfo = ({
   travelRights,
   status,
   hasActiveTravelCard = false,
+  isInspectable,
 }: TicketInfoProps) => {
   const {
     tariff_zones: tariffZones,
@@ -65,6 +67,7 @@ const TicketInfo = ({
       userProfilesWithCount={userProfilesWithCount}
       status={status}
       hasActiveTravelCard={hasActiveTravelCard}
+      isInspectable={isInspectable}
     />
   );
 };
@@ -76,6 +79,7 @@ type TicketInfoViewProps = {
   userProfilesWithCount: UserProfileWithCount[];
   status: TicketInfoProps['status'];
   hasActiveTravelCard?: boolean;
+  isInspectable?: boolean;
 };
 
 export const TicketInfoView = (props: TicketInfoViewProps) => {
@@ -157,34 +161,37 @@ const TicketInspectionSymbol = ({
   toTariffZone,
   preassignedFareProduct,
   status,
+  isInspectable = true,
 }: TicketInfoViewProps) => {
   const styles = useStyles();
   const {theme} = useTheme();
   const {language} = useTranslation();
   if (!fromTariffZone || !toTariffZone) return null;
-  const icon = IconForStatus(status);
+  const icon = IconForStatus(status, isInspectable);
   if (!icon) return null;
+  const showAsInspectable = isInspectable || status !== 'valid';
+  const isValid = status === 'valid';
   return (
     <View
       style={[
-        status !== 'uninspectable' && styles.symbolContainer,
-        status === 'valid' && {
+        showAsInspectable && styles.symbolContainer,
+        isValid && {
           ...styles.symbolContainerCircle,
           backgroundColor:
-            preassignedFareProduct?.type === 'period'
+            preassignedFareProduct?.type === 'period' && isInspectable
               ? theme.colors.primary_1.backgroundColor
               : 'none',
         },
-        status === 'uninspectable' && {
-          ...styles.symbolContainerCircle,
-          ...styles.textContainer,
-          borderColor: theme.status.warning.main.backgroundColor,
-        },
+        isValid &&
+          !isInspectable && {
+            ...styles.textContainer,
+            borderColor: theme.status.warning.main.backgroundColor,
+          },
       ]}
-      accessibilityElementsHidden={status !== 'uninspectable'}
+      accessibilityElementsHidden={isInspectable}
     >
       <>
-        {status === 'valid' && (
+        {status === 'valid' && isInspectable && (
           <ThemeText
             type="body__primary--bold"
             allowFontScaling={false}
@@ -203,12 +210,27 @@ const TicketInspectionSymbol = ({
 
 const IconForStatus = (
   status: TicketInfoProps['status'],
+  isInspectable: boolean,
 ): ReactElement | null => {
   const {t} = useTranslation();
-
   switch (status) {
     case 'valid':
-      return <ThemeIcon svg={BusSide} colorType="primary" size={'large'} />;
+      if (isInspectable)
+        return <ThemeIcon svg={BusSide} colorType="primary" size={'large'} />;
+      else
+        return (
+          <ThemeText
+            type="body__tertiary"
+            style={{
+              textAlign: 'center',
+            }}
+            accessibilityLabel={t(
+              TicketTexts.ticketInfo.noInspectionIconA11yLabel,
+            )}
+          >
+            {t(TicketTexts.ticketInfo.noInspectionIcon)}
+          </ThemeText>
+        );
     case 'expired':
     case 'refunded':
       return <ThemeIcon svg={InvalidTicket} colorType="error" size={'large'} />;
@@ -216,20 +238,6 @@ const IconForStatus = (
       return <ThemeIcon svg={AddTicket} colorType="primary" size={'large'} />;
     case 'upcoming':
       return <ThemeIcon svg={Wait} colorType="primary" size={'large'} />;
-    case 'uninspectable':
-      return (
-        <ThemeText
-          type="body__tertiary"
-          style={{
-            textAlign: 'center',
-          }}
-          accessibilityLabel={t(
-            TicketTexts.ticketInfo.noInspectionIconA11yLabel,
-          )}
-        >
-          {t(TicketTexts.ticketInfo.noInspectionIcon)}
-        </ThemeText>
-      );
     case 'reserving':
     case 'unknown':
       return null;

--- a/src/screens/Ticketing/Ticket/ValidityHeader.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityHeader.tsx
@@ -18,19 +18,20 @@ const ValidityHeader: React.FC<{
   now: number;
   validFrom: number;
   validTo: number;
-}> = ({status, now, validFrom, validTo}) => {
+  isInspectable: boolean;
+}> = ({status, now, validFrom, validTo, isInspectable}) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
 
   return (
     <View style={styles.validityHeader}>
       <View style={styles.validityContainer}>
-        <ValidityIcon status={status} />
+        <ValidityIcon status={status} isInspectable={isInspectable} />
         <ThemeText
           style={styles.validityText}
           type="body__secondary"
           accessibilityHint={
-            status === 'uninspectable'
+            !isInspectable
               ? t(TicketTexts.ticketInfo.noInspectionIconA11yLabel)
               : undefined
           }
@@ -82,9 +83,6 @@ function validityTimeText(
     }
     case 'reserving':
       return t(TicketTexts.validityHeader.reserving);
-    case 'uninspectable':
-      const dateText = formatToLongDateTime(toDate(validTo), language);
-      return t(TicketTexts.validityHeader.uninspectable(dateText));
     case 'unknown':
       return t(TicketTexts.validityHeader.unknown);
   }

--- a/src/screens/Ticketing/Ticket/ValidityIcon.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityIcon.tsx
@@ -8,28 +8,46 @@ import {Wait} from '@atb/assets/svg/icons/transportation';
 import {TicketTexts, useTranslation} from '@atb/translations';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 
-const ValidityIcon: React.FC<{status: ValidityStatus}> = ({status}) => {
+const ValidityIcon: React.FC<{
+  status: ValidityStatus;
+  isInspectable: boolean;
+}> = ({status, isInspectable}) => {
   const {theme} = useTheme();
   return (
     <View style={{marginRight: theme.spacings.medium}}>
-      <ValidityIconSvg status={status} />
+      <ValidityIconSvg status={status} isInspectable={isInspectable} />
     </View>
   );
 };
 
-const ValidityIconSvg = ({status}: {status: ValidityStatus}) => {
+const ValidityIconSvg = ({
+  status,
+  isInspectable,
+}: {
+  status: ValidityStatus;
+  isInspectable: boolean;
+}) => {
   const {theme} = useTheme();
   const {t} = useTranslation();
   const a11yLabel = t(TicketTexts.validityIcon[status]) + screenReaderPause;
   switch (status) {
     case 'valid':
-      return (
-        <ThemeIcon
-          svg={ValidTicket}
-          colorType="valid"
-          accessibilityLabel={a11yLabel}
-        />
-      );
+      if (isInspectable)
+        return (
+          <ThemeIcon
+            svg={ValidTicket}
+            colorType="valid"
+            accessibilityLabel={a11yLabel}
+          />
+        );
+      else
+        return (
+          <ThemeIcon
+            svg={ValidTicket}
+            colorType="secondary"
+            accessibilityLabel={a11yLabel}
+          />
+        );
     case 'reserving':
       return (
         <ThemeIcon
@@ -52,14 +70,6 @@ const ValidityIconSvg = ({status}: {status: ValidityStatus}) => {
         <ThemeIcon
           svg={InvalidTicket}
           colorType="error"
-          accessibilityLabel={a11yLabel}
-        />
-      );
-    case 'uninspectable':
-      return (
-        <ThemeIcon
-          svg={ValidTicket}
-          colorType="secondary"
           accessibilityLabel={a11yLabel}
         />
       );

--- a/src/screens/Ticketing/Ticket/ValidityLine.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityLine.tsx
@@ -15,6 +15,7 @@ type Props =
       now: number;
       validFrom: number;
       validTo: number;
+      isInspectable: boolean;
     }
   | {status: Exclude<ValidityStatus, 'valid'>};
 
@@ -30,18 +31,14 @@ const ValidityLine = (props: Props): ReactElement => {
         />
       );
     case 'valid':
-      const {now, validFrom, validTo} = props;
+      const {now, validFrom, validTo, isInspectable} = props;
       const validityPercent = getValidityPercent(now, validFrom, validTo);
-      return (
+      return isInspectable ? (
         <LineWithVerticalBars
           backgroundColor={theme.colors.primary_1.backgroundColor}
           validityPercent={validityPercent}
         />
-      );
-    case 'upcoming':
-    case 'refunded':
-    case 'expired':
-      return (
+      ) : (
         <View style={styles.container}>
           <Dash
             style={{width: '100%'}}
@@ -52,7 +49,9 @@ const ValidityLine = (props: Props): ReactElement => {
           />
         </View>
       );
-    case 'uninspectable':
+    case 'upcoming':
+    case 'refunded':
+    case 'expired':
       return (
         <View style={styles.container}>
           <Dash

--- a/src/screens/Ticketing/Ticket/index.tsx
+++ b/src/screens/Ticketing/Ticket/index.tsx
@@ -37,6 +37,7 @@ const SimpleTicket: React.FC<Props> = ({
         isInspectable={isInspectable}
         hideDetails={hideDetails}
         onPressDetails={onPressDetails}
+        hasActiveTravelCard={hasActiveTravelCard}
       />
     );
   } else if (isCarnetTicket(firstTravelRight)) {

--- a/src/screens/Ticketing/Ticket/utils.ts
+++ b/src/screens/Ticketing/Ticket/utils.ts
@@ -6,8 +6,7 @@ export type ValidityStatus =
   | RelativeValidityStatus
   | 'reserving'
   | 'unknown'
-  | 'refunded'
-  | 'uninspectable';
+  | 'refunded';
 
 export function getRelativeValidity(
   now: number,
@@ -25,9 +24,7 @@ export function getValidityStatus(
   validFrom: number,
   validTo: number,
   state: FareContractState,
-  inspectable: boolean,
 ): ValidityStatus {
   if (state === FareContractState.Refunded) return 'refunded';
-  if (!inspectable) return 'uninspectable';
   return getRelativeValidity(now, validFrom, validTo);
 }

--- a/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
@@ -41,7 +41,7 @@ const TicketsScrollView: React.FC<Props> = ({
   const navigation = useNavigation<RootNavigationProp>();
   const {t} = useTranslation();
 
-  const hasActiveTravelCard = !!travelCard?.id;
+  const hasActiveTravelCard = !!travelCard;
 
   return (
     <View style={styles.container}>

--- a/src/translations/screens/Ticket.ts
+++ b/src/translations/screens/Ticket.ts
@@ -18,8 +18,6 @@ const TicketTexts = {
     reserving: _(`Reserverer…`, `Reserving…`),
     unknown: _(`Ukjent`, `Unknown`),
     inactiveCarnet: _(`Ingen aktive klipp`, `No active ticket`),
-    uninspectable: (duration: string) =>
-      _(`Utløper ${duration}`, `Expires ${duration}`),
     durationDelimiter: _(' og ', ' and '),
   },
   validityIcon: {
@@ -28,7 +26,6 @@ const TicketTexts = {
     expired: _(`Utløpt billett`, `Expired ticket`),
     refunded: _(`Refundert billett`, 'Refunded ticket'),
     upcoming: _(`Kommende billett`, `Upcoming ticket`),
-    uninspectable: _(`Ikke inspiserbar billett`, `Uninspectable ticket`),
     unknown: _(`Ukjent billett`, `Unknown ticket`),
   },
   usedAccessValidityIcon: {


### PR DESCRIPTION
Oppdatert "inspiserbarheten" til en billett til å være en prop `isInspectable` istedet for en egen billett-status-type. Dette betyr at en billett beholder de fleste egenskapene sine (tekst, ikon osv.) selv om den ikke er inspiserbar. 

<img width="409" alt="Screenshot 2021-10-19 at 09 19 06" src="https://user-images.githubusercontent.com/1774972/137870576-fc604a3b-e7e5-4594-9d78-8f7cb46fac07.png">

#1671
 