### PR TITLE
test: e2e tests fixes

### DIFF
--- a/e2e/tests/tickets.e2e.ts
+++ b/e2e/tests/tickets.e2e.ts
@@ -19,6 +19,7 @@ import {
   ensureTicketingIsAccepted,
   getTravelInfoForRecentTicket,
   newTicketExists,
+  setZone,
   setZones,
   verifyTravellersAndZoneInSummary,
 } from '../utils/tickets';
@@ -77,7 +78,7 @@ describe('Tickets anonymous', () => {
     await expectToBeVisibleByPartOfText('Travel in 1 zone');
     await expectIdToHaveText(
       'offerTotalPriceText',
-      `Total: ${ticketInfo.singleTicketAdultPrice} kr`,
+      `Total ${ticketInfo.singleTicketAdultPrice}.00 kr`,
     );
 
     await tapById('goToPaymentButton');
@@ -98,7 +99,7 @@ describe('Tickets anonymous', () => {
     await expectToBeVisibleByText('1 Adult');
     await expectIdToHaveText(
       'offerTotalPriceText',
-      `Total: ${ticketInfo.singleTicketAdultPrice} kr`,
+      `Total ${ticketInfo.singleTicketAdultPrice}.00 kr`,
     );
 
     // Change the number of travellers
@@ -114,7 +115,7 @@ describe('Tickets anonymous', () => {
 
     // Verify
     await expectToBeVisibleByText('2 Adult, 1 Child');
-    await expectIdToHaveText('offerTotalPriceText', `Total: ${totPrice} kr`);
+    await expectIdToHaveText('offerTotalPriceText', `Total ${totPrice}.00 kr`);
 
     await tapById('goToPaymentButton');
     await expectToBeVisibleByText(`${totPrice} kr`);
@@ -128,36 +129,28 @@ describe('Tickets anonymous', () => {
     await tapById('singleTicket');
 
     // Set zone A -> A
-    await tapById('selectZonesButton');
-    await tapById('searchFromButton');
-    await tapById('tariffZoneAButton');
-    await tapById('searchToButton');
-    await tapById('tariffZoneAButton');
-    await tapById('saveZonesButton');
+    await setZones('A', 'A');
 
     // Verify
     await expectToBeVisibleByText('Travel in 1 zone');
     await expectToBeVisibleByText('Zone A');
     await expectIdToHaveText(
       'offerTotalPriceText',
-      `Total: ${ticketInfo.singleTicketAdultPrice} kr`,
+      `Total ${ticketInfo.singleTicketAdultPrice}.00 kr`,
     );
     await tapById('goToPaymentButton');
     await expectToBeVisibleByText('Valid in zone A');
     await goBack();
 
     // Set zone A -> B1
-    await tapById('selectZonesButton');
-    await tapById('searchToButton');
-    await tapById('tariffZoneB1Button');
-    await tapById('saveZonesButton');
+    await setZone('To', 'B1');
 
     // Verify
     await expectToBeVisibleByText('Travel in 2 zones');
     await expectToBeVisibleByText('Zone A to zone B1');
     await expectIdToHaveText(
       'offerTotalPriceText',
-      `Total: ${ticketInfo.singleTicketZoneAZoneB1Price} kr`,
+      `Total ${ticketInfo.singleTicketZoneAZoneB1Price}.00 kr`,
     );
     await tapById('goToPaymentButton');
     await expectToBeVisibleByText('Valid from zone A to zone B1');
@@ -245,7 +238,7 @@ describe('Tickets authorized', () => {
 
       await expectIdToHaveText(
         'offerTotalPriceText',
-        `Total: ${ticketInfo.singleTicketAdultPrice} kr`,
+        `Total ${ticketInfo.singleTicketAdultPrice}.00 kr`,
       );
 
       // Set zone E1 -> E1
@@ -307,7 +300,7 @@ describe('Tickets authorized', () => {
 
       await expectIdToHaveText(
         'offerTotalPriceText',
-        `Total: ${ticketInfo.periodic30daysPrice} kr`,
+        `Total ${ticketInfo.periodic30daysPrice}.00 kr`,
       );
 
       await tapById('goToPaymentButton');

--- a/e2e/tests/travelsearch.e2e.ts
+++ b/e2e/tests/travelsearch.e2e.ts
@@ -372,6 +372,84 @@ describe('Travel Search', () => {
     await verifyLegTypeOnQuays(departure, arrival, noQuays);
   });
 
+  // Check that recent journeys are listed and able to choose
+  it('should list recent journeys', async () => {
+    const departure1 = 'Prinsens gate';
+    const departure2 = 'Nidarosdomen';
+    const arrival1 = 'Melhus skysstasjon';
+    const arrival2 = 'Melhus sentrum';
+
+    // Remove the search history
+    await goToTab('profile');
+    await removeSearchHistory();
+    await goToTab('assistant');
+
+    // Search #1
+    await travelSearch(departure1, arrival1);
+
+    // Search #2
+    await tapById('searchToButton');
+    await setInputById('locationSearchInput', arrival2);
+    await chooseSearchResult('locationSearchItem0');
+
+    // Search #3
+    await tapById('searchFromButton');
+    await setInputById('locationSearchInput', departure2);
+    await chooseSearchResult('locationSearchItem0');
+
+    // Verify recent journeys with given departure
+    await tapById('searchFromButton');
+    await expectIdToHaveChildText(
+      'journeyHistoryItem0',
+      `${departure2} - ${arrival2}`,
+    );
+
+    // Verify recent journeys with any departure
+    await clearInputById('locationSearchInput');
+    await expectIdToHaveChildText(
+      'journeyHistoryItem0',
+      `${departure2} - ${arrival2}`,
+    );
+    await expectIdToHaveChildText(
+      'journeyHistoryItem1',
+      `${departure1} - ${arrival2}`,
+    );
+    await expectIdToHaveChildText(
+      'journeyHistoryItem2',
+      `${departure1} - ${arrival1}`,
+    );
+  });
+
+  // Check that recent locations are listed and able to choose
+  it('should list recent locations', async () => {
+    const departure1 = 'Prinsens gate';
+    const departure2 = 'Studentersamfundet';
+    const arrival1 = 'Melhus skysstasjon';
+    const arrival2 = 'Melhus sentrum';
+
+    // Remove the search history
+    await goToTab('profile');
+    await removeSearchHistory();
+    await goToTab('assistant');
+
+    // Search #1
+    await travelSearch(departure1, arrival1);
+
+    // Search #2
+    await travelSearch(departure2, arrival2);
+
+    // Verify no recent locations with given departure
+    await tapById('searchFromButton');
+    await expectNotToExistsById('previousResultItem0');
+
+    // Verify recent journeys with any departure
+    await clearInputById('locationSearchInput');
+    await expectIdToHaveText('previousResultItem0Name', arrival2);
+    await expectIdToHaveText('previousResultItem1Name', departure2);
+    await expectIdToHaveText('previousResultItem2Name', arrival1);
+    await expectIdToHaveText('previousResultItem3Name', departure1);
+  });
+
   // Test the use of favourites in a travel search
   it('should be able to use favourites in the travel search', async () => {
     const fav1 = 'Prinsens gate';
@@ -422,74 +500,6 @@ describe('Travel Search', () => {
     await goToTab('assistant');
     await expectToExistsById('favoriteChip0');
     await expectNotToExistsById('favoriteChip1');
-  });
-
-  // Check that recent journeys are listed and able to choose
-  it('should list recent journeys', async () => {
-    const departure1 = 'Prinsens gate';
-    const departure2 = 'Nidarosdomen';
-    const arrival1 = 'Melhus skysstasjon';
-    const arrival2 = 'Melhus sentrum';
-
-    // Search #1
-    await travelSearch(departure1, arrival1);
-
-    // Search #2
-    await tapById('searchToButton');
-    await setInputById('locationSearchInput', arrival2);
-    await chooseSearchResult('locationSearchItem0');
-
-    // Search #3
-    await tapById('searchFromButton');
-    await setInputById('locationSearchInput', departure2);
-    await chooseSearchResult('locationSearchItem0');
-
-    // Verify recent journeys with given departure
-    await tapById('searchFromButton');
-    await expectIdToHaveChildText(
-      'journeyHistoryItem0',
-      `${departure2} - ${arrival2}`,
-    );
-
-    // Verify recent journeys with any departure
-    await clearInputById('locationSearchInput');
-    await expectIdToHaveChildText(
-      'journeyHistoryItem0',
-      `${departure2} - ${arrival2}`,
-    );
-    await expectIdToHaveChildText(
-      'journeyHistoryItem1',
-      `${departure1} - ${arrival2}`,
-    );
-    await expectIdToHaveChildText(
-      'journeyHistoryItem2',
-      `${departure1} - ${arrival1}`,
-    );
-  });
-
-  // Check that recent locations are listed and able to choose
-  it('should list recent locations', async () => {
-    const departure1 = 'Prinsens gate';
-    const departure2 = 'Studentersamfundet';
-    const arrival1 = 'Melhus skysstasjon';
-    const arrival2 = 'Melhus sentrum';
-
-    // Search #1
-    await travelSearch(departure1, arrival1);
-
-    // Search #2
-    await travelSearch(departure2, arrival2);
-
-    // Verify no recent locations with given departure
-    await tapById('searchFromButton');
-    await expectNotToExistsById('previousResultItem0');
-
-    // Verify recent journeys with any departure
-    await clearInputById('locationSearchInput');
-    await expectIdToHaveText('previousResultItem0Name', arrival2);
-    await expectIdToHaveText('previousResultItem1Name', departure2);
-    await expectIdToHaveText('previousResultItem2Name', arrival1);
-    await expectIdToHaveText('previousResultItem3Name', departure1);
   });
 
   // Tapping should reset the travel search

--- a/e2e/utils/tickets.ts
+++ b/e2e/utils/tickets.ts
@@ -45,13 +45,30 @@ export const newTicketExists = async (zoneInfo: string = '') => {
   }
 };
 
+// Helper for handling keyboard-popup
+const tapZone = async (zoneId: string) => {
+  await tapById(zoneId);
+  const zoneIdExists = await idExists(by.id(zoneId));
+  if (zoneIdExists) {
+    await tapById(zoneId);
+  }
+};
+
+// Set one zone
+export const setZone = async (direction: 'To' | 'From', zone: string) => {
+  await tapById('selectZonesButton');
+  await tapById(`search${direction}Button`);
+  await tapZone(`tariffZone${zone}Button`);
+  await tapById('saveZonesButton');
+};
+
 // Set zones
 export const setZones = async (fromZone: string, toZone: string) => {
   await tapById('selectZonesButton');
   await tapById('searchFromButton');
-  await tapById(`tariffZone${fromZone}Button`);
+  await tapZone(`tariffZone${fromZone}Button`);
   await tapById('searchToButton');
-  await tapById(`tariffZone${toZone}Button`);
+  await tapZone(`tariffZone${toZone}Button`);
   await tapById('saveZonesButton');
 };
 

--- a/src/screens/Ticketing/Purchase/Overview/components/Summary.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Summary.tsx
@@ -58,7 +58,11 @@ export default function ({
         <ActivityIndicator size="large" />
       ) : (
         <>
-          <ThemeText type="body__primary--bold" style={styles.price}>
+          <ThemeText
+            type="body__primary--bold"
+            style={styles.price}
+            testID="offerTotalPriceText"
+          >
             {t(PurchaseOverviewTexts.summary.price(formattedPrice))}
           </ThemeText>
           <ThemeText type="body__secondary" style={styles.message}>


### PR DESCRIPTION
There are som failing e2e test scenarios on GH Actions:
- travelsearch: should list recent locations
    - the elements for tapping is hiding behind the keyboard. Solved by resetting the search history.
- ticketing: should get an offer for a single ticket
    - add the missing test-ID offerTotalPriceText
- ticketing: should be able to change travellers
    - add the missing test-ID offerTotalPriceText
- ticketing: should be able to change zone
    - tapping a zone removes the keyboard, so another tap is in order to actually tap the chosen zone