### PR TITLE
chore: Use yalc during staing build

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -17,6 +17,13 @@ jobs:
     timeout-minutes: 90
     runs-on: macos-11
     steps:
+      - name: Checkout temp mobiletoken sdk
+        uses: actions/checkout@v3
+        with:
+          repository: 'AtB-AS/temp-mobiletoken-sdk'
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Publish temp mobiletoken sdk
+        run: npx yalc publish
       - name: Checkout project
         uses: actions/checkout@v1
       - name: Set global env vars
@@ -34,6 +41,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
+      - name: Yalc add temp mobiletoken sdk
+        run: npx yalc add @entur/atb-mobile-client-sdk
       - name: Get potential cached node_modules
         uses: actions/cache@v2
         id: modules-cache

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -1,5 +1,6 @@
 name: Build staging iOS project
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -16,8 +17,17 @@ jobs:
     timeout-minutes: 90
     runs-on: macos-11
     steps:
+      - name: Checkout temp mobiletoken sdk
+        uses: actions/checkout@v3
+        with:
+          repository: 'AtB-AS/temp-mobiletoken-sdk'
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Publish temp mobiletoken sdk
+        run: npx yalc publish
       - name: Checkout project
         uses: actions/checkout@v1
+      - name: Yalc add temp mobiletoken sdk
+        run: npx yalc add @entur/atb-mobile-client-sdk
       - name: Setup build dependencies, environment and assets
         uses: ./.github/actions/ios-build-setup
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ vendor/bundle
 # Design system
 assets/design-assets
 src/assets/svg
+
+# Yalc
+.yalc/
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@entur/sdk": "^3.4.0",
     "@leile/lobo-t": "^1.0.5",
     "@mapbox/polyline": "^1.1.1",
+    "@entur/atb-mobile-client-sdk": "file:./.yalc/@entur/atb-mobile-client-sdk",
     "@react-native-async-storage/async-storage": "^1.15.9",
     "@react-native-clipboard/clipboard": "^1.8.4",
     "@react-native-community/datetimepicker": "^3.5.2",


### PR DESCRIPTION
Done in the same way that is advised locally. This is just temporary until Entur hosts the libraries, and we can't do a production release with this method as of now as the native code is not obfuscated.