### PR TITLE
fix: format totalPrice in purchase confirmation

### DIFF
--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -163,6 +163,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
 
   const vatAmountString = formatDecimalNumber(vatAmount, language);
   const vatPercentString = formatDecimalNumber(vatPercent, language);
+  const totalPriceString = formatDecimalNumber(totalPrice, language);
 
   useEffect(() => {
     const prevMethod = getPreviousPaymentMethod(
@@ -341,7 +342,9 @@ const Confirmation: React.FC<ConfirmationProps> = ({
           </View>
 
           {!isSearchingOffer ? (
-            <ThemeText type="body__primary--jumbo">{totalPrice} kr</ThemeText>
+            <ThemeText type="body__primary--jumbo">
+              {totalPriceString} kr
+            </ThemeText>
           ) : (
             <ActivityIndicator
               size={theme.spacings.medium}


### PR DESCRIPTION
ref https://mittatb.slack.com/archives/C02EEG7D8EL/p1663767182403119?thread_ts=1663759032.715949&cid=C02EEG7D8EL

Still building the app locally to test this, but looking at the other code this should fix our decimal issue.
