### PR TITLE
fix: hide results from screen reader when search is empty

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -460,16 +460,18 @@ const Assistant: React.FC<Props> = ({
       alertContext="travel"
     >
       <ScreenReaderAnnouncement message={searchStateMessage} />
-      <Results
-        tripPatterns={tripPatterns}
-        isSearching={isSearching}
-        showEmptyScreen={showEmptyScreen}
-        isEmptyResult={isEmptyResult}
-        resultReasons={noResultReasons}
-        onDetailsPressed={onPressed}
-        errorType={error}
-        searchTime={searchTime}
-      />
+      {isValidLocations && (
+        <Results
+          tripPatterns={tripPatterns}
+          isSearching={isSearching}
+          showEmptyScreen={showEmptyScreen}
+          isEmptyResult={isEmptyResult}
+          resultReasons={noResultReasons}
+          onDetailsPressed={onPressed}
+          errorType={error}
+          searchTime={searchTime}
+        />
+      )}
       {!error && isValidLocations && (
         <TouchableOpacity
           onPress={loadMore}


### PR DESCRIPTION
Det ble oppdaget en feil med skjermleser hvor man fikk opp "Vi fant dessverre ingen reiseruter som passer til ditt søk." uten at man hadde gjort et søk. Fikser det ved å skjule hele `Results` når det ikke har blitt gjort noe søk.