### PR TITLE
feat: use native spinner when loading tripPatterns

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -436,6 +436,7 @@ const Assistant: React.FC<Props> = ({
       renderHeader={renderHeader}
       highlightComponent={newsBanner}
       onRefresh={refresh}
+      isRefreshing={searchState === 'searching'}
       useScroll={useScroll}
       headerTitle={t(AssistantTexts.header.title)}
       isFullHeight={isHeaderFullHeight}
@@ -474,19 +475,29 @@ const Assistant: React.FC<Props> = ({
           testID="loadMoreButton"
         >
           {searchState === 'searching' ? (
-            <>
-              <ActivityIndicator
-                color={theme.text.colors.secondary}
-                style={{
-                  marginRight: theme.spacings.medium,
-                }}
-              />
-              <ThemeText color="secondary" testID="searchingForResults">
-                {tripPatterns.length
-                  ? t(AssistantTexts.results.fetchingMore)
-                  : t(AssistantTexts.searchState.searching)}
-              </ThemeText>
-            </>
+            <View style={styles.loadingIndicator}>
+              {tripPatterns.length ? (
+                <>
+                  <ActivityIndicator
+                    color={theme.text.colors.secondary}
+                    style={{
+                      marginRight: theme.spacings.medium,
+                    }}
+                  />
+                  <ThemeText color="secondary" testID="searchingForResults">
+                    {t(AssistantTexts.results.fetchingMore)}
+                  </ThemeText>
+                </>
+              ) : (
+                <ThemeText
+                  color="secondary"
+                  style={styles.loadingText}
+                  testID="searchingForResults"
+                >
+                  {t(AssistantTexts.searchState.searching)}
+                </ThemeText>
+              )}
+            </View>
           ) : (
             <>
               {loadMore ? (
@@ -536,6 +547,13 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   fadeChild: {
     marginVertical: theme.spacings.medium,
+  },
+  loadingIndicator: {
+    marginTop: theme.spacings.xLarge,
+    flexDirection: 'row',
+  },
+  loadingText: {
+    marginTop: theme.spacings.xLarge * 2,
   },
   loadMoreButton: {
     paddingVertical: theme.spacings.medium,

--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -436,7 +436,7 @@ const Assistant: React.FC<Props> = ({
       renderHeader={renderHeader}
       highlightComponent={newsBanner}
       onRefresh={refresh}
-      isRefreshing={searchState === 'searching'}
+      isRefreshing={searchState === 'searching' && !tripPatterns.length}
       useScroll={useScroll}
       headerTitle={t(AssistantTexts.header.title)}
       isFullHeight={isHeaderFullHeight}

--- a/src/translations/screens/Assistant.ts
+++ b/src/translations/screens/Assistant.ts
@@ -54,7 +54,7 @@ const AssistantTexts = {
     },
   },
   searchState: {
-    searching: _('Laster søkeresultater', 'Loading search results'),
+    searching: _('Laster søkeresultater...', 'Loading search results...'),
     searchSuccess: _(
       'Søkeresultater er lastet inn',
       'Search results are loaded',

--- a/src/translations/screens/Assistant.ts
+++ b/src/translations/screens/Assistant.ts
@@ -54,7 +54,7 @@ const AssistantTexts = {
     },
   },
   searchState: {
-    searching: _('Laster søkeresultater...', 'Loading search results...'),
+    searching: _('Laster søkeresultater…', 'Loading search results…'),
     searchSuccess: _(
       'Søkeresultater er lastet inn',
       'Search results are loaded',


### PR DESCRIPTION
Forslag på løsning for buggy spinner ved lasting av reiseforslag. Denne implementasjonen lener seg mer på native refresh implementasjon, men bruker fortsatt custom melding ved lasting av "flere" resultat. ~Litt rar oppførsel på Andorid med spinner når man laster flere, så vurderer å legge inn en sjekk på OS-type, og heller løse det forskjellig mellom plattformene.~

Tar gjerne tilbakemeldinger på hvordan det kan se ut og oppføre seg. Mer info om bakgrunn i linket issue #1997.

### Demo

https://user-images.githubusercontent.com/1774972/160110400-9488cfe0-d9a8-48cc-9663-ce2ee66f75be.mov

