### PR TITLE
fix: gap in disappearing header for some cases on iOS. fixes #2077

### DIFF
--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -49,8 +49,6 @@ type Props = {
   alternativeTitleComponent?: React.ReactNode;
   showAlterntativeTitle?: Boolean;
 
-  headerMargin?: number;
-
   leftButton?: LeftButtonProps;
 
   onEndReached?(e: NativeScrollEvent): void;
@@ -92,12 +90,12 @@ const DisappearingHeader: React.FC<Props> = ({
 
   onEndReached,
   onEndReachedThreshold = 10,
-  headerMargin = 12,
 
   onFullscreenTransitionEnd,
   alertContext,
 }) => {
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
+  const [fullheightTransitioned, setTransitioned] = useState(isFullHeight);
   const {
     boxHeight,
     contentHeight,
@@ -105,8 +103,6 @@ const DisappearingHeader: React.FC<Props> = ({
     onScreenHeaderLayout,
     onHeaderContentLayout,
   } = useCalculateHeaderContentHeight(isAnimating);
-  const [fullheightTransitioned, setTransitioned] = useState(isFullHeight);
-  const {width: windowWidth} = useWindowDimensions();
   const scrollableContentRef = React.useRef<ScrollView>(null);
   useScrollToTop(
     React.useRef<Scrollable>({
@@ -115,7 +111,6 @@ const DisappearingHeader: React.FC<Props> = ({
     }),
   );
 
-  const [scrollYValue, setScrollY] = useState<number>(0);
   const styles = useThemeStyles();
   const {theme} = useTheme();
   const scrollYRef = useRef(
@@ -188,8 +183,6 @@ const DisappearingHeader: React.FC<Props> = ({
 
   const onScrolling = useCallback(
     (e: NativeScrollEvent) => {
-      const scrollPos = e.contentOffset.y;
-      setScrollY(scrollPos);
       endReachListener(e);
     },
     [endReachListener],
@@ -282,20 +275,19 @@ const DisappearingHeader: React.FC<Props> = ({
               contentContainerStyle={[
                 {paddingTop: !IS_IOS ? contentHeight : 0},
               ]}
+              automaticallyAdjustContentInsets={false}
               contentInset={{
-                top: contentHeight + headerMargin,
+                top: contentHeight,
               }}
               contentOffset={{
-                y: -contentHeight - headerMargin,
+                y: -contentHeight,
                 x: 0,
               }}
             >
               {children}
             </Animated.ScrollView>
           ) : (
-            <View style={{flex: 1, paddingTop: contentHeight + headerMargin}}>
-              {children}
-            </View>
+            <View style={{flex: 1, paddingTop: contentHeight}}>{children}</View>
           )}
         </View>
       </View>

--- a/src/components/disappearing-header/simple.tsx
+++ b/src/components/disappearing-header/simple.tsx
@@ -34,8 +34,6 @@ type Props = {
   headerTitle: React.ReactNode;
   alternativeTitleComponent?: React.ReactNode;
 
-  headerMargin?: number;
-
   leftButton: LeftButtonProps;
 
   onEndReached?(e: NativeScrollEvent): void;

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -417,7 +417,6 @@ const Assistant: React.FC<Props> = ({
       onRefresh={refresh}
       useScroll={useScroll}
       headerTitle={t(AssistantTexts.header.title)}
-      headerMargin={24}
       isFullHeight={isHeaderFullHeight}
       alternativeTitleComponent={altHeaderComp}
       showAlterntativeTitle={Boolean(from && to)}


### PR DESCRIPTION
Uten at jeg skal gå for hardt ut her, men nå tror jeg de problemene med mystisk space på iOS for enkelte reisesøk er borte. Det var uforutsigbar oppførsel hvor det noen ganger ble feil og andre ganger ikke. Av en grunn så oppstod det i langt større grad på Reisesøk v2 enn v1.

Feilen ser ut til å være ganske banal og irriterende. Det skjer en automatisk endring av insets kompansert i iOS i bakkant basert på toolbar og tabbar. Som gjorde at den ble varierende høyde i enkelte tilfeller. Men vi styrer insets manuelt og det ble derfor trekt fra/lagt til alt ettersom i ulike tilfeller.

Her deaktiverer vi automatisk justering av insets og med det håper jeg å kunne sette punktum på et problem fra november 2020.

Dette gjør og i mer eller mindre grad at headerMargin ikke trengs (som trolig var et forsøk på kompansering på et tidspunkt).


Closes #746
Closes #2077


---

Før:
![Screenshot 2022-03-18 at 16 00 02](https://user-images.githubusercontent.com/606374/159027507-ba9be10e-080a-44d2-b0bd-f230587e8620.png)


Etter:

![Screenshot 2022-03-18 at 15 35 53](https://user-images.githubusercontent.com/606374/159027321-92fd85bf-8c2e-4619-806d-6b28a36c2c66.png)
