### PR TITLE
feat: Åpne kontaktskjema i stedet for Intercom når Intercom er deaktivert

### DIFF
--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {View} from 'react-native';
+import {Linking, View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import Button from '../button';
 import ThemeText from '@atb/components/text';
 import {useTranslation, FeedbackTexts} from '@atb/translations';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import Intercom from 'react-native-intercom';
-import {Chat} from '@atb/assets/svg/mono-icons/actions';
+import {Chat, Support} from '@atb/assets/svg/mono-icons/actions';
 import {FeedbackQuestionsViewContext} from './FeedbackContext';
 import {Opinions} from '.';
 
@@ -24,18 +25,23 @@ const SubmittedComponent = ({
 }: SubmittedComponentProps) => {
   const styles = useSubmittedComponentStyles();
   const {t} = useTranslation();
+  const {customer_service_url, enable_intercom} = useRemoteConfig();
 
   const handleButtonClick = () => {
-    const alternativeArrayConvertedToString =
-      selectedTextAlternatives.join(', ');
-    Intercom.logEvent('feedback-given', {
-      viewContext: `Bruker har gitt feedback på ${viewContext}.`,
-      mainImpression: `Hovedinntrykket var ${opinion}.`,
-      selectedAlternatives:
-        alternativeArrayConvertedToString || 'Ingen alternativer valgt.',
-      firebaseId,
-    });
-    Intercom.displayMessageComposer();
+    if (enable_intercom) {
+      const alternativeArrayConvertedToString =
+        selectedTextAlternatives.join(', ');
+      Intercom.logEvent('feedback-given', {
+        viewContext: `Bruker har gitt feedback på ${viewContext}.`,
+        mainImpression: `Hovedinntrykket var ${opinion}.`,
+        selectedAlternatives:
+          alternativeArrayConvertedToString || 'Ingen alternativer valgt.',
+        firebaseId,
+      });
+      Intercom.displayMessageComposer();
+    } else {
+      Linking.openURL(customer_service_url);
+    }
   };
 
   return (
@@ -50,13 +56,23 @@ const SubmittedComponent = ({
         {t(FeedbackTexts.additionalFeedback.text)}
       </ThemeText>
       <View style={styles.button}>
-        <Button
-          onPress={handleButtonClick}
-          text={t(FeedbackTexts.additionalFeedback.button)}
-          icon={Chat}
-          color="primary_2"
-          iconPosition="right"
-        />
+        {enable_intercom ? (
+          <Button
+            onPress={handleButtonClick}
+            text={t(FeedbackTexts.additionalFeedback.intercomButton)}
+            icon={Chat}
+            color="primary_2"
+            iconPosition="right"
+          />
+        ) : (
+          <Button
+            onPress={handleButtonClick}
+            text={t(FeedbackTexts.additionalFeedback.contactsheetButton)}
+            icon={Support}
+            color="primary_2"
+            iconPosition="right"
+          />
+        )}
       </View>
     </View>
   );

--- a/src/translations/screens/Feedback.ts
+++ b/src/translations/screens/Feedback.ts
@@ -16,7 +16,8 @@ const FeedbackTexts = {
       'Mer på hjertet? Vi hører gjerne fra deg!',
       'Additional thoughts? Please tell us!',
     ),
-    button: _('Snakk med app-teamet', 'Chat with the app team'),
+    intercomButton: _('Snakk med app-teamet', 'Chat with the app team'),
+    contactsheetButton: _('Kontakt kundeservice', 'Contact customer support'),
   },
 };
 


### PR DESCRIPTION
Berører hovedsakelig OOS-aktører som ikke har Intercom aktivert. Da håndteres muligheten for å gi ekstra feedback på samme måte som kundeservice, altså at en valgfri link åpnes i ekstern nettleser.

NFK:
![Simulator Screen Recording - iPhone 13 - 2022-03-28 at 13 55 52](https://user-images.githubusercontent.com/21310942/160392978-918d5633-68f3-4236-a745-c3086906f740.gif)

AtB:
![Simulator Screen Recording - iPhone 13 - 2022-03-28 at 14 16 17](https://user-images.githubusercontent.com/21310942/160395877-67c6990d-382d-4c0f-bb59-a82269a923db.gif)