### PR TITLE
feat: add textType prop to link-item

### DIFF
--- a/src/components/sections/link-item.tsx
+++ b/src/components/sections/link-item.tsx
@@ -12,6 +12,7 @@ import NavigationIcon, {
 } from '@atb/components/theme-icon/navigation-icon';
 import {SectionItem, useSectionItem, useSectionStyle} from './section-utils';
 import {StyleSheet} from '@atb/theme';
+import {TextNames} from '@atb/theme/colors';
 
 export type LinkItemProps = SectionItem<{
   text: string;
@@ -20,6 +21,7 @@ export type LinkItemProps = SectionItem<{
   icon?: NavigationIconTypes | JSX.Element;
   disabled?: boolean;
   accessibility?: AccessibilityProps;
+  textType?: TextNames;
 }>;
 export default function LinkItem({
   text,
@@ -28,6 +30,7 @@ export default function LinkItem({
   icon,
   accessibility,
   disabled,
+  textType,
   ...props
 }: LinkItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -50,7 +53,9 @@ export default function LinkItem({
       {...accessibilityWithOverrides}
     >
       <View style={[style.spaceBetween, disabledStyle]}>
-        <ThemeText style={contentContainer}>{text}</ThemeText>
+        <ThemeText style={contentContainer} type={textType}>
+          {text}
+        </ThemeText>
         {iconEl}
       </View>
       {subtitle && (


### PR DESCRIPTION
I nye den avganger visningen er det nyttig å kunne sette `textType` for en LinkItem i lister, som i dette eksemelet med bold tekst. Gjør den som egen PR for å gjøre #1734 litt mindre.

![Simulator Screen Shot - iPhone 11 - 2021-11-26 at 13 05 48](https://user-images.githubusercontent.com/1774972/143579279-1fd249a9-1647-4291-b26e-8b54a55dc8e4.png)
