### PR TITLE
fix: use "min" as shorthand for "minute" in English

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -275,7 +275,7 @@ function getShortHumanizer(
         w: () => 'w',
         d: () => 'd',
         h: () => 'h',
-        m: () => 'm',
+        m: () => 'min',
         s: () => 's',
         ms: () => 'ms',
       },


### PR DESCRIPTION
fixes #1964

![collage](https://user-images.githubusercontent.com/1774972/148774484-d8f7159e-b995-4da6-9eba-0e7a1c196846.png)
