### PR TITLE
fix: Listener warnings (in our code)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/lodash.orderby": "^4.6.6",
     "@types/lodash.pickby": "^4.6.6",
     "@types/marked": "^3.0.0",
-    "@types/react-native": "^0.63.48",
+    "@types/react-native": "0.66.8",
     "@types/react-test-renderer": "^16.9.5",
     "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^4.29.1",

--- a/src/components/sections/phone-input.tsx
+++ b/src/components/sections/phone-input.tsx
@@ -21,7 +21,7 @@ import composeRefs from '@seznam/compose-react-refs';
 import {Expand, ExpandLess} from '@atb/assets/svg/icons/navigation';
 import {ScrollView} from 'react-native-gesture-handler';
 import {countryPhoneData} from 'phone';
-import * as Sections from '@atb/components/sections';
+import {Section, GenericClickableItem} from '@atb/components/sections';
 import useFocusOnLoad from '@atb/utils/use-focus-on-load';
 import {loginPhoneInputId} from '@atb/test-ids';
 
@@ -192,9 +192,9 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
         </View>
         {isSelectingPrefix && (
           <ScrollView style={styles.prefixList} ref={prefixListRef}>
-            <Sections.Section>
+            <Section>
               {prefixes.map((country) => (
-                <Sections.GenericClickableItem
+                <GenericClickableItem
                   key={country.country_code + country.country_name}
                   onPress={() => onSelectPrefix(country.country_code)}
                 >
@@ -206,9 +206,9 @@ const PhoneInput = forwardRef<InternalTextInput, TextProps>(
                       {country.country_name}
                     </ThemeText>
                   </View>
-                </Sections.GenericClickableItem>
+                </GenericClickableItem>
               ))}
-            </Sections.Section>
+            </Section>
           </ScrollView>
         )}
       </View>

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -208,7 +208,7 @@ export function LocationSearchContent({
             onClear={() => setText('')}
             placeholder={placeholder}
             autoCorrect={false}
-            autoCompleteType="off"
+            autoComplete="off"
             autoFocus={!a11yContext.isScreenReaderEnabled}
           />
         </View>

--- a/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
@@ -153,7 +153,7 @@ const Index: React.FC<Props> = ({
             onClear={() => setText('')}
             placeholder={t(TariffZoneSearchTexts.searchField.placeholder)}
             autoCorrect={false}
-            autoCompleteType="off"
+            autoComplete="off"
           />
         </View>
       </View>

--- a/src/screens/Ticketing/Ticket/Details/ReceiptScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/ReceiptScreen.tsx
@@ -91,7 +91,7 @@ export default function ReceiptScreen({navigation, route}: Props) {
             onChangeText={setEmail}
             keyboardType="email-address"
             autoCapitalize="none"
-            autoCompleteType="email"
+            autoComplete="email"
             autoCorrect={false}
             autoFocus={!a11yContext.isScreenReaderEnabled}
           />

--- a/src/utils/use-keyboard-height.ts
+++ b/src/utils/use-keyboard-height.ts
@@ -13,11 +13,17 @@ export default function useKeyboardHeight() {
   }
 
   useEffect(() => {
-    Keyboard.addListener('keyboardWillShow', onKeyboardWillShow);
-    Keyboard.addListener('keyboardWillHide', onKeyboardWillHide);
+    const showListener = Keyboard.addListener(
+      'keyboardWillShow',
+      onKeyboardWillShow,
+    );
+    const hideListener = Keyboard.addListener(
+      'keyboardWillHide',
+      onKeyboardWillHide,
+    );
     return () => {
-      Keyboard.removeListener('keyboardWillShow', onKeyboardWillShow);
-      Keyboard.removeListener('keyboardWillHide', onKeyboardWillHide);
+      showListener.remove();
+      hideListener.remove();
     };
   }, []);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,10 +2687,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/react-native@^0.63.48":
-  version "0.63.48"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.48.tgz#83ebffe2900b8dee7e420bad9d8d0efea86efe92"
-  integrity sha512-6+7WsHfVkcYEwO/u3wxarMwZq/mbJZ5iDYCXwX5bs8lm0vEIuBdMsk9jrwxuCBvaXhGdB0lriwTgfew/7VN2Kg==
+"@types/react-native@0.66.8":
+  version "0.66.8"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.66.8.tgz#0f9d42202452e9951e4f45277c254de12d1e11b9"
+  integrity sha512-xiW7MfTPzd6xsJB8VEtheF9RH1Vyr1FlbM5jguMa+3ZtnFlE38H4TZSCFAaA3YGIZDnAOlG7qT13RUWyFpW2uw==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Med RN-oppgradering så har de deprecated gamle-måten å remove listener subscription på Keyboard (og andre EventEmitters). Vi får masse warnings på de, men flesteparten av de kommer fra bruk i andre avhengigheter. Så vi burde i grunn oppgradere de etter ny butikk-release. Men vi kan fikse en plass, og det er i vår egen kodebase.