### PR TITLE
fix: hide notInspectableWarning on expired or refunded tickets

### DIFF
--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -100,6 +100,7 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
     userProfilesWithCount,
     isInspectable,
     omitUserProfileCount,
+    status,
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
@@ -149,14 +150,16 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
           {tariffZoneSummary}
         </ThemeText>
       )}
-      {isInspectable === false && (
-        <View style={styles.notInspectableWarning}>
-          <ThemeIcon svg={Warning} style={styles.notInspectableWarningIcon} />
-          <ThemeText isMarkdown={true}>
-            {t(TicketTexts.ticketInfo.notInspectableWarning)}
-          </ThemeText>
-        </View>
-      )}
+      {isInspectable === false &&
+        status !== 'expired' &&
+        status !== 'refunded' && (
+          <View style={styles.notInspectableWarning}>
+            <ThemeIcon svg={Warning} style={styles.notInspectableWarningIcon} />
+            <ThemeText isMarkdown={true}>
+              {t(TicketTexts.ticketInfo.notInspectableWarning)}
+            </ThemeText>
+          </View>
+        )}
     </View>
   );
 };


### PR DESCRIPTION
Fjerner ikon og melding om at billetten ikke kan inspiseres fra Utløpte billetter-visningen. Gjør også det samme for refunderte billetter. 