### PR TITLE
ci: invalidate ipa build cache when assets changes to include new images

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             AtB.ipa
             AtB.app.dSYM.zip
-          key: ${{ matrix.org }}-${{ runner.os }}-ios-cache-${{ hashFiles('ios/**') }}-${{ hashFiles('.yalc/**') }}-${{ hashFiles('.env') }}
+          key: ${{ matrix.org }}-${{ runner.os }}-ios-cache-${{ hashFiles('ios/**') }}-${{ hashFiles('.yalc/**') }}-${{ hashFiles('.env') }}-${{ hashFiles('assets/') }}
       - name: Run fastlane cert match
         run: fastlane ios get_cert
         env:


### PR DESCRIPTION
Invalidates IPA cache when assets change. This will cause new images to be included in the bundle. Will invalidate the cache when assets change (changes in generated assets and other assets).

This is not an issue in store as it is not cached.