### PR TITLE
test: handle multiple junit files

### DIFF
--- a/.github/workflows/test-e2e-ios.yml
+++ b/.github/workflows/test-e2e-ios.yml
@@ -59,14 +59,14 @@ jobs:
         run: detox test --configuration ios.release --retries 2 --take-screenshots failing
       - name: Upload test report json
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: junit.xml
-          path: ./e2e/results/junit.xml
+          name: junit-results
+          path: ./e2e/results/*.xml
           retention-days: 5
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-artifacts
           path: artifacts

--- a/e2e/config.json
+++ b/e2e/config.json
@@ -9,7 +9,8 @@
       "jest-junit",
       {
         "outputDirectory": "e2e/results",
-        "outputName": "junit.xml",
+        "outputName": "junit",
+        "uniqueOutputName": "true",
         "classNameTemplate": "{filename}",
         "titleTemplate": "{title}"
       }


### PR DESCRIPTION
When Detox discovers an error, it retries the failures again. The retry creates a new junit file that overrides the junit file from the previous run. Here, an `UUID` is added to the junit filename.