### PR TITLE
fix: show error message if payment fails while buying a ticket

### DIFF
--- a/src/screens/Ticketing/Tickets/ErroredTicket.tsx
+++ b/src/screens/Ticketing/Tickets/ErroredTicket.tsx
@@ -1,0 +1,43 @@
+import MessageBox from '@atb/components/message-box';
+import {TicketsTexts, useTranslation} from '@atb/translations';
+import React, {useEffect, useState} from 'react';
+import {StyleSheet} from '@atb/theme';
+import {Reservation} from '@atb/tickets';
+import {getPaymentMode} from '@atb/screens/Ticketing/Tickets/utils';
+
+const ErroredTicket = ({reservation}: {reservation: Reservation}) => {
+  const styles = useStyles();
+  const {t} = useTranslation();
+  const [shouldShowError, setShouldShowError] = useState(false);
+  useEffect(() => {
+    setShouldShowError(reservation.paymentStatus === 'REJECT');
+  }, [reservation.paymentStatus]);
+
+  if (shouldShowError) {
+    return (
+      <MessageBox
+        containerStyle={styles.messageBox}
+        type="error"
+        message={t(
+          TicketsTexts.reservation.paymentError(
+            reservation.orderId,
+            getPaymentMode(reservation.paymentType, t),
+            reservation.created.toDate().toLocaleString(),
+          ),
+        )}
+        isDismissable={true}
+        onDismiss={() => setShouldShowError(false)}
+      />
+    );
+  } else {
+    return <></>;
+  }
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  messageBox: {
+    marginBottom: theme.spacings.large,
+  },
+}));
+
+export default ErroredTicket;

--- a/src/screens/Ticketing/Tickets/TicketReservation.tsx
+++ b/src/screens/Ticketing/Tickets/TicketReservation.tsx
@@ -9,6 +9,7 @@ import Bugsnag from '@bugsnag/react-native';
 import React from 'react';
 import {ActivityIndicator, Linking, TouchableOpacity, View} from 'react-native';
 import ValidityLine from '../Ticket/ValidityLine';
+import {getPaymentMode} from '@atb/screens/Ticketing/Tickets/utils';
 
 type Props = {
   reservation: Reservation;
@@ -27,10 +28,7 @@ const TicketReservation: React.FC<Props> = ({reservation}) => {
     }
   }
 
-  const paymentType =
-    reservation.paymentType === PaymentType.Vipps
-      ? t(TicketsTexts.reservation.paymentType.vipps)
-      : t(TicketsTexts.reservation.paymentType.creditcard);
+  const paymentType = getPaymentMode(reservation.paymentType, t);
 
   return (
     <TouchableOpacity>

--- a/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
+++ b/src/screens/Ticketing/Tickets/TicketsScrollView.tsx
@@ -1,4 +1,3 @@
-import ThemeText from '@atb/components/text';
 import ErrorBoundary from '@atb/error-boundary';
 import {RootStackParamList} from '@atb/navigation';
 import {StyleSheet, useTheme} from '@atb/theme';
@@ -21,6 +20,7 @@ import TravelCardInformation from './TravelCardInformation';
 import MessageBox from '@atb/components/message-box';
 import TravelTokenBox from '@atb/travel-token-box';
 import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
+import ErroredTicket from '@atb/screens/Ticketing/Tickets/ErroredTicket';
 
 type RootNavigationProp = NavigationProp<RootStackParamList>;
 
@@ -92,9 +92,13 @@ const TicketsScrollView: React.FC<Props> = ({
             message={noTicketsLabel}
           />
         )}
-        {reservations?.map((res) => (
-          <TicketReservation key={res.orderId} reservation={res} />
-        ))}
+        {reservations?.map((res) =>
+          res.paymentStatus !== 'REJECT' ? (
+            <TicketReservation key={res.orderId} reservation={res} />
+          ) : (
+            <ErroredTicket key={res.orderId} reservation={res} />
+          ),
+        )}
         {fareContracts?.map((fc, index) => (
           <ErrorBoundary
             key={fc.orderId}

--- a/src/screens/Ticketing/Tickets/utils.ts
+++ b/src/screens/Ticketing/Tickets/utils.ts
@@ -1,0 +1,11 @@
+import {PaymentType} from '@atb/tickets';
+import {TicketsTexts, TranslateFunction} from '@atb/translations';
+
+export const getPaymentMode = (
+  paymentType: PaymentType,
+  t: TranslateFunction,
+) => {
+  return paymentType === PaymentType.Vipps
+    ? t(TicketsTexts.reservation.paymentType.vipps)
+    : t(TicketsTexts.reservation.paymentType.creditcard);
+};

--- a/src/tickets/TicketContext.tsx
+++ b/src/tickets/TicketContext.tsx
@@ -189,7 +189,7 @@ function isOlderThanAnHour(date: Date): boolean {
   return differenceInMinutes(new Date(), date) > 60;
 }
 
-const abortedPaymentStatus: PaymentStatus[] = ['CANCEL', 'CREDIT', 'REJECT'];
+const abortedPaymentStatus: PaymentStatus[] = ['CANCEL', 'CREDIT'];
 
 function isAbortedPaymentStatus(status: PaymentStatus): boolean {
   return abortedPaymentStatus.includes(status);

--- a/src/translations/screens/Tickets.ts
+++ b/src/translations/screens/Tickets.ts
@@ -144,6 +144,11 @@ const TicketsTexts = {
       approved: (type: string) => _(`Betalt med ${type}`, `Paid with ${type}`),
     },
     goToVipps: _('Gå til Vipps for betaling', 'Go to Vipps for payment'),
+    paymentError: (orderId: string, paymentMode: string, orderDate: any) =>
+      _(
+        `Oops! Betalingen feilet. Vennligst prøv igjen 🤞 \n\nOrdre-id: ${orderId} \nBetalingsmetode: ${paymentMode} \nBestillingsdato: ${orderDate}`,
+        `Whoops! Payment failed. Please try again 🤞  \n\nOrder ID: ${orderId} \nPayment mode: ${paymentMode} \nOrder date: ${orderDate}`,
+      ),
   },
   scrollView: {
     errorLoadingTicket: (orderId: string) =>


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/2090

**Points to note:**

1. A separate dismissable error for every failed order/payment
2. The dismiss state is saved locally and hence would be erased on refresh. But it is kind of fine because we listen to payment status from firestore, which is REJECT for failed payments, and gets updated to CANCEL in 5 minutes and hence not listened anymore. 
3. We show a generic error message because we do not have underlying reasons for failed paymenmts
4. This is tested by changing the status in firestore to REJECT manually 😬  , as we dont have any way to simulate Insufficient Funds in non-production environment.

<img width=350 src="https://user-images.githubusercontent.com/29625161/189347778-e41ef328-d553-476a-939a-71d1bc630ea9.png"/>

