### PR TITLE
refactor: Filter globalMessages to app before fetching

### DIFF
--- a/src/global-messages/GlobalMessagesContext.tsx
+++ b/src/global-messages/GlobalMessagesContext.tsx
@@ -73,9 +73,6 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
     (context: GlobalMessageContext) => {
       return globalMessages.filter((a) => {
         if (!a.context) return false;
-        if (typeof a.context === 'string') {
-          return a.context === context;
-        }
         return a.context.find((cont) => cont === context);
       });
     },

--- a/src/global-messages/GlobalMessagesContext.tsx
+++ b/src/global-messages/GlobalMessagesContext.tsx
@@ -48,6 +48,11 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
       firestore()
         .collection('globalMessages')
         .where('active', '==', true)
+        .where('context', 'array-contains-any', [
+          'app-ticketing',
+          'app-departures',
+          'app-assistant',
+        ])
         .onSnapshot(
           (snapshot) => {
             const globalMessages = (


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/2220

Filters globalMessages in app Firestore query (which means irrelevant globalMessages, such as for webshop, won't be fetched).

This also removes the possibility to enter a single context as a string, now context must be given as an array with strings.