### PR TITLE
fix: Fix sca exemption flow

### DIFF
--- a/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
+++ b/src/screens/Ticketing/Purchase/Payment/CreditCard/index.tsx
@@ -16,10 +16,7 @@ import WebView from 'react-native-webview';
 import {TicketingStackParams} from '../..';
 import {TicketTabsNavigatorParams} from '../../../Tickets';
 import Processing from '../Processing';
-import useTerminalState, {
-  ErrorContext,
-  LoadingState,
-} from './use-terminal-state';
+import useTerminalState, {ErrorContext} from './use-terminal-state';
 import FullScreenHeader from '@atb/components/screen-header/full-header';
 import Bugsnag from '@bugsnag/react-native';
 import {
@@ -72,13 +69,14 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
   }
 
   const {
-    loadingState,
+    isLoading,
     terminalUrl,
     onWebViewLoadEnd,
+    onWebViewNavigationChange,
     error,
     restartTerminal,
     cancelPayment,
-    handleInitialLoadingError,
+    onWebViewError,
   } = useTerminalState(
     offers,
     paymentType,
@@ -102,7 +100,7 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
       <View
         style={{
           flex: 1,
-          position: !loadingState && !error ? 'relative' : 'absolute',
+          position: !isLoading && !error ? 'relative' : 'absolute',
         }}
       >
         {terminalUrl && showWebView && (
@@ -110,15 +108,16 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
             source={{
               uri: terminalUrl,
             }}
-            onError={handleInitialLoadingError}
+            onError={onWebViewError}
             onLoadStart={onWebViewLoadStart}
-            onNavigationStateChange={onWebViewLoadEnd}
+            onLoadEnd={onWebViewLoadEnd}
+            onNavigationStateChange={onWebViewNavigationChange}
           />
         )}
       </View>
-      {loadingState && (
+      {isLoading && (
         <View style={styles.center}>
-          <Processing message={translateLoadingMessage(loadingState, t)} />
+          <Processing message={t(PaymentCreditCardTexts.loading)} />
         </View>
       )}
       {!!error && (
@@ -145,20 +144,6 @@ const CreditCard: React.FC<Props> = ({route, navigation}) => {
       )}
     </View>
   );
-};
-
-const translateLoadingMessage = (
-  loadingState: LoadingState,
-  t: TranslateFunction,
-) => {
-  switch (loadingState) {
-    case 'reserving-offer':
-      return t(PaymentCreditCardTexts.stateMessages.reserving);
-    case 'loading-terminal':
-      return t(PaymentCreditCardTexts.stateMessages.loading);
-    case 'processing-payment':
-      return t(PaymentCreditCardTexts.stateMessages.processing);
-  }
 };
 
 const translateError = (

--- a/src/translations/screens/subscreens/PaymentCreditCard.ts
+++ b/src/translations/screens/subscreens/PaymentCreditCard.ts
@@ -22,10 +22,6 @@ const PaymentCreditCardTexts = {
       'Whoops - we failed while processing the payment. Please try again 🤞',
     ),
   },
-  stateMessages: {
-    reserving: _('Reserverer billett…', 'Reserving ticket…'),
-    loading: _('Laster betalingsterminal…', 'Loading payment terminal…'),
-    processing: _('Prosesserer betaling…', 'Processing payment…'),
-  },
+  loading: _('Laster…', 'Loading…'),
 };
 export default PaymentCreditCardTexts;


### PR DESCRIPTION
Sca exemption flow was not working as the bankid authentication was "hidden" from
the user. The code was simplified some to fix this, and will now only have a
screen saying "loading", and not inspect redirect urls to find out the appropriate
loading screen text.

Fixes AtB-AS/kundevendt#2114