### PR TITLE
feat: render results and hence error messages even when the to and from locations combo is not valid

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -453,7 +453,7 @@ const Assistant: React.FC<Props> = ({
       alertContext="travel"
     >
       <ScreenReaderAnnouncement message={searchStateMessage} />
-      {isValidLocations && (
+      {from && to && (
         <Results
           tripPatterns={tripPatterns}
           isSearching={isSearching}


### PR DESCRIPTION
Solves https://github.com/AtB-AS/kundevendt/issues/1944

The messages are already in place but were not being rendered. So just had to modify a condition to get them back. 
<div>
<img width="300" src="https://user-images.githubusercontent.com/29625161/182151008-e1a59986-d078-4910-8984-7d274cf523cc.png"/>
<img width="300" src="https://user-images.githubusercontent.com/29625161/182151053-7a51f2b6-4caa-4cba-b232-03024bdf0a42.png"/>
</div>