### PR TITLE
feat: use timeRange for StopPlace departures

### DIFF
--- a/src/api/departures/stops-nearest.ts
+++ b/src/api/departures/stops-nearest.ts
@@ -25,10 +25,10 @@ export type StopPlaceDeparturesPayload = {
 };
 
 export type StopPlaceDeparturesQuery = {
-  filterByInUse?: boolean;
   id: string;
   numberOfDepartures?: number;
   startTime?: string;
+  timeRange?: number;
 };
 
 export type QuayDeparturesVariables = {

--- a/src/screens/Departures/state/quay-state.ts
+++ b/src/screens/Departures/state/quay-state.ts
@@ -262,16 +262,26 @@ export function useQuayData(
   };
 }
 
+// Get seconds until midnight, but a minimum of `minSeconds`
+export function getSecondsUntilMidnightOrMinimum(
+  isoTime: string,
+  minimumSeconds: number = 0,
+): number {
+  const timeUntilMidnight = differenceInSeconds(
+    addDays(parseISO(isoTime), 1).setHours(0, 0, 0),
+    parseISO(isoTime),
+  );
+  return Math.round(Math.max(timeUntilMidnight, minimumSeconds));
+}
+
 async function fetchEstimatedCalls(
   queryInput: DepartureGroupsQuery,
   quay: DepartureTypes.Quay,
 ): Promise<DepartureTypes.EstimatedCall[]> {
-  // Get seconds until midnight, but a minimum of 3 hours
-  const timeUntilMidnight = differenceInSeconds(
-    addDays(parseISO(queryInput.startTime), 1).setHours(0, 0, 0),
-    parseISO(queryInput.startTime),
+  const timeRange = getSecondsUntilMidnightOrMinimum(
+    queryInput.startTime,
+    MIN_TIME_RANGE,
   );
-  const timeRange = Math.round(Math.max(timeUntilMidnight, MIN_TIME_RANGE));
 
   const result = await getQuayDepartures({
     id: quay.id,

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -21,6 +21,7 @@ import {updateDeparturesWithRealtimeV2} from '../../../departure-list/utils';
 import {getStopPlaceDepartures} from '@atb/api/departures/stops-nearest';
 import {flatMap} from 'lodash';
 import {EstimatedCall, Place} from '@atb/api/types/departures';
+import {getSecondsUntilMidnightOrMinimum} from './quay-state';
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
 
@@ -270,10 +271,16 @@ async function fetchEstimatedCalls(
   queryInput: DepartureGroupsQuery,
   stopPlace: Place,
 ): Promise<EstimatedCall[]> {
+  const timeRange = getSecondsUntilMidnightOrMinimum(
+    queryInput.startTime,
+    MIN_TIME_RANGE,
+  );
+
   const result = await getStopPlaceDepartures({
     id: stopPlace.id,
     startTime: queryInput.startTime,
     numberOfDepartures: queryInput.limitPerLine,
+    timeRange: timeRange,
   });
 
   return flatMap(


### PR DESCRIPTION
Legger til at avganger som listes ut for et stoppested, er begrenset til samme dag eller minimum 3 timer, slik som for quays.

Eksempel: Ladeveien har flere enn 2 avganger neste dag som ville blitt listet ut før, men nå begrenes det til 3 timer, siden søket er fra kl. 23:50.

![Simulator Screen Shot - iPhone 13 - 2022-02-08 at 15 59 31](https://user-images.githubusercontent.com/1774972/153013690-65a7e76f-79b5-4324-b31d-cc84f666ba6f.png)


closes #2131 