### PR TITLE
fix: update language and translations

### DIFF
--- a/src/screens/Profile/TravelToken/index.tsx
+++ b/src/screens/Profile/TravelToken/index.tsx
@@ -84,7 +84,7 @@ const FaqSection = () => {
           key={index}
           text={t(question)}
           showIconText={false}
-          expandContent={<ThemeText>{t(answer)}</ThemeText>}
+          expandContent={<ThemeText isMarkdown={true}>{t(answer)}</ThemeText>}
         />
       ))}
     </Sections.Section>

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -25,35 +25,35 @@ const TravelTokenBoxTexts = {
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },
   howToChange: _(
-    'Du kan bytte hvor du bruker billetten din fra Min profil',
-    'TODO', // TODO
+    'Du kan bytte hvor du bruker billetten din fra **Min profil**.',
+    'Head over to **My profile** if you want to switch, and use the ticket on a t:card or a different phone instead.',
   ),
   errorMessages: {
     tokensNotLoadedTitle: _(
-      'Klarer ikke hente informasjon om mobil / t:kort',
-      'TODO', // TODO
+      'Klarer ikke hente informasjon om mobil / t:kort.',
+      'Unable to get information about your phones or t:card.',
     ),
     tokensNotLoaded: _(
       'Billetter må brukes på enten et t:kort eller en mobil, men akkurat nå klarer vi ikke finne ut hvor den er i bruk. Sjekk at du har tilgang på nett der du er.',
-      'TODO', // TODO
+      `Tickets must be used on either a t:card or a phone, but right now we are unable to determine where your tickets are used. Make sure you're online.`,
     ),
     emptyTokensTitle: _(
-      'Vi finner ingen t:kort eller mobiler tilknyttet profilen din',
-      'TODO', // TODO
+      'Vi finner ingen t:kort eller mobiler tilknyttet profilen din.',
+      `We can't find any phones or t:card on your account.`,
     ),
     emptyTokens: _(
       'Sjekk at du har tilgang på nett. Hvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.' +
         '\n\n' +
         'Om problemet vedvarer kan du ta kontakt med AtB kundesenter.',
-      'TODO', // TODO
+      `Make sure you're online. We'll keep trying but if the problem persists, please get in touch with AtB customer service. `,
     ),
     noInspectableTokenTitle: _(
       'Velg hvor du vil bruke billettene dine',
-      'TODO', // TODO
+      'Choose where your tickets are used',
     ),
     noInspectableToken: _(
       'Billetter må brukes på enten et t:kort eller en mobil, og det ser ikke ut som du har valgt en av dem. Gå til Min profil > Bytt mellom mobil / t:kort for å velge.',
-      'TODO', // TODO
+      'Tickets must be used on either a t:card or a phone, but it seems none are chosen. Go to settings in **My profile** and make a choice.',
     ),
   },
 };

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -45,7 +45,7 @@ const TravelTokenBoxTexts = {
       'Sjekk at du har tilgang på nett. Hvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.' +
         '\n\n' +
         'Om problemet vedvarer kan du ta kontakt med AtB kundesenter.',
-      `Make sure you're online. We'll keep trying but if the problem persists, please get in touch with AtB customer service. `,
+      `Make sure you're online. We'll keep trying but if the problem persists, please get in touch with AtB service center. `,
     ),
     noInspectableTokenTitle: _(
       'Velg hvor du vil bruke billettene dine',

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -20,7 +20,7 @@ const TravelTokenBoxTexts = {
     a11yLabel: (deviceName: string) =>
       _(
         `Du bruker nå mobilen ${deviceName}. Ta med deg mobilen når du er ute og reiser.`,
-        `You are now using the mobile phone ${deviceName}. Bring your phone when you are travelling`,
+        `You are now using the phone ${deviceName}. Bring your phone when you are travelling`,
       ),
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -38,7 +38,7 @@ const ProfileTexts = {
         travelToken: {
           label: _(
             'Bruk billett på mobil / t:kort',
-            'Use ticket on mobile / t:card',
+            'Use ticket on phone / t:card',
           ),
           flag: _('Ny', 'New'),
         },

--- a/src/translations/screens/subscreens/Information.ts
+++ b/src/translations/screens/subscreens/Information.ts
@@ -111,7 +111,7 @@ const SelectStartScreenTexts = {
       ),
       part1Bullet3: _(
         `${bulletPoint} at mobiletelefonen fungerer normalt, skjermen er leselig og har nok batterikapasitet så lenge reisen varer slik at gyldig billett kan fremvises. Dersom du ikke kan fremvise billett, vil det anses som å reise uten gyldig billett.`,
-        `${bulletPoint} ensure the mobile phone works properly, the screen is readable and the battery has enough power to present a valid ticket during the whole trip. If you cannot provide a valid ticket upon inspection, you will be considered as travelling without a ticket.`,
+        `${bulletPoint} ensure the phone works properly, the screen is readable and the battery has enough power to present a valid ticket during the whole trip. If you cannot provide a valid ticket upon inspection, you will be considered as travelling without a ticket.`,
       ),
       part2Heading: _(
         'Det vil komme flere betalingsmåter',

--- a/src/translations/screens/subscreens/Information.ts
+++ b/src/translations/screens/subscreens/Information.ts
@@ -111,7 +111,7 @@ const SelectStartScreenTexts = {
       ),
       part1Bullet3: _(
         `${bulletPoint} at mobiletelefonen fungerer normalt, skjermen er leselig og har nok batterikapasitet så lenge reisen varer slik at gyldig billett kan fremvises. Dersom du ikke kan fremvise billett, vil det anses som å reise uten gyldig billett.`,
-        `${bulletPoint} ensure the phone works properly, the screen is readable and the battery has enough power to present a valid ticket during the whole trip. If you cannot provide a valid ticket upon inspection, you will be considered as travelling without a ticket.`,
+        `${bulletPoint} make sure the phone works properly, the screen is readable and the battery has enough power to present a valid ticket during the whole trip. If you cannot provide a valid ticket upon inspection, you will be considered as travelling without a ticket.`,
       ),
       part2Heading: _(
         'Det vil komme flere betalingsmåter',

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -39,7 +39,10 @@ const LoginTexts = {
     input: {
       heading: _('Mobilnummer', 'phone number'),
       label: _('+47', '+47'),
-      placeholder: _('Skriv inn ditt telefonnummer', 'Type your phone number'),
+      placeholder: _(
+        'Skriv inn ditt telefonnummer',
+        'Type in your phone number',
+      ),
     },
     mainButton: _('Send engangskode', 'Send one-time code'),
     errors: {

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -34,12 +34,12 @@ const LoginTexts = {
     title: _('Logg inn', 'Log in'),
     description: _(
       'Logg inn med engangskode sendt til din mobil',
-      'Log in with a one-time code sent to your mobile',
+      'Log in with a one-time code sent to your phone',
     ),
     input: {
-      heading: _('Mobilnummer', 'Mobile number'),
+      heading: _('Mobilnummer', 'phone number'),
       label: _('+47', '+47'),
-      placeholder: _('Skriv inn ditt telefonnummer', 'Type your mobile number'),
+      placeholder: _('Skriv inn ditt telefonnummer', 'Type your phone number'),
     },
     mainButton: _('Send engangskode', 'Send one-time code'),
     errors: {

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -63,23 +63,23 @@ const SelectTravelTokenTexts = {
       tCard: {
         title: _('T:kort', 'T:card'),
         description: _(
-          'Les av t:kortet ditt på holdeplass eller ombord. Kortet leses av ved kontroll.',
-          'Scan your t:card at the stop place or on board. The card will be scanned for ticket inspection',
+          'Les av t:kortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
+          'Validate your t:card at the bus stop or on board. The card will be scanned in a ticket inspection.',
         ),
         a11yLabel: _(
           'T:kort. Les av t-kortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
-          't:card. Scan the t:card at the stop place or on board. The card will be scanned for ticket inspection',
+          't:card. Validate your t:card at the bus stop or on board. The card will be scanned in a ticket inspection.',
         ),
         a11yHint: _('Aktivér for å velge t:kort.', 'Activate to select t:card'),
       },
       phone: {
         title: _('Mobil', 'Phone'),
         description: _(
-          'Gå ombord med mobilen. Mobilen vises frem ved kontroll.',
+          'Gå om bord med mobilen. Mobilen vises frem ved kontroll.',
           'Board with your phone. Present the phone for ticket inspection.',
         ),
         a11yLabel: _(
-          'Mobil. Gå ombord med mobilen. Mobilen vises frem ved kontroll.',
+          'Mobil. Gå om bord med mobilen. Mobilen vises frem ved kontroll.',
           'Board with your phone. Present the phone for ticket inspection.',
         ),
         a11yHint: _('Aktivér for å velge mobil.', 'Activate to select phone'),
@@ -97,7 +97,7 @@ const SelectTravelTokenTexts = {
     ),
     noMobileToken: _(
       'Vi forsøker å klargjøre din mobil til å kunne bruke billettene på den, men det ser ut som det tar litt tid. Du kan sjekke om du har nettilgang og hvis ikke så vil appen forsøke på nytt neste gang du får tilgang.',
-      'We are trying to make your phone ready to be used for the tickets, but it seems it is taking some time. Check that your device is connected to the Internet and if not the phone will try again when the Internet connection is back.',
+      `We're trying to get your phone ready for ticket usage, but it seems like it's taking some time. Check that your device is connected to the internet, if not we'll try again once the internet connection is restored.`,
     ),
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -4,12 +4,12 @@ const SelectTravelTokenTexts = {
     header: {
       title: _(
         'Bruk billett på mobil / t:kort',
-        'Use ticket on mobile / t:card',
+        'Use ticket on phone / t:card',
       ),
     },
     changeTokenButton: _(
       'Bytt mellom mobil / t:kort',
-      'Switch between mobile / t:card',
+      'Switch between phone / t:card',
     ),
     faq: {
       title: _('Ofte stilte spørsmål', 'Frequently asked questions'),
@@ -18,17 +18,17 @@ const SelectTravelTokenTexts = {
       {
         question: _(
           'Hva skjer om jeg mister mobilen eller t:kortet?',
-          'What happens if I lose my mobile or t:card?',
+          'What happens if I lose my phone or t:card?',
         ),
         answer: _(
           'Du kan enkelt velge å bruke billetten din på et annet t:kort eller mobil. Det gjør du på **Min profil**.',
-          'You can easily head over to **My profile** to switch and use your ticket on another t:card or mobile.',
+          'You can easily head over to **My profile** to switch and use your ticket on another t:card or phone.',
         ),
       },
       {
         question: _(
           'Kan jeg bruke billetten på både t:kort og mobil samtidig?',
-          'Can I use the ticket on both t:card and mobile at the same time?',
+          'Can I use the ticket on both t:card and phone at the same time?',
         ),
         answer: _(
           'Nei. Billetten kan bare brukes på en dings om gangen, og billetten kan ikke deles med andre.',
@@ -58,7 +58,7 @@ const SelectTravelTokenTexts = {
     ],
   },
   toggleToken: {
-    title: _('Bytt mellom mobil / t:kort', 'Switch between mobile / t:card'),
+    title: _('Bytt mellom mobil / t:kort', 'Switch between phone / t:card'),
     radioBox: {
       tCard: {
         title: _('T:kort', 'T:card'),
@@ -97,7 +97,7 @@ const SelectTravelTokenTexts = {
     ),
     noMobileToken: _(
       'Vi forsøker å klargjøre din mobil til å kunne bruke billettene på den, men det ser ut som det tar litt tid. Du kan sjekke om du har nettilgang og hvis ikke så vil appen forsøke på nytt neste gang du får tilgang.',
-      'We are trying to make your mobile phone ready to be used for the tickets, but it seems it is taking some time. Check that your device is connected to the Internet and if not the phone will try again when the Internet connection is back.',
+      'We are trying to make your phone ready to be used for the tickets, but it seems it is taking some time. Check that your device is connected to the Internet and if not the phone will try again when the Internet connection is back.',
     ),
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -58,17 +58,17 @@ const SelectTravelTokenTexts = {
     ],
   },
   toggleToken: {
-    title: _('Bytt mellom mobil / t:kort', 'Switch between mobile / t:card'), // TODO
+    title: _('Bytt mellom mobil / t:kort', 'Switch between mobile / t:card'),
     radioBox: {
       tCard: {
         title: _('T:kort', 'T:card'),
         description: _(
           'Les av t:kortet ditt på holdeplass eller ombord. Kortet leses av ved kontroll.',
-          'TODO', // TODO
+          'Scan your t:card at the stop place or on board. The card will be scanned for ticket inspection',
         ),
         a11yLabel: _(
           'T:kort. Les av t-kortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
-          'TODO', // TODO
+          't:card. Scan the t:card at the stop place or on board. The card will be scanned for ticket inspection',
         ),
         a11yHint: _('Aktivér for å velge t:kort.', 'Activate to select t:card'),
       },
@@ -76,26 +76,23 @@ const SelectTravelTokenTexts = {
         title: _('Mobil', 'Phone'),
         description: _(
           'Gå ombord med mobilen. Mobilen vises frem ved kontroll.',
-          'TODO', // TODO
+          'Board with your phone. Present the phone for ticket inspection.',
         ),
         a11yLabel: _(
           'Mobil. Gå ombord med mobilen. Mobilen vises frem ved kontroll.',
-          'TODO', // TODO
+          'Board with your phone. Present the phone for ticket inspection.',
         ),
-        a11yHint: _(
-          'Aktivér for å velge mobil.',
-          'TODO', // TODO
-        ),
+        a11yHint: _('Aktivér for å velge mobil.', 'Activate to select phone'),
         selection: {
-          heading: _('Velg enhet', 'Select device'), // TODO
+          heading: _('Velg enhet', 'Select device'),
           thisDeviceSuffix: _(' (denne enheten)', ' (this device)'),
         },
       },
     },
-    saveButton: _('Lagre valg', 'Confirm selection'), // TODO
-    errorMessage: _('Noe gikk galt', 'Something went wrong'), // TODO
+    saveButton: _('Lagre valg', 'Confirm selection'),
+    errorMessage: _('Noe gikk galt', 'Something went wrong'),
     noTravelCard: _(
-      'Du har ikke et t:kort registrert. Hvis du ønsker å bruke t:kort kan du legge til dette på din profil i [nettbutikken](https://nettbutikk.atb.no).', // TODO
+      'Du har ikke et t:kort registrert. Hvis du ønsker å bruke t:kort kan du legge til dette på din profil i [nettbutikken](https://nettbutikk.atb.no).',
       'You have no t:card registered, If you wish to use t:card as travel token you may add this to your profile in the [webshop](https://nettbutikk.atb.no).',
     ),
     noMobileToken: _(

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -16,24 +16,43 @@ const SelectTravelTokenTexts = {
     },
     faqs: [
       {
-        question: _('Hva om jeg mister mobilen eller t:kortet?', ''), // TODO
+        question: _(
+          'Hva skjer om jeg mister mobilen eller t:kortet?',
+          'What happens if I lose my mobile or t:card?',
+        ),
         answer: _(
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', // TODO
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', // TODO
+          'Du kan enkelt velge å bruke billetten din på et annet t:kort eller mobil. Det gjør du på **Min profil**.',
+          'You can easily head over to **My profile** to switch and use your ticket on another t:card or mobile.',
         ),
       },
       {
-        question: _('Kan jeg reise med t:kort og mobil samtidig?', ''), // TODO
+        question: _(
+          'Kan jeg bruke billetten på både t:kort og mobil samtidig?',
+          'Can I use the ticket on both t:card and mobile at the same time?',
+        ),
         answer: _(
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', // TODO
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', // TODO
+          'Nei. Billetten kan bare brukes på en dings om gangen, og billetten kan ikke deles med andre.',
+          'No. You can only use the ticket on one gadget at a time and the ticket can not be shared with others.',
         ),
       },
       {
-        question: _('Kan jeg reise uten mobil eller t:kort?', ''), // TODO
+        question: _(
+          'Kan jeg reise uten t:kort eller mobil?',
+          'Can I travel without my t:card or phone?',
+        ),
         answer: _(
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', // TODO
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', // TODO
+          'Nei. Du mpå alltid ha med deg den dingsen du har valgt å bruke billetten på.',
+          'No. You must always bring the gadget you gave chosen to use your ticket on.',
+        ),
+      },
+      {
+        question: _(
+          `Har du flere spørsmål om billettkjøp?`,
+          `Do you have any other questions about ticket purchases?`,
+        ),
+        answer: _(
+          `Se flere måter å kontakte oss på atb.no/kontakt`,
+          `See how to contact us at atb.no/en/contact`,
         ),
       },
     ],

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -96,7 +96,7 @@ const SelectTravelTokenTexts = {
       'You have no t:card registered, If you wish to use t:card as travel token you may add this to your profile in the [webshop](https://nettbutikk.atb.no).',
     ),
     noMobileToken: _(
-      'Vi forsøker å klargjøre din mobil til å kunne bruke billettene på den, men det ser ut som det tar litt tid. Du kan sjekke om du har nettilgang og hvis ikke så vil appen forsøke på nytt neste gang du får tilgang.', // TODO
+      'Vi forsøker å klargjøre din mobil til å kunne bruke billettene på den, men det ser ut som det tar litt tid. Du kan sjekke om du har nettilgang og hvis ikke så vil appen forsøke på nytt neste gang du får tilgang.',
       'We are trying to make your mobile phone ready to be used for the tickets, but it seems it is taking some time. Check that your device is connected to the Internet and if not the phone will try again when the Internet connection is back.',
     ),
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),

--- a/src/travel-token-box/index.tsx
+++ b/src/travel-token-box/index.tsx
@@ -71,6 +71,7 @@ export default function TravelTokenBox({
           style={styles.howToChange}
           color="primary_2"
           type={'body__tertiary'}
+          isMarkdown={true}
         >
           {t(TravelTokenBoxTexts.howToChange)}
         </ThemeText>


### PR DESCRIPTION
- missing english translations
- FAQ
- token toggle texts and translations
- use "phone", not "mobile" in english translations
