### PR TITLE
fix: use undefined as non-inspectable icon background

### DIFF
--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -185,7 +185,7 @@ const TicketInspectionSymbol = ({
           backgroundColor:
             preassignedFareProduct?.type === 'period' && isInspectable
               ? theme.colors.primary_1.backgroundColor
-              : 'none',
+              : undefined,
         },
         isValid &&
           !isInspectable && {


### PR DESCRIPTION
Fiks av feil farger på "Ikke vis i kontroll"-ikonet ([Slack](https://mittatb.slack.com/archives/C0116FMPX4Y/p1646129545400579)), som dukket opp i QA #2211.

Fikk til å gjenskape problemet ved å logge inn på en bruker med ikke-inspiserbare billetter, men det ble riktig igjen etter restart av appen. 

Oppdaterer fra `backgroundColor: 'none'` til `backgroundColor: undefined`. Selv om jeg ikke fullt og helt forstår hvordan feilen oppstod, klarer jeg ikke å gjenskape det lengre, og er ganske sikker på at dette er det som forårsaker feilen.