### PR TITLE
chore: Don't run E2E as secondary job

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -86,9 +86,3 @@ jobs:
         env:
           ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_STAGING}}
           ENTUR_CLIENT_SECRET: ${{ secrets.ABT_ENTUR_CLIENT_SECRET_STAGING}}
-  run-e2e-tests:
-    uses: ./.github/workflows/test-e2e.yml
-    with: 
-      e2econfig: ios.release
-    secrets:
-      git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}

--- a/.github/workflows/test-e2e-ios.yml
+++ b/.github/workflows/test-e2e-ios.yml
@@ -1,14 +1,8 @@
-name: E2E test workflow
-
+name: E2E tests on iOS
 on:
-  workflow_call:
-    inputs:
-      e2econfig:
-        required: true
-        type: string
-    secrets:
-      git-crypt-key:
-        required: true
+  push:
+    branches:
+      - master
 
 jobs:
   run_tests:
@@ -25,7 +19,7 @@ jobs:
           use-build-cache: 'true'
           app-environment: 'staging'
           app-org: 'atb'
-          git-crypt-key: ${{ secrets.git-crypt-key }}
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
       - name: Get potentially cached app
         uses: actions/cache@v2
         id: detox-app-cache
@@ -49,9 +43,9 @@ jobs:
         run: detox clean-framework-cache && detox build-framework-cache
       - name: Build Detox-version of app
         if: steps.detox-app-cache.outputs.cache-hit != 'true'
-        run: detox build --configuration ${{ inputs.e2econfig }}
+        run: detox build --configuration ios.release
       - name: Replace bundle in app cache
         if: steps.detox-app-cache.outputs.cache-hit == 'true'
         run: npx react-native bundle --platform ios --dev false --reset-cache --entry-file index.js --bundle-output main.jsbundle && mv main.jsbundle build/detox/ios/Build/Products/Release-iphonesimulator/AtB.app/
       - name: Run tests
-        run: detox test --configuration ${{ inputs.e2econfig }} --loglevel trace
+        run: detox test --configuration ios.release --loglevel trace --retries 3

--- a/.github/workflows/test-e2e-ios.yml
+++ b/.github/workflows/test-e2e-ios.yml
@@ -48,4 +48,11 @@ jobs:
         if: steps.detox-app-cache.outputs.cache-hit == 'true'
         run: npx react-native bundle --platform ios --dev false --reset-cache --entry-file index.js --bundle-output main.jsbundle && mv main.jsbundle build/detox/ios/Build/Products/Release-iphonesimulator/AtB.app/
       - name: Run tests
-        run: detox test --configuration ios.release --loglevel trace --retries 3
+        run: detox test --configuration ios.release --loglevel trace --retries 3 --take-screenshots failing
+      - name: Upload test artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e-artifacts
+          path: artifacts
+          retention-days: 5


### PR DESCRIPTION
Lagt om litt E2E, kjører som en egen workflow - ikke som en del av staging-bygget. Og har lagt på retries (tror det er en race condition på språk, at den ikke switcher fort nok til engelsk selv om det er satt som device language). Og så tar jeg screenshots på feilende tester, og laster opp disse hvis det feiler.