### PR TITLE
feat: require enable_ticketing to show ticket warnings

### DIFF
--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -89,6 +89,8 @@ export default function DepartureDetails({navigation, route}: Props) {
   );
 
   const someLegsAreByTrain = mode === TransportMode.RAIL;
+  const isTicketingEnabledAndWeCantSellTicketForDeparture =
+    enable_ticketing && !canSellTicketsForDeparture;
 
   const onPaginactionPress = (newPage: number) => {
     animateNextChange();
@@ -150,7 +152,7 @@ export default function DepartureDetails({navigation, route}: Props) {
             </View>
           )}
 
-          {enable_ticketing && !canSellTicketsForDeparture && (
+          {isTicketingEnabledAndWeCantSellTicketForDeparture && (
             <MessageBox
               containerStyle={styles.ticketMessage}
               type="warning"

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -67,6 +67,7 @@ export default function DepartureDetails({navigation, route}: Props) {
   const [activeItemIndexState, setActiveItem] = useState(activeItemIndex);
   const {theme} = useTheme();
   const {modesWeSellTicketsFor} = useFirestoreConfiguration();
+  const {enable_ticketing} = useRemoteConfig();
 
   const activeItem: ServiceJourneyDeparture | undefined =
     items[activeItemIndexState];
@@ -149,7 +150,7 @@ export default function DepartureDetails({navigation, route}: Props) {
             </View>
           )}
 
-          {!canSellTicketsForDeparture && (
+          {enable_ticketing && !canSellTicketsForDeparture && (
             <MessageBox
               containerStyle={styles.ticketMessage}
               type="warning"

--- a/src/screens/TripDetails/components/TripMessages.tsx
+++ b/src/screens/TripDetails/components/TripMessages.tsx
@@ -35,6 +35,8 @@ const TripMessages: React.FC<TripMessagesProps> = ({
   const canUseCollabTicket = someLegsAreByTrain(tripPattern);
   const shortWaitTime = hasShortWaitTime(tripPattern.legs);
   const {enable_ticketing} = useRemoteConfig();
+  const isTicketingEnabledAndSomeTicketsAreUnavailableInApp =
+    enable_ticketing && someTicketsAreUnavailableInApp;
 
   return (
     <>
@@ -45,7 +47,7 @@ const TripMessages: React.FC<TripMessagesProps> = ({
           message={t(TripDetailsTexts.messages.shortTime)}
         />
       )}
-      {enable_ticketing && someTicketsAreUnavailableInApp && (
+      {isTicketingEnabledAndSomeTicketsAreUnavailableInApp && (
         <MessageBox
           containerStyle={messageStyle}
           type="warning"

--- a/src/screens/TripDetails/components/TripMessages.tsx
+++ b/src/screens/TripDetails/components/TripMessages.tsx
@@ -14,6 +14,7 @@ import {TripPattern} from '@atb/api/types/trips';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {hasShortWaitTime} from '@atb/screens/TripDetails/components/utils';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 type TripMessagesProps = {
   tripPattern: TripPattern;
@@ -33,6 +34,7 @@ const TripMessages: React.FC<TripMessagesProps> = ({
   );
   const canUseCollabTicket = someLegsAreByTrain(tripPattern);
   const shortWaitTime = hasShortWaitTime(tripPattern.legs);
+  const {enable_ticketing} = useRemoteConfig();
 
   return (
     <>
@@ -43,7 +45,7 @@ const TripMessages: React.FC<TripMessagesProps> = ({
           message={t(TripDetailsTexts.messages.shortTime)}
         />
       )}
-      {someTicketsAreUnavailableInApp && (
+      {enable_ticketing && someTicketsAreUnavailableInApp && (
         <MessageBox
           containerStyle={messageStyle}
           type="warning"


### PR DESCRIPTION
Denne PR baserer seg på bruk av `enable-ticketing` flagget i RemoteConfig. 

Det vil si at dersom `enable-ticketing` er satt til `false` vil ikke advarsler knyttet til billettkjøp vises, og i praksis vil irrelevante AtB-varsler ikke vises i Reis-appen. 

Med andre ord må dette håndteres på nytt når NFK en dag lanserer billettering, hvis info om samarbeidsbilletten fremdeles er aktuelt.