### PR TITLE
feat: automatically navigate to stop places in depatures

### DIFF
--- a/src/api/departures/stops-nearest.ts
+++ b/src/api/departures/stops-nearest.ts
@@ -7,6 +7,7 @@ import {StopPlaceQuayDepartures} from '../types/departures';
 import {stringifyUrl} from 'query-string';
 import {QuayDeparturesQuery} from '../types/generated/QuayDeparturesQuery';
 import {NearestStopPlacesQuery} from '../types/generated/NearestStopPlacesQuery';
+import {StopsDetailsQuery} from '../types/generated/StopsDetailsQuery';
 
 export type StopsNearestQuery = CursoredQuery<{
   latitude: number;
@@ -14,6 +15,10 @@ export type StopsNearestQuery = CursoredQuery<{
   count?: number;
   distance?: number;
   after?: string;
+}>;
+
+export type StopsDetailsVariables = CursoredQuery<{
+  ids: string[];
 }>;
 
 export type StopPlaceDeparturesPayload = {
@@ -51,6 +56,14 @@ export async function getNearestStops(
   return request(url, opts);
 }
 
+export async function getStopsDetails(
+  query: StopsDetailsVariables,
+  opts?: AxiosRequestConfig,
+): Promise<StopsDetailsQuery> {
+  const url = `${BASE_URL}/stops-details`;
+  return requestStopsDetails(stringifyUrl({url, query}), opts);
+}
+
 export async function getStopPlaceDepartures(
   query: StopPlaceDeparturesQuery,
   opts?: AxiosRequestConfig,
@@ -73,6 +86,14 @@ async function request(
   opts?: AxiosRequestConfig,
 ): Promise<NearestStopPlacesQuery> {
   const response = await client.get<NearestStopPlacesQuery>(url, opts);
+  return response.data;
+}
+
+async function requestStopsDetails(
+  url: string,
+  opts?: AxiosRequestConfig,
+): Promise<StopsDetailsQuery> {
+  const response = await client.get<StopsDetailsQuery>(url, opts);
   return response.data;
 }
 

--- a/src/api/types/generated/StopsDetailsQuery.ts
+++ b/src/api/types/generated/StopsDetailsQuery.ts
@@ -1,0 +1,17 @@
+import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type StopsDetailsQuery = {
+  stopPlaces: Array<{
+    name: string;
+    transportMode?: Array<Types.TransportMode>;
+    description?: string;
+    id: string;
+    quays?: Array<{
+      id: string;
+      description?: string;
+      name: string;
+      publicCode?: string;
+      stopPlace?: {id: string};
+    }>;
+  }>;
+};

--- a/src/api/types/generated/StopsDetailsQuery.ts
+++ b/src/api/types/generated/StopsDetailsQuery.ts
@@ -6,6 +6,8 @@ export type StopsDetailsQuery = {
     transportMode?: Array<Types.TransportMode>;
     description?: string;
     id: string;
+    latitude?: number;
+    longitude?: number;
     quays?: Array<{
       id: string;
       description?: string;

--- a/src/screens/Departures/NearbyPlaces.tsx
+++ b/src/screens/Departures/NearbyPlaces.tsx
@@ -195,8 +195,8 @@ const PlacesOverview: React.FC<PlacesOverviewProps> = ({
           openLocationSearch={openLocationSearch}
           setCurrentLocationOrRequest={setCurrentLocationOrRequest}
           setLocation={(location: LocationWithMetadata) => {
-            navigation.setParams({
-              location,
+            navigation.navigate('PlaceScreen', {
+              place: location as Place,
             });
           }}
         />

--- a/src/screens/Departures/NearbyPlaces.tsx
+++ b/src/screens/Departures/NearbyPlaces.tsx
@@ -124,6 +124,14 @@ const PlacesOverview: React.FC<PlacesOverviewProps> = ({
       initialLocation: fromLocation,
     });
 
+  useEffect(() => {
+    if (fromLocation?.layer === 'venue') {
+      navigation.navigate('PlaceScreen', {
+        place: fromLocation,
+      });
+    }
+  }, [fromLocation?.id]);
+
   function setCurrentLocationAsFrom() {
     navigation.setParams({
       location: currentLocation && {
@@ -195,9 +203,13 @@ const PlacesOverview: React.FC<PlacesOverviewProps> = ({
           openLocationSearch={openLocationSearch}
           setCurrentLocationOrRequest={setCurrentLocationOrRequest}
           setLocation={(location: LocationWithMetadata) => {
-            navigation.navigate('PlaceScreen', {
-              place: location as Place,
-            });
+            location.layer === 'venue'
+              ? navigation.navigate('PlaceScreen', {
+                  place: location as Place,
+                })
+              : navigation.setParams({
+                  location,
+                });
           }}
         />
       }

--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -1,6 +1,6 @@
 import FullScreenHeader from '@atb/components/screen-header/full-header';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {View} from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 import React, {useState} from 'react';
 import {FlatList} from 'react-native-gesture-handler';
 import {StackNavigationProp} from '@react-navigation/stack';
@@ -13,6 +13,7 @@ import {DeparturesStackParams} from '.';
 import QuayView from './QuayView';
 import StopPlaceView from './StopPlaceView';
 import {SearchTime} from './NearbyPlaces';
+import {useStopsDetailsData} from './state/stop-place-details-state';
 
 export type PlaceScreenParams = {
   place: Place;
@@ -44,6 +45,14 @@ export default function PlaceScreen({
     date: new Date().toISOString(),
   });
 
+  const hasQuays = place.quays === undefined;
+
+  let {state} = useStopsDetailsData(hasQuays ? [place.id] : undefined);
+
+  if (state.data) {
+    place = state.data.stopPlaces[0];
+  }
+
   const navigateToDetails = (
     serviceJourneyId: string,
     serviceDate: string,
@@ -72,20 +81,28 @@ export default function PlaceScreen({
       <FlatList
         data={place.quays}
         style={styles.quayChipContainer}
-        horizontal={true}
+        horizontal={hasQuays}
         showsHorizontalScrollIndicator={false}
         keyExtractor={(item) => item.id}
         ListHeaderComponent={
-          <Button
-            onPress={() => {
-              navigation.setParams({selectedQuay: undefined});
-            }}
-            text={t(DeparturesTexts.quayChips.allStops)}
-            color={selectedQuay ? 'secondary_2' : 'secondary_3'}
-            style={[styles.quayChip, {marginLeft: theme.spacings.medium}]}
-            accessibilityHint={t(DeparturesTexts.quayChips.a11yAllStopsHint)}
-            testID="allStopsSelectionButton"
-          ></Button>
+          <>
+            {!hasQuays ? (
+              <ActivityIndicator size="large"></ActivityIndicator>
+            ) : (
+              <Button
+                onPress={() => {
+                  navigation.setParams({selectedQuay: undefined});
+                }}
+                text={t(DeparturesTexts.quayChips.allStops)}
+                color={selectedQuay ? 'secondary_2' : 'secondary_3'}
+                style={[styles.quayChip, {marginLeft: theme.spacings.medium}]}
+                accessibilityHint={t(
+                  DeparturesTexts.quayChips.a11yAllStopsHint,
+                )}
+                testID="allStopsSelectionButton"
+              ></Button>
+            )}
+          </>
         }
         renderItem={({item}: quayChipData) => (
           <Button

--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -45,7 +45,9 @@ export default function PlaceScreen({
     date: new Date().toISOString(),
   });
 
-  const {state} = useStopsDetailsData([place.id]);
+  const {state} = useStopsDetailsData(
+    place.quays === undefined ? [place.id] : undefined,
+  );
 
   if (state.data && place.quays === undefined) {
     place = state.data.stopPlaces[0];
@@ -87,7 +89,7 @@ export default function PlaceScreen({
         ListHeaderComponent={
           <>
             {isMissingQuays ? (
-              <ActivityIndicator size="large"></ActivityIndicator>
+              <ActivityIndicator size="large" />
             ) : (
               <Button
                 onPress={() => {

--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -45,13 +45,13 @@ export default function PlaceScreen({
     date: new Date().toISOString(),
   });
 
-  const hasQuays = place.quays === undefined;
+  const {state} = useStopsDetailsData([place.id]);
 
-  let {state} = useStopsDetailsData(hasQuays ? [place.id] : undefined);
-
-  if (state.data) {
+  if (state.data && place.quays === undefined) {
     place = state.data.stopPlaces[0];
   }
+
+  const isMissingQuays = place.quays === undefined;
 
   const navigateToDetails = (
     serviceJourneyId: string,
@@ -81,12 +81,12 @@ export default function PlaceScreen({
       <FlatList
         data={place.quays}
         style={styles.quayChipContainer}
-        horizontal={hasQuays}
+        horizontal={!isMissingQuays}
         showsHorizontalScrollIndicator={false}
         keyExtractor={(item) => item.id}
         ListHeaderComponent={
           <>
-            {!hasQuays ? (
+            {isMissingQuays ? (
               <ActivityIndicator size="large"></ActivityIndicator>
             ) : (
               <Button

--- a/src/screens/Departures/state/stop-place-details-state.ts
+++ b/src/screens/Departures/state/stop-place-details-state.ts
@@ -1,0 +1,135 @@
+import {useCallback, useEffect} from 'react';
+import useReducerWithSideEffects, {
+  NoUpdate,
+  ReducerWithSideEffects,
+  Update,
+  UpdateWithSideEffect,
+} from 'use-reducer-with-side-effects';
+import {ErrorType, getAxiosErrorType} from '@atb/api/utils';
+import {getStopsDetails} from '@atb/api/departures/stops-nearest';
+import {StopsDetailsQuery} from '@atb/api/types/generated/StopsDetailsQuery';
+
+export type StopsDetailsDataState = {
+  data: StopsDetailsQuery | null;
+  error?: {type: ErrorType};
+  ids?: Array<string>;
+  isLoading: boolean;
+};
+
+const initialState: StopsDetailsDataState = {
+  data: null,
+  error: undefined,
+  ids: undefined,
+  isLoading: false,
+};
+
+type StopsDetailsDataActions =
+  | {
+      type: 'LOAD_DETAILS';
+      locations?: Array<string>;
+    }
+  | {
+      type: 'STOP_LOADER';
+    }
+  | {
+      type: 'UPDATE_STOP_DETAILS';
+      ids?: Array<string>;
+      result: StopsDetailsQuery;
+    }
+  | {
+      type: 'SET_ERROR';
+      error: ErrorType;
+    };
+
+const reducer: ReducerWithSideEffects<
+  StopsDetailsDataState,
+  StopsDetailsDataActions
+> = (state, action) => {
+  switch (action.type) {
+    case 'LOAD_DETAILS': {
+      if (!action.locations) return NoUpdate();
+      return UpdateWithSideEffect<
+        StopsDetailsDataState,
+        StopsDetailsDataActions
+      >(
+        {
+          ...state,
+          isLoading: true,
+          error: undefined,
+        },
+        async (state, dispatch) => {
+          if (!action.locations) return;
+          try {
+            const result = await getStopsDetails({ids: action.locations});
+            dispatch({
+              type: 'UPDATE_STOP_DETAILS',
+              ids: action.locations,
+              result,
+            });
+          } catch (e) {
+            dispatch({
+              type: 'SET_ERROR',
+              error: getAxiosErrorType(e),
+            });
+          } finally {
+            dispatch({type: 'STOP_LOADER'});
+          }
+        },
+      );
+    }
+
+    case 'STOP_LOADER': {
+      return Update<StopsDetailsDataState>({
+        ...state,
+        isLoading: false,
+      });
+    }
+
+    case 'UPDATE_STOP_DETAILS': {
+      return Update<StopsDetailsDataState>({
+        ...state,
+        isLoading: false,
+        ids: action.ids,
+        data: action.result,
+      });
+    }
+
+    case 'SET_ERROR': {
+      return Update<StopsDetailsDataState>({
+        ...state,
+        error: {
+          type: action.error,
+        },
+        data: state.data,
+      });
+    }
+
+    default:
+      return NoUpdate();
+  }
+};
+
+/***
+ * Use state for fetching details for a list of stopPlaces
+ *
+ * @param {Array<string>} [locationIds] - NSR ids to fetch details for
+ */
+export function useStopsDetailsData(locationIds?: Array<string>) {
+  const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
+
+  const refresh = useCallback(
+    () =>
+      dispatch({
+        type: 'LOAD_DETAILS',
+        locations: locationIds,
+      }),
+    [locationIds],
+  );
+
+  useEffect(refresh, [JSON.stringify(locationIds)]);
+
+  return {
+    state,
+    refresh,
+  };
+}

--- a/src/screens/Departures/state/stop-place-details-state.ts
+++ b/src/screens/Departures/state/stop-place-details-state.ts
@@ -117,14 +117,11 @@ const reducer: ReducerWithSideEffects<
 export function useStopsDetailsData(locationIds?: Array<string>) {
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
 
-  const refresh = useCallback(
-    () =>
-      dispatch({
-        type: 'LOAD_DETAILS',
-        locations: locationIds,
-      }),
-    [locationIds],
-  );
+  const refresh = () =>
+    dispatch({
+      type: 'LOAD_DETAILS',
+      locations: locationIds,
+    });
 
   useEffect(refresh, [JSON.stringify(locationIds)]);
 


### PR DESCRIPTION
Legger til funksjonalitet for autonavigering når man søker eller velger en favoritt som er en holdeplass, ikke adresse. Dette krever nytt endepunkt i BFF (https://github.com/AtB-AS/atb-bff/pull/132) siden når man navigerer til et stopp, har listen med nærmeste holdeplasser ikke nødvendigvis lastet allerede, slik at man må hente holdeplass-detaljer etter navigasjon. 

Noen detaljer som er verdt å påpeke:
- Når man velger en holdeplass fra søk eller favoritt som er del av et multimodal stopp, er det "barn-nodene" som blir vist, mens holdeplasser som dukker opp i listen "i nærheten" er multimodale.
	- F.eks. om man har busstasjonen ved Trondheim S som favoritt, får man ikke se tog-plattformene etter autonavigering. Holdeplasser "i nærheten" er multimodale, slik at man ser både buss og tog fra Trondheim S når man navigerer manuelt herfra.
- Implementerte autonavigeringen slik at det er litt forskjell mellom hvordan favoritter og søkeboksen fungerer. (Vises også i demo)
	1. Trykk på favoritt som er en adresse: Søket og listen "i nærheten" oppdateres. Ingen autonavigering.
	2. Søk som er en adresse: Søket og listen "i nærheten" oppdateres. Ingen autonavigering.
	3. Trykk på favoritt som er en holdeplass: Autonavigering til holdeplassen, **mens søkefeltet og listen "i nærheten" er uforandret**.
	4. Søk som er en holdeplass: Autonavigering til holdeplassen, **samtidig som søkefeltet og listen "i nærheten" oppdateres**. Dette gjelder også dersom man velger en favoritt fra søkevinduet.

## Demo 

https://user-images.githubusercontent.com/1774972/161046885-f4cb483d-3ed3-4207-81d6-a3c5092ecbae.mp4

closes #2227 
