### PR TITLE
fix: change implementation of background colors for ticketing

### DIFF
--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -43,7 +43,7 @@ export const AvailableTickets = ({
   const shouldShowSummerPass = false;
 
   return (
-    <View style={containerStyle}>
+    <View style={[containerStyle, styles.container]}>
       <ThemeText type="body__secondary" style={styles.heading}>
         {t(TicketsTexts.availableTickets.allTickets)}
       </ThemeText>
@@ -104,6 +104,9 @@ export const AvailableTickets = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    paddingBottom: theme.spacings.medium,
+  },
   heading: {
     margin: theme.spacings.medium,
     marginLeft: theme.spacings.xLarge,

--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -1,4 +1,4 @@
-import {View} from 'react-native';
+import {View, ViewStyle} from 'react-native';
 import {TicketsTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {StyleSheet} from '@atb/theme';
@@ -12,10 +12,12 @@ export const AvailableTickets = ({
   onBuySingleTicket,
   onBuyPeriodTicket,
   onBuyHour24Ticket,
+  containerStyle,
 }: {
   onBuySingleTicket: () => void;
   onBuyPeriodTicket: () => void;
   onBuyHour24Ticket: () => void;
+  containerStyle: ViewStyle;
 }) => {
   const styles = useStyles();
   const hasEnabledMobileToken = useHasEnabledMobileToken();
@@ -41,7 +43,7 @@ export const AvailableTickets = ({
   const shouldShowSummerPass = false;
 
   return (
-    <View>
+    <View style={containerStyle}>
       <ThemeText type="body__secondary" style={styles.heading}>
         {t(TicketsTexts.availableTickets.allTickets)}
       </ThemeText>

--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -17,7 +17,7 @@ export const AvailableTickets = ({
   onBuySingleTicket: () => void;
   onBuyPeriodTicket: () => void;
   onBuyHour24Ticket: () => void;
-  containerStyle: ViewStyle;
+  containerStyle?: ViewStyle;
 }) => {
   const styles = useStyles();
   const hasEnabledMobileToken = useHasEnabledMobileToken();

--- a/src/screens/Ticketing/Tickets/RecentTickets/RecentTickets.tsx
+++ b/src/screens/Ticketing/Tickets/RecentTickets/RecentTickets.tsx
@@ -56,9 +56,7 @@ export const RecentTickets = () => {
   );
 
   return (
-    <View
-      style={{backgroundColor: theme.static.background.background_1.background}}
-    >
+    <View>
       {loading && (
         <View
           style={{

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -8,6 +8,7 @@ import {ScrollView} from 'react-native';
 import {RecentTickets} from './RecentTickets/RecentTickets';
 import {TicketsScreenProps} from './types';
 import UpgradeSplash from './UpgradeSplash';
+import useRecentTickets from './use-recent-tickets';
 
 type Props = TicketsScreenProps<'BuyTickets'>;
 
@@ -16,6 +17,8 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const {abtCustomerId, authenticationType} = useAuthState();
   const isSignedInAsAbtCustomer = !!abtCustomerId;
   const {theme} = useTheme();
+  const {recentTickets} = useRecentTickets();
+  const hasRecentTickets = enable_recent_tickets && recentTickets.length;
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 
@@ -72,7 +75,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
         onBuyPeriodTicket={onBuyPeriodTicket}
         onBuyHour24Ticket={onBuyHour24Ticket}
         containerStyle={
-          enable_recent_tickets
+          hasRecentTickets
             ? {
                 backgroundColor:
                   theme.static.background.background_2.background,

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -64,15 +64,21 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   };
 
   return isSignedInAsAbtCustomer ? (
-    <ScrollView
-      style={{backgroundColor: theme.static.background.background_2.background}}
-    >
+    <ScrollView>
       {enable_recent_tickets && <RecentTickets />}
       {authenticationType !== 'phone' && <AnonymousPurchaseWarning />}
       <AvailableTickets
         onBuySingleTicket={onBuySingleTicket}
         onBuyPeriodTicket={onBuyPeriodTicket}
         onBuyHour24Ticket={onBuyHour24Ticket}
+        containerStyle={
+          enable_recent_tickets
+            ? {
+                backgroundColor:
+                  theme.static.background.background_2.background,
+              }
+            : undefined
+        }
       />
     </ScrollView>
   ) : null;


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/2333

On the ticketing screen, the background color is now set as default to the same color as the tab, which solves the "scroll area" from being the wrong color as described in https://github.com/AtB-AS/kundevendt/issues/2333.

Also handles the case where the user has no previous purchases, which makes the "All products" section the same color as the tab.

### See proposed solution in Figma:
[Tickets / Buy](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?node-id=11562%3A50133)
[Tickets / Buy (with Recent tickets)](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?node-id=6648%3A45714)
[Tickets / Buy  (loading)](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?node-id=11562%3A50788)

### Demo


https://user-images.githubusercontent.com/1774972/196419080-fb082bf0-1762-488a-aaf4-5054e6030cad.mp4

