### PR TITLE
fix: Show error if loading is done, but callGroups is empty

### DIFF
--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -140,6 +140,15 @@ export default function DepartureDetails({navigation, route}: Props) {
             </View>
           )}
 
+          {!isLoading &&
+            Object.values(callGroups).every((item) => item.length === 0) && (
+              <MessageBox
+                type="error"
+                title={t(DepartureDetailsTexts.errorMessageBox.title)}
+                message={t(DepartureDetailsTexts.errorMessageBox.pleaseWait)}
+              />
+            )}
+
           {!canSellTicketsForDeparture && (
             <MessageBox
               containerStyle={styles.ticketMessage}
@@ -147,7 +156,6 @@ export default function DepartureDetails({navigation, route}: Props) {
               message={t(DepartureDetailsTexts.messages.ticketsWeDontSell)}
             />
           )}
-
           <View style={styles.allGroups}>
             {mapGroup(callGroups, (name, group) => (
               <CallGroup

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -16,5 +16,9 @@ const DepartureDetailsTexts = {
     ),
     noAlighting: _('Ingen avstigning', 'No disembarking'),
   },
+  errorMessageBox: {
+    title: _('Det oppstod en feil', 'An error occurred'),
+    pleaseWait: _('Vennligst vent', 'Please wait'),
+  },
 };
 export default DepartureDetailsTexts;


### PR DESCRIPTION
Dette løser ikke det underliggende problemet tror jeg, men behandler heller symptomene. Jeg ser ikke noen errorhandling på den data-flowen(?), men jeg er ikke veldig kjent med graphQL.

Denne løsninger antar at noe er galt om loading er ferdig, men callGroups ikke har noen verdier.


https://github.com/AtB-AS/mittatb-app/issues/1543