### PR TITLE
revert: "build: Avoid changelog error after org-... (#2742)"

### DIFF
--- a/tools/release/changelog.config.js
+++ b/tools/release/changelog.config.js
@@ -1,7 +1,7 @@
 const {execSync} = require('child_process');
 
 const latestReleaseTag = execSync(
-  `git tag --sort=creatordate |  grep -E '/(?!(.*(atb|nfk).*))((alpha-.*)|(v.*))' | tail -1`,
+  `git tag --sort=creatordate |  grep -E '(^alpha-.*)|(^v.*)' | tail -1`,
 )
   .toString('utf-8')
   .trim();


### PR DESCRIPTION
This reverts commit 21ebd2c1bce703abe640ed2e69814a0070ec5154.

Running `yarn release-draft` has been failing since this change, so changing it back here. The change would generate change logs based on the previous org-specific release, instead of the previous release in general. Since we're changing it back, we need to do some manual work if we're not synchronizing our releases, but since that's the plan, this is a less important feature.