### PR TITLE
fix: incorrect sorting of stop places when distance is 0

### DIFF
--- a/src/screens/Departures/NearbyPlaces.tsx
+++ b/src/screens/Departures/NearbyPlaces.tsx
@@ -297,8 +297,8 @@ function sortAndFilterStopPlaces(
 
   // Sort StopPlaces on distance from search location
   const sortedEdges = edges?.sort((edgeA, edgeB) => {
-    if (!edgeA.node?.distance) return 1;
-    if (!edgeB.node?.distance) return -1;
+    if (edgeA.node?.distance === undefined) return 1;
+    if (edgeB.node?.distance === undefined) return -1;
     return edgeA.node?.distance > edgeB.node?.distance ? 1 : -1;
   });
 


### PR DESCRIPTION
Fixes incorrect sorting when distance to stop place is exactly 0.

![Simulator Screen Shot - iPhone 13 - 2022-04-20 at 11 09 34](https://user-images.githubusercontent.com/1774972/164195365-5e0bb18b-be1e-4ad2-8631-4c2e17c592f4.png)


fixes #2524