### PR TITLE
refactor: Some fixes to the zones component

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, AccessibilityProps} from 'react-native';
+import {View, AccessibilityProps, StyleProp, ViewStyle} from 'react-native';
 import ThemeText from '@atb/components/text';
 import * as Sections from '@atb/components/sections';
 import {StyleSheet} from '@atb/theme';
@@ -11,25 +11,24 @@ import {
   tariffZonesDescription,
   TariffZoneWithMetadata,
 } from '../../TariffZones';
-import {
-  PurchaseOverviewTexts,
-  TariffZonesTexts,
-  useTranslation,
-} from '@atb/translations';
+import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {useNavigation} from '@react-navigation/native';
-export type ZoneItemProps = {
+type ZonesProps = {
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
+  style?: StyleProp<ViewStyle>;
 };
 
-export default function ZoneItem({
+export default function Zones({
   fromTariffZone,
   toTariffZone,
-}: ZoneItemProps) {
+  style,
+}: ZonesProps) {
   const itemStyle = useStyles();
   const {t, language} = useTranslation();
   const navigation = useNavigation<OverviewNavigationProp>();
   const accessibility: AccessibilityProps = {
+    accessible: true,
     accessibilityRole: 'button',
     accessibilityLabel:
       tariffZonesSummary(fromTariffZone, toTariffZone, language, t) +
@@ -38,13 +37,13 @@ export default function ZoneItem({
   };
 
   return (
-    <View>
+    <View style={style}>
       <ThemeText
         type="body__secondary"
         color="secondary"
         style={itemStyle.sectionText}
       >
-        {t(TariffZonesTexts.header.title)}
+        {t(PurchaseOverviewTexts.zones.label)}
       </ThemeText>
       <Sections.Section {...accessibility}>
         <Sections.ButtonInput
@@ -75,7 +74,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingTop: theme.spacings.xSmall,
   },
   sectionText: {
-    marginTop: theme.spacings.xLarge,
     marginBottom: theme.spacings.medium,
   },
 }));

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -19,7 +19,7 @@ import {
 } from '@atb/translations';
 import {RouteProp} from '@react-navigation/native';
 import {UserProfileWithCount} from '../Travellers/use-user-count-state';
-import ZoneItem from './components/zone-item';
+import Zones from './components/Zones';
 
 import {
   getReferenceDataName,
@@ -273,7 +273,11 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
           </Sections.GenericItem>
         </Sections.Section>
 
-        <ZoneItem fromTariffZone={fromTariffZone} toTariffZone={toTariffZone} />
+        <Zones
+          fromTariffZone={fromTariffZone}
+          toTariffZone={toTariffZone}
+          style={styles.zones}
+        />
       </View>
 
       {showProfileTravelcardWarning && (
@@ -465,6 +469,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   selectionLinks: {margin: theme.spacings.medium},
   totalSection: {flex: 1, textAlign: 'center'},
+  zones: {marginTop: theme.spacings.medium},
   toPaymentButton: {marginHorizontal: theme.spacings.medium},
   warning: {
     marginHorizontal: theme.spacings.medium,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -64,6 +64,9 @@ const PurchaseOverviewTexts = {
     'Du kan ikke reise med denne mobilen. Du kan bytte hvor du bruker billetten din fra **Min profil**.',
     `You can't travel with this phone. Go to **My profile** to switch where your tickets are used.`,
   ),
+  zones: {
+    label: _('Velg sone(r)', 'Select zone(s)'),
+  },
 };
 
 export default orgSpecificTranslations(PurchaseOverviewTexts, {


### PR DESCRIPTION
After implementing the Summary-component i saw some small changes that
could be done to make the implementations more aligned.

- Renamed to 'Zones'. Follow the pattern with components named with
  CamelCase. Also not necessary with suffix "Item" or "Component" since
  it is inside a components-folder.
- Moved specifying the top margin from inside the component to the
  overview screen. Components should generally not handle margins around
  the component, this should be handled where the component is used.
- Added "accessible: true" on the section. Without this the
  "accessibilityRole: 'button'" was not working as intended, atleast on
  iOS.