### PR TITLE
fix: if searchdate is in past, update it

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1044,7 +1044,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CryptoSwift: a532e74ed010f8c95f611d00b8bbae42e9fe7c17
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   entur-react-native-traveller: d4156cacd6b76f8395ae3ab743d7439762d1e369
   FBLazyVector: de148e8310b8b878db304ceea2fec13f2c02e3a0
   FBReactNativeSpec: 6192956c9e346013d5f1809ba049af720b11c6a4
@@ -1069,7 +1069,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   GoogleAppMeasurement: 89e1a64593f968713b0506ba1b53b38a154bf9a5
   GoogleDataTransport: 116c84c4bdeb76be2a7a46de51244368f9794eab
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
@@ -1080,7 +1080,7 @@ SPEC CHECKSUMS:
   Kronos: 0ca73a1c00dc9a49a0bab4a6ed42f282562a7058
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  Mapbox-iOS-SDK: 6a67397df2bcafe5d2851604192aa8de6f8d6c89
+  Mapbox-iOS-SDK: 2563ed87ead6ec08f1c2090873977b8a7be335a8
   MapboxMobileEvents: e78db24b348f48e41e5895be7dc16e5b1bb43562
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -52,6 +52,7 @@ import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {StoredType} from '@atb/favorites/storage';
 import {FavoriteDeparture} from '@atb/favorites/types';
 import FavoriteDialogSheet from '@atb/departure-list/section-items/FavoriteDialogSheet';
+import {parseISO} from 'date-fns';
 
 export type LineItemProps = SectionItem<{
   group: DepartureGroup;
@@ -158,6 +159,9 @@ function labelForTime(
   t: TFunc<typeof Language>,
   language: Language,
 ) {
+  if (isInThePast(parseISO(time))) {
+    searchDate = new Date().toISOString();
+  }
   const resultTime = formatToClockOrRelativeMinutes(
     time,
     language,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -178,11 +178,23 @@ export const isWithin24Hours = (
   });
 };
 
+const dateInPast = (date: Date) => {
+  let now = new Date();
+  now.setHours(0, 0, 0, 0);
+  date.setHours(0, 0, 0, 0);
+  return date <= now;
+};
+
 export const isWithinSameDate = (
   dateLeft: Date | string,
   dateRight: Date | string,
+  includePresent?: boolean,
 ) => {
-  const leftParsed = parseIfNeeded(dateLeft);
+  let leftParsed = parseIfNeeded(dateLeft);
+  if (!includePresent && dateInPast(leftParsed)) {
+    leftParsed = new Date();
+  }
+
   const rightParsed = parseIfNeeded(dateRight);
   return isSameDay(leftParsed, rightParsed);
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -178,7 +178,7 @@ export const isWithin24Hours = (
   });
 };
 
-const dateInPast = (date: Date) => {
+export const dateInPast = (date: Date) => {
   let now = new Date();
   now.setHours(0, 0, 0, 0);
   date.setHours(0, 0, 0, 0);
@@ -188,13 +188,8 @@ const dateInPast = (date: Date) => {
 export const isWithinSameDate = (
   dateLeft: Date | string,
   dateRight: Date | string,
-  includePresent?: boolean,
 ) => {
   let leftParsed = parseIfNeeded(dateLeft);
-  if (!includePresent && dateInPast(leftParsed)) {
-    leftParsed = new Date();
-  }
-
   const rightParsed = parseIfNeeded(dateRight);
   return isSameDay(leftParsed, rightParsed);
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -189,7 +189,7 @@ export const isWithinSameDate = (
   dateLeft: Date | string,
   dateRight: Date | string,
 ) => {
-  let leftParsed = parseIfNeeded(dateLeft);
+  const leftParsed = parseIfNeeded(dateLeft);
   const rightParsed = parseIfNeeded(dateRight);
   return isSameDay(leftParsed, rightParsed);
 };


### PR DESCRIPTION
Noe usikker på om dette kan få følgefeil, men tror ikke det.

Problemet som skal løses er at searchdate ikke oppdaterer seg når enheten begever seg over i ny dag. Det ser dog ut som om reisesøket sine forslag er riktige, men får en unødvendig dagsvisning.