### PR TITLE
fix: format offer prices in purchase confirmation

### DIFF
--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -163,7 +163,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
 
   const vatAmountString = formatDecimalNumber(vatAmount, language);
   const vatPercentString = formatDecimalNumber(vatPercent, language);
-  const totalPriceString = formatDecimalNumber(totalPrice, language);
+  const totalPriceString = formatDecimalNumber(totalPrice, language, 2);
 
   useEffect(() => {
     const prevMethod = getPreviousPaymentMethod(
@@ -286,7 +286,12 @@ const Confirmation: React.FC<ConfirmationProps> = ({
                       {u.count} {getReferenceDataName(u, language)}
                     </ThemeText>
                     <ThemeText>
-                      {u.count * (u.offer.prices[0].amount_float || 0)} kr
+                      {formatDecimalNumber(
+                        u.count * (u.offer.prices[0].amount_float || 0),
+                        language,
+                        2,
+                      )}{' '}
+                      kr
                     </ThemeText>
                   </View>
                 ))}


### PR DESCRIPTION
Follow up to https://github.com/AtB-AS/mittatb-app/pull/2964

- Noticed the offer prices when purchasing for more than one traveler type also had the decimal issue from QA, [ref. slack](https://mittatb.slack.com/archives/C02EEG7D8EL/p1663767182403119?thread_ts=1663759032.715949&cid=C02EEG7D8EL)
- Price would sometimes be rounded the wrong way, without the `2` as set param to `formatDecimalNumber`

![Simulator Screen Shot - iPhone 13 - 2022-09-21 at 16 01 51](https://user-images.githubusercontent.com/1774972/191525852-16190030-ab41-4182-bcb8-63a00861fa1c.png)

