### PR TITLE
refactor: fix StartTimeSelection a11y issues

### DIFF
--- a/src/components/radio-segments/index.tsx
+++ b/src/components/radio-segments/index.tsx
@@ -10,6 +10,7 @@ export type SegmentOptions = {
   subtext?: string;
   selected?: boolean;
   accessibilityHint?: string;
+  accessibilityLabel?: string;
 };
 
 type RadioSegmentsProps = {
@@ -58,9 +59,7 @@ export default function RadioSegments({
             accessible={true}
             accessibilityRole="radio"
             accessibilityState={{selected}}
-            accessibilityLabel={
-              option.subtext ? option.text + '. ' + option.subtext : option.text
-            }
+            accessibilityLabel={getAccessibilityLabel(option)}
             accessibilityHint={option.accessibilityHint}
             style={[
               styles.optionBox,
@@ -94,6 +93,11 @@ export default function RadioSegments({
     </View>
   );
 }
+
+const getAccessibilityLabel = (option: SegmentOptions) => {
+  if (option.accessibilityLabel) return option.accessibilityLabel;
+  return option.subtext ? option.text + '. ' + option.subtext : option.text;
+};
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   radioSegments: {

--- a/src/components/radio-segments/index.tsx
+++ b/src/components/radio-segments/index.tsx
@@ -96,7 +96,8 @@ export default function RadioSegments({
 
 const getAccessibilityLabel = (option: SegmentOptions) => {
   if (option.accessibilityLabel) return option.accessibilityLabel;
-  return option.subtext ? option.text + '. ' + option.subtext : option.text;
+  if (option.subtext) return option.text + '. ' + option.subtext;
+  return option.text;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/screens/Ticketing/Purchase/Overview/components/StartTimeSelection.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/StartTimeSelection.tsx
@@ -4,7 +4,10 @@ import ThemeText from '@atb/components/text';
 import {InteractiveColor} from '@atb/theme/colors';
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {formatToShortDateTimeWithoutYear} from '@atb/utils/date';
+import {
+  formatToShortDateTimeWithoutYear,
+  formatToVerboseDateTime,
+} from '@atb/utils/date';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import TravelDateSheet from '@atb/screens/Ticketing/Purchase/TravelDate/TravelDateSheet';
 import RadioSegments from '@atb/components/radio-segments';
@@ -39,6 +42,15 @@ export default function StartTimeSelection({
     ));
   };
 
+  const subtext = validFromTime
+    ? formatToShortDateTimeWithoutYear(validFromTime, language)
+    : undefined;
+  const accessibilityLabel = validFromTime
+    ? t(PurchaseOverviewTexts.startTime.later) +
+      ', ' +
+      formatToVerboseDateTime(validFromTime, language)
+    : undefined;
+
   return (
     <View style={style}>
       <ThemeText type="body__secondary" color="secondary">
@@ -56,10 +68,9 @@ export default function StartTimeSelection({
           },
           {
             text: t(PurchaseOverviewTexts.startTime.later),
-            subtext: validFromTime
-              ? formatToShortDateTimeWithoutYear(validFromTime, language)
-              : undefined,
+            subtext,
             onPress: openTravelDateSheet,
+            accessibilityLabel,
             accessibilityHint: t(PurchaseOverviewTexts.startTime.a11yLaterHint),
           },
         ]}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -8,6 +8,7 @@ import {
   getMinutes,
   isPast,
   isSameDay,
+  isToday,
   isWithinInterval,
   Locale,
   parse,
@@ -221,7 +222,9 @@ export function formatToVerboseDateTime(
     locale: languageToLocale(language),
   });
 
-  return `${dateString} ${at} ${timeString}`;
+  return isToday(parseIfNeeded(date))
+    ? `${timeString}`
+    : `${dateString} ${at} ${timeString}`;
 }
 
 export const isWithin24Hours = (


### PR DESCRIPTION
Fix of UU feedback from #2459, about misleading screen reader texts in the StartTimeSelection component. When the "Later" button is selected, the accessibilityLabel is now e.g. "Later, 14 may at 13:37" for dates that are not today, and "Later, 13:37" for dates that are today.

- Updates `formatToVerboseDateTime()` to omit date when the date is "today". The function is only used in `DateNavigator` in Departures 2.0, but just for dates that are not "today", so it should be unaffected by this change.
- Added `accessibilityLabel` param to the RadioSegment component.
