### PR TITLE
chore: Use APP_VERSION for version in iOS project + scripts

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -13,9 +13,6 @@ There are some project files where the version number must be bumped. This is a 
 Bump the version number in these files:
   - All .env-files
   - package.json
-  - ios/atb.xcodeproj/project.pbxproj
-  - ios/atbTests/Info.plist
-  - scripts/ios/upload-sourcemaps.sh
 
 Do this in a commit with message "chore: Bump to version x.xx". 
     

--- a/ios/atb.xcodeproj/project.pbxproj
+++ b/ios/atb.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.16;
+				MARKETING_VERSION = "$(APP_VERSION)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -636,7 +636,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.16;
+				MARKETING_VERSION = "$(APP_VERSION)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/atbTests/Info.plist
+++ b/ios/atbTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16</string>
+	<string>$(APP_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/scripts/ios/upload-sourcemaps.sh
+++ b/scripts/ios/upload-sourcemaps.sh
@@ -3,10 +3,12 @@
 if [[
     -z "${BUGSNAG_API_KEY}"
     || -z "${BUILD_ID}"
+    || -z "${APP_VERSION}"
    ]]; then
     echo "Argument error!"
     echo "Expected two env variables: 
   - BUGSNAG_API_KEY
+  - APP_VERSION
   - BUILD_ID"
 
     exit 1
@@ -14,7 +16,7 @@ else
 echo "Uploading iOS source maps"
     curl --http1.1 https://upload.bugsnag.com/react-native-source-map \
         -F apiKey=$BUGSNAG_API_KEY \
-        -F appVersion=1.16 \
+        -F appVersion=$APP_VERSION \
         -F appBundleVersion=$BUILD_ID \
         -F dev=false \
         -F platform=ios \


### PR DESCRIPTION
Vi sender allerede inn `APP_VERSION` via `.env`-filene til både iOS-prosjektet + kjørende scripts. Så vi kan heller bruke denne og kun bumpe i `.env`-filene fremfor manuelt så mange plasser. Burde forenkle release-prosessen litt.

På sikt hadde kanskje også vært fordelaktig å se på `.env`-merging på tvers av filer, og kun override de som er forskjellig per organisasjon/miljø. En annen forbedringspotensiale er å sende inn `APP_VERSION` fra release-data/tag. 

(Vi henter allerede ut release-notater i workflow i dette [steget](https://github.com/AtB-AS/mittatb-app/blob/beeae85aecfa160b6465b2d5be843acbb74c87eb/.github/workflows/build-store-android.yml#L34), og sender det inn når det [pushes mot AppCenter](https://github.com/AtB-AS/mittatb-app/blob/beeae85aecfa160b6465b2d5be843acbb74c87eb/.github/workflows/build-store-android.yml#L60). Hadde vært mulig å utvide dette til å hente ut versjonsummer på sikt, så slipper vi manuell bump).