### PR TITLE
build: fix upload of source maps

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - rosvik/build-fix-upload-souce-maps
 
 jobs:
   build-ios:

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - rosvik/build-fix-upload-souce-maps
 
 jobs:
   build-ios:

--- a/scripts/ios/upload-sourcemaps.sh
+++ b/scripts/ios/upload-sourcemaps.sh
@@ -6,13 +6,13 @@ if [[
     || -z "${APP_VERSION}"
    ]]; then
     echo "Argument error!"
-    echo "Expected three env variables: 
+    echo "Expected three env variables:
   - BUGSNAG_API_KEY
   - APP_VERSION
   - BUILD_ID"
 
     exit 1
-else 
+else
 echo "Uploading iOS source maps"
     npx bugsnag-source-maps upload-react-native \
         --api-key=$BUGSNAG_API_KEY \
@@ -21,5 +21,4 @@ echo "Uploading iOS source maps"
         --platform=ios \
         --source-map=bundle/main.jsbundle.map \
         --bundle=bundle/main.jsbundle
-        --project-root=`pwd`
 fi


### PR DESCRIPTION
Ble ikke riktig å ha med `--project-root='pwd'` i oppdatert upload-sourcemaps, så fjerner denne her. 

Denne gangen fikk jeg testet det skikkelig også, i bygg https://github.com/AtB-AS/mittatb-app/runs/5552376900?check_suite_focus=true