### PR TITLE
refactor: make recent ticket "other categories" text match Figma

### DIFF
--- a/src/screens/Ticketing/Tickets/RecentTickets/RecentTicketComponent.tsx
+++ b/src/screens/Ticketing/Tickets/RecentTickets/RecentTicketComponent.tsx
@@ -159,7 +159,7 @@ export const RecentTicketComponent = ({
                       />
                     ))}
                     <View style={styles.additionalCategories}>
-                      <ThemeText>
+                      <ThemeText type="body__tertiary">
                         + {userProfilesWithCount.slice(1).length}{' '}
                         {t(RecentTicketsTexts.titles.moreTravelers)}
                       </ThemeText>
@@ -235,7 +235,7 @@ const useStyles = StyleSheet.createThemeHook((theme, themeName) => ({
   },
   additionalCategories: {
     marginHorizontal: theme.spacings.small,
-    marginVertical: theme.spacings.small,
+    marginVertical: theme.spacings.xSmall,
   },
   buyButton: {
     flexDirection: 'row',

--- a/src/screens/Ticketing/Tickets/RecentTickets/RecentTicketComponent.tsx
+++ b/src/screens/Ticketing/Tickets/RecentTickets/RecentTicketComponent.tsx
@@ -88,7 +88,7 @@ export const RecentTicketComponent = ({
     const travellerInfo = `${t(
       RecentTicketsTexts.a11yPreLabels.travellers,
     )}: ${userProfilesWithCount
-      .map((u) => '1' + getReferenceDataName(u, language))
+      .map((u) => u.count + ' ' + getReferenceDataName(u, language))
       .join(', ')}`;
 
     const zoneInfo = `${

--- a/src/translations/screens/subscreens/RecentTicketsTexts.ts
+++ b/src/translations/screens/subscreens/RecentTicketsTexts.ts
@@ -8,7 +8,7 @@ const RecentTicketsTexts = {
     duration: _('Gyldighet', 'Validity'),
     days: _('dager', 'days'),
     hours: _('timer', 'hours'),
-    moreTravelers: _('andre', 'others'),
+    moreTravelers: _('andre kategorier', 'other categories'),
     loading: _('Laster tidligere kjøp', 'Loading recent purchases'),
   },
   a11yPreLabels: {


### PR DESCRIPTION
Her var ordet kategorier manglende, pluss at teksten er gjort til tertiary. Har ikke satt farge eksplisitt, men det skal vel ikke være nødvendig. Har også redusert litt på avstanden vertikalt, siden den virket litt stor i forhold til skissene.

![image](https://user-images.githubusercontent.com/21310942/165920441-4216f617-4555-4f10-a82f-f2fcd42e6158.png)

Fikser også denne om antall kategorier for skjermleser: https://mittatb.slack.com/archives/C0116FMPX4Y/p1651225167558959