### PR TITLE
chore: Add a lot more test ids, and way to visualize them

### DIFF
--- a/e2e/tests/onboarding.e2e.ts
+++ b/e2e/tests/onboarding.e2e.ts
@@ -43,7 +43,7 @@ describe('Onboarding', () => {
     await element(by.id('locationSearchItem0')).tap();
 
     await element(
-      by.type('RCTScrollView').withDescendant(by.id('assistantScrollView')),
+      by.type('RCTScrollView').withDescendant(by.id('assistantContentView')),
     ).scrollTo('bottom');
   });
 });

--- a/e2e/tests/onboarding.e2e.ts
+++ b/e2e/tests/onboarding.e2e.ts
@@ -24,12 +24,26 @@ describe('Onboarding', () => {
   });
 
   it('should show help us make app better after next', async () => {
-    await element(by.text('Next')).tap();
+    await element(by.id('nextButton')).tap();
     await expect(element(by.text('Help us make the app better'))).toBeVisible();
   });
 
   it('should assistant view after onboarding', async () => {
-    await element(by.text('Start using the app')).tap();
+    await element(by.id('nextButton')).tap();
     await expect(element(by.text('Travel assistant'))).toBeVisible();
+  });
+
+  it('should be able to search and scroll', async () => {
+    await element(by.id('searchFromButton')).tap();
+    await element(by.id('locationSearchInput')).replaceText('Orkanger');
+    await element(by.id('locationSearchItem0')).tap();
+
+    await element(by.id('searchToButton')).tap();
+    await element(by.id('locationSearchInput')).replaceText('Prinsens gate');
+    await element(by.id('locationSearchItem0')).tap();
+
+    await element(
+      by.type('RCTScrollView').withDescendant(by.id('assistantScrollView')),
+    ).scrollTo('bottom');
   });
 });

