### PR TITLE
fix: a11y for passed trips

### DIFF
--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -174,7 +174,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
 
   return (
     <TouchableOpacity
-      accessibilityLabel={tripSummary(tripPattern, t, language)}
+      accessibilityLabel={tripSummary(tripPattern, t, language, isInPast)}
       accessibilityHint={t(
         AssistantTexts.results.resultItem.footer.detailsHint,
       )}
@@ -410,11 +410,14 @@ const tripSummary = (
   tripPattern: TripPattern,
   t: TranslateFunction,
   language: Language,
+  isInPast: boolean,
 ) => {
   const nonFootLegs = tripPattern.legs.filter((l) => l.mode !== 'foot') ?? [];
   const firstLeg = nonFootLegs[0];
 
   return `
+    ${isInPast ? t(AssistantTexts.results.resultItem.passedTrip) : ''}
+
     ${
       firstLeg
         ? t(

--- a/src/translations/screens/Assistant.ts
+++ b/src/translations/screens/Assistant.ts
@@ -124,6 +124,7 @@ const AssistantTexts = {
         _(`I overmorgen - ${date}`, `Day after tomorrow - ${date}`),
     },
     resultItem: {
+      passedTrip: _('Passert reise, ', 'Passed trip, '),
       header: {
         time: (startTime: string, endTime: string) =>
           _(


### PR DESCRIPTION
Legger til UU beskrivelse av reiseforslag som er tilbake i tid.

Vet ikke om "Passert reise" / "Passed trip" er beste måten å beskrive forslagene på, så åpen for forslag på språk.

closes #2194 