### PR TITLE
feat: disable favorites toggle on quays without favorites

### DIFF
--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -1,14 +1,13 @@
 import {Place, Quay} from '@atb/api/types/departures';
 import {useFavorites} from '@atb/favorites';
-import {SearchTime} from '@atb/screens/Departures/utils';
+import {SearchTime, hasFavorites} from '@atb/screens/Departures/utils';
 import {StyleSheet} from '@atb/theme';
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {RefreshControl, SectionList, SectionListData, View} from 'react-native';
 import DateNavigation from './components/DateNavigator';
 import FavoriteToggle from './components/FavoriteToggle';
 import QuaySection from './components/QuaySection';
 import {useQuayData} from './state/quay-state';
-import {hasFavorites} from './StopPlaceView';
 
 export type QuayViewParams = {
   quay: Quay;
@@ -42,25 +41,18 @@ export default function QuayView({
 }: QuayViewProps) {
   const styles = useStyles();
   const {favoriteDepartures} = useFavorites();
+
+  const quayHasFavorites = hasFavorites(favoriteDepartures, undefined, [
+    quay.id,
+  ]);
+
   const {state, refresh} = useQuayData(
     quay,
-    showOnlyFavorites,
+    showOnlyFavorites && quayHasFavorites,
     searchTime?.option !== 'now' ? searchTime.date : undefined,
   );
 
   const quayListData: SectionListData<Quay>[] = [{data: [quay]}];
-
-  const placeHasFavorites = hasFavorites(
-    favoriteDepartures,
-    stopPlace.id,
-    stopPlace.quays?.map((q) => q.id),
-  );
-
-  // If all favorites are removed while setShowOnlyFavorites is true, reset the
-  // value to false
-  useEffect(() => {
-    if (!placeHasFavorites) setShowOnlyFavorites(false);
-  }, [favoriteDepartures]);
 
   useEffect(() => {
     refresh();
@@ -70,7 +62,7 @@ export default function QuayView({
     <SectionList
       ListHeaderComponent={
         <View style={styles.header}>
-          {placeHasFavorites && (
+          {quayHasFavorites && (
             <FavoriteToggle
               enabled={showOnlyFavorites}
               setEnabled={setShowOnlyFavorites}

--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -87,7 +87,7 @@ export default function QuayView({
           navigateToDetails={navigateToDetails}
           testID={'quaySection'}
           stopPlace={stopPlace}
-          showOnlyFavorites={showOnlyFavorites}
+          showOnlyFavorites={showOnlyFavorites && quayHasFavorites}
         />
       )}
     />

--- a/src/screens/Departures/utils.ts
+++ b/src/screens/Departures/utils.ts
@@ -1,6 +1,20 @@
+import {UserFavoriteDepartures} from '@atb/favorites/types';
+
 export const DateOptions = ['now', 'departure'] as const;
 export type DateOptionType = typeof DateOptions[number];
 export type SearchTime = {
   option: DateOptionType;
   date: string;
 };
+
+export function hasFavorites(
+  favorites: UserFavoriteDepartures,
+  stopPlaceId?: string,
+  quayIds?: string[],
+) {
+  return favorites.some(
+    (favorite) =>
+      stopPlaceId === favorite.stopId ||
+      quayIds?.some((quayId) => favorite.quayId === quayId),
+  );
+}


### PR DESCRIPTION
follow up to https://github.com/AtB-AS/mittatb-app/pull/2846

After a discussion with @ckbilstad, we decided to disable favorites filtering on quays that has no favorites. Previously, the list would display as empty if the toggle was enabled.

https://user-images.githubusercontent.com/1774972/185149741-529992f6-b485-420e-a5e4-4bcb50c2c510.mp4

Acceptance criteria:
- [ ] Only quays with favorites gets the toggle
- [ ] Toggling other places does not filter departures in the quay without favorites
- [ ] Adding the first favorite for a quay makes the toggle appear. It inherits the toggle state from the other views. 
- [ ] Removing every favorite from a quay makes the toggle disappear