### PR TITLE
feat: handle rail replacement bus services

### DIFF
--- a/src/components/rail-replacement-bus-message/index.tsx
+++ b/src/components/rail-replacement-bus-message/index.tsx
@@ -1,0 +1,26 @@
+import {TripPattern} from '@atb/api/types/trips';
+import {Warning} from '@atb/assets/svg/color/situations';
+import {useTheme} from '@atb/theme';
+import {useTranslation} from '@atb/translations';
+import RailReplacementBusTexts from '@atb/translations/components/RailReplacementBusMessage';
+import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
+import React from 'react';
+
+const WarnWhenRailReplacementBus: React.FC<{
+  tripPattern: TripPattern;
+}> = ({tripPattern}) => {
+  const {t} = useTranslation();
+  const {theme} = useTheme();
+  return tripPattern.legs.some(
+    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
+  ) ? (
+    <Warning
+      accessibilityLabel={t(
+        RailReplacementBusTexts.tripIncludesRailReplacementBus,
+      )}
+      style={{marginLeft: theme.spacings.small}}
+    />
+  ) : null;
+};
+
+export default WarnWhenRailReplacementBus;

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -74,6 +74,22 @@ function getFirstQuayName(legs: Leg[]) {
   const publicCodeOutput = fromQuay.publicCode ? ' ' + fromQuay.publicCode : '';
   return fromQuay.name + publicCodeOutput;
 }
+const WarnWhenRailReplacementBus: React.FC<{
+  tripPattern: TripPattern;
+}> = ({tripPattern}) => {
+  const {t} = useTranslation();
+  const styles = useThemeStyles();
+  return tripPattern.legs.some(
+    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
+  ) ? (
+    <Warning
+      accessibilityLabel={t(
+        AssistantTexts.results.resultItem.tripIncludesRailReplacementBus,
+      )}
+      style={styles.warningIcon}
+    />
+  ) : null;
+};
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
   strikethrough: boolean;
