### PR TITLE
fix: correct tabselector background colour

### DIFF
--- a/src/screens/Departures/NearbyPlacesScreen.tsx
+++ b/src/screens/Departures/NearbyPlacesScreen.tsx
@@ -39,7 +39,7 @@ export default function NearbyPlacesScreen() {
               theme.interactive.interactive_1.active.text,
             tabBarIndicatorStyle: {
               backgroundColor:
-                theme.static.background.background_accent_0.background,
+                theme.interactive.interactive_1.active.background,
               height: '100%',
               borderRadius: 12,
               borderColor: theme.interactive.interactive_1.default.background,


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/2617

It seems that the label text colours were given by `interactive_1.default.text`, while the background colour were set using 
`background_accent_0.background`. Updated it now to using the same interactive colour, in line with my understanding of the AtB figma sketches. 

<img width="617" alt="image" src="https://user-images.githubusercontent.com/21310942/194051002-4d229dad-fa77-4859-a9a6-4ae8634c89bd.png">


<details>
<summary>Screenshots - AtB</summary>

![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 13 09 40](https://user-images.githubusercontent.com/21310942/194050663-3d54d5dd-4bf4-4c0b-9173-c7c356604ae8.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 13 09 34](https://user-images.githubusercontent.com/21310942/194050669-6dcd65ad-7cd7-487c-b792-a3a494403a13.png)


</details>

<details>
<summary>Screenshots - NFK</summary>

![simulator_screenshot_78423F6C-0513-43AD-A68A-65252D3D4C47](https://user-images.githubusercontent.com/21310942/194050704-6dcef3d8-8c85-47a7-8ef5-b6cb00acc403.png)
![simulator_screenshot_07E22B2F-872F-4C20-A8BE-E9F9B3D7F071](https://user-images.githubusercontent.com/21310942/194050737-f4f4101a-19f1-4b0b-b2d9-6a6f7306955e.png)

</details>