### PR TITLE
fix: update offer defaults when updating preassignedFareProduct

### DIFF
--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -40,7 +40,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
     params.toTariffZone,
   );
 
-  const setSelectedPreassignedFareProduct = (fp: PreassignedFareProduct) => {
+  const onSelectPreassignedFareProduct = (fp: PreassignedFareProduct) => {
     navigation.setParams({
       preassignedFareProduct: fp,
     });
@@ -105,7 +105,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             <DurationSelection
               color="interactive_2"
               selectedProduct={preassignedFareProduct}
-              setSelectedProduct={setSelectedPreassignedFareProduct}
+              setSelectedProduct={onSelectPreassignedFareProduct}
               style={styles.selectionComponent}
             />
           )}

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -1,6 +1,7 @@
 import MessageBox from '@atb/components/message-box';
 import FullScreenFooter from '@atb/components/screen-footer/full-footer';
 import FullScreenHeader from '@atb/components/screen-header/full-header';
+import {PreassignedFareProduct} from '@atb/reference-data/types';
 import {StyleSheet} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import MessageBoxTexts from '@atb/translations/components/MessageBox';
@@ -39,15 +40,18 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
     params.toTariffZone,
   );
 
-  const [selectedPreassignedFareProduct, setSelectedPreassignedFareProduct] =
-    useState(preassignedFareProduct);
+  const setSelectedPreassignedFareProduct = (fp: PreassignedFareProduct) => {
+    navigation.setParams({
+      preassignedFareProduct: fp,
+    });
+  };
   const [travellerSelection, setTravellerSelection] =
     useState(selectableTravellers);
   const hasSelection = travellerSelection.some((u) => u.count);
   const [travelDate, setTravelDate] = useState<string | undefined>();
 
   const {isSearchingOffer, error, totalPrice, refreshOffer} = useOfferState(
-    selectedPreassignedFareProduct,
+    preassignedFareProduct,
     fromTariffZone,
     toTariffZone,
     travellerSelection,
@@ -75,9 +79,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
     <View style={styles.container}>
       <FullScreenHeader
         title={t(
-          PurchaseOverviewTexts.header.title[
-            selectedPreassignedFareProduct.type
-          ],
+          PurchaseOverviewTexts.header.title[preassignedFareProduct.type],
         )}
         leftButton={{
           type: 'cancel',
@@ -102,7 +104,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
           {durationSelectionEnabled && (
             <DurationSelection
               color="interactive_2"
-              selectedProduct={selectedPreassignedFareProduct}
+              selectedProduct={preassignedFareProduct}
               setSelectedProduct={setSelectedPreassignedFareProduct}
               style={styles.selectionComponent}
             />
@@ -120,7 +122,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             toTariffZone={toTariffZone}
             style={styles.selectionComponent}
             isApplicableOnSingleZoneOnly={
-              selectedPreassignedFareProduct.isApplicableOnSingleZoneOnly
+              preassignedFareProduct.isApplicableOnSingleZoneOnly
             }
           />
 
@@ -136,7 +138,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
         </View>
 
         <PurchaseMessages
-          preassignedFareProductType={selectedPreassignedFareProduct.type}
+          preassignedFareProductType={preassignedFareProduct.type}
           fromTariffZone={fromTariffZone}
           toTariffZone={toTariffZone}
         />
@@ -149,7 +151,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             fromTariffZone={fromTariffZone}
             toTariffZone={toTariffZone}
             userProfilesWithCount={travellerSelection}
-            preassignedFareProduct={selectedPreassignedFareProduct}
+            preassignedFareProduct={preassignedFareProduct}
             travelDate={travelDate}
             style={styles.summary}
           />


### PR DESCRIPTION
Fixes an issue where the student category was missing when purchasing periodic tickets in the app, because the list wasn't updated with the correct set of travellers when selecting a different fare product.

In order to keep the list of selectable travellers updated, this PR uses navigation params instead of a local state. This updates the offer defaults, and the list of travellers.

https://user-images.githubusercontent.com/1774972/196380100-c55efe1f-d08a-4a38-8b43-e636b4218587.mp4
