### PR TITLE
fix: move AnonymousPurchaseWarning from repeat purchase section

### DIFF
--- a/src/screens/Ticketing/Tickets/AnonymousPurchaseWarning.tsx
+++ b/src/screens/Ticketing/Tickets/AnonymousPurchaseWarning.tsx
@@ -30,7 +30,7 @@ const AnonymousPurchaseWarning = () => {
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   warning: {
-    marginTop: theme.spacings.large,
+    marginTop: theme.spacings.xLarge,
     paddingHorizontal: theme.spacings.medium,
   },
 }));

--- a/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
+++ b/src/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets.tsx
@@ -12,12 +12,10 @@ export const AvailableTickets = ({
   onBuySingleTicket,
   onBuyPeriodTicket,
   onBuyHour24Ticket,
-  containerStyle,
 }: {
   onBuySingleTicket: () => void;
   onBuyPeriodTicket: () => void;
   onBuyHour24Ticket: () => void;
-  containerStyle?: ViewStyle;
 }) => {
   const styles = useStyles();
   const hasEnabledMobileToken = useHasEnabledMobileToken();
@@ -43,7 +41,7 @@ export const AvailableTickets = ({
   const shouldShowSummerPass = false;
 
   return (
-    <View style={[containerStyle, styles.container]}>
+    <View style={styles.container}>
       <ThemeText type="body__secondary" style={styles.heading}>
         {t(TicketsTexts.availableTickets.allTickets)}
       </ThemeText>

--- a/src/screens/Ticketing/Tickets/Tabs.tsx
+++ b/src/screens/Ticketing/Tickets/Tabs.tsx
@@ -4,7 +4,7 @@ import AnonymousPurchaseWarning from '@atb/screens/Ticketing/Tickets/AnonymousPu
 import {AvailableTickets} from '@atb/screens/Ticketing/Tickets/AvailableTickets/AvailableTickets';
 import {useTheme} from '@atb/theme';
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import {RecentTickets} from './RecentTickets/RecentTickets';
 import {TicketsScreenProps} from './types';
 import UpgradeSplash from './UpgradeSplash';
@@ -18,7 +18,7 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
   const isSignedInAsAbtCustomer = !!abtCustomerId;
   const {theme} = useTheme();
   const {recentTickets} = useRecentTickets();
-  const hasRecentTickets = enable_recent_tickets && recentTickets.length;
+  const hasRecentTickets = enable_recent_tickets && !!recentTickets.length;
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 
@@ -68,21 +68,21 @@ export const BuyTickets: React.FC<Props> = ({navigation}) => {
 
   return isSignedInAsAbtCustomer ? (
     <ScrollView>
-      {enable_recent_tickets && <RecentTickets />}
-      {authenticationType !== 'phone' && <AnonymousPurchaseWarning />}
-      <AvailableTickets
-        onBuySingleTicket={onBuySingleTicket}
-        onBuyPeriodTicket={onBuyPeriodTicket}
-        onBuyHour24Ticket={onBuyHour24Ticket}
-        containerStyle={
-          hasRecentTickets
-            ? {
-                backgroundColor:
-                  theme.static.background.background_2.background,
-              }
-            : undefined
-        }
-      />
+      {hasRecentTickets && <RecentTickets />}
+      <View
+        style={{
+          backgroundColor: hasRecentTickets
+            ? theme.static.background.background_2.background
+            : undefined,
+        }}
+      >
+        {authenticationType !== 'phone' && <AnonymousPurchaseWarning />}
+        <AvailableTickets
+          onBuySingleTicket={onBuySingleTicket}
+          onBuyPeriodTicket={onBuyPeriodTicket}
+          onBuyHour24Ticket={onBuyHour24Ticket}
+        />
+      </View>
     </ScrollView>
   ) : null;
 };


### PR DESCRIPTION
ref. https://github.com/AtB-AS/kundevendt/issues/2333#issuecomment-1285218487

Fixes an inconsistency with [sketches](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?node-id=10194%3A48114) where the warning message for anonymous users was shown in the same section as recent tickets.

Now the ticketing screen looks like this:

![collage](https://user-images.githubusercontent.com/1774972/197178550-ac340513-ca64-4b25-8caa-4a4e4e2cba5f.png)
