### PR TITLE
build: Avoid changelog error after org-specific releases

### DIFF
--- a/tools/release/changelog.config.js
+++ b/tools/release/changelog.config.js
@@ -1,7 +1,7 @@
 const {execSync} = require('child_process');
 
 const latestReleaseTag = execSync(
-  `git tag --sort=creatordate |  grep -E '(^alpha-.*)|(^v.*)|(.*nfk.*)' | tail -1`,
+  `git tag --sort=creatordate |  grep -E '/(?!(.*atb.*)|(.*nfk.*))((alpha-.*)|(v.*))' | tail -1`,
 )
   .toString('utf-8')
   .trim();

--- a/tools/release/changelog.config.js
+++ b/tools/release/changelog.config.js
@@ -1,7 +1,7 @@
 const {execSync} = require('child_process');
 
 const latestReleaseTag = execSync(
-  `git tag --sort=creatordate |  grep -E '(^alpha-.*)|(^v.*)' | tail -1`,
+  `git tag --sort=creatordate |  grep -E '(^alpha-.*)|(^v.*)|(.*nfk.*)' | tail -1`,
 )
   .toString('utf-8')
   .trim();

--- a/tools/release/changelog.config.js
+++ b/tools/release/changelog.config.js
@@ -1,7 +1,7 @@
 const {execSync} = require('child_process');
 
 const latestReleaseTag = execSync(
-  `git tag --sort=creatordate |  grep -E '/(?!(.*atb.*)|(.*nfk.*))((alpha-.*)|(v.*))' | tail -1`,
+  `git tag --sort=creatordate |  grep -E '/(?!(.*(atb|nfk).*))((alpha-.*)|(v.*))' | tail -1`,
 )
   .toString('utf-8')
   .trim();


### PR DESCRIPTION
Skips nfk-only releases when finding latest releasetag, so that all changes are included in the changelog of next common release.