### PR TITLE
fix: use status theme color for MessageBox content

### DIFF
--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -81,7 +81,11 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const topMessage = (
     <View style={{paddingBottom: theme.spacings.large}}>
       <MessageBox>
-        <ThemeText type="body__primary" color="primary_1" isMarkdown={true}>
+        <ThemeText
+          type="body__primary"
+          style={{color: theme.status.info.main.color}}
+          isMarkdown={true}
+        >
           {t(TicketsTexts.buyTicketsTab.reactivateSplash.message)}
         </ThemeText>
 
@@ -91,7 +95,10 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
             TicketsTexts.buyTicketsTab.reactivateSplash.linkA11yHint,
           )}
         >
-          <ThemeText type="body__primary--underline" color="primary_1">
+          <ThemeText
+            type="body__primary--underline"
+            style={{color: theme.status.info.main.color}}
+          >
             {t(TicketsTexts.buyTicketsTab.reactivateSplash.linkText)}
           </ThemeText>
         </TouchableOpacity>


### PR DESCRIPTION
I tickets følger ikke `topMessage` sitt innhold fargen til info status, men er satt til primary_1. Får en liten issue med det når jeg oppdaterer design systemet.

# Før/etter
![collage](https://user-images.githubusercontent.com/1774972/144064147-87f4fcd5-53f0-4541-bd32-3433ce5df406.png)


