### PR TITLE
refactor: fix translation in english

### DIFF
--- a/src/assets/information-data/ticketInspectionInformation.json
+++ b/src/assets/information-data/ticketInspectionInformation.json
@@ -61,7 +61,7 @@
             "type": "bullet-point"
         },
         {
-            "text": "Minors under 15 years: NOK 900 regardless of payment method",
+            "text": "Minors over 15 years: NOK 900 regardless of payment method",
             "type": "bullet-point"
         },
         {

--- a/src/translations/screens/subscreens/Information.ts
+++ b/src/translations/screens/subscreens/Information.ts
@@ -154,7 +154,7 @@ const SelectStartScreenTexts = {
       ),
       part1Bullet2: _(
         `${bulletPoint} Mindreårige som er fylt 15 år: 900 kroner uansett oppgjørsform.`,
-        `${bulletPoint} Minors under 15 years: NOK 900 regardless of payment method`,
+        `${bulletPoint} Minors over 15 years: NOK 900 regardless of payment method`,
       ),
       part1Bullet3: _(
         `${bulletPoint} Misbruk eller forfalsking av billett: 2000 kroner, og billetten blir inndratt. Dersom du forfalsker en billett, vil du også bli politianmeldt.`,


### PR DESCRIPTION
The Norwegian version states that minors over 15 will be fined. In English its mentioned minors under 15 are fined. The Norwegian version is correct, hence fixed the english version. 