### PR TITLE
fix: update quay section padding

### DIFF
--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -42,7 +42,7 @@ export default function QuaySection({
 
   return (
     <View>
-      <Sections.Section withPadding>
+      <Sections.Section withPadding withBottomPadding>
         <Sections.GenericClickableItem
           type="inline"
           onPress={() => {


### PR DESCRIPTION
Under refaktorering av avganger ble forandringene i #2045 med padding mellom quays overskrevet, så jeg prøver igjen!

![Simulator Screen Shot - iPhone 13 - 2022-02-16 at 15 01 19](https://user-images.githubusercontent.com/1774972/154280553-3d6052e7-e4b2-48aa-8fd5-0dcaf02f76f0.png)