--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -12,6 +12,7 @@ import {ScreenHeaderTexts, useTranslation} from '@atb/translations';
 
 export default function useChatIcon(
   color?: ThemeColor,
+  testID?: string,
 ): IconButton | undefined {
   const unreadCount = useChatUnreadCount();
   const styles = useStyles();
@@ -26,7 +27,7 @@ export default function useChatIcon(
 
   return {
     icon: (
-      <View style={styles.chatContainer}>
+      <View style={styles.chatContainer} testID={testID}>
         {unreadCount ? (
           <ThemeIcon colorType={color} svg={ChatUnread} />
         ) : (

--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -202,7 +202,7 @@ const DisappearingHeader: React.FC<Props> = ({
         <View onLayout={onScreenHeaderLayout}>
           <AnimatedScreenHeader
             title={headerTitle}
-            rightButton={{type: 'chat', color: themeColor}}
+            rightButton={{type: 'chat', color: themeColor, testID: 'rhb'}}
             alternativeTitleComponent={alternativeTitleComponent}
             showAlternativeTitle={showAlterntativeTitle && !isAnimating}
             scrollRef={scrollYRef}

--- a/src/components/disappearing-header/simple.tsx
+++ b/src/components/disappearing-header/simple.tsx
@@ -130,7 +130,7 @@ const SimpleDisappearingHeader: React.FC<Props> = ({
         <View onLayout={onScreenHeaderLayout}>
           <AnimatedScreenHeader
             title={headerTitle}
-            rightButton={{type: 'chat', color: themeColor}}
+            rightButton={{type: 'chat', color: themeColor, testID: 'rhb'}}
             alternativeTitleComponent={alternativeTitleComponent}
             scrollRef={isRefreshing ? nullRef : scrollYRef}
             leftButton={leftButton}

--- a/src/components/screen-header/HeaderButton.tsx
+++ b/src/components/screen-header/HeaderButton.tsx
@@ -23,6 +23,7 @@ export type HeaderButtonProps = {
   onPress?: () => void;
   color?: ThemeColor;
   text?: string;
+  testID?: string;
 } & AccessibilityProps;
 
 export type IconButton = Omit<HeaderButtonProps, 'type'> & {
@@ -42,6 +43,7 @@ export type HeaderButtonWithoutNavigationProps = {
   text: string;
   onPress: () => void;
   color?: ThemeColor;
+  testID?: string;
 } & AccessibilityProps;
 
 export const HeaderButtonWithoutNavigation = ({
@@ -79,7 +81,7 @@ const useIconButton = (
 ): IconButton | undefined => {
   const navigation = useNavigation();
   const navigateHome = useNavigateToStartScreen();
-  const chatIcon = useChatIcon(buttonProps.color);
+  const chatIcon = useChatIcon(buttonProps.color, buttonProps.testID);
   const {t} = useTranslation();
   switch (buttonProps.type) {
     case 'back':

--- a/src/components/screen-header/index.tsx
+++ b/src/components/screen-header/index.tsx
@@ -53,12 +53,12 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = (props) => {
   const themeColor = props.color ?? 'background_accent';
 
   const leftIcon = props.leftButton ? (
-    <HeaderButton color={themeColor} {...props.leftButton} />
+    <HeaderButton color={themeColor} {...props.leftButton} testID="lhb" />
   ) : (
     <View />
   );
   const rightIcon = props.rightButton ? (
-    <HeaderButton color={themeColor} {...props.rightButton} />
+    <HeaderButton color={themeColor} {...props.rightButton} testID="rhb" />
   ) : (
     <View />
   );

--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -29,6 +29,7 @@ export default function ActionItem({
   mode = 'check',
   checked = false,
   accessibility,
+  testID,
   ...props
 }: ActionItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -41,6 +42,7 @@ export default function ActionItem({
           value={checked}
           onValueChange={(value) => onPress?.(value)}
           accessibilityLabel={text}
+          testID={testID}
           {...accessibility}
         />
       </InternalLabeledItem>
@@ -54,6 +56,7 @@ export default function ActionItem({
     <TouchableOpacity
       onPress={() => onPress?.(!checked)}
       style={[style.spaceBetween, topContainer]}
+      testID={testID}
       accessibilityRole={role}
       accessibilityState={{
         [stateName]: checked,

--- a/src/components/sections/button-input.tsx
+++ b/src/components/sections/button-input.tsx
@@ -24,6 +24,7 @@ export type ButtonInputProps = SectionItem<{
   highlighted?: boolean;
   icon?: NavigationIconTypes | JSX.Element;
   containerStyle?: ViewStyle;
+  testID?: string;
 }> &
   AccessibilityProps;
 

--- a/src/components/sections/counter-input.tsx
+++ b/src/components/sections/counter-input.tsx
@@ -19,6 +19,7 @@ export default function CounterInput({
   count,
   addCount,
   removeCount,
+  testID,
   ...props
 }: CounterInputProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -28,7 +29,7 @@ export default function CounterInput({
   const {theme} = useTheme();
   const removeButtonDisabled = count === 0;
   return (
-    <View style={[topContainer, counterStyles.countContainer]}>
+    <View style={[topContainer, counterStyles.countContainer]} testID={testID}>
       <View style={[style.spaceBetween, contentContainer]}>
         <ThemeText accessibilityLabel={`${count} ${text}`}>{text}</ThemeText>
       </View>
@@ -53,6 +54,7 @@ export default function CounterInput({
           accessibilityState={{disabled: removeButtonDisabled}}
           hitSlop={insets.all(theme.spacings.medium)}
           style={counterStyles.removeCount}
+          testID={testID + '_rem'}
         >
           <ThemeIcon
             svg={Remove}
@@ -81,6 +83,7 @@ export default function CounterInput({
           )}
           hitSlop={insets.all(8)}
           style={counterStyles.addCount}
+          testID={testID + '_add'}
         >
           <ThemeIcon svg={Add} />
         </TouchableOpacity>

--- a/src/components/sections/favorite-item.tsx
+++ b/src/components/sections/favorite-item.tsx
@@ -39,6 +39,7 @@ export default function FavoriteItem(props: FavoriteItemProps) {
       accessibilityLabel={a11yLabel + screenReaderPause}
       accessibilityRole="button"
       onPress={(e) => props.onPress(props.favorite, e)}
+      testID={props.testID}
       {...props.accessibility}
     >
       <FavoriteItemContent {...props} />

--- a/src/components/sections/link-item.tsx
+++ b/src/components/sections/link-item.tsx
@@ -34,6 +34,7 @@ export default function LinkItem({
   accessibility,
   disabled,
   textType,
+  testID,
   ...props
 }: LinkItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -53,6 +54,7 @@ export default function LinkItem({
       disabled={disabled}
       accessibilityState={{disabled}}
       style={topContainer}
+      testID={testID}
       {...accessibilityWithOverrides}
     >
       <View style={[style.spaceBetween, disabledStyle]}>

--- a/src/components/sections/radio-section.tsx
+++ b/src/components/sections/radio-section.tsx
@@ -31,6 +31,7 @@ export default function RadioSectionGroup<T>({
           checked={item == selected}
           text={itemToText(item, index)}
           onPress={() => onSelect?.(item, index)}
+          testID={'radioButton' + index}
         />
       ))}
     </SectionGroup>

--- a/src/components/sections/section-utils/use-section-item.ts
+++ b/src/components/sections/section-utils/use-section-item.ts
@@ -10,6 +10,7 @@ export type SectionItemProps = {
   type?: ContainerSizingType;
   radius?: RadiusMode;
   radiusSize?: RadiusSizes;
+  testID?: string;
 };
 export type SectionItem<T> = T & SectionItemProps;
 

--- a/src/components/sections/section.tsx
+++ b/src/components/sections/section.tsx
@@ -10,6 +10,7 @@ export type SectionProps = PropsWithChildren<{
   withBottomPadding?: boolean;
   type?: ContainerSizingType;
   style?: ViewStyle;
+  testID?: string;
 }> &
   AccessibilityProps;
 

--- a/src/departure-list/DeparturesList.tsx
+++ b/src/departure-list/DeparturesList.tsx
@@ -83,6 +83,7 @@ export default function DeparturesList({
               defaultExpanded={i === 0}
               disableCollapsing={disableCollapsing}
               searchDate={searchDate}
+              testID={'stopDeparture' + i}
             />
           ))}
           <FooterLoader isFetchingMore={isFetchingMore} />
@@ -128,6 +129,7 @@ type StopDeparturesProps = {
   defaultExpanded?: boolean;
   disableCollapsing?: boolean;
   searchDate: string;
+  testID?: string;
 };
 const StopDepartures = React.memo(function StopDepartures({
   stopPlaceGroup,
@@ -136,6 +138,7 @@ const StopDepartures = React.memo(function StopDepartures({
   defaultExpanded = false,
   disableCollapsing = false,
   searchDate,
+  testID,
 }: StopDeparturesProps) {
   const {t} = useTranslation();
   const [expanded, setExpanded] = useState(
@@ -154,7 +157,7 @@ const StopDepartures = React.memo(function StopDepartures({
   }
 
   return (
-    <View accessibilityState={{expanded}}>
+    <View accessibilityState={{expanded}} testID={testID}>
       {!disableCollapsing && (
         <ActionItem
           transparent
@@ -176,7 +179,7 @@ const StopDepartures = React.memo(function StopDepartures({
       )}
 
       {expanded &&
-        stopPlaceGroup.quays.map((quayGroup) => (
+        stopPlaceGroup.quays.map((quayGroup, i) => (
           <QuaySection
             key={quayGroup.quay.id}
             stop={stopPlaceGroup.stopPlace}
@@ -184,6 +187,7 @@ const StopDepartures = React.memo(function StopDepartures({
             currentLocation={currentLocation}
             lastUpdated={lastUpdated}
             searchDate={searchDate}
+            testID={'quaySection' + i}
           />
         ))}
     </View>

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -67,6 +67,7 @@ export default function LineItem({
   quay,
   accessibility,
   searchDate,
+  testID,
   ...props
 }: LineItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -102,7 +103,7 @@ export default function LineItem({
   const nextValids = group.departures.filter(isValidDeparture);
 
   return (
-    <View style={[topContainer, {padding: 0}]}>
+    <View style={[topContainer, {padding: 0}]} testID={testID}>
       <View style={[topContainer, sectionStyle.spaceBetween]}>
         <TouchableOpacity
           style={[styles.lineHeader, contentContainer]}
@@ -147,6 +148,7 @@ export default function LineItem({
             key={departure.serviceJourneyId + departure.aimedTime}
             onPress={() => onPress(i)}
             searchDate={searchDate}
+            testID={'depTime' + i}
           />
         ))}
       </ScrollView>
@@ -238,11 +240,13 @@ type DepartureTimeItemProps = {
   departure: DepartureTime;
   onPress(departure: DepartureTime): void;
   searchDate: string;
+  testID?: string;
 };
 function DepartureTimeItem({
   departure,
   onPress,
   searchDate,
+  testID,
 }: DepartureTimeItemProps) {
   const styles = useItemStyles();
   const {t, language} = useTranslation();
@@ -261,6 +265,7 @@ function DepartureTimeItem({
       textStyle={styles.departureText}
       icon={hasSituations(departure) ? Warning : undefined}
       iconPosition="right"
+      testID={testID}
     />
   );
 }

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -21,6 +21,7 @@ type QuaySectionProps = {
   lastUpdated?: Date;
   hidden?: Date;
   searchDate: string;
+  testID?: string;
 };
 
 const QuaySection = React.memo(function QuaySection({
@@ -29,6 +30,7 @@ const QuaySection = React.memo(function QuaySection({
   currentLocation,
   lastUpdated,
   searchDate,
+  testID,
 }: QuaySectionProps) {
   const [limit, setLimit] = useState(LIMIT_SIZE);
   const {t} = useTranslation();
@@ -51,19 +53,20 @@ const QuaySection = React.memo(function QuaySection({
 
   return (
     <Fragment>
-      <Section>
+      <Section testID={testID}>
         <QuayHeaderItem
           quay={quayGroup.quay}
           distance={getDistanceInfo(quayGroup, currentLocation)}
         />
 
-        {sorted.map((group) => (
+        {sorted.map((group, i) => (
           <LineItem
             group={group}
             stop={stop}
             quay={quayGroup.quay}
             key={group.lineInfo?.lineId + String(group.lineInfo?.lineName)}
             searchDate={searchDate}
+            testID={'lineItem' + i}
           />
         ))}
         {hasMoreItems && (

--- a/src/favorite-chips/index.tsx
+++ b/src/favorite-chips/index.tsx
@@ -65,6 +65,7 @@ const FavoriteChips: React.FC<Props> = ({
               accessibilityHint={chipActionHint ?? ''}
               icon={CurrentLocationArrow}
               onPress={onCurrentLocation}
+              testID="currentLocationChip"
             />
           )}
           {activeType('map') && !disableMap && (
@@ -75,6 +76,7 @@ const FavoriteChips: React.FC<Props> = ({
               onPress={onMapSelection}
               color={themeColor}
               mode="secondary"
+              testID="mapLocationChip"
             />
           )}
         </View>
@@ -107,6 +109,7 @@ const FavoriteChips: React.FC<Props> = ({
                   ? {marginRight: 0}
                   : undefined
               }
+              testID={'favoriteChip' + i}
             />
           ))}
         {activeType('add-favorite') && (
@@ -120,6 +123,7 @@ const FavoriteChips: React.FC<Props> = ({
               navigation.navigate('AddEditFavorite', {screen: 'SearchLocation'})
             }
             style={{marginRight: 0}}
+            testID={'addFavoriteButton'}
           />
         )}
       </ScrollView>

--- a/src/location-search/JourneyHistory.tsx
+++ b/src/location-search/JourneyHistory.tsx
@@ -40,7 +40,7 @@ export default function JourneyHistory({
         {journeyHistory
           .slice(0, DEFAULT_HISTORY_LIMIT)
           .map(mapToVisibleSearchResult)
-          .map((searchResult) => (
+          .map((searchResult, idx) => (
             <TouchableOpacity
               accessible={true}
               key={searchResult.key}
@@ -57,6 +57,7 @@ export default function JourneyHistory({
               )}
               accessibilityRole="button"
               onPress={() => onSelect(searchResult.selectable)}
+              testID={'journeyHistoryItem' + idx}
             >
               <GenericItem transparent>
                 <ThemeText type="body__primary--bold">

--- a/src/location-search/LocationResults.tsx
+++ b/src/location-search/LocationResults.tsx
@@ -15,9 +15,15 @@ type Props = {
   title?: string;
   locations: LocationSearchResult[];
   onSelect: (location: LocationSearchResult) => void;
+  testIDItemPrefix: string;
 };
 
-const LocationResults: React.FC<Props> = ({title, locations, onSelect}) => {
+const LocationResults: React.FC<Props> = ({
+  title,
+  locations,
+  onSelect,
+  testIDItemPrefix,
+}) => {
   const styles = useThemeStyles();
   const {t} = useTranslation();
   return (
@@ -28,7 +34,7 @@ const LocationResults: React.FC<Props> = ({title, locations, onSelect}) => {
         </View>
       )}
       <View>
-        {locations.map(mapToVisibleSearchResult).map((searchResult) => (
+        {locations.map(mapToVisibleSearchResult).map((searchResult, idx) => (
           <View style={styles.rowContainer} key={searchResult.key}>
             <View style={styles.locationButtonContainer}>
               <TouchableOpacity
@@ -43,6 +49,7 @@ const LocationResults: React.FC<Props> = ({title, locations, onSelect}) => {
                 hitSlop={insets.symmetric(8, 1)}
                 onPress={() => onSelect(searchResult.selectable)}
                 style={styles.locationButton}
+                testID={testIDItemPrefix + idx}
               >
                 <View style={{flexDirection: 'column'}}>
                   {searchResult.emoji ? (

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -210,6 +210,7 @@ export function LocationSearchContent({
             autoCorrect={false}
             autoComplete="off"
             autoFocus={!a11yContext.isScreenReaderEnabled}
+            testID="locationSearchInput"
           />
         </View>
 
@@ -248,6 +249,7 @@ export function LocationSearchContent({
               title={t(LocationSearchTexts.results.previousResults.heading)}
               locations={previousLocations}
               onSelect={onSearchSelect}
+              testIDItemPrefix="previousResultItem"
             />
           )}
           {hasResults && (
@@ -255,6 +257,7 @@ export function LocationSearchContent({
               title={t(LocationSearchTexts.results.searchResults.heading)}
               locations={filteredLocations}
               onSelect={onSearchSelect}
+              testIDItemPrefix="locationSearchItem"
             />
           )}
         </ScrollView>

--- a/src/login/ConfirmCode.tsx
+++ b/src/login/ConfirmCode.tsx
@@ -142,11 +142,13 @@ export default function ConfirmCode({
                   icon={ArrowRight}
                   iconPosition="right"
                   style={styles.submitButton}
+                  testID="submitButton"
                 />
                 <TouchableOpacity
                   style={styles.resendButton}
                   onPress={onResendCode}
                   accessibilityRole="button"
+                  testID="resendCodeButton"
                 >
                   <ThemeText
                     style={styles.resendButtonText}

--- a/src/login/LoginOnboarding.tsx
+++ b/src/login/LoginOnboarding.tsx
@@ -72,12 +72,14 @@ export default function LoginOnboarding({
             text={t(LoginTexts.onboarding.button)}
             icon={ArrowRight}
             iconPosition="right"
+            testID="loginButton"
           />
         </View>
         <TouchableOpacity
           style={styles.laterButton}
           onPress={navigation.goBack}
           accessibilityRole="button"
+          testID="loginLaterButton"
         >
           <ThemeText
             style={styles.laterButtonText}

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -153,6 +153,7 @@ export default function PhoneInput({
                 disabled={!isValidPhoneNumber(phoneNumber)}
                 icon={ArrowRight}
                 iconPosition="right"
+                testID="sendCodeButton"
               />
             )}
           </View>

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -69,6 +69,7 @@ const NavigationRoot = () => {
           t(dictionary.navigation.assistant),
           AssistantIcon,
           lineHeight,
+          'assistantTab',
         )}
       />
       <Tab.Screen
@@ -79,6 +80,7 @@ const NavigationRoot = () => {
           t(dictionary.navigation.nearby),
           Nearby,
           lineHeight,
+          'departuresTab',
         )}
       />
       <Tab.Screen
@@ -89,6 +91,7 @@ const NavigationRoot = () => {
           t(dictionary.navigation.ticketing),
           Tickets,
           lineHeight,
+          'ticketsTab',
         )}
       />
       <Tab.Screen
@@ -99,6 +102,7 @@ const NavigationRoot = () => {
           t(dictionary.navigation.profile_a11y),
           Profile,
           lineHeight,
+          'profileTab',
         )}
       />
     </Tab.Navigator>
@@ -118,6 +122,7 @@ type TabSettings = {
     color: string;
     size: number;
   }): JSX.Element;
+  testID?: string;
 };
 
 function tabSettings(
@@ -125,6 +130,7 @@ function tabSettings(
   tabBarA11yLabel: string,
   Icon: (svg: SvgProps) => JSX.Element,
   lineHeight: number,
+  testID: string,
 ): TabSettings {
   return {
     tabBarLabel: ({color}) => (
@@ -132,6 +138,7 @@ function tabSettings(
         type="body__secondary"
         style={{color, textAlign: 'center', lineHeight}}
         accessibilityLabel={tabBarA11yLabel}
+        testID={testID}
       >
         {tabBarLabel}
       </ThemeText>

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -31,6 +31,7 @@ import transitionSpec from './transitionSpec';
 import LoginInAppStack, {
   LoginInAppStackParams,
 } from '@atb/login/in-app/LoginInAppStack';
+import useTestIds from './use-test-ids';
 
 export type RootStackParamList = {
   NotFound: undefined;
@@ -49,6 +50,8 @@ const Stack = createStackNavigator<RootStackParamList>();
 const NavigationRoot = () => {
   const {isLoading, onboarded} = useAppState();
   const {theme} = useTheme();
+
+  useTestIds();
 
   const ref = useRef<NavigationContainerRef>(null);
   const {getInitialState} = useLinking(ref, {

--- a/src/navigation/use-test-ids.ts
+++ b/src/navigation/use-test-ids.ts
@@ -1,0 +1,20 @@
+import {usePreferences} from '@atb/preferences';
+import {
+  setTestIdPrototypes,
+  resetTestIdPrototypes,
+} from '@atb/utils/test-visualize-ids';
+import {useEffect} from 'react';
+
+export default function useTestIds() {
+  const {
+    preferences: {showTestIds},
+  } = usePreferences();
+
+  useEffect(() => {
+    if (showTestIds) {
+      setTestIdPrototypes();
+    } else {
+      resetTestIdPrototypes();
+    }
+  }, [showTestIds]);
+}

--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -30,6 +30,7 @@ export type UserPreferences = {
   departuresShowOnlyFavorites?: boolean;
   newDepartures?: boolean;
   useExperimentalTripSearch?: boolean;
+  showTestIds?: boolean;
   tripSearchPreferences?: TripSearchPreferences;
 };
 

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -349,6 +349,7 @@ const Assistant: React.FC<Props> = ({
               accessibilityHint={t(AssistantTexts.dateInput.a11yHint)}
               color="primary_2"
               onPress={onSearchTimePress}
+              testID="datePickerButton"
             />
           </View>
         </FadeBetween>
@@ -467,6 +468,7 @@ const Assistant: React.FC<Props> = ({
         color: themeColor,
         onPress: resetView,
         accessibilityLabel: t(AssistantTexts.header.accessibility.logo),
+        testID: 'lhb',
       }}
       onFullscreenTransitionEnd={(fullHeight) => {
         if (fullHeight) {

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -290,6 +290,7 @@ const Assistant: React.FC<Props> = ({
                     : t(AssistantTexts.location.locationButton.a11yLabel.use),
                 accessibilityRole: 'button',
               }}
+              testID="searchFromButton"
             />
 
             <LocationInput
@@ -308,6 +309,7 @@ const Assistant: React.FC<Props> = ({
                   screenReaderPause,
                 accessibilityRole: 'button',
               }}
+              testID="searchToButton"
             />
           </Section>
         </View>

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -44,6 +44,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 type ResultItemProps = {
   tripPattern: TripPattern;
   onDetailsPressed(): void;
+  testID?: string;
 };
 
 function legWithQuay(leg: Leg) {
@@ -114,6 +115,7 @@ const ResultItemHeader: React.FC<{
 const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   tripPattern,
   onDetailsPressed,
+  testID,
   ...props
 }) => {
   const styles = useThemeStyles();
@@ -129,6 +131,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
       )}
       onPress={onDetailsPressed}
       accessible={true}
+      testID={testID}
     >
       <View style={styles.result} {...props} accessible={false}>
         <ResultItemHeader tripPattern={tripPattern} />

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -108,7 +108,7 @@ const Results: React.FC<Props> = ({
   }
 
   return (
-    <View style={styles.container}>
+    <View style={styles.container} testID="assistantScrollView">
       {tripPatterns?.map((item, i) => (
         <Fragment key={String(item.id ?? i)}>
           <DayLabel
@@ -119,6 +119,7 @@ const Results: React.FC<Props> = ({
           <ResultItem
             tripPattern={item}
             onDetailsPressed={() => onDetailsPressed(item.id, tripPatterns, i)}
+            testID={'assistantSearchResult' + i}
           />
         </Fragment>
       ))}

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -108,7 +108,7 @@ const Results: React.FC<Props> = ({
   }
 
   return (
-    <View style={styles.container} testID="assistantScrollView">
+    <View style={styles.container} testID="assistantContentView">
       {tripPatterns?.map((item, i) => (
         <Fragment key={String(item.id ?? i)}>
           <DayLabel

--- a/src/screens/Assistant/journey-date-picker/index.tsx
+++ b/src/screens/Assistant/journey-date-picker/index.tsx
@@ -88,8 +88,16 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
 
         {option !== 'now' && (
           <Section withBottomPadding>
-            <DateInputItem value={dateString} onChange={setDate} />
-            <TimeInputItem value={timeString} onChange={setTime} />
+            <DateInputItem
+              value={dateString}
+              onChange={setDate}
+              testID="dateInput"
+            />
+            <TimeInputItem
+              value={timeString}
+              onChange={setTime}
+              testID="timeInput"
+            />
           </Section>
         )}
 
@@ -97,6 +105,7 @@ const JourneyDatePicker: React.FC<JourneyDatePickerProps> = ({
           onPress={onSelect}
           color="primary_2"
           text={t(JourneyDatePickerTexts.searchButton.text)}
+          testID="searchButton"
         ></Button>
       </ScrollView>
     </View>

--- a/src/screens/Assistant_v2/Assistant.tsx
+++ b/src/screens/Assistant_v2/Assistant.tsx
@@ -262,6 +262,7 @@ const Assistant: React.FC<Props> = ({
                     : t(AssistantTexts.location.locationButton.a11yLabel.use),
                 accessibilityRole: 'button',
               }}
+              testID="searchFromButton"
             />
 
             <LocationInput
@@ -280,6 +281,7 @@ const Assistant: React.FC<Props> = ({
                   screenReaderPause,
                 accessibilityRole: 'button',
               }}
+              testID="searchToButton"
             />
           </Section>
         </View>

--- a/src/screens/Assistant_v2/Assistant.tsx
+++ b/src/screens/Assistant_v2/Assistant.tsx
@@ -424,6 +424,7 @@ const Assistant: React.FC<Props> = ({
         color: themeColor,
         onPress: resetView,
         accessibilityLabel: t(AssistantTexts.header.accessibility.logo),
+        testID: 'lhb',
       }}
       onFullscreenTransitionEnd={(fullHeight) => {
         if (fullHeight) {

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -256,6 +256,7 @@ const NearbyOverview: React.FC<Props> = ({
             mode="toggle"
             checked={showOnlyFavorites}
             onPress={toggleShowFavorites}
+            testID="showOnlyFavoritesButton"
           />
         </View>
       )}

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -227,7 +227,7 @@ const NearbyOverview: React.FC<Props> = ({
       }
       headerTitle={t(NearbyTexts.header.title)}
       useScroll={activateScroll}
-      leftButton={{type: 'home', color: themeColor}}
+      leftButton={{type: 'home', color: themeColor, testID: 'lhb'}}
       alternativeTitleComponent={
         <AccessibleText
           prefix={t(NearbyTexts.header.altTitle.a11yPrefix)}
@@ -316,6 +316,7 @@ const Header = React.memo(function Header({
             ),
             accessibilityRole: 'button',
           }}
+          testID="searchFromButton"
         />
       </Section>
       <View style={styles.paddedContainer} key="dateInput">
@@ -328,6 +329,7 @@ const Header = React.memo(function Header({
           onPress={onNowPress}
           viewContainerStyle={styles.dateInputButtonContainer}
           style={styles.dateInputButton}
+          testID="searchTimeNowButton"
         />
         <Button
           mode={searchTime.option == 'now' ? 'tertiary' : 'primary'}
@@ -342,6 +344,7 @@ const Header = React.memo(function Header({
           onPress={onLaterTimePress}
           viewContainerStyle={styles.dateInputButtonContainer}
           style={styles.dateInputButton}
+          testID="searchTimeLaterButton"
         />
       </View>
     </>

--- a/src/screens/Onboarding/IntercomInfo.tsx
+++ b/src/screens/Onboarding/IntercomInfo.tsx
@@ -47,6 +47,7 @@ export default function IntercomInfo() {
             text={t(OnboardingTexts.intercom.mainButton)}
             icon={Confirm}
             iconPosition="right"
+            testID="nextButton"
           />
         </FullScreenFooter>
       </View>

--- a/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/src/screens/Onboarding/WelcomeScreen.tsx
@@ -87,6 +87,7 @@ const WelcomeScreen = ({
             text={t(OnboardingTexts.welcome.mainButton)}
             icon={ArrowRight}
             iconPosition="right"
+            testID="nextButton"
           />
         </FullScreenFooter>
       </View>

--- a/src/screens/Profile/AddEditFavorite/AddForm.tsx
+++ b/src/screens/Profile/AddEditFavorite/AddForm.tsx
@@ -188,6 +188,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
                 initialLocation: location,
               })
             }
+            testID="locationSearchButton"
           />
         </Sections.Section>
 
@@ -200,6 +201,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
             autoCapitalize="sentences"
             accessibilityHint={t(AddEditFavoriteTexts.fields.name.a11yHint)}
             placeholder={t(AddEditFavoriteTexts.fields.name.placeholder)}
+            testID="nameInput"
           />
         </Sections.Section>
 
@@ -218,6 +220,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
                 <ThemeText type="body__primary">{emoji}</ThemeText>
               )
             }
+            testID="iconButton"
           />
         </Sections.Section>
       </ScrollView>
@@ -231,6 +234,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
               icon={SvgDelete}
               iconPosition="right"
               text={t(AddEditFavoriteTexts.delete.label)}
+              testID="deleteButton"
             />
           )}
           <Button
@@ -239,6 +243,7 @@ export default function AddEditFavorite({navigation, route}: AddEditProps) {
             icon={SvgConfirm}
             iconPosition="right"
             text={t(AddEditFavoriteTexts.save.label)}
+            testID="saveButton"
           />
         </ButtonGroup>
       </FullScreenFooter>

--- a/src/screens/Profile/DebugInfo/index.tsx
+++ b/src/screens/Profile/DebugInfo/index.tsx
@@ -58,7 +58,7 @@ export default function DebugInfo() {
 
   const {
     setPreference,
-    preferences: {tripSearchPreferences},
+    preferences: {tripSearchPreferences, showTestIds},
   } = usePreferences();
 
   const tripSearchDefaults = {
@@ -78,6 +78,14 @@ export default function DebugInfo() {
 
       <ScrollView>
         <Sections.Section withPadding withTopPadding>
+          <Sections.ActionItem
+            mode="toggle"
+            text="Toggle test-ID"
+            checked={showTestIds}
+            onPress={(showTestIds) => {
+              setPreference({showTestIds});
+            }}
+          />
           <Sections.LinkItem
             text="Restart onboarding"
             onPress={() => {

--- a/src/screens/Profile/FavoriteList/SortableList.tsx
+++ b/src/screens/Profile/FavoriteList/SortableList.tsx
@@ -41,7 +41,14 @@ export default function SortableList({
     <FlatList
       data={data}
       contentContainerStyle={styles.container}
-      renderItem={(obj) => <Item {...obj} onPress={resort} length={length} />}
+      renderItem={(obj) => (
+        <Item
+          {...obj}
+          onPress={resort}
+          length={length}
+          testID={'favoriteItem' + obj.index}
+        />
+      )}
       keyExtractor={(item) => item.name + item.id}
     />
   );
@@ -75,7 +82,10 @@ function Item(props: ItemProps) {
   const styles = useListStyle();
 
   return (
-    <View style={[styles.item, sectionStyles.spaceBetween, topContainer]}>
+    <View
+      style={[styles.item, sectionStyles.spaceBetween, topContainer]}
+      testID={props.testID}
+    >
       <View importantForAccessibility={'no-hide-descendants'}>
         <FavoriteIcon favorite={item} />
       </View>
@@ -135,6 +145,7 @@ function MoveIcon({direction, item, index, length, onPress}: MoveIconProps) {
       accessibilityHint={hint}
       style={styles.moveIcon}
       hitSlop={insets.symmetric(theme.spacings.small, theme.spacings.xSmall)}
+      testID={direction}
     >
       <ThemeIcon svg={Icon} />
     </TouchableOpacity>

--- a/src/screens/Profile/FavoriteList/index.tsx
+++ b/src/screens/Profile/FavoriteList/index.tsx
@@ -59,7 +59,7 @@ export default function FavoriteList({navigation}: ProfileScreenProps) {
         )}
 
         <Sections.Section withTopPadding withPadding>
-          {items.map((favorite) => (
+          {items.map((favorite, i) => (
             <Sections.FavoriteItem
               key={favorite.name + favorite.location.id}
               favorite={favorite}
@@ -67,6 +67,7 @@ export default function FavoriteList({navigation}: ProfileScreenProps) {
                 accessibilityHint: t(FavoriteListTexts.favoriteItem.a11yHint),
               }}
               onPress={navigateToEdit}
+              testID={'favorite' + i}
             />
           ))}
         </Sections.Section>
@@ -77,12 +78,14 @@ export default function FavoriteList({navigation}: ProfileScreenProps) {
               text={t(FavoriteListTexts.buttons.changeOrder)}
               onPress={onSortClick}
               icon={<ThemeIcon svg={SvgReorder} />}
+              testID="changeOrderButton"
             />
           )}
           <Sections.LinkItem
             text={t(FavoriteListTexts.buttons.addFavorite)}
             onPress={onAddButtonClick}
             icon={<ThemeIcon svg={Add} />}
+            testID="addFavoriteButton"
           />
         </Sections.Section>
       </ScrollView>

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -85,7 +85,10 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
         rightButton={{type: 'chat'}}
       />
 
-      <ScrollView contentContainerStyle={style.scrollView}>
+      <ScrollView
+        contentContainerStyle={style.scrollView}
+        testID="profileHomeScrollView"
+      >
         <Sections.Section withPadding>
           <Sections.HeaderItem
             text={t(ProfileTexts.sections.account.heading)}
@@ -123,12 +126,14 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                   },
                 })
               }
+              testID="loginButton"
             />
           )}
           {authenticationType === 'phone' && (
             <Sections.LinkItem
               text={t(ProfileTexts.sections.account.linkItems.logout.label)}
               onPress={signOut}
+              testID="logoutButton"
             />
           )}
           <Sections.LinkItem
@@ -136,6 +141,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               ProfileTexts.sections.account.linkItems.expiredTickets.label,
             )}
             onPress={() => navigation.navigate('ExpiredTickets')}
+            testID="expiredTicketsButton"
           />
         </Sections.Section>
 
@@ -146,6 +152,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
           <Sections.LinkItem
             text={t(ProfileTexts.sections.settings.linkItems.userProfile.label)}
             onPress={() => navigation.navigate('DefaultUserProfile')}
+            testID="defaultTravellerButton"
           />
           {authenticationType === 'phone' && hasEnabledMobileToken && (
             <Sections.LinkItem
@@ -156,20 +163,24 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                 ProfileTexts.sections.settings.linkItems.travelToken.flag,
               )}
               onPress={() => navigation.navigate('TravelToken')}
+              testID="travelTokenButton"
             />
           )}
           <Sections.LinkItem
             text={t(ProfileTexts.sections.settings.linkItems.appearance.label)}
             onPress={() => navigation.navigate('Appearance')}
+            testID="appearanceButton"
           />
           <Sections.LinkItem
             text={t(ProfileTexts.sections.settings.linkItems.startScreen.label)}
             onPress={() => navigation.navigate('SelectStartScreen')}
+            testID="startScreenButton"
           />
           {enable_i18n && (
             <Sections.LinkItem
               text={t(ProfileTexts.sections.settings.linkItems.language.label)}
               onPress={() => navigation.navigate('Language')}
+              testID="languageButton"
             />
           )}
         </Sections.Section>
@@ -190,6 +201,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             mode="toggle"
             text={t(ProfileTexts.sections.newFeatures.departures)}
             checked={newDepartures}
+            testID="newDeparturesToggle"
             onPress={(newDepartures) => {
               analytics().logEvent('toggle_beta_departures', {
                 toggle: newDepartures ? 'enable' : 'disable',
@@ -204,6 +216,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             mode="toggle"
             text={t(ProfileTexts.sections.newFeatures.assistant)}
             checked={useExperimentalTripSearch}
+            testID="newAssistantToggle"
             onPress={(useExperimentalTripSearch) => {
               analytics().logEvent('toggle_beta_tripsearch', {
                 toggle: useExperimentalTripSearch ? 'enable' : 'disable',
@@ -219,6 +232,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
           <Sections.LinkItem
             text={t(ProfileTexts.sections.settings.linkItems.enrollment.label)}
             onPress={() => navigation.navigate('Enrollment')}
+            testID="invitationCodeButton"
           />
         </Sections.Section>
 
@@ -233,6 +247,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                 ProfileTexts.sections.favorites.linkItems.places.a11yHint,
               ),
             }}
+            testID="favoriteLocationsButton"
             onPress={() => navigation.navigate('FavoriteList')}
           />
           <Sections.LinkItem
@@ -242,6 +257,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                 ProfileTexts.sections.favorites.linkItems.departures.a11yHint,
               ),
             }}
+            testID="favoriteDeparturesButton"
             onPress={() => navigation.navigate('FavoriteDepartures')}
           />
         </Sections.Section>
@@ -257,6 +273,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                 ProfileTexts.sections.privacy.linkItems.privacy.a11yHint,
               ),
             }}
+            testID="privacyButton"
             onPress={() => Linking.openURL(privacy_policy_url)}
           />
           <Sections.LinkItem
@@ -266,6 +283,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                 ProfileTexts.sections.privacy.linkItems.clearHistory.a11yHint,
               ),
             }}
+            testID="clearHistoryButton"
             onPress={() =>
               Alert.alert(
                 t(ProfileTexts.sections.privacy.linkItems.clearHistory.confirm),
@@ -303,22 +321,26 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
               text={t(
                 ProfileTexts.sections.information.linkItems.ticketing.label,
               )}
+              testID="ticketingInfoButton"
               onPress={() => navigation.navigate('TicketingInformation')}
             />
             <Sections.LinkItem
               text={t(
                 ProfileTexts.sections.information.linkItems.payment.label,
               )}
+              testID="paymentInfoButton"
               onPress={() => navigation.navigate('PaymentInformation')}
             />
             <Sections.LinkItem
               text={t(ProfileTexts.sections.information.linkItems.terms.label)}
+              testID="termsInfoButton"
               onPress={() => navigation.navigate('TermsInformation')}
             />
             <Sections.LinkItem
               text={t(
                 ProfileTexts.sections.information.linkItems.inspection.label,
               )}
+              testID="inspectionInfoButton"
               onPress={() => navigation.navigate('TicketInspectionInformation')}
             />
           </Sections.Section>
@@ -331,10 +353,12 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             <Sections.HeaderItem text="Developer menu" />
             <Sections.LinkItem
               text="Design system"
+              testID="designSystemButton"
               onPress={() => navigation.navigate('DesignSystem')}
             />
             <Sections.LinkItem
               text="Debug"
+              testID="debugButton"
               onPress={() => navigation.navigate('DebugInfo')}
             />
           </Sections.Section>

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -376,6 +376,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                 )}
                 onPress={selectPaymentMethod}
                 viewContainerStyle={styles.paymentButton}
+                testID="choosePaymentOptionButton"
               />
             )}
           </View>

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -300,6 +300,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
           }}
           icon={ArrowRight}
           iconPosition="right"
+          testID="goToPaymentButton"
         />
       </View>
     </View>

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -204,6 +204,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
                 screenReaderPause,
               accessibilityHint: t(PurchaseOverviewTexts.product.a11yHint),
             }}
+            testID="selectProductButton"
           />
           <Sections.LinkItem
             text={createTravellersText(
@@ -226,6 +227,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
                 ) + screenReaderPause,
               accessibilityHint: t(PurchaseOverviewTexts.travellers.a11yHint),
             }}
+            testID="selectTravellersButton"
           />
           <Sections.LinkItem
             text={createTravelDateText(t, language, travelDate)}
@@ -238,6 +240,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
                 screenReaderPause,
               accessibilityHint: t(PurchaseOverviewTexts.travelDate.a11yHint),
             }}
+            testID="selectStartTimeButton"
           />
           <Sections.LinkItem
             text={tariffZonesSummary(fromTariffZone, toTariffZone, language, t)}
@@ -254,12 +257,17 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
                 screenReaderPause,
               accessibilityHint: t(PurchaseOverviewTexts.tariffZones.a11yHint),
             }}
+            testID="selectZonesButton"
           />
           <Sections.GenericItem>
             {isSearchingOffer ? (
               <ActivityIndicator style={styles.totalSection} />
             ) : (
-              <ThemeText style={styles.totalSection} type="body__primary--bold">
+              <ThemeText
+                style={styles.totalSection}
+                type="body__primary--bold"
+                testID="offerTotalPriceText"
+              >
                 {t(PurchaseOverviewTexts.totalPrice(totalPrice))}
               </ThemeText>
             )}

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -170,10 +170,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
           setFocusOnLoad={false}
         />
         <View style={{flexShrink: 100, flexGrow: 100}}>
-          <ScrollView
-            style={styles.paymentOptions}
-            testID="paymentOptionsScrollView"
-          >
+          <ScrollView style={styles.paymentOptions}>
             {defaultPaymentOptions.map((option, index) => {
               return (
                 <PaymentOptionView

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -170,8 +170,11 @@ const SelectPaymentMethod: React.FC<Props> = ({
           setFocusOnLoad={false}
         />
         <View style={{flexShrink: 100, flexGrow: 100}}>
-          <ScrollView style={styles.paymentOptions}>
-            {defaultPaymentOptions.map((option) => {
+          <ScrollView
+            style={styles.paymentOptions}
+            testID="paymentOptionsScrollView"
+          >
+            {defaultPaymentOptions.map((option, index) => {
               return (
                 <PaymentOptionView
                   key={option.paymentType}
@@ -180,6 +183,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
                   onSelect={(val: PaymentMethod) => {
                     setSelectedOption(val);
                   }}
+                  index={index}
                 />
               );
             })}
@@ -203,7 +207,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
               </View>
             )}
 
-            {remoteOptions.map((option) => {
+            {remoteOptions.map((option, index) => {
               return (
                 <PaymentOptionView
                   key={
@@ -216,6 +220,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
                   onSelect={(val: PaymentMethod) => {
                     setSelectedOption(val);
                   }}
+                  index={index}
                 />
               );
             })}
@@ -246,6 +251,7 @@ const SelectPaymentMethod: React.FC<Props> = ({
             disabled={!selectedOption}
             icon={ArrowRight}
             iconPosition="right"
+            testID="confirmButton"
           />
         </FullScreenFooter>
       </View>
@@ -257,14 +263,15 @@ type PaymentOptionsProps = {
   option: SavedPaymentOption;
   selected: boolean;
   onSelect: (value: PaymentMethod) => void;
+  index: number;
 };
 
 const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
   option,
   selected,
   onSelect,
+  index,
 }) => {
-  const {theme} = useTheme();
   const [save, setSave] = useState<boolean>(false);
   const {t} = useTranslation();
   const styles = useStyles();
@@ -281,31 +288,24 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
     label: string;
     hint: string;
   } {
-    let paymentTypeString =
-      option.paymentType === PaymentType.VISA
-        ? 'Visa'
-        : option.paymentType === PaymentType.MasterCard
-        ? 'MasterCard'
-        : option.paymentType === PaymentType.Vipps
-        ? 'Vipps'
-        : '';
+    let paymentTypeName = getPaymentTypeName(option.paymentType);
 
     if (option.savedType === 'normal') {
       return {
-        text: paymentTypeString,
+        text: paymentTypeName,
         label: t(
           PurchaseConfirmationTexts.paymentWithDefaultServices.a11yLabel(
-            paymentTypeString,
+            paymentTypeName,
           ),
         ),
         hint: t(PurchaseConfirmationTexts.paymentWithDefaultServices.a11Hint),
       };
     } else if (option.savedType === 'recurring') {
       return {
-        text: paymentTypeString,
+        text: paymentTypeName,
         label: t(
           PurchaseConfirmationTexts.paymentWithStoredCard.a11yLabel(
-            paymentTypeString,
+            paymentTypeName,
             option.recurringCard.masked_pan,
           ),
         ),
@@ -317,6 +317,14 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
         label: '',
         hint: '',
       };
+    }
+  }
+
+  function getPaymentTestId(option: SavedPaymentOption, index: number) {
+    if (option.savedType === 'normal') {
+      return getPaymentTypeName(option.paymentType) + 'Button';
+    } else {
+      return 'recurringPayment' + index;
     }
   }
 
@@ -365,6 +373,7 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
         accessibilityHint={paymentTexts.hint}
         accessibilityRole="radio"
         accessibilityState={{selected: selected}}
+        testID={getPaymentTestId(option, index)}
       >
         <View style={styles.column}>
           <View style={styles.row}>
@@ -429,6 +438,19 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
     </View>
   );
 };
+
+function getPaymentTypeName(paymentType: PaymentType) {
+  switch (paymentType) {
+    case PaymentType.VISA:
+      return 'Visa';
+    case PaymentType.MasterCard:
+      return 'MasterCard';
+    case PaymentType.Vipps:
+      return 'Vipps';
+    default:
+      return '';
+  }
+}
 
 type CheckedProps = {
   checked: boolean;

--- a/src/screens/Ticketing/Purchase/Product/ProductSheet.tsx
+++ b/src/screens/Ticketing/Purchase/Product/ProductSheet.tsx
@@ -45,6 +45,7 @@ const ProductSheet = forwardRef<ScrollView, Props>(
             type: 'cancel',
             onPress: close,
             text: t(ScreenHeaderTexts.headerButton.cancel.text),
+            testID: 'cancelButton',
           }}
           color={'background_2'}
           setFocusOnLoad={false}
@@ -70,6 +71,7 @@ const ProductSheet = forwardRef<ScrollView, Props>(
               save(selectedProduct);
               close();
             }}
+            testID="saveTicketTypeButton"
           />
         </FullScreenFooter>
       </BottomSheetContainer>

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -353,6 +353,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
               ) : undefined
             }
             highlighted={selectedZones.selectNext === 'from'}
+            testID="searchFromButton"
           />
           <ButtonInput
             label={t(TariffZonesTexts.location.destinationPicker.label)}
@@ -377,6 +378,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
               ) : undefined
             }
             highlighted={selectedZones.selectNext === 'to'}
+            testID="searchToButton"
           />
         </Section>
       </View>
@@ -398,6 +400,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
               color="primary_2"
               text={t(TariffZonesTexts.saveButton.text)}
               accessibilityHint={t(TariffZonesTexts.saveButton.a11yHint)}
+              testID="saveZonesButton"
             />
           </View>
         </>
@@ -483,6 +486,7 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
                 color="primary_2"
                 text={t(TariffZonesTexts.saveButton.text)}
                 accessibilityHint={t(TariffZonesTexts.saveButton.a11yHint)}
+                testID="saveZonesButton"
               />
             </View>
           </View>

--- a/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/TariffZoneResults.tsx
@@ -48,6 +48,7 @@ const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                 hitSlop={insets.symmetric(8, 1)}
                 onPress={() => onSelect(tariffZone)}
                 style={styles.tariffZoneButton}
+                testID={'tariffZone' + tariffZone.name.value + 'Button'}
               >
                 <View style={{flexDirection: 'column'}}>
                   <ThemeIcon svg={MapPointPin} width={20} />

--- a/src/screens/Ticketing/Purchase/TariffZones/search/VenueResults.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/VenueResults.tsx
@@ -31,7 +31,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
         </ThemeText>
       </View>
       <View>
-        {locationsAndTariffZones.map(({location, tariffZone}) => (
+        {locationsAndTariffZones.map(({location, tariffZone}, index) => (
           <View style={styles.rowContainer} key={location.id}>
             <View style={styles.tariffZoneButtonContainer}>
               <TouchableOpacity
@@ -51,6 +51,7 @@ const VenueResults: React.FC<Props> = ({locationsAndTariffZones, onSelect}) => {
                 hitSlop={insets.symmetric(8, 1)}
                 onPress={() => onSelect(location)}
                 style={styles.tariffZoneButton}
+                testID={'venueResult' + index}
               >
                 <View style={{flexDirection: 'column'}}>
                   <LocationIcon

--- a/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/search/index.tsx
@@ -154,6 +154,7 @@ const Index: React.FC<Props> = ({
             placeholder={t(TariffZoneSearchTexts.searchField.placeholder)}
             autoCorrect={false}
             autoComplete="off"
+            testID="searchInput"
           />
         </View>
       </View>

--- a/src/screens/Ticketing/Purchase/TravelDate/TravelDateSheet.tsx
+++ b/src/screens/Ticketing/Purchase/TravelDate/TravelDateSheet.tsx
@@ -59,6 +59,7 @@ const TravelDate = forwardRef<ScrollView, Props>(
             type: 'cancel',
             onPress: close,
             text: t(ScreenHeaderTexts.headerButton.cancel.text),
+            testID: 'cancelButton',
           }}
           color="background_2"
           setFocusOnLoad={false}
@@ -91,6 +92,7 @@ const TravelDate = forwardRef<ScrollView, Props>(
             color="primary_2"
             text={t(TravelDateTexts.primaryButton)}
             style={styles.saveButton}
+            testID="confirmTimeButton"
           />
         </FullScreenFooter>
       </BottomSheetContainer>

--- a/src/screens/Ticketing/Purchase/Travellers/MultipleTravellersSelection.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/MultipleTravellersSelection.tsx
@@ -32,7 +32,7 @@ export default function MultipleTravellersSelection({
 
   return (
     <Sections.Section>
-      {userProfilesWithCount.map((u) => (
+      {userProfilesWithCount.map((u, i) => (
         <Sections.CounterInput
           key={u.userTypeString}
           text={getReferenceDataName(u, language)}
@@ -40,6 +40,7 @@ export default function MultipleTravellersSelection({
           addCount={() => addTraveller(u.userTypeString)}
           removeCount={() => removeTraveller(u.userTypeString)}
           type="spacious"
+          testID={'counterInput' + i}
         />
       ))}
     </Sections.Section>

--- a/src/screens/Ticketing/Purchase/Travellers/TravellersSheet.tsx
+++ b/src/screens/Ticketing/Purchase/Travellers/TravellersSheet.tsx
@@ -45,6 +45,7 @@ const TravellersSheet = forwardRef<ScrollView, Props>(
             type: 'cancel',
             onPress: close,
             text: t(ScreenHeaderTexts.headerButton.cancel.text),
+            testID: 'cancelButton',
           }}
           color={'background_2'}
           setFocusOnLoad={false}
@@ -99,6 +100,7 @@ const TravellersSheet = forwardRef<ScrollView, Props>(
               save(userCountState.userProfilesWithCount);
               close();
             }}
+            testID="saveTravellersButton"
           />
         </FullScreenFooter>
       </BottomSheetContainer>

--- a/src/screens/Ticketing/Ticket/Carnet/index.tsx
+++ b/src/screens/Ticketing/Ticket/Carnet/index.tsx
@@ -25,6 +25,7 @@ type Props = {
   travelRights: CarnetTicket[];
   now: number;
   isInspectable: boolean;
+  testID?: string;
 };
 
 const CarnetTicketInfo: React.FC<Props> = ({
@@ -32,6 +33,7 @@ const CarnetTicketInfo: React.FC<Props> = ({
   travelRights,
   now,
   isInspectable,
+  testID,
 }) => {
   const styles = useStyles();
   const {theme} = useTheme();
@@ -55,7 +57,7 @@ const CarnetTicketInfo: React.FC<Props> = ({
   );
 
   return (
-    <Sections.Section withBottomPadding>
+    <Sections.Section withBottomPadding testID={testID}>
       <Sections.GenericItem>
         {fareContractValidityStatus !== 'valid' ? (
           <ValidityHeader

--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -94,6 +94,7 @@ const DetailsContent: React.FC<Props> = ({
           text={t(TicketTexts.details.askForReceipt)}
           onPress={onReceiptNavigate}
           accessibility={{accessibilityRole: 'button'}}
+          testID="receiptButton"
         />
         {hasEnabledMobileToken ? (
           <QrCode validityStatus={validityStatus} />

--- a/src/screens/Ticketing/Ticket/Details/PaperQrCode.tsx
+++ b/src/screens/Ticketing/Ticket/Details/PaperQrCode.tsx
@@ -39,6 +39,7 @@ export default function PaperQrCode({
         style={styles.qrCode}
         accessible={true}
         accessibilityLabel={t(TicketTexts.details.qrCodeA11yLabel)}
+        testID="paperQRCode"
       >
         <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
       </View>

--- a/src/screens/Ticketing/Ticket/Details/QrCode.tsx
+++ b/src/screens/Ticketing/Ticket/Details/QrCode.tsx
@@ -86,6 +86,7 @@ const QrCodeSvg = ({
           style={styles.qrCode}
           accessible={true}
           accessibilityLabel={t(TicketTexts.details.qrCodeA11yLabel)}
+          testID="mobileTokenQRCode"
         >
           <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
         </View>

--- a/src/screens/Ticketing/Ticket/PreactivatedTicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/PreactivatedTicketInfo.tsx
@@ -14,6 +14,7 @@ type Props = {
   isInspectable: boolean;
   hideDetails?: boolean;
   onPressDetails?: () => void;
+  testID?: string;
 };
 
 const PreactivatedTicketInfo: React.FC<Props> = ({
@@ -23,6 +24,7 @@ const PreactivatedTicketInfo: React.FC<Props> = ({
   isInspectable,
   hideDetails,
   onPressDetails,
+  testID,
 }) => {
   const {t} = useTranslation();
 
@@ -37,7 +39,7 @@ const PreactivatedTicketInfo: React.FC<Props> = ({
     fareContractState,
   );
   return (
-    <Sections.Section withBottomPadding>
+    <Sections.Section withBottomPadding testID={testID}>
       <Sections.GenericItem>
         <ValidityHeader
           status={validityStatus}
@@ -68,6 +70,7 @@ const PreactivatedTicketInfo: React.FC<Props> = ({
               : TicketTexts.detailsLink.notValid,
           )}
           onPress={onPressDetails}
+          testID="showDetailsButton"
         />
       )}
     </Sections.Section>

--- a/src/screens/Ticketing/Ticket/index.tsx
+++ b/src/screens/Ticketing/Ticket/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   hideDetails?: boolean;
   onPressDetails?: () => void;
   hasActiveTravelCard?: boolean;
+  testID?: string;
 };
 
 const SimpleTicket: React.FC<Props> = ({
@@ -26,6 +27,7 @@ const SimpleTicket: React.FC<Props> = ({
   now,
   hideDetails,
   onPressDetails,
+  testID,
   hasActiveTravelCard = false,
 }) => {
   const firstTravelRight = fc.travelRights?.[0];
@@ -48,6 +50,7 @@ const SimpleTicket: React.FC<Props> = ({
         isInspectable={inspectable}
         hideDetails={hideDetails}
         onPressDetails={onPressDetails}
+        testID={testID}
       />
     );
   } else if (isCarnetTicket(firstTravelRight)) {
@@ -57,6 +60,7 @@ const SimpleTicket: React.FC<Props> = ({
         travelRights={fc.travelRights.filter(isCarnetTicket)}
         now={now}
         isInspectable={inspectable}
+        testID={testID}
       />
     );
   } else {

--- a/src/screens/Ticketing/Tickets/TabBar.tsx
+++ b/src/screens/Ticketing/Tickets/TabBar.tsx
@@ -52,7 +52,6 @@ const TicketsTabBar: React.FC<MaterialTopTabBarProps> = ({
             accessibilityRole="button"
             accessibilityState={isFocused ? {selected: true} : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}
-            testID={options.tabBarTestID}
             onPress={onPress}
             onLongPress={onLongPress}
             style={[
@@ -65,6 +64,7 @@ const TicketsTabBar: React.FC<MaterialTopTabBarProps> = ({
             <ThemeText
               type={isFocused ? 'body__primary--bold' : 'body__primary'}
               color={tabColor}
+              testID={options.tabBarTestID}
             >
               {label}
             </ThemeText>

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -125,6 +125,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
             onPress={onBuySingleTicket}
             icon={AddTicket}
             iconPosition={'right'}
+            testID="singleTicketBuyButton"
           />
           {hasEnabledMobileToken && (
             <Button
@@ -138,6 +139,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
               viewContainerStyle={styles.buyPeriodTicketButton}
               icon={AddTicket}
               iconPosition={'right'}
+              testID="periodTicketBuyButton"
             />
           )}
         </View>

--- a/src/screens/Ticketing/Tickets/TicketInformationalOverlay.tsx
+++ b/src/screens/Ticketing/Tickets/TicketInformationalOverlay.tsx
@@ -80,6 +80,7 @@ export default function TicketInformationalOverlay() {
             iconPosition="right"
             color="primary_2"
             onPress={onAccept}
+            testID="confirmButton"
           />
         </View>
       </ScrollView>

--- a/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
@@ -85,7 +85,7 @@ const TicketsScrollView: React.FC<Props> = ({
         {reservations?.map((res) => (
           <TicketReservation key={res.orderId} reservation={res} />
         ))}
-        {fareContracts?.map((fc) => (
+        {fareContracts?.map((fc, index) => (
           <ErrorBoundary
             key={fc.orderId}
             message={t(TicketsTexts.scrollView.errorLoadingTicket(fc.orderId))}
@@ -100,6 +100,7 @@ const TicketsScrollView: React.FC<Props> = ({
                   params: {orderId: fc.orderId},
                 })
               }
+              testID={'ticket' + index}
             />
           </ErrorBoundary>
         ))}

--- a/src/screens/Ticketing/Tickets/index.tsx
+++ b/src/screens/Ticketing/Tickets/index.tsx
@@ -51,6 +51,7 @@ export default function TicketTabs() {
           options={{
             tabBarLabel: t(TicketsTexts.buyTicketsTab.label),
             tabBarAccessibilityLabel: t(TicketsTexts.buyTicketsTab.a11yLabel),
+            tabBarTestID: 'buyTicketsTab',
           }}
         />
         <Tab.Screen
@@ -61,6 +62,7 @@ export default function TicketTabs() {
             tabBarAccessibilityLabel: t(
               TicketsTexts.activeTicketsTab.a11yLabel,
             ),
+            tabBarTestID: 'validTicketsTab',
           }}
         />
       </Tab.Navigator>

--- a/src/utils/test-visualize-ids.ts
+++ b/src/utils/test-visualize-ids.ts
@@ -26,7 +26,7 @@ export const setTestIdPrototypes = () => {
     overrideRenderWithToolTip(TouchableWithoutFeedback, fragmentWrapper),
     overrideRenderWithToolTip(View, viewWrapper),
     overrideRenderWithToolTip(ScrollView, viewWrapper),
-    overrideRenderWithToolTip(Switch, viewWrapper),
+    overrideRenderWithToolTip(Switch, fragmentWrapper),
     overrideRenderWithToolTip(TextInput, fragmentWrapper),
     overrideRenderWithToolTip(Text, fragmentWrapper),
   );

--- a/src/utils/test-visualize-ids.ts
+++ b/src/utils/test-visualize-ids.ts
@@ -1,0 +1,118 @@
+import {
+  TouchableWithoutFeedback,
+  View,
+  ScrollView,
+  Switch,
+  Text,
+  TextInput,
+  ViewStyle,
+} from 'react-native';
+import React from 'react';
+import {v4 as uuid} from 'uuid';
+
+const resetFunctions: Array<() => void> = [];
+
+export const resetTestIdPrototypes = () => {
+  while (resetFunctions.length) {
+    const cb = resetFunctions.pop();
+    cb?.();
+  }
+};
+
+export const setTestIdPrototypes = () => {
+  if (resetFunctions.length) return;
+
+  resetFunctions.push(
+    overrideRenderWithToolTip(TouchableWithoutFeedback, fragmentWrapper),
+    overrideRenderWithToolTip(View, viewWrapper),
+    overrideRenderWithToolTip(ScrollView, viewWrapper),
+    overrideRenderWithToolTip(Switch, viewWrapper),
+    overrideRenderWithToolTip(TextInput, fragmentWrapper),
+    overrideRenderWithToolTip(Text, fragmentWrapper),
+  );
+};
+
+function overrideRenderWithToolTip(
+  component: any,
+  wrapper: (
+    tooltip: React.ReactElement,
+    children: React.ReactChildren,
+  ) => React.ReactElement,
+) {
+  const originalRender = component.render;
+
+  component.render = function render() {
+    if (arguments[0]?.testID) {
+      const {testID} = arguments[0];
+
+      return wrapper(
+        testIdTooltip(testID),
+        originalRender.apply(this, arguments),
+      );
+    }
+
+    return originalRender.apply(this, arguments);
+  };
+
+  return function resetRender() {
+    component.render = originalRender;
+  };
+}
+
+function testIdTooltip(testId: string): React.ReactElement {
+  const text = React.createElement(
+    Text,
+    {
+      style: {
+        color: 'black',
+        fontSize: 12,
+        backgroundColor: 'red',
+        padding: 2,
+      },
+      key: uuid(),
+    },
+    testId,
+  );
+
+  return React.createElement(
+    View,
+    {
+      style: {position: 'absolute', top: -5, left: 0, zIndex: 1000},
+      key: uuid(),
+    },
+    text,
+  );
+}
+
+function fragmentWrapper(
+  toolTip: React.ReactElement,
+  children: React.ReactChildren,
+) {
+  return React.createElement(
+    React.Fragment,
+    {
+      key: uuid(),
+    },
+    [toolTip, children],
+  );
+}
+
+function viewWrapper(
+  toolTip: React.ReactElement,
+  children: React.ReactChildren,
+) {
+  return React.createElement(
+    View,
+    {
+      style: [
+        {
+          borderWidth: 0.5,
+          borderColor: 'red',
+          zIndex: 1000,
+        },
+      ],
+      key: uuid(),
+    },
+    [toolTip, children],
+  );
+}


### PR DESCRIPTION
Har lagt til en toggle under Debug-menyen, som lar deg skru på "visuelle" testIDs. Dette gjør at render-funksjonen for enkelte innebygde komponenter blir overskrevet og viser en label ved siden av seg. En må reloade appen etter det er skrudd på siden den ikke re-rendrer automatisk. 

Tanken er at dette skal gjøre det enklere for @tormoseng å skrive E2E-tester. Altså at han kan skru på dette for å vite navn på labels, men også slik at det er enklere å legge til nye. Testene skal også bli adskillig mye kjappere om vi bruker testIDs framfor å søke opp tekst

Det er endringer i flere filer men det viktigste er å sjekke ut [src/utils/test-visualize-ids.ts](https://github.com/AtB-AS/mittatb-app/pull/2252/files#diff-eefe48347861e8500faf78ccf5e06b3484273f92ec56325775303ad1db66e659) og [src/navigation/use-test-ids.ts](https://github.com/AtB-AS/mittatb-app/pull/2252/files#diff-4a7d2dcbf1a1d1d79bafa326cc58eb1b8fe953f36bfe37785f1b409f3c4c3fe0).

Sistnevnte brukes i [src/navigation/index.tsx](https://github.com/AtB-AS/mittatb-app/pull/2252/files#diff-c0888b8ab065e5ac6cdc56208bc21e65f64ed9ae0d5c001aa42e6c1fc899ca2f)

Mye resten er bare jeg som har lagt til en hel dunge testIDs.

En video som demoer det nogenlunde:
https://user-images.githubusercontent.com/4932625/156447961-4f5cc6dc-fbdd-4299-8350-8e129c3afbaa.mov

![image](https://user-images.githubusercontent.com/4932625/156448218-02e75a6a-66cd-4845-bcd0-2567bd4ada90.png)
![image](https://user-images.githubusercontent.com/4932625/156517150-f29cfc88-2470-4f11-9258-6c8a9e24d72f.png)
![image](https://user-images.githubusercontent.com/4932625/156448275-a94d4ef4-e1d1-4b6b-bc0a-9a0c25edaacb.png)
