### PR TITLE
chore: Switch AtB TestFlight-upload to Fastlane

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -53,6 +53,6 @@ This key must be added to a JSON-file with the following format (this is an exam
 
 The `key_id`, and `issues_id` is available in the `Users and Access -> Keys -> App Store Connect API`-tab on App Store Connect.
 
-The `key` is a `.p8`-file which you have to download when generating the key.
+The `key` is a `.p8`-file which you have to download when generating the key. You will need to manually add `\n` instead of line breaks in the key. Also remove all whitespaces.
 
 This JSON-file must be base64-encoded and added as a `APP_STORE_CONNECT_API_KEY`-secret on Github Actions for the given organization/environment.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,33 +1,58 @@
 # Managing new releases
+
 ## Build staging android workflow
+
 Each organisation with internal access must setup an [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) on Github
- with secrets required for the workflow.
+with secrets required for the workflow.
 
 ---
 
 ### Secrets required for Firebase App Distribution:
 
- `FIREBASE_APP_ID` - Your app's Firebase App ID e.g. `app: "1:1234567890:android:0a1b2c3d4e5f67890"`
+`FIREBASE_APP_ID` - Your app's Firebase App ID e.g. `app: "1:1234567890:android:0a1b2c3d4e5f67890"`
 
- `FIREBASE_DISTRIBUTION_CREDENTIALS` - base64 encoded service account with `Firebase App Distribution Admin role`
-
+`FIREBASE_DISTRIBUTION_CREDENTIALS` - base64 encoded service account with `Firebase App Distribution Admin role`
 
 ### Secrets required for App Center Distribution:
 
- `APPCENTER_ANDROID_API_KEY`
-
+`APPCENTER_ANDROID_API_KEY`
 
 ### Secrets required for all
 
- `KEYSTORE` - base64 encoded keystore with signing key
+`KEYSTORE` - base64 encoded keystore with signing key
 
- `KEYSTORE_PASS` - password for keystore with signing key
+`KEYSTORE_PASS` - password for keystore with signing key
 
- `KEYSTORE_KEY_ALIAS` - alias of key used for signing
+`KEYSTORE_KEY_ALIAS` - alias of key used for signing
 
- `KEYSTORE_KEY_PASS` - password for key used for signing
+`KEYSTORE_KEY_PASS` - password for key used for signing
 
- `GIT_CRYPT_KEY`
+`GIT_CRYPT_KEY`
 
+`BUGSNAG_API_KEY`
 
- `BUGSNAG_API_KEY`
+### App Store Connect API Key for uploading to TestFlight
+
+We use Fastlanes `upload_to_testflight` to push the app to TestFlight: https://docs.fastlane.tools/actions/pilot/
+
+This requires an API-key per organization, which is encoded into a JSON-file. Ref `app-store-connect-api-key.json` in the `build-store-ios.yml` workflow.
+
+The following docs explain how to generate a an API-key: https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api
+
+This key must be added to a JSON-file with the following format (this is an example, not a real key):
+
+```json
+{
+  "key_id": "D383SF739",
+  "issuer_id": "6053b7fe-68a8-4acb-89be-165aa6465141",
+  "key": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHknlhdlYdLu\n-----END PRIVATE KEY-----",
+  "duration": 1200, # optional (maximum 1200)
+  "in_house": false # optional but may be required if using match/sigh
+}
+```
+
+The `key_id`, and `issues_id` is available in the `Users and Access -> Keys -> App Store Connect API`-tab on App Store Connect.
+
+The `key` is a `.p8`-file which you have to download when generating the key.
+
+This JSON-file must be base64-encoded and added as a `APP_STORE_CONNECT_API_KEY`-secret on Github Actions for the given organization/environment.

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -41,15 +41,7 @@ jobs:
         uses: bruceadams/get-release@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Distribute to TestFlight via appcenter
-        if: matrix.org == 'atb'
-        run: fastlane ios appcenter_testflight
-        env:
-          APPCENTER_API_KEY: ${{ secrets.APPCENTER_IOS_API_KEY }}
-          RELEASE_NOTES: ${{ steps.get_release.outputs.body }}
-          RELEASE_URL: ${{ steps.get_release.outputs.html_url }}
       - name: Distribute to TestFlight
-        if: matrix.org == 'nfk'
         run: |
           echo ${{ secrets.APP_STORE_CONNECT_API_KEY}} | base64 --decode > app-store-connect-api-key.json
           fastlane ios testflight_prod


### PR DESCRIPTION
Also add docs on how to generate the necessary API-key

Fordelen med dette er at vi slipper å gå inn kontinuerlig å re-authetnicate koblingen mot App Store inni AppCenter