### PR TITLE
ci: updates cocoapods to latest version (1.11.3)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "dotenv"
-gem "cocoapods", "1.10.1"
+gem "cocoapods", "1.11.3"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)


### PR DESCRIPTION
Fixes issue from 777717e028efdcd66d1c0b7a88d180b74ef1164b. Connected to https://github.com/AtB-AS/kundevendt/issues/1776

Update Cocoapods to the latest version. Min. required is 1.10.2 but I don't know if there's a reason _not_ to use the latest as long as Fastlane and AppCenter support it.