### PR TITLE
refactor: show zone symbol for 24 h as periodic tickets

### DIFF
--- a/src/screens/Ticketing/Ticket/Component/ZoneSymbol.tsx
+++ b/src/screens/Ticketing/Ticket/Component/ZoneSymbol.tsx
@@ -19,7 +19,10 @@ const ZoneSymbol = ({
   const {language} = useTranslation();
   if (!fromTariffZone || !toTariffZone) return null;
   const themeColor: StaticColor | undefined =
-    preassignedFareProduct?.type === 'period' ? 'valid' : undefined;
+    preassignedFareProduct?.type === 'period' ||
+    preassignedFareProduct?.type === 'hour24'
+      ? 'valid'
+      : undefined;
   const fillColor = getStaticColor(
     themeName,
     themeColor || 'background_3',


### PR DESCRIPTION
Solves https://github.com/AtB-AS/kundevendt/issues/1755
Fixing this as part of upgrading the tickets view.
<div>
  <img width=250 src="https://user-images.githubusercontent.com/29625161/186407213-eca580fc-1b95-41fc-a7a6-79cfe004015a.jpg"/>
</div>