### PR TITLE
bump theme package to reflect bigger fonts for label uppercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "link-assets": "react-native link"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.0.0-alpha.5",
+    "@atb-as/theme": "^6.0.0-alpha.6",
     "@bugsnag/react-native": "^7.12.0",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur/atb-mobile-client-sdk": "file:.yalc/@entur/atb-mobile-client-sdk",


### PR DESCRIPTION
We have now increased the size of label__uppercase to 10 from 8. This has been done as part of https://github.com/AtB-AS/kundevendt/issues/1666. 

Please find one such example below!

Before: 
![image](https://user-images.githubusercontent.com/29625161/174612598-bddeb1a5-e71a-434d-afdd-c2e6ca35a4c2.png)

After: 
![image](https://user-images.githubusercontent.com/29625161/174613352-6673434e-8515-45d8-9424-4d17fa1236ce.png)


