### PR TITLE
build: add staging build for release branches

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - release/**
 
 jobs:
   build-android:

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - release/**
 
 jobs:
   build-ios:


### PR DESCRIPTION
Oppdatert staging workflow til å også gjelde på release branches, slik at de kan testes i App Center. 