### PR TITLE
fix: update travel-token-box title styling

### DIFF
--- a/src/travel-token-box/index.tsx
+++ b/src/travel-token-box/index.tsx
@@ -92,16 +92,24 @@ const TravelCardTitle = ({
           >
             {t(TravelTokenBoxTexts.tcard.title)}
           </ThemeText>
-          <ThemeText type="heading__title" color="primary_2">
+          <ThemeText
+            type="heading__title"
+            color="primary_2"
+            style={styles.lightText}
+          >
             {' XXXX XX'}
           </ThemeText>
           <ThemeText type="heading__title" color="primary_2">
-            {inspectableToken.travelCardId?.substr(0, 2) +
+            {inspectableToken.travelCardId?.substring(0, 2) +
               ' ' +
-              inspectableToken.travelCardId?.substr(2)}
+              inspectableToken.travelCardId?.substring(2)}
           </ThemeText>
-          <ThemeText type="heading__title" color="primary_2">
-            {' X'}
+          <ThemeText
+            type="heading__title"
+            color="primary_2"
+            style={styles.lightText}
+          >
+            {'X'}
           </ThemeText>
         </View>
       );
@@ -137,5 +145,9 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
   },
   howToChange: {
     marginTop: theme.spacings.xLarge,
+  },
+  lightText: {
+    fontWeight: '400',
+    opacity: 0.6,
   },
 }));

--- a/src/travel-token-box/index.tsx
+++ b/src/travel-token-box/index.tsx
@@ -92,11 +92,7 @@ const TravelCardTitle = ({
           >
             {t(TravelTokenBoxTexts.tcard.title)}
           </ThemeText>
-          <ThemeText
-            type="heading__title"
-            color="primary_2"
-            style={styles.lightText}
-          >
+          <ThemeText color="primary_2" style={styles.transparent}>
             {' XXXX XX'}
           </ThemeText>
           <ThemeText type="heading__title" color="primary_2">
@@ -104,11 +100,7 @@ const TravelCardTitle = ({
               ' ' +
               inspectableToken.travelCardId?.substring(2)}
           </ThemeText>
-          <ThemeText
-            type="heading__title"
-            color="primary_2"
-            style={styles.lightText}
-          >
+          <ThemeText color="primary_2" style={styles.transparent}>
             {'X'}
           </ThemeText>
         </View>
@@ -146,8 +138,7 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
   howToChange: {
     marginTop: theme.spacings.xLarge,
   },
-  lightText: {
-    fontWeight: '400',
+  transparent: {
     opacity: 0.6,
   },
 }));


### PR DESCRIPTION
Oppdatert styling på tittel i travel-token-box. Ref. [slack-tråd](https://mittatb.slack.com/archives/C0116FMPX4Y/p1646134161002599)

![Simulator Screen Shot - iPhone 13 - 2022-03-01 at 15 53 15](https://user-images.githubusercontent.com/1774972/156191578-ed1a9974-def8-4703-b0f4-501a6e4b8041.png)
