### PR TITLE
refactor: fly to current position always

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -119,6 +119,7 @@ const Map = ({initialLocation, selectionMode, onLocationSelect}: MapProps) => {
             <PositionArrow
               onPress={() => {
                 onMapClick(currentLocation.coordinates);
+                flyToLocation(currentLocation.coordinates, 750, mapCameraRef);
               }}
             />
           )}


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/2374#issuecomment-1265410056

We were relying on **useEffect** hook inside **useSelectedFeatureChangeEffect** to fly to current location, however we realized that hook would not be called in all situations causing a bug where the user is not taken to the current position always.

Hence added flyToLocation always on button click, to avoid any bugs for this. 