### PR TITLE
fix: UU for UsedAccessValidityHeader

### DIFF
--- a/src/screens/Ticketing/Ticket/Carnet/UsedAccessValidityHeader.tsx
+++ b/src/screens/Ticketing/Ticket/Carnet/UsedAccessValidityHeader.tsx
@@ -23,6 +23,7 @@ type Props = {
 function UsedAccessValidityHeader(props: Props) {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const usedAccessValidityText = getUsedAccessValidityText(props, t, language);
 
   return (
     <View style={styles.validityHeader}>
@@ -34,13 +35,15 @@ function UsedAccessValidityHeader(props: Props) {
         <ThemeText
           style={styles.validityText}
           type="body__secondary"
-          accessibilityHint={
+          accessibilityLabel={
             !props.isInspectable
-              ? t(TicketTexts.ticketInfo.noInspectionIconA11yLabel)
+              ? usedAccessValidityText +
+                ', ' +
+                t(TicketTexts.ticketInfo.noInspectionIconA11yLabel)
               : undefined
           }
         >
-          {getUsedAccessValidityText(props, t, language)}
+          {usedAccessValidityText}
         </ThemeText>
       </View>
     </View>


### PR DESCRIPTION
Samme UU fiks som i AtB-AS/mittatb-app#1696, for `UsedAccessValidityHeader`, med oppdatering fra accessibilityHint til accessibilityLabel.

ref AtB-AS/kundevendt#1613