### PR TITLE
build: upload ios source maps with bugsnag-source-maps cli

### DIFF
--- a/scripts/ios/upload-sourcemaps.sh
+++ b/scripts/ios/upload-sourcemaps.sh
@@ -18,9 +18,8 @@ echo "Uploading iOS source maps"
         --api-key=$BUGSNAG_API_KEY \
         --app-version=$APP_VERSION \
         --app-bundle-version=$BUILD_ID \
-        --dev=false \
         --platform=ios \
-        --source-map=@bundle/main.jsbundle.map \
-        --bundle=@bundle/main.jsbundle
+        --source-map=bundle/main.jsbundle.map \
+        --bundle=bundle/main.jsbundle
         --project-root=`pwd`
 fi

--- a/scripts/ios/upload-sourcemaps.sh
+++ b/scripts/ios/upload-sourcemaps.sh
@@ -6,7 +6,7 @@ if [[
     || -z "${APP_VERSION}"
    ]]; then
     echo "Argument error!"
-    echo "Expected two env variables: 
+    echo "Expected three env variables: 
   - BUGSNAG_API_KEY
   - APP_VERSION
   - BUILD_ID"
@@ -14,13 +14,13 @@ if [[
     exit 1
 else 
 echo "Uploading iOS source maps"
-    curl --http1.1 https://upload.bugsnag.com/react-native-source-map \
-        -F apiKey=$BUGSNAG_API_KEY \
-        -F appVersion=$APP_VERSION \
-        -F appBundleVersion=$BUILD_ID \
-        -F dev=false \
-        -F platform=ios \
-        -F sourceMap=@bundle/main.jsbundle.map \
-        -F bundle=@bundle/main.jsbundle \
-        -F projectRoot=`pwd`
+    npx bugsnag-source-maps upload-react-native \
+        --api-key=$BUGSNAG_API_KEY \
+        --app-version=$APP_VERSION \
+        --app-bundle-version=$BUILD_ID \
+        --dev=false \
+        --platform=ios \
+        --source-map=@bundle/main.jsbundle.map \
+        --bundle=@bundle/main.jsbundle
+        --project-root=`pwd`
 fi


### PR DESCRIPTION
Oppdaterer upload-sourcemaps.sh til å bruke upload-source-maps pakken for iOS, på samme måte som det ble gjort for android i #2215. For at scriptene skal fungerer på samme måte, og ikke som et api-kall.
