### PR TITLE
fix: add accessibilityLabel to date in ValidityHeader

### DIFF
--- a/src/screens/Ticketing/Ticket/ValidityHeader.tsx
+++ b/src/screens/Ticketing/Ticket/ValidityHeader.tsx
@@ -39,10 +39,11 @@ const ValidityHeader: React.FC<{
         <ThemeText
           style={styles.validityText}
           type="body__secondary"
-          accessibilityLabel={validityTime}
-          accessibilityHint={
+          accessibilityLabel={
             !isInspectable
-              ? t(TicketTexts.ticketInfo.noInspectionIconA11yLabel)
+              ? validityTime +
+                ', ' +
+                t(TicketTexts.ticketInfo.noInspectionIconA11yLabel)
               : undefined
           }
         >


### PR DESCRIPTION
Forandrer `accessibilityHint` til en `accessibilityLabel` som mangler i håp om at TalkBack plukker opp det.

Ref AtB-AS/kundevendt#1613