### PR TITLE
feat: Temporarily disable mobiletoken retry

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import {setupMobileTokenClient} from '@atb/mobile-token/client';
 import {TokenStatus} from '@entur/react-native-traveller/lib/typescript/token/types';
-import useInterval from '@atb/utils/use-interval';
 import {useAuthState} from '@atb/auth';
 import Bugsnag from '@bugsnag/react-native';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
@@ -48,29 +47,29 @@ const MobileTokenContextProvider: React.FC = ({children}) => {
     }
   }, [userCreationFinished, client, abtCustomerId, abtCustomerId]);
 
-  useInterval(
-    () => {
-      setRetryCount(retryCount + 1);
-      client?.retry(false); // todo: better retry logic
-    },
-    5000,
-    [client?.retry, tokenStatus?.error],
-    !client || !tokenStatus?.error || retryCount >= 5,
-  );
-
-  useInterval(
-    () => {
-      setRetryCount(retryCount + 1);
-      Bugsnag.notify(tokenStatus!.error!.message, (event) => {
-        event.addMetadata('mobiletoken', {...tokenStatus!.error});
-        event.severity = 'error';
-      });
-      client?.retry(true); // todo: better retry logic
-    },
-    30000,
-    [client?.retry, tokenStatus?.error],
-    !client || !tokenStatus?.error || retryCount < 5,
-  );
+  // useInterval(
+  //   () => {
+  //     setRetryCount(retryCount + 1);
+  //     client?.retry(false); // todo: better retry logic
+  //   },
+  //   5000,
+  //   [client?.retry, tokenStatus?.error],
+  //   !client || !tokenStatus?.error || retryCount >= 5,
+  // );
+  //
+  // useInterval(
+  //   () => {
+  //     setRetryCount(retryCount + 1);
+  //     Bugsnag.notify(tokenStatus!.error!.message, (event) => {
+  //       event.addMetadata('mobiletoken', {...tokenStatus!.error});
+  //       event.severity = 'error';
+  //     });
+  //     client?.retry(true); // todo: better retry logic
+  //   },
+  //   30000,
+  //   [client?.retry, tokenStatus?.error],
+  //   !client || !tokenStatus?.error || retryCount < 5,
+  // );
 
   return (
     <MobileTokenContext.Provider


### PR DESCRIPTION
The mobiletoken sdk currently causes crashes. This is for help locating
the error. Disabling the retry mechanism helps us to more manually
controll the retry flow, and may also reveal a fault in the app retry
mechanism itself.