### PR TITLE
feat: update transportation icons

### DIFF
--- a/src/components/transportation-icon/index.tsx
+++ b/src/components/transportation-icon/index.tsx
@@ -26,11 +26,17 @@ const TransportationIcon: React.FC<TransportationIconProps> = ({
   subMode,
 }) => {
   const {t} = useTranslation();
-  const color = useTransportationColor(mode, subMode);
+  const color = useTransportationColor(mode, subMode, 'color');
+  const backgroundColor = useTransportationColor(
+    mode,
+    subMode,
+    'backgroundColor',
+  );
   const svg = getTransportModeSvg(mode);
+  const styles = useStyles();
 
   return svg ? (
-    <View>
+    <View style={[styles.transportationIcon, {backgroundColor}]}>
       <ThemeIcon
         svg={svg}
         fill={color}
@@ -61,3 +67,10 @@ function getTransportModeSvg(mode?: LegMode | TransportMode) {
       return null;
   }
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  transportationIcon: {
+    padding: 3,
+    borderRadius: theme.border.radius.small,
+  },
+}));

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -300,6 +300,7 @@ const useItemStyles = StyleSheet.createThemeHook((theme, themeName) => ({
   },
   lineHeader: {
     flexDirection: 'row',
+    alignItems: 'center',
   },
   scrollContainer: {
     marginBottom: theme.spacings.medium,

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -12,6 +12,8 @@ import {textNames, TextNames, ThemeColor} from '@atb/theme/colors';
 import React from 'react';
 import {Alert, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
+import {LegMode, TransportSubmode} from '@atb/sdk';
+import TransportationIcon from '@atb/components/transportation-icon';
 
 export default function DesignSystem() {
   const style = useProfileHomeStyle();
@@ -48,6 +50,15 @@ export default function DesignSystem() {
 
               <ThemeIcon svg={BlankTicket} colorType="error" />
               <ThemeIcon svg={BlankTicket} colorType="disabled" size="small" />
+            </View>
+            <View style={style.icons}>
+              <TransportationIcon
+                mode={LegMode.BUS}
+                subMode={TransportSubmode.LOCAL_BUS}
+              />
+              {Object.values(LegMode).map((mode) => (
+                <TransportationIcon mode={mode} />
+              ))}
             </View>
           </Sections.GenericItem>
         </Sections.Section>

--- a/src/utils/use-transportation-color.ts
+++ b/src/utils/use-transportation-color.ts
@@ -4,24 +4,25 @@ import {useTheme} from '@atb/theme';
 export function useTransportationColor(
   mode?: LegMode | TransportMode,
   subMode?: TransportSubmode,
+  colorType: 'color' | 'backgroundColor' = 'backgroundColor',
 ): string {
   const {theme} = useTheme();
   switch (mode) {
     case 'bus':
     case 'coach':
       if (subMode === 'localBus') {
-        return theme.colors.transport_city.backgroundColor;
+        return theme.colors.transport_city[colorType];
       }
-      return theme.colors.transport_region.backgroundColor;
+      return theme.colors.transport_region[colorType];
     case 'rail':
-      return theme.colors.transport_train.backgroundColor;
+      return theme.colors.transport_train[colorType];
     case 'tram':
-      return theme.colors.transport_city.backgroundColor;
+      return theme.colors.transport_city[colorType];
     case 'water':
-      return theme.colors.transport_boat.backgroundColor;
+      return theme.colors.transport_boat[colorType];
     case 'air':
-      return theme.colors.transport_plane.backgroundColor;
+      return theme.colors.transport_plane[colorType];
     default:
-      return theme.colors.transport_other.backgroundColor;
+      return theme.colors.transport_other[colorType];
   }
 }


### PR DESCRIPTION
- Legger til en `colorType: 'color' | 'backgroundColor'` parameter til `useTransportationColor()` slik at man kan hente både forgrunn og bakgrunnsfarge. `TransportationIcon` komponenten tar i bruk dette til en ramme rundt ikonene. 
- La også inn oversikt over alle typer Transportation ikoner i design systemet.

![collage](https://user-images.githubusercontent.com/1774972/144997453-9ba3a731-fd58-41ae-b4c2-83308265225d.png)

closes #1844 