### PR TITLE
fix: reset dashboard travel search when navigating

### DIFF
--- a/src/screens/Dashboard/Dashboard.tsx
+++ b/src/screens/Dashboard/Dashboard.tsx
@@ -78,9 +78,17 @@ const DashboardRoot: React.FC<RootProps> = ({navigation}) => {
   const {from, to} = useLocations(currentLocation);
   useEffect(() => {
     if (!!to && !!from) {
+      const toLocation = to;
+      const fromLocation = from;
+
+      // Reset search params before navigation to TripSearch to prevent the
+      // search fields being filled when navigating back.
+      setCurrentLocationAsFrom();
+      navigation.setParams({toLocation: undefined});
+
       navigation.navigate('TripSearch', {
-        fromLocation: from,
-        toLocation: to,
+        fromLocation,
+        toLocation,
         searchTime: undefined,
       });
     }

--- a/src/screens/Dashboard/Dashboard.tsx
+++ b/src/screens/Dashboard/Dashboard.tsx
@@ -82,10 +82,9 @@ const DashboardRoot: React.FC<RootProps> = ({navigation}) => {
       const fromLocation = from;
 
       // Reset search params before navigating to TripSearch in order to prevent
-      // the search fields both being filled (which is an invalid state) when
-      // navigating back
-      setCurrentLocationAsFrom();
-      navigation.setParams({toLocation: undefined});
+      // the search fields from both being filled (which is an invalid state)
+      // when navigating back.
+      reset();
 
       navigation.navigate('TripSearch', {
         fromLocation,
@@ -144,6 +143,11 @@ const DashboardRoot: React.FC<RootProps> = ({navigation}) => {
       newTo: translateLocation(from),
     });
     navigation.setParams({fromLocation: to, toLocation: from});
+  }
+
+  function reset() {
+    setCurrentLocationAsFrom();
+    navigation.setParams({toLocation: undefined});
   }
 
   function fillNextAvailableLocation(selectedLocation: Location) {

--- a/src/screens/Dashboard/Dashboard.tsx
+++ b/src/screens/Dashboard/Dashboard.tsx
@@ -81,8 +81,9 @@ const DashboardRoot: React.FC<RootProps> = ({navigation}) => {
       const toLocation = to;
       const fromLocation = from;
 
-      // Reset search params before navigation to TripSearch to prevent the
-      // search fields being filled when navigating back.
+      // Reset search params before navigating to TripSearch in order to prevent
+      // the search fields both being filled (which is an invalid state) when
+      // navigating back
       setCurrentLocationAsFrom();
       navigation.setParams({toLocation: undefined});
 

--- a/src/screens/Dashboard/TripSearch.tsx
+++ b/src/screens/Dashboard/TripSearch.tsx
@@ -201,13 +201,7 @@ const TripSearch: React.FC<RootProps> = ({navigation}) => {
         rightButton={{type: 'chat'}}
         leftButton={{
           type: 'back',
-          onPress: () => {
-            navigation.navigate('DashboardRoot', {
-              toLocation: undefined,
-              fromLocation: currentLocation,
-              searchTime: undefined,
-            });
-          },
+          onPress: () => navigation.goBack(),
         }}
       />
 


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/2576

This resets the travel search in dashboard at the same time as navigating to the trip search screen. This means we don't have to bother with reseting the search field when navigating back to the dashboard  (in cases like swiping back / android back button / double tapping the navbar).