### PR TITLE
chore: set proper ruby/bundler versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '2.7.5'
+ruby '2.7.6'
 
 
 gem "fastlane"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  ruby
   universal-darwin-21
 
 DEPENDENCIES
@@ -285,5 +286,8 @@ DEPENDENCIES
   fastlane-plugin-appcenter
   fastlane-plugin-firebase_app_distribution
 
+RUBY VERSION
+   ruby 2.7.6p219
+
 BUNDLED WITH
-   2.3.20
+   2.3.22


### PR DESCRIPTION
Sets correct versions of gem, ruby and bundler. Fixes borked builds (example of fix: https://github.com/AtB-AS/mittatb-app/actions/runs/3080712866/jobs/4978387060)