### PR TITLE
feat: add beta features analytics

### DIFF
--- a/src/chat/metadata.ts
+++ b/src/chat/metadata.ts
@@ -17,6 +17,8 @@ type Metadata = {
   'AtB-Mobile-Token-State': string;
   'AtB-Mobile-Token-VisualState': string;
   'AtB-Mobile-Token-Error': string;
+  'AtB-Beta-Departures': string;
+  'AtB-Beta-TripSearch': string;
 };
 
 export async function updateMetadata(metadata: Partial<Metadata>) {

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -23,6 +23,7 @@ import {
   useTicketState,
 } from '@atb/tickets';
 import {usePreferences} from '@atb/preferences';
+import analytics from '@react-native-firebase/analytics';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -172,7 +173,12 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             mode="toggle"
             text={t(ProfileTexts.sections.newFeatures.departures)}
             checked={newDepartures}
-            onPress={(newDepartures) => setPreference({newDepartures})}
+            onPress={(newDepartures) => {
+              analytics().logEvent('toggle_beta_departures', {
+                toggle: newDepartures ? 'enable' : 'disable',
+              });
+              setPreference({newDepartures});
+            }}
           />
         </Sections.Section>
 
@@ -283,9 +289,12 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               mode="toggle"
               text={t(ProfileTexts.sections.newFeatures.assistant)}
               checked={useExperimentalTripSearch}
-              onPress={(useExperimentalTripSearch) =>
-                setPreference({useExperimentalTripSearch})
-              }
+              onPress={(useExperimentalTripSearch) => {
+                analytics().logEvent('toggle_beta_tripsearch', {
+                  toggle: useExperimentalTripSearch ? 'enable' : 'disable',
+                });
+                setPreference({useExperimentalTripSearch});
+              }}
             />
             <Sections.LinkItem
               text="Design system"

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '@atb/tickets';
 import {usePreferences} from '@atb/preferences';
 import analytics from '@react-native-firebase/analytics';
+import {updateMetadata} from '@atb/chat/metadata';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -177,6 +178,9 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               analytics().logEvent('toggle_beta_departures', {
                 toggle: newDepartures ? 'enable' : 'disable',
               });
+              updateMetadata({
+                'AtB-Beta-Departures': newDepartures ? 'enabled' : 'disabled',
+              });
               setPreference({newDepartures});
             }}
           />
@@ -292,6 +296,11 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               onPress={(useExperimentalTripSearch) => {
                 analytics().logEvent('toggle_beta_tripsearch', {
                   toggle: useExperimentalTripSearch ? 'enable' : 'disable',
+                });
+                updateMetadata({
+                  'AtB-Beta-TripSearch': useExperimentalTripSearch
+                    ? 'enabled'
+                    : 'disabled',
                 });
                 setPreference({useExperimentalTripSearch});
               }}


### PR DESCRIPTION
closes #1957

### Google analytics

Logger en event `enable_beta_departures` og `enable_beta_tripsearch` hver gang noen toggler en betafunksjon av eller på, som legges som parameter "toggle: enable / disable". 

Dette betyr at samme bruker kan telles som flere aktiveringer hvis man skrur av og på flere ganger, men tenker det er ok i denne omgang.

### Intercom

Legger til to attributter for intercom `AtB-Beta-TripSearch` og `AtB-Beta-Departures`, som er disabled eller enabled. Disse settes ved aktiverering / deaktivering, så den vil ikke være satt for de som allerede har skrudd betafunksjonene på før denne funksjonen er lagt til.

[Eksempel i intercom](https://app.intercom.com/a/apps/xcvep5se/inbox/inbox/5163675/conversations/159542700000718)
![Screenshot 2022-02-08 at 10 10 06](https://user-images.githubusercontent.com/1774972/152955266-11bc8aa0-ebbe-435b-8ace-80f2d7577f36.png)
