### PR TITLE
fix: use `aimedDepartureTime` as part of EstimatedCallItem key

### DIFF
--- a/src/api/types/generated/QuayDeparturesQuery.ts
+++ b/src/api/types/generated/QuayDeparturesQuery.ts
@@ -1,26 +1,27 @@
 import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
 
 export type QuayDeparturesQuery = {
-  quay?: Types.Maybe<{
+  quay?: {
     id: string;
-    description?: Types.Maybe<string>;
-    publicCode?: Types.Maybe<string>;
+    description?: string;
+    publicCode?: string;
     name: string;
     estimatedCalls: Array<{
-      expectedDepartureTime?: Types.Maybe<any>;
-      realtime?: Types.Maybe<boolean>;
-      quay?: Types.Maybe<{id: string}>;
-      destinationDisplay?: Types.Maybe<{frontText?: Types.Maybe<string>}>;
-      serviceJourney?: Types.Maybe<{
+      expectedDepartureTime?: any;
+      aimedDepartureTime?: any;
+      realtime?: boolean;
+      quay?: {id: string};
+      destinationDisplay?: {frontText?: string};
+      serviceJourney?: {
         id: string;
         line: {
           id: string;
-          description?: Types.Maybe<string>;
-          publicCode?: Types.Maybe<string>;
-          transportMode?: Types.Maybe<Types.TransportMode>;
-          transportSubmode?: Types.Maybe<Types.TransportSubmode>;
+          description?: string;
+          publicCode?: string;
+          transportMode?: Types.TransportMode;
+          transportSubmode?: Types.TransportSubmode;
         };
-      }>;
+      };
     }>;
-  }>;
+  };
 };

--- a/src/api/types/generated/StopQuayDeparturesQuery.ts
+++ b/src/api/types/generated/StopQuayDeparturesQuery.ts
@@ -1,30 +1,27 @@
 import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
 
 export type StopPlaceQuayDeparturesQuery = {
-  stopPlace?: Types.Maybe<{
+  stopPlace?: {
     id: string;
-    quays?: Types.Maybe<
-      Array<
-        Types.Maybe<{
+    quays?: Array<{
+      id: string;
+      estimatedCalls: Array<{
+        expectedDepartureTime?: any;
+        aimedDepartureTime?: any;
+        realtime?: boolean;
+        quay?: {id: string};
+        destinationDisplay?: {frontText?: string};
+        serviceJourney?: {
           id: string;
-          estimatedCalls: Array<{
-            expectedDepartureTime?: Types.Maybe<any>;
-            realtime?: Types.Maybe<boolean>;
-            quay?: Types.Maybe<{id: string}>;
-            destinationDisplay?: Types.Maybe<{frontText?: Types.Maybe<string>}>;
-            serviceJourney?: Types.Maybe<{
-              id: string;
-              line: {
-                id: string;
-                description?: Types.Maybe<string>;
-                publicCode?: Types.Maybe<string>;
-                transportMode?: Types.Maybe<Types.TransportMode>;
-                transportSubmode?: Types.Maybe<Types.TransportSubmode>;
-              };
-            }>;
-          }>;
-        }>
-      >
-    >;
-  }>;
+          line: {
+            id: string;
+            description?: string;
+            publicCode?: string;
+            transportMode?: Types.TransportMode;
+            transportSubmode?: Types.TransportSubmode;
+          };
+        };
+      }>;
+    }>;
+  };
 };

--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -90,7 +90,12 @@ export default function QuaySection({
                 ></EstimatedCallItem>
               </Sections.GenericItem>
             )}
-            keyExtractor={(item) => item.serviceJourney?.id || ''}
+            keyExtractor={(item: EstimatedCall) =>
+              // ServiceJourney ID is not a unique key if a ServiceJourney
+              // passes by the same stop several times, (e.g. Ringen in Oslo)
+              // which is why it is used in combination with aimedDepartureTime.
+              item.serviceJourney?.id + item.aimedDepartureTime
+            }
             ListEmptyComponent={
               <>
                 {data && (


### PR DESCRIPTION
fixes #2090 