### PR TITLE
refactor: spacing on passenger category component

### DIFF
--- a/src/components/sections/action-item.tsx
+++ b/src/components/sections/action-item.tsx
@@ -97,7 +97,7 @@ export default function ActionItem({
           <ThemeText
             type="body__secondary"
             color="secondary"
-            style={{marginTop: theme.spacings.medium}}
+            style={{marginTop: theme.spacings.small}}
           >
             {subtext}
           </ThemeText>

--- a/src/components/sections/counter-input.tsx
+++ b/src/components/sections/counter-input.tsx
@@ -150,6 +150,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       flex: 1,
       flexDirection: 'row',
       alignItems: 'center',
+      padding: theme.spacings.medium,
     },
     countActions: {
       flexDirection: 'row',

--- a/src/components/sections/counter-input.tsx
+++ b/src/components/sections/counter-input.tsx
@@ -144,7 +144,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       marginRight: theme.spacings.medium,
     },
     infoSubtext: {
-      marginTop: theme.spacings.medium,
+      marginTop: theme.spacings.small,
     },
     countContainer: {
       flex: 1,


### PR DESCRIPTION
Refactor https://github.com/AtB-AS/kundevendt/issues/2217 

I have updated the spacing for the passenger categories component in buy tickets according to https://github.com/AtB-AS/kundevendt/issues/2217. 

<details>
<summary>Screenshots</summary>

**Before:**

![image](https://user-images.githubusercontent.com/43166974/187679049-e6246d5c-3f40-4b06-ba43-cbd5f66bb790.png)

![image](https://user-images.githubusercontent.com/43166974/187679130-de496f75-bfd7-4e66-a1d9-3813825a9f04.png)


**After:**

![image](https://user-images.githubusercontent.com/43166974/187679368-a2d77c08-783d-48d2-9397-0c3556f1e8b9.png)

![image](https://user-images.githubusercontent.com/43166974/187679426-ce2dbe67-3fbf-4d46-baec-d5ff6f9a82ac.png)


</details>