### PR TITLE
build: Update register scripts

### DIFF
--- a/scripts/android/register-app-version.sh
+++ b/scripts/android/register-app-version.sh
@@ -87,7 +87,8 @@ json=$(cat <<EOJ
     },
     android: {
       "apk_package_name": "$ANDROID_APPLICATION_ID",
-      "application_version_id": "$concat_app_version",
+      "version_name": "$concat_app_version",
+      "version_code": "$BUILD_ID",
       "certificate_digests": [
         "$certificate_digest"
       ],

--- a/scripts/ios/register-app-version.sh
+++ b/scripts/ios/register-app-version.sh
@@ -80,7 +80,7 @@ json=$(cat <<EOJ
     "ios": {
       "team_identifiers": ["$IOS_DEVELOPMENT_TEAM_ID"],
       "bundle_id": "$IOS_BUNDLE_IDENTIFIER",
-      "application_version_id": "$APP_VERSION"
+      "version_name": "$APP_VERSION"
     },
     "active": true
   }


### PR DESCRIPTION
The field 'application_version_id' is changed to 'version_name'. In
addition we start using the field 'version_code' for Android, which is
necessary for Play Integrity.

Resolves https://github.com/AtB-AS/kundevendt/issues/2687