### PR TITLE
test: fix-failed-e2e-tests

### DIFF
--- a/e2e/tests/travelsearch.e2e.ts
+++ b/e2e/tests/travelsearch.e2e.ts
@@ -56,6 +56,7 @@ import {
 import {
   addFavouriteLocation,
   deleteFavouriteLocation,
+  removeSearchHistory,
 } from '../utils/myprofile';
 
 describe('Travel Search', () => {
@@ -110,11 +111,7 @@ describe('Travel Search', () => {
     await expectToBeVisibleByPartOfText('Trip time');
 
     // Show intermediate stops - and expect a specific intermediate stop
-    await scrollContentToId(
-      'tripDetailsContentView',
-      'intermediateStops',
-      'up',
-    );
+    await scrollContent('tripDetailsContentView', 'top');
     await tapById('intermediateStops');
     // Note space at the end
     await scrollContentToText(
@@ -499,6 +496,11 @@ describe('Travel Search', () => {
   it('should be able to reset the travel search', async () => {
     const departure = 'Prinsens gate';
     const arrival = 'Melhus skysstasjon';
+
+    // Remove the search history
+    await goToTab('profile');
+    await removeSearchHistory();
+    await goToTab('assistant');
 
     // Do a travel search
     await travelSearch(departure, arrival);

--- a/e2e/utils/commonHelpers.ts
+++ b/e2e/utils/commonHelpers.ts
@@ -1,5 +1,5 @@
 import {by, element, expect} from 'detox';
-import {tapById} from './interactionHelpers';
+import {scrollToId, tapById} from './interactionHelpers';
 
 // Go to the given tab
 export async function goToTab(
@@ -38,6 +38,7 @@ export const clearInputById = async (id: string) => {
 };
 
 export const chooseSearchResult = async (id: string) => {
+  await scrollToId('historyAndResultsScrollView', id, 'down', 100);
   await tapById(id);
 };
 
@@ -85,11 +86,22 @@ export const getNumberOfHierarchyIds = async (
 
 // true: id or idHierarchy exists
 // false: id or idHierarchy does not exists
-export const idExists = async (elementMatcher: Detox.NativeMatcher) => {
-  return await expect(element(elementMatcher))
-    .toExist()
-    .then((e) => true)
-    .catch((e) => false);
+export const idExists = async (
+  elementMatcher: Detox.NativeMatcher,
+  withWaiting: boolean = false,
+) => {
+  if (withWaiting) {
+    return await waitFor(element(elementMatcher))
+      .toExist()
+      .withTimeout(10000)
+      .then((e) => true)
+      .catch((e) => false);
+  } else {
+    return await expect(element(elementMatcher))
+      .toExist()
+      .then((e) => true)
+      .catch((e) => false);
+  }
 };
 
 // Get current time

--- a/e2e/utils/expectHelpers.ts
+++ b/e2e/utils/expectHelpers.ts
@@ -54,6 +54,11 @@ export const expectIdToHaveText = async (id: string, text: string) => {
   await expect(element(by.id(id))).toHaveText(text);
 };
 
+export const expectIdToNotHaveText = async (id: string, text: string) => {
+  await expectExists(element(by.id(id)));
+  await expect(element(by.id(id))).not.toHaveText(text);
+};
+
 export const expectIdToHaveLabel = async (id: string, label: string) => {
   await expect(element(by.id(id).and(by.label(label)))).toExist();
 };

--- a/e2e/utils/interactionHelpers.ts
+++ b/e2e/utils/interactionHelpers.ts
@@ -46,19 +46,26 @@ export const scrollTo = async (
   scrollViewRef: Detox.NativeMatcher,
   scrollToRef: Detox.NativeElement,
   direction: Detox.Direction,
+  pixels: number = 400,
 ) => {
   await waitFor(scrollToRef)
     .toBeVisible()
     .whileElement(scrollViewRef)
-    .scroll(400, direction);
+    .scroll(pixels, direction);
 };
 
 export const scrollToId = async (
   scrollViewId: string,
   scrollToId: string,
   direction: 'left' | 'right' | 'up' | 'down',
+  pixels: number = 400,
 ) => {
-  await scrollTo(by.id(scrollViewId), element(by.id(scrollToId)), direction);
+  await scrollTo(
+    by.id(scrollViewId),
+    element(by.id(scrollToId)),
+    direction,
+    pixels,
+  );
 };
 
 export const scrollToText = async (
@@ -103,5 +110,5 @@ export const scrollContentToId = async (
 export const waitToExistById = async (id: string, timeout: number) => {
   await waitFor(element(by.id(id)))
     .toExist()
-    .withTimeout(timeout)
+    .withTimeout(timeout);
 };

--- a/e2e/utils/myprofile.ts
+++ b/e2e/utils/myprofile.ts
@@ -1,7 +1,12 @@
 import {by, element, expect} from 'detox';
-import {scrollToId, tapById, tapByText} from './interactionHelpers';
+import {
+  scroll,
+  scrollToId,
+  tapById,
+  tapByText,
+} from './interactionHelpers';
 import {expectToBeVisibleByText} from './expectHelpers';
-import {chooseSearchResult, setInputById} from './commonHelpers';
+import {chooseSearchResult, goToTab, setInputById} from './commonHelpers';
 
 // Toggle language
 export const toggleLanguage = async (useMyPhoneSettings: boolean) => {
@@ -100,4 +105,14 @@ export const expectNumberOfFavourites = async (numFav: number) => {
     let favId = 'favorite' + numFav;
     await expect(element(by.id(favId))).not.toExist();
   }
+};
+
+// Removes the search history
+export const removeSearchHistory = async () => {
+  await scroll('profileHomeScrollView', 'top');
+  await scrollToId('profileHomeScrollView', 'clearHistoryButton', 'down');
+  await tapById('clearHistoryButton');
+  await element(
+    by.type('_UIAlertControllerActionView').and(by.label('Clear history')),
+  ).tap();
 };

--- a/src/location-search/LocationSearch.tsx
+++ b/src/location-search/LocationSearch.tsx
@@ -237,6 +237,7 @@ export function LocationSearchContent({
           contentContainerStyle={styles.contentBlock}
           keyboardShouldPersistTaps="handled"
           onScrollBeginDrag={() => Keyboard.dismiss()}
+          testID="historyAndResultsScrollView"
         >
           {includeJourneyHistory && (
             <JourneyHistory


### PR DESCRIPTION
The e2e-tests fails due to the keyboard popping up when giving a search input. This was not foreseen on the local simulation as the keyboard was toggled off. Here, a testID is added to be able to scroll among the recent locations and journeys.