### PR TITLE
feat: fetch more departures that shown in screen to show when one or more trips have passed

### DIFF
--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -11,6 +11,7 @@ import {EstimatedCall, Place, Quay} from '@atb/api/types/departures';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import EstimatedCallItem from './EstimatedCallItem';
 import SectionSeparator from '@atb/components/sections/section-separator';
+import {DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW} from '@atb/screens/Departures/state/stop-place-state';
 
 type QuaySectionProps = {
   quay: Quay;
@@ -88,7 +89,10 @@ export default function QuaySection({
         {!isHidden && (
           <FlatList
             ItemSeparatorComponent={SectionSeparator}
-            data={departures}
+            data={
+              departures &&
+              departures.slice(0, DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW)
+            }
             renderItem={({item: departure, index}: EstimatedCallRenderItem) => (
               <Sections.GenericItem
                 radius={

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -23,7 +23,12 @@ import {flatMap} from 'lodash';
 import {EstimatedCall, Place} from '@atb/api/types/departures';
 import {getSecondsUntilMidnightOrMinimum} from './quay-state';
 
-const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
+export const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
+
+//We fetch double the number of departures to be shown,
+// so that we have more departures to show when one or more departures have already passed
+export const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_BE_FETCHED =
+  DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW * 2;
 
 // Used to re-trigger full refresh after N minutes.
 // To repopulate the view when we get fewer departures.
@@ -42,7 +47,7 @@ export type DepartureDataState = {
 };
 
 const initialQueryInput: DepartureGroupsQuery = {
-  limitPerLine: DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW,
+  limitPerLine: DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_BE_FETCHED,
   startTime: new Date().toISOString(),
 };
 const initialState: DepartureDataState = {
@@ -100,7 +105,7 @@ const reducer: ReducerWithSideEffects<
       // Update input data with new date as this
       // is a fresh fetch. We should fetch the latest information.
       const queryInput: DepartureGroupsQuery = {
-        limitPerLine: DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW,
+        limitPerLine: DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_BE_FETCHED,
         startTime: action.startTime ?? new Date().toISOString(),
       };
 

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -25,7 +25,7 @@ import {getSecondsUntilMidnightOrMinimum} from './quay-state';
 
 export const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
 
-// We fetch double the number of departures to be shown, so that we have more 
+// We fetch double the number of departures to be shown, so that we have more
 // departures to show when one or more departures have already passed.
 export const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_BE_FETCHED =
   DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW * 2;

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -25,8 +25,8 @@ import {getSecondsUntilMidnightOrMinimum} from './quay-state';
 
 export const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
 
-//We fetch double the number of departures to be shown,
-// so that we have more departures to show when one or more departures have already passed
+// We fetch double the number of departures to be shown, so that we have more 
+// departures to show when one or more departures have already passed.
 export const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_BE_FETCHED =
   DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW * 2;
 


### PR DESCRIPTION
Solves https://github.com/AtB-AS/kundevendt/issues/2065 

We load more departures than displayed and show from backup in case one or more departures have passed.