### PR TITLE
test: fix on e2e departure v2 tests

### DIFF
--- a/e2e/tests/departuresV2.e2e.ts
+++ b/e2e/tests/departuresV2.e2e.ts
@@ -45,12 +45,12 @@ describe('Departures v2', () => {
   });
 
   beforeEach(async () => {
-    // Activate when more test cases are implemented
-    //await device.reloadReactNative();
+    await device.reloadReactNative();
     await goToTab('departures');
   });
 
-  it('should search for a platform and find departures', async () => {
+  it('should search for a place and find nearby departures', async () => {
+    const placeSearch = 'Emilies ELD';
     const departureStop = 'Prinsens gate';
     const departureQuay0 = 'Prinsens gate P1';
     const departureQuay0Description = 'ved Bunnpris';
@@ -66,8 +66,99 @@ describe('Departures v2', () => {
     await goToTab('departures');
 
     // Do a departure search
-    await departureSearch(departureStop);
+    await departureSearch(placeSearch);
     await chooseBusStop('stopPlaceItem0', departureStop);
+
+    // Platform buttons
+    await expectIdToHaveChildText('quaySelectionButton', departureQuay0);
+    await expectIdToHaveChildText('quaySelectionButton', departureQuay1);
+
+    await expectToBeEnabled('allStopsSelectionButton');
+    await expectNotToBeEnabled('quaySelectionButton', 0);
+    await expectNotToBeEnabled('quaySelectionButton', 1);
+
+    // ** Quay 0 **
+
+    await expectIdToHaveText('quaySection0Name', departureQuay0);
+    await expectIdToHaveText(
+      'quaySection0Description',
+      departureQuay0Description,
+    );
+
+    // Hide and expand departures
+    let noDepTimesQuay0Expanded = await numberOfDepartures('quaySection0');
+    expectGreaterThan(noDepTimesQuay0Expanded, 0);
+
+    await tapById('quaySection0HideAction');
+
+    let noDepTimesQuay0Hidden = await numberOfDepartures('quaySection0');
+    expectNumber(noDepTimesQuay0Hidden, 0);
+
+    await tapById('quaySection0HideAction');
+
+    // ** Quay 1 **
+
+    await scrollToId('departuresContentView', 'quaySection1', 'down');
+
+    await expectIdToHaveText('quaySection1Name', departureQuay1);
+    await expectIdToHaveText(
+      'quaySection1Description',
+      departureQuay1Description,
+    );
+
+    // Hide and expand departures
+    let noDepTimesQuay1Expanded = await numberOfDepartures('quaySection1');
+    expectGreaterThan(noDepTimesQuay1Expanded, 0);
+
+    await tapById('quaySection1HideAction');
+
+    let noDepTimesQuay1Hidden = await numberOfDepartures('quaySection1');
+    expectNumber(noDepTimesQuay1Hidden, 0);
+
+    await tapById('quaySection1HideAction');
+
+    // ** Departure details Quay 0 **
+
+    await scroll('departuresContentView', 'top');
+
+    // Collect info to check in details
+    let lineTitle = await getLineTitleV2('quaySection0', 'departureItem0');
+
+    // Get travel details of first travel
+    await tapDeparture('quaySection0', 'departureItem0');
+
+    await expectToBeVisibleByText(lineTitle);
+    await expectToBeVisibleByText(departureQuay0 + ' ');
+
+    // Choose a stop place on the line
+    await tapByText(nextDepartureStop + ' ');
+    await expectIdToHaveText('quaySection0Title', nextDepartureStop);
+
+    // Go back
+    await goBack();
+    await goBack();
+    await expectToBeVisibleByText(departureStop);
+    await goBack();
+    await expectToBeVisibleByText('Departures');
+  });
+
+  it('should search for a platform and automatically find departures', async () => {
+    const departureStop = 'Prinsens gate';
+    const departureQuay0 = 'Prinsens gate P1';
+    const departureQuay0Description = 'ved Bunnpris';
+    const departureQuay1 = 'Prinsens gate P2';
+    const departureQuay1Description = 'ved AtB Kundesenter';
+    const nextDepartureStop = 'Nidarosdomen';
+
+    // Enable v2
+    await goToTab('profile');
+    await toggleDeparturesV2(true);
+
+    // Go to departures
+    await goToTab('departures');
+
+    // Do a departure search - that should automatically display the stop
+    await departureSearch(departureStop);
 
     // Platform buttons
     await expectIdToHaveChildText('quaySelectionButton', departureQuay0);


### PR DESCRIPTION
The tests have failed after a search for a bus stop in departures v2 automatically sends the user to the departures view without having to choose the platform. This should fix that. Also included a test for searching after
- a bus stop that automatically leads to the departure view
- a place that necessitates the user to choose a bus top nearby