### PR TITLE
feat: Use correct theme color on line number text

### DIFF
--- a/src/components/transportation-icon/index.tsx
+++ b/src/components/transportation-icon/index.tsx
@@ -10,10 +10,10 @@ import {
   Subway,
 } from '@atb/assets/svg/icons/transportation';
 import {LegMode, TransportSubmode, TransportMode} from '@atb/sdk';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 import {
   Mode as Mode_v2,
@@ -37,17 +37,16 @@ const TransportationIcon: React.FC<TransportationIconProps> = ({
   lineNumber,
 }) => {
   const {t} = useTranslation();
-  const color = useTransportationColor(mode, subMode, 'color');
-  const backgroundColor = useTransportationColor(
-    mode,
-    subMode,
-    'backgroundColor',
-  );
+  const {theme} = useTheme();
+  const themeColor = useThemeColorForTransportMode(mode, subMode);
+  const backgroundColor = theme.colors[themeColor].backgroundColor;
   const svg = getTransportModeSvg(mode);
   const styles = useStyles();
 
   const lineNumberElement = lineNumber ? (
-    <ThemeText type="body__primary--bold">{lineNumber}</ThemeText>
+    <ThemeText type="body__primary--bold" color={themeColor}>
+      {lineNumber}
+    </ThemeText>
   ) : null;
 
   return svg ? (
@@ -55,7 +54,7 @@ const TransportationIcon: React.FC<TransportationIconProps> = ({
       <ThemeIcon
         style={styles.lineNumber}
         svg={svg}
-        fill={color}
+        colorType={themeColor}
         accessibilityLabel={t(getTranslatedModeName(mode))}
       />
       {lineNumberElement}

--- a/src/utils/use-transportation-color.ts
+++ b/src/utils/use-transportation-color.ts
@@ -1,30 +1,39 @@
 import {useTheme} from '@atb/theme';
 import {AnyMode, AnySubMode} from '@atb/components/transportation-icon';
+import {ThemeColor} from '@atb/theme/colors';
 
 export function useTransportationColor(
   mode?: AnyMode,
   subMode?: AnySubMode,
   colorType: 'color' | 'backgroundColor' = 'backgroundColor',
 ): string {
+  const themeColor = useThemeColorForTransportMode(mode, subMode);
   const {theme} = useTheme();
+  return theme.colors[themeColor][colorType];
+}
+
+export const useThemeColorForTransportMode = (
+  mode?: AnyMode,
+  subMode?: AnySubMode,
+): ThemeColor => {
   switch (mode) {
     case 'bus':
     case 'coach':
       if (subMode === 'localBus') {
-        return theme.colors.transport_city[colorType];
+        return 'transport_city';
       }
-      return theme.colors.transport_region[colorType];
+      return 'transport_region';
     case 'rail':
-      return theme.colors.transport_train[colorType];
+      return 'transport_train';
     case 'tram':
-      return theme.colors.transport_city[colorType];
+      return 'transport_city';
     case 'water':
-      return theme.colors.transport_boat[colorType];
+      return 'transport_boat';
     case 'air':
-      return theme.colors.transport_plane[colorType];
+      return 'transport_plane';
     case 'metro':
-      return theme.colors.transport_train[colorType];
+      return 'transport_train';
     default:
-      return theme.colors.transport_other[colorType];
+      return 'transport_other';
   }
-}
+};


### PR DESCRIPTION
Før / Etter
<div>
<img width="399" alt="Screenshot 2022-01-19 at 10 03 14" src="https://user-images.githubusercontent.com/675421/150104113-bcb147aa-e551-47a3-81e9-b85710e6410e.png">
<img width="399" alt="Screenshot 2022-01-19 at 10 37 23" src="https://user-images.githubusercontent.com/675421/150104105-075dce0f-4fe6-4bb8-9e4f-6807244e7433.png">
</div>