### PR TITLE
feat: use different accessibility labels for different stop icons

### DIFF
--- a/src/components/location-icon/index.tsx
+++ b/src/components/location-icon/index.tsx
@@ -3,9 +3,9 @@ import {Location as LocationMonoIcon} from '@atb/assets/svg/mono-icons/places';
 import * as TransportationIcons from '@atb/assets/svg/mono-icons/transportation';
 import * as EnturTransportationIcons from '@atb/assets/svg/mono-icons/transportation-entur';
 import {Location} from '@atb/favorites/types';
-import {FeatureCategory} from '@atb/sdk';
 import React from 'react';
 import ThemeIcon from '@atb/components/theme-icon';
+import {getVenueIconTypes} from '@atb/location-search/utils';
 
 const LocationIcon = ({
   location,
@@ -22,9 +22,7 @@ const LocationIcon = ({
     case 'address':
       return <ThemeIcon svg={Pin} />;
     case 'venue':
-      const venueIconTypes = location.category
-        .map(mapCategoryToVenueIconType)
-        .filter((v, i, arr) => arr.indexOf(v) === i); // get distinct values
+      const venueIconTypes = getVenueIconTypes(location.category);
 
       if (!venueIconTypes.length) {
         return <ThemeIcon svg={Pin} />;
@@ -88,29 +86,6 @@ const mapTypeToIconComponent = (iconType: VenueIconType) => {
       return (
         <ThemeIcon svg={Pin} accessibilityLabel="Lokasjon" key="unknown" />
       );
-  }
-};
-
-const mapCategoryToVenueIconType = (category: FeatureCategory) => {
-  switch (category) {
-    case 'onstreetBus':
-    case 'busStation':
-    case 'coachStation':
-      return 'bus';
-    case 'onstreetTram':
-    case 'tramStation':
-      return 'tram';
-    case 'railStation':
-    case 'metroStation':
-      return 'rail';
-    case 'airport':
-      return 'airport';
-    case 'harbourPort':
-    case 'ferryPort':
-    case 'ferryStop':
-      return 'boat';
-    default:
-      return 'unknown';
   }
 };
 

--- a/src/location-search/LocationResults.tsx
+++ b/src/location-search/LocationResults.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import {View, TouchableOpacity} from 'react-native';
+import {TouchableOpacity, View} from 'react-native';
 import {StyleSheet} from '../theme';
 import LocationIcon from '../components/location-icon';
 import insets from '../utils/insets';
-import {ArrowUpLeft} from '../assets/svg/mono-icons/navigation';
 import {LocationSearchResult} from './types';
 import {FavoriteIcon} from '../favorites';
 import ThemeText from '../components/text';
-import ThemeIcon from '../components/theme-icon';
 import {screenReaderPause} from '../components/accessible-text';
-import {LocationSearchTexts, useTranslation} from '@atb/translations';
+import {
+  LocationSearchTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
+import {getVenueIconTypes} from '@atb/location-search/utils';
+import {SearchLocation} from '@atb/favorites/types';
 
 type Props = {
   title?: string;
@@ -26,6 +30,7 @@ const LocationResults: React.FC<Props> = ({
 }) => {
   const styles = useThemeStyles();
   const {t} = useTranslation();
+
   return (
     <>
       {title && (
@@ -40,7 +45,9 @@ const LocationResults: React.FC<Props> = ({
               <TouchableOpacity
                 accessible={true}
                 accessibilityLabel={
-                  searchResult.location.label + screenReaderPause
+                  getLocationIconAccessibilityLabel(searchResult.location, t) +
+                  searchResult.location.label +
+                  screenReaderPause
                 }
                 accessibilityHint={t(
                   LocationSearchTexts.locationResults.a11y.activateToUse,
@@ -108,6 +115,21 @@ function mapToVisibleSearchResult(searchResult: LocationSearchResult) {
     emoji: searchResult.favoriteInfo.emoji,
   };
 }
+
+const getLocationIconAccessibilityLabel = (
+  {layer, category}: SearchLocation,
+  t: TranslateFunction,
+) => {
+  switch (layer) {
+    case 'venue':
+      return getVenueIconTypes(category)
+        .map((c) => t(LocationSearchTexts.locationResults.category[c]))
+        .join(',');
+    case 'address':
+    default:
+      return t(LocationSearchTexts.locationResults.category.location);
+  }
+};
 
 export default LocationResults;
 

--- a/src/location-search/utils.ts
+++ b/src/location-search/utils.ts
@@ -6,6 +6,7 @@ import {
 import {useSearchHistory} from '@atb/search-history';
 import {LocationSearchResult} from './types';
 import {getLocationLayer} from '@atb/utils/location';
+import {FeatureCategory} from '@atb/sdk';
 
 export function useFilteredJourneySearch(searchText?: string) {
   const {journeyHistory} = useSearchHistory();
@@ -76,4 +77,33 @@ export const filterCurrentLocation = (
   return locations
     .filter((l) => !previousLocations.some((pl) => pl.location.id === l.id))
     .map((location) => ({location}));
+};
+
+export const getVenueIconTypes = (category: FeatureCategory[]) => {
+  return category
+    .map(mapLocationCategoryToVenueType)
+    .filter((v, i, arr) => arr.indexOf(v) === i); // get distinct values
+};
+
+const mapLocationCategoryToVenueType = (category: FeatureCategory) => {
+  switch (category) {
+    case 'onstreetBus':
+    case 'busStation':
+    case 'coachStation':
+      return 'bus';
+    case 'onstreetTram':
+    case 'tramStation':
+      return 'tram';
+    case 'railStation':
+    case 'metroStation':
+      return 'rail';
+    case 'airport':
+      return 'airport';
+    case 'harbourPort':
+    case 'ferryPort':
+    case 'ferryStop':
+      return 'boat';
+    default:
+      return 'unknown';
+  }
 };

--- a/src/translations/screens/subscreens/LocationSearch.ts
+++ b/src/translations/screens/subscreens/LocationSearch.ts
@@ -38,6 +38,15 @@ const LocationSearchTexts = {
         'Activate to use this location',
       ),
     },
+    category: {
+      bus: _('Bussholdeplass', 'Bus stop'),
+      tram: _('Trikkeholdeplass', 'Tram stop'),
+      rail: _('Togstasjon', 'Train station'),
+      airport: _('Flyplass', 'Airport'),
+      boat: _('Fergeleie', 'Ferry stop'),
+      unknown: _('Lokasjon', 'Location'),
+      location: _('Lokasjon', 'Location'),
+    },
   },
   messages: {
     networkError: _(


### PR DESCRIPTION
Solves https://github.com/AtB-AS/kundevendt/issues/111

Please find some examples of how the accessibility labels would sound like :

- Tram stop Skansen, Trondheim. Activate to use this location.
- Bus stop Skansen, Trondheim. Activate to use this location.
- Airport Trondheim lufthavan, Størdal. Activate to use this location.
- Location Skansen, Trondheim. Activate to use this location. (This would be used when the resulted location is not a specific stop but just a location)