### PR TITLE
feat: add separate tab for favourite tabs

### DIFF
--- a/src/components/disappearing-header/simple.tsx
+++ b/src/components/disappearing-header/simple.tsx
@@ -31,7 +31,7 @@ type Props = {
   isFullHeight?: boolean;
 
   useScroll?: boolean;
-  headerTitle: React.ReactNode;
+  headerTitle?: React.ReactNode;
   alternativeTitleComponent?: React.ReactNode;
 
   leftButton?: LeftButtonProps;
@@ -123,17 +123,19 @@ const SimpleDisappearingHeader: React.FC<Props> = ({
 
   return (
     <>
-      <View style={[styles.topBorder, screenTopStyle]} />
+      <View style={headerTitle ? [styles.topBorder, screenTopStyle] : {}} />
       <View style={styles.screen}>
         <View onLayout={onScreenHeaderLayout}>
-          <AnimatedScreenHeader
-            title={headerTitle}
-            rightButton={{type: 'chat', color: themeColor, testID: 'rhb'}}
-            alternativeTitleComponent={alternativeTitleComponent}
-            scrollRef={isRefreshing ? nullRef : scrollYRef}
-            leftButton={leftButton}
-            setFocusOnLoad={setFocusOnLoad}
-          />
+          {headerTitle && (
+            <AnimatedScreenHeader
+              title={headerTitle}
+              rightButton={{type: 'chat', color: themeColor, testID: 'rhb'}}
+              alternativeTitleComponent={alternativeTitleComponent}
+              scrollRef={isRefreshing ? nullRef : scrollYRef}
+              leftButton={leftButton}
+              setFocusOnLoad={setFocusOnLoad}
+            />
+          )}
           <View style={styles.alertBoxContainer}>
             <AlertBox alertContext={alertContext} style={styles.alertBox} />
           </View>

--- a/src/screens/Departures/FavouriteStopsOverview.tsx
+++ b/src/screens/Departures/FavouriteStopsOverview.tsx
@@ -5,7 +5,9 @@ import {Place, StopPlacePosition} from '@atb/api/types/departures';
 import {CompositeNavigationProp} from '@react-navigation/native';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import {useTranslation} from '@atb/translations';
-import StopPlaces from '@atb/screens/Departures/components/StopPlaces';
+import StopPlaces, {
+  NoStopPlaceMessage,
+} from '@atb/screens/Departures/components/StopPlaces';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {DeparturesStackParams} from '@atb/screens/Departures/index';
 import {RootStackParamList} from '@atb/navigation';
@@ -76,7 +78,10 @@ const FavouriteStopsOverview = ({navigation}: RootProps) => {
       testID={'favouriteStopsContainerView'}
     />
   ) : (
-    <></>
+    <NoStopPlaceMessage
+      header={t(DeparturesTexts.resultType.favourites)}
+      notStopPlaceMessage={t(DeparturesTexts.message.noFavourites)}
+    />
   );
 };
 

--- a/src/screens/Departures/FavouriteStopsOverview.tsx
+++ b/src/screens/Departures/FavouriteStopsOverview.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {useStopsDetailsData} from '@atb/screens/Departures/state/stop-place-details-state';
+import {useFavorites} from '@atb/favorites';
+import {Place, StopPlacePosition} from '@atb/api/types/departures';
+import {CompositeNavigationProp} from '@react-navigation/native';
+import DeparturesTexts from '@atb/translations/screens/Departures';
+import {useTranslation} from '@atb/translations';
+import StopPlaces from '@atb/screens/Departures/components/StopPlaces';
+import {StackNavigationProp} from '@react-navigation/stack';
+import {DeparturesStackParams} from '@atb/screens/Departures/index';
+import {RootStackParamList} from '@atb/navigation';
+import {useGeolocationState} from '@atb/GeolocationContext';
+import {coordinatesDistanceInMetres} from '@atb/utils/location';
+
+type FavouritePlacesNavigationProp = CompositeNavigationProp<
+  StackNavigationProp<DeparturesStackParams>,
+  StackNavigationProp<RootStackParamList>
+>;
+
+type RootProps = {
+  navigation: FavouritePlacesNavigationProp;
+};
+
+const FavouriteStopsOverview = ({navigation}: RootProps) => {
+  const {favoriteDepartures} = useFavorites();
+  const {location} = useGeolocationState();
+  const favouriteStopIds = new Set(favoriteDepartures.map((fd) => fd.stopId));
+  const {state} = useStopsDetailsData(Array.from(favouriteStopIds));
+  const currentLocation = location || undefined;
+
+  const getDistanceFromCurrentLocation = (
+    latitude?: number,
+    longitude?: number,
+  ) => {
+    return (
+      currentLocation &&
+      latitude &&
+      longitude &&
+      coordinatesDistanceInMetres(currentLocation.coordinates, {
+        latitude: latitude,
+        longitude: longitude,
+      })
+    );
+  };
+
+  const favouriteStopsDetails = state.data?.stopPlaces
+    .map((stopPlace): StopPlacePosition => {
+      return {
+        node: {
+          distance: getDistanceFromCurrentLocation(
+            stopPlace.latitude,
+            stopPlace.longitude,
+          ),
+          place: {...stopPlace},
+        },
+      };
+    })
+    .sort((edgeA, edgeB) => {
+      if (edgeA.node?.distance === undefined) return 1;
+      if (edgeB.node?.distance === undefined) return -1;
+      return edgeA.node?.distance > edgeB.node?.distance ? 1 : -1;
+    });
+
+  const {t} = useTranslation();
+  const navigateToPlace = (place: Place) => {
+    navigation.navigate('PlaceScreen', {
+      place,
+    });
+  };
+
+  return favouriteStopsDetails ? (
+    <StopPlaces
+      header={t(DeparturesTexts.resultType.favourites)}
+      stopPlaces={favouriteStopsDetails}
+      navigateToPlace={navigateToPlace}
+      testID={'favouriteStopsContainerView'}
+    />
+  ) : (
+    <></>
+  );
+};
+
+export default FavouriteStopsOverview;

--- a/src/screens/Departures/NearbyPlacesScreen.tsx
+++ b/src/screens/Departures/NearbyPlacesScreen.tsx
@@ -33,8 +33,8 @@ export default function NearbyPlacesScreen() {
       <View style={style.container}>
         <Tab.Navigator
           tabBarOptions={{
-            activeTintColor: theme.interactive.interactive_2.default.background,
-            inactiveTintColor: theme.text.colors.disabled,
+            activeTintColor: theme.interactive.interactive_1.active.text,
+            inactiveTintColor: theme.interactive.interactive_1.active.text,
             indicatorStyle: {
               backgroundColor:
                 theme.static.background.background_accent_0.background,

--- a/src/screens/Departures/NearbyPlacesScreen.tsx
+++ b/src/screens/Departures/NearbyPlacesScreen.tsx
@@ -1,0 +1,93 @@
+import {useGeolocationState} from '@atb/GeolocationContext';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {useTranslation} from '@atb/translations';
+import React from 'react';
+import {View} from 'react-native';
+import Loading from '../Loading';
+import DeparturesTexts from '@atb/translations/screens/Departures';
+import {useServiceDisruptionSheet} from '@atb/service-disruptions';
+import FavouriteStopsOverview from '@atb/screens/Departures/FavouriteStopsOverview';
+import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
+import FullScreenHeader from '@atb/components/screen-header/full-header';
+import {AllStopsOverview} from '@atb/screens/Departures/AllStopsOverview';
+
+const Tab = createMaterialTopTabNavigator();
+
+export default function NearbyPlacesScreen() {
+  const {theme} = useTheme();
+  const {t} = useTranslation();
+  const {status} = useGeolocationState();
+  const {leftButton} = useServiceDisruptionSheet();
+  const style = useStyles();
+  if (!status) {
+    return <Loading />;
+  }
+  return (
+    <>
+      <FullScreenHeader
+        title={t(DeparturesTexts.header.title)}
+        rightButton={{type: 'chat'}}
+        leftButton={leftButton}
+        alertContext="ticketing"
+      />
+      <View style={style.container}>
+        <Tab.Navigator
+          tabBarOptions={{
+            activeTintColor: theme.interactive.interactive_2.default.background,
+            inactiveTintColor: theme.text.colors.disabled,
+            indicatorStyle: {
+              backgroundColor:
+                theme.static.background.background_accent_0.background,
+              height: '100%',
+              borderRadius: 12,
+              borderColor: theme.interactive.interactive_1.default.background,
+              borderWidth: theme.border.width.medium * 2,
+            },
+            style: {
+              backgroundColor:
+                theme.interactive.interactive_1.default.background,
+              borderRadius: 12,
+              margin: theme.spacings.medium,
+              marginBottom: theme.spacings.large,
+              alignContent: 'center',
+              justifyContent: 'center',
+            },
+            labelStyle: {
+              textTransform: 'none',
+              fontSize: theme.typography.body__primary.fontSize,
+            },
+            tabStyle: {
+              justifyContent: 'center',
+            },
+          }}
+        >
+          <Tab.Screen
+            name={'AllStopsOverview'}
+            options={{
+              tabBarLabel: t(DeparturesTexts.resultType.all),
+              tabBarAccessibilityLabel: t(DeparturesTexts.resultType.all),
+            }}
+            component={AllStopsOverview}
+          />
+          <Tab.Screen
+            name={'FavouriteStopsOverview'}
+            component={FavouriteStopsOverview}
+            options={{
+              tabBarLabel: t(DeparturesTexts.resultType.favourites),
+              tabBarAccessibilityLabel: t(
+                DeparturesTexts.resultType.favourites,
+              ),
+            }}
+          />
+        </Tab.Navigator>
+      </View>
+    </>
+  );
+}
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.static.background.background_accent_0.background,
+  },
+}));

--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -12,8 +12,8 @@ import DeparturesTexts from '@atb/translations/screens/Departures';
 import {DeparturesStackParams} from '.';
 import QuayView from './QuayView';
 import StopPlaceView from './StopPlaceView';
-import {SearchTime} from './NearbyPlaces';
 import {useStopsDetailsData} from './state/stop-place-details-state';
+import {SearchTime} from '@atb/screens/Departures/utils';
 
 export type PlaceScreenParams = {
   place: Place;

--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect} from 'react';
 import {RefreshControl, SectionList, SectionListData} from 'react-native';
 import {Place, Quay} from '@atb/api/types/departures';
-import {SearchTime} from './NearbyPlaces';
 import DateNavigation from './components/DateNavigator';
 import QuaySection from './components/QuaySection';
 import {useQuayData} from './state/quay-state';
 import stop from '@atb/assets/svg/mono-icons/places/Stop';
+import {SearchTime} from '@atb/screens/Departures/utils';
 
 export type QuayViewParams = {
   quay: Quay;

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -2,10 +2,10 @@ import React, {useEffect, useMemo} from 'react';
 import {RefreshControl, SectionList, SectionListData} from 'react-native';
 import {useStopPlaceData} from './state/stop-place-state';
 import {Place, Quay} from '@atb/api/types/departures';
-import {SearchTime} from './NearbyPlaces';
 import DateNavigation from './components/DateNavigator';
 import QuaySection from './components/QuaySection';
 import Feedback from '@atb/components/feedback';
+import {SearchTime} from '@atb/screens/Departures/utils';
 
 type StopPlaceViewProps = {
   stopPlace: Place;

--- a/src/screens/Departures/components/DateNavigator.tsx
+++ b/src/screens/Departures/components/DateNavigator.tsx
@@ -1,5 +1,5 @@
 import {StyleSheet, useTheme} from '@atb/theme';
-import React, {Dispatch, SetStateAction} from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import Button from '@atb/components/button';
 import {Language, useTranslation} from '@atb/translations';
@@ -11,11 +11,11 @@ import {
 } from '@atb/utils/date';
 import {ArrowLeft, ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {Date as DateIcon} from '@atb/assets/svg/mono-icons/time';
-import {SearchTime} from '../NearbyPlaces';
 import {addDays, isSameDay, isToday, parseISO} from 'date-fns';
 import DepartureTimeSheet from '../../Nearby/DepartureTimeSheet';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import DeparturesTexts from '@atb/translations/screens/Departures';
+import {SearchTime} from '@atb/screens/Departures/utils';
 
 type DateNavigationProps = {
   searchTime: SearchTime;

--- a/src/screens/Departures/components/StopPlaces.tsx
+++ b/src/screens/Departures/components/StopPlaces.tsx
@@ -2,8 +2,10 @@ import ThemeText from '@atb/components/text';
 import {Place, StopPlacePosition} from '@atb/api/types/departures';
 import StopPlaceItem from '@atb/screens/Departures/components/StopPlaceItem';
 import React from 'react';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {ScrollView} from 'react-native-gesture-handler';
+import {View} from 'react-native';
+import MessageBox from '@atb/components/message-box';
 
 const StopPlaces = ({
   header,
@@ -21,7 +23,7 @@ const StopPlaces = ({
     <ScrollView style={styles.container} testID={testID}>
       {header && (
         <ThemeText
-          style={styles.listDescription}
+          style={styles.header}
           type="body__secondary"
           color="secondary"
         >
@@ -40,13 +42,39 @@ const StopPlaces = ({
   );
 };
 
+export const NoStopPlaceMessage = ({
+  header,
+  notStopPlaceMessage,
+}: {
+  header: string;
+  notStopPlaceMessage: string;
+}) => {
+  const styles = useStyles();
+  const {theme} = useTheme();
+  return (
+    <View style={styles.container}>
+      <ThemeText style={styles.header} type="body__secondary" color="secondary">
+        {header}
+      </ThemeText>
+      <MessageBox type="info" containerStyle={styles.noStopMessage}>
+        <ThemeText style={{color: theme.static.status.warning.text}}>
+          {notStopPlaceMessage}
+        </ThemeText>
+      </MessageBox>
+    </View>
+  );
+};
+
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     paddingVertical: theme.spacings.medium,
   },
-  listDescription: {
+  header: {
     paddingVertical: theme.spacings.medium,
     paddingHorizontal: theme.spacings.medium * 2,
+  },
+  noStopMessage: {
+    marginHorizontal: theme.spacings.large,
   },
 }));
 

--- a/src/screens/Departures/components/StopPlaces.tsx
+++ b/src/screens/Departures/components/StopPlaces.tsx
@@ -1,0 +1,53 @@
+import ThemeText from '@atb/components/text';
+import {Place, StopPlacePosition} from '@atb/api/types/departures';
+import StopPlaceItem from '@atb/screens/Departures/components/StopPlaceItem';
+import React from 'react';
+import {StyleSheet} from '@atb/theme';
+import {ScrollView} from 'react-native-gesture-handler';
+
+const StopPlaces = ({
+  header,
+  stopPlaces,
+  navigateToPlace,
+  testID,
+}: {
+  header?: string;
+  stopPlaces: StopPlacePosition[];
+  navigateToPlace: (place: Place) => void;
+  testID: string;
+}) => {
+  const styles = useStyles();
+  return (
+    <ScrollView style={styles.container} testID={testID}>
+      {header && (
+        <ThemeText
+          style={styles.listDescription}
+          type="body__secondary"
+          color="secondary"
+        >
+          {header}
+        </ThemeText>
+      )}
+      {stopPlaces.map((stopPlacePosition: StopPlacePosition) => (
+        <StopPlaceItem
+          key={stopPlacePosition.node?.place?.id}
+          stopPlacePosition={stopPlacePosition}
+          onPress={navigateToPlace}
+          testID={'stopPlaceItem' + stopPlaces.indexOf(stopPlacePosition)}
+        />
+      ))}
+    </ScrollView>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    paddingVertical: theme.spacings.medium,
+  },
+  listDescription: {
+    paddingVertical: theme.spacings.medium,
+    paddingHorizontal: theme.spacings.medium * 2,
+  },
+}));
+
+export default StopPlaces;

--- a/src/screens/Departures/index.tsx
+++ b/src/screens/Departures/index.tsx
@@ -1,9 +1,6 @@
 import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 import React from 'react';
-import DeparturesRoot, {
-  NearbyPlacesParams,
-  DeparturesProps,
-} from './NearbyPlaces';
+import DeparturesRoot from './NearbyPlacesScreen';
 import PlaceScreen, {PlaceScreenParams} from './PlaceScreen';
 import DepartureDetails, {
   DepartureDetailsRouteParams,
@@ -13,9 +10,11 @@ import QuayDepartures, {
 } from '../TripDetails/QuayDepartures';
 import TripDetailsRoot, {DetailsStackParams} from '../TripDetails';
 import TravelDetailsMap, {MapDetailRouteParams} from '../TripDetails/Map';
+import {AllStopsOverviewParams} from '@atb/screens/Departures/AllStopsOverview';
 
 export type DeparturesStackParams = {
-  DeparturesRoot: NearbyPlacesParams;
+  DeparturesRoot: undefined;
+  AllStopsOverview: AllStopsOverviewParams;
   PlaceScreen: PlaceScreenParams;
   DepartureDetails: DepartureDetailsRouteParams;
   QuayDepartures: QuayDeparturesRouteParams;
@@ -25,21 +24,13 @@ export type DeparturesStackParams = {
 
 const Stack = createStackNavigator<DeparturesStackParams>();
 
-type DeparturesRootProps = {
-  route: DeparturesProps;
-};
-
-const DeparturesScreen = ({route}: DeparturesRootProps) => {
+const DeparturesScreen = () => {
   return (
     <Stack.Navigator
       initialRouteName="DeparturesRoot"
       screenOptions={{headerShown: false}}
     >
-      <Stack.Screen
-        name="DeparturesRoot"
-        component={DeparturesRoot}
-        initialParams={route.params}
-      />
+      <Stack.Screen name="DeparturesRoot" component={DeparturesRoot} />
       <Stack.Screen name="PlaceScreen" component={PlaceScreen} />
       <Stack.Screen name="DepartureDetails" component={DepartureDetails} />
       <Stack.Screen name="QuayDepartures" component={QuayDepartures} />

--- a/src/screens/Departures/utils.ts
+++ b/src/screens/Departures/utils.ts
@@ -1,0 +1,6 @@
+export const DateOptions = ['now', 'departure'] as const;
+export type DateOptionType = typeof DateOptions[number];
+export type SearchTime = {
+  option: DateOptionType;
+  date: string;
+};

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -63,5 +63,9 @@ const DeparturesTexts = {
     'Aktiver for å se detaljer',
     'Activate to view details',
   ),
+  resultType: {
+    all: _('Alle holdeplasser', 'All Stops'),
+    favourites: _('Favoritter', 'Favourites'),
+  },
 };
 export default DeparturesTexts;

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -67,5 +67,11 @@ const DeparturesTexts = {
     all: _('Alle holdeplasser', 'All Stops'),
     favourites: _('Favoritter', 'Favourites'),
   },
+  message: {
+    noFavourites: _(
+      'Det er ingen avganger som skal vises, da du ikke har noen stopp merket som favoritter.',
+      'There are no departures to be shown, as you have no stops marked as favorites.',
+    ),
+  },
 };
 export default DeparturesTexts;


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/151

Every stop that has one or more lines marked as Favourite, should appear in the favorites tab. 

<div>
<img width="250" src="https://user-images.githubusercontent.com/29625161/182127227-740d1788-3134-4cf7-979d-0817cf1a3f95.png"/>
<img width="250" src="https://user-images.githubusercontent.com/29625161/182127288-aa644571-dcfc-469a-9f08-7ee4e9fea87b.png"/>
<img width="250" src="https://user-images.githubusercontent.com/29625161/182935658-76948516-5c66-4ac5-a72a-6f6f7c4d9b10.png"/>
</div>

