### PR TITLE
fix: add globalMessagesBox to dashboard

### DIFF
--- a/src/screens/Dashboard/Dashboard.tsx
+++ b/src/screens/Dashboard/Dashboard.tsx
@@ -38,6 +38,7 @@ import {DashboardBackground} from '@atb/assets/svg/color/images';
 import {BuyTicketsScreenName} from '../Ticketing/Tickets';
 import {TabNavigatorParams} from '@atb/navigation/TabNavigator';
 import FavouritesWidget from './DeparturesWidget';
+import GlobalMessageBox from '@atb/global-messages/GlobalMessage';
 
 type DashboardRouteName = 'DashboardRoot';
 const DashboardRouteNameStatic: DashboardRouteName = 'DashboardRoot';
@@ -189,6 +190,10 @@ const DashboardRoot: React.FC<RootProps> = ({navigation}) => {
       >
         <View style={style.searchHeader}>
           <View style={style.paddedContainer}>
+            <GlobalMessageBox
+              style={style.dashboardGlobalmessages}
+              globalMessageContext="app-assistant"
+            />
             <Section>
               <LocationInput
                 accessibilityLabel={
@@ -413,6 +418,9 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   },
   searchHeader: {
     backgroundColor: theme.static.background[themeBackgroundColor].background,
+  },
+  dashboardGlobalmessages: {
+    marginBottom: theme.spacings.medium,
   },
 }));
 


### PR DESCRIPTION
Fixing issue with missing GlobalMessages in the new dashboard as stated here: https://github.com/AtB-AS/kundevendt/issues/1876#issuecomment-1229844347

<details>
<summary>Screenshot with multiple messages</summary>

![simulator_screenshot_45B11329-295B-4A46-91C2-E0B666D4DBBD](https://user-images.githubusercontent.com/21310942/188745037-1fd82e59-ecf3-4573-b7a2-d4a109c74cc1.png)

</details>
