### PR TITLE
fix: Forslag for å sette custom BFF URL

### DIFF
--- a/scripts/override-environment.sh
+++ b/scripts/override-environment.sh
@@ -1,4 +1,4 @@
-if [ "$#" -ne 2 ]
+if [ "$#" -lt 2 ]
 then
     echo "Argument error!"
     echo "First argument should be the environment name."
@@ -11,7 +11,8 @@ then
     echo "Available app variant names:
 -atb
 -nfk"
-
+    echo "Third argument is optional an can be used to set BFF host to localhost."
+    echo "For android this would normally be 'http://10.0.2.2:8080' since the emulator redirects this to you dev localhost"
     echo "Example:
 ./override-environment.sh store atb"
     exit 1
@@ -45,4 +46,8 @@ else
 
     echo "Copying boot splash image to assets/"
     cp $ORG_FOLDER/bootsplash_logo_original.png assets/
+    if [ ! -z "$3" ]
+    then
+      echo "\nBFF_URL=$3" >> .env
+    fi
 fi

--- a/scripts/override-environment.sh
+++ b/scripts/override-environment.sh
@@ -11,8 +11,8 @@ then
     echo "Available app variant names:
 -atb
 -nfk"
-    echo "Third argument is optional an can be used to set BFF host to localhost."
-    echo "For android this would normally be 'http://10.0.2.2:8080' since the emulator redirects this to you dev localhost"
+    echo "Third argument is optional an can be used to override BFF host."
+    echo "For android this would normally be 'http://10.0.2.2:8080' for local development."
     echo "Example:
 ./override-environment.sh store atb"
     exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-if [ "$#" -ne 2 ]
+if [ "$#" -lt 2 ]
 then
     echo "Argument error!"
     echo "First argument should be the environment name."
@@ -11,11 +11,12 @@ then
     echo "Available app variant names:
 -atb
 -nfk"
-
+    echo "Third argument is optional an can be used to set BFF host to localhost."
+    echo "For android this would normally be 'http://10.0.2.2:8080' since the emulator redirects this to you dev localhost"
     echo "Example:
-./setup.sh dev atb"
+./setup.sh dev atb "
     exit 1
 else
-    sh ./scripts/override-environment.sh $1 $2
+    sh ./scripts/override-environment.sh $1 $2 $3
     sh ./scripts/generate-native-assets.sh
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -11,8 +11,8 @@ then
     echo "Available app variant names:
 -atb
 -nfk"
-    echo "Third argument is optional an can be used to set BFF host to localhost."
-    echo "For android this would normally be 'http://10.0.2.2:8080' since the emulator redirects this to you dev localhost"
+    echo "Third argument is optional an can be used to override BFF host."
+    echo "For android this would normally be 'http://10.0.2.2:8080' for local development."
     echo "Example:
 ./setup.sh dev atb "
     exit 1

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios, {AxiosError, AxiosRequestConfig} from 'axios';
 import {v4 as uuid} from 'uuid';
