### PR TITLE
refactor: Add app scheme to AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/app_scheme" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
This should fix linking to app not working on Android phones after dependency upgrades.

Fixes https://github.com/AtB-AS/kundevendt/issues/2228