### PR TITLE
feat: add staticColor swatches to design system

### DIFF
--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -8,7 +8,13 @@ import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 import MessageBox from '@atb/components/message-box';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
-import {InteractiveColor, textNames, TextNames} from '@atb/theme/colors';
+import {ContrastColor} from '@atb-as/theme';
+import {
+  InteractiveColor,
+  StaticColorByType,
+  textNames,
+  TextNames,
+} from '@atb/theme/colors';
 import React, {useState} from 'react';
 import {Alert, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
@@ -34,6 +40,41 @@ export default function DesignSystem() {
       interactiveColor={color as InteractiveColor}
     />
   ));
+
+  const Swatch: React.FC<{color: ContrastColor; name: string}> = ({
+    color,
+    name,
+  }) => (
+    <ThemeText
+      style={{
+        backgroundColor: color.background,
+        color: color.text,
+        padding: theme.spacings.medium,
+      }}
+    >
+      {name}
+    </ThemeText>
+  );
+
+  const backgroundSwatches = Object.keys(theme.static.background).map(
+    (color) => {
+      const staticColor =
+        theme.static.background[color as StaticColorByType<'background'>];
+      return <Swatch color={staticColor} name={color} key={color} />;
+    },
+  );
+
+  const transportSwatches = Object.keys(theme.static.transport).map((color) => {
+    const staticColor =
+      theme.static.transport[color as StaticColorByType<'transport'>];
+    return <Swatch color={staticColor} name={color} key={color} />;
+  });
+
+  const statusSwatches = Object.keys(theme.static.status).map((color) => {
+    const staticColor =
+      theme.static.status[color as StaticColorByType<'status'>];
+    return <Swatch color={staticColor} name={color} key={color} />;
+  });
 
   const radioSegmentsOptions = [
     {text: 'Option 1', onPress: () => setSegmentedSelection(0)},
@@ -277,6 +318,10 @@ export default function DesignSystem() {
           <ButtonGroup>{buttons}</ButtonGroup>
         </View>
 
+        <View style={style.swatchGroup}>{backgroundSwatches}</View>
+        <View style={style.swatchGroup}>{transportSwatches}</View>
+        <View style={style.swatchGroup}>{statusSwatches}</View>
+
         <View style={{margin: theme.spacings.medium}}>
           <ThemeText>Segmented controls:</ThemeText>
           {radioSegments}
@@ -300,5 +345,8 @@ const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   },
   buttons: {
     marginHorizontal: theme.spacings.medium,
+  },
+  swatchGroup: {
+    margin: theme.spacings.medium,
   },
 }));


### PR DESCRIPTION
Legger til swatches i design systemet, med alle `staticColors`.

Klarte ikke helt å unngå å duplisere kode her, fordi jeg ikke klarer å generalisere linjen 
```
theme.static.transport[color as StaticColorByType<'transport'>];
```
uten å hardkode `transport`.



![Simulator Screen Shot - iPhone 13 - 2022-05-19 at 13 10 07](https://user-images.githubusercontent.com/1774972/169281710-f68545fd-c1d9-44b1-9edd-c7d1001df517.png)
