### PR TITLE
fix: include env file hash to cache key in build steps

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -53,7 +53,7 @@ jobs:
         id: apk-cache
         with:
           path: app-staging.apk
-          key: ${{ matrix.org }}-${{ runner.os }}-android-cache-${{ hashFiles('android/**') }}-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}-${{ hashFiles('.yalc/**') }}
+          key: ${{ matrix.org }}-${{ runner.os }}-android-cache-${{ hashFiles('android/**') }}-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}-${{ hashFiles('.yalc/**')-${{ hashFiles('.env') }}
       - name: Decode Android keystore
         run: sh ./scripts/android/create-keystore-file.sh
         env:

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -34,7 +34,7 @@ jobs:
           path: |
             AtB.ipa
             AtB.app.dSYM.zip
-          key: ${{ matrix.org }}-${{ runner.os }}-ios-cache-${{ hashFiles('ios/**') }}-${{ hashFiles('.yalc/**') }}
+          key: ${{ matrix.org }}-${{ runner.os }}-ios-cache-${{ hashFiles('ios/**') }}-${{ hashFiles('.yalc/**') }}-${{ hashFiles('.env') }}
       - name: Run fastlane cert match
         run: fastlane ios get_cert
         env:


### PR DESCRIPTION
Registrert feil med feil versjon på APK som sendes til AppCenter (https://mittatb.slack.com/archives/C02EEG7D8EL/p1647422820463809). Det gjør at det blir feil versjon sendt videre og registrering av app til Entur får feil versjon. Konsekvens er at Android staging er på feil versjon og fungerer ikke.

Hypotesen er at det er cache-mekanismen som slår til her. Ser du på byggingen til [bump av 1.17](https://github.com/AtB-AS/mittatb-app/runs/5509338055?check_suite_focus=true) så slår cachen fremdeles til. På iOS fungerer dette for `ios/`-mappen endres med plists som har fått endret versjon. Men for Android er det kun en referanse til miljøvariabel via gradle, så de endrer seg ikke, og får hit på cachen.

Dette vil ikke skje på samme måte i store build, for der er det ikke apk/ipa cache.

Forslaget her inkluderer hash av .env fil i cache key, for det slo meg at det kan være nyttig uansett. Dersom .env-fil er byttet så burde det bygges cleant for det kan være noe variabler inni der som forutsetter det kanskje. Alternativt er å inkludere versjonsnummer i cache-key.