### PR TITLE
refactor: do not toggle if selected token is already inspectable one

### DIFF
--- a/src/screens/Profile/TravelToken/SelectTravelTokenScreen.tsx
+++ b/src/screens/Profile/TravelToken/SelectTravelTokenScreen.tsx
@@ -8,6 +8,7 @@ import {RemoteToken} from '@atb/mobile-token/types';
 import {
   findInspectable,
   getDeviceName,
+  isInspectable,
   isMobileToken,
   isTravelCardToken,
 } from '@atb/mobile-token/utils';
@@ -60,6 +61,10 @@ export default function SelectTravelTokenScreen({navigation}: Props) {
 
   const onSave = useCallback(async () => {
     if (selectedToken) {
+      if (isInspectable(selectedToken)) {
+        navigation.goBack();
+        return;
+      }
       setSaveState({saving: true, error: false});
       const success = await toggleToken(selectedToken.id);
       if (success) {


### PR DESCRIPTION
Solves a part of https://github.com/AtB-AS/kundevendt/issues/2511

Currently, we are calling abt-token-server and eventually Entur if a user tries to toggle to the already inspectable token. Now when we are introducing the restriction on the number of times a user can toggle, this can create problems. So we allow the user to toggle but don't really do anything in that case.