### PR TITLE
fix: add missing `)` to Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,6 +210,7 @@ platform :android do
       track: "internal",
       json_key:ENV['GOOGLE_PLAY_SERVICE_ACCOUNT_PATH'],
       apk: ENV['APK_FILE_NAME']
+    )
   end
 
   lane :appcenter_staging do


### PR DESCRIPTION
Ser at bygget feiler pga. en syntaksfeil i Fastfile. Legger til en manglende parantes.


f.eks. https://github.com/AtB-AS/mittatb-app/runs/5478910974?check_suite_focus=true