### PR TITLE
test: not use cache on first run

### DIFF
--- a/.github/workflows/test-e2e-ios.yml
+++ b/.github/workflows/test-e2e-ios.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup build dependencies, environment and assets
         uses: ./.github/actions/ios-build-setup
         with:
-          use-build-cache: 'true'
+          use-build-cache: 'false'
           app-environment: 'staging'
           app-org: 'atb'
           git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}


### PR DESCRIPTION
The GH Action still picks up the SDK from the temp location. Try with *false* as value for the *use-build-cache* field