### PR TITLE
feat: update translations "period" -> "periodic"

### DIFF
--- a/src/translations/screens/Tickets.ts
+++ b/src/translations/screens/Tickets.ts
@@ -19,10 +19,10 @@ const TicketsTexts = {
         ),
       },
       period: {
-        text: _('Ny periodebillett', 'New period ticket'),
+        text: _('Ny periodebillett', 'New periodic ticket'),
         a11yHint: _(
           'Aktivér for å kjøpe ny periodebillett',
-          'Activate to buy a new period ticket',
+          'Activate to buy a new periodic ticket',
         ),
       },
     },

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -16,7 +16,7 @@ const LoginTexts = {
   onboarding: {
     title: _(
       'Nå kan du kjøpe periodebilletter!',
-      'Period tickets – available now!',
+      'Periodic tickets – available now!',
     ),
     description: _(
       'Når du logger inn kan du kjøpe periodebilletter på 7, 30 eller 180 dagers varighet.',

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -4,7 +4,7 @@ const PurchaseConfirmationTexts = {
   header: {
     title: {
       single: _('Enkeltbillett', 'Single ticket'),
-      period: _('Periodebillett', 'Period ticket'),
+      period: _('Periodebillett', 'Periodic ticket'),
       carnet: _('Klippekort', 'Carnet ticket'),
     },
   },

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -5,7 +5,7 @@ const PurchaseOverviewTexts = {
   header: {
     title: {
       single: _('Enkeltbillett', 'Single ticket'),
-      period: _('Periodebillett', 'Period ticket'),
+      period: _('Periodebillett', 'Periodic ticket'),
       carnet: _('Klippekort', 'Carnet ticket'),
     },
   },


### PR DESCRIPTION
Ønske fra @hildeor om å forandre navn fra "period ticket" til "periodic ticket". Fant 4 steder det var brukt: Kjøpsknapp, billettkjøp onboarding, og to titteltekster under kjøpsprosessen. 

![collage](https://user-images.githubusercontent.com/1774972/156375559-3885e125-9305-4931-a154-9c07e1b4f60e.png)


