### PR TITLE
fix: sort departures on realtime updates

### DIFF
--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -128,6 +128,11 @@ export function updateDeparturesWithRealtimeV2(
         expectedDepartureTime: departureRealtime.timeData.expectedDepartureTime,
         realtime: departureRealtime.timeData.realtime,
       };
+    })
+    .sort((a, b) => {
+      // Sort departures based on expectedDepartureTime, for cases where a
+      // realtime update shows that a departure has passed another.
+      return a.expectedDepartureTime < b.expectedDepartureTime ? 0 : 1;
     });
 }
 


### PR DESCRIPTION
Denne sorterer alle avganger hver gang det kommer sanntidsoppdateringer. 

### Ytelse

Tenkte at dette kom til å bli et ytelseproblem når det er snakk om mange avganger, men nå klarer jeg ikke å måle noen tydelig forskjell i millisekunder for rundt 700 avganger. Dette er fordi jeg bare sammeligner dato strings (f.eks `2022-02-09T11:16:21+01:00 < 2022-02-09T11:06:44+01:00`), som ser til å ha veldig god ytelse. 

I mine målinger, tar hele `updateDeparturesWithRealtimeV2` vanligvis 3-4ms. Prøvde først å parse datoene, og så bruke `isBefore` fra date-fns til å sammenligne, men da så jeg en økning på ca. 20ms. Etter å ha gått over til å bare sammenligne strings, tar hele funksjonen fortsatt 3-4ms, så ingen betydelig økning.

### Hyppig oppdatering av listen

Som følge av forandringen, oppdaget jeg at ved travle stoppesteder som i Prinsens Gate, så bytter busser rekkefølge ganske ofte. Nå oppdaterer jeg listen hvert 10 sekund, og som vist i opptaket under, så er det ikke uvanlig at noen busser bytter rekkefølge hver gang listen oppdateres. Vet ikke om dette er et problem, og om jeg bør øke tiden mellom oppdateringer (var 30 sek før), eller om det bare er en god ting at brukeren opplever at listen holdes oppdatert. Noen som har innspill?

https://user-images.githubusercontent.com/1774972/153167474-c774b207-0b3e-4ef8-9f99-1253e61e8b9f.mp4

fixes #2015