### PR TITLE
fix: alignment of start time in resultItemFooter

### DIFF
--- a/src/screens/Assistant_v2/ResultItem.tsx
+++ b/src/screens/Assistant_v2/ResultItem.tsx
@@ -214,18 +214,19 @@ function ResultItemFooter({legs}: {legs: Leg[]}) {
 
   return (
     <View style={styles.resultFooter}>
-      <ThemeText
-        type={'body__secondary'}
-        style={{flexShrink: 1}}
-        numberOfLines={1}
-      >
-        {t(AssistantTexts.results.resultItem.footer.fromPlace(quayName))}
-      </ThemeText>
-
-      <ThemeText>
-        {timePrefix + formatToClock(quayStartTime, language)}
-      </ThemeText>
-
+      <View style={styles.resultFooterText}>
+        <ThemeText
+          type={'body__secondary'}
+          style={styles.resultFooterText}
+          numberOfLines={1}
+        >
+          {t(AssistantTexts.results.resultItem.footer.fromPlace(quayName)) +
+            ' '}
+        </ThemeText>
+        <ThemeText type="body__secondary">
+          {timePrefix + formatToClock(quayStartTime, language)}
+        </ThemeText>
+      </View>
       <View style={styles.detailsTextWrapper}>
         <ThemeText type="body__secondary">
           {t(AssistantTexts.results.resultItem.footer.detailsLabel)}
@@ -266,6 +267,10 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     padding: theme.spacings.medium,
     justifyContent: 'space-between',
     alignItems: 'center',
+  },
+  resultFooterText: {
+    flexShrink: 1,
+    flexDirection: 'row',
   },
   detailsTextWrapper: {
     flexDirection: 'row',

--- a/src/screens/Assistant_v2/ResultItem.tsx
+++ b/src/screens/Assistant_v2/ResultItem.tsx
@@ -216,8 +216,8 @@ function ResultItemFooter({legs}: {legs: Leg[]}) {
     <View style={styles.resultFooter}>
       <View style={styles.resultFooterText}>
         <ThemeText
-          type={'body__secondary'}
-          style={styles.resultFooterText}
+          type="body__secondary"
+          style={styles.fromPlaceText}
           numberOfLines={1}
         >
           {t(AssistantTexts.results.resultItem.footer.fromPlace(quayName)) +
@@ -271,6 +271,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   resultFooterText: {
     flexShrink: 1,
     flexDirection: 'row',
+  },
+  fromPlaceText: {
+    flexShrink: 1,
   },
   detailsTextWrapper: {
     flexDirection: 'row',


### PR DESCRIPTION
Fiks av aligment av klokkeslett i resultFooter, slik at det henger sammen med holdeplass-teksten, men det er holdeplass-teksten som blir forkortet hvis der ikke er nok plass.

## Før/etter: (ignorer tekststørrelse)

![collage](https://user-images.githubusercontent.com/1774972/156575703-765c348a-5758-42a5-9b35-039796cfc75e.png)
