### PR TITLE
feat: add fallback for undefined device name

### DIFF
--- a/src/screens/Profile/TravelToken/SelectTravelTokenScreen.tsx
+++ b/src/screens/Profile/TravelToken/SelectTravelTokenScreen.tsx
@@ -132,7 +132,7 @@ export default function SelectTravelTokenScreen({navigation}: Props) {
               items={activatedMobileTokens}
               keyExtractor={(tt) => tt.id}
               itemToText={(tt) =>
-                tt.name +
+                (tt.name || t(TravelTokenTexts.toggleToken.unknownDevice)) +
                 (tt.isThisDevice
                   ? t(
                       TravelTokenTexts.toggleToken.radioBox.phone.selection

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -83,6 +83,7 @@ const SelectTravelTokenTexts = {
       'Vi forsøker å klargjøre din mobil til å kunne bruke billettene på den, men det ser ut som det tar litt tid. Du kan sjekke om du har nettilgang og hvis ikke så vil appen forsøke på nytt neste gang du får tilgang.', // TODO
       'We are trying to make your mobile phone ready to be used for the tickets, but it seems it is taking some time. Check that your device is connected to the Internet and if not the phone will try again when the Internet connection is back.',
     ),
+    unknownDevice: _('Enhet uten navn', 'Unnamed device'),
   },
 };
 export default SelectTravelTokenTexts;

--- a/src/travel-token-box/index.tsx
+++ b/src/travel-token-box/index.tsx
@@ -8,7 +8,7 @@ import {
 import React from 'react';
 import {StyleSheet, Theme} from '@atb/theme';
 import {TravelToken} from '@atb/mobile-token/types';
-import {useTranslation} from '@atb/translations';
+import {useTranslation, TravelTokenTexts} from '@atb/translations';
 import TravelTokenBoxTexts from '@atb/translations/components/TravelTokenBox';
 import MessageBox from '@atb/components/message-box';
 
@@ -110,7 +110,8 @@ const TravelDeviceTitle = ({
     case 'mobile':
       return (
         <ThemeText type="heading__title" color="primary_2" style={styles.title}>
-          {inspectableToken.name}
+          {inspectableToken.name ||
+            t(TravelTokenTexts.toggleToken.unknownDevice)}
         </ThemeText>
       );
   }


### PR DESCRIPTION
Dette er enkleste mulige løsning for at noen tokens får undefined navn. Det burde nok undersøkes nærmere hvorfor det blir undefined, og heller gi et navn som "iOS device" eller "iPhone 12", men dette er uansett en grei fallback for tilfeller der det skjer. En dato for når token ble opprettet er også en forbedring, men ikke i scope til 1.17. 

![collage](https://user-images.githubusercontent.com/1774972/157466168-24dd35a6-1425-40dc-9396-16471fa8e373.png)

