### PR TITLE
fix: Move invitation code to beta-section

### DIFF
--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -159,10 +159,6 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               onPress={() => navigation.navigate('Language')}
             />
           )}
-          <Sections.LinkItem
-            text={t(ProfileTexts.sections.settings.linkItems.enrollment.label)}
-            onPress={() => navigation.navigate('Enrollment')}
-          />
         </Sections.Section>
         <Sections.Section withPadding>
           <Sections.GenericItem>
@@ -190,6 +186,10 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               });
               setPreference({newDepartures});
             }}
+          />
+          <Sections.LinkItem
+            text={t(ProfileTexts.sections.settings.linkItems.enrollment.label)}
+            onPress={() => navigation.navigate('Enrollment')}
           />
         </Sections.Section>
 

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -46,7 +46,7 @@ const ProfileTexts = {
           label: _('Språk', 'Language'),
         },
         enrollment: {
-          label: _('Ny funksjonalitet', 'New features'),
+          label: _('Invitasjonskode', 'Invitation code'),
         },
       },
     },


### PR DESCRIPTION
Ref. https://mittatb.slack.com/archives/CS3JNRXEV/p1644484599374919

Flytter invitasjonskode-knappen til under beta-seksjonen

![image](https://user-images.githubusercontent.com/4932625/153435425-d8418688-6e61-4db6-b544-0fbc6ee0f4cb.png)
