### PR TITLE
feat: additional feedback through Intercom after using generic feedback component

### DIFF
--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -41,7 +41,7 @@ const SubmittedComponent = ({
   };
 
   return (
-    <View style={[styles.container]}>
+    <View style={styles.container}>
       <ThemeText
         type="body__primary--bold"
         style={[styles.questionText, styles.centerText]}

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -27,9 +27,7 @@ const SubmittedComponent = ({
 
   const handleButtonClick = () => {
     const alternativeArrayConvertedToString =
-      selectedTextAlternatives[0] === undefined
-        ? null
-        : selectedTextAlternatives.join(', ');
+      selectedTextAlternatives.join(', ');
     Intercom.logEvent('feedback-given', {
       viewContext: `Bruker har gitt feedback på ${viewContext}.`,
       mainImpression: `Hovedinntrykket var ${opinion}.`,

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {View} from 'react-native';
+import {StyleSheet} from '@atb/theme';
+import ThemeText from '@atb/components/text';
+import {useTranslation, FeedbackTexts} from '@atb/translations';
+
+const SubmittedComponent = () => {
+  const styles = useSubmittedComponentStyles();
+  const {t} = useTranslation();
+
+  return (
+    <View style={[styles.container, styles.submittedView]}>
+      <ThemeText
+        type="body__primary--bold"
+        style={[styles.questionText, styles.centerText]}
+      >
+        {t(FeedbackTexts.submittedText.thanks)}
+      </ThemeText>
+      <ThemeText>🎉</ThemeText>
+    </View>
+  );
+};
+
+const useSubmittedComponentStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    backgroundColor: theme.colors.background_1.backgroundColor,
+    borderRadius: theme.border.radius.regular,
+    paddingHorizontal: theme.spacings.xLarge,
+    paddingBottom: theme.spacings.xLarge,
+    marginVertical: theme.spacings.medium,
+  },
+  submittedView: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  centerText: {
+    textAlign: 'center',
+  },
+  questionText: {
+    marginTop: theme.spacings.xLarge,
+    marginBottom: theme.spacings.large,
+  },
+}));
+
+export default SubmittedComponent;

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -1,22 +1,41 @@
 import React from 'react';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
+import Button from '../button';
 import ThemeText from '@atb/components/text';
 import {useTranslation, FeedbackTexts} from '@atb/translations';
+import Intercom from 'react-native-intercom';
+import {Chat} from '@atb/assets/svg/mono-icons/actions';
 
 const SubmittedComponent = () => {
   const styles = useSubmittedComponentStyles();
   const {t} = useTranslation();
 
+  const handleButtonClick = () => {
+    console.log('clickity');
+    Intercom.displayMessenger;
+  };
+
   return (
-    <View style={[styles.container, styles.submittedView]}>
+    <View style={[styles.container]}>
       <ThemeText
         type="body__primary--bold"
         style={[styles.questionText, styles.centerText]}
       >
         {t(FeedbackTexts.submittedText.thanks)}
       </ThemeText>
-      <ThemeText>🎉</ThemeText>
+      <ThemeText style={styles.centerText}>
+        {t(FeedbackTexts.additionalFeedback.text)}
+      </ThemeText>
+      <View style={styles.button}>
+        <Button
+          onPress={handleButtonClick}
+          text={t(FeedbackTexts.additionalFeedback.button)}
+          mode="primary"
+          icon={Chat}
+          iconPosition="right"
+        />
+      </View>
     </View>
   );
 };
@@ -29,16 +48,15 @@ const useSubmittedComponentStyles = StyleSheet.createThemeHook((theme) => ({
     paddingBottom: theme.spacings.xLarge,
     marginVertical: theme.spacings.medium,
   },
-  submittedView: {
-    flex: 1,
-    alignItems: 'center',
-  },
   centerText: {
     textAlign: 'center',
   },
   questionText: {
     marginTop: theme.spacings.xLarge,
     marginBottom: theme.spacings.large,
+  },
+  button: {
+    marginTop: theme.spacings.large,
   },
 }));
 

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -55,8 +55,8 @@ const SubmittedComponent = ({
         <Button
           onPress={handleButtonClick}
           text={t(FeedbackTexts.additionalFeedback.button)}
-          mode="primary"
           icon={Chat}
+          color="primary_2"
           iconPosition="right"
         />
       </View>

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -6,14 +6,38 @@ import ThemeText from '@atb/components/text';
 import {useTranslation, FeedbackTexts} from '@atb/translations';
 import Intercom from 'react-native-intercom';
 import {Chat} from '@atb/assets/svg/mono-icons/actions';
+import {FeedbackQuestionsMode} from './FeedbackContext';
+import {Opinions} from '.';
 
-const SubmittedComponent = () => {
+type SubmittedComponentProps = {
+  viewContext: FeedbackQuestionsMode;
+  opinion: Opinions;
+  selectedTextAlternatives: (string | undefined)[];
+  firebaseId?: string;
+};
+
+const SubmittedComponent = ({
+  viewContext,
+  opinion,
+  selectedTextAlternatives,
+  firebaseId,
+}: SubmittedComponentProps) => {
   const styles = useSubmittedComponentStyles();
   const {t} = useTranslation();
 
   const handleButtonClick = () => {
-    console.log('clickity');
-    Intercom.displayMessenger;
+    const alternativeArrayConvertedToString =
+      selectedTextAlternatives[0] === undefined
+        ? null
+        : selectedTextAlternatives.join(', ');
+    Intercom.logEvent('feedback-given', {
+      viewContext: `Bruker har gitt feedback på ${viewContext}.`,
+      mainImpression: `Hovedinntrykket var ${opinion}.`,
+      selectedAlternatives:
+        alternativeArrayConvertedToString || 'Ingen alternativer valgt.',
+      firebaseId,
+    });
+    Intercom.displayMessageComposer();
   };
 
   return (

--- a/src/components/feedback/index.tsx
+++ b/src/components/feedback/index.tsx
@@ -87,6 +87,7 @@ export const Feedback = ({mode, tripPattern, quayListData}: FeedbackProps) => {
   const [selectedAlternativeIds, setSelectedAlternativeIds] = useState<
     number[]
   >([]);
+  const [firebaseId, setFirebaseId] = useState<string>();
 
   const toggleSelectedAlternativeId = useCallback(
     (alternativeId: number) => {
@@ -123,7 +124,10 @@ export const Feedback = ({mode, tripPattern, quayListData}: FeedbackProps) => {
         selectedAnswers,
       };
 
-      await firestore().collection('feedback').add(dataToServer);
+      const submittedFeedbackDoc = await firestore()
+        .collection('feedback')
+        .add(dataToServer);
+      setFirebaseId(submittedFeedbackDoc.id);
     } catch (err: any) {
       Bugsnag.notify(err);
     } finally {
@@ -139,7 +143,23 @@ export const Feedback = ({mode, tripPattern, quayListData}: FeedbackProps) => {
   }, [tripPattern]);
 
   if (!category) return null;
-  if (submitted) return <SubmittedComponent />;
+  if (submitted) {
+    const selectedTextAlternatives = selectedAlternativeIds.map(
+      (altId) =>
+        category?.question?.alternatives.find(
+          (alt) => alt.alternativeId === altId,
+        )?.alternativeText.nb,
+    );
+
+    return (
+      <SubmittedComponent
+        viewContext={mode}
+        opinion={selectedOpinion}
+        selectedTextAlternatives={selectedTextAlternatives}
+        firebaseId={firebaseId}
+      />
+    );
+  }
 
   if (quayListData || tripPattern)
     return (

--- a/src/components/feedback/index.tsx
+++ b/src/components/feedback/index.tsx
@@ -8,27 +8,11 @@ import {Quay} from '@atb/api/types/departures';
 import {useTranslation, FeedbackTexts} from '@atb/translations';
 import {FeedbackQuestionsMode, useFeedbackQuestion} from './FeedbackContext';
 import GoodOrBadButton from './GoodOrBadButton';
+import SubmittedComponent from './SubmittedComponent';
 import {RenderQuestion} from './RenderQuestions';
 import firestore from '@react-native-firebase/firestore';
 import Bugsnag from '@bugsnag/react-native';
 import {APP_ORG, APP_VERSION} from '@env';
-
-const SubmittedComponent = () => {
-  const styles = useFeedbackStyles();
-  const {t} = useTranslation();
-
-  return (
-    <View style={[styles.container, styles.submittedView]}>
-      <ThemeText
-        type="body__primary--bold"
-        style={[styles.questionText, styles.centerText]}
-      >
-        {t(FeedbackTexts.submittedText.thanks)}
-      </ThemeText>
-      <ThemeText>🎉</ThemeText>
-    </View>
-  );
-};
 
 export enum Opinions {
   Good = 'GOOD',

--- a/src/translations/screens/Feedback.ts
+++ b/src/translations/screens/Feedback.ts
@@ -17,6 +17,10 @@ const FeedbackTexts = {
       'Additional thoughts? Please tell us!',
     ),
     button: _('Snakk med app-teamet', 'Chat with the app team'),
+    prefill: _(
+      'Hei! Jeg ble sendt til chatten her etter å ha gitt tilbakemelding på',
+      'Hi! I was transferred to the chat after giving feedback on',
+    ),
   },
 };
 

--- a/src/translations/screens/Feedback.ts
+++ b/src/translations/screens/Feedback.ts
@@ -9,7 +9,14 @@ const FeedbackTexts = {
     submitFeedback: _('Send tilbakemelding', 'Submit feedback'),
   },
   submittedText: {
-    thanks: _('Takk for tilbakemeldingen!', 'Thanks for the feedback!'),
+    thanks: _('Takk for tilbakemeldingen! 🎉', 'Thanks for the feedback! 🎉'),
+  },
+  additionalFeedback: {
+    text: _(
+      'Mer på hjertet? Vi hører gjerne fra deg!',
+      'Additional thoughts? Please tell us!',
+    ),
+    button: _('Snakk med app-teamet', 'Chat with the app team'),
   },
 };
 

--- a/src/translations/screens/Feedback.ts
+++ b/src/translations/screens/Feedback.ts
@@ -17,10 +17,6 @@ const FeedbackTexts = {
       'Additional thoughts? Please tell us!',
     ),
     button: _('Snakk med app-teamet', 'Chat with the app team'),
-    prefill: _(
-      'Hei! Jeg ble sendt til chatten her etter å ha gitt tilbakemelding på',
-      'Hi! I was transferred to the chat after giving feedback on',
-    ),
   },
 };
 


### PR DESCRIPTION
This feature makes it possible to submit additonal feedback through Intercom, and receive an answer, after giving feedback in our generic feedback component. 

The feedback given in the component is submitted as an Intercom-event to make the chat operators job easier, along with the Firebase documentID, so that additional info such as TripPatterns or QuayListData submitted from the generic component can be examined when needed.

<img width="430" alt="image" src="https://user-images.githubusercontent.com/21310942/157886872-7ab58b09-dd8d-4ba5-9f6c-fa7bcadb3364.png">

<img width="432" alt="image" src="https://user-images.githubusercontent.com/21310942/157886993-a992588a-2faa-4df6-bbe5-f12b6a352dbb.png">

![image](https://user-images.githubusercontent.com/21310942/157888417-35c9e9b8-0650-47db-aadb-7505a79171dd.png)

