### PR TITLE
fix: Change order of the terms t:kort and mobilen

### DIFF
--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -30,8 +30,8 @@ const TravelTokenBoxTexts = {
   ),
   errorMessages: {
     tokensNotLoadedTitle: _(
-      'Klarer ikke hente informasjon om mobil / t:kort.',
-      'Unable to retrieve information about your phone / t:card.',
+      'Klarer ikke hente informasjon om t:kort / mobil.',
+      'Unable to retrieve information about your t:card / phone.',
     ),
     tokensNotLoaded: _(
       'Billetter må brukes på enten et t:kort eller en mobil, men akkurat nå klarer vi ikke finne ut hvor den er i bruk. Sjekk at du har tilgang på nett der du er.',
@@ -42,8 +42,8 @@ const TravelTokenBoxTexts = {
       'Choose where your tickets are used',
     ),
     noInspectableToken: _(
-      'Billetter må brukes på enten et t:kort eller en mobil, og det ser ikke ut som du har valgt en av dem.\n\nGå til **Min profil, Bytt mellom mobil / t:kort** for å velge.',
-      `Tickets must be used on either a t:card or a phone, and it looks like you haven't chosen one. Go to **My profile, switch between phone / t:card** to select`,
+      'Billetter må brukes på enten et t:kort eller en mobil, og det ser ikke ut som du har valgt en av dem.\n\nGå til **Min profil, Bytt mellom t:kort / mobil** for å velge.',
+      `Tickets must be used on either a t:card or a phone, and it looks like you haven't chosen one. Go to **My profile, switch between t:card / phone** to select`,
     ),
   },
 };

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -48,8 +48,8 @@ const ProfileTexts = {
         },
         travelToken: {
           label: _(
-            'Bruk billett på mobil / t:kort',
-            'Use ticket on phone / t:card',
+            'Bruk billett på t:kort / mobil',
+            'Use ticket on t:card / phone',
           ),
           flag: _('Ny', 'New'),
         },

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -3,13 +3,13 @@ const SelectTravelTokenTexts = {
   travelToken: {
     header: {
       title: _(
-        'Bruk billett på mobil / t:kort',
-        'Use ticket on phone / t:card',
+        'Bruk billett på t:kort / mobil',
+        'Use ticket on t:card / phone',
       ),
     },
     changeTokenButton: _(
-      'Bytt mellom mobil / t:kort',
-      'Switch between phone / t:card',
+      'Bytt mellom t:kort / mobil',
+      'Switch between t:card / phone',
     ),
     faq: {
       title: _('Ofte stilte spørsmål', 'Frequently asked questions'),
@@ -17,8 +17,8 @@ const SelectTravelTokenTexts = {
     faqs: [
       {
         question: _(
-          'Hva skjer om jeg mister mobilen eller t:kortet?',
-          'What happens if I lose my phone or t:card?',
+          'Hva skjer om jeg mister t:kortet eller mobilen?',
+          'What happens if I lose my t:card or phone?',
         ),
         answer: _(
           'Du kan enkelt velge å bruke billetten din på et annet t:kort eller mobil. Det gjør du på **Min profil**.',
@@ -58,7 +58,7 @@ const SelectTravelTokenTexts = {
     ],
   },
   toggleToken: {
-    title: _('Bytt mellom mobil / t:kort', 'Switch between phone / t:card'),
+    title: _('Bytt mellom t:kort / mobil', 'Switch between t:card / phone'),
     radioBox: {
       tCard: {
         title: _('t:kort', 't:card'),


### PR DESCRIPTION
The translations have been changed with the right order for t:kort and mobilen / t:card and phone.