### PR TITLE
fix: use contentContainerStyle in SelectTravelToken ScrollView

### DIFF
--- a/src/screens/Profile/TravelToken/SelectTravelTokenScreen.tsx
+++ b/src/screens/Profile/TravelToken/SelectTravelTokenScreen.tsx
@@ -67,7 +67,7 @@ export default function SelectTravelTokenScreen({navigation}: Props) {
         title={t(TravelTokenTexts.toggleToken.title)}
         leftButton={{type: 'back'}}
       />
-      <ScrollView style={styles.scrollView}>
+      <ScrollView contentContainerStyle={styles.scrollView}>
         <View style={styles.radioArea}>
           <RadioBox
             title={t(TravelTokenTexts.toggleToken.radioBox.tCard.title)}


### PR DESCRIPTION
Ref. [slack](https://mittatb.slack.com/archives/C0116FMPX4Y/p1646662437063149)

Fiks av at padding ble lagt som `style` på et scrollview istedet for `contentContainerStyle`.