### PR TITLE
fix: close instead of cancel in frontpage favs bottomsheet

### DIFF
--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -119,7 +119,7 @@ const SelectFavouritesBottomSheet = ({
         leftButton={{
           type: 'cancel',
           onPress: close,
-          text: t(ScreenHeaderTexts.headerButton.cancel.text),
+          text: t(ScreenHeaderTexts.headerButton.close.text),
         }}
         color="background_1"
       />


### PR DESCRIPTION
Is now "Lukk" or "Close" instead of "Avbryt" or "Cancel":

<img width="404" alt="image" src="https://user-images.githubusercontent.com/21310942/188865516-bf2b02f1-a6fc-4128-9065-4132f0f49e12.png">

<img width="396" alt="image" src="https://user-images.githubusercontent.com/21310942/188865564-e09b5a60-ffe8-4b54-88eb-85d0c4420a0d.png">
