### PR TITLE
fix: update DepartureDetails navigation

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -93,7 +93,7 @@ export default function LineItem({
   }));
 
   const onPress = (activeItemIndex: number) => {
-    navigation.navigate('TripDetails', {
+    navigation.push('TripDetails', {
       screen: 'DepartureDetails',
       params: {
         activeItemIndex,

--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -67,7 +67,7 @@ export default function PlaceScreen({
     isTripCancelled?: boolean,
   ) => {
     if (!serviceJourneyId || !date) return;
-    navigation.navigate('DepartureDetails', {
+    navigation.push('DepartureDetails', {
       items: [
         {
           serviceJourneyId,
@@ -77,6 +77,7 @@ export default function PlaceScreen({
           isTripCancelled,
         },
       ],
+      activeItemIndex: 0,
     });
   };
   const navigateToQuay = (quay: Quay) => {

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -69,8 +69,7 @@ export default function DepartureDetails({navigation, route}: Props) {
   const {modesWeSellTicketsFor} = useFirestoreConfiguration();
   const {enable_ticketing} = useRemoteConfig();
 
-  const activeItem: ServiceJourneyDeparture | undefined =
-    items[activeItemIndexState];
+  const activeItem = items[activeItemIndexState];
   const hasMultipleItems = items.length > 1;
 
   const styles = useStopsStyle();
@@ -126,15 +125,23 @@ export default function DepartureDetails({navigation, route}: Props) {
           style={styles.scrollView__content}
           testID="departureDetailsContentView"
         >
-          <PaginatedDetailsHeader
-            page={activeItemIndexState + 1}
-            totalPages={items.length}
-            onNavigate={onPaginactionPress}
-            showPagination={hasMultipleItems}
-            currentDate={activeItem?.date}
-            isTripCancelled={activeItem.isTripCancelled}
-          />
-          {activeItem.isTripCancelled && <CancelledDepartureMessage />}
+          {activeItem ? (
+            <PaginatedDetailsHeader
+              page={activeItemIndexState + 1}
+              totalPages={items.length}
+              onNavigate={onPaginactionPress}
+              showPagination={hasMultipleItems}
+              currentDate={activeItem?.date}
+              isTripCancelled={activeItem?.isTripCancelled}
+            />
+          ) : (
+            <MessageBox
+              type="error"
+              message={t(DepartureDetailsTexts.messages.noActiveItem)}
+            />
+          )}
+
+          {activeItem?.isTripCancelled && <CancelledDepartureMessage />}
           <SituationMessages
             situations={parentSituations}
             containerStyle={styles.situationsContainer}

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -46,7 +46,7 @@ import {usePreferenceItems} from '@atb/preferences';
 
 export type DepartureDetailsRouteParams = {
   items: ServiceJourneyDeparture[];
-  activeItemIndex?: number;
+  activeItemIndex: number;
 };
 
 export type DetailScreenRouteProp = RouteProp<
@@ -63,7 +63,7 @@ type Props = {
 };
 
 export default function DepartureDetails({navigation, route}: Props) {
-  const {activeItemIndex = 0, items} = route.params;
+  const {activeItemIndex, items} = route.params;
   const [activeItemIndexState, setActiveItem] = useState(activeItemIndex);
   const {theme} = useTheme();
   const {modesWeSellTicketsFor} = useFirestoreConfiguration();

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -4,11 +4,7 @@ import Header from '@atb/components/screen-header';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {TripDetailsTexts, useTranslation} from '@atb/translations';
 import usePollableResource from '@atb/utils/use-pollable-resource';
-import {
-  NavigationProp,
-  RouteProp,
-  useIsFocused,
-} from '@react-navigation/native';
+import {RouteProp, useIsFocused} from '@react-navigation/native';
 import Axios, {AxiosError} from 'axios';
 import React, {useCallback, useEffect, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';

--- a/src/screens/TripDetails/Details/index.tsx
+++ b/src/screens/TripDetails/Details/index.tsx
@@ -19,6 +19,7 @@ import CompactMap from '../Map/CompactMap';
 import {StaticColorByType} from '@atb/theme/colors';
 import {singleTripSearch} from '@atb/api/trips_v2';
 import {TripPattern} from '@atb/api/types/trips';
+import {StackNavigationProp} from '@react-navigation/stack';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -29,7 +30,8 @@ export type DetailsRouteParams = {
 
 export type DetailScreenRouteProp = RouteProp<DetailsStackParams, 'Details'>;
 
-export type DetailScreenNavigationProp = NavigationProp<DetailsStackParams>;
+export type DetailScreenNavigationProp =
+  StackNavigationProp<DetailsStackParams>;
 
 type Props = {
   route: DetailScreenRouteProp;

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -229,7 +229,10 @@ const IntermediateInfo = (leg: Leg) => {
         fromQuayId: leg.fromPlace.quay?.id,
         toQuayId: leg.toPlace.quay?.id,
       };
-      navigation.navigate('DepartureDetails', {items: [departureData]});
+      navigation.push('DepartureDetails', {
+        items: [departureData],
+        activeItemIndex: 0,
+      });
     }
     return null;
   };

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -20,6 +20,10 @@ const DepartureDetailsTexts = {
       `\n\nWith a single or periodic ticket for zone A from AtB, you can travel by train in the zone.`,
     ),
     noAlighting: _('Ingen avstigning', 'No disembarking'),
+    noActiveItem: _(
+      'Ojda! Noe gikk galt med lasting av detaljer for denne reisen.',
+      'Oops! We had some issues loading the details for this journey.',
+    ),
   },
 };
 export default orgSpecificTranslations(DepartureDetailsTexts, {


### PR DESCRIPTION
Fixes comment https://github.com/AtB-AS/kundevendt/issues/2448#issuecomment-1250718276

This PR fixes a crash that happens when navigating to DepartureDetails with activeItemIndex being undefined. (_The actual issue was that even though the default was specified as `0` in the code, it became `1` in practice. I still don't understand why this is 🙃_)

- `activeItemIndex` is now set as a required parameter to fix the bug.
- Uses of DepartureDetails are now also implemented with stack navigation, with `push` instead of `navigate`. This will be visible to the user as navigating further and further down the stack, instead of being thrown "back" to the previous screen when opening DepartureDetails. This also makes error handling easier.
- Added an error message "Oops! We had some issues loading the details for this journey." if the same issue should appear in the future, as shown below. If my code is correct, this shouldn't appear in practice 🤞


![Simulator Screen Shot - iPhone 13 - 2022-09-19 at 14 55 13](https://user-images.githubusercontent.com/1774972/191022325-ca2a70ad-1d01-4e87-a802-f379ec2d02ca.png)


