### PR TITLE
refactor: fix a11y label on android

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/components/DurationSelection.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/DurationSelection.tsx
@@ -92,6 +92,7 @@ function DurationChip({color, text, selected, onPress}: DurationChipProps) {
       accessible={true}
       accessibilityRole="radio"
       accessibilityState={{selected}}
+      accessibilityLabel={text}
       accessibilityHint={t(PurchaseOverviewTexts.duration.chipHint)}
     >
       <ThemeText


### PR DESCRIPTION
Fix of android talkback accessibility label in the DurationSelection component (ref https://github.com/AtB-AS/mittatb-app/issues/2457#issuecomment-1118488504)
