### PR TITLE
add android specific-property-to-make-irrelevant-info-inaccessible

### DIFF
--- a/src/components/sections/counter-input.tsx
+++ b/src/components/sections/counter-input.tsx
@@ -98,6 +98,7 @@ export default function CounterInput({
         >
           <ThemeText
             accessible={false}
+            importantForAccessibility={'no'}
             style={[
               counterStyles.countText,
               activeColor && {color: activeColor.text},


### PR DESCRIPTION
Seems like accessible={false} is not enough for our case to work in android, so I have added an android specific flag which marks the element not important for accessibility and hence it would be ignored.


https://github.com/AtB-AS/kundevendt/issues/130