### PR TITLE
fix: replace color values for onboarding dots

### DIFF
--- a/src/components/page-indicator/index.tsx
+++ b/src/components/page-indicator/index.tsx
@@ -31,9 +31,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     width: theme.spacings.medium,
     marginHorizontal: theme.spacings.medium / 2,
     borderRadius: theme.border.radius.regular,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: theme.static.background.background_0.background,
   },
   activeDot: {
-    backgroundColor: theme.static.background.background_accent_3.background,
+    backgroundColor: theme.interactive.interactive_0.default.background,
   },
 }));


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/2620

Changes colours of onboarding progress dots to be in line with Figma sketches, solving strange colours for NFK. The inactive dots were hardcoded as #FFFFFF for AtB, they will now turn dark in dark mode.

<details>
<summary>Screenshots - AtB</summary>

![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 20 40](https://user-images.githubusercontent.com/21310942/194072141-e0f6393e-6049-459a-a8af-c048a6e26bd7.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 20 45](https://user-images.githubusercontent.com/21310942/194072145-4e9636bb-4e8c-46ef-8d1e-78aca513afd4.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 20 52](https://user-images.githubusercontent.com/21310942/194072148-e5204f58-457f-4742-95ec-4dd109696f4d.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 20 57](https://user-images.githubusercontent.com/21310942/194072150-4e8970a2-e125-4a45-a427-34db1d296c5e.png)

</details>

<details>
<summary>Screenshots - NFK</summary>

![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 10 39](https://user-images.githubusercontent.com/21310942/194072071-5b315f9f-d814-4019-a027-ab211897f86b.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 10 43](https://user-images.githubusercontent.com/21310942/194072081-37e13e16-125d-43e4-90dc-bbe83b9284c0.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 10 49](https://user-images.githubusercontent.com/21310942/194072086-61eef451-5b25-434b-84de-46cf1fc46068.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-10-05 at 15 10 55](https://user-images.githubusercontent.com/21310942/194072090-a6808ba9-ef3f-4819-8ff3-c72ce964fc93.png)

</details>