### PR TITLE
refactor: Duplicate requests for departure v2

### DIFF
--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -260,20 +260,16 @@ export function useStopPlaceData(
   const isFocused = useIsFocused();
   const {favoriteDepartures} = useFavorites();
 
-  const dispatchLoadInitialDepartures = () =>
-    dispatch({
-      type: 'LOAD_INITIAL_DEPARTURES',
-      stopPlace,
-      startTime,
-      favoriteDepartures: showOnlyFavorites ? favoriteDepartures : undefined,
-    });
-
-  const refresh = useCallback(dispatchLoadInitialDepartures, [
-    stopPlace.id,
-    startTime,
-    showOnlyFavorites,
-    favoriteDepartures,
-  ]);
+  const refresh = useCallback(
+    () =>
+      dispatch({
+        type: 'LOAD_INITIAL_DEPARTURES',
+        stopPlace,
+        startTime,
+        favoriteDepartures: showOnlyFavorites ? favoriteDepartures : undefined,
+      }),
+    [stopPlace.id, startTime, showOnlyFavorites, favoriteDepartures],
+  );
 
   useEffect(
     () =>
@@ -286,7 +282,7 @@ export function useStopPlaceData(
       }),
     [stopPlace.id, favoriteDepartures, showOnlyFavorites],
   );
-  useEffect(dispatchLoadInitialDepartures, [stopPlace.id, startTime]);
+  useEffect(refresh, [stopPlace.id, startTime]);
   useEffect(() => {
     if (!state.tick) {
       return;
@@ -294,7 +290,7 @@ export function useStopPlaceData(
     const diff = differenceInMinutes(state.tick, state.lastRefreshTime);
 
     if (diff >= HARD_REFRESH_LIMIT_IN_MINUTES) {
-      dispatchLoadInitialDepartures();
+      refresh();
     }
   }, [state.tick, state.lastRefreshTime]);
   useInterval(

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -108,7 +108,7 @@ const reducer: ReducerWithSideEffects<
 > = (state, action) => {
   switch (action.type) {
     case 'LOAD_INITIAL_DEPARTURES': {
-      if (state.isLoading == true) {
+      if (state.isLoading === true) {
         return NoUpdate();
       }
 


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/2366

A short explanation of the changes:

Due to many `hooks` being called for filtering favourites, time pickers, and more.. was producing multiple calls to the server end-point at the same time with the `useEffect`, to avoid this the `state` value from  `ReducerWithSideEffects` is compared while `isLoading` (Requesting data) otherwise then proceed to load the data.