### PR TITLE
feat: show specific warning messages if the relevant token is not the one in hand

### DIFF
--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -9,7 +9,7 @@ import {
   getReferenceDataName,
 } from '@atb/reference-data/utils';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {PreactivatedTicket, useTicketState} from '@atb/tickets';
+import {PreactivatedTicket} from '@atb/tickets';
 import {TicketTexts, useTranslation} from '@atb/translations';
 import React, {ReactElement} from 'react';
 import {View} from 'react-native';
@@ -21,10 +21,17 @@ import {ValidityStatus} from '@atb/screens/Ticketing/Ticket/utils';
 import {TicketAdd, TicketInvalid} from '@atb/assets/svg/mono-icons/ticketing';
 import {screenReaderPause} from '@atb/components/accessible-text';
 import {Warning} from '@atb/assets/svg/color/situations';
-import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
+import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';
 import {flatStaticColors, getStaticColor, StaticColor} from '@atb/theme/colors';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {Time} from '@atb/assets/svg/mono-icons/time';
+import {
+  findInspectable,
+  getDeviceName,
+  isMobileToken,
+  isTravelCardToken,
+} from '@atb/mobile-token/utils';
+import {RemoteToken} from '@atb/mobile-token/types';
 
 type TicketInfoProps = {
   travelRights: PreactivatedTicket[];
@@ -96,6 +103,49 @@ export const TicketInfoView = (props: TicketInfoViewProps) => {
   );
 };
 
