### PR TITLE
fix: update validation of GlobalMessage data

### DIFF
--- a/src/global-messages/converters.ts
+++ b/src/global-messages/converters.ts
@@ -29,6 +29,7 @@ function mapToGlobalMessage(
   if (!body) return;
   if (!context) return;
   if (!type) return;
+  if (typeof result.active !== 'boolean') return;
 
   return {
     id,

--- a/src/global-messages/converters.ts
+++ b/src/global-messages/converters.ts
@@ -23,14 +23,16 @@ function mapToGlobalMessage(
   const body = mapToLanguageAndTexts(result.body);
   const title = mapToLanguageAndTexts(result.title);
   const context = mapToContexts(result.context);
+  const type = mapToMessageType(result.type);
 
   if (!result.active) return;
   if (!body) return;
   if (!context) return;
+  if (!type) return;
 
   return {
     id,
-    type: mapToMessageType(result.type),
+    type,
     active: result.active,
     context,
     body,
@@ -39,11 +41,10 @@ function mapToGlobalMessage(
 }
 
 function mapToMessageType(type: any) {
-  const defaultType = 'info';
   const options = ['info', 'valid', 'warning', 'error'];
 
-  if (typeof type !== 'string') return defaultType;
-  if (!options.includes(type)) return defaultType;
+  if (typeof type !== 'string') return;
+  if (!options.includes(type)) return;
   return type as Statuses;
 }
 

--- a/src/global-messages/converters.ts
+++ b/src/global-messages/converters.ts
@@ -1,3 +1,4 @@
+import {Statuses} from '@atb-as/theme';
 import {LanguageAndText} from '@atb/reference-data/types';
 import {FirebaseFirestoreTypes} from '@react-native-firebase/firestore';
 import {isArray} from 'lodash';
@@ -29,12 +30,21 @@ function mapToGlobalMessage(
 
   return {
     id,
-    type: result.type ?? 'info',
+    type: mapToMessageType(result.type),
     active: result.active,
     context,
     body,
     title,
   };
+}
+
+function mapToMessageType(type: any) {
+  const defaultType = 'info';
+  const options = ['info', 'valid', 'warning', 'error'];
+
+  if (typeof type !== 'string') return defaultType;
+  if (!options.includes(type)) return defaultType;
+  return type as Statuses;
 }
 
 function mapToContexts(data: any): GlobalMessageContext[] | undefined {


### PR DESCRIPTION
Noticed a weakness in the data validation of global messages, where if `type` or `active` is set to some value not in the Status-type, the invalid value would slip trough, eventually leading to the app crashing.

This would be an issue if a typo is made in firestore, or if we add more status types in the future. Since the bug is part of v1.23, it will stay an issue for users on that version of the app.

Also related to https://github.com/AtB-AS/kundevendt/issues/2190