### PR TITLE
feat: add hex code alert to design system color buttons

### DIFF
--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -21,7 +21,9 @@ export default function DesignSystem() {
     <Button
       key={themeName}
       text={themeName}
-      onPress={presser}
+      onPress={() =>
+        Alert.alert(theme.colors[themeName as ThemeColor].backgroundColor)
+      }
       color={themeName as ThemeColor}
     />
   ));


### PR DESCRIPTION
Etter ønske fra @hildeor får man nå hex-kode som alert når man trykker på en "farge-knapp" på design system skjermen.


https://user-images.githubusercontent.com/1774972/144057442-5f338848-7036-42a6-9adb-d19393cbe516.mp4

