### PR TITLE
refactor: empty default new_favourites_info_url

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -60,7 +60,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_vipps_login: false,
   enable_map_page: false,
   favourite_departures_poll_interval: 30000,
-  new_favourites_info_url: 'https://www.atb.no',
+  new_favourites_info_url: '',
 };
 
 export function getConfig(): RemoteConfig {


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/2655

by setting the default remote config value `new_favourites_info_url` to be an empty string. This is a falsy value which hides the link from the widget. 