### PR TITLE
fix: Announce feedback alternatives on Android

### DIFF
--- a/src/components/feedback/GoodOrBadButton.tsx
+++ b/src/components/feedback/GoodOrBadButton.tsx
@@ -35,11 +35,15 @@ export const GoodOrBadButton = ({
         }
         accessibilityRole="radio"
         accessibilityState={{selected: checked}}
-        accessibilityHint={
+        accessibilityHint={`${
+          opinion === Opinions.Good && t(FeedbackTexts.goodOrBadTexts.good)
+        }
+        ${opinion === Opinions.Bad && t(FeedbackTexts.goodOrBadTexts.bad)}
+        ${
           checked
             ? t(FeedbackTexts.alternatives.a11yHints.checked)
             : t(FeedbackTexts.alternatives.a11yHints.unchecked)
-        }
+        }`}
       >
         <View
           style={

--- a/src/components/feedback/RenderQuestions.tsx
+++ b/src/components/feedback/RenderQuestions.tsx
@@ -82,11 +82,11 @@ function AlternativeItem({
       onPress={() => handleAnswerPress(alternative.alternativeId)}
       accessibilityRole="checkbox"
       accessibilityState={{checked: isChecked}}
-      accessibilityHint={
+      accessibilityHint={`${alternative.alternativeText[language]} ${
         isChecked
           ? t(FeedbackTexts.alternatives.a11yHints.checked)
           : t(FeedbackTexts.alternatives.a11yHints.unchecked)
-      }
+      }`}
     >
       <View
         style={


### PR DESCRIPTION
Utbedrer kommentar nevnt i #2345. Blir ikke helt klok på hva som er ideell måte å gjøre ting på, for å tekkes både Android og iOS, men nå skal i hvert "bra" eller "dårlig" bli lest opp på Android også, i tillegg til alternativtekstene.