### PR TITLE
refactor: set toggle limit to zero if somhow max limit ends up being less than times toggled by user

### DIFF
--- a/src/screens/Profile/TravelToken/use-token-toggle-details.ts
+++ b/src/screens/Profile/TravelToken/use-token-toggle-details.ts
@@ -13,8 +13,13 @@ const useTokenToggleDetails = (shouldFetchTokenDetails: boolean) => {
     const toggleToggleDetails = await getTokenToggleDetails();
     if (toggleToggleDetails) {
       const {toggleMaxLimit, toggledCount} = toggleToggleDetails;
-      if (toggleMaxLimit && toggleMaxLimit >= toggledCount) {
-        setToggleLimit(toggleMaxLimit - toggledCount);
+      if (toggleMaxLimit) {
+        if (toggleMaxLimit >= toggledCount) {
+          setToggleLimit(toggleMaxLimit - toggledCount);
+        } else {
+          //We can end up here if we decide to reduce max limit value in firestore
+          setToggleLimit(0);
+        }
       }
       setMaxToggleLimit(toggleMaxLimit);
     }


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/2511#issuecomment-1285071939

We can end up in a situation when toggle max limit becomes less than the number of times toggled by the user. This can happen when we reduce the max limit in firestore and the user has already toggled more than the new max limit. Hence setting toggle attempts left to zero for the user in such case.