### PR TITLE
refactor: replace NFK traffic situation url

### DIFF
--- a/src/translations/components/ServiceDisruptions.ts
+++ b/src/translations/components/ServiceDisruptions.ts
@@ -1,4 +1,5 @@
 import {translation as _} from '../commons';
+import orgSpecificTranslations from '../utils';
 
 const ServiceDisruptionsTexts = {
   header: {
@@ -19,4 +20,15 @@ const ServiceDisruptionsTexts = {
     ),
   },
 };
-export default ServiceDisruptionsTexts;
+
+export default orgSpecificTranslations(ServiceDisruptionsTexts, {
+  nfk: {
+    body: _(
+      'Oversikt over endringer, forsinkelser og avvik finner du på reisnordland.no:',
+      'Get an overview of changes, delays and service disruptions at reisnordland.no (Norwegian only):',
+    ),
+    button: {
+      text: _('Åpne i nettleser', 'Open in browser'),
+    },
+  },
+});


### PR DESCRIPTION
Avoids showing atb.no references in NFK app.

<img width="412" alt="image (2)" src="https://user-images.githubusercontent.com/21310942/170231715-d4d08466-1a18-4722-ac2a-882879a217e0.png">
<img width="410" alt="image (1)" src="https://user-images.githubusercontent.com/21310942/170231718-60e952ea-c9cb-4a0f-8c88-d474317861af.png">


