### PR TITLE
Update build-store-ios.yml

### DIFF
--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -50,11 +50,6 @@ jobs:
           PROVISIONING_PROFILE: $IOS_PROVISIONING_PROFILE_SPECIFIER
           EXPORT_METHOD: 'app-store'
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-      - name: Get Github-release data
-        id: get_release
-        uses: bruceadams/get-release@v1.2.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Distribute to TestFlight
         run: |
           echo ${{ secrets.APP_STORE_CONNECT_API_KEY}} | base64 --decode > app-store-connect-api-key.json


### PR DESCRIPTION
Github actions are failing at https://github.com/AtB-AS/mittatb-app/actions/runs/3158145874/jobs/5142031779#step:10:23
which means there is something wrong with the library https://github.com/bruceadams/get-release.

I saw this library also being used on android without issues, however, for iOS it was there but non-used.

NOTE: Recently there was an upgrade in the OS version, it might break the library in the iOS build, but based on what the library does and the usage it has (none) is safe to remove.

This PR does:

- Remove unused action that among other things is causing a fail.