### PR TITLE
refactor: future proof date-fns and shortWaitTime

### DIFF
--- a/__tests__/utils-test.ts
+++ b/__tests__/utils-test.ts
@@ -58,7 +58,7 @@ describe('Short wait time evaluator', () => {
   } as Leg;
 
   const weirdLeg: Leg = {
-    expectedStartTime: false,
+    expectedStartTime: 'non parsable string',
     expectedEndTime: {weird: true},
   } as Leg;
 

--- a/__tests__/utils-test.ts
+++ b/__tests__/utils-test.ts
@@ -56,6 +56,12 @@ describe('Short wait time evaluator', () => {
     expectedStartTime: addMinutes(nowDate, 15),
     expectedEndTime: addMinutes(nowDate, 20),
   } as Leg;
+
+  const weirdLeg: Leg = {
+    expectedStartTime: false,
+    expectedEndTime: {weird: true},
+  } as Leg;
+
   it('catches a short wait', () => {
     const isShortWait = hasShortWaitTime([Leg1, Leg2]);
     expect(isShortWait).toBe(true);
@@ -74,6 +80,10 @@ describe('Short wait time evaluator', () => {
   });
   it('passes with empty array', () => {
     const isShortWait = hasShortWaitTime([]);
+    expect(isShortWait).toBe(false);
+  });
+  it('passes on weird data', () => {
+    const isShortWait = hasShortWaitTime([weirdLeg, weirdLeg]);
     expect(isShortWait).toBe(false);
   });
 });

--- a/src/screens/TripDetails/components/utils.ts
+++ b/src/screens/TripDetails/components/utils.ts
@@ -1,16 +1,24 @@
 import {Leg} from '@atb/api/types/trips';
 import {iterateWithNext} from '@atb/utils/array';
 import {timeIsShort} from '@atb/screens/TripDetails/Details/utils';
-import {differenceInSeconds} from 'date-fns';
+import {differenceInSeconds, parseISO} from 'date-fns';
 
 export function hasShortWaitTime(legs: Leg[]) {
   return iterateWithNext(legs)
     .map((pair) => {
       return differenceInSeconds(
-        pair.next.expectedStartTime,
-        pair.current.expectedEndTime,
+        parseDateIfString(pair.next.expectedStartTime),
+        parseDateIfString(pair.current.expectedEndTime),
       );
     })
     .filter((waitTime) => waitTime > 0)
     .some((waitTime) => timeIsShort(waitTime));
+}
+
+function parseDateIfString(date: any): Date {
+  if (typeof date === 'string') {
+    return parseISO(date);
+  } else {
+    return date;
+  }
 }


### PR DESCRIPTION
Date-fns show warnings that it will now longer support dates in string type.

updatet isShortWaitTime to parse any strings and updated tests with a "weird" case. 

![image](https://user-images.githubusercontent.com/1464594/169048817-a380f39b-d4a9-4b60-8beb-4597437095af.png)
