### PR TITLE
fix: Issue when NFC is not available

### DIFF
--- a/ios/atb/AtB.entitlements
+++ b/ios/atb/AtB.entitlements
@@ -6,5 +6,10 @@
 	<string>development</string>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>NDEF</string>
+		<string>TAG</string>
+	</array>
 </dict>
 </plist>

--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NFCReaderUsageDescription</key>
+	<string>Vi må bruke NFC for sikkerhetsformål.</string>
 	<key>AppTeamIdentifier</key>
 	<string>CSV447Q97L</string>
 	<key>AppEnvironment</key>


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/1983

We have noticed that for the newest version of iOS `15.6.1` there is an issue where asking for the status of the NFC is failing due to an exception: `NFCHardwareManager areFeaturesSupported:outError`. The issue comes random on some devices, but what I have noticed is that the call from swift calls an Objective-C implementation that returns nil when the issue happens and interprets on swift as a false in the condition, causing the exception but not broking the app, in such cases, the condition returns false as no NFC supported.

The proposed solution adds an extra feature use of (NFC) hardware status, preventing the issue arise.