### PR TITLE
fix: disable strike through when searching for trips 'now'

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -444,6 +444,7 @@ const Assistant: React.FC<Props> = ({
         resultReasons={noResultReasons}
         onDetailsPressed={onPressed}
         errorType={error}
+        searchTime={searchTime}
       />
       {!error && isValidLocations && (
         <TouchableOpacity

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -49,8 +49,8 @@ import {SearchTime} from './journey-date-picker';
 type ResultItemProps = {
   tripPattern: TripPattern;
   onDetailsPressed(): void;
+  searchTime: SearchTime;
   testID?: string;
-  searchTime?: SearchTime;
 };
 
 function legWithQuay(leg: Leg) {

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -44,11 +44,13 @@ import {
 import {ScrollView} from 'react-native-gesture-handler';
 import {Leg, TripPattern} from '@atb/api/types/trips';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {SearchTime} from './journey-date-picker';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
   onDetailsPressed(): void;
   testID?: string;
+  searchTime?: SearchTime;
 };
 
 function legWithQuay(leg: Leg) {
@@ -74,13 +76,13 @@ function getFirstQuayName(legs: Leg[]) {
 }
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
-}> = ({tripPattern}) => {
+  strikethrough: boolean;
+}> = ({tripPattern, strikethrough}) => {
   const styles = useThemeStyles();
   const {t, language} = useTranslation();
   const durationText = secondsToDurationShort(tripPattern.duration, language);
   const startTime = tripPattern.legs[0].expectedStartTime;
   const endTime = tripPattern.legs[tripPattern.legs.length - 1].expectedEndTime;
-  const isInPast = isInThePast(startTime);
 
   return (
     <View style={styles.resultHeader}>
@@ -89,7 +91,7 @@ const ResultItemHeader: React.FC<{
         color="secondary"
         style={[
           styles.resultHeaderLabel,
-          isInPast && styles.resultHeaderLabelInPast,
+          strikethrough && styles.strikethrough,
         ]}
         accessibilityLabel={t(
           AssistantTexts.results.resultItem.header.time(
@@ -128,6 +130,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   tripPattern,
   onDetailsPressed,
   testID,
+  searchTime,
   ...props
 }) => {
   const styles = useThemeStyles();
@@ -164,7 +167,10 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
     numberOfExpandedLegs,
     tripPattern.legs.length,
   );
-  const isInPast = isInThePast(tripPattern.legs[0].expectedStartTime);
+
+  const isInPast =
+    isInThePast(tripPattern.legs[0].expectedStartTime) &&
+    searchTime?.option !== 'now';
 
   return (
     <TouchableOpacity
@@ -186,7 +192,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
         accessible={false}
         onLayout={(e) => setCollapsableParentWidth(e.nativeEvent.layout.width)}
       >
-        <ResultItemHeader tripPattern={tripPattern} />
+        <ResultItemHeader tripPattern={tripPattern} strikethrough={isInPast} />
         <ScrollView
           horizontal={true}
           showsHorizontalScrollIndicator={false}
@@ -275,7 +281,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   resultHeaderLabel: {
     flex: 3,
   },
-  resultHeaderLabelInPast: {
+  strikethrough: {
     textDecorationLine: 'line-through',
   },
   legOutput: {

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -13,6 +13,7 @@ import {Text, View} from 'react-native';
 import ResultItem from '@atb/screens/Assistant/ResultItem';
 import {TripPattern} from '@atb/api/types/trips';
 import {TripPatternWithKey} from '@atb/screens/Assistant/types';
+import {SearchTime} from './journey-date-picker';
 
 type Props = {
   tripPatterns: TripPatternWithKey[];
@@ -22,6 +23,7 @@ type Props = {
   resultReasons: String[];
   onDetailsPressed(tripPatterns?: TripPattern[], index?: number): void;
   errorType?: ErrorType;
+  searchTime?: SearchTime;
 };
 
 export type ResultTabParams = {
@@ -35,6 +37,7 @@ const Results: React.FC<Props> = ({
   resultReasons,
   onDetailsPressed,
   errorType,
+  searchTime,
 }) => {
   const styles = useThemeStyles();
   const {theme} = useTheme();
@@ -125,6 +128,7 @@ const Results: React.FC<Props> = ({
             onDetailsPressed={() => {
               onDetailsPressed(tripPatterns, i);
             }}
+            searchTime={searchTime}
             testID={'assistantSearchResult' + i}
           />
         </Fragment>

--- a/src/screens/Assistant/Results.tsx
+++ b/src/screens/Assistant/Results.tsx
@@ -23,7 +23,7 @@ type Props = {
   resultReasons: String[];
   onDetailsPressed(tripPatterns?: TripPattern[], index?: number): void;
   errorType?: ErrorType;
-  searchTime?: SearchTime;
+  searchTime: SearchTime;
 };
 
 export type ResultTabParams = {


### PR DESCRIPTION
Deaktivert gjennomstreking når searchTime.option er 'now'. Ref. https://github.com/AtB-AS/mittatb-app/issues/2194#issuecomment-1075187479. 


fixes #2194 