### PR TITLE
fix: sorting of realtime departures

### DIFF
--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -132,7 +132,7 @@ export function updateDeparturesWithRealtimeV2(
     .sort((a, b) => {
       // Sort departures based on expectedDepartureTime, for cases where a
       // realtime update shows that a departure has passed another.
-      return a.expectedDepartureTime < b.expectedDepartureTime ? 0 : 1;
+      return a.expectedDepartureTime < b.expectedDepartureTime ? -1 : 1;
     });
 }
 


### PR DESCRIPTION
Fixes a bug with incorrect sorting of realtime departures. This was done with the function 

```js
return a.expectedDepartureTime < b.expectedDepartureTime ? 0 : 1
```

which returns 0 if `a` is less than `b`, and 1 otherwise.

From the docs:

>`param sortFn()`: Function used to determine the order of the elements. It is expected to return a negative value if the first argument is less than the second argument, _zero if they're equal_, and a positive value otherwise. If omitted, the elements are sorted in ascending, ASCII character order.

Note **"zero if they're equal"**. 

The function would essentially return "equal" instead of "less than", when sorting departures, which surprisingly worked ok-ish for most phones. On some Android devices however, this resulted in "not at all sorted sorting", as described in https://github.com/AtB-AS/kundevendt/issues/92.

The solution is to actually read documentation, and use -1 instead of 0 🤦‍♂️

fixes https://github.com/AtB-AS/kundevendt/issues/92