### PR TITLE
fix: When setting "useSystemLanguage", set language to a value if undefined

### DIFF
--- a/src/screens/Profile/Language/index.tsx
+++ b/src/screens/Profile/Language/index.tsx
@@ -36,7 +36,12 @@ export default function Language() {
             mode="toggle"
             text={t(LanguageSettingsTexts.usePhoneSettings)}
             checked={useSystemLanguage}
-            onPress={(checked) => setPreference({useSystemLanguage: checked})}
+            onPress={(checked) => {
+              setPreference({
+                useSystemLanguage: checked,
+                language: language || DEFAULT_LANGUAGE,
+              });
+            }}
           />
         </Section>
         {!useSystemLanguage && (


### PR DESCRIPTION
Fikser issue https://github.com/AtB-AS/mittatb-app/issues/1627

Problemet som oppsto er at når en enhet har et annet systemspråk enn norsk, og brukeren huker av "useSystemLanguage" er language fortsatt undefined. Nå oppdateres language når useSystemLanguage oppdateres