### PR TITLE
fix: add 24 hour ticket in recent purchase

### DIFF
--- a/src/screens/Ticketing/Tickets/RecentTickets/RecentTickets.tsx
+++ b/src/screens/Ticketing/Tickets/RecentTickets/RecentTickets.tsx
@@ -45,7 +45,8 @@ export const RecentTickets = () => {
         if (
           ticketType === 'single' ||
           ticketType === 'period' ||
-          ticketType === 'carnet'
+          ticketType === 'carnet' ||
+          ticketType === 'hour24'
         )
           return true;
         else return false;


### PR DESCRIPTION
Now when we have added 24 hour ticket as a new ticket type, it got missed from recent purchases. So have added it here. 