### PR TITLE
Workaround for higher time-out

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -53,6 +53,10 @@ jobs:
         if: steps.ipa-cache.outputs.cache-hit != 'true'
         run: fastlane ios build
         env:
+          # A workaround for Github Actions which breaks for a timeout in some cases, 
+          # so this sets a higher value for TIMEOUT and reduces the number of retries
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 1
           PROVISIONING_PROFILE: $IOS_PROVISIONING_PROFILE_SPECIFIER
           EXPORT_METHOD: 'ad-hoc'
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Run fastlane build
         run: fastlane ios build
         env:
+          # A workaround for Github Actions which breaks for a timeout in some cases, 
+          # so this sets a higher value for TIMEOUT and reduces the number of retries
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 1
           PROVISIONING_PROFILE: $IOS_PROVISIONING_PROFILE_SPECIFIER
           EXPORT_METHOD: 'app-store'
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
It handles "large" time-out times when building, something built can be slow due to a large number of dependencies or limited resources in the host machine, so is good to have these.