### PR TITLE
build: require specific androidXBrowser

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,8 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 31
         targetSdkVersion = 31
+        // Setting androidXBrowser to avoid react-native-reborn picking newest alpha requiring SDK 33
+        androidXBrowser = "1.4.0"
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
Following the [release of AndroidXBrowser v 1.5.0-alpha01](https://developer.android.com/jetpack/androidx/releases/browser#1.5.0-alpha01) last evening, building the app on Android required compiling to Android SDK version 33, which requires some testing. Because we had a lower SDK version, building the Android app failed with a Gradle Error.

Mikael discovered that our dependency package `react-native-inappbrowser-reborn` picked whatever newest AndroidX packages [it could find](https://github.com/proyecto26/react-native-inappbrowser/blob/a51ecc774e8e0fe494879d1dc60ed23148fea886/README.md#mostly-automatic-installation) if we didn't [specify a version](https://github.com/proyecto26/react-native-inappbrowser/blob/a51ecc774e8e0fe494879d1dc60ed23148fea886/README.md#mostly-automatic-installation) we wanted, so therefore we are specifying it now, to make the app build again. 

Testing: 
Verify that the Android app builds in staging action.