### PR TITLE
feat: preserve time selection across views and dates

### DIFF
--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -1,7 +1,7 @@
 import FullScreenHeader from '@atb/components/screen-header/full-header';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {View} from 'react-native';
-import React from 'react';
+import React, {useState} from 'react';
 import {FlatList} from 'react-native-gesture-handler';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {RouteProp} from '@react-navigation/native';
@@ -12,6 +12,7 @@ import DeparturesTexts from '@atb/translations/screens/Departures';
 import {DeparturesStackParams} from '.';
 import QuayView from './QuayView';
 import StopPlaceView from './StopPlaceView';
+import {SearchTime} from './NearbyPlaces';
 
 export type PlaceScreenParams = {
   place: Place;
@@ -38,6 +39,10 @@ export default function PlaceScreen({
   const styles = useStyles();
   const {theme} = useTheme();
   const {t} = useTranslation();
+  const [searchTime, setSearchTime] = useState<SearchTime>({
+    option: 'now',
+    date: new Date().toISOString(),
+  });
 
   const navigateToDetails = (
     serviceJourneyId?: string,
@@ -94,12 +99,19 @@ export default function PlaceScreen({
         )}
       />
       {selectedQuay ? (
-        <QuayView quay={selectedQuay} navigateToDetails={navigateToDetails} />
+        <QuayView
+          quay={selectedQuay}
+          navigateToDetails={navigateToDetails}
+          searchTime={searchTime}
+          setSearchTime={setSearchTime}
+        />
       ) : (
         <StopPlaceView
           stopPlace={place}
           navigateToDetails={navigateToDetails}
           navigateToQuay={navigateToQuay}
+          searchTime={searchTime}
+          setSearchTime={setSearchTime}
         />
       )}
     </View>

--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -40,8 +40,6 @@ export default function QuayView({
 
   return (
     <SectionList
-      stickySectionHeadersEnabled={true}
-      stickyHeaderIndices={[0]}
       ListHeaderComponent={
         <DateNavigation
           searchTime={searchTime}

--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import {RefreshControl, SectionList, SectionListData} from 'react-native';
 import {Quay} from '@atb/api/types/departures';
 import {SearchTime} from './NearbyPlaces';
@@ -17,13 +17,16 @@ export type QuayViewProps = {
     date?: string,
     fromQuayId?: string,
   ) => void;
+  searchTime: SearchTime;
+  setSearchTime: (searchTime: SearchTime) => void;
 };
 
-export default function QuayView({quay, navigateToDetails}: QuayViewProps) {
-  const [searchTime, setSearchTime] = useState<SearchTime>({
-    option: 'now',
-    date: new Date().toISOString(),
-  });
+export default function QuayView({
+  quay,
+  navigateToDetails,
+  searchTime,
+  setSearchTime,
+}: QuayViewProps) {
   const {state, refresh} = useQuayData(
     quay,
     searchTime?.option !== 'now' ? searchTime.date : undefined,

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -49,8 +49,6 @@ export default function StopPlaceView({
     <>
       {quayListData && (
         <SectionList
-          stickySectionHeadersEnabled={true}
-          stickyHeaderIndices={[0]}
           ListHeaderComponent={
             <DateNavigation
               searchTime={searchTime}

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useMemo, useState} from 'react';
-import {RefreshControl, SectionList, SectionListData, View} from 'react-native';
+import React, {useEffect, useMemo} from 'react';
+import {RefreshControl, SectionList, SectionListData} from 'react-native';
 import {useStopPlaceData} from './state/stop-place-state';
-import {Place, Quay, StopPlacePosition} from '@atb/api/types/departures';
+import {Place, Quay} from '@atb/api/types/departures';
 import {SearchTime} from './NearbyPlaces';
 import DateNavigation from './components/DateNavigator';
 import QuaySection from './components/QuaySection';
@@ -14,17 +14,17 @@ type StopPlaceViewProps = {
     date?: string,
     fromQuayId?: string,
   ) => void;
+  searchTime: SearchTime;
+  setSearchTime: (searchTime: SearchTime) => void;
 };
 
 export default function StopPlaceView({
   stopPlace,
   navigateToQuay,
   navigateToDetails,
+  searchTime,
+  setSearchTime,
 }: StopPlaceViewProps) {
-  const [searchTime, setSearchTime] = useState<SearchTime>({
-    option: 'now',
-    date: new Date().toISOString(),
-  });
   const {state, refresh} = useStopPlaceData(
     stopPlace,
     searchTime?.option !== 'now' ? searchTime.date : undefined,

--- a/src/screens/Departures/components/DateNavigator.tsx
+++ b/src/screens/Departures/components/DateNavigator.tsx
@@ -19,7 +19,7 @@ import DeparturesTexts from '@atb/translations/screens/Departures';
 
 type DateNavigationProps = {
   searchTime: SearchTime;
-  setSearchTime: Dispatch<SetStateAction<SearchTime>>;
+  setSearchTime: (searchTime: SearchTime) => void;
 };
 
 export default function DateNavigation({

--- a/src/screens/Departures/components/DateNavigator.tsx
+++ b/src/screens/Departures/components/DateNavigator.tsx
@@ -133,10 +133,13 @@ export default function DateNavigation({
 }
 
 function changeDay(searchTime: SearchTime, days: number): SearchTime {
-  const date = addDays(parseISO(searchTime.date).setHours(0, 0), days);
+  const date =
+    searchTime.option === 'now'
+      ? addDays(parseISO(searchTime.date).setHours(0, 0), days)
+      : addDays(parseISO(searchTime.date), days);
   return {
-    option: isToday(date) ? 'now' : 'departure',
-    date: isToday(date) ? new Date().toISOString() : date.toISOString(),
+    option: isInThePast(date) ? 'now' : 'departure',
+    date: isInThePast(date) ? new Date().toISOString() : date.toISOString(),
   };
 }
 


### PR DESCRIPTION
Som beskrevet i issue:

- Dato og klokkeslett bevares hvis man hopper mellom plattformer / "alle stopp"
- Klokkeslett bevares hvis man hopper mellom datoer ("Neste dag" / "Forrige dag")
- Dato og tid blir resatt til nåtidspunkt hvis man går ut av stoppestedet og tilbake til søkeskjermen

Klokkeslett blir også resatt til "nå" hvis man går til dagens dato, og klokkeslett er tilbake i tid. 

https://user-images.githubusercontent.com/1774972/153556225-999a253d-690a-49fa-903a-5e305b7ac5cf.mp4



closes #2146 