### PR TITLE
fallback to unnamed device when device name could not be fetched

### DIFF
--- a/src/screens/Ticketing/Ticket/TicketInfo.tsx
+++ b/src/screens/Ticketing/Ticket/TicketInfo.tsx
@@ -32,6 +32,7 @@ import {
   isTravelCardToken,
 } from '@atb/mobile-token/utils';
 import {RemoteToken} from '@atb/mobile-token/types';
+import TravelTokenBoxTexts from '@atb/translations/components/TravelTokenBox';
 
 type TicketInfoProps = {
   travelRights: PreactivatedTicket[];
@@ -133,7 +134,8 @@ const WarningMessage = (
       <ThemeText type="body__secondary">
         {t(
           TicketTexts.warning.anotherMobileAsToken(
-            getDeviceName(inspectableToken),
+            getDeviceName(inspectableToken) ||
+              t(TicketTexts.warning.unnamedDevice),
           ),
         )}
       </ThemeText>

--- a/src/translations/screens/Ticket.ts
+++ b/src/translations/screens/Ticket.ts
@@ -139,6 +139,7 @@ const TicketTexts = {
         `Bruk ${deviceName} når du reiser`,
         `Bring ${deviceName} when you travel`,
       ),
+    unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },
 };
 export default TicketTexts;


### PR DESCRIPTION
Found minor bug while verifying https://github.com/AtB-AS/kundevendt/issues/220.