### PR TITLE
refactor: hide StartTimeSelection for single tickets

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -237,13 +237,15 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             style={styles.selectionComponent}
           />
 
-          <StartTimeSelection
-            color="interactive_2"
-            travelDate={travelDate}
-            setTravelDate={setTravelDate}
-            validFromTime={travelDate}
-            style={styles.selectionComponent}
-          />
+          {preassignedFareProduct.type === 'period' && (
+            <StartTimeSelection
+              color="interactive_2"
+              travelDate={travelDate}
+              setTravelDate={setTravelDate}
+              validFromTime={travelDate}
+              style={styles.selectionComponent}
+            />
+          )}
         </View>
 
         {showProfileTravelcardWarning && (


### PR DESCRIPTION
I forgot to add logic to hide the StartTimeSelection component from the single ticket purchase view in #2626. This PR fixes that. 