### PR TITLE
fix: use place id for navigating from TripDetails to PlaceScreen

### DIFF
--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -48,7 +48,6 @@ export async function getFeatureFromVenue(
       lon: venue.coordinates.longitude,
       limit: 1,
       layers: ['venue'],
-      tariff_zone_authorities: TARIFF_ZONE_AUTHORITY,
     },
     {skipNull: true},
   );

--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -48,6 +48,7 @@ export async function getFeatureFromVenue(
       lon: venue.coordinates.longitude,
       limit: 1,
       layers: ['venue'],
+      tariff_zone_authorities: TARIFF_ZONE_AUTHORITY,
     },
     {skipNull: true},
   );

--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -22,19 +22,19 @@ export type TripsQuery = {
       searchWindowUsed: number;
     };
     tripPatterns: Array<{
-      expectedStartTime?: any;
-      expectedEndTime?: any;
+      expectedStartTime: any;
+      expectedEndTime: any;
       duration?: any;
       walkDistance?: number;
       legs: Array<{
-        mode?: Types.Mode;
-        distance?: number;
-        duration?: any;
-        aimedStartTime?: any;
-        aimedEndTime?: any;
-        expectedEndTime?: any;
-        expectedStartTime?: any;
-        realtime?: boolean;
+        mode: Types.Mode;
+        distance: number;
+        duration: any;
+        aimedStartTime: any;
+        aimedEndTime: any;
+        expectedEndTime: any;
+        expectedStartTime: any;
+        realtime: boolean;
         transportSubmode?: Types.TransportSubmode;
         line?: {
           id: string;
@@ -43,15 +43,15 @@ export type TripsQuery = {
           publicCode?: string;
         };
         fromEstimatedCall?: {
-          aimedDepartureTime?: any;
-          expectedDepartureTime?: any;
+          aimedDepartureTime: any;
+          expectedDepartureTime: any;
           destinationDisplay?: {frontText?: string};
           quay?: {publicCode?: string; name: string};
           notices: Array<{text?: string; id: string}>;
         };
         situations: Array<{
           situationNumber?: string;
-          description: Array<{value?: string}>;
+          description: Array<{value: string}>;
         }>;
         fromPlace: {
           name?: string;
@@ -63,7 +63,12 @@ export type TripsQuery = {
             name: string;
             longitude?: number;
             latitude?: number;
-            stopPlace?: {longitude?: number; latitude?: number; name: string};
+            stopPlace?: {
+              id: string;
+              longitude?: number;
+              latitude?: number;
+              name: string;
+            };
           };
         };
         toPlace: {
@@ -76,7 +81,12 @@ export type TripsQuery = {
             name: string;
             longitude?: number;
             latitude?: number;
-            stopPlace?: {longitude?: number; latitude?: number; name: string};
+            stopPlace?: {
+              id: string;
+              longitude?: number;
+              latitude?: number;
+              name: string;
+            };
           };
         };
         serviceJourney?: {id: string};

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -219,15 +219,12 @@ const TripSection: React.FC<TripSectionProps> = ({
   );
 
   async function handleQuayPress(quay: Quay | undefined) {
-    const location = await searchByStopPlace(quay?.stopPlace);
-    if (!location) {
-      return;
-    }
     if (newDepartures) {
+      if (!quay?.stopPlace?.id) return;
       navigation.push('PlaceScreen', {
         place: {
-          id: location.id,
-          name: location.name,
+          id: quay?.stopPlace?.id,
+          name: quay?.stopPlace?.name,
         },
         selectedQuay:
           quay?.id && quay.name
@@ -238,6 +235,9 @@ const TripSection: React.FC<TripSectionProps> = ({
             : undefined,
       });
     } else {
+      const location = await searchByStopPlace(quay?.stopPlace);
+      if (!location) return;
+
       navigation.push('QuayDepartures', {
         location,
       });

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -223,16 +223,13 @@ const TripSection: React.FC<TripSectionProps> = ({
       if (!quay?.stopPlace?.id) return;
       navigation.push('PlaceScreen', {
         place: {
-          id: quay?.stopPlace?.id,
-          name: quay?.stopPlace?.name,
+          id: quay.stopPlace.id,
+          name: quay.stopPlace.name,
         },
-        selectedQuay:
-          quay?.id && quay.name
-            ? {
-                id: quay.id,
-                name: quay.name,
-              }
-            : undefined,
+        selectedQuay: {
+          id: quay.id,
+          name: quay.name,
+        },
       });
     } else {
       const location = await searchByStopPlace(quay?.stopPlace);


### PR DESCRIPTION
When departures v2 is enabled, if we have access to the relevant stop place id, we do not need to make a bff call before we navigate. The ID is made accessible with an bff update: https://github.com/AtB-AS/atb-bff/pull/167/files

This fixes https://github.com/AtB-AS/kundevendt/issues/73 and https://github.com/AtB-AS/kundevendt/issues/481 when departures v2 is enabled, as shown in this screen recording:

https://user-images.githubusercontent.com/1774972/194310360-09b06012-6415-45d5-b912-ae57a396b377.mp4

I tried to summarize whats needed to solve the issue for depatures v1 [here](https://github.com/AtB-AS/kundevendt/issues/481#issuecomment-1269907024)