### PR TITLE
feat: Add explicit icons to profile links

### DIFF
--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -6,6 +6,7 @@ import {RootStackParamList} from '@atb/navigation';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {useSearchHistory} from '@atb/search-history';
 import {StyleSheet, Theme} from '@atb/theme';
+import {LogOut} from '@atb/assets/svg/mono-icons/profile';
 import {ProfileTexts, useTranslation} from '@atb/translations';
 import useLocalConfig from '@atb/utils/use-local-config';
 import {IS_QA_ENV} from '@env';
@@ -29,6 +30,7 @@ import {updateMetadata} from '@atb/chat/metadata';
 import parsePhoneNumber from 'libphonenumber-js';
 import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
 import DeleteProfileTexts from '@atb/translations/screens/subscreens/DeleteProfile';
+import ThemeIcon from '@atb/components/theme-icon';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -153,6 +155,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             {authenticationType === 'phone' && (
               <Sections.LinkItem
                 text={t(ProfileTexts.sections.account.linkItems.logout.label)}
+                icon={<ThemeIcon svg={LogOut} />}
                 onPress={signOut}
                 testID="logoutButton"
               />

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -6,6 +6,7 @@ import {RootStackParamList} from '@atb/navigation';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {useSearchHistory} from '@atb/search-history';
 import {StyleSheet, Theme} from '@atb/theme';
+import {Delete} from '@atb/assets/svg/mono-icons/actions';
 import {LogOut} from '@atb/assets/svg/mono-icons/profile';
 import {ProfileTexts, useTranslation} from '@atb/translations';
 import useLocalConfig from '@atb/utils/use-local-config';
@@ -287,6 +288,7 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
           />
           <Sections.LinkItem
             text={t(ProfileTexts.sections.privacy.linkItems.clearHistory.label)}
+            icon={<ThemeIcon svg={Delete} />}
             accessibility={{
               accessibilityHint: t(
                 ProfileTexts.sections.privacy.linkItems.clearHistory.a11yHint,


### PR DESCRIPTION
Adds icons as explained in https://github.com/AtB-AS/kundevendt/issues/67.

New icons for:
- Signing out
![image](https://user-images.githubusercontent.com/21310942/173364414-b14ff610-da55-4e10-ae9c-55c41f45e104.png)


- Deleting search history
![image](https://user-images.githubusercontent.com/21310942/173364351-86f5c9d1-a46f-4732-b9ed-8549951d9f54.png)