-import {API_BASE_URL} from '@env';
+import {API_BASE_URL, BFF_URL} from '@env';
 import {getAxiosErrorMetadata, getAxiosErrorType} from './utils';
 import Bugsnag from '@bugsnag/react-native';
 import {
@@ -14,6 +14,8 @@ import {getBooleanConfigValue} from '../remote-config';
 import auth from '@react-native-firebase/auth';
 
 export default createClient(API_BASE_URL);
+
+export const bffClient = createClient(BFF_URL ?? API_BASE_URL);
 
 const RETRY_COUNT = 3;
 

--- a/src/api/departures/departure-group.ts
+++ b/src/api/departures/departure-group.ts
@@ -2,7 +2,7 @@ import {AxiosRequestConfig} from 'axios';
 import {FavoriteDeparture} from '@atb/favorites/types';
 import {CursoredData, CursoredQuery} from '@atb/sdk';
 import {stringifyWithDate} from '@atb/utils/querystring';
-import client from '../client';
+import {bffClient} from '../client';
 import {StopPlaceGroup} from './types';
 
 export type DepartureGroupsPayload = {
@@ -56,7 +56,7 @@ async function request(
   payload: DepartureGroupsPayload,
   opts?: AxiosRequestConfig,
 ): Promise<DepartureGroupMetadata> {
-  const response = await client.post<DepartureGroupMetadata>(
+  const response = await bffClient.post<DepartureGroupMetadata>(
     url,
     payload,
     opts,

--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -8,7 +8,7 @@ import {
   StopPlaceDetails,
 } from '@atb/sdk';
 import {flatMap} from '@atb/utils/array';
-import client from '../client';
+import {bffClient} from '../client';
 import {DepartureGroupsQuery} from './departure-group';
 import {StopPlaceGroup} from './types';
 
@@ -26,7 +26,11 @@ export async function getDepartures(
   const {numberOfDepartures, pageOffset = 0, pageSize = 2} = query;
   const startTime = query.startTime;
   let url = `bff/v1/departures-from-location-paging?limit=${numberOfDepartures}&pageSize=${pageSize}&pageOffset=${pageOffset}&startTime=${startTime}`;
-  const response = await client.post<DeparturesMetadata>(url, location, opts);
+  const response = await bffClient.post<DeparturesMetadata>(
+    url,
+    location,
+    opts,
+  );
   return response.data;
 }
 
@@ -45,7 +49,7 @@ export async function getRealtimeDeparture(
   });
 
   let url = `bff/v1/departures-realtime?${params}`;
-  const response = await client.get<DeparturesRealtimeData>(url, opts);
+  const response = await bffClient.get<DeparturesRealtimeData>(url, opts);
   return response.data;
 }
 
@@ -64,7 +68,7 @@ export async function getRealtimeDepartureV2(
   });
 
   let url = `bff/v2/departures/realtime?${params}`;
-  const response = await client.get<DeparturesRealtimeData>(url, opts);
+  const response = await bffClient.get<DeparturesRealtimeData>(url, opts);
   return response.data;
 }
 

--- a/src/api/departures/stops-nearest.ts
+++ b/src/api/departures/stops-nearest.ts
@@ -1,7 +1,7 @@
 import {AxiosRequestConfig} from 'axios';
 import {CursoredData, CursoredQuery, StopPlaceDetails} from '@atb/sdk';
 import {stringifyWithDate} from '@atb/utils/querystring';
-import client from '../client';
+import {bffClient} from '../client';
 import {FavoriteDeparture} from '@atb/favorites/types';
 import {StopPlaceQuayDepartures} from '../types/departures';
 import {stringifyUrl} from 'query-string';
@@ -72,7 +72,7 @@ async function request(
   url: string,
   opts?: AxiosRequestConfig,
 ): Promise<NearestStopPlacesQuery> {
-  const response = await client.get<NearestStopPlacesQuery>(url, opts);
+  const response = await bffClient.get<NearestStopPlacesQuery>(url, opts);
   return response.data;
 }
 
@@ -80,7 +80,7 @@ async function requestQuayDepartures(
   url: string,
   opts?: AxiosRequestConfig,
 ): Promise<QuayDeparturesQuery> {
-  const response = await client.get<QuayDeparturesQuery>(url, opts);
+  const response = await bffClient.get<QuayDeparturesQuery>(url, opts);
   return response.data;
 }
 
@@ -88,6 +88,6 @@ async function requestStopPlaceDepartures(
   url: string,
   opts?: AxiosRequestConfig,
 ): Promise<StopPlaceQuayDepartures> {
-  const response = await client.get<StopPlaceQuayDepartures>(url, opts);
+  const response = await bffClient.get<StopPlaceQuayDepartures>(url, opts);
   return response.data;
 }

--- a/src/api/enrollment.ts
+++ b/src/api/enrollment.ts
@@ -1,5 +1,5 @@
 import qs from 'query-string';
-import client from './client';
+import {bffClient} from './client';
 import {stringifyUrl} from './utils';
 
 type EnrollmentResponse =
@@ -14,7 +14,7 @@ export async function enrollIntoBetaGroups(inviteKey: string) {
     inviteKey,
   });
 
