### PR TITLE
fix: prevent queryInput from having undefined values

### DIFF
--- a/src/api/departures/stops-nearest.ts
+++ b/src/api/departures/stops-nearest.ts
@@ -35,15 +35,15 @@ export type DeparturesPayload = {
 
 export type StopPlaceDeparturesQuery = {
   id: string;
-  numberOfDepartures?: number;
-  startTime?: string;
+  numberOfDepartures: number;
+  startTime: string;
   timeRange?: number;
 };
 
 export type QuayDeparturesVariables = {
   id: string;
-  numberOfDepartures?: number;
-  startTime?: string;
+  numberOfDepartures: number;
+  startTime: string;
   timeRange?: number;
 };
 

--- a/src/screens/Departures/state/quay-state.ts
+++ b/src/screens/Departures/state/quay-state.ts
@@ -114,7 +114,7 @@ const reducer: ReducerWithSideEffects<
       const queryInput: QuayDeparturesVariables = {
         id: action.quay.id,
         numberOfDepartures: MAX_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW,
-        startTime: action.startTime,
+        startTime: action.startTime ?? new Date().toISOString(),
       };
 
       return UpdateWithSideEffect<DepartureDataState, DepartureDataActions>(
@@ -159,8 +159,6 @@ const reducer: ReducerWithSideEffects<
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            if (!state.queryInput.numberOfDepartures) return;
-            if (!state.queryInput.startTime) return;
             const quayIds = [action.quay.id];
 
             const realtimeData = await getRealtimeDepartureV2(quayIds, {
@@ -328,8 +326,8 @@ export function getSecondsUntilMidnightOrMinimum(
 }
 
 type QueryInput = {
-  numberOfDepartures?: number;
-  startTime?: string;
+  numberOfDepartures: number;
+  startTime: string;
   timeRange?: number;
 };
 
@@ -339,7 +337,7 @@ async function fetchEstimatedCalls(
   favoriteDepartures?: UserFavoriteDepartures,
 ): Promise<DepartureTypes.EstimatedCall[]> {
   const timeRange = getSecondsUntilMidnightOrMinimum(
-    queryInput.startTime ?? new Date().toISOString(),
+    queryInput.startTime,
     MIN_TIME_RANGE,
   );
 

--- a/src/screens/Departures/state/quay-state.ts
+++ b/src/screens/Departures/state/quay-state.ts
@@ -269,7 +269,7 @@ export function useQuayData(
         startTime,
         favoriteDepartures: showOnlyFavorites ? favoriteDepartures : undefined,
       }),
-    [quay?.id, startTime, showOnlyFavorites, favoriteDepartures],
+    [quay.id, startTime, showOnlyFavorites, favoriteDepartures],
   );
 
   useEffect(
@@ -281,7 +281,7 @@ export function useQuayData(
         showOnlyFavorites,
         favoriteDepartures,
       }),
-    [quay?.id, favoriteDepartures, showOnlyFavorites],
+    [quay.id, favoriteDepartures, showOnlyFavorites],
   );
   useEffect(refresh, [startTime]);
   useEffect(() => {

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -112,7 +112,7 @@ const reducer: ReducerWithSideEffects<
       // is a fresh fetch. We should fetch the latest information.
       const queryInput: QueryInput = {
         numberOfDepartures: DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_BE_FETCHED,
-        startTime: action.startTime,
+        startTime: action.startTime ?? new Date().toISOString(),
       };
 
       return UpdateWithSideEffect<DepartureDataState, DepartureDataActions>(
@@ -159,10 +159,7 @@ const reducer: ReducerWithSideEffects<
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            if (!state.queryInput.numberOfDepartures) return;
-            if (!state.queryInput.startTime) return;
-
-            const quayIds = action.stopPlace?.quays?.map((q) => q.id);
+            const quayIds = action.stopPlace.quays?.map((q) => q.id);
             const realtimeData = await getRealtimeDepartureV2(quayIds, {
               limitPerLine: state.queryInput.numberOfDepartures,
               startTime: state.queryInput.startTime,
@@ -315,8 +312,8 @@ export function useStopPlaceData(
 }
 
 type QueryInput = {
-  numberOfDepartures?: number;
-  startTime?: string;
+  numberOfDepartures: number;
+  startTime: string;
 };
 
 async function fetchEstimatedCalls(

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -71,7 +71,7 @@ type DepartureDataActions =
     }
   | {
       type: 'LOAD_REALTIME_DATA';
-      stopPlace?: StopPlace;
+      stopPlace: StopPlace;
     }
   | {
       type: 'STOP_LOADER';
@@ -124,9 +124,6 @@ const reducer: ReducerWithSideEffects<
         },
         async (state, dispatch) => {
           try {
-            if (!action.stopPlace) return;
-            if (!action.favoriteDepartures) return;
-
             const result = await fetchEstimatedCalls(
               queryInput,
               action.stopPlace,
@@ -267,7 +264,7 @@ export function useStopPlaceData(
         startTime,
         favoriteDepartures: showOnlyFavorites ? favoriteDepartures : undefined,
       }),
-    [stopPlace?.id, startTime, showOnlyFavorites, favoriteDepartures],
+    [stopPlace.id, startTime, showOnlyFavorites, favoriteDepartures],
   );
 
   useEffect(
@@ -279,9 +276,9 @@ export function useStopPlaceData(
         showOnlyFavorites,
         favoriteDepartures,
       }),
-    [stopPlace?.id, favoriteDepartures, showOnlyFavorites],
+    [stopPlace.id, favoriteDepartures, showOnlyFavorites],
   );
-  useEffect(refresh, [stopPlace?.id, startTime]);
+  useEffect(refresh, [stopPlace.id, startTime]);
   useEffect(() => {
     if (!state.tick) {
       return;
@@ -295,7 +292,7 @@ export function useStopPlaceData(
   useInterval(
     () => dispatch({type: 'LOAD_REALTIME_DATA', stopPlace}),
     updateFrequencyInSeconds * 1000,
-    [stopPlace?.id],
+    [stopPlace.id],
     !isFocused,
   );
   useInterval(


### PR DESCRIPTION
After https://github.com/AtB-AS/mittatb-app/pull/2838, the startTime value in departures would be undefined, which broke realtime. Updates to use default value, and always be defined.

Also updates some other potentially-undefined values in departure states, to prevent a similar issue appearing again.