### PR TITLE
fix: only show chat count indicator if intercom enabled

### DIFF
--- a/src/chat/use-chat-unread-count.ts
+++ b/src/chat/use-chat-unread-count.ts
@@ -1,8 +1,10 @@
 import Intercom from 'react-native-intercom';
 import {useEffect, useState, useCallback} from 'react';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 export default function useChatUnreadCount() {
   const [count, setCount] = useState(0);
+  const {enable_intercom} = useRemoteConfig();
 
   const callback = useCallback(({count}: {count: number}) => {
     setCount(count);
@@ -28,5 +30,8 @@ export default function useChatUnreadCount() {
     };
   }, []);
 
+  if (!enable_intercom) {
+    return 0;
+  }
   return count;
 }

--- a/src/chat/use-chat-unread-count.ts
+++ b/src/chat/use-chat-unread-count.ts
@@ -11,6 +11,11 @@ export default function useChatUnreadCount() {
   }, []);
 
   useEffect(() => {
+    if (!enable_intercom) {
+      setCount(0);
+      return;
+    }
+
     let mounted = true;
     async function getInitialUnreadCount() {
       const initialCount = await Intercom.getUnreadConversationCount();
@@ -28,10 +33,7 @@ export default function useChatUnreadCount() {
         callback,
       );
     };
-  }, []);
+  }, [enable_intercom]);
 
-  if (!enable_intercom) {
-    return 0;
-  }
   return count;
 }


### PR DESCRIPTION
Per nå vises chat count dersom intercom ikke er aktivert også. For de fleste tilfeller vil dette vel være 0, så ikke sikkert det er et problem. Men det kan være tilfeller hvor AtB går fra å ha Intercom aktivt til å være inaktivt hvor det henger igjen count.

Ikke viktig sak, men rett skal være rett osv.