### PR TITLE
feat: Date on next day departures

### DIFF
--- a/src/departure-list/DeparturesList.tsx
+++ b/src/departure-list/DeparturesList.tsx
@@ -1,7 +1,6 @@
 import {StopPlaceGroup} from '@atb/api/departures/types';
 import ScreenReaderAnnouncement from '@atb/components/screen-reader-announcement';
 import {ActionItem} from '@atb/components/sections';
-import ThemeText from '@atb/components/text';
 import {Location} from '@atb/favorites/types';
 import MessageBox from '@atb/components/message-box';
 import {StyleSheet, useTheme} from '@atb/theme';
@@ -22,6 +21,7 @@ type DeparturesListProps = {
   isInitialScreen: boolean;
   showOnlyFavorites: boolean;
   disableCollapsing?: boolean;
+  searchDate: string;
 };
 
 export default function DeparturesList({
@@ -34,6 +34,7 @@ export default function DeparturesList({
   currentLocation,
   showOnlyFavorites,
   disableCollapsing = false,
+  searchDate,
 }: DeparturesListProps) {
   const styles = useDeparturesListStyle();
   const {t} = useTranslation();
@@ -81,6 +82,7 @@ export default function DeparturesList({
               lastUpdated={lastUpdated}
               defaultExpanded={i === 0}
               disableCollapsing={disableCollapsing}
+              searchDate={searchDate}
             />
           ))}
           <FooterLoader isFetchingMore={isFetchingMore} />
@@ -125,6 +127,7 @@ type StopDeparturesProps = {
   lastUpdated?: Date;
   defaultExpanded?: boolean;
   disableCollapsing?: boolean;
+  searchDate: string;
 };
 const StopDepartures = React.memo(function StopDepartures({
   stopPlaceGroup,
@@ -132,6 +135,7 @@ const StopDepartures = React.memo(function StopDepartures({
   lastUpdated,
   defaultExpanded = false,
   disableCollapsing = false,
+  searchDate,
 }: StopDeparturesProps) {
   const {t} = useTranslation();
   const [expanded, setExpanded] = useState(
@@ -179,6 +183,7 @@ const StopDepartures = React.memo(function StopDepartures({
             quayGroup={quayGroup}
             currentLocation={currentLocation}
             lastUpdated={lastUpdated}
+            searchDate={searchDate}
           />
         ))}
     </View>

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -20,6 +20,7 @@ type QuaySectionProps = {
   currentLocation?: Location;
   lastUpdated?: Date;
   hidden?: Date;
+  searchDate: string;
 };
 
 const QuaySection = React.memo(function QuaySection({
@@ -27,6 +28,7 @@ const QuaySection = React.memo(function QuaySection({
   stop,
   currentLocation,
   lastUpdated,
+  searchDate,
 }: QuaySectionProps) {
   const [limit, setLimit] = useState(LIMIT_SIZE);
   const {t} = useTranslation();
@@ -62,6 +64,7 @@ const QuaySection = React.memo(function QuaySection({
             stop={stop}
             quay={quayGroup.quay}
             key={group.lineInfo?.lineId + String(group.lineInfo?.lineName)}
+            searchDate={searchDate}
           />
         ))}
         {hasMoreItems && (

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -284,6 +284,7 @@ const NearbyOverview: React.FC<Props> = ({
         isLoading={isLoading}
         isInitialScreen={isInitialScreen}
         error={error ? translateErrorType(error.type, t) : undefined}
+        searchDate={searchTime.date}
       />
     </SimpleDisappearingHeader>
   );

--- a/src/screens/TripDetails/QuayDepartures/index.tsx
+++ b/src/screens/TripDetails/QuayDepartures/index.tsx
@@ -53,6 +53,7 @@ const QuayDepartures: React.FC<RootProps> = ({route}) => {
             showOnlyFavorites={false}
             isLoading={isLoading}
             disableCollapsing={true}
+            searchDate={new Date().toISOString()}
           />
         </View>
       </ScrollView>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,5 @@
 import {
+  addHours,
   differenceInCalendarDays,
   differenceInMinutes,
   differenceInSeconds,
@@ -7,6 +8,7 @@ import {
   getMinutes,
   isPast,
   isSameDay,
+  isWithinInterval,
   Locale,
   parse,
   parseISO,
@@ -160,6 +162,27 @@ export {isSameDay};
 
 export function formatToSimpleDate(date: Date | string, language: Language) {
   return format(parseIfNeeded(date), 'do MMMM', {
+    locale: languageToLocale(language),
+  });
+}
+
+export const isWithin24Hours = (
+  dateLeft: Date | string,
+  dateRight: Date | string,
+) => {
+  const leftParsed = parseIfNeeded(dateLeft);
+  const rightParsed = parseIfNeeded(dateRight);
+  return isWithinInterval(rightParsed, {
+    start: leftParsed,
+    end: addHours(leftParsed, 24),
+  });
+};
+
+export function formatToShortSimpleDate(
+  date: Date | string,
+  language: Language,
+) {
+  return format(parseIfNeeded(date), 'do MMM', {
     locale: languageToLocale(language),
   });
 }


### PR DESCRIPTION
If a departure on the departures screen is more than 24 hours in the
future, it will be prefixed with the date.