### PR TITLE
fix: replace activeTintColor in TabNavigator

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "link-assets": "react-native link"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.0.0-alpha.1",
+    "@atb-as/theme": "^6.0.0-alpha.2",
     "@bugsnag/react-native": "^7.12.0",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur/react-native-traveller": "file:.yalc/@entur/react-native-traveller",

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -50,10 +50,10 @@ const NavigationRoot = () => {
     <Tab.Navigator
       tabBarOptions={{
         labelPosition: 'below-icon',
-        activeTintColor: theme.interactive.interactive_0.default.background,
+        activeTintColor: theme.interactive.interactive_2.outline.background,
         inactiveTintColor: theme.text.colors.secondary,
         style: {
-          backgroundColor: theme.static.background.background_0.background,
+          backgroundColor: theme.interactive.interactive_2.default.background,
           ...useBottomNavigationStyles(),
         },
       }}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -50,7 +50,7 @@ const NavigationRoot = () => {
     <Tab.Navigator
       tabBarOptions={{
         labelPosition: 'below-icon',
-        activeTintColor: theme.static.background.background_accent_3.background,
+        activeTintColor: theme.static.background.background_accent_3.text,
         inactiveTintColor: theme.text.colors.secondary,
         style: {
           backgroundColor: theme.static.background.background_0.background,

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -50,7 +50,7 @@ const NavigationRoot = () => {
     <Tab.Navigator
       tabBarOptions={{
         labelPosition: 'below-icon',
-        activeTintColor: theme.static.background.background_accent_3.text,
+        activeTintColor: theme.interactive.interactive_0.default.background,
         inactiveTintColor: theme.text.colors.secondary,
         style: {
           backgroundColor: theme.static.background.background_0.background,

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,14 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^1.0.7"
 
+"@atb-as/theme@^6.0.0-alpha.2":
+  version "6.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.0.0-alpha.2.tgz#655acd7eb7dcf671104cf3c1a9c492e260a1cc5b"
+  integrity sha512-f8y8AXOZ55Ji1PL4Rraw6c5i/3k4ldHkDkoOco5cJFIXk2VWkCahZ33EsKBgkG9MVZqlAM3NQyd3CtcDWbyfSQ==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^1.0.7"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"


### PR DESCRIPTION
Fixes invisible active tab in NFK-app in combination with design-system PR: https://github.com/AtB-AS/design-system/pull/41

With the changes in the design system from here: https://github.com/AtB-AS/design-system/pull/41 the app looks like this:

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-11 at 11 16 06](https://user-images.githubusercontent.com/21310942/167815349-7cc62761-6391-4306-b4a9-fd1a48a8e30f.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-11 at 11 15 57](https://user-images.githubusercontent.com/21310942/167815569-f3eb90bf-1850-4b78-bf45-7e73895956cb.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-11 at 11 06 27](https://user-images.githubusercontent.com/21310942/167815740-243aa25c-0a89-4c74-9446-7b0ba8faa7f4.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-11 at 11 05 24](https://user-images.githubusercontent.com/21310942/167815865-f0827792-ad9a-4957-9c92-561cf0f6baf3.png)

