### PR TITLE
fix: merge selecting and displaying frontpage favourites

### DIFF
--- a/src/api/departures/types.ts
+++ b/src/api/departures/types.ts
@@ -58,3 +58,5 @@ export type StopPlaceGroup = {
   stopPlace: StopPlaceInfo;
   quays: QuayGroup[];
 };
+
+export type QuaySectionMode = 'departures' | 'frontpage';

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -363,8 +363,6 @@ function ToggleFavoriteDepartureButton({
 
   const {open: openBottomSheet} = useBottomSheet();
 
-  console.log('mode', mode);
-
   if (mode === 'frontpage') {
     return null;
   }

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -3,6 +3,7 @@ import {
   DepartureLineInfo,
   DepartureTime,
   QuayInfo,
+  QuaySectionMode,
   StopPlaceInfo,
 } from '@atb/api/departures/types';
 import SvgFavorite from '@atb/assets/svg/mono-icons/places/Favorite';
@@ -60,6 +61,7 @@ export type LineItemProps = SectionItem<{
   quay: QuayInfo;
   accessibility?: AccessibilityProps;
   searchDate: string;
+  mode: QuaySectionMode;
 }>;
 export default function LineItem({
   group,
@@ -68,6 +70,7 @@ export default function LineItem({
   accessibility,
   searchDate,
   testID,
+  mode,
   ...props
 }: LineItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -136,6 +139,7 @@ export default function LineItem({
           line={group.lineInfo}
           stop={stop}
           quay={quay}
+          mode={mode}
         />
       </View>
       <ScrollView
@@ -343,8 +347,14 @@ type FavoriteStarProps = {
   line?: DepartureLineInfo;
   stop: StopPlaceInfo;
   quay: QuayInfo;
+  mode: QuaySectionMode;
 };
-function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
+function ToggleFavoriteDepartureButton({
+  line,
+  stop,
+  quay,
+  mode = 'departures',
+}: FavoriteStarProps) {
   const {getFavoriteDeparture, addFavoriteDeparture, removeFavoriteDeparture} =
     useFavorites();
   const {t} = useTranslation();
@@ -353,6 +363,11 @@ function ToggleFavoriteDepartureButton({line, stop, quay}: FavoriteStarProps) {
 
   const {open: openBottomSheet} = useBottomSheet();
 
+  console.log('mode', mode);
+
+  if (mode === 'frontpage') {
+    return null;
+  }
   if (!line) {
     return null;
   }

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -106,7 +106,14 @@ export default function LineItem({
   const nextValids = group.departures.filter(isValidDeparture);
 
   return (
-    <View style={[topContainer, {padding: 0}]} testID={testID}>
+    <View
+      style={
+        mode === 'frontpage'
+          ? [topContainer, styles.roundedSection]
+          : [topContainer, styles.unRoundedSection]
+      }
+      testID={testID}
+    >
       <View style={[topContainer, sectionStyle.spaceBetween]}>
         <TouchableOpacity
           style={[styles.lineHeader, contentContainer]}
@@ -340,6 +347,14 @@ const useItemStyles = StyleSheet.createThemeHook((theme, themeName) => ({
   },
   favoriteButton: {
     paddingLeft: theme.spacings.medium,
+  },
+  roundedSection: {
+    padding: 0,
+    borderBottomLeftRadius: theme.border.radius.regular,
+    borderBottomRightRadius: theme.border.radius.regular,
+  },
+  unRoundedSection: {
+    padding: 0,
   },
 }));
 

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -1,4 +1,8 @@
-import {QuayGroup, StopPlaceInfo} from '@atb/api/departures/types';
+import {
+  QuayGroup,
+  QuaySectionMode,
+  StopPlaceInfo,
+} from '@atb/api/departures/types';
 import {Section} from '@atb/components/sections';
 import {useTheme} from '@atb/theme';
 import {NearbyTexts, useTranslation} from '@atb/translations';
@@ -22,6 +26,7 @@ type QuaySectionProps = {
   hidden?: Date;
   searchDate: string;
   testID?: string;
+  mode: QuaySectionMode;
 };
 
 const QuaySection = React.memo(function QuaySection({
@@ -31,6 +36,7 @@ const QuaySection = React.memo(function QuaySection({
   lastUpdated,
   searchDate,
   testID,
+  mode = 'departures',
 }: QuaySectionProps) {
   const [limit, setLimit] = useState(LIMIT_SIZE);
   const {t} = useTranslation();
@@ -68,6 +74,7 @@ const QuaySection = React.memo(function QuaySection({
             key={group.lineInfo?.lineId + String(group.lineInfo?.lineName)}
             searchDate={searchDate}
             testID={'lineItem' + i}
+            mode={mode}
           />
         ))}
         {hasMoreItems && (

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -26,7 +26,7 @@ type QuaySectionProps = {
   hidden?: Date;
   searchDate: string;
   testID?: string;
-  mode: QuaySectionMode;
+  mode?: QuaySectionMode;
 };
 
 const QuaySection = React.memo(function QuaySection({

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -4,7 +4,7 @@ import {
   StopPlaceInfo,
 } from '@atb/api/departures/types';
 import {Section} from '@atb/components/sections';
-import {useTheme} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {NearbyTexts, useTranslation} from '@atb/translations';
 import haversineDistance from 'haversine-distance';
 import sortBy from 'lodash.sortby';
@@ -41,6 +41,7 @@ const QuaySection = React.memo(function QuaySection({
   const [limit, setLimit] = useState(LIMIT_SIZE);
   const {t} = useTranslation();
   const {theme} = useTheme();
+  const styles = useStyles();
 
   useEffect(() => {
     setLimit(LIMIT_SIZE);
@@ -59,7 +60,7 @@ const QuaySection = React.memo(function QuaySection({
 
   return (
     <Fragment>
-      <Section testID={testID}>
+      <Section testID={testID} style={styles.quaySection}>
         <QuayHeaderItem
           quay={quayGroup.quay}
           distance={getDistanceInfo(quayGroup, currentLocation)}
@@ -110,3 +111,10 @@ function getDistanceInfo(group: QuayGroup, currentLocation?: Location): number {
     ? 0
     : haversineDistance(currentLocation.coordinates, pos);
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  quaySection: {
+    backgroundColor: theme.static.background.background_1.background,
+    borderRadius: theme.border.radius.regular,
+  },
+}));

--- a/src/favorites/FavoritesContext.tsx
+++ b/src/favorites/FavoritesContext.tsx
@@ -100,8 +100,11 @@ const FavoritesContextProvider: React.FC = ({children}) => {
     },
     async removeFavoriteDeparture(id: string) {
       const favorites = await departures.removeFavorite(id);
-      await frontpageFavourites.removeFrontpageFavorite(id);
+      const frontpageFavs = await frontpageFavourites.removeFrontpageFavorite(
+        id,
+      );
       setFavoriteDeparturesState(favorites);
+      setFrontPageFavouriteDepartures(frontpageFavs);
     },
     getFavoriteDeparture(potential: FavoriteDepartureId) {
       return favoriteDepartures.find(function (favorite) {

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -27,6 +27,7 @@ export type RemoteConfig = {
   enable_flex_tickets: boolean;
   enable_vipps_login: boolean;
   favourite_departures_poll_interval: number;
+  new_favourites_info_url: string;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -55,6 +56,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_flex_tickets: false,
   enable_vipps_login: false,
   favourite_departures_poll_interval: 30000,
+  new_favourites_info_url: 'https://www.atb.no',
 };
 
 export function getConfig(): RemoteConfig {
@@ -124,6 +126,10 @@ export function getConfig(): RemoteConfig {
     values['favourite_departures_poll_interval']?.asNumber() ??
     defaultRemoteConfig.favourite_departures_poll_interval;
 
+  const new_favourites_info_url =
+    values['new_favourites_info_url']?.asString() ??
+    defaultRemoteConfig.new_favourites_info_url;
+
   return {
     enable_network_logging,
     enable_ticketing,
@@ -150,6 +156,7 @@ export function getConfig(): RemoteConfig {
     enable_flex_tickets,
     enable_vipps_login,
     favourite_departures_poll_interval,
+    new_favourites_info_url,
   };
 }
 

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -8,7 +8,11 @@ import ThemeText from '@atb/components/text';
 import FullScreenFooter from '@atb/components/screen-footer/full-footer';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 import {StyleSheet} from '@atb/theme';
-import {TranslatedString, useTranslation} from '@atb/translations';
+import {
+  ScreenHeaderTexts,
+  TranslatedString,
+  useTranslation,
+} from '@atb/translations';
 import SelectFavouriteDeparturesText from '@atb/translations/screens/subscreens/SelectFavouriteDeparturesTexts';
 import TransportationIcon from '@atb/components/transportation-icon';
 import {useFavorites} from '@atb/favorites';
@@ -115,7 +119,7 @@ const SelectFavouritesBottomSheet = ({
         leftButton={{
           type: 'cancel',
           onPress: close,
-          text: 'Close',
+          text: t(ScreenHeaderTexts.headerButton.cancel.text),
         }}
         color="background_1"
       />

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -167,11 +167,9 @@ const SelectFavouritesBottomSheet = ({
           </>
         )}
         {!favouriteItems.length && (
-          <MessageBox type="info">
-            <ThemeText>
-              {t(SelectFavouriteDeparturesText.noFavourites.text)}
-            </ThemeText>
-          </MessageBox>
+          <MessageBox
+            message={t(SelectFavouriteDeparturesText.noFavourites.text)}
+          />
         )}
       </ScrollView>
 

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -78,9 +78,6 @@ const FavouritesWidget: React.FC = () => {
     });
   }
 
-  console.log('favs', favoriteDepartures);
-  console.log('frontpageFavs', frontPageFavouriteDepartures);
-
   return (
     <View style={styles.container}>
       <ThemeText

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -147,5 +147,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     borderRadius: theme.border.radius.regular,
     alignItems: 'center',
     padding: theme.spacings.medium,
+    marginBottom: theme.spacings.medium,
   },
 }));

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -30,12 +30,9 @@ const FavouritesWidget: React.FC = () => {
   const {favourite_departures_poll_interval} = useRemoteConfig();
 
   const fetchFavouriteDepartures = async () => {
-    await getFavouriteDepartures(favoriteDepartures).then((data) => {
-      if (data) {
-        setFavResults(data);
-        setSearchDate(new Date().toISOString());
-      }
-    });
+    const data = await getFavouriteDepartures(favoriteDepartures);
+    setFavResults(data || []);
+    setSearchDate(new Date().toISOString());
   };
 
   // timer orchestration

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -15,7 +15,7 @@ import DeparturesTexts from '@atb/translations/screens/Departures';
 import {useIsFocused} from '@react-navigation/native';
 
 import React, {useEffect, useState} from 'react';
-import {Linking, View} from 'react-native';
+import {Linking, TouchableOpacity, View} from 'react-native';
 
 const FavouritesWidget: React.FC = () => {
   const styles = useStyles();
@@ -98,11 +98,17 @@ const FavouritesWidget: React.FC = () => {
               : t(DeparturesTexts.message.noFrontpageFavouritesWidget)}
           </ThemeText>
           {new_favourites_info_url && (
-            <Button
-              mode="tertiary"
-              text={t(DeparturesTexts.message.readMoreUrl)}
+            <TouchableOpacity
               onPress={() => Linking.openURL(new_favourites_info_url)}
-            />
+            >
+              <ThemeText
+                color="background_0"
+                type="body__primary--underline"
+                style={styles.noFavouritesUrl}
+              >
+                {t(DeparturesTexts.message.readMoreUrl)}
+              </ThemeText>
+            </TouchableOpacity>
           )}
         </View>
       )}
@@ -154,8 +160,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   noFavouritesView: {
     backgroundColor: theme.static.background.background_0.background,
     borderRadius: theme.border.radius.regular,
-    alignItems: 'center',
     padding: theme.spacings.medium,
     marginBottom: theme.spacings.medium,
+  },
+  noFavouritesUrl: {
+    marginVertical: theme.spacings.xSmall,
   },
 }));

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -20,7 +20,7 @@ import {View} from 'react-native';
 const FavouritesWidget: React.FC = () => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {favoriteDepartures} = useFavorites();
+  const {frontPageFavouriteDepartures} = useFavorites();
   const {location} = useGeolocationState();
   const [polling, setPolling] = useState(false);
   const [favResults, setFavResults] = useState<StopPlaceGroup[]>([]);
@@ -29,8 +29,8 @@ const FavouritesWidget: React.FC = () => {
   const isFocused = useIsFocused();
   const {favourite_departures_poll_interval} = useRemoteConfig();
 
-  const fetchFavouriteDepartures = async () => {
-    const data = await getFavouriteDepartures(favoriteDepartures);
+  const fetchFavouriteFrontpageDepartures = async () => {
+    const data = await getFavouriteDepartures(frontPageFavouriteDepartures);
     setFavResults(data || []);
     setSearchDate(new Date().toISOString());
   };
@@ -39,9 +39,9 @@ const FavouritesWidget: React.FC = () => {
   useEffect(() => {
     let interval: NodeJS.Timeout | undefined = undefined;
     if (polling) {
-      fetchFavouriteDepartures();
+      fetchFavouriteFrontpageDepartures();
       interval = setInterval(
-        fetchFavouriteDepartures,
+        fetchFavouriteFrontpageDepartures,
         favourite_departures_poll_interval,
       );
     } else {
@@ -57,19 +57,19 @@ const FavouritesWidget: React.FC = () => {
     };
   }, [polling]);
 
-  // do polling only when screen has focus and user has favourites.
+  // do polling only when screen has focus and user has frontpage favourites.
   useEffect(() => {
-    if (isFocused && !!favoriteDepartures.length) {
+    if (isFocused && !!frontPageFavouriteDepartures.length) {
       setPolling(true);
     } else {
       setPolling(false);
     }
-  }, [isFocused, !!favoriteDepartures.length]);
+  }, [isFocused, !!frontPageFavouriteDepartures.length]);
 
   // refresh favourite departures when user adds or removees a favourite
   useEffect(() => {
-    fetchFavouriteDepartures();
-  }, [favoriteDepartures.length]);
+    fetchFavouriteFrontpageDepartures();
+  }, [frontPageFavouriteDepartures.length]);
 
   const {open: openBottomSheet} = useBottomSheet();
   async function openFrontpageFavouritesBottomSheet() {
@@ -100,6 +100,7 @@ const FavouritesWidget: React.FC = () => {
                   stop={stopPlaceInfo}
                   searchDate={searchDate}
                   currentLocation={location || undefined}
+                  mode="frontpage"
                 />
               );
             })}

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -15,11 +15,12 @@ import DeparturesTexts from '@atb/translations/screens/Departures';
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 
 import React, {useEffect, useState} from 'react';
-import {View} from 'react-native';
+import {Linking, View} from 'react-native';
 
 const FavouritesWidget: React.FC = () => {
   const styles = useStyles();
   const {t} = useTranslation();
+  const {new_favourites_info_url} = useRemoteConfig();
   const {favoriteDepartures, frontPageFavouriteDepartures} = useFavorites();
   const {location} = useGeolocationState();
   const [polling, setPolling] = useState(false);
@@ -95,6 +96,13 @@ const FavouritesWidget: React.FC = () => {
               ? t(DeparturesTexts.message.noFavouritesWidget)
               : t(DeparturesTexts.message.noFrontpageFavouritesWidget)}
           </ThemeText>
+          {new_favourites_info_url && (
+            <Button
+              mode="tertiary"
+              text={t(DeparturesTexts.message.readMoreUrl)}
+              onPress={() => Linking.openURL(new_favourites_info_url)}
+            />
+          )}
         </View>
       )}
 

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -20,7 +20,7 @@ import {View} from 'react-native';
 const FavouritesWidget: React.FC = () => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {frontPageFavouriteDepartures} = useFavorites();
+  const {favoriteDepartures, frontPageFavouriteDepartures} = useFavorites();
   const {location} = useGeolocationState();
   const [polling, setPolling] = useState(false);
   const [favResults, setFavResults] = useState<StopPlaceGroup[]>([]);
@@ -78,6 +78,9 @@ const FavouritesWidget: React.FC = () => {
     });
   }
 
+  console.log('favs', favoriteDepartures);
+  console.log('frontpageFavs', frontPageFavouriteDepartures);
+
   return (
     <View style={styles.container}>
       <ThemeText
@@ -87,6 +90,16 @@ const FavouritesWidget: React.FC = () => {
       >
         {t(DeparturesTexts.widget.heading)}
       </ThemeText>
+
+      {!frontPageFavouriteDepartures.length && (
+        <View style={styles.noFavouritesView}>
+          <ThemeText>
+            {!favoriteDepartures.length
+              ? t(DeparturesTexts.message.noFavouritesWidget)
+              : t(DeparturesTexts.message.noFrontpageFavouritesWidget)}
+          </ThemeText>
+        </View>
+      )}
 
       {favResults.map((stopPlaceGroup) => {
         const stopPlaceInfo = stopPlaceGroup.stopPlace;
@@ -108,14 +121,16 @@ const FavouritesWidget: React.FC = () => {
         );
       })}
 
-      <Button
-        mode="secondary"
-        type="block"
-        onPress={openFrontpageFavouritesBottomSheet}
-        text={t(DeparturesTexts.button.text)}
-        icon={Edit}
-        iconPosition="right"
-      />
+      {!!favoriteDepartures.length && (
+        <Button
+          mode="secondary"
+          type="block"
+          onPress={openFrontpageFavouritesBottomSheet}
+          text={t(DeparturesTexts.button.text)}
+          icon={Edit}
+          iconPosition="right"
+        />
+      )}
     </View>
   );
 };
@@ -129,5 +144,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   heading: {
     marginTop: theme.spacings.large,
     marginBottom: theme.spacings.medium,
+  },
+  noFavouritesView: {
+    backgroundColor: theme.static.background.background_0.background,
+    borderRadius: theme.border.radius.regular,
+    alignItems: 'center',
+    padding: theme.spacings.medium,
   },
 }));

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -33,7 +33,7 @@ const FavouritesWidget: React.FC = () => {
 
   const fetchFavouriteFrontpageDepartures = async () => {
     const data = await getFavouriteDepartures(frontPageFavouriteDepartures);
-    setFavResults(data || []);
+    setFavouritesResults(data || []);
     setSearchDate(new Date().toISOString());
   };
 
@@ -107,7 +107,7 @@ const FavouritesWidget: React.FC = () => {
         </View>
       )}
 
-      {favResults.map((stopPlaceGroup) => {
+      {favouritesResults.map((stopPlaceGroup) => {
         const stopPlaceInfo = stopPlaceGroup.stopPlace;
         return (
           <View key={stopPlaceGroup.stopPlace.id}>

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -84,11 +84,11 @@ const DeparturesTexts = {
     ),
     noFavouritesWidget: _(
       'For å vise dine favoritter på forsiden må du først legge til noen favoritter. Du kan legge til en favoritt ved å klikke på stjernen ved avganger i Avganger-visningen.',
-      'To show your favourites in this widget, you will need to add one or more favourite departures. You may add a favourite by clicking a star next to a departure in the Departure view.',
+      'To show your favourites in this widget, you will need to add one or more favourite departures. You may add a favourite by clicking the star next to a departure in the Departure view.',
     ),
     noFrontpageFavouritesWidget: _(
-      'Du kan vise noen av dine favorittavganger her på den nye forsiden! Bare klikk på knappen under, og velg hvilke avganger du vil ha her på fremsiden, så er du i gang!',
-      'You may show some of your favourite departures, right here in your new dashboard. Just click the button below, and toggle the departures you would like to have displayed here.',
+      'Du kan vise favorittavganger på denne siden. Du kan velge hvilke avganger du vil vise med knappen under.',
+      'You can now show your favourite departures in this section. You may select the favourites you would like to display, using the button below.',
     ),
   },
   button: {

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -90,6 +90,7 @@ const DeparturesTexts = {
       'Du kan vise favorittavganger på denne siden. Du kan velge hvilke avganger du vil vise med knappen under.',
       'You can now show your favourite departures in this section. You may select the favourites you would like to display, using the button below.',
     ),
+    readMoreUrl: _('Les mer', 'Read more'),
   },
   button: {
     text: _('Velg favorittavganger', 'Select favourite departures'),

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -82,6 +82,14 @@ const DeparturesTexts = {
       'Det er ingen avganger som skal vises, da du ikke har noen stopp merket som favoritter.',
       'There are no departures to be shown, as you have no stops marked as favourites.',
     ),
+    noFavouritesWidget: _(
+      'For å vise dine favoritter på forsiden må du først legge til noen favoritter. Du kan legge til en favoritt ved å klikke på stjernen ved avganger i Avganger-visningen.',
+      'To show your favourites in this widget, you will need to add one or more favourite departures. You may add a favourite by clicking a star next to a departure in the Departure view.',
+    ),
+    noFrontpageFavouritesWidget: _(
+      'Du kan vise noen av dine favorittavganger her på den nye forsiden! Bare klikk på knappen under, og velg hvilke avganger du vil ha her på fremsiden, så er du i gang!',
+      'You may show some of your favourite departures, right here in your new dashboard. Just click the button below, and toggle the departures you would like to have displayed here.',
+    ),
   },
   button: {
     text: _('Velg favorittavganger', 'Select favourite departures'),


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/2350 

Fixes:
- Widget departure list is now populated based on the [list of frontpage favourites, not the list of the usual favourites](https://mittatb.slack.com/archives/C0116FMPX4Y/p1662029593492219?thread_ts=1662018942.356549&cid=C0116FMPX4Y).
- [Wrong color textbox for no favourites in bottomsheet](https://mittatb.slack.com/archives/C0116FMPX4Y/p1662018985293819)
- [Only Norwegian text for "Close" button in bottomsheet](https://mittatb.slack.com/archives/C0116FMPX4Y/p1662020632484449?thread_ts=1662018985.293819&cid=C0116FMPX4Y)
- [Hide stars from QuaySections in frontpage](https://mittatb.slack.com/archives/C0116FMPX4Y/p1662032715985089?thread_ts=1662018942.356549&cid=C0116FMPX4Y)
- Added widget box explaining that the widget only works if you have selected favourite departures.
- Added widget box explaining that you will have to explicitly activate frontpage favourites from your favourite departures (I don't think these were part of the original issue, but I think it should be there, please remove if not.
- Add background to quaySections so that [line has custom colour instead of being transparent](https://github.com/AtB-AS/kundevendt/issues/1877#issuecomment-1237019030).
- Fix [lack of bottom border](https://github.com/AtB-AS/kundevendt/issues/1877#issuecomment-1238029964) in certain QuaySections.
- Text button in `noFavouritesView` can now be found both in dark and light mode.

Missing:
- Fancy graphics for no favourites boxes in widget. Currently there is only text and a URL. Making this in a separate PR because this one already has enough fixes to distract the most experienced reviewer, and design system changes are also needed.