### PR TITLE
refactor: replace deprecated removeEventListener calls

### DIFF
--- a/src/utils/use-app-state-status.ts
+++ b/src/utils/use-app-state-status.ts
@@ -9,10 +9,10 @@ export function useAppStateStatus() {
     setAppState(newState);
   }
   useEffect(() => {
-    AppState.addEventListener('change', onChange);
+    const appStateSubscription = AppState.addEventListener('change', onChange);
 
     return () => {
-      AppState.removeEventListener('change', onChange);
+      appStateSubscription.remove();
     };
   }, []);
 

--- a/src/utils/use-is-screen-reader-enabled.ts
+++ b/src/utils/use-is-screen-reader-enabled.ts
@@ -12,10 +12,13 @@ export default function useIsScreenReaderEnabled() {
     };
 
     fetch();
-    AccessibilityInfo.addEventListener('screenReaderChanged', setEnabled);
+    const accessibilityInfoSubscription = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      setEnabled,
+    );
     return () => {
       mounted = false;
-      AccessibilityInfo.removeEventListener('screenReaderChanged', setEnabled);
+      accessibilityInfoSubscription.remove();
     };
   }, []);
 


### PR DESCRIPTION
Found two hooks with deprecated `removeEventListener()` calls:

```
@deprecated
Use the remove() method on the event subscription returned by addEventListener().
```

The `useIsScreenReaderEnabled` hook would sometimes cause a crash while I was working on https://github.com/AtB-AS/mittatb-app/pull/2983, which was fixed by this update. I'm not sure if `useAppStateStatus` has a similar issue.