### PR TITLE
fix: add correct label on buttons

### DIFF
--- a/src/screens/MobileTokenOnboarding/InspectableTokenScreen.tsx
+++ b/src/screens/MobileTokenOnboarding/InspectableTokenScreen.tsx
@@ -78,7 +78,11 @@ export function InspectableTokenScreen({
             onPress={() => {
               navigation.navigate('SelectTravelToken');
             }}
-            text={t(MobileTokenOnboardingTexts.phone.button)}
+            text={
+              isTravelCardToken(inspectableToken)
+                ? t(MobileTokenOnboardingTexts.tCard.button)
+                : t(MobileTokenOnboardingTexts.phone.button)
+            }
             testID="switchButton"
           />
         </View>


### PR DESCRIPTION
**Needs to be included in v1.22**

As of now we have same label for both the cases which is not relevant to both of them. 
Please ignore the error in place of relevant token details, its the buttons that have been fiexed.

<div><img width="200" alt="image" src="https://user-images.githubusercontent.com/29625161/178930859-f6fce5d0-3b72-40c4-bd68-0338909cfa0a.jpg">
<img width="200" alt="image" src="https://user-images.githubusercontent.com/29625161/178930873-bf9c1ded-3b9d-491a-8fc6-2424fa30d112.jpg">
</div>


