### PR TITLE
fix: add correct information regarding train/night buses for 24 hour pass

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -44,6 +44,7 @@ import TravellerSelection from './components/TravellerSelection';
 import FullScreenFooter from '@atb/components/screen-footer/full-footer';
 import {getPurchaseFlow} from '../utils';
 import {getOtherDeviceIsInspectableWarning} from '../../Ticket/utils';
+import {getTrainTicketNoticeText} from '../../utils';
 
 export type OverviewNavigationProp = DismissableStackNavigationProp<
   TicketingStackParams,
@@ -143,7 +144,8 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
 
   const shouldShowValidTrainTicketNotice =
     (preassignedFareProduct.type === 'single' ||
-      preassignedFareProduct.type === 'period') &&
+      preassignedFareProduct.type === 'period' ||
+      preassignedFareProduct.type === 'hour24') &&
     fromTariffZone.id === 'ATB:TariffZone:1' &&
     toTariffZone.id === 'ATB:TariffZone:1';
 
@@ -237,11 +239,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
         {shouldShowValidTrainTicketNotice && (
           <MessageBox
             containerStyle={styles.warning}
-            message={
-              preassignedFareProduct.type === 'single'
-                ? t(PurchaseOverviewTexts.samarbeidsbillettenInfo.single)
-                : t(PurchaseOverviewTexts.samarbeidsbillettenInfo.period)
-            }
+            message={getTrainTicketNoticeText(t, preassignedFareProduct.type)}
             type="info"
           />
         )}

--- a/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/Ticket/Details/DetailsScreen.tsx
@@ -1,10 +1,6 @@
 import {StyleSheet} from '@atb/theme';
 import {isPreactivatedTicket, useTicketState} from '@atb/tickets';
-import {
-  PurchaseOverviewTexts,
-  TicketTexts,
-  useTranslation,
-} from '@atb/translations';
+import {TicketTexts, useTranslation} from '@atb/translations';
 import useInterval from '@atb/utils/use-interval';
 import {RouteProp} from '@react-navigation/native';
 import React, {useState} from 'react';
@@ -16,6 +12,7 @@ import MessageBox from '@atb/components/message-box';
 import {getValidityStatus} from '../utils';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {findReferenceDataById} from '@atb/reference-data/utils';
+import {getTrainTicketNoticeText} from '../../utils';
 
 export type TicketDetailsRouteParams = {
   orderId: string;
@@ -72,13 +69,6 @@ export default function DetailsScreen({navigation, route}: Props) {
       (val: string) => val === 'ATB:TariffZone:1',
     );
 
-  const getTrainTicketNoticeText = (fareProductType?: string) => {
-    if (fareProductType === 'single')
-      return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.single);
-    if (fareProductType === 'hour24')
-      return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.hour24);
-    return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.period);
-  };
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -98,7 +88,7 @@ export default function DetailsScreen({navigation, route}: Props) {
 
         {shouldShowValidTrainTicketNotice && (
           <MessageBox
-            message={getTrainTicketNoticeText(preassignedFareProduct?.type)}
+            message={getTrainTicketNoticeText(t, preassignedFareProduct?.type)}
             type="info"
           />
         )}

--- a/src/screens/Ticketing/utils.ts
+++ b/src/screens/Ticketing/utils.ts
@@ -1,0 +1,13 @@
+import {Language, PurchaseOverviewTexts} from '@atb/translations';
+import {TFunc} from '@leile/lobo-t';
+
+export function getTrainTicketNoticeText(
+  t: TFunc<typeof Language>,
+  fareProductType?: string,
+) {
+  if (fareProductType === 'single')
+    return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.single);
+  if (fareProductType === 'hour24')
+    return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.hour24);
+  return t(PurchaseOverviewTexts.samarbeidsbillettenInfo.period);
+}


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/2247. 

Added missing information regarding train/night buses to the purchase view for 24 hour pass. 
I also extracted the function getTrainTicketNoticeText in a seperate utils file as the same check is done for multiple views (ticket details and purchase view). 

