### PR TITLE
fix: color for text on ticketing splash

### DIFF
--- a/src/screens/Ticketing/Splash/Info.tsx
+++ b/src/screens/Ticketing/Splash/Info.tsx
@@ -36,10 +36,10 @@ export default function SplashInfo({navigation}: Props) {
       <ScrollView contentContainerStyle={styles.scrollContainer}>
         <View style={styles.contentContainer}>
           <View style={styles.textContent}>
-            <ThemeText style={[styles.text, styles.bold]}>
+            <ThemeText color="primary_2" style={[styles.text, styles.bold]}>
               {t(TicketSplashTexts.splash.title)}
             </ThemeText>
-            <ThemeText style={styles.text}>
+            <ThemeText color="primary_2" style={styles.text}>
               {t(TicketSplashTexts.splash.paragraph1)}
             </ThemeText>
           </View>

--- a/src/translations/screens/TicketSplash.ts
+++ b/src/translations/screens/TicketSplash.ts
@@ -11,7 +11,7 @@ const TicketSplashTexts = {
     title: _('Billettkjøp i app kommer snart!', 'App ticketing on its way!'),
     paragraph1: _(
       'Her kan du snart kjøpe og administrere billetter til reisen din! Da vil du ha alt du trenger i en og samme app.',
-      'Soon you can purchase and organise tickets for your trips – righ here in the app!',
+      'Soon you can purchase and organise tickets for your trips – right here in the app!',
     ),
     betaButtonLabel: _(
       'Jeg har kode til beta for billettkjøp',


### PR DESCRIPTION
Feil farge valgt på ticketing splash:

Før:
<img width="370" alt="Screenshot 2022-01-27 at 13 48 53" src="https://user-images.githubusercontent.com/606374/151362041-099ef42c-e27e-4fe5-8586-fc5543054fbd.png">

Etter:
<img width="371" alt="Screenshot 2022-01-27 at 13 48 48" src="https://user-images.githubusercontent.com/606374/151362048-7c8367ee-5bde-4ded-9c34-2bd99ee06800.png">