+const WarningMessage = (
+  isError: boolean,
+  remoteTokens?: RemoteToken[],
+  isInspectable?: boolean,
+) => {
+  const {t} = useTranslation();
+  const inspectableToken = findInspectable(remoteTokens);
+  if (isError)
+    return (
+      <ThemeText type="body__secondary">
+        {t(TicketTexts.warning.unableToRetrieveToken)}
+      </ThemeText>
+    );
+  if (remoteTokens && remoteTokens.length === 0)
+    return (
+      <ThemeText type="body__secondary">
+        {t(TicketTexts.warning.noTokenFound)}
+      </ThemeText>
+    );
+  if (!inspectableToken)
+    return (
+      <ThemeText type="body__secondary">
+        {t(TicketTexts.warning.noInspectableTokenFound)}
+      </ThemeText>
+    );
+  if (isTravelCardToken(inspectableToken))
+    return (
+      <ThemeText type="body__secondary">
+        {t(TicketTexts.warning.travelCardAstoken)}
+      </ThemeText>
+    );
+  if (isMobileToken(inspectableToken) && !isInspectable)
+    return (
+      <ThemeText type="body__secondary">
+        {t(
+          TicketTexts.warning.anotherMobileAsToken(
+            getDeviceName(inspectableToken),
+          ),
+        )}
+      </ThemeText>
+    );
+};
+
 const TicketInfoTexts = (props: TicketInfoViewProps) => {
   const {
     preassignedFareProduct,
@@ -104,7 +154,6 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
     userProfilesWithCount,
     isInspectable,
     omitUserProfileCount,
-    status,
     testID,
   } = props;
   const {t, language} = useTranslation();
@@ -124,16 +173,8 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
       ? `${getReferenceDataName(u, language)}`
       : `${u.count} ${getReferenceDataName(u, language)}`;
 
-  const tokensEnabled = useHasEnabledMobileToken();
-  const {customerProfile} = useTicketState();
-  const hasTravelCard = !!customerProfile?.travelcard;
-
-  // show warning to use inspectable t:card for travellers still not on tokens, for tickets that are valid
-  const showTravelCardActiveWarning =
-    !tokensEnabled &&
-    hasTravelCard &&
-    status !== 'expired' &&
-    status !== 'refunded';
+  const {isError, remoteTokens} = useMobileTokenContextState();
+  const warning = WarningMessage(isError, remoteTokens, isInspectable);
 
   return (
     <View style={styles.textsContainer} accessible={true}>
@@ -169,12 +210,10 @@ const TicketInfoTexts = (props: TicketInfoViewProps) => {
           {tariffZoneSummary}
         </ThemeText>
       )}
-      {showTravelCardActiveWarning && (
-        <View style={styles.notInspectableWarning}>
-          <ThemeIcon svg={Warning} style={styles.notInspectableWarningIcon} />
-          <ThemeText isMarkdown={true}>
-            {t(TicketTexts.ticketInfo.travelcardIsActive)}
-          </ThemeText>
+      {warning && (
+        <View style={styles.warning}>
+          <ThemeIcon svg={Warning} style={styles.warningIcon} />
+          {warning}
         </View>
       )}
     </View>
@@ -340,11 +379,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     aspectRatio: 1,
     padding: theme.spacings.small,
   },
-  notInspectableWarning: {
+  warning: {
     flexDirection: 'row',
     paddingVertical: theme.spacings.small,
   },
-  notInspectableWarningIcon: {
+  warningIcon: {
     marginRight: theme.spacings.small,
   },
 }));

--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -116,12 +116,6 @@ const WarningMessage = (
         {t(TicketTexts.warning.unableToRetrieveToken)}
       </ThemeText>
     );
-  if (remoteTokens && remoteTokens.length === 0)
-    return (
-      <ThemeText type="body__secondary">
-        {t(TicketTexts.warning.noTokenFound)}
-      </ThemeText>
-    );
   if (!inspectableToken)
     return (
       <ThemeText type="body__secondary">

--- a/src/translations/screens/Ticket.ts
+++ b/src/translations/screens/Ticket.ts
@@ -126,10 +126,6 @@ const TicketTexts = {
       'Feil ved uthenting av mobil / t:kort',
       'Error retrieving mobile / t: card',
     ),
-    noTokenFound: _(
-      'Finner ikke t:kort / mobil på profilen din',
-      "Can't find t: card / mobile on your profile",
-    ),
     noInspectableTokenFound: _(
       'Du må bruke billett på t:kort eller mobil',
       'You must use a ticket on t: card or mobile',

--- a/src/translations/screens/Ticket.ts
+++ b/src/translations/screens/Ticket.ts
@@ -118,12 +118,31 @@ const TicketTexts = {
       _(`Ordre-id: ${orderId}`, `Order ID: ${orderId}`),
   },
   ticketInfo: {
-    travelcardIsActive: _(
-      'Du har valgt **t:kort** som gyldig reisebevis',
-      'You have specified **t:card** as valid travel token',
-    ),
     noInspectionIcon: _('Ikke bruk\ni kontroll', 'Not for\ninspection'),
     noInspectionIconA11yLabel: _('Ikke bruk i kontroll', 'Not for inspection'),
+  },
+  warning: {
+    unableToRetrieveToken: _(
+      'Feil ved uthenting av mobil / t:kort',
+      'Error retrieving mobile / t: card',
+    ),
+    noTokenFound: _(
+      'Finner ikke t:kort / mobil på profilen din',
+      "Can't find t: card / mobile on your profile",
+    ),
+    noInspectableTokenFound: _(
+      'Du må bruke billett på t:kort eller mobil',
+      'You must use a ticket on t: card or mobile',
+    ),
+    travelCardAstoken: _(
+      'Bruk t:kort når du reiser',
+      'Bring your t:card when you travel',
+    ),
+    anotherMobileAsToken: (deviceName?: string) =>
+      _(
+        `Bruk ${deviceName} når du reiser`,
+        `Bring ${deviceName} when you travel`,
+      ),
   },
 };
 export default TicketTexts;


### PR DESCRIPTION
Solves: https://github.com/AtB-AS/kundevendt/issues/220

Scenarios covered:

Case 1: Info on the ticket itself about errors (internet lack ex.)
Case 2: Info on the ticket itself if not token
Case 3: Info on the ticket itself when tokens are missing
Case 4: Info that the t: card is used as a travel document inside the ticket itself
Case 5: Info about mobile token is used as a travel document inside the ticket itself

Eg Case 5:

![Screenshot_20220629-154134](https://user-images.githubusercontent.com/29625161/176451264-ee3b6337-71ed-4b82-9986-505e419d34bd.jpg)


