### PR TITLE
fix: update searchTime on refresh of trip search

### DIFF
--- a/src/screens/Assistant/Assistant.tsx
+++ b/src/screens/Assistant/Assistant.tsx
@@ -415,6 +415,13 @@ const Assistant: React.FC<Props> = ({
     navigation.setParams({
       fromLocation: from?.resultType === 'geolocation' ? currentLocation : from,
       toLocation: to?.resultType === 'geolocation' ? currentLocation : to,
+      searchTime:
+        searchTime.option === 'now'
+          ? {
+              option: 'now',
+              date: new Date().toISOString(),
+            }
+          : searchTime,
     });
   };
 

--- a/src/screens/Dashboard/TripSearch.tsx
+++ b/src/screens/Dashboard/TripSearch.tsx
@@ -189,6 +189,13 @@ const TripSearch: React.FC<RootProps> = ({navigation}) => {
     navigation.setParams({
       fromLocation: from?.resultType === 'geolocation' ? currentLocation : from,
       toLocation: to?.resultType === 'geolocation' ? currentLocation : to,
+      searchTime:
+        searchTime.option === 'now'
+          ? {
+              option: 'now',
+              date: new Date().toISOString(),
+            }
+          : searchTime,
     });
   };
 


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/2181

When search time "now" is selected, refreshing the Assistant (or TripSearch when front page is enabled) will also update the searchTime date.