### PR TITLE
fix: cancel trip search for very short distances

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -34,6 +34,7 @@ import {
   locationDistanceInMetres as distanceInMetres,
   LOCATIONS_REALLY_CLOSE_THRESHOLD,
   locationsAreEqual,
+  validateTripLocations,
 } from '@atb/utils/location';
 import {useLayout} from '@atb/utils/use-layout';
 import Bugsnag from '@bugsnag/react-native';
@@ -372,6 +373,7 @@ const Assistant: React.FC<Props> = ({
     </View>
   );
   const noResultReasons = computeNoResultReasons(t, searchTime, from, to);
+  const isValidLocations = validateTripLocations(from, to);
 
   const onPressed = useCallback(
     (tripPatterns, startIndex) =>
@@ -443,7 +445,7 @@ const Assistant: React.FC<Props> = ({
         onDetailsPressed={onPressed}
         errorType={error}
       />
-      {!error && (
+      {!error && isValidLocations && (
         <TouchableOpacity
           onPress={loadMore}
           disabled={searchState === 'searching'}

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -34,7 +34,7 @@ import {
   locationDistanceInMetres as distanceInMetres,
   LOCATIONS_REALLY_CLOSE_THRESHOLD,
   locationsAreEqual,
-  validateTripLocations,
+  isValidTripLocations,
 } from '@atb/utils/location';
 import {useLayout} from '@atb/utils/use-layout';
 import Bugsnag from '@bugsnag/react-native';
@@ -373,7 +373,7 @@ const Assistant: React.FC<Props> = ({
     </View>
   );
   const noResultReasons = computeNoResultReasons(t, searchTime, from, to);
-  const isValidLocations = validateTripLocations(from, to);
+  const isValidLocations = isValidTripLocations(from, to);
 
   const onPressed = useCallback(
     (tripPatterns, startIndex) =>

--- a/src/screens/Assistant/use-trips-query.ts
+++ b/src/screens/Assistant/use-trips-query.ts
@@ -18,6 +18,7 @@ import Bugsnag from '@bugsnag/react-native';
 import {useSearchHistory} from '@atb/search-history';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {TripSearchPreferences, usePreferences} from '@atb/preferences';
+import {validateTripLocations} from '@atb/utils/location';
 
 export default function useTripsQuery(
   fromLocation?: Location,
@@ -81,6 +82,11 @@ export default function useTripsQuery(
             setSearchState('searching');
             let performedSearchesCount = 0;
             let tripsFoundCount = 0;
+
+            if (!validateTripLocations(fromLocation, toLocation)) {
+              setSearchState('search-empty-result');
+              return;
+            }
 
             try {
               // Fire and forget add journey search entry

--- a/src/screens/Assistant/use-trips-query.ts
+++ b/src/screens/Assistant/use-trips-query.ts
@@ -18,7 +18,7 @@ import Bugsnag from '@bugsnag/react-native';
 import {useSearchHistory} from '@atb/search-history';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {TripSearchPreferences, usePreferences} from '@atb/preferences';
-import {validateTripLocations} from '@atb/utils/location';
+import {isValidTripLocations} from '@atb/utils/location';
 
 export default function useTripsQuery(
   fromLocation?: Location,
@@ -83,7 +83,7 @@ export default function useTripsQuery(
             let performedSearchesCount = 0;
             let tripsFoundCount = 0;
 
-            if (!validateTripLocations(fromLocation, toLocation)) {
+            if (!isValidTripLocations(fromLocation, toLocation)) {
               setSearchState('search-empty-result');
               return;
             }

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -41,3 +41,11 @@ export function primitiveLocationDistanceInMetres(
     ),
   );
 }
+
+export function validateTripLocations(from?: Location, to?: Location): boolean {
+  if (!from || !to) return false;
+  if (locationsAreEqual(from, to)) return false;
+  if (locationDistanceInMetres(from, to) < LOCATIONS_REALLY_CLOSE_THRESHOLD)
+    return false;
+  return true;
+}

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -42,7 +42,7 @@ export function primitiveLocationDistanceInMetres(
   );
 }
 
-export function validateTripLocations(from?: Location, to?: Location): boolean {
+export function isValidTripLocations(from?: Location, to?: Location): boolean {
   if (!from || !to) return false;
   if (locationsAreEqual(from, to)) return false;
   if (locationDistanceInMetres(from, to) < LOCATIONS_REALLY_CLOSE_THRESHOLD)


### PR DESCRIPTION
Implementert at reisesøk blir avbrutt hvis det er samme, eller to nære stopp (innenfor 200m). Dette er implementert litt annerledes enn for reisesøk v1, fordi OTP2 faktisk gir en del forslag selv om det er fra og til samme sted. Nå avbrytes søket hvis det er for kort avstand, istedet for å reagere på at resultatet er tomt. 

https://user-images.githubusercontent.com/1774972/158805983-85c5adc8-900e-4fc6-a875-ea0791bb84bc.mp4


closes #1993