### PR TITLE
fix: use text color tint for disappearing header spinner

### DIFF
--- a/src/components/disappearing-header/index.tsx
+++ b/src/components/disappearing-header/index.tsx
@@ -256,7 +256,7 @@ const DisappearingHeader: React.FC<Props> = ({
                   refreshing={isRefreshing}
                   onRefresh={onRefresh}
                   progressViewOffset={contentHeight}
-                  tintColor={theme.colors[themeColor].color}
+                  tintColor={theme.text.colors.secondary}
                 />
               }
               onScroll={Animated.event(


### PR DESCRIPTION
Oppdaterer spinner tint på iOS, siden den ikke var særlig synlig i light mode.

Tenkte det var greit å ta i samme runde som #1997, men ikke egentlig relatert.

## Før / etter

https://user-images.githubusercontent.com/1774972/160566534-07ad46eb-d548-44d6-907f-55d70debc064.mp4

