### PR TITLE
refactor: fix various dashboard favorites bugs

### DIFF
--- a/src/favorites/FavoritesContext.tsx
+++ b/src/favorites/FavoritesContext.tsx
@@ -16,6 +16,7 @@ type FavoriteContextState = {
   favoriteDepartures: UserFavoriteDepartures;
   addFavoriteLocation(location: LocationFavorite): Promise<void>;
   removeFavoriteLocation(id: string): Promise<void>;
+  setFavoriteDepartures(favorite: UserFavoriteDepartures): Promise<void>;
   setDashboardFavorite(id: string, value: boolean): Promise<void>;
   updateFavoriteLocation(favorite: StoredLocationFavorite): Promise<void>;
   setFavoriteLocationss(favorites: UserFavorites): Promise<void>;
@@ -88,6 +89,10 @@ const FavoritesContextProvider: React.FC = ({children}) => {
     async removeFavoriteDeparture(id: string) {
       const favorites = await departures.removeFavorite(id);
       setFavoriteDeparturesState(favorites);
+    },
+    async setFavoriteDepartures(favorites: UserFavoriteDepartures) {
+      setFavoriteDeparturesState(favorites);
+      await departures.setFavorites(favorites);
     },
     async setDashboardFavorite(id: string, value: boolean) {
       const updatedFavorites = favoriteDepartures.map((f) =>

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -115,7 +115,7 @@ const SelectFavouritesBottomSheet = ({
   };
 
   const saveAndExit = async () => {
-    await setFavoriteDepartures(updatedFavorites);
+    setFavoriteDepartures(updatedFavorites);
     close();
   };
 

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -126,7 +126,7 @@ const SelectFavouritesBottomSheet = ({
         leftButton={{
           type: 'cancel',
           onPress: close,
-          text: t(ScreenHeaderTexts.headerButton.close.text),
+          text: t(ScreenHeaderTexts.headerButton.cancel.text),
         }}
         color="background_1"
       />

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -114,7 +114,7 @@ const SelectFavouritesBottomSheet = ({
     );
   };
 
-  const saveAndExit = async () => {
+  const saveAndExit = () => {
     setFavoriteDepartures(updatedFavorites);
     close();
   };

--- a/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Assistant/SelectFavouritesBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Platform, ScrollView, View} from 'react-native';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import Button from '@atb/components/button';
@@ -102,9 +102,22 @@ const SelectFavouritesBottomSheet = ({
 }: SelectFavouritesBottomSheetProps) => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {favoriteDepartures, setDashboardFavorite} = useFavorites();
+  const {favoriteDepartures, setFavoriteDepartures} = useFavorites();
   const favouriteItems = favoriteDepartures ?? [];
-  const dashboardFavorites = favouriteItems.filter((f) => f.visibleOnDashboard);
+  const [updatedFavorites, setUpdatedFavorites] = useState(favoriteDepartures);
+
+  const handleSwitchFlip = (id: string, active: boolean) => {
+    setUpdatedFavorites(
+      updatedFavorites.map((f) =>
+        f.id == id ? {...f, visibleOnDashboard: active} : f,
+      ),
+    );
+  };
+
+  const saveAndExit = async () => {
+    await setFavoriteDepartures(updatedFavorites);
+    close();
+  };
 
   return (
     <BottomSheetContainer>
@@ -126,12 +139,12 @@ const SelectFavouritesBottomSheet = ({
             </ThemeText>
 
             <View>
-              {favouriteItems &&
-                favouriteItems.map((favorite, index) => {
+              {updatedFavorites &&
+                updatedFavorites.map((favorite, index) => {
                   return (
                     <View key={favorite.id}>
                       <SelectableFavouriteDeparture
-                        handleSwitchFlip={setDashboardFavorite}
+                        handleSwitchFlip={handleSwitchFlip}
                         favouriteId={favorite.id}
                         active={!!favorite.visibleOnDashboard}
                         departureStation={favorite.quayName}
@@ -171,7 +184,7 @@ const SelectFavouritesBottomSheet = ({
           accessibilityHint={t(
             SelectFavouriteDeparturesText.confirm_button.a11yhint,
           )}
-          onPress={close}
+          onPress={saveAndExit}
           disabled={false}
           icon={Confirm}
           iconPosition="right"

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -23,8 +23,7 @@ const FavouritesWidget: React.FC = () => {
   const {location} = useGeolocationState();
   const {state, loadInitialDepartures, searchDate} = useFavoriteDepartureData();
 
-  // refresh favourite departures when user adds or removees a favourite
-  useEffect(() => loadInitialDepartures, [favoriteDepartures]);
+  useEffect(() => loadInitialDepartures(), [favoriteDepartures]);
 
   const {open: openBottomSheet} = useBottomSheet();
   async function openFrontpageFavouritesBottomSheet() {

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -11,7 +11,7 @@ import {StyleSheet} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import React, {useEffect} from 'react';
-import {Linking, TouchableOpacity, View} from 'react-native';
+import {ActivityIndicator, Linking, TouchableOpacity, View} from 'react-native';
 import {useFavoriteDepartureData} from './state';
 import {NoFavouriteDeparture} from '@atb/assets/svg/color/images/';
 
@@ -66,6 +66,10 @@ const FavouritesWidget: React.FC = () => {
             )}
           </View>
         </View>
+      )}
+
+      {state.isLoading && (
+        <ActivityIndicator size="large" style={styles.activityIndicator} />
       )}
 
       {state.data?.map((stopPlaceGroup) => {
@@ -126,5 +130,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   noFavouritesUrl: {
     marginVertical: theme.spacings.xSmall,
+  },
+  activityIndicator: {
+    marginVertical: theme.spacings.medium,
   },
 }));

--- a/src/screens/Dashboard/state.ts
+++ b/src/screens/Dashboard/state.ts
@@ -75,7 +75,7 @@ type DepartureDataActions =
   | {
       type: 'UPDATE_DEPARTURES';
       reset?: boolean;
-      result: DepartureGroupMetadata;
+      result: DepartureGroupMetadata | null;
     }
   | {
       type: 'SET_ERROR';
@@ -97,11 +97,8 @@ const reducer: ReducerWithSideEffects<
 > = (state, action) => {
   switch (action.type) {
     case 'LOAD_INITIAL_DEPARTURES': {
-      if (!action.favoriteDepartures) return NoUpdate();
-
       // Update input data with new date as this
       // is a fresh fetch. We should fetch the latest information.
-
       const {option, date} = state.searchTime;
 
       const startTime = option === 'now' ? new Date().toISOString() : date;
@@ -129,7 +126,6 @@ const reducer: ReducerWithSideEffects<
               queryInput,
             );
 
-            if (!result) return;
             dispatch({
               type: 'UPDATE_DEPARTURES',
               reset: true,
@@ -195,9 +191,9 @@ const reducer: ReducerWithSideEffects<
         ...state,
         isLoading: false,
         data: action.reset
-          ? action.result.data
-          : (state.data ?? []).concat(action.result.data),
-        cursorInfo: action.result.metadata,
+          ? action.result?.data ?? []
+          : (state.data ?? []).concat(action.result?.data ?? []),
+        cursorInfo: action.result?.metadata,
         tick: new Date(),
       });
     }


### PR DESCRIPTION
- Removes unused `location` param for dashboard favorites state
- Save favorites to storage only on "Save selection", not on close/cancel
- Adds ActivityIndicator when favorites are loading
- Handles the case where there are no selected dashboard favorites
