### PR TITLE
feat: add message on ticket purchase to bring t:card

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -38,6 +38,7 @@ import {screenReaderPause} from '@atb/components/accessible-text';
 import FullScreenHeader from '@atb/components/screen-header/full-header';
 import TravellersSheet from '@atb/screens/Ticketing/Purchase/Travellers/TravellersSheet';
 import TravelDateSheet from '@atb/screens/Ticketing/Purchase/TravelDate/TravelDateSheet';
+import {useTicketState} from '@atb/tickets';
 
 export type OverviewProps = {
   navigation: DismissableStackNavigationProp<
@@ -53,6 +54,9 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
 }) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const {customerProfile} = useTicketState();
+
+  const hasTravelCard = !!customerProfile?.travelcard;
 
   const {
     tariff_zones: tariffZones,
@@ -237,6 +241,14 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
         </Sections.Section>
       </View>
 
+      {hasTravelCard && (
+        <MessageBox
+          containerStyle={styles.warning}
+          message={t(PurchaseOverviewTexts.warning)}
+          type="warning"
+        />
+      )}
+
       <View style={styles.toPaymentButton}>
         <Button
           color="primary_2"
@@ -397,6 +409,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   selectionLinks: {margin: theme.spacings.medium},
   totalSection: {flex: 1, textAlign: 'center'},
   toPaymentButton: {marginHorizontal: theme.spacings.medium},
+  warning: {
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.medium,
+  },
 }));
 
 export default PurchaseOverview;

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -45,5 +45,9 @@ const PurchaseOverviewTexts = {
   totalPrice: (totalPrice: number) =>
     _(`Totalt: ${totalPrice} kr`, `Total: ${totalPrice} kr`),
   primaryButton: _('Gå til betaling', 'Go to payment'),
+  warning: _(
+    'Når du er ute og reiser må du ha med t:kortet som er registrert på din profil.',
+    'When traveling, you need to bring the t:card registered on your profile.',
+  ),
 };
 export default PurchaseOverviewTexts;


### PR DESCRIPTION

Når brukeren har registrert t:kort på profilen, vises det en advarsel om at man må ta med t:kort når man reiser.

## Oversettelse: 

    'Når du er ute og reiser må du ha med t:kortet som er registrert på din profil.',
    'When traveling, you need to bring the t:card registered on your profile.',

## Skjermbilde 

![Simulator Screen Shot - iPhone 11 - 2021-10-20 at 13 15 56](https://user-images.githubusercontent.com/1774972/138083010-3174ceae-d9b9-4bb1-939a-3abfe772ce96.png)

resolves #1674
