### PR TITLE
feat: set status bar content color on map screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^5.3.0-alpha.0",
+    "@atb-as/generate-assets": "^5.3.0-alpha.1",
     "@babel/core": "^7.18.13",
     "@babel/runtime": "^7.18.9",
     "@entur-private/abt-token-server-javascript-interface": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^5.1.0-alpha.11",
+    "@atb-as/generate-assets": "^5.3.0-alpha.0",
     "@babel/core": "^7.18.13",
     "@babel/runtime": "^7.18.9",
     "@entur-private/abt-token-server-javascript-interface": "1.1.5",

--- a/src/screens/Map/MapScreen.tsx
+++ b/src/screens/Map/MapScreen.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import {Map} from '@atb/components/map';
+import useIsScreenReaderEnabled from '@atb/utils/use-is-screen-reader-enabled';
+import {MapDisabledForScreenReader} from './components/MapDisabledForScreenReader';
 
 export function MapScreen() {
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
+  if (isScreenReaderEnabled) return <MapDisabledForScreenReader />;
+
   return <Map selectionMode={'ExploreStops'} />;
 }

--- a/src/screens/Map/MapScreen.tsx
+++ b/src/screens/Map/MapScreen.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import {Map} from '@atb/components/map';
 import useIsScreenReaderEnabled from '@atb/utils/use-is-screen-reader-enabled';
 import {MapDisabledForScreenReader} from './components/MapDisabledForScreenReader';
+import StatusBarOnFocus from './components/StatusBarOnFocus';
 
 export function MapScreen() {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
   if (isScreenReaderEnabled) return <MapDisabledForScreenReader />;
 
-  return <Map selectionMode={'ExploreStops'} />;
+  return (
+    <>
+      <StatusBarOnFocus barStyle="dark-content" />
+      <Map selectionMode="ExploreStops" />
+    </>
+  );
 }

--- a/src/screens/Map/components/MapDisabledForScreenReader.tsx
+++ b/src/screens/Map/components/MapDisabledForScreenReader.tsx
@@ -1,0 +1,34 @@
+import ThemeText from '@atb/components/text';
+import {StyleSheet} from '@atb/theme';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {Map as MapImage} from '@atb/assets/svg/color/images';
+import {MapTexts, useTranslation} from '@atb/translations';
+
+export function MapDisabledForScreenReader() {
+  const styles = useStyles();
+  const {t} = useTranslation();
+  return (
+    <SafeAreaView style={styles.container}>
+      <MapImage style={styles.illustration} />
+      <ThemeText type="body__primary--bold" style={styles.header}>
+        {t(MapTexts.disabledForScreenReader.title)}
+      </ThemeText>
+      <ThemeText>{t(MapTexts.disabledForScreenReader.description)}</ThemeText>
+    </SafeAreaView>
+  );
+}
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.static.background.background_0.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    marginBottom: theme.spacings.medium,
+  },
+  illustration: {
+    marginBottom: theme.spacings.medium,
+  },
+}));

--- a/src/screens/Map/components/MapDisabledForScreenReader.tsx
+++ b/src/screens/Map/components/MapDisabledForScreenReader.tsx
@@ -1,21 +1,35 @@
+import {screenReaderPause} from '@atb/components/accessible-text';
 import ThemeText from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
 import {ThemedMapImage} from '@atb/theme/ThemedAssets';
 import {MapTexts, useTranslation} from '@atb/translations';
