### PR TITLE
refactor: split title and message in destructive alerts

### DIFF
--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -160,8 +160,13 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
                 icon={<ThemeIcon svg={LogOut} />}
                 onPress={() =>
                   destructiveAlert({
-                    confirmMessageString: t(
-                      ProfileTexts.sections.account.linkItems.logout.confirm,
+                    alertTitleString: t(
+                      ProfileTexts.sections.account.linkItems.logout
+                        .confirmTitle,
+                    ),
+                    alertMessageString: t(
+                      ProfileTexts.sections.account.linkItems.logout
+                        .confirmMessage,
                     ),
                     cancelAlertString: t(
                       ProfileTexts.sections.account.linkItems.logout.alert
@@ -313,8 +318,9 @@ export default function ProfileHome({navigation}: ProfileScreenProps) {
             testID="clearHistoryButton"
             onPress={() =>
               destructiveAlert({
-                confirmMessageString: t(
-                  ProfileTexts.sections.privacy.linkItems.clearHistory.confirm,
+                alertTitleString: t(
+                  ProfileTexts.sections.privacy.linkItems.clearHistory
+                    .confirmTitle,
                 ),
                 cancelAlertString: t(
                   ProfileTexts.sections.privacy.linkItems.clearHistory.alert

--- a/src/screens/Profile/Home/utils.ts
+++ b/src/screens/Profile/Home/utils.ts
@@ -1,19 +1,21 @@
 import {Alert} from 'react-native';
 
 type destructiveAlertProps = {
-  confirmMessageString: string;
+  alertTitleString: string;
+  alertMessageString?: string;
   cancelAlertString: string;
   confirmAlertString: string;
   destructiveArrowFunction: () => void;
 };
 
 export const destructiveAlert = ({
-  confirmMessageString,
+  alertTitleString,
+  alertMessageString,
   cancelAlertString,
   confirmAlertString,
   destructiveArrowFunction,
 }: destructiveAlertProps): void =>
-  Alert.alert(confirmMessageString, undefined, [
+  Alert.alert(alertTitleString, alertMessageString, [
     {
       text: cancelAlertString,
       style: 'cancel',

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -13,7 +13,11 @@ const ProfileTexts = {
         },
         logout: {
           label: _('Logg ut', 'Log out'),
-          confirm: _(
+          confirmTitle: _(
+            'Er du sikker på at du vil logge ut?',
+            'Are you sure you want to log out?',
+          ),
+          confirmMessage: _(
             'Billettene dine vil ikke være tilgjengelig i appen hvis du logger ut. De blir tilgjengelige igjen hvis du logger inn.',
             'Your tickets will be inaccessible in the app after logging out. You can access them again by logging in.',
           ),
@@ -98,9 +102,9 @@ const ProfileTexts = {
             'Aktivér for å tømme tidligere søk',
             'Activate to clear previous searches',
           ),
-          confirm: _(
-            'Dette vil fjerne søkehistorikk.',
-            'This will permanently clear search history.',
+          confirmTitle: _(
+            'Er du sikker på at du vil slette søkehistorikk?',
+            'Are you sure you want to delete your search history?',
           ),
           alert: {
             cancel: _('Avbryt', 'Cancel'),


### PR DESCRIPTION
Solves https://github.com/AtB-AS/kundevendt/issues/1756 and refactors https://github.com/AtB-AS/mittatb-app/pull/2754

Destructive alerts are now split into a title and a message. The message is optional, title is currently required.

With title:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/21310942/173820211-06ac8b6b-22f4-4ac4-8d9c-1a08e3097e5c.png">

Without title (same as before):
<img width="376" alt="image" src="https://user-images.githubusercontent.com/21310942/173820289-778107d2-e388-40ec-a30b-7a402e16619f.png">