### PR TITLE
refactor: fix carnet dot colors

### DIFF
--- a/src/screens/Ticketing/Ticket/Carnet/CarnetFooter.tsx
+++ b/src/screens/Ticketing/Ticket/Carnet/CarnetFooter.tsx
@@ -135,7 +135,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     height: 16,
   },
   dot__unused: {
-    backgroundColor: theme.static.background.background_accent_1.text,
+    backgroundColor: theme.static.background.background_0.background,
   },
   dotFill__active: {
     borderTopRightRadius: 20,
@@ -143,7 +143,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     height: '100%',
     width: '50%',
     marginLeft: '50%',
-    backgroundColor: theme.static.background.background_accent_1.text,
+    backgroundColor: theme.static.background.background_0.background,
   },
 }));
 


### PR DESCRIPTION
Det ble feil farge på brukte og aktive klipp i klippekort i appen etter oppdateringen av design system, oppdatert til å bruke background_0 nå.


## Før/etter

![collage](https://user-images.githubusercontent.com/1774972/165763442-249cec68-60b5-41fb-bdd7-1d63a195deef.png)
