### PR TITLE
fix: Omit user profile count for carnet tickets

### DIFF
--- a/src/screens/Ticketing/Ticket/Carnet/index.tsx
+++ b/src/screens/Ticketing/Ticket/Carnet/index.tsx
@@ -88,12 +88,11 @@ const CarnetTicketInfo: React.FC<Props> = ({
           />
         </View>
         <TicketInfo
-          // Slice to only show 1 traveller
-          // makes no sense to show multiple for carnet travel rights
-          travelRights={travelRights.slice(0, 1)}
+          travelRights={travelRights}
           status={fareContractValidityStatus}
           isInspectable={isInspectable}
           hasActiveTravelCard={hasActiveTravelCard}
+          omitUserProfileCount={true}
         />
       </Sections.GenericItem>
       <Sections.GenericItem>

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -28,6 +28,7 @@ type TicketInfoProps = {
   status: ValidityStatus | 'recent';
   hasActiveTravelCard: boolean;
   isInspectable: boolean;
+  omitUserProfileCount?: boolean;
 };
 
 const TicketInfo = ({
@@ -35,6 +36,7 @@ const TicketInfo = ({
   status,
   hasActiveTravelCard,
   isInspectable,
+  omitUserProfileCount,
 }: TicketInfoProps) => {
   const {
     tariff_zones: tariffZones,
@@ -68,6 +70,7 @@ const TicketInfo = ({
       status={status}
       hasActiveTravelCard={hasActiveTravelCard}
       isInspectable={isInspectable}
+      omitUserProfileCount={omitUserProfileCount}
     />
   );
 };
@@ -80,6 +83,7 @@ type TicketInfoViewProps = {
   status: TicketInfoProps['status'];
   hasActiveTravelCard?: boolean;
   isInspectable?: boolean;
+  omitUserProfileCount?: boolean;
 };
 
 export const TicketInfoView = (props: TicketInfoViewProps) => {
@@ -99,6 +103,7 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
     toTariffZone,
     userProfilesWithCount,
     hasActiveTravelCard,
+    omitUserProfileCount,
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
@@ -113,7 +118,9 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
       : undefined;
 
   const userProfileCountAndName = (u: UserProfileWithCount) =>
-    `${u.count} ${getReferenceDataName(u, language)}`;
+    omitUserProfileCount
+      ? `${getReferenceDataName(u, language)}`
+      : `${u.count} ${getReferenceDataName(u, language)}`;
 
   return (
     <View style={styles.textsContainer} accessible={true}>


### PR DESCRIPTION
Fjerner antallet foran reisende på klippekort

![image](https://user-images.githubusercontent.com/4932625/138490041-c74423e3-be7a-439a-9ed3-fa1d9267cce1.png)
