### PR TITLE
fix: frontpage favourites minor improvements

### DIFF
--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -78,7 +78,7 @@ const QuaySection = React.memo(function QuaySection({
             mode={mode}
           />
         ))}
-        {hasMoreItems && (
+        {hasMoreItems && mode !== 'frontpage' && (
           <MoreItem
             onPress={() => setLimit(limit + LIMIT_SIZE)}
             text={t(NearbyTexts.results.quayResult.showMoreToggler.text)}

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -21,6 +21,7 @@ import {AnyMode} from '@atb/components/transportation-icon';
 import {LegMode, TransportSubmode} from '@entur/sdk';
 import SectionSeparator from '@atb/components/sections/section-separator';
 import MessageBox from '@atb/components/message-box';
+import {getTranslatedModeName} from '@atb/utils/transportation-names';
 
 type SelectableFavouriteDepartureData = {
   handleSwitchFlip: (favouriteId: any) => void;
@@ -49,7 +50,15 @@ const SelectableFavouriteDeparture = ({
   const {t} = useTranslation();
 
   return (
-    <View style={styles.selectableDeparture}>
+    <View
+      style={styles.selectableDeparture}
+      accessible={true}
+      accessibilityLabel={`${t(
+        getTranslatedModeName(lineTransportationMode),
+      )} ${lineIdentifier} ${lineName}, ${t(
+        SelectFavouriteDeparturesText.accessibleText.from,
+      )} ${departureStation} ${departureQuay && departureQuay}`}
+    >
       <View style={styles.lineModeIcon}>
         <TransportationIcon
           mode={lineTransportationMode}

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -31,6 +31,7 @@ type SelectableFavouriteDepartureData = {
   lineIdentifier: string;
   lineName: string | TranslatedString;
   departureStation: string;
+  departureQuay?: string;
 };
 
 const SelectableFavouriteDeparture = ({
@@ -42,6 +43,7 @@ const SelectableFavouriteDeparture = ({
   lineIdentifier,
   lineName,
   departureStation,
+  departureQuay,
 }: SelectableFavouriteDepartureData) => {
   const styles = useStyles();
   const {t} = useTranslation();
@@ -60,7 +62,8 @@ const SelectableFavouriteDeparture = ({
         </ThemeText>
 
         <ThemeText type="body__secondary" style={styles.secondaryText}>
-          {t(SelectFavouriteDeparturesText.departures.from)} {departureStation}
+          {t(SelectFavouriteDeparturesText.departures.from)} {departureStation}{' '}
+          {departureQuay}
         </ThemeText>
       </View>
 
@@ -145,6 +148,7 @@ const SelectFavouritesBottomSheet = ({
                           )
                         }
                         departureStation={departureDetails.quayName}
+                        departureQuay={departureDetails.quayPublicCode}
                         lineIdentifier={departureDetails.lineLineNumber ?? ''}
                         lineName={
                           departureDetails.lineName ??

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -62,8 +62,8 @@ const SelectableFavouriteDeparture = ({
         </ThemeText>
 
         <ThemeText type="body__secondary" style={styles.secondaryText}>
-          {t(SelectFavouriteDeparturesText.departures.from)} {departureStation}{' '}
-          {departureQuay}
+          {t(SelectFavouriteDeparturesText.departures.from)} {departureStation}
+          {departureQuay && ' ' + departureQuay}
         </ThemeText>
       </View>
 

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -58,6 +58,8 @@ const SelectableFavouriteDeparture = ({
       )} ${lineIdentifier} ${lineName}, ${t(
         SelectFavouriteDeparturesText.accessibleText.from,
       )} ${departureStation} ${departureQuay && departureQuay}`}
+      accessibilityState={{checked: active}}
+      onAccessibilityTap={() => handleSwitchFlip(favouriteId)}
     >
       <View style={styles.lineModeIcon}>
         <TransportationIcon

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -83,14 +83,17 @@ const DeparturesTexts = {
       'There are no departures to be shown, as you have no stops marked as favourites.',
     ),
     noFavouritesWidget: _(
-      'For å vise dine favoritter på forsiden må du først legge til noen favoritter. Du kan legge til en favoritt ved å klikke på stjernen ved avganger i Avganger-visningen.',
-      'To show your favourites in this widget, you will need to add one or more favourite departures. You may add a favourite by clicking the star next to a departure in the Departure view.',
+      'Du har ingen favorittavganger. Trykk på stjernesymbolet i Avganger-visningen for å lagre en avgang du bruker ofte.',
+      'You have no favorite departures. Tap a star in the Departures view to save a frequently used departure.',
     ),
     noFrontpageFavouritesWidget: _(
-      'Du kan vise favorittavganger på denne siden. Du kan velge hvilke avganger du vil vise med knappen under.',
-      'You can now show your favourite departures in this section. You may select the favourites you would like to display, using the button below.',
+      'Velg hvilke av dine favorittavganger du vil se her med knappen under.',
+      'Choose which of your favorite departures you want displayed here with the button below.',
     ),
-    readMoreUrl: _('Les mer', 'Read more'),
+    readMoreUrl: _(
+      'Les mer og se flere nyttige tips',
+      'Read more and find other useful tips',
+    ),
   },
   button: {
     text: _('Velg favorittavganger', 'Select favourite departures'),

--- a/src/translations/screens/subscreens/SelectFavouriteDeparturesTexts.ts
+++ b/src/translations/screens/subscreens/SelectFavouriteDeparturesTexts.ts
@@ -33,6 +33,9 @@ const SelectFavouriteDeparturesText = {
       'Activate to save the selected favourite departures',
     ),
   },
+  accessibleText: {
+    from: _('fra', 'from'),
+  },
 };
 
 export default SelectFavouriteDeparturesText;


### PR DESCRIPTION
Additions:
- Displaying public code in frontpage favourite bottomsheet
- Hiding "Load more departures" button from `LineSection` in frontpage
- Displaying correct texts from marketing in no favourites box
- Improved accessabilityLabel and actions for selecting favourites from bottomsheet

Still missing (and will be handled in a later PR):
- Removal of mysterious shadow below LineSection
- Facilitate both English and Norwegian urls, a general issue that will be resolved with Firestore-config