### PR TITLE
feat: add information on single tickets on train in zone A

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -118,6 +118,11 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
     travelDate,
   );
 
+  const shouldShowValidTrainTicketNotice =
+    preassignedFareProduct.type === 'single' &&
+    fromTariffZone.id === 'ATB:TariffZone:1' &&
+    toTariffZone.id === 'ATB:TariffZone:1';
+
   useEffect(() => {
     if (params?.refreshOffer) {
       refreshOffer();
@@ -270,15 +275,13 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
         />
       )}
 
-      {preassignedFareProduct.type === 'single' &&
-        fromTariffZone.id === 'ATB:TariffZone:1' &&
-        toTariffZone.id === 'ATB:TariffZone:1' && (
-          <MessageBox
-            containerStyle={styles.warning}
-            message={t(PurchaseOverviewTexts.samarbeidsbillettenInfo)}
-            type="info"
-          />
-        )}
+      {shouldShowValidTrainTicketNotice && (
+        <MessageBox
+          containerStyle={styles.warning}
+          message={t(PurchaseOverviewTexts.samarbeidsbillettenInfo)}
+          type="info"
+        />
+      )}
 
       <View style={styles.toPaymentButton}>
         <Button

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -270,6 +270,16 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
         />
       )}
 
+      {preassignedFareProduct.type === 'single' &&
+        fromTariffZone.id === 'ATB:TariffZone:1' &&
+        toTariffZone.id === 'ATB:TariffZone:1' && (
+          <MessageBox
+            containerStyle={styles.warning}
+            message={t(PurchaseOverviewTexts.samarbeidsbillettenInfo)}
+            type="info"
+          />
+        )}
+
       <View style={styles.toPaymentButton}>
         <Button
           color="primary_2"

--- a/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
@@ -1,5 +1,9 @@
 import {StyleSheet} from '@atb/theme';
-import {isPreactivatedTicket, useTicketState} from '@atb/tickets';
+import {
+  isPreactivatedTicket,
+  isSingleTicket,
+  useTicketState,
+} from '@atb/tickets';
 import {
   PurchaseOverviewTexts,
   TicketTexts,
@@ -46,6 +50,13 @@ export default function DetailsScreen({navigation, route}: Props) {
       orderVersion: fc.version,
     });
 
+  const shouldShowValidTrainTicketNotice =
+    isSingleTicket(firstTravelRight) &&
+    isPreactivatedTicket(firstTravelRight) &&
+    firstTravelRight.tariffZoneRefs.every(
+      (val: string) => val === 'ATB:TariffZone:1',
+    );
+
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -62,16 +73,12 @@ export default function DetailsScreen({navigation, route}: Props) {
           />
         )}
 
-        {firstTravelRight?.type === 'PreActivatedSingleTicket' &&
-          isPreactivatedTicket(firstTravelRight) &&
-          firstTravelRight.tariffZoneRefs.every(
-            (val: string) => val === 'ATB:TariffZone:1',
-          ) && (
-            <MessageBox
-              message={t(PurchaseOverviewTexts.samarbeidsbillettenInfo)}
-              type="info"
-            />
-          )}
+        {shouldShowValidTrainTicketNotice && (
+          <MessageBox
+            message={t(PurchaseOverviewTexts.samarbeidsbillettenInfo)}
+            type="info"
+          />
+        )}
       </ScrollView>
     </View>
   );

--- a/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
@@ -1,6 +1,10 @@
 import {StyleSheet} from '@atb/theme';
-import {useTicketState} from '@atb/tickets';
-import {TicketTexts, useTranslation} from '@atb/translations';
+import {isPreactivatedTicket, useTicketState} from '@atb/tickets';
+import {
+  PurchaseOverviewTexts,
+  TicketTexts,
+  useTranslation,
+} from '@atb/translations';
 import useInterval from '@atb/utils/use-interval';
 import {RouteProp} from '@react-navigation/native';
 import React, {useState} from 'react';
@@ -8,6 +12,7 @@ import {ScrollView, View} from 'react-native';
 import {TicketModalNavigationProp, TicketModalStackParams} from '.';
 import DetailsContent from './DetailsContent';
 import FullScreenHeader from '@atb/components/screen-header/full-header';
+import MessageBox from '@atb/components/message-box';
 
 export type TicketDetailsRouteParams = {
   orderId: string;
@@ -29,6 +34,7 @@ export default function DetailsScreen({navigation, route}: Props) {
   useInterval(() => setNow(Date.now()), 2500);
   const {findFareContractByOrderId, customerProfile} = useTicketState();
   const fc = findFareContractByOrderId(route?.params?.orderId);
+  const firstTravelRight = fc?.travelRights[0];
   const {t} = useTranslation();
 
   const hasActiveTravelCard = !!customerProfile?.travelcard;
@@ -55,6 +61,17 @@ export default function DetailsScreen({navigation, route}: Props) {
             hasActiveTravelCard={hasActiveTravelCard}
           />
         )}
+
+        {firstTravelRight?.type === 'PreActivatedSingleTicket' &&
+          isPreactivatedTicket(firstTravelRight) &&
+          firstTravelRight.tariffZoneRefs.every(
+            (val: string) => val === 'ATB:TariffZone:1',
+          ) && (
+            <MessageBox
+              message={t(PurchaseOverviewTexts.samarbeidsbillettenInfo)}
+              type="info"
+            />
+          )}
       </ScrollView>
     </View>
   );

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -50,6 +50,10 @@ const PurchaseOverviewTexts = {
     'Når du er ute og reiser må du ha med t:kortet som er registrert på din profil.',
     'When traveling, you need to bring the t:card registered on your profile.',
   ),
+  samarbeidsbillettenInfo: _(
+    'Visste du at enkeltbilletter i sone A også kan brukes på tog i sone A?',
+    'Single tickets in zone A can also be used for trips by train in zone A.',
+  ),
 };
 export default orgSpecificTranslations(PurchaseOverviewTexts, {
   nfk: {


### PR DESCRIPTION
Dette er et _forslag_ på en veldig simpel implementasjonen av meldingsboks for samarbeidsbilletten. Er med på at dette kan gjøres mer generelt og vakkert, men lurer på om dette er en grei nok midlertidig™ løsning. Kan godt forandre på implementasjonen, men da trenger jeg noen forslag for hvilken retning jeg skal ta den.

Matcher på sonevalg fra og til "ATB:TariffZone:1", så den skal ikke dukke opp for NFK/Fram.

### Oversettelse

- 'Visste du at enkeltbilletter i sone A også kan brukes på tog i sone A?'
- 'Single tickets in zone A can also be used for trips by train in zone A.'

### Demo, med utdatert engelsk oversettelse:

https://user-images.githubusercontent.com/1774972/155524312-7f7f808d-858e-4325-8737-96441fac285a.mp4


closes #2155 