### PR TITLE
refactor: revamp NFK splashes

### DIFF
--- a/src/screens/Ticketing/Splash/Info.tsx
+++ b/src/screens/Ticketing/Splash/Info.tsx
@@ -33,6 +33,7 @@ export default function SplashInfo({navigation}: Props) {
         <View style={styles.contentContainer}>
           <View style={styles.textContent}>
             <ThemeText
+              type="body__primary--jumbo--bold"
               color="background_accent_3"
               style={[styles.text, styles.bold]}
             >
@@ -74,7 +75,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginBottom: theme.spacings.medium,
   },
   text: {
-    textAlign: 'center',
     marginBottom: theme.spacings.large,
   },
   bold: {fontWeight: 'bold'},

--- a/src/screens/Ticketing/Splash/Info.tsx
+++ b/src/screens/Ticketing/Splash/Info.tsx
@@ -3,6 +3,7 @@ import Button from '@atb/components/button';
 import Header from '@atb/components/screen-header';
 import ThemeText from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
+import {StaticColor} from '@atb/theme/colors';
 import {TicketSplashTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {useWindowDimensions, View} from 'react-native';
@@ -19,12 +20,14 @@ export default function SplashInfo({navigation}: Props) {
   const {width: windowWidth} = useWindowDimensions();
   const {t} = useTranslation();
 
+  const bgcolor: StaticColor = 'background_accent_0';
+
   return (
     <SafeAreaView style={styles.container}>
       <Header
         title={t(TicketSplashTexts.header.title)}
         rightButton={{type: 'chat'}}
-        color="background_accent_3"
+        color={bgcolor}
       />
       <View style={styles.bannerContainer}>
         <TicketSplash width={windowWidth} height={windowWidth / 2} />
@@ -34,12 +37,12 @@ export default function SplashInfo({navigation}: Props) {
           <View style={styles.textContent}>
             <ThemeText
               type="body__primary--jumbo--bold"
-              color="background_accent_3"
-              style={[styles.text, styles.bold]}
+              color={bgcolor}
+              style={styles.text}
             >
               {t(TicketSplashTexts.splash.title)}
             </ThemeText>
-            <ThemeText color="background_accent_3" style={styles.text}>
+            <ThemeText color={bgcolor} style={styles.text}>
               {t(TicketSplashTexts.splash.paragraph1)}
             </ThemeText>
           </View>
@@ -52,7 +55,7 @@ export default function SplashInfo({navigation}: Props) {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    backgroundColor: theme.static.background.background_accent_3.background,
+    backgroundColor: theme.static.background.background_accent_0.background,
   },
   scrollContainer: {
     flexGrow: 1,
@@ -77,7 +80,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   text: {
     marginBottom: theme.spacings.large,
   },
-  bold: {fontWeight: 'bold'},
   bannerContainer: {
     position: 'absolute',
     bottom: theme.spacings.large,

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -36,8 +36,8 @@ export default orgSpecificTranslations(OnboardingTexts, {
       titleA11yLabel: _('Velkommen til Reis appen', 'Welcome to the Reis app'),
       description: {
         part1: _(
-          'Her kan du planlegge reiser og sjekke avgangstider i hele Nordland. Flere tjenester og billettyper kommer!',
-          'Plan trips and check departure times throughout Nordland. More features and ticket products are coming soon!',
+          'Her kan du planlegge reiser og sjekke avgangstider i hele Nordland. Snart kommer også billettkjøp, slik at du kan planlegge, betale og gjennomføre reisen din i en og samme app!',
+          'Plan trips and check departure times throughout Nordland. App ticketing is coming soon, so that you may plan and buy tickets for your trip using only one app!',
         ),
         part3: _(
           'Du vil også kunne administrere billetter og eventuelle reisekort på den nye nettbutikken med samme konto.',

--- a/src/translations/screens/TicketSplash.ts
+++ b/src/translations/screens/TicketSplash.ts
@@ -24,12 +24,12 @@ export default orgSpecificTranslations(TicketSplashTexts, {
   nfk: {
     splash: {
       title: _(
-        'Her kommer billettkjøp i app!',
-        'App ticketing will be available here!',
+        'Billettkjøp i app kommer snart!',
+        'App ticketing is coming soon!',
       ),
       paragraph1: _(
-        'Når dette er på plass, kan du kjøpe og administrere bussbilletter til reisen i Reis appen din. Du vil da ha alt du trenger for å reise med kollektivtransport i Nordland i en og samme app! \nI mellomtiden må appen «Billett Nordland» brukes til kjøp av bussbilletter.',
-        'Once this is in place, you can buy and manage bus tickets for your trip in the “Reis app”. You will then have everything you need to travel with public transport in Nordland in one app! \nIn the meantime, the app "Billett Nordland" must be used to buy bus tickets.',
+        'Her kan du snart kjøpe og administrere billetter til reisen din. Du vil da ha alt du trenger for å reise med kollektivtransport i Nordland i en og samme app! \n\nI mellomtiden ber vi deg bruke appen «Billett Nordland» til kjøp av billetter.',
+        'You will soon be able to purchase and manage tickets for your trip here. You will then have everything you need to travel with public transport in Nordland in one app! \n\nIn the meantime, we ask you to use the "Billett Nordland" app to purchase tickets.',
       ),
     },
   },


### PR DESCRIPTION
Updated styling and text for NFK splashes, solves #2671 

For the introduction splash, we have now updated the text to be in line with current features of the app. 

For the ticketing splash, all text is now left adjusted, and the heading is now jumbo_bold in line with the intro splash and the AtB splash for activating ticketing that may be used when ticketing is released at NFK. The paragraph text has also been updated.

<details>
<summary>Screenshots for the intro</summary>

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-16 at 06 50 05](https://user-images.githubusercontent.com/21310942/168522151-07f1d9e7-1242-459c-89ac-e0f3ddbc1d88.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-16 at 06 49 33](https://user-images.githubusercontent.com/21310942/168522156-b83d5a59-54b5-4b07-ac10-cef08cb6c6e5.png)
</details>

<details>
<summary>Screenshots ticketing</summary>

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-16 at 06 37 53](https://user-images.githubusercontent.com/21310942/168520921-2e27941c-8bc4-4144-8e17-f46ac13db48e.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-16 at 06 37 28](https://user-images.githubusercontent.com/21310942/168520927-cf660c3d-c5b4-47be-bfdc-ac28c35b87ab.png)
<details>

