### PR TITLE
fix: hide TravelTokenBox on expired tickets screen

### DIFF
--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -186,6 +186,7 @@ export const ActiveTickets: React.FC<Props> = () => {
         )}
         now={now}
         didPaymentFail={didPaymentFail}
+        showMobileTokenInfo={true}
       />
     </View>
   );

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -186,7 +186,7 @@ export const ActiveTickets: React.FC<Props> = () => {
         )}
         now={now}
         didPaymentFail={didPaymentFail}
-        showMobileTokenInfo={true}
+        showTokenInfo={true}
       />
     </View>
   );

--- a/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
@@ -33,7 +33,7 @@ type Props = {
   now: number;
   travelCard?: TravelCard;
   didPaymentFail?: boolean;
-  showMobileTokenInfo?: boolean;
+  showTokenInfo?: boolean;
 };
 
 const TicketsScrollView: React.FC<Props> = ({
@@ -45,7 +45,7 @@ const TicketsScrollView: React.FC<Props> = ({
   now,
   travelCard,
   didPaymentFail = false,
-  showMobileTokenInfo,
+  showTokenInfo,
 }) => {
   const {theme} = useTheme();
   const styles = useStyles();
@@ -67,11 +67,15 @@ const TicketsScrollView: React.FC<Props> = ({
           />
         }
       >
-        {hasEnabledMobileToken && showMobileTokenInfo ? (
-          <TravelTokenBox showIfThisDevice={false} showHowToChangeHint={true} />
-        ) : hasActiveTravelCard ? (
-          <TravelCardInformation travelCard={travelCard} />
-        ) : null}
+        {showTokenInfo &&
+          (hasEnabledMobileToken ? (
+            <TravelTokenBox
+              showIfThisDevice={false}
+              showHowToChangeHint={true}
+            />
+          ) : hasActiveTravelCard ? (
+            <TravelCardInformation travelCard={travelCard} />
+          ) : null)}
         {didPaymentFail && (
           <MessageBox
             containerStyle={styles.messageBox}

--- a/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
@@ -33,6 +33,7 @@ type Props = {
   now: number;
   travelCard?: TravelCard;
   didPaymentFail?: boolean;
+  showMobileTokenInfo?: boolean;
 };
 
 const TicketsScrollView: React.FC<Props> = ({
@@ -44,6 +45,7 @@ const TicketsScrollView: React.FC<Props> = ({
   now,
   travelCard,
   didPaymentFail = false,
+  showMobileTokenInfo,
 }) => {
   const {theme} = useTheme();
   const styles = useStyles();
@@ -65,7 +67,7 @@ const TicketsScrollView: React.FC<Props> = ({
           />
         }
       >
-        {hasEnabledMobileToken ? (
+        {hasEnabledMobileToken && showMobileTokenInfo ? (
           <TravelTokenBox showIfThisDevice={false} showHowToChangeHint={true} />
         ) : hasActiveTravelCard ? (
           <TravelCardInformation travelCard={travelCard} />


### PR DESCRIPTION
Legger til en `showMobileTokenInfo` parameter på `TicketsScrollView`, så vises info om token kun i fanen for aktive billetter.