### PR TITLE
build: Adds a fix to the keychain for Github Actions

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,21 +44,13 @@ platform :ios do
       env_vars: ['MATCH_PASSWORD', 'FASTLANE_MATCH_GIT_SSH_URL', 'FASTLANE_MATCH_TYPE', 'IOS_BUNDLE_IDENTIFIER', 'IOS_DEVELOPMENT_TEAM_ID']
     )
     if is_ci
-      create_keychain(
-        name: "CI",
-        password: ENV["MATCH_PASSWORD"],
-        default_keychain: true,
-        unlock: true,
-        timeout: 3600,
-        lock_when_sleeps: false
-      )
+      setup_ci()
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],
         app_identifier: ENV['IOS_BUNDLE_IDENTIFIER'],
         storage_mode: 'git',
         git_url: ENV['FASTLANE_MATCH_GIT_SSH_URL'],
         readonly: true,
-        keychain_name: "CI",
         keychain_password: ENV["MATCH_PASSWORD"],
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,7 +195,6 @@ platform :android do
     )
   end
 
-
   lane :playstore_internal do
     ensure_env_vars(
       env_vars: ['GOOGLE_PLAY_SERVICE_ACCOUNT_PATH','APK_FILE_NAME','ANDROID_PACKAGE_NAME']

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,13 +44,21 @@ platform :ios do
       env_vars: ['MATCH_PASSWORD', 'FASTLANE_MATCH_GIT_SSH_URL', 'FASTLANE_MATCH_TYPE', 'IOS_BUNDLE_IDENTIFIER', 'IOS_DEVELOPMENT_TEAM_ID']
     )
     if is_ci
-      setup_ci()
+      create_keychain(
+        name: "CI",
+        password: ENV["MATCH_PASSWORD"],
+        default_keychain: true,
+        unlock: true,
+        timeout: 10800,
+        lock_when_sleeps: false
+      )
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],
         app_identifier: ENV['IOS_BUNDLE_IDENTIFIER'],
         storage_mode: 'git',
         git_url: ENV['FASTLANE_MATCH_GIT_SSH_URL'],
         readonly: true,
+        keychain_name: "CI",
         keychain_password: ENV["MATCH_PASSWORD"],
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )


### PR DESCRIPTION
Short explanation: The keychain that stores the certificates for signing is expired before the compilation ends, causing an endless loop in the linking process. Ensuring more time `timeout` in the creation guarantee to be available.