### PR TITLE
feat: add departure details navigation

### DIFF
--- a/src/screens/Departures/StopPlaceScreen.tsx
+++ b/src/screens/Departures/StopPlaceScreen.tsx
@@ -121,10 +121,7 @@ export default function StopPlaceScreen({
         ListHeaderComponent={
           <Button
             onPress={() => {
-              navigation.navigate('StopPlaceScreen', {
-                stopPlacePosition,
-                selectedQuay: undefined,
-              });
+              navigation.setParams({selectedQuay: undefined});
             }}
             text={t(DeparturesTexts.quayChips.allStops)}
             color={selectedQuay ? 'secondary_2' : 'secondary_3'}
@@ -134,10 +131,7 @@ export default function StopPlaceScreen({
         renderItem={({item}: quayChipData) => (
           <Button
             onPress={() => {
-              navigation.navigate('StopPlaceScreen', {
-                stopPlacePosition,
-                selectedQuay: item,
-              });
+              navigation.setParams({selectedQuay: item});
             }}
             text={
               item.publicCode ? item.name + ' ' + item.publicCode : item.name
@@ -171,10 +165,7 @@ export default function StopPlaceScreen({
               data={state.data}
               navigation={navigation}
               navigateToQuay={(quay) => {
-                navigation.navigate('StopPlaceScreen', {
-                  stopPlacePosition,
-                  selectedQuay: quay,
-                });
+                navigation.setParams({selectedQuay: quay});
               }}
             />
           )}

--- a/src/screens/Departures/StopPlaceScreen.tsx
+++ b/src/screens/Departures/StopPlaceScreen.tsx
@@ -13,6 +13,7 @@ import {
   RefreshControl,
   SectionList,
   SectionListData,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import {FlatList} from 'react-native-gesture-handler';
@@ -52,6 +53,7 @@ import {Mode as Mode_v2} from '@atb/api/types/generated/journey_planner_v3_types
 import useFontScale from '@atb/utils/use-font-scale';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import {DeparturesStackParams} from '.';
+import {DepartureDetailsRouteParams} from '../TripDetails/DepartureDetails';
 
 export type StopPlaceScreenParams = {
   stopPlacePosition: StopPlacePosition;
@@ -167,6 +169,7 @@ export default function StopPlaceScreen({
               quay={item}
               selectedQuayId={selectedQuay?.id}
               data={state.data}
+              navigation={navigation}
               navigateToQuay={(quay) => {
                 navigation.navigate('StopPlaceScreen', {
                   stopPlacePosition,
@@ -183,6 +186,7 @@ export default function StopPlaceScreen({
 
 type EstimatedCallLineProps = {
   departure: EstimatedCall;
+  navigation: StackNavigationProp<DeparturesStackParams>;
 };
 
 function getDeparturesForQuay(
@@ -301,6 +305,7 @@ type QuaySectionProps = {
   selectedQuayId: String | undefined;
   data: EstimatedCall[] | null;
   navigateToQuay: (arg0: Quay) => void;
+  navigation: StackNavigationProp<DeparturesStackParams>;
 };
 
 function QuaySection({
@@ -308,6 +313,7 @@ function QuaySection({
   selectedQuayId,
   data,
   navigateToQuay,
+  navigation,
 }: QuaySectionProps): JSX.Element {
   const [isHidden, setIsHidden] = useState(false);
   const styles = useStyles();
@@ -368,7 +374,10 @@ function QuaySection({
                     : undefined
                 }
               >
-                <EstimatedCallLine departure={item}></EstimatedCallLine>
+                <EstimatedCallLine
+                  departure={item}
+                  navigation={navigation}
+                ></EstimatedCallLine>
               </Sections.GenericItem>
             )}
             keyExtractor={(item) => item.serviceJourney?.id || ''}
@@ -418,7 +427,10 @@ function changeDay(searchTime: SearchTime, days: number): SearchTime {
   };
 }
 
-function EstimatedCallLine({departure}: EstimatedCallLineProps): JSX.Element {
+function EstimatedCallLine({
+  departure,
+  navigation,
+}: EstimatedCallLineProps): JSX.Element {
   const {t, language} = useTranslation();
   const styles = useStyles();
 
@@ -436,8 +448,22 @@ function EstimatedCallLine({departure}: EstimatedCallLineProps): JSX.Element {
     ? time
     : t(dictionary.a11yMissingRealTimePrefix) + time;
 
+  const navigateToDetails = () => {
+    if (!departure.serviceJourney) return;
+    navigation.navigate('DepartureDetails', {
+      items: [
+        {
+          serviceJourneyId: departure.serviceJourney.id,
+          date: departure.expectedDepartureTime,
+          fromQuayId: departure.quay?.id,
+        },
+      ],
+    });
+  };
+
   return (
-    <View
+    <TouchableOpacity
+      onPress={navigateToDetails}
       style={styles.estimatedCallLine}
       accessible={true}
       accessibilityLabel={t(
@@ -459,7 +485,7 @@ function EstimatedCallLine({departure}: EstimatedCallLineProps): JSX.Element {
         {departure.destinationDisplay?.frontText}
       </ThemeText>
       <ThemeText type="body__primary--bold">{timeWithRealtimePrefix}</ThemeText>
-    </View>
+    </TouchableOpacity>
   );
 }
 

--- a/src/screens/Departures/StopPlaceScreen.tsx
+++ b/src/screens/Departures/StopPlaceScreen.tsx
@@ -109,6 +109,23 @@ export default function StopPlaceScreen({
     [stopPlace],
   );
 
+  const navigateToDetails = (
+    serviceJourneyId?: string,
+    date?: string,
+    fromQuayId?: string,
+  ) => {
+    if (!serviceJourneyId || !date) return;
+    navigation.navigate('DepartureDetails', {
+      items: [
+        {
+          serviceJourneyId,
+          date,
+          fromQuayId,
+        },
+      ],
+    });
+  };
+
   return (
     <View style={styles.container}>
       <FullScreenHeader title={stopPlace?.name} leftButton={{type: 'back'}} />
@@ -163,7 +180,7 @@ export default function StopPlaceScreen({
               quay={item}
               selectedQuayId={selectedQuay?.id}
               data={state.data}
-              navigation={navigation}
+              navigateToDetails={navigateToDetails}
               navigateToQuay={(quay) => {
                 navigation.setParams({selectedQuay: quay});
               }}
@@ -174,11 +191,6 @@ export default function StopPlaceScreen({
     </View>
   );
 }
-
-type EstimatedCallLineProps = {
-  departure: EstimatedCall;
-  navigation: StackNavigationProp<DeparturesStackParams>;
-};
 
 function getDeparturesForQuay(
   departures: EstimatedCall[] | null,
@@ -296,7 +308,11 @@ type QuaySectionProps = {
   selectedQuayId: String | undefined;
   data: EstimatedCall[] | null;
   navigateToQuay: (arg0: Quay) => void;
-  navigation: StackNavigationProp<DeparturesStackParams>;
+  navigateToDetails: (
+    serviceJourneyId?: string,
+    date?: string,
+    fromQuayId?: string,
+  ) => void;
 };
 
 function QuaySection({
@@ -304,7 +320,7 @@ function QuaySection({
   selectedQuayId,
   data,
   navigateToQuay,
-  navigation,
+  navigateToDetails,
 }: QuaySectionProps): JSX.Element {
   const [isHidden, setIsHidden] = useState(false);
   const styles = useStyles();
@@ -367,7 +383,7 @@ function QuaySection({
               >
                 <EstimatedCallLine
                   departure={item}
-                  navigation={navigation}
+                  navigateToDetails={navigateToDetails}
                 ></EstimatedCallLine>
               </Sections.GenericItem>
             )}
@@ -418,9 +434,18 @@ function changeDay(searchTime: SearchTime, days: number): SearchTime {
   };
 }
 
+type EstimatedCallLineProps = {
+  departure: EstimatedCall;
+  navigateToDetails: (
+    serviceJourneyId?: string,
+    date?: string,
+    fromQuayId?: string,
+  ) => void;
+};
+
 function EstimatedCallLine({
   departure,
-  navigation,
+  navigateToDetails,
 }: EstimatedCallLineProps): JSX.Element {
   const {t, language} = useTranslation();
   const styles = useStyles();
@@ -439,22 +464,15 @@ function EstimatedCallLine({
     ? time
     : t(dictionary.a11yMissingRealTimePrefix) + time;
 
-  const navigateToDetails = () => {
-    if (!departure.serviceJourney) return;
-    navigation.navigate('DepartureDetails', {
-      items: [
-        {
-          serviceJourneyId: departure.serviceJourney.id,
-          date: departure.expectedDepartureTime,
-          fromQuayId: departure.quay?.id,
-        },
-      ],
-    });
-  };
-
   return (
     <TouchableOpacity
-      onPress={navigateToDetails}
+      onPress={() =>
+        navigateToDetails(
+          departure.serviceJourney?.id,
+          departure.expectedDepartureTime,
+          departure.quay?.id,
+        )
+      }
       style={styles.estimatedCallLine}
       accessible={true}
       accessibilityLabel={t(

--- a/src/screens/Departures/index.tsx
+++ b/src/screens/Departures/index.tsx
@@ -7,10 +7,14 @@ import DeparturesRoot, {
 import StopPlaceScreen, {
   StopPlaceScreenParams,
 } from '../Departures/StopPlaceScreen';
+import DepartureDetails, {
+  DepartureDetailsRouteParams,
+} from '../TripDetails/DepartureDetails';
 
 export type DeparturesStackParams = {
   DeparturesRoot: DeparturesScreenParams;
   StopPlaceScreen: StopPlaceScreenParams;
+  DepartureDetails: DepartureDetailsRouteParams;
 };
 
 const Stack = createStackNavigator<DeparturesStackParams>();
@@ -31,6 +35,7 @@ const DeparturesScreen = ({route}: DeparturesScreenRootProps) => {
         initialParams={route.params}
       />
       <Stack.Screen name="StopPlaceScreen" component={StopPlaceScreen} />
+      <Stack.Screen name="DepartureDetails" component={DepartureDetails} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/Departures/index.tsx
+++ b/src/screens/Departures/index.tsx
@@ -10,11 +10,17 @@ import StopPlaceScreen, {
 import DepartureDetails, {
   DepartureDetailsRouteParams,
 } from '../TripDetails/DepartureDetails';
+import QuayDepartures, {
+  QuayDeparturesRouteParams,
+} from '../TripDetails/QuayDepartures';
+import TripDetailsRoot, {DetailsStackParams} from '../TripDetails';
 
 export type DeparturesStackParams = {
   DeparturesRoot: DeparturesScreenParams;
   StopPlaceScreen: StopPlaceScreenParams;
   DepartureDetails: DepartureDetailsRouteParams;
+  QuayDepartures: QuayDeparturesRouteParams;
+  TripDetails: DetailsStackParams;
 };
 
 const Stack = createStackNavigator<DeparturesStackParams>();
@@ -36,6 +42,8 @@ const DeparturesScreen = ({route}: DeparturesScreenRootProps) => {
       />
       <Stack.Screen name="StopPlaceScreen" component={StopPlaceScreen} />
       <Stack.Screen name="DepartureDetails" component={DepartureDetails} />
+      <Stack.Screen name="QuayDepartures" component={QuayDepartures} />
+      <Stack.Screen name="TripDetails" component={TripDetailsRoot} />
     </Stack.Navigator>
   );
 };

--- a/src/screens/Departures/index.tsx
+++ b/src/screens/Departures/index.tsx
@@ -1,4 +1,4 @@
-import {createStackNavigator} from '@react-navigation/stack';
+import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 import React from 'react';
 import DeparturesRoot, {
   DeparturesScreenParams,
@@ -14,6 +14,7 @@ import QuayDepartures, {
   QuayDeparturesRouteParams,
 } from '../TripDetails/QuayDepartures';
 import TripDetailsRoot, {DetailsStackParams} from '../TripDetails';
+import TravelDetailsMap, {MapDetailRouteParams} from '../TripDetails/Map';
 
 export type DeparturesStackParams = {
   DeparturesRoot: DeparturesScreenParams;
@@ -21,6 +22,7 @@ export type DeparturesStackParams = {
   DepartureDetails: DepartureDetailsRouteParams;
   QuayDepartures: QuayDeparturesRouteParams;
   TripDetails: DetailsStackParams;
+  DetailsMap: MapDetailRouteParams;
 };
 
 const Stack = createStackNavigator<DeparturesStackParams>();
@@ -44,6 +46,13 @@ const DeparturesScreen = ({route}: DeparturesScreenRootProps) => {
       <Stack.Screen name="DepartureDetails" component={DepartureDetails} />
       <Stack.Screen name="QuayDepartures" component={QuayDepartures} />
       <Stack.Screen name="TripDetails" component={TripDetailsRoot} />
+      <Stack.Screen
+        name="DetailsMap"
+        component={TravelDetailsMap}
+        options={{
+          ...TransitionPresets.SlideFromRightIOS,
+        }}
+      />
     </Stack.Navigator>
   );
 };


### PR DESCRIPTION
Lagt til navigasjon til detaljvisning fra nye avganger. Bruker foreløbig de gamle skjermene med JP2, og viser også til "gamle" avganger når man navigerer til et stopp fra detaljer.

https://user-images.githubusercontent.com/1774972/149936850-70ee3618-f576-4421-84e3-354a861860c3.mp4

closes #2012 