+import useFocusOnLoad from '@atb/utils/use-focus-on-load';
+import {View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 export function MapDisabledForScreenReader() {
   const styles = useStyles();
   const {t} = useTranslation();
+  const focusRef = useFocusOnLoad();
   return (
     <SafeAreaView style={styles.container}>
       <ThemedMapImage />
-      <ThemeText type="body__primary--bold" style={styles.header}>
-        {t(MapTexts.disabledForScreenReader.title)}
-      </ThemeText>
-      <ThemeText style={styles.description}>
-        {t(MapTexts.disabledForScreenReader.description)}
-      </ThemeText>
+      <View
+        ref={focusRef}
+        accessible={true}
+        accessibilityLabel={
+          t(MapTexts.disabledForScreenReader.title) +
+          screenReaderPause +
+          t(MapTexts.disabledForScreenReader.description)
+        }
+      >
+        <ThemeText type="body__primary--bold" style={styles.header}>
+          {t(MapTexts.disabledForScreenReader.title)}
+        </ThemeText>
+        <ThemeText style={styles.description}>
+          {t(MapTexts.disabledForScreenReader.description)}
+        </ThemeText>
+      </View>
     </SafeAreaView>
   );
 }

--- a/src/screens/Map/components/MapDisabledForScreenReader.tsx
+++ b/src/screens/Map/components/MapDisabledForScreenReader.tsx
@@ -1,19 +1,21 @@
 import ThemeText from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
-import {SafeAreaView} from 'react-native-safe-area-context';
-import {Map as MapImage} from '@atb/assets/svg/color/images';
+import {ThemedMapImage} from '@atb/theme/ThemedAssets';
 import {MapTexts, useTranslation} from '@atb/translations';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 export function MapDisabledForScreenReader() {
   const styles = useStyles();
   const {t} = useTranslation();
   return (
     <SafeAreaView style={styles.container}>
-      <MapImage style={styles.illustration} />
+      <ThemedMapImage />
       <ThemeText type="body__primary--bold" style={styles.header}>
         {t(MapTexts.disabledForScreenReader.title)}
       </ThemeText>
-      <ThemeText>{t(MapTexts.disabledForScreenReader.description)}</ThemeText>
+      <ThemeText style={styles.description}>
+        {t(MapTexts.disabledForScreenReader.description)}
+      </ThemeText>
     </SafeAreaView>
   );
 }
@@ -26,9 +28,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'center',
   },
   header: {
-    marginBottom: theme.spacings.medium,
+    marginVertical: theme.spacings.medium,
+    textAlign: 'center',
   },
-  illustration: {
-    marginBottom: theme.spacings.medium,
+  description: {
+    textAlign: 'center',
   },
 }));

