### PR TITLE
revert: remove handling of line items border radius on dashboard

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -106,14 +106,7 @@ export default function LineItem({
   const nextValids = group.departures.filter(isValidDeparture);
 
   return (
-    <View
-      style={
-        mode === 'frontpage'
-          ? [topContainer, styles.roundedSection]
-          : [topContainer, styles.unRoundedSection]
-      }
-      testID={testID}
-    >
+    <View style={[topContainer, {padding: 0}]} testID={testID}>
       <View style={[topContainer, sectionStyle.spaceBetween]}>
         <TouchableOpacity
           style={[styles.lineHeader, contentContainer]}
@@ -347,14 +340,6 @@ const useItemStyles = StyleSheet.createThemeHook((theme, themeName) => ({
   },
   favoriteButton: {
     paddingLeft: theme.spacings.medium,
-  },
-  roundedSection: {
-    padding: 0,
-    borderBottomLeftRadius: theme.border.radius.regular,
-    borderBottomRightRadius: theme.border.radius.regular,
-  },
-  unRoundedSection: {
-    padding: 0,
   },
 }));
 


### PR DESCRIPTION
reverts parts of 70aaf32d84f267cb1b4146cf060ae0eaa8bbea7a

Fixes a border radius that would appear on line items that shouldn't have them.

![Screenshot 2022-09-14 at 14 32 52](https://user-images.githubusercontent.com/1774972/190154464-77c8ab29-6801-4f21-83ad-ea1b8b7dfc9b.png)
