### PR TITLE
ci: fix missing brew on latest ubuntu agent

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -26,6 +26,7 @@ jobs:
           echo "KEYSTORE_PATH=./android/app/keystore.jks" >> $GITHUB_ENV
           echo "APK_FILE_NAME=app-staging.apk" >> $GITHUB_ENV
           echo "JAVA_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
       - name: Decrypt env files
         run: bash ./scripts/git-crypt-unlock.sh
         env:

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -12,7 +12,7 @@ jobs:
         org: [atb, nfk]
     environment: ${{ matrix.org }}
     timeout-minutes: 180
-    runs-on: macos-11
+    runs-on: ubuntu-latest
     steps:
       - name: Check if release tag is org specific and exit for other orgs
         if: ${{ (matrix.org == 'atb' && contains(github.ref, 'nfk')) || (matrix.org == 'nfk' && contains(github.ref, 'atb')) }}
@@ -26,6 +26,7 @@ jobs:
           echo "KEYSTORE_PATH=./android/app/keystore.jks" >> $GITHUB_ENV
           echo "APK_FILE_NAME=app-store.apk" >> $GITHUB_ENV
           echo "JAVA_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
       - name: Decrypt env files
         run: bash ./scripts/git-crypt-unlock.sh
         env:


### PR DESCRIPTION
Ubuntu deprecated brew from PATH (as seen in top link here: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md).

This re-adds it to the path for the two android builds (also fixes a build missing wrong env)

Running example: https://github.com/AtB-AS/mittatb-app/actions/runs/3130611534/jobs/5081043717