@@ -83,9 +99,6 @@ const ResultItemHeader: React.FC<{
   const durationText = secondsToDurationShort(tripPattern.duration, language);
   const startTime = tripPattern.legs[0].expectedStartTime;
   const endTime = tripPattern.legs[tripPattern.legs.length - 1].expectedEndTime;
-  const tripIncludesRailReplacementBus = tripPattern.legs.some(
-    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
-  );
 
   return (
     <View style={styles.resultHeader}>
@@ -118,14 +131,7 @@ const ResultItemHeader: React.FC<{
         </AccessibleText>
       </View>
 
-      {tripIncludesRailReplacementBus && (
-        <Warning
-          accessibilityLabel={t(
-            AssistantTexts.results.resultItem.tripIncludesRailReplacementBus,
-          )}
-          style={styles.warningIcon}
-        />
-      )}
+      <WarnWhenRailReplacementBus tripPattern={tripPattern} />
 
       <SituationWarningIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -43,8 +43,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Leg, TripPattern} from '@atb/api/types/trips';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {SearchTime} from './journey-date-picker';
-import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
-import {Warning} from '@atb/assets/svg/color/situations';
+import WarnWhenRailReplacementBus from '@atb/components/rail-replacement-bus-message';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -74,22 +73,6 @@ function getFirstQuayName(legs: Leg[]) {
   const publicCodeOutput = fromQuay.publicCode ? ' ' + fromQuay.publicCode : '';
   return fromQuay.name + publicCodeOutput;
 }
-const WarnWhenRailReplacementBus: React.FC<{
-  tripPattern: TripPattern;
-}> = ({tripPattern}) => {
-  const {t} = useTranslation();
-  const styles = useThemeStyles();
-  return tripPattern.legs.some(
-    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
-  ) ? (
-    <Warning
-      accessibilityLabel={t(
-        AssistantTexts.results.resultItem.tripIncludesRailReplacementBus,
-      )}
-      style={styles.warningIcon}
-    />
-  ) : null;
-};
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
   strikethrough: boolean;

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -43,6 +43,8 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Leg, TripPattern} from '@atb/api/types/trips';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {SearchTime} from './journey-date-picker';
+import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
+import {Warning} from '@atb/assets/svg/color/situations';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -81,6 +83,9 @@ const ResultItemHeader: React.FC<{
   const durationText = secondsToDurationShort(tripPattern.duration, language);
   const startTime = tripPattern.legs[0].expectedStartTime;
   const endTime = tripPattern.legs[tripPattern.legs.length - 1].expectedEndTime;
+  const tripIncludesRailReplacementBus = tripPattern.legs.some(
+    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
+  );
 
   return (
     <View style={styles.resultHeader}>
@@ -112,6 +117,15 @@ const ResultItemHeader: React.FC<{
           {durationText}
         </AccessibleText>
       </View>
+
+      {tripIncludesRailReplacementBus && (
+        <Warning
+          accessibilityLabel={t(
+            AssistantTexts.results.resultItem.tripIncludesRailReplacementBus,
+          )}
+          style={styles.warningIcon}
+        />
+      )}
 
       <SituationWarningIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}

--- a/src/screens/Dashboard/ResultItem.tsx
+++ b/src/screens/Dashboard/ResultItem.tsx
@@ -43,6 +43,8 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Leg, TripPattern} from '@atb/api/types/trips';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {SearchTime} from '@atb/screens/Dashboard/journey-date-picker';
+import {Warning} from '@atb/assets/svg/color/situations';
+import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -81,6 +83,9 @@ const ResultItemHeader: React.FC<{
   const durationText = secondsToDurationShort(tripPattern.duration, language);
   const startTime = tripPattern.legs[0].expectedStartTime;
   const endTime = tripPattern.legs[tripPattern.legs.length - 1].expectedEndTime;
+  const resultIncludesRailReplacementBus = tripPattern.legs.some(
+    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
+  );
 
   return (
     <View style={styles.resultHeader}>
@@ -113,6 +118,13 @@ const ResultItemHeader: React.FC<{
         </AccessibleText>
       </View>
 
+      {resultIncludesRailReplacementBus && (
+        <Warning
+          accessibilityLabel={t(
+            TripSearchTexts.results.resultItem.hasSituationsTip,
+          )}
+        />
+      )}
       <SituationWarningIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         accessibilityLabel={t(

--- a/src/screens/Dashboard/ResultItem.tsx
+++ b/src/screens/Dashboard/ResultItem.tsx
@@ -123,6 +123,7 @@ const ResultItemHeader: React.FC<{
           accessibilityLabel={t(
             TripSearchTexts.results.resultItem.hasSituationsTip,
           )}
+          style={styles.warningIcon}
         />
       )}
       <SituationWarningIcon

--- a/src/screens/Dashboard/ResultItem.tsx
+++ b/src/screens/Dashboard/ResultItem.tsx
@@ -74,6 +74,22 @@ function getFirstQuayName(legs: Leg[]) {
   const publicCodeOutput = fromQuay.publicCode ? ' ' + fromQuay.publicCode : '';
   return fromQuay.name + publicCodeOutput;
 }
+const WarnWhenRailReplacementBus: React.FC<{
+  tripPattern: TripPattern;
+}> = ({tripPattern}) => {
+  const {t} = useTranslation();
+  const styles = useThemeStyles();
+  return tripPattern.legs.some(
+    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
+  ) ? (
+    <Warning
+      accessibilityLabel={t(
+        TripSearchTexts.results.resultItem.hasSituationsTip,
+      )}
+      style={styles.warningIcon}
+    />
+  ) : null;
+};
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
   strikethrough: boolean;
@@ -83,9 +99,6 @@ const ResultItemHeader: React.FC<{
   const durationText = secondsToDurationShort(tripPattern.duration, language);
   const startTime = tripPattern.legs[0].expectedStartTime;
   const endTime = tripPattern.legs[tripPattern.legs.length - 1].expectedEndTime;
-  const tripIncludesRailReplacementBus = tripPattern.legs.some(
-    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
-  );
 
   return (
     <View style={styles.resultHeader}>
@@ -118,14 +131,8 @@ const ResultItemHeader: React.FC<{
         </AccessibleText>
       </View>
 
-      {tripIncludesRailReplacementBus && (
-        <Warning
-          accessibilityLabel={t(
-            TripSearchTexts.results.resultItem.hasSituationsTip,
-          )}
-          style={styles.warningIcon}
-        />
-      )}
+      <WarnWhenRailReplacementBus tripPattern={tripPattern} />
+
       <SituationWarningIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         accessibilityLabel={t(

--- a/src/screens/Dashboard/ResultItem.tsx
+++ b/src/screens/Dashboard/ResultItem.tsx
@@ -43,8 +43,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {Leg, TripPattern} from '@atb/api/types/trips';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {SearchTime} from '@atb/screens/Dashboard/journey-date-picker';
-import {Warning} from '@atb/assets/svg/color/situations';
-import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
+import WarnWhenRailReplacementBus from '@atb/components/rail-replacement-bus-message';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -74,22 +73,6 @@ function getFirstQuayName(legs: Leg[]) {
   const publicCodeOutput = fromQuay.publicCode ? ' ' + fromQuay.publicCode : '';
   return fromQuay.name + publicCodeOutput;
 }
-const WarnWhenRailReplacementBus: React.FC<{
-  tripPattern: TripPattern;
-}> = ({tripPattern}) => {
-  const {t} = useTranslation();
-  const styles = useThemeStyles();
-  return tripPattern.legs.some(
-    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
-  ) ? (
-    <Warning
-      accessibilityLabel={t(
-        TripSearchTexts.results.resultItem.hasSituationsTip,
-      )}
-      style={styles.warningIcon}
-    />
-  ) : null;
-};
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
   strikethrough: boolean;

--- a/src/screens/TripDetails/components/TripMessages.tsx
+++ b/src/screens/TripDetails/components/TripMessages.tsx
@@ -15,6 +15,7 @@ import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurati
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {hasShortWaitTime} from '@atb/screens/TripDetails/components/utils';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
 
 type TripMessagesProps = {
   tripPattern: TripPattern;
@@ -37,9 +38,19 @@ const TripMessages: React.FC<TripMessagesProps> = ({
   const {enable_ticketing} = useRemoteConfig();
   const isTicketingEnabledAndSomeTicketsAreUnavailableInApp =
     enable_ticketing && someTicketsAreUnavailableInApp;
+  const tripIncludesRailReplacementBus = tripPattern.legs.some(
+    (leg) => leg.transportSubmode === TransportSubmode.RailReplacementBus,
+  );
 
   return (
     <>
+      {tripIncludesRailReplacementBus && (
+        <MessageBox
+          containerStyle={messageStyle}
+          type="warning"
+          message={t(TripDetailsTexts.messages.tripIncludesRailReplacementBus)}
+        />
+      )}
       {shortWaitTime && (
         <MessageBox
           containerStyle={messageStyle}

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -4,7 +4,7 @@ import {Interchange} from '@atb/assets/svg/mono-icons/actions';
 import AccessibleText, {
   screenReaderPause,
 } from '@atb/components/accessible-text';
-import {TinyMessageBox} from '@atb/components/message-box';
+import MessageBox, {TinyMessageBox} from '@atb/components/message-box';
 import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 import TransportationIcon from '@atb/components/transportation-icon';
@@ -24,6 +24,7 @@ import {
   getTranslatedModeName,
 } from '@atb/utils/transportation-names';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
 import {useNavigation} from '@react-navigation/native';
 import React from 'react';
 import {View} from 'react-native';
@@ -139,6 +140,15 @@ const TripSection: React.FC<TripSectionProps> = ({
         {!!leg.situations.length && (
           <TripRow rowLabel={<ThemeIcon svg={Warning} />}>
             <SituationMessages mode="no-icon" situations={leg.situations} />
+          </TripRow>
+        )}
+        {leg.transportSubmode === TransportSubmode.RailReplacementBus && (
+          <TripRow rowLabel={<ThemeIcon svg={Warning} />}>
+            <MessageBox type="warning" icon={null}>
+              <ThemeText>
+                {t(TripDetailsTexts.messages.departureIsRailReplacementBus)}
+              </ThemeText>
+            </MessageBox>
           </TripRow>
         )}
 

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -11,7 +11,7 @@ import TransportationIcon from '@atb/components/transportation-icon';
 import {searchByStopPlace} from '@atb/geocoder/search-for-location';
 import {ServiceJourneyDeparture} from '@atb/screens/TripDetails/DepartureDetails/types';
 import SituationMessages from '@atb/situations';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {
   Language,
   TranslateFunction,
@@ -66,6 +66,7 @@ const TripSection: React.FC<TripSectionProps> = ({
 }) => {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
+  const {theme} = useTheme();
 
   const isWalkSection = leg.mode === 'foot';
   const legColor = useTransportationColor(leg.mode, leg.line?.transportSubmode);
@@ -144,11 +145,13 @@ const TripSection: React.FC<TripSectionProps> = ({
         )}
         {leg.transportSubmode === TransportSubmode.RailReplacementBus && (
           <TripRow rowLabel={<ThemeIcon svg={Warning} />}>
-            <MessageBox type="warning" icon={null}>
-              <ThemeText>
-                {t(TripDetailsTexts.messages.departureIsRailReplacementBus)}
-              </ThemeText>
-            </MessageBox>
+            <MessageBox
+              type="warning"
+              icon={null}
+              message={t(
+                TripDetailsTexts.messages.departureIsRailReplacementBus,
+              )}
+            />
           </TripRow>
         )}
 

--- a/src/translations/components/RailReplacementBusMessage.ts
+++ b/src/translations/components/RailReplacementBusMessage.ts
@@ -1,0 +1,10 @@
+import {translation as _} from '../commons';
+
+const RailReplacementBusTexts = {
+  tripIncludesRailReplacementBus: _(
+    'Reisen inkluderer buss for tog.',
+    'This trip includes rail replacement bus.',
+  ),
+};
+
+export default RailReplacementBusTexts;

--- a/src/translations/screens/Assistant.ts
+++ b/src/translations/screens/Assistant.ts
@@ -182,10 +182,6 @@ const AssistantTexts = {
             `From ${fromPlace}, at ${fromPlaceDepartureTime}`,
           ),
       },
-      tripIncludesRailReplacementBus: _(
-        'Reisen inkluderer buss for tog.',
-        'This trip includes rail replacement bus.',
-      ),
     },
   },
 };

--- a/src/translations/screens/Assistant.ts
+++ b/src/translations/screens/Assistant.ts
@@ -182,6 +182,10 @@ const AssistantTexts = {
             `From ${fromPlace}, at ${fromPlaceDepartureTime}`,
           ),
       },
+      tripIncludesRailReplacementBus: _(
+        'Reisen inkluderer buss for tog.',
+        'This trip includes rail replacement bus.',
+      ),
     },
   },
 };

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -133,6 +133,11 @@ const TripDetailsTexts = {
       'Vi kunne ikke oppdatere reiseforslaget ditt. Det kan hende reisen har endra seg eller er utdatert?',
       'We could not update your trip plan. Perhaps your trip has changed or timed out?',
     ),
+    tripIncludesRailReplacementBus: _(
+      'Reisen inkluderer buss for tog.',
+      'This trip includes rail replacement bus.',
+    ),
+    departureIsRailReplacementBus: _('Buss for tog', 'Rail replacement bus'),
     interchange: (
       fromPublicCode: string,
       toPublicCode: string,


### PR DESCRIPTION
Solves https://github.com/AtB-AS/kundevendt/issues/2566

This has not been designed by Christian (but he has agreed on trying it in production), so have a short look at the visual stuff as well :) 

**Features**

Show yellow warning icon indicating a situation in result list:

<img width="365" alt="image" src="https://user-images.githubusercontent.com/21310942/192561327-3f89989c-7efe-4243-8a1a-af3a5edb971a.png">

In trip overview, say that trip includes rail replacement bus. And also inform which leg is rail replacement bus:

![simulator_screenshot_304DD0A4-3DF7-451A-804A-B9BBE2F5AF03](https://user-images.githubusercontent.com/21310942/192562808-09427ca5-d524-45de-8e47-c7e87cd54129.png)
