### PR TITLE
fix: recover saving of Nets-based payment methods

### DIFF
--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -44,10 +44,10 @@ export type RouteParams = {
   headerLeftButton: LeftButtonProps;
 };
 
-async function getPreviousPaymentMethod(
+function getPreviousPaymentMethod(
   previousPaymentMethod: SavedPaymentOption | undefined,
   paymentTypes: PaymentType[],
-): Promise<PaymentMethod | undefined> {
+): PaymentMethod | undefined {
   if (!previousPaymentMethod) return undefined;
 
   if (!paymentTypes.includes(previousPaymentMethod.paymentType))
@@ -141,15 +141,11 @@ const Confirmation: React.FC<ConfirmationProps> = ({
   const vatPercentString = formatDecimalNumber(vatPercent, language);
 
   useEffect(() => {
-    const getPrevMethod = async () => {
-      const prevMethod = await getPreviousPaymentMethod(
-        previousPaymentMethod,
-        paymentTypes,
-      );
-      setPreviousMethod(prevMethod);
-    };
-
-    getPrevMethod();
+    const prevMethod = getPreviousPaymentMethod(
+      previousPaymentMethod,
+      paymentTypes,
+    );
+    setPreviousMethod(prevMethod);
   }, [previousPaymentMethod]);
 
   async function payWithVipps(option: PaymentMethod) {

--- a/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
@@ -78,6 +78,7 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
     error,
     restartTerminal,
     cancelPayment,
+    handleInitialLoadingError,
   } = useTerminalState(
     offers,
     paymentType,
@@ -109,8 +110,9 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
             source={{
               uri: terminalUrl,
             }}
+            onError={handleInitialLoadingError}
             onLoadStart={onWebViewLoadStart}
-            onLoadEnd={onWebViewLoadEnd}
+            onNavigationStateChange={onWebViewLoadEnd}
           />
         )}
       </View>

--- a/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/SelectPaymentMethod/index.tsx
@@ -339,6 +339,11 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
           paymentType: option.paymentType,
           recurringPaymentId: option.recurringCard.id,
         };
+      case 'recurring-without-card':
+        return {
+          paymentType: option.paymentType,
+          recurringPaymentId: option.recurringPaymentId,
+        };
     }
   }
 

--- a/src/screens/Ticketing/Purchase/types.ts
+++ b/src/screens/Ticketing/Purchase/types.ts
@@ -29,5 +29,13 @@ export type RecurringPaymentOption = {
   paymentType: PaymentType.Visa | PaymentType.Mastercard;
   recurringCard: SavedRecurringPayment;
 };
+export type RecurringPaymentWithoutCardOption = {
+  savedType: 'recurring-without-card';
+  paymentType: PaymentType.Visa | PaymentType.Mastercard;
+  recurringPaymentId: number;
+};
 
-export type SavedPaymentOption = DefaultPaymentOption | RecurringPaymentOption;
+export type SavedPaymentOption =
+  | DefaultPaymentOption
+  | RecurringPaymentOption
+  | RecurringPaymentWithoutCardOption;


### PR DESCRIPTION
Should fix https://github.com/AtB-AS/kundevendt/issues/108

Could be worth looking at the error handling, a bit unsure about that part. Maybe you remember what we were planning there, @mikaelbr?

A bit unsure about how this actually worked before, but we are now migrating from listening to the `onLoadEnd` event in the WebView, and instead listening to the `onNavigationStateChange` events. This is because the `onLoadEnd` event never fired, because the WebView itself seemed to be navigated away from and interrupted before the event.

Additionally, we previously saved all recurring payment data at Entur just after purchase, and fetched it back immediately, which probably hasn't been working for some time. We are now only saving the payment data at Entur during the purchase, and fetching it back the first time when trying to use it. This mitigates the race condition that occured when both saving and fetching the recurring payment details simultaneously, and it also seems it has shaved some microseconds off the payment process.