### PR TITLE
fix: header spaceing + android fix

### DIFF
--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -91,7 +91,10 @@ const MessageBox: React.FC<MessageBoxProps> = ({
       </View>
       <View style={styles.content}>
         {title && (
-          <ThemeText style={{...styles.title, color: textColor}}>
+          <ThemeText
+            type="body__primary--bold"
+            style={{...styles.title, color: textColor}}
+          >
             {title}
           </ThemeText>
         )}
@@ -150,8 +153,7 @@ const useBoxStyle = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
   },
   title: {
-    fontSize: 16,
-    fontWeight: '600',
+    marginBottom: theme.spacings.small,
   },
 }));
 

--- a/src/components/text/markdown-renderer.tsx
+++ b/src/components/text/markdown-renderer.tsx
@@ -5,7 +5,7 @@ import {textTypeStyles} from '@atb/theme/colors';
 import Bugsnag from '@bugsnag/react-native';
 
 export default function render(markdown: string): React.ReactElement[] {
-  const tree = lexer(markdown);
+  const tree = lexer(markdown, {smartypants: true});
   return tree.map(renderToken);
 }
 

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -98,6 +98,14 @@ export default function DesignSystem() {
               onPress={presser}
             />
           </Sections.GenericItem>
+
+          <Sections.GenericItem>
+            <MessageBox
+              isMarkdown={true}
+              title="Markdown"
+              message={`This is a message with markdown,\nSupporting **bold** and *italics*\nand special characters like ', " + æøå`}
+            />
+          </Sections.GenericItem>
         </Sections.Section>
 
         <MessageBox


### PR DESCRIPTION
- Space under title
- bold tekst funker ikke på android hvis man bruke fontWeight direkte. endret til å bruke type="body__primary--bold"
- Støtte for quotes: '' og "" i markup