### PR TITLE
fix: quay section border

### DIFF
--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -100,7 +100,7 @@ export default function QuaySection({
               <>
                 {data && (
                   <Sections.GenericItem
-                    radius={navigateToQuay ? 'bottom' : undefined}
+                    radius={!navigateToQuay ? 'bottom' : undefined}
                   >
                     <ThemeText color="secondary">
                       {t(DeparturesTexts.noDepartures)}


### PR DESCRIPTION
Liten fiks av feil logikk i om liste skulle ha border i bunnen eller ikke.

### Før / etter

![IMG_0502](https://user-images.githubusercontent.com/1774972/153007994-9b1ac383-0d75-44d1-9d57-7f9daebb80b3.jpg)
![IMG_AA1217989614-1](https://user-images.githubusercontent.com/1774972/153008208-0a080c31-47bf-4871-8498-daf20555bdcc.jpeg)

