### PR TITLE
refactor: update language to use "log in" over "sign in"

### DIFF
--- a/e2e/tests/myprofile.e2e.ts
+++ b/e2e/tests/myprofile.e2e.ts
@@ -104,7 +104,7 @@ describe('My profile', () => {
     await expectToBeVisibleByText('My account');
     await expectToBeVisibleByText('Customer number');
     await expectToBeVisibleById('loginButton');
-    await expectToBeVisibleByText('Sign in');
+    await expectToBeVisibleByText('Log in');
     await expectToBeVisibleById('expiredTicketsButton');
     await expectToBeVisibleByText('Expired tickets');
   });

--- a/src/assets/information-data/paymentInformation.json
+++ b/src/assets/information-data/paymentInformation.json
@@ -19,7 +19,7 @@
             "type": "heading"
         },
         {
-            "text": "All transactions performed with Vipps are processed by Vipps. If you have selected Vipps as your default payment method, the Vipps app will open when you pay. You are then asked to sign in to Vipps in the usual way. The AtB app will request access to Vipps, which you must answer yes to. Vipps will use your chosen payment method, account or card selected in the Vipps app. Information about your account, your cards or other personal information is not stored in the AtB app or at AtB.",
+            "text": "All transactions performed with Vipps are processed by Vipps. If you have selected Vipps as your default payment method, the Vipps app will open when you pay. You are then asked to log in to Vipps in the usual way. The AtB app will request access to Vipps, which you must answer yes to. Vipps will use your chosen payment method, account or card selected in the Vipps app. Information about your account, your cards or other personal information is not stored in the AtB app or at AtB.",
             "type": "text"
         },
         {

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -11,7 +11,7 @@ const OnboardingTexts = {
       ),
       part2: _(
         'Hvis du logger inn vil du alltid ha tilgang til billettene dine, selv om du bytter eller mister telefonen din.',
-        'If you sign in you will always have access to your tickets, even if you switch or lose your phone.',
+        'If you log in you will always have access to your tickets, even if you switch or lose your phone.',
       ),
       part3: _(
         'Du vil også kunne administrere billetter og eventuelle t:kort på den nye nettbutikken med samme konto.',

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -10,10 +10,10 @@ const ProfileTexts = {
       heading: _('Min konto', 'My account'),
       linkItems: {
         login: {
-          label: _('Logg inn', 'Sign in'),
+          label: _('Logg inn', 'Log in'),
         },
         logout: {
-          label: _('Logg ut', 'Sign out'),
+          label: _('Logg ut', 'Log out'),
         },
         expiredTickets: {
           label: _('Utløpte billetter', 'Expired tickets'),

--- a/src/translations/screens/subscreens/Information.ts
+++ b/src/translations/screens/subscreens/Information.ts
@@ -86,7 +86,7 @@ const SelectStartScreenTexts = {
       part1Heading: _('Vipps', 'Vipps'),
       part1Text: _(
         'Alle transaksjoner utført med Vipps blir behandlet av Vipps. Har du valgt Vipps som standard betalingsmåte, vil Vipps-appen åpne seg når du skal betale. Du blir så bedt om å logge på Vipps på vanlig måte. Appen AtB vil be om tilgang til Vipps, dette må du svare ja på. Vipps vil benytte din valgte betalingsmetode, konto eller kort valgt i Vipps appen. Informasjon om din konto, dine kort eller andre personopplysninger blir ikke lagret i appen AtB eller hos AtB.',
-        'All transactions performed with Vipps are processed by Vipps. If you have selected Vipps as your default payment method, the Vipps app will open when you pay. You are then asked to sign in to Vipps in the usual way. The AtB app will request access to Vipps, which you must answer yes to. Vipps will use your chosen payment method, account or card selected in the Vipps app. Information about your account, your cards or other personal information is not stored in the AtB app or at AtB.',
+        'All transactions performed with Vipps are processed by Vipps. If you have selected Vipps as your default payment method, the Vipps app will open when you pay. You are then asked to log in to Vipps in the usual way. The AtB app will request access to Vipps, which you must answer yes to. Vipps will use your chosen payment method, account or card selected in the Vipps app. Information about your account, your cards or other personal information is not stored in the AtB app or at AtB.',
       ),
       part2Heading: _(
         'Det vil komme flere betalingsmåter',
@@ -192,7 +192,7 @@ export default orgSpecificTranslations(SelectStartScreenTexts, {
       texts: {
         part1Text: _(
           'Alle transaksjoner utført med Vipps blir behandlet av Vipps. Har du valgt Vipps som standard betalingsmåte, vil Vipps-appen åpne seg når du skal betale. Du blir så bedt om å logge på Vipps på vanlig måte. Appen Reis vil be om tilgang til Vipps, dette må du svare ja på. Vipps vil benytte din valgte betalingsmetode, konto eller kort valgt i Vipps appen. Informasjon om din konto, dine kort eller andre personopplysninger blir ikke lagret i appen Reis eller hos Reis Nordland.',
-          'All transactions performed with Vipps are processed by Vipps. If you have selected Vipps as your default payment method, the Vipps app will open when you pay. You are then asked to sign in to Vipps in the usual way. The Reis app will request access to Vipps, which you must answer yes to. Vipps will use your chosen payment method, account or card selected in the Vipps app. Information about your account, your cards or other personal information is not stored in the Reis app or at Reis Nordland.',
+          'All transactions performed with Vipps are processed by Vipps. If you have selected Vipps as your default payment method, the Vipps app will open when you pay. You are then asked to log in to Vipps in the usual way. The Reis app will request access to Vipps, which you must answer yes to. Vipps will use your chosen payment method, account or card selected in the Vipps app. Information about your account, your cards or other personal information is not stored in the Reis app or at Reis Nordland.',
         ),
       },
     },

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -88,10 +88,10 @@ const LoginTexts = {
     title: _('Er du sikker?', 'Are you sure?'),
     description: _(
       'Hvis du bytter eller mister telefonen vil vi ikke kunne finne fram billettene dine igjen.\n\nDu kan også logge inn senere under "Min profil"',
-      'If you switch or lose your phone your tickets will be lost.\n\nYou can also sign in at a later time under "My profile"',
+      'If you switch or lose your phone your tickets will be lost.\n\nYou can also log in at a later time under "My profile"',
     ),
     mainButton: _('Godta og gå videre', 'Accept and continue'),
-    wantToLoginButton: _('Jeg vil logge inn likevel', 'I want to sign in'),
+    wantToLoginButton: _('Jeg vil logge inn likevel', 'I want to log in'),
   },
 };
 export default LoginTexts;


### PR DESCRIPTION
Ref. [discussion on slack](https://mittatb.slack.com/archives/C036F9Q15R8/p1654066778806459) on updating translations for "sign in" to "log in".