### PR TITLE
feat: Own Firestore-flag for enabling mobile-token

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,8 +58,8 @@ const App = () => {
                       <SearchHistoryContextProvider>
                         <GeolocationContextProvider>
                           <RemoteConfigContextProvider>
-                            <MobileTokenContextProvider>
-                              <TicketContextProvider>
+                            <TicketContextProvider>
+                              <MobileTokenContextProvider>
                                 <AppLanguageProvider>
                                   <AlertsContextProvider>
                                     <BottomSheetProvider>
@@ -67,8 +67,8 @@ const App = () => {
                                     </BottomSheetProvider>
                                   </AlertsContextProvider>
                                 </AppLanguageProvider>
-                              </TicketContextProvider>
-                            </MobileTokenContextProvider>
+                              </MobileTokenContextProvider>
+                            </TicketContextProvider>
                           </RemoteConfigContextProvider>
                         </GeolocationContextProvider>
                       </SearchHistoryContextProvider>

--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -11,9 +11,11 @@ import ValidityHeader from '../ValidityHeader';
 import ValidityLine from '../ValidityLine';
 import {getValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
 import QrCode from '@atb/screens/Ticketing/Ticket/Details/QrCode';
-import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import PaperQrCode from '@atb/screens/Ticketing/Ticket/Details/PaperQrCode';
-import {useMobileContextState} from '@atb/mobile-token/MobileTokenContext';
+import {
+  useHasEnabledMobileToken,
+  useMobileContextState,
+} from '@atb/mobile-token/MobileTokenContext';
 
 type Props = {
   fareContract: FareContract;
@@ -29,7 +31,7 @@ const DetailsContent: React.FC<Props> = ({
   hasActiveTravelCard = false,
 }) => {
   const {t, language} = useTranslation();
-  const {enable_period_tickets} = useRemoteConfig();
+  const hasEnabledMobileToken = useHasEnabledMobileToken();
   const {tokenStatus} = useMobileContextState();
 
   const firstTravelRight = fc.travelRights[0];
@@ -92,7 +94,7 @@ const DetailsContent: React.FC<Props> = ({
           onPress={onReceiptNavigate}
           accessibility={{accessibilityRole: 'button'}}
         />
-        {enable_period_tickets ? (
+        {hasEnabledMobileToken ? (
           <QrCode validityStatus={validityStatus} isInspectable={inspectable} />
         ) : (
           <PaperQrCode

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -5,7 +5,6 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
   filterActiveOrCanBeUsedFareContracts,
-  filterExpiredFareContracts,
   isValidRightNowFareContract,
   useTicketState,
 } from '@atb/tickets';
@@ -21,6 +20,7 @@ import {AddTicket} from '@atb/assets/svg/mono-icons/ticketing';
 import ThemeText from '@atb/components/text';
 import MessageBox from '@atb/components/message-box';
 import {useAppState} from '@atb/AppContext';
+import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
 
 export type TicketingScreenNavigationProp =
   StackNavigationProp<RootStackParamList>;
@@ -32,8 +32,8 @@ type Props = {
 export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {must_upgrade_ticketing, enable_recent_tickets, enable_period_tickets} =
-    useRemoteConfig();
+  const {must_upgrade_ticketing, enable_recent_tickets} = useRemoteConfig();
+  const hasEnabledMobileToken = useHasEnabledMobileToken();
   const {abtCustomerId, authenticationType} = useAuthState();
   const {t} = useTranslation();
   const appContext = useAppState();
@@ -128,7 +128,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
             icon={AddTicket}
             iconPosition={'right'}
           />
-          {enable_period_tickets && (
+          {hasEnabledMobileToken && (
             <Button
               mode="primary"
               color="primary_2"

--- a/src/tickets/types.ts
+++ b/src/tickets/types.ts
@@ -187,6 +187,7 @@ export type CustomerProfile = {
   surname?: string;
   travelcard?: TravelCard;
   debug?: boolean;
+  enableMobileToken?: boolean;
 };
 
 export type TravelCard = {


### PR DESCRIPTION
Forslag til hvordan vi kan remotely enable mobile-token for enkelte brukere via Firestore. Tanken er, de som allerede har brukt invitasjonskode og har fått `enable_period_ticket` satt skal få fortsette med det. Men vi kan også skru på et flagg på kundeprofilen i Firestore for å enable både mobile-token og periodebillett. 

Hvis ønskelig kan også denne løsningen utvides på BFF til å samtidig sette flagget i Firestore når folk inputter invitasjonskoden.