### PR TITLE
feat: extract 24 h ticket out of periodic ticket 2

### DIFF
--- a/src/reference-data/defaults/preassigned-fare-products.json
+++ b/src/reference-data/defaults/preassigned-fare-products.json
@@ -31,6 +31,68 @@
     }
   },
   {
+    "id": "ATB:PreassignedFareProduct:1fb2d3e4",
+    "version": "",
+    "type": "hour24",
+    "durationDays": 1,
+    "distributionChannel": [
+      "app",
+      "web"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "24-timersbillett"
+    },
+    "alternativeNames": [
+      {
+        "lang": "eng",
+        "value": "24 hour pass"
+      },
+      {
+        "lang": "nno",
+        "value": "24-timersbillett"
+      }
+    ],
+    "limitations": {
+      "userProfileRefs": [
+        "ATB:UserProfile:d3e4ec09",
+        "ATB:UserProfile:8ee842e3",
+        "ATB:UserProfile:2832569f"
+      ]
+    }
+  },
+  {
+    "id": "ATB:PreassignedFareProduct:6dd9beab",
+    "version": "ATB:Version:c7e5a0d8-78e8-46e9-a019-07348b8328db",
+    "type": "period",
+    "durationDays": 7,
+    "distributionChannel": [
+      "app",
+      "web"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "7-dagersbillett"
+    },
+    "alternativeNames": [
+      {
+        "lang": "nno",
+        "value": "7-dagersbillett"
+      },
+      {
+        "lang": "eng",
+        "value": "Weekly pass"
+      }
+    ],
+    "limitations": {
+      "userProfileRefs": [
+        "ATB:UserProfile:d3e4ec09",
+        "ATB:UserProfile:8ee842e3",
+        "ATB:UserProfile:2832569f"
+      ]
+    }
+  },
+  {
     "id": "ATB:PreassignedFareProduct:925469fb",
     "version": "ATB:Version:12b94a4d-b347-41c9-a6c6-35bc3386d4f4",
     "type": "period",
@@ -63,18 +125,82 @@
     }
   },
   {
-    "id": "ATB:PreassignedFareProduct:f87316e6",
-    "version": "ATB:Version:62736d83-3854-4c71-b9f2-d2d9b52997ab",
+    "id": "ATB:PreassignedFareProduct:c19cf036",
+    "version": "",
     "type": "period",
-    "durationDays": 180,
-    "name": {
-      "lang": "nob",
-      "value": "180-dagersbillett"
-    },
+    "durationDays": 60,
     "distributionChannel": [
       "app",
       "web"
     ],
+    "name": {
+      "lang": "nob",
+      "value": "60-dagersbillett"
+    },
+    "alternativeNames": [
+      {
+        "lang": "eng",
+        "value": "60 days pass"
+      },
+      {
+        "lang": "nno",
+        "value": "60-dagersbillett"
+      }
+    ],
+    "limitations": {
+      "userProfileRefs": [
+        "ATB:UserProfile:1ae560ba",
+        "ATB:UserProfile:d3e4ec09",
+        "ATB:UserProfile:8ee842e3",
+        "ATB:UserProfile:2832569f"
+      ]
+    }
+  },
+  {
+    "id": "ATB:PreassignedFareProduct:39bcf20e",
+    "version": "",
+    "type": "period",
+    "durationDays": 90,
+    "distributionChannel": [
+      "app",
+      "web"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "90-dagersbillett"
+    },
+    "alternativeNames": [
+      {
+        "lang": "eng",
+        "value": "90 days pass"
+      },
+      {
+        "lang": "nno",
+        "value": "90-dagersbillett"
+      }
+    ],
+    "limitations": {
+      "userProfileRefs": [
+        "ATB:UserProfile:1ae560ba",
+        "ATB:UserProfile:d3e4ec09",
+        "ATB:UserProfile:8ee842e3",
+        "ATB:UserProfile:2832569f"
+      ]
+    }
+  },
+  {
+    "id": "ATB:PreassignedFareProduct:f87316e6",
+    "version": "ATB:Version:62736d83-3854-4c71-b9f2-d2d9b52997ab",
+    "type": "period",
+    "durationDays": 180,
+    "distributionChannel": [
+      "app",
+      "web"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "180-dagersbillett"
+    },
     "alternativeNames": [
       {
         "lang": "eng",
@@ -88,37 +214,6 @@
     "limitations": {
       "userProfileRefs": [
         "ATB:UserProfile:1ae560ba",
-        "ATB:UserProfile:d3e4ec09",
-        "ATB:UserProfile:8ee842e3",
-        "ATB:UserProfile:2832569f"
-      ]
-    }
-  },
-  {
-    "id": "ATB:PreassignedFareProduct:6dd9beab",
-    "version": "ATB:Version:c7e5a0d8-78e8-46e9-a019-07348b8328db",
-    "type": "period",
-    "durationDays": 7,
-    "distributionChannel": [
-      "app",
-      "web"
-    ],
-    "name": {
-      "lang": "nob",
-      "value": "7-dagersbillett"
-    },
-    "alternativeNames": [
-      {
-        "lang": "nno",
-        "value": "7-dagersbillett"
-      },
-      {
-        "lang": "eng",
-        "value": "Weekly pass"
-      }
-    ],
-    "limitations": {
-      "userProfileRefs": [
         "ATB:UserProfile:d3e4ec09",
         "ATB:UserProfile:8ee842e3",
         "ATB:UserProfile:2832569f"

--- a/src/reference-data/defaults/preassigned-fare-products.json
+++ b/src/reference-data/defaults/preassigned-fare-products.json
@@ -35,6 +35,7 @@
     "version": "",
     "type": "hour24",
     "durationDays": 1,
+    "isApplicableOnSingleZoneOnly": true,
     "distributionChannel": [
       "app",
       "web"

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -5,7 +5,11 @@ export type LanguageAndText = {
   value: string;
 };
 
-export type PreassignedFareProductType = 'single' | 'period' | 'carnet' | 'hour24';
+export type PreassignedFareProductType =
+  | 'single'
+  | 'period'
+  | 'carnet'
+  | 'hour24';
 
 export type DistributionChannel = 'web' | 'app';
 
@@ -18,6 +22,7 @@ export type PreassignedFareProduct = {
   version: string;
   type: PreassignedFareProductType;
   durationDays: number;
+  isApplicableOnSingleZoneOnly?: boolean;
   limitations: {
     userProfileRefs: string[];
   };

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -5,7 +5,7 @@ export type LanguageAndText = {
   value: string;
 };
 
-export type PreassignedFareProductType = 'single' | 'period' | 'carnet';
+export type PreassignedFareProductType = 'single' | 'period' | 'carnet' | 'hour24';
 
 export type DistributionChannel = 'web' | 'app';
 

--- a/src/screens/Ticketing/Purchase/Overview/components/TravellerSelection.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/TravellerSelection.tsx
@@ -133,7 +133,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
     iosToggle: {
       marginLeft: theme.spacings.xSmall,
-      transform: [{scale: 0.7 * scale}, {translateY: -10 }],
+      transform: [{scale: 0.7 * scale}, {translateY: -10}],
     },
   };
 });

--- a/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
@@ -17,12 +17,14 @@ type ZonesProps = {
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
   style?: StyleProp<ViewStyle>;
+  isApplicableOnSingleZoneOnly?: boolean;
 };
 
 export default function Zones({
   fromTariffZone,
   toTariffZone,
   style,
+  isApplicableOnSingleZoneOnly,
 }: ZonesProps) {
   const itemStyle = useStyles();
   const {t, language} = useTranslation();
@@ -61,6 +63,7 @@ export default function Zones({
             navigation.push('TariffZones', {
               fromTariffZone,
               toTariffZone,
+              isApplicableOnSingleZoneOnly: isApplicableOnSingleZoneOnly,
             });
           }}
           testID="selectZonesButton"

--- a/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
@@ -44,9 +44,17 @@ export default function Zones({
         type="body__secondary"
         color="secondary"
         style={itemStyle.sectionText}
-        accessibilityLabel={t(PurchaseOverviewTexts.zones.label.a11yLabel)}
+        accessibilityLabel={t(
+          PurchaseOverviewTexts.zones.label[
+            isApplicableOnSingleZoneOnly ? 'singleZone' : 'multipleZone'
+          ].a11yLabel,
+        )}
       >
-        {t(PurchaseOverviewTexts.zones.label.text)}
+        {t(
+          PurchaseOverviewTexts.zones.label[
+            isApplicableOnSingleZoneOnly ? 'singleZone' : 'multipleZone'
+          ].text,
+        )}
       </ThemeText>
       <Sections.Section {...accessibility}>
         <Sections.ButtonInput

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -166,6 +166,9 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             fromTariffZone={fromTariffZone}
             toTariffZone={toTariffZone}
             style={styles.selectionComponent}
+            isApplicableOnSingleZoneOnly={
+              preassignedFareProduct.isApplicableOnSingleZoneOnly
+            }
           />
 
           {travelDateSelectionEnabled && (

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -486,7 +486,9 @@ const TariffZones: React.FC<Props> = ({navigation, route: {params}}) => {
                     ['==', selectedZones.from.id, ['id']],
                     hexToRgba(theme.static.status.valid.background, 0.6),
                     ['==', selectedZones.to.id, ['id']],
-                    hexToRgba(theme.static.status.info.background, 0.6),
+                    !isApplicableOnSingleZoneOnly
+                      ? hexToRgba(theme.static.status.info.background, 0.6)
+                      : 'transparent',
                     'transparent',
                   ],
                 }}

--- a/src/screens/Ticketing/Purchase/utils.ts
+++ b/src/screens/Ticketing/Purchase/utils.ts
@@ -17,7 +17,7 @@ export type PurchaseFlow = {
 export const getPurchaseFlow = (
   product: PreassignedFareProduct,
 ): PurchaseFlow => {
-  if (product.type === 'period') {
+  if (product.type === 'period' || product.type === 'hour24') {
     return {
       travellerSelectionMode: 'single',
       travelDateSelectionEnabled: true,

--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -3,7 +3,6 @@ import {TicketsTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {StyleSheet} from '@atb/theme';
 import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
-import {ScrollView} from 'react-native-gesture-handler';
 import ThemeText from '@atb/components/text';
 import {
   Mode,
@@ -16,9 +15,11 @@ import Ticket from '@atb/screens/Ticketing/Tickets/AvailableTickets/Ticket';
 export const AvailableTickets = ({
   onBuySingleTicket,
   onBuyPeriodTicket,
+  onBuyHour24Ticket,
 }: {
   onBuySingleTicket: () => void;
   onBuyPeriodTicket: () => void;
+  onBuyHour24Ticket: () => void;
 }) => {
   const styles = useStyles();
   const hasEnabledMobileToken = useHasEnabledMobileToken();
@@ -36,6 +37,10 @@ export const AvailableTickets = ({
     preassignedFareproducts.filter(productIsSellableInApp).some((product) => {
       return product.type === 'period';
     });
+
+  const shouldShowOneDayTicket = preassignedFareproducts
+    .filter(productIsSellableInApp)
+    .some((product) => product.type === 'hour24');
 
   const shouldShowSummerPass = false;
 
@@ -81,6 +86,25 @@ export const AvailableTickets = ({
           />
         )}
       </View>
+      {shouldShowOneDayTicket && (
+        <View style={styles.ticketsContainer}>
+          <Ticket
+            title={t(TicketsTexts.availableTickets.hour24.title)}
+            transportationModeTexts={t(
+              TicketsTexts.availableTickets.hour24.transportModes,
+            )}
+            transportationModeIcons={[
+              {mode: Mode.Bus, subMode: TransportSubmode.LocalBus},
+            ]}
+            description={t(
+              TicketsTexts.availableTickets.hour24.description,
+            )}
+            ticketIllustration="H24"
+            onPress={onBuyHour24Ticket}
+            testID="24HourTicket"
+          />
+        </View>
+      )}
       {shouldShowSummerPass && (
         <View style={styles.ticketsContainer}>
           <Ticket

--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -38,7 +38,7 @@ export const AvailableTickets = ({
       return product.type === 'period';
     });
 
-  const shouldShowOneDayTicket = preassignedFareproducts
+  const shouldShowHour24Ticket = preassignedFareproducts
     .filter(productIsSellableInApp)
     .some((product) => product.type === 'hour24');
 
@@ -86,7 +86,7 @@ export const AvailableTickets = ({
           />
         )}
       </View>
-      {shouldShowOneDayTicket && (
+      {shouldShowHour24Ticket && (
         <View style={styles.ticketsContainer}>
           <Ticket
             title={t(TicketsTexts.availableTickets.hour24.title)}

--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -96,9 +96,7 @@ export const AvailableTickets = ({
             transportationModeIcons={[
               {mode: Mode.Bus, subMode: TransportSubmode.LocalBus},
             ]}
-            description={t(
-              TicketsTexts.availableTickets.hour24.description,
-            )}
+            description={t(TicketsTexts.availableTickets.hour24.description)}
             ticketIllustration="H24"
             onPress={onBuyHour24Ticket}
             testID="24HourTicket"

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -56,6 +56,15 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
     }
   };
 
+  const onBuyHour24Ticket = () => {
+    navigation.navigate('TicketPurchase', {
+      screen: 'PurchaseOverview',
+      params: {
+        selectableProductType: 'hour24',
+      },
+    });
+  };
+
   return isSignedInAsAbtCustomer ? (
     <ScrollView
       style={{backgroundColor: theme.static.background.background_2.background}}
@@ -64,6 +73,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
       <AvailableTickets
         onBuySingleTicket={onBuySingleTicket}
         onBuyPeriodTicket={onBuyPeriodTicket}
+        onBuyHour24Ticket={onBuyHour24Ticket}
       />
     </ScrollView>
   ) : null;

--- a/src/translations/screens/Tickets.ts
+++ b/src/translations/screens/Tickets.ts
@@ -99,6 +99,15 @@ const TicketsTexts = {
       pilot_description: _('', ''),
       transportModes: _('Buss/trikk', 'Bus/tram'),
     },
+    hour24: {
+      title: _('24-timersbillett', '24 hour pass'),
+      description: _(
+        'Når du vil reise flere ganger på et døgn',
+        'For travelling several times in 24 hours',
+      ),
+      pilot_description: _('', ''),
+      transportModes: _('Buss/trikk', 'Bus/tram'),
+    },
     summerPass: {
       title: _('AtB SommerPass', 'Summer pass'),
       description: _(

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -6,6 +6,7 @@ const PurchaseConfirmationTexts = {
       single: _('Enkeltbillett', 'Single ticket'),
       period: _('Periodebillett', 'Periodic ticket'),
       carnet: _('Klippekort', 'Carnet ticket'),
+      hour24: _('24-timersbillett', '24 hour pass'),
     },
   },
   errorMessageBox: {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -7,6 +7,7 @@ const PurchaseOverviewTexts = {
       single: _('Enkeltbillett', 'Single ticket'),
       period: _('Periodebillett', 'Periodic ticket'),
       carnet: _('Klippekort', 'Carnet ticket'),
+      hour24: _('24-timersbillett', '24 hour pass'),
     },
   },
   errorMessageBox: {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -64,8 +64,14 @@ const PurchaseOverviewTexts = {
   ),
   zones: {
     label: {
-      text: _('Velg sone(r)', 'Select zone(s)'),
-      a11yLabel: _('Velg soner', 'Select zones'),
+      singleZone: {
+        text: _('Velg sone (kun én)', 'Select zone (only one)'),
+        a11yLabel: _('Velg sone (kun én)', 'Select zone (only one)'),
+      },
+      multipleZone: {
+        text: _('Velg sone(r)', 'Select zone(s)'),
+        a11yLabel: _('Velg soner', 'Select zones'),
+      },
     },
   },
   duration: {

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -2,7 +2,10 @@ import {translation as _} from '../../commons';
 
 const TariffZonesTexts = {
   header: {
-    title: _('Velg soner', 'Select zones'),
+    title: {
+      singleZone: _('Velg sone', 'Select zone'),
+      multipleZone: _('Velg soner', 'Select zones'),
+    },
   },
   zoneSummary: {
     a11yLabelPrefix: _(`Sonevalget er`, `The zone selection is`),
@@ -41,6 +44,9 @@ const TariffZonesTexts = {
   },
 
   location: {
+    singleZone: {
+      label: _('Reise i ', 'Travel in '),
+    },
     departurePicker: {
       value: {
         noVenue: (zoneName: string) =>


### PR DESCRIPTION
1. It has been decided that user should be able to buy 24h ticket anonymously unlike other periodic tickets. 

2. This PR also requires changes in Fire store to update preassignedFareProducts_v2.

- change ticket type of 24 hour ticker to 'hour24' from 'period'
- add isApplicableOnSingleZoneOnly as true for 24h ticket
- remove Student as a valid user for the same

 The changes have been done in  firestore config in staging but should be done in PROD file while moving this change to production. 

Github issue: https://github.com/AtB-AS/kundevendt/issues/56