### PR TITLE
fix: improve multiple zone text in valid and buy tickets

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Zones.tsx
@@ -7,11 +7,14 @@ import {OverviewNavigationProp} from '@atb/screens/Ticketing/Purchase/Overview';
 import {screenReaderPause} from '@atb/components/accessible-text';
 import {
   tariffZonesSummary,
-  tariffZonesTitle,
   tariffZonesDescription,
   TariffZoneWithMetadata,
 } from '../../TariffZones';
-import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import {
+  PurchaseOverviewTexts,
+  TariffZonesTexts,
+  useTranslation,
+} from '@atb/translations';
 import {useNavigation} from '@react-navigation/native';
 type ZonesProps = {
   fromTariffZone: TariffZoneWithMetadata;
@@ -58,7 +61,7 @@ export default function Zones({
       </ThemeText>
       <Sections.Section {...accessibility}>
         <Sections.ButtonInput
-          label={tariffZonesTitle(fromTariffZone, toTariffZone, language, t)}
+          label={t(TariffZonesTexts.zoneTitle)}
           value={tariffZonesDescription(
             fromTariffZone,
             toTariffZone,

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -106,16 +106,6 @@ export const tariffZonesSummary = (
   }
 };
 
-export const tariffZonesTitle = (
-  fromTariffZone: TariffZone,
-  toTariffZone: TariffZone,
-  language: Language,
-  t: TranslateFunction,
-): string => {
-  const numberOfZones = fromTariffZone.id === toTariffZone.id ? 1 : 2;
-  return t(TariffZonesTexts.zoneTitle.text(numberOfZones));
-};
-
 export const tariffZonesDescription = (
   fromTariffZone: TariffZone,
   toTariffZone: TariffZone,

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -14,23 +14,12 @@ const TariffZonesTexts = {
         _(`Reise i 1 sone (${zoneName})`, `Travel in 1 zone (${zoneName})`),
       multipleZone: (zoneNameFrom: string, zoneNameTo: string) =>
         _(
-          `Reise fra sone ${zoneNameFrom} til sone ${zoneNameTo}`,
-          `Travel from zone ${zoneNameFrom} to zone ${zoneNameTo}`,
+          `Reise mellom sone ${zoneNameFrom} og sone ${zoneNameTo}`,
+          `Travel between zone ${zoneNameFrom} and zone ${zoneNameTo}`,
         ),
     },
   },
-  zoneTitle: {
-    text: (numberOfZones: number) => {
-      if (numberOfZones > 1) {
-        return _(
-          `Reise i ${numberOfZones} soner`,
-          `Travel in ${numberOfZones} zones`,
-        );
-      }
-
-      return _(`Reise i 1 sone`, `Travel in 1 zone`);
-    },
-  },
+  zoneTitle: _(`Reisesone(r)`, `Travel zone(s)`),
   zoneDescription: {
     text: {
       singleZone: (zoneName: string) =>


### PR DESCRIPTION
Solves zone text as part of https://github.com/AtB-AS/kundevendt/issues/330

Before: 

<div>
  <img width=250 src="https://user-images.githubusercontent.com/29625161/187165563-055a01f7-5ff4-4b3f-a3a3-9b655f3ee127.jpg"/>
  <img width=250 src="https://user-images.githubusercontent.com/29625161/187165559-b7202c1c-ba54-4d0b-abdb-3e403524bafc.jpg"/>
</div>


After: 

<div>
  <img width=250 src="https://user-images.githubusercontent.com/29625161/187165285-adb0660a-5b3f-47f7-8c12-af1beae1b3af.jpg"/>
  <img width=250 src="https://user-images.githubusercontent.com/29625161/187165292-32332473-8997-49d1-963a-cd9506581cc3.jpg"/>
</div>