### PR TITLE
fix: display correct info regarding trains/night buses on 24 hour pass

### DIFF
--- a/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsContent.tsx
@@ -14,13 +14,13 @@ import {
   useHasEnabledMobileToken,
   useMobileTokenContextState,
 } from '@atb/mobile-token/MobileTokenContext';
-import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
-import {findReferenceDataById} from '@atb/reference-data/utils';
 import OrderDetails from '@atb/screens/Ticketing/Ticket/Details/OrderDetails';
 import {UnknownTicketDetails} from '@atb/screens/Ticketing/Ticket/Details/UnknownTicketDetails';
+import {PreassignedFareProduct} from '@atb/reference-data/types';
 
 type Props = {
   fareContract: FareContract;
+  preassignedFareProduct?: PreassignedFareProduct;
   now: number;
   onReceiptNavigate: () => void;
   hasActiveTravelCard?: boolean;
@@ -28,6 +28,7 @@ type Props = {
 
 const DetailsContent: React.FC<Props> = ({
   fareContract: fc,
+  preassignedFareProduct,
   now,
   onReceiptNavigate,
   hasActiveTravelCard = false,
@@ -41,7 +42,6 @@ const DetailsContent: React.FC<Props> = ({
   } = useMobileTokenContextState();
 
   const firstTravelRight = fc.travelRights[0];
-  const {preassignedFareproducts} = useFirestoreConfiguration();
 
   if (isPreactivatedTicket(firstTravelRight)) {
     const validFrom = firstTravelRight.startDateTime.toMillis();
@@ -53,11 +53,6 @@ const DetailsContent: React.FC<Props> = ({
       deviceIsInspectable,
       mobileTokenError,
       fallbackEnabled,
-    );
-
-    const preassignedFareProduct = findReferenceDataById(
-      preassignedFareproducts,
-      firstTravelRight.fareProductRef,
     );
 
     const validityStatus = getValidityStatus(now, validFrom, validTo, fc.state);

--- a/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
@@ -71,6 +71,14 @@ export default function DetailsScreen({navigation, route}: Props) {
     firstTravelRight.tariffZoneRefs.every(
       (val: string) => val === 'ATB:TariffZone:1',
     );
+
+  const getTrainTicketNoticeText = (fareProductType?: string) => {
+    if (fareProductType === 'single')
+      return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.single);
+    if (fareProductType === 'hour24')
+      return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.hour24);
+    return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.period);
+  };
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -90,13 +98,7 @@ export default function DetailsScreen({navigation, route}: Props) {
 
         {shouldShowValidTrainTicketNotice && (
           <MessageBox
-            message={
-              preassignedFareProduct?.type === 'single'
-                ? t(PurchaseOverviewTexts.samarbeidsbillettenInfo.single)
-                : preassignedFareProduct?.type === 'hour24'
-                ? t(PurchaseOverviewTexts.samarbeidsbillettenInfo.hour24)
-                : t(PurchaseOverviewTexts.samarbeidsbillettenInfo.period)
-            }
+            message={getTrainTicketNoticeText(preassignedFareProduct?.type)}
             type="info"
           />
         )}

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -57,6 +57,10 @@ const PurchaseOverviewTexts = {
       'Periodebilletter i sone A kan også brukes på tog i sone A.',
       'Periodic tickets in zone A can also be used on train in zone A.',
     ),
+    hour24: _(
+      '24-timersbillett kan ikke brukes på tog eller nattbuss.',
+      '24 hour pass can not be used on trains nor night busses.',
+    ),
   },
   zones: {
     label: {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -59,7 +59,7 @@ const PurchaseOverviewTexts = {
     ),
     hour24: _(
       '24-timersbillett kan ikke brukes på tog eller nattbuss.',
-      '24 hour pass can not be used on trains nor night busses.',
+      '24 hour pass can not be used on trains nor night buses.',
     ),
   },
   zones: {


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/2247 

Updated information regarding trains and night buses for 24 hour pass. It was previously the same as for period tickets.  

Single tickets were not available in staging during the time of testing and I was therefore not able to verify that the information is still correct for other ticket types. 

<details>
<summary>Screenshots</summary>

Details screen for 24h pass before: 
![sim_before](https://user-images.githubusercontent.com/43166974/187451850-416a8180-1823-48f2-82f4-a6fa54ab0d3c.png)

Details screen for 24h pass after:
![sim_after](https://user-images.githubusercontent.com/43166974/187451910-03da0f8c-dc63-462e-b612-28e5f7521d73.png)

</details>