### PR TITLE
ci: fix sourcemap path for hermes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,7 +184,7 @@ platform :android do
     sh("cp", "../android/app/build/outputs/apk/#{build_type}/app-#{build_type}.apk", "../")
     sh("mkdir", "-p", "../bundle")
     sh("cp", "../android/app/build/generated/assets/react/#{build_type}/index.android.bundle", "../bundle")
-    sh("cp", "../android/app/build/generated/sourcemaps/react/#{build_type}/index.android.bundle.map", "../bundle")
+    sh("cp", "../android/app/build/intermediates/sourcemaps/react/#{build_type}/index.android.bundle.packager.map", "../bundle")
   end
 
   lane :firebase_distribution_staging do

--- a/scripts/android/upload-sourcemaps.sh
+++ b/scripts/android/upload-sourcemaps.sh
@@ -17,6 +17,6 @@ echo "Generating and uploading Android source maps"
         --app-version=$BUILD_ID \
         --platform=android \
         --bundle=bundle/index.android.bundle \
-        --source-map=bundle/index.android.bundle.map \
+        --source-map=bundle/index.android.bundle.packager.map \
         --overwrite
 fi


### PR DESCRIPTION
The path for source maps in Hermes has changed for Android builds.

Related to: https://github.com/AtB-AS/mittatb-app/pull/2880

Verified fix here: https://github.com/AtB-AS/mittatb-app/actions/runs/3081458452/jobs/4980030720