### PR TITLE
fix: use "place" param for trips from stop venues

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -23,7 +23,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {screenReaderHidden} from '@atb/utils/accessibility';
-import {flatMap} from '@atb/utils/array';
+import {flatMap, interpose} from '@atb/utils/array';
 import {
   formatToClock,
   isInThePast,
@@ -192,20 +192,20 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
           {...screenReaderHidden}
           onContentSizeChange={(width) => setCollapsableWidth(width)}
         >
-          {expandedLegs.map(function (leg, i) {
-            return (
-              <View style={styles.legOutput} key={leg.aimedStartTime}>
-                {leg.mode === 'foot' ? (
-                  <FootLeg leg={leg} nextLeg={tripPattern.legs[i + 1]} />
-                ) : (
-                  <>
+          <View style={styles.legOutput}>
+            {interpose(
+              expandedLegs.map((leg, i) => (
+                <View key={leg.aimedStartTime}>
+                  {leg.mode === 'foot' ? (
+                    <FootLeg leg={leg} nextLeg={tripPattern.legs[i + 1]} />
+                  ) : (
                     <TransportationLeg leg={leg} />
-                    <ThemeIcon svg={ChevronRight} size={'small'} />
-                  </>
-                )}
-              </View>
-            );
-          })}
+                  )}
+                </View>
+              )),
+              <ThemeIcon svg={ChevronRight} size="small" />,
+            )}
+          </View>
           <View style={styles.legOutput}>
             <CollapsedLegs legs={collapsedLegs} />
           </View>
@@ -348,7 +348,6 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
       ) : (
         <ThemeIcon svg={WalkingPerson} />
       )}
-      {nextLeg && <ThemeIcon svg={ChevronRight} size="small" />}
     </View>
   );
 };

--- a/src/screens/Assistant/use-trips-query.ts
+++ b/src/screens/Assistant/use-trips-query.ts
@@ -199,9 +199,21 @@ async function doSearch(
   cancelToken: CancelTokenSource,
   tripSearchPreferences?: TripSearchPreferences,
 ) {
+  const isFromVenue = fromLocation.layer === 'venue';
+  const isToVenue = toLocation.layer === 'venue';
+
+  const from = {
+    ...fromLocation,
+    place: isFromVenue ? fromLocation.id : undefined,
+  };
+  const to = {
+    ...toLocation,
+    place: isToVenue ? toLocation.id : undefined,
+  };
+
   const query: TripsQueryVariables = {
-    from: fromLocation,
-    to: toLocation,
+    from,
+    to,
     cursor,
     when: searchTime?.date,
     arriveBy,

--- a/src/screens/Assistant/use-trips-query.ts
+++ b/src/screens/Assistant/use-trips-query.ts
@@ -199,16 +199,13 @@ async function doSearch(
   cancelToken: CancelTokenSource,
   tripSearchPreferences?: TripSearchPreferences,
 ) {
-  const isFromVenue = fromLocation.layer === 'venue';
-  const isToVenue = toLocation.layer === 'venue';
-
   const from = {
     ...fromLocation,
-    place: isFromVenue ? fromLocation.id : undefined,
+    place: fromLocation.layer === 'venue' ? fromLocation.id : undefined,
   };
   const to = {
     ...toLocation,
-    place: isToVenue ? toLocation.id : undefined,
+    place: toLocation.layer === 'venue' ? toLocation.id : undefined,
   };
 
   const query: TripsQueryVariables = {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -4,3 +4,13 @@ export function flatMap<T, U>(
 ): U[] {
   return Array.prototype.concat(...array.map(callbackfn));
 }
+
+/*
+Takes an array and an element and returns a new array with the given element
+inserted in between every element of the original array.
+
+E.g. interpose([1,2,3], '+') -> [1, '+', 2, '+', 3]
+*/
+export function interpose<T, U>(array: Array<T>, delim: U) {
+  return flatMap(array, (el) => [delim, el]).slice(1);
+}


### PR DESCRIPTION
- Når man gjør reisesøk fra eller til en holdeplass, brukes nå "place" parameteret til journey planner med NSR ID. Slik får man ikke lenger beskjed om å gå korte distanser i enden av hvert reiseforslag.
- Legger til en `interpose()` funksjon i utils/array. Forklart oppførsel i koden, men det tilsvarer [lodash-contrib sin `_.interpose`](https://www.geeksforgeeks.org/lodash-_-interpose-method/).
- Bruker interpose til å gjøre innsetting av ChevronRight -ikonene i reisesøk på en mer smooth måte.

https://user-images.githubusercontent.com/1774972/159000515-a95c1252-623d-4461-aef1-b6b004187e32.mp4

## Før/etter

![collage](https://user-images.githubusercontent.com/1774972/159000773-2bad581e-538f-4ece-b1ac-55bdcf002625.png)

closes #2296 