### PR TITLE
feat: make global messages dissmisable

### DIFF
--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, StyleProp, ViewStyle} from 'react-native';
+import {View, StyleProp, ViewStyle, TouchableOpacity} from 'react-native';
 import {
   Check,
   Error as ErrorIcon,
@@ -11,6 +11,7 @@ import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon';
 import MessageBoxTexts from '@atb/translations/components/MessageBox';
 import {useTranslation} from '@atb/translations';
+import {Close} from '@atb/assets/svg/mono-icons/actions';
 
 type WithMessage = {
   message: string;
@@ -33,6 +34,8 @@ export type MessageBoxProps = {
   containerStyle?: StyleProp<ViewStyle>;
   title?: string;
   withMargin?: boolean;
+  isDismissable?: boolean;
+  onDismiss?: () => void;
 } & (WithMessage | WithChildren);
 
 const MessageBox: React.FC<MessageBoxProps> = ({
@@ -46,6 +49,8 @@ const MessageBox: React.FC<MessageBoxProps> = ({
   isMarkdown = false,
   onPress,
   onPressText,
+  isDismissable,
+  onDismiss,
 }) => {
   const {theme} = useTheme();
   const styles = useBoxStyle();
@@ -101,6 +106,13 @@ const MessageBox: React.FC<MessageBoxProps> = ({
         )}
         <View>{child}</View>
       </View>
+      {isDismissable && (
+        <TouchableOpacity onPress={onDismiss}>
+          <View style={styles.iconContainer}>
+            <ThemeIcon fill={textColor} svg={Close} />
+          </View>
+        </TouchableOpacity>
+      )}
     </View>
   );
 };

--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -108,9 +108,7 @@ const MessageBox: React.FC<MessageBoxProps> = ({
       </View>
       {isDismissable && (
         <TouchableOpacity onPress={onDismiss}>
-          <View style={styles.iconContainer}>
-            <ThemeIcon fill={textColor} svg={Close} />
-          </View>
+          <ThemeIcon fill={textColor} svg={Close} />
         </TouchableOpacity>
       )}
     </View>

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -16,7 +16,11 @@ type Props = {
 
 const GlobalMessageBox = ({globalMessageContext, style}: Props) => {
   const {language} = useTranslation();
-  const {findGlobalMessages} = useGlobalMessagesState();
+  const {
+    findGlobalMessages,
+    dismissedGlobalMessages,
+    addDismissedGlobalMessages,
+  } = useGlobalMessagesState();
 
   const globalMessages = globalMessageContext
     ? findGlobalMessages(globalMessageContext)
@@ -26,18 +30,30 @@ const GlobalMessageBox = ({globalMessageContext, style}: Props) => {
     return null;
   }
 
+  const dismissGlobalMessage = (globalMessage: GlobalMessage) => {
+    globalMessage.isDismissable && addDismissedGlobalMessages(globalMessage);
+  };
+
+  const isNotADismissedMessage = (globalMessage: GlobalMessage) =>
+    !globalMessage.isDismissable ||
+    dismissedGlobalMessages.map((dga) => dga.id).indexOf(globalMessage.id) < 0;
+
   return (
     <>
-      {globalMessages.map((globalMessage: GlobalMessage) => (
-        <MessageBox
-          key={globalMessage.id}
-          containerStyle={style}
-          title={getReferenceDataText(globalMessage.title ?? [], language)}
-          message={getReferenceDataText(globalMessage.body, language)}
-          type={globalMessage.type}
-          isMarkdown={true}
-        />
-      ))}
+      {globalMessages
+        .filter(isNotADismissedMessage)
+        .map((globalMessage: GlobalMessage) => (
+          <MessageBox
+            key={globalMessage.id}
+            containerStyle={style}
+            title={getReferenceDataText(globalMessage.title ?? [], language)}
+            message={getReferenceDataText(globalMessage.body, language)}
+            type={globalMessage.type}
+            isMarkdown={true}
+            isDismissable={globalMessage.isDismissable}
+            onDismiss={() => dismissGlobalMessage(globalMessage)}
+          />
+        ))}
     </>
   );
 };

--- a/src/global-messages/GlobalMessagesContext.tsx
+++ b/src/global-messages/GlobalMessagesContext.tsx
@@ -9,6 +9,11 @@ import firestore from '@react-native-firebase/firestore';
 import {LanguageAndText} from '@atb/reference-data/types';
 import {Statuses} from '@atb/theme';
 import {mapToGlobalMessages} from './converters';
+import {
+  addDismissedMessageInStore,
+  getDismissedMessagesFromStore,
+  setDismissedMessagesInStore,
+} from '@atb/global-messages/storage';
 
 export type GlobalMessage = {
   id: string;
@@ -17,6 +22,7 @@ export type GlobalMessage = {
   body: LanguageAndText[];
   type: Statuses;
   context: GlobalMessageContext[];
+  isDismissable?: boolean;
 };
 
 export type GlobalMessageContext =
@@ -28,20 +34,27 @@ export type GlobalMessageContext =
 
 type GlobalMessageContextState = {
   findGlobalMessages: (context: GlobalMessageContext) => GlobalMessage[];
+  dismissedGlobalMessages: GlobalMessage[];
+  addDismissedGlobalMessages: (dismissedMessage: GlobalMessage) => void;
+  resetDismissedGlobalMessages: () => void;
 };
 
 const defaultGlobalMessageState = {
   findGlobalMessages: () => [],
+  dismissedGlobalMessages: [],
+  addDismissedGlobalMessages: (dismissedMessage: GlobalMessage) => {},
+  resetDismissedGlobalMessages: () => {},
 };
-
 const GlobalMessagesContext = createContext<GlobalMessageContextState>(
   defaultGlobalMessageState,
 );
 
 const GlobalMessagesContextProvider: React.FC = ({children}) => {
   const [globalMessages, setGlobalMessages] = useState<GlobalMessage[]>([]);
+  const [dismissedGlobalMessages, setDismissedGlobalMessages] = useState<
+    GlobalMessage[]
+  >([]);
   const [error, setError] = useState(false);
-
   useEffect(
     () =>
       firestore()
@@ -53,9 +66,10 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
           'app-assistant',
         ])
         .onSnapshot(
-          (snapshot) => {
+          async (snapshot) => {
             const globalMessages = mapToGlobalMessages(snapshot.docs);
             setGlobalMessages(globalMessages);
+            await setLatestDismissedGlobalMessages(globalMessages);
             setError(false);
           },
           (err) => {
@@ -65,6 +79,40 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
         ),
     [],
   );
+
+  const isCurrentlyActive = (
+    dismissedMessageId: string,
+    globalMessages: GlobalMessage[],
+  ) => {
+    return globalMessages.map((gm) => gm.id).indexOf(dismissedMessageId) > -1;
+  };
+
+  const setLatestDismissedGlobalMessages = async (
+    globalMessages: GlobalMessage[],
+  ) => {
+    const dismissedGlobalMessages = await getDismissedMessagesFromStore();
+    const currentlyActiveDismissedMessages = dismissedGlobalMessages
+      ? dismissedGlobalMessages.filter((dgm: GlobalMessage) =>
+          isCurrentlyActive(dgm.id, globalMessages),
+        )
+      : [];
+    setDismissedMessagesInStore(currentlyActiveDismissedMessages);
+    setDismissedGlobalMessages(currentlyActiveDismissedMessages);
+  };
+
+  const addDismissedGlobalMessages = async (
+    dismissedMessage: GlobalMessage,
+  ) => {
+    const dismissedGlobalMessages = await addDismissedMessageInStore(
+      dismissedMessage,
+    );
+    setDismissedGlobalMessages(dismissedGlobalMessages);
+  };
+
+  const resetDismissedGlobalMessages = async () => {
+    await setDismissedMessagesInStore([]);
+    setDismissedGlobalMessages([]);
+  };
 
   const findGlobalMessages = useCallback(
     (context: GlobalMessageContext) => {
@@ -79,6 +127,9 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
     <GlobalMessagesContext.Provider
       value={{
         findGlobalMessages,
+        dismissedGlobalMessages,
+        addDismissedGlobalMessages,
+        resetDismissedGlobalMessages,
       }}
     >
       {children}

--- a/src/global-messages/GlobalMessagesContext.tsx
+++ b/src/global-messages/GlobalMessagesContext.tsx
@@ -112,6 +112,7 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
   const resetDismissedGlobalMessages = async () => {
     await setDismissedMessagesInStore([]);
     setDismissedGlobalMessages([]);
+    console.warn('Reset dismissed messages');
   };
 
   const findGlobalMessages = useCallback(

--- a/src/global-messages/converters.ts
+++ b/src/global-messages/converters.ts
@@ -24,6 +24,7 @@ function mapToGlobalMessage(
   const title = mapToLanguageAndTexts(result.title);
   const context = mapToContexts(result.context);
   const type = mapToMessageType(result.type);
+  const isDismissable = result.isDismissable;
 
   if (!result.active) return;
   if (!body) return;
@@ -38,6 +39,7 @@ function mapToGlobalMessage(
     context,
     body,
     title,
+    isDismissable,
   };
 }
 

--- a/src/global-messages/storage.ts
+++ b/src/global-messages/storage.ts
@@ -1,0 +1,30 @@
+import storage from '@atb/storage';
+import {GlobalMessage} from '@atb/global-messages/GlobalMessagesContext';
+
+export const DISMISSED_GLOBAL_MESSAGES_KEY =
+  '@ATB_user_dismissed_global_messages';
+
+export async function addDismissedMessageInStore(
+  dismissedGlobalMessage: GlobalMessage,
+) {
+  const dismissedGlobalMessages = await getDismissedMessagesFromStore();
+  dismissedGlobalMessages.push(dismissedGlobalMessage);
+  setDismissedMessagesInStore(dismissedGlobalMessages);
+  return dismissedGlobalMessages;
+}
+
+export async function getDismissedMessagesFromStore() {
+  const dismissedGlobalMessages = await storage.get(
+    DISMISSED_GLOBAL_MESSAGES_KEY,
+  );
+  return dismissedGlobalMessages ? JSON.parse(dismissedGlobalMessages) : [];
+}
+
+export async function setDismissedMessagesInStore(
+  dismissedGlobalMessages: GlobalMessage[],
+) {
+  await storage.set(
+    DISMISSED_GLOBAL_MESSAGES_KEY,
+    JSON.stringify(dismissedGlobalMessages),
+  );
+}

--- a/src/screens/Profile/DebugInfo/index.tsx
+++ b/src/screens/Profile/DebugInfo/index.tsx
@@ -123,7 +123,7 @@ export default function DebugInfo() {
             onPress={restartMobileTokenOnboarding}
           />
           <Sections.LinkItem
-            text="Reset dismissable Global messages"
+            text="Reset dismissed Global messages"
             onPress={resetDismissedGlobalMessages}
           />
           <Sections.LinkItem

--- a/src/screens/Profile/DebugInfo/index.tsx
+++ b/src/screens/Profile/DebugInfo/index.tsx
@@ -19,6 +19,7 @@ import {usePreferences} from '@atb/preferences';
 import {get, keys} from 'lodash';
 import Button from '@atb/components/button';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useGlobalMessagesState} from '@atb/global-messages';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -29,6 +30,7 @@ export default function DebugInfo() {
   const style = useProfileHomeStyle();
   const appDispatch = useAppDispatch();
   const {restartMobileTokenOnboarding} = useAppState();
+  const {resetDismissedGlobalMessages} = useGlobalMessagesState();
   const {user, abtCustomerId} = useAuthState();
   const [idToken, setIdToken] = useState<
     FirebaseAuthTypes.IdTokenResult | undefined
@@ -119,6 +121,10 @@ export default function DebugInfo() {
           <Sections.LinkItem
             text="Set mobile token onboarded to false"
             onPress={restartMobileTokenOnboarding}
+          />
+          <Sections.LinkItem
+            text="Reset dismissable Global messages"
+            onPress={resetDismissedGlobalMessages}
           />
           <Sections.LinkItem
             text="Copy link to customer in Firestore (staging)"


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/1997

### How do messages look if dismissable/non-dismissable?

<div> 
<img width=300 src="https://user-images.githubusercontent.com/29625161/188622888-cd42a5a8-b630-4927-af7b-1fe2d99ca771.png"/>
</div>

### Option to reset dismissed alerts for testing purpose

<div> 
  <img width=300 src="https://user-images.githubusercontent.com/29625161/188624395-2686c4b5-7aa9-4c03-a391-83ab1f001eb8.png"/>
</div>

### Flag to be used in firestore:   **isDismissable**

  <img width=600 src="https://user-images.githubusercontent.com/29625161/188623191-50b2ee67-9299-4467-9567-25e11f2024a7.png"/>




