### PR TITLE
fix: stop details should be updated to empty array when input is empty

### DIFF
--- a/src/screens/Departures/FavouriteStopsOverview.tsx
+++ b/src/screens/Departures/FavouriteStopsOverview.tsx
@@ -72,7 +72,7 @@ const FavouriteStopsOverview = ({navigation}: RootProps) => {
     });
   };
 
-  return favouriteStopsDetails ? (
+  return favouriteStopsDetails && favouriteStopsDetails.length > 0 ? (
     <StopPlaces
       header={t(DeparturesTexts.resultType.favourites)}
       stopPlaces={favouriteStopsDetails}

--- a/src/screens/Departures/state/stop-place-details-state.ts
+++ b/src/screens/Departures/state/stop-place-details-state.ts
@@ -59,6 +59,14 @@ const reducer: ReducerWithSideEffects<
         },
         async (state, dispatch) => {
           if (!action.locations) return;
+          if (action.locations.length === 0) {
+            dispatch({
+              type: 'UPDATE_STOP_DETAILS',
+              ids: action.locations,
+              result: {stopPlaces: []},
+            });
+            return;
+          }
           try {
             const result = await getStopsDetails({ids: action.locations});
             dispatch({


### PR DESCRIPTION
Even when requested location ids were empty we were sending a request to BFF, which in return gives a 400, but doesn't do anything with the existing state. This results in an incorrect state in favorites tab and probably elsewhere as well.

So, here we set the output to empty when the input is empty without even calling BFF. 