### PR TITLE
feat: sort dashboard departures by distance

### DIFF
--- a/src/screens/Dashboard/DeparturesWidget.tsx
+++ b/src/screens/Dashboard/DeparturesWidget.tsx
@@ -40,7 +40,7 @@ const DeparturesWidget: React.FC = () => {
 
   const sortedStopPlaceGroups = location
     ? state.data?.sort((a, b) =>
-        sortStopsByDistance(a.stopPlace, b.stopPlace, location.coordinates),
+        compareStopsByDistance(a.stopPlace, b.stopPlace, location.coordinates),
       )
     : state.data;
 
@@ -124,7 +124,7 @@ const DeparturesWidget: React.FC = () => {
   );
 };
 
-function sortStopsByDistance(
+function compareStopsByDistance(
   a: StopPlaceInfo,
   b: StopPlaceInfo,
   geolocation: Coordinates,
@@ -141,10 +141,7 @@ function sortStopsByDistance(
     {lat: b.latitude, lon: b.longitude},
     geolocation,
   );
-
-  if (distanceToA > distanceToB) return 1;
-  if (distanceToA < distanceToB) return -1;
-  return 0;
+  return distanceToA - distanceToB;
 }
 
 export default DeparturesWidget;


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/2595

Sorts dashboard favorite departures by distance to the user geolocation. If location permission is not given, the app keeps the default order.

<img width="300px" src="https://user-images.githubusercontent.com/1774972/196697299-1e70f948-e428-4498-a10f-6c9704b4ba9f.png">
