### PR TITLE
fix: use text color as fill of TicketInspectionSymbol

### DIFF
--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -22,7 +22,7 @@ import {TicketAdd, TicketInvalid} from '@atb/assets/svg/mono-icons/ticketing';
 import {screenReaderPause} from '@atb/components/accessible-text';
 import {Warning} from '@atb/assets/svg/color/situations';
 import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
-import {flatStaticColors, StaticColor} from '@atb/theme/colors';
+import {flatStaticColors, getStaticColor, StaticColor} from '@atb/theme/colors';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {Time} from '@atb/assets/svg/mono-icons/time';
 
@@ -235,10 +235,16 @@ const IconForStatus = (
   themeColor?: StaticColor,
 ): ReactElement | null => {
   const {t} = useTranslation();
+  const {themeName} = useTheme();
+  const fillColor = getStaticColor(
+    themeName,
+    themeColor || 'background_0',
+  ).text;
+
   switch (status) {
     case 'valid':
       if (isInspectable)
-        return <ThemeIcon svg={Bus} colorType={themeColor} size={'large'} />;
+        return <ThemeIcon svg={Bus} fill={fillColor} size={'large'} />;
       else
         return (
           <ThemeText


### PR DESCRIPTION
Fiks av issue fra QA 1.18 https://mittatb.slack.com/archives/C0116FMPX4Y/p1651142612065779?thread_ts=1651142412.623509&cid=C0116FMPX4Y

![collage](https://user-images.githubusercontent.com/1774972/165757677-447d5f11-e067-4b2a-a801-ae54c82986c9.png)
