### PR TITLE
refactor: use jp3 for realtime data on dashboard favorites

### DIFF
--- a/src/screens/Dashboard/state.ts
+++ b/src/screens/Dashboard/state.ts
@@ -10,7 +10,7 @@ import useReducerWithSideEffects, {
 } from 'use-reducer-with-side-effects';
 import {
   getFavouriteDepartures,
-  getRealtimeDeparture,
+  getRealtimeDepartureV2,
 } from '@atb/api/departures';
 import {
   DepartureGroupMetadata,
@@ -24,6 +24,7 @@ import {differenceInMinutes} from 'date-fns';
 import useInterval from '@atb/utils/use-interval';
 import {updateStopsWithRealtime} from '../../departure-list/utils';
 import {SearchTime} from '../Nearby/types';
+import {flatMap} from '@atb/utils/array';
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW = 7;
 
@@ -152,8 +153,8 @@ const reducer: ReducerWithSideEffects<
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            const realtimeData = await getRealtimeDeparture(
-              state.data ?? [],
+            const realtimeData = await getRealtimeDepartureV2(
+              flatMap(state.data ?? [], (f) => f.quays.map((q) => q.quay.id)),
               state.queryInput,
             );
             dispatch({

--- a/src/screens/Dashboard/state.ts
+++ b/src/screens/Dashboard/state.ts
@@ -119,7 +119,7 @@ const reducer: ReducerWithSideEffects<
           lastRefreshTime: new Date(),
           queryInput,
         },
-        async (state, dispatch) => {
+        async (_, dispatch) => {
           try {
             // Fresh fetch, reset paging and use new query input with new startTime
             const result = await getFavouriteDepartures(
@@ -149,7 +149,7 @@ const reducer: ReducerWithSideEffects<
       if (!state.data?.length) return NoUpdate();
 
       return SideEffect<DepartureDataState, DepartureDataActions>(
-        async (state2, dispatch) => {
+        async (_, dispatch) => {
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {


### PR DESCRIPTION
Updates dashboard favorites to use JP3 endopoint `bff/v2/departures/realtime` instead of `bff/v1/departures-realtime`.

~Unsure whether to merge to master or release branch for this one. @tormoseng Do we have time to re-test?~