### PR TITLE
refactor: rename FavouritesWidget to DeparturesWidget

### DIFF
--- a/src/screens/Dashboard/Dashboard.tsx
+++ b/src/screens/Dashboard/Dashboard.tsx
@@ -30,7 +30,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import CompactTickets from './CompactTickets';
-import FavouritesWidget from './DeparturesWidget';
+import DeparturesWidget from './DeparturesWidget';
 import {DashboardScreenProps} from './types';
 
 type DashboardRouteName = 'DashboardRoot';
@@ -283,7 +283,7 @@ const DashboardRoot: React.FC<RootProps> = ({navigation}) => {
             }
           />
         )}
-        <FavouritesWidget />
+        <DeparturesWidget />
       </ScrollView>
     </View>
   );

--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -15,7 +15,7 @@ import {ActivityIndicator, Linking, TouchableOpacity, View} from 'react-native';
 import {useFavoriteDepartureData} from './state';
 import {NoFavouriteDeparture} from '@atb/assets/svg/color/images/';
 
-const FavouritesWidget: React.FC = () => {
+const DeparturesWidget: React.FC = () => {
   const styles = useStyles();
   const {t} = useTranslation();
   const {new_favourites_info_url} = useRemoteConfig();
@@ -120,7 +120,7 @@ const FavouritesWidget: React.FC = () => {
   );
 };
 
-export default FavouritesWidget;
+export default DeparturesWidget;
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {


### PR DESCRIPTION
The "departue favorites widget" has two names, `FavoritesWidget` for the component when exported, and `DeparturesWidget` for the file name. I suggest we use `DeparturesWidget` both places.