### PR TITLE
fix: update behaviour on no favorite departures

### DIFF
--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -95,6 +95,7 @@ export default function QuayView({
           navigateToDetails={navigateToDetails}
           testID={'quaySection'}
           stopPlace={stopPlace}
+          showOnlyFavorites={showOnlyFavorites}
         />
       )}
     />

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -113,6 +113,7 @@ export default function StopPlaceView({
                 navigateToQuay={navigateToQuay}
                 testID={'quaySection' + index}
                 stopPlace={stopPlace}
+                showOnlyFavorites={showOnlyFavorites}
               />
               {index === 0 && (
                 <Feedback

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -45,12 +45,8 @@ export default function StopPlaceView({
     showOnlyFavorites,
     searchTime?.option !== 'now' ? searchTime.date : undefined,
   );
-  const filteredQuays = stopPlace.quays?.filter((quay) => {
-    if (!showOnlyFavorites) return true;
-    return favoriteDepartures.find((favorite) => quay.id === favorite.quayId);
-  });
-  const quayListData: SectionListData<Quay>[] | undefined = filteredQuays
-    ? [{data: filteredQuays}]
+  const quayListData: SectionListData<Quay>[] | undefined = stopPlace.quays
+    ? [{data: stopPlace.quays}]
     : undefined;
 
   const placeHasFavorites = hasFavorites(

--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -30,6 +30,7 @@ type QuaySectionProps = {
     isTripCancelled?: boolean,
   ) => void;
   stopPlace: StopPlace;
+  showOnlyFavorites: boolean;
 };
 
 type EstimatedCallRenderItem = {
@@ -45,6 +46,7 @@ export default function QuaySection({
   navigateToQuay,
   navigateToDetails,
   stopPlace,
+  showOnlyFavorites,
 }: QuaySectionProps): JSX.Element {
   const [isHidden, setIsHidden] = useState(false);
   const styles = useStyles();
@@ -125,8 +127,14 @@ export default function QuaySection({
                   <Sections.GenericItem
                     radius={!navigateToQuay ? 'bottom' : undefined}
                   >
-                    <ThemeText color="secondary">
-                      {t(DeparturesTexts.noDepartures)}
+                    <ThemeText
+                      color="secondary"
+                      type="body__secondary"
+                      style={{textAlign: 'center', width: '100%'}}
+                    >
+                      {showOnlyFavorites
+                        ? t(DeparturesTexts.noDeparturesForFavorites)
+                        : t(DeparturesTexts.noDepartures)}
                     </ThemeText>
                   </Sections.GenericItem>
                 )}

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -47,8 +47,12 @@ const DeparturesTexts = {
       _(`Valgt dato: ${dateTime}`, `Selected date, ${dateTime}`),
   },
   noDepartures: _(
-    'Ingen avganger i nærmeste fremtid',
-    'No departures in the near future',
+    'Ingen avganger i dette tidsrommet.',
+    'No departures in the selected period of time.',
+  ),
+  noDeparturesForFavorites: _(
+    'Fant ingen avganger blant favorittene dine. Deaktiver "Vis kun favorittavganger" for å se alle avganger.',
+    'We found no departures among your favourites. Disable "View favourite departures only" to show all departures.',
   ),
   quaySection: {
     a11yExpand: _('Aktiver for å utvide', 'Activate to expand'),


### PR DESCRIPTION
https://github.com/AtB-AS/kundevendt/issues/150

- Adds a message to departures that suggest toggling favorites off when there are no results.
- Minimizes quays instead of hiding them when favorites are toggled.

https://user-images.githubusercontent.com/1774972/184355562-0fd0508c-7ea4-4510-a321-75d148c85da4.mp4


