### PR TITLE
feat: favorites tab shows only favorites by default

### DIFF
--- a/src/screens/Departures/FavouriteStopsOverview.tsx
+++ b/src/screens/Departures/FavouriteStopsOverview.tsx
@@ -69,6 +69,7 @@ const FavouriteStopsOverview = ({navigation}: RootProps) => {
   const navigateToPlace = (place: Place) => {
     navigation.navigate('PlaceScreen', {
       place,
+      showOnlyFavoritesByDefault: true,
     });
   };
 

--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -18,6 +18,7 @@ import {SearchTime} from '@atb/screens/Departures/utils';
 export type PlaceScreenParams = {
   place: Place;
   selectedQuay?: Quay;
+  showOnlyFavoritesByDefault?: boolean;
 };
 
 type PlaceScreenRouteProps = RouteProp<DeparturesStackParams, 'PlaceScreen'>;
@@ -34,7 +35,7 @@ export type PlaceScreenProps = {
 export default function PlaceScreen({
   navigation,
   route: {
-    params: {place, selectedQuay},
+    params: {place, selectedQuay, showOnlyFavoritesByDefault},
   },
 }: PlaceScreenProps) {
   const styles = useStyles();
@@ -44,7 +45,9 @@ export default function PlaceScreen({
     option: 'now',
     date: new Date().toISOString(),
   });
-  const [showOnlyFavorites, setShowOnlyFavorites] = useState<boolean>(false);
+  const [showOnlyFavorites, setShowOnlyFavorites] = useState<boolean>(
+    showOnlyFavoritesByDefault || false,
+  );
 
   const {state} = useStopsDetailsData(
     place.quays === undefined ? [place.id] : undefined,


### PR DESCRIPTION
Follow up improvement to https://github.com/AtB-AS/kundevendt/issues/151

When navigating from the favorites tab, filtering on favorites are turned on by default.

https://user-images.githubusercontent.com/1774972/185370381-4de0309b-a3ea-45d3-8262-ebca2f954271.mp4