--- a/src/screens/Map/components/MapDisabledForScreenReader.tsx
+++ b/src/screens/Map/components/MapDisabledForScreenReader.tsx
@@ -1,18 +1,23 @@
 import {screenReaderPause} from '@atb/components/accessible-text';
 import ThemeText from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {ThemedMapImage} from '@atb/theme/ThemedAssets';
 import {MapTexts, useTranslation} from '@atb/translations';
 import useFocusOnLoad from '@atb/utils/use-focus-on-load';
 import {View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import StatusBarOnFocus from './StatusBarOnFocus';
 
 export function MapDisabledForScreenReader() {
   const styles = useStyles();
   const {t} = useTranslation();
+  const {themeName} = useTheme();
   const focusRef = useFocusOnLoad();
   return (
     <SafeAreaView style={styles.container}>
+      <StatusBarOnFocus
+        barStyle={themeName === 'light' ? 'dark-content' : 'light-content'}
+      />
       <ThemedMapImage />
       <View
         ref={focusRef}

--- a/src/screens/Map/components/StatusBarOnFocus.tsx
+++ b/src/screens/Map/components/StatusBarOnFocus.tsx
@@ -1,0 +1,12 @@
+import {useIsFocused} from '@react-navigation/native';
+import React from 'react';
+import {StatusBar, StatusBarProps} from 'react-native';
+
+export default function StatusBarOnFocus(
+  props: StatusBarProps,
+): JSX.Element | null {
+  const isFocused = useIsFocused();
+  if (!isFocused) return null;
+
+  return <StatusBar {...props} />;
+}

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -3,6 +3,8 @@ import {Travelcard as DarkTravelCard} from '@atb/assets/svg/color/illustrations/
 import {Travelcard as LightTravelCard} from '@atb/assets/svg/color/illustrations/token/travelcard/light/';
 import {Phone as DarkPhone} from '@atb/assets/svg/color/illustrations/token/mobile/dark/';
 import {Phone as LightPhone} from '@atb/assets/svg/color/illustrations/token/mobile/light/';
+import {Map as LightMap} from '@atb/assets/svg/color/images/light';
+import {Map as DarkMap} from '@atb/assets/svg/color/images/dark';
 import {useTheme} from '@atb/theme/ThemeContext';
 
 export const ThemedTokenTravelCard = () => {
@@ -15,4 +17,10 @@ export const ThemedTokenPhone = () => {
   const {themeName} = useTheme();
   const Phone = themeName === 'dark' ? DarkPhone : LightPhone;
   return <Phone />;
+};
+
+export const ThemedMapImage = () => {
+  const {themeName} = useTheme();
+  const Map = themeName === 'dark' ? DarkMap : LightMap;
+  return <Map />;
 };

--- a/src/translations/components/Map.ts
+++ b/src/translations/components/Map.ts
@@ -28,5 +28,12 @@ const MapTexts = {
       ),
     },
   },
+  disabledForScreenReader: {
+    title: _('Kart kan ikke vises', 'Map cannot be viewed'),
+    description: _(
+      'Kart er ikke synlig når du bruker skjermleser.',
+      'The map is not visible while using screen reader.',
+    ),
+  },
 };
 export default MapTexts;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,12 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^5.1.0-alpha.11":
-  version "5.1.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.1.0-alpha.11.tgz#e744a78e41a30fb8fe64fce357c66267fd2b5a66"
-  integrity sha512-R9kSMRZ2BFiOTNRUSEQhtlb2RxkaGL6QN9TPN0dBC5x99qLxOSR5wvS1Hw7A8d7hkj37IaTEu98ZKjwmwrhm9w==
+"@atb-as/generate-assets@^5.3.0-alpha.0":
+  version "5.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.3.0-alpha.0.tgz#8be2d4a0494a85a032e096995244110960a20a79"
+  integrity sha512-Plci2nSYmdvceJkgT2aK3kW9M55Bm3WY2yvrRlRVbxVJRLvAzkwBpaxYEkaaxpk8fSyz96ibaJgfEBAJgjFjDw==
   dependencies:
-    "@atb-as/theme" "^6.0.0-alpha.7"
+    "@atb-as/theme" "^6.1.0-alpha.0"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
@@ -28,6 +28,14 @@
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^1.0.7"
+
+"@atb-as/theme@^6.1.0-alpha.0":
+  version "6.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.1.0-alpha.0.tgz#2eb2acd0f7fec72796f45cda5e11a6c6b832c1f5"
+  integrity sha512-jdqGL0tQlVlROlHsIQqPiWEnj0Dorj8zRdoFncTLwSaDWarVDHYOy3pt3pYgOBIW1xEla0+63ftfjeZIEz0nUw==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@~7.10.4":
   version "7.10.4"
@@ -10572,6 +10580,11 @@ ts-deepmerge@^1.0.7:
   version "1.1.0"
   resolved "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-1.1.0.tgz"
   integrity sha512-VvwaV/6RyYMwT9d8dClmfHIsG2PCdm6WY430QKOIbPRR50Y/1Q2ilp4i2XEZeHFcNqfaYnAQzpyUC6XA0AqqBg==
+
+ts-deepmerge@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ts-deepmerge/-/ts-deepmerge-4.0.0.tgz#e236314a601ff9a6526cbd07c4b97e885f58532a"
+  integrity sha512-IrjjAwfM/J6ajWv5wDRZBdpVaTmuONJN1vC85mXlWVPXKelouLFiqsjR7m0h245qY6zZEtcDtcOTc4Rozgg1TQ==
 
 ts-jest@^29.0.1:
   version "29.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^5.3.0-alpha.0":
-  version "5.3.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.3.0-alpha.0.tgz#8be2d4a0494a85a032e096995244110960a20a79"
-  integrity sha512-Plci2nSYmdvceJkgT2aK3kW9M55Bm3WY2yvrRlRVbxVJRLvAzkwBpaxYEkaaxpk8fSyz96ibaJgfEBAJgjFjDw==
+"@atb-as/generate-assets@^5.3.0-alpha.1":
+  version "5.3.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.3.0-alpha.1.tgz#1aee6c497d4831b3f0b7e14d1a800a072c8edadd"
+  integrity sha512-g7gVKDqO89/AdNMb0/ZhrynVi8R5cYvtNTfM8iPv5ZnGzHi/PDpO940WQiwcnyCQta9lJXDwKwuR/qB0XHKHnw==
   dependencies:
     "@atb-as/theme" "^6.1.0-alpha.0"
     commander "^9.4.0"


### PR DESCRIPTION
In order to make the statusbar more visible on the map page, we need to update the status bar content color when one of the screens are focused. My suggestion is to create a `StatusBarOnFocus` component which wraps `useIsFocused`, but not sure it's the best solution, so open to feedback.

https://user-images.githubusercontent.com/1774972/195813383-ef1e154c-d485-4801-ab44-d319b6a2b486.mp4
