### PR TITLE
refactor: improve screen reader and rejected ticket details UI

### DIFF
--- a/src/screens/Ticketing/Tickets/TicketReservation.tsx
+++ b/src/screens/Ticketing/Tickets/TicketReservation.tsx
@@ -58,7 +58,7 @@ const TicketReservation: React.FC<Props> = ({reservation}) => {
           </View>
         </View>
         <VerifyingValidityLine status={status} />
-        <View style={styles.ticketInfoContainer}>
+        <View style={styles.ticketInfoContainer} accessible={true}>
           <ThemeText style={styles.detail}>
             {t(TicketsTexts.reservation.orderId(reservation.orderId))}
           </ThemeText>

--- a/src/screens/Ticketing/Tickets/TicketReservation.tsx
+++ b/src/screens/Ticketing/Tickets/TicketReservation.tsx
@@ -59,14 +59,8 @@ const TicketReservation: React.FC<Props> = ({reservation}) => {
         </View>
         <VerifyingValidityLine status={status} />
         <View style={styles.ticketInfoContainer} accessible={true}>
-          <ThemeText style={styles.detail}>
-            {t(TicketsTexts.reservation.orderId(reservation.orderId))}
-          </ThemeText>
-          <ThemeText style={styles.detail}>
-            {t(TicketsTexts.reservation.paymentMethod(paymentType))}
-          </ThemeText>
           {status == 'rejected' && (
-            <ThemeText style={styles.detail}>
+            <ThemeText type="body__secondary" color="secondary">
               {t(
                 TicketsTexts.reservation.orderDate(
                   formatToLongDateTime(
@@ -77,6 +71,16 @@ const TicketReservation: React.FC<Props> = ({reservation}) => {
               )}
             </ThemeText>
           )}
+          <ThemeText
+            type="body__secondary"
+            color="secondary"
+            style={styles.detail}
+          >
+            {t(TicketsTexts.reservation.paymentMethod(paymentType))}
+          </ThemeText>
+          <ThemeText style={styles.detail}>
+            {t(TicketsTexts.reservation.orderId(reservation.orderId))}
+          </ThemeText>
           {reservation.paymentType === PaymentType.Vipps &&
             status === 'reserving' && (
               <Button


### PR DESCRIPTION
Closes comments on https://github.com/AtB-AS/kundevendt/issues/2090

1. Made the view accessible so that screen reader takes all the three details together
2. Updated view to be in sync with the one in ticket details screen

Now:
  <img width=250 src="https://user-images.githubusercontent.com/29625161/192779407-2da00416-df42-4fad-9ae5-7f05e5f21a4e.jpg"/>

Before:
  <img width=250 src="https://user-images.githubusercontent.com/29625161/192779402-cca64dd6-a0ef-4da5-97db-b13cd6ad1f56.jpg"/>