-  return await client.post<EnrollmentResponse>(
+  return await bffClient.post<EnrollmentResponse>(
     stringifyUrl(url, query),
     undefined,
     {

--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -1,6 +1,6 @@
 import {FOCUS_LATITUDE, FOCUS_LONGITUDE} from '@env';
 import {Feature, Coordinates} from '../sdk';
-import client from './client';
+import {bffClient} from './client';
 import qs from 'query-string';
 import {stringifyUrl} from './utils';
 import {AxiosRequestConfig} from 'axios';
@@ -28,7 +28,7 @@ export async function autocomplete(
     {skipNull: true},
   );
 
-  return await client.get<Feature[]>(stringifyUrl(url, query), config);
+  return await bffClient.get<Feature[]>(stringifyUrl(url, query), config);
 }
 
 export async function getFeatureFromVenue(
@@ -51,7 +51,7 @@ export async function getFeatureFromVenue(
     {skipNull: true},
   );
 
-  return await client.get<Feature[]>(stringifyUrl(url, query), config);
+  return await bffClient.get<Feature[]>(stringifyUrl(url, query), config);
 }
 
 export async function reverse(
@@ -64,5 +64,5 @@ export async function reverse(
     lon: coordinates?.longitude,
   });
 
-  return await client.get<Feature[]>(stringifyUrl(url, query), config);
+  return await bffClient.get<Feature[]>(stringifyUrl(url, query), config);
 }

--- a/src/api/serviceJourney.ts
+++ b/src/api/serviceJourney.ts
@@ -1,6 +1,6 @@
 import {formatISO} from 'date-fns';
 import {EstimatedCall, ServiceJourneyMapInfoData} from '../sdk';
-import client from './client';
+import {bffClient} from './client';
 import qs from 'query-string';
 import {stringifyUrl} from './utils';
 
@@ -16,7 +16,7 @@ export async function getDepartures(
   if (date) {
     url = url + `?date=${formatISO(date, {representation: 'date'})}`;
   }
-  const response = await client.get<ServiceJourneDepartures>(url);
+  const response = await bffClient.get<ServiceJourneDepartures>(url);
   return response.data?.value ?? [];
 }
 
@@ -33,7 +33,7 @@ export async function getServiceJourneyMapLegs(
     },
     {skipNull: true},
   );
-  const response = await client.get<ServiceJourneyMapInfoData>(
+  const response = await bffClient.get<ServiceJourneyMapInfoData>(
     stringifyUrl(url, query),
   );
   return (

--- a/src/api/trips.ts
+++ b/src/api/trips.ts
@@ -1,5 +1,5 @@
 import {TripPattern} from '@atb/sdk';
-import client from './client';
+import {bffClient} from './client';
 import {Location} from '@atb/favorites/types';
 import {AxiosRequestConfig} from 'axios';
 
@@ -11,7 +11,7 @@ export default async function search(
   opts?: AxiosRequestConfig,
 ) {
   const url = 'bff/v1/journey/trip';
-  return await client.post<TripPattern[]>(
+  return await bffClient.post<TripPattern[]>(
     url,
     {
       from: {
@@ -36,7 +36,7 @@ export async function getSingleTripPattern(
   opts?: AxiosRequestConfig,
 ) {
   const url = `bff/v1/journey/single-trip?id=${tripPatternId}`;
-  const result = await client.get<TripPattern>(url, {
+  const result = await bffClient.get<TripPattern>(url, {
     ...opts,
     skipErrorLogging: (error) => error.response?.status === 410,
   });

--- a/src/api/trips_v2.ts
+++ b/src/api/trips_v2.ts
@@ -1,4 +1,4 @@
-import client from './client';
+import {bffClient} from './client';
 import {AxiosRequestConfig} from 'axios';
 import {TripsQuery} from '@atb/api/types/trips';
 import {TripsQueryVariables} from '@atb/api/types/generated/TripsQuery';
@@ -51,7 +51,7 @@ async function post<T>(
   query: any,
   opts?: AxiosRequestConfig<any>,
 ) {
-  const response = await client.post<T>(url, query, {
+  const response = await bffClient.post<T>(url, query, {
     ...opts,
   });
 

--- a/types/react-native-dotenv.d.ts
+++ b/types/react-native-dotenv.d.ts
@@ -16,4 +16,5 @@ declare module '@env' {
   export const FOCUS_LONGITUDE: number;
   export const IS_QA_ENV: string | undefined;
   export const SAFETY_NET_API_KEY: string;
+  export const BFF_URL: string;
 }


### PR DESCRIPTION
hva tenker dere om å gjøre det slik?

bff-url kan settes via setup-scriptet.
det legges i så fall inn en .env-property BFF_URL
BFF-apier importer en bff-client istedet for en "vanlig" client, der forskjellen er at bff-clienten sjekker om BFF_URL er satt, og bruker i så fall den istedet for API_BASE_URL

jeg har bare lagt inn instruksjoner for android, siden jeg ikke vet hva som må gjøres på ios.

- det er litt rotete at API-er må være bevisst på om de skal bruke en vanlig eller en bff-client
- men: man vil alltid falle tilbake til vanlig client hvis man gjør noe feil.
