### PR TITLE
fix: replace stop with stops if several intermediate stops

### DIFF
--- a/src/translations/screens/TicketSplash.ts
+++ b/src/translations/screens/TicketSplash.ts
@@ -12,7 +12,7 @@ const TicketSplashTexts = {
     title: _('Billettkjøp i app kommer snart!', 'App ticketing on its way!'),
     paragraph1: _(
       'Her kan du snart kjøpe og administrere billetter til reisen din! Da vil du ha alt du trenger i en og samme app.',
-      'Soon you can purchase and organise tickets for your trips – right here in the app!',
+      'Soon you can purchase and organize tickets for your trips – right here in the app!',
     ),
     betaButtonLabel: _(
       'Jeg har kode til beta for billettkjøp',

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -48,7 +48,9 @@ const TripDetailsTexts = {
         label: (count: number, duration: string) =>
           _(
             `${count} mellomstopp \n${duration}`,
-            `${count} intermediate stop \n${duration}`,
+            count > 1
+              ? `${count} intermediate stops \n${duration}`
+              : `${count} intermediate stop \n${duration}`,
           ),
         a11yHint: _(
           'Aktivér for å vise alle mellomstopp.',


### PR DESCRIPTION
Denne PR løser #2604 og gjør to ting:

- Viser "X intermediate stops" i stedet for "X intermediate stop" på engelsk, hvis flere enn ett stopp
![image](https://user-images.githubusercontent.com/21310942/166227705-9f08b806-0def-4310-947d-76fd837bd27b.png)
![image](https://user-images.githubusercontent.com/21310942/166227926-b9d8010a-138e-4b1b-97bd-201499a593ec.png)


- Endrer til organize i stedet for organise på Nordland sin ticket-splash
![image](https://user-images.githubusercontent.com/21310942/166227607-242dde79-9417-4039-9230-2accf67c067e.png)

For øvrig er jeg litt usikker på hvorvidt denne bør merges til `release/1.18` eller `master`, men det blir i hvert fall merge conflicts om jeg velger master.