### PR TITLE
fix: replace NFK NoFavouriteDepartures illustration

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^5.3.0-alpha.1",
+    "@atb-as/generate-assets": "^5.3.0-alpha.2",
     "@babel/core": "^7.18.13",
     "@babel/runtime": "^7.18.9",
     "@entur-private/abt-token-server-javascript-interface": "1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^5.3.0-alpha.1":
-  version "5.3.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.3.0-alpha.1.tgz#1aee6c497d4831b3f0b7e14d1a800a072c8edadd"
-  integrity sha512-g7gVKDqO89/AdNMb0/ZhrynVi8R5cYvtNTfM8iPv5ZnGzHi/PDpO940WQiwcnyCQta9lJXDwKwuR/qB0XHKHnw==
+"@atb-as/generate-assets@^5.3.0-alpha.2":
+  version "5.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.3.0-alpha.2.tgz#04c2404e43975f34e2bc7af89cbb58940b0ace56"
+  integrity sha512-wS2yTt07U8srLZj1gwRV/lPQC47uJa644mMM4+Xct1ZRGmjk3aFDV9C7PTgMSa6eawOEX8eMmOs4YYKxbgVidA==
   dependencies:
     "@atb-as/theme" "^6.1.0-alpha.0"
     commander "^9.4.0"


### PR DESCRIPTION
Partly solving https://github.com/AtB-AS/kundevendt/issues/2628

This PR bumps the version number of generate-assets to include a new NFK noFavouriteDepartures widget illustration. 

Shouldn't affect AtB in any way, but I understand you might want to wait after making a release candidate. Design system PR for reference: https://github.com/AtB-AS/design-system/pull/76

Screenshot for NFK:
![simulator_screenshot_887A455D-CB9A-42D3-BC1B-B8624DB40C2B](https://user-images.githubusercontent.com/21310942/196963048-0d4500ea-1540-4fc3-ac85-11c57af91c7b.png)
