### PR TITLE
fix: move AnonymousPurchaseWarning from repeat purchase section

### DIFF
--- a/src/screens/Ticketing/FareProducts/AvailableFareProducts/AvailableFareProducts.tsx
+++ b/src/screens/Ticketing/FareProducts/AvailableFareProducts/AvailableFareProducts.tsx
@@ -12,12 +12,10 @@ export const AvailableFareProducts = ({
   onBuySingleFareProduct,
   onBuyPeriodFareProduct,
   onBuyHour24FareProduct,
-  containerStyle,
 }: {
   onBuySingleFareProduct: () => void;
   onBuyPeriodFareProduct: () => void;
   onBuyHour24FareProduct: () => void;
-  containerStyle?: ViewStyle;
 }) => {
   const styles = useStyles();
   const hasEnabledMobileToken = useHasEnabledMobileToken();
@@ -43,7 +41,7 @@ export const AvailableFareProducts = ({
   const shouldShowSummerPass = false;
 
   return (
-    <View style={[containerStyle, styles.container]}>
+    <View style={styles.container}>
       <ThemeText type="body__secondary" style={styles.heading}>
         {t(TicketingTexts.availableFareProducts.allTickets)}
       </ThemeText>

--- a/src/screens/Ticketing/FareProducts/PurchaseTab.tsx
+++ b/src/screens/Ticketing/FareProducts/PurchaseTab.tsx
@@ -4,7 +4,7 @@ import AnonymousPurchaseWarning from '@atb/screens/Ticketing/Purchase/AnonymousP
 import {AvailableFareProducts} from '@atb/screens/Ticketing/FareProducts/AvailableFareProducts/AvailableFareProducts';
 import {useTheme} from '@atb/theme';
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import {RecentFareContracts} from './RecentFareProducts/RecentFareContracts';
 import {TicketingScreenProps} from '../types';
 import UpgradeSplash from './UpgradeSplash';
@@ -19,7 +19,7 @@ export const PurchaseTab: React.FC<Props> = ({navigation}) => {
   const {theme} = useTheme();
   const {recentFareContracts} = useRecentFareContracts();
   const hasRecentFareContracts =
-    enable_recent_tickets && recentFareContracts.length;
+    enable_recent_tickets && !!recentFareContracts.length;
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 
@@ -69,21 +69,21 @@ export const PurchaseTab: React.FC<Props> = ({navigation}) => {
 
   return isSignedInAsAbtCustomer ? (
     <ScrollView>
-      {enable_recent_tickets && <RecentFareContracts />}
-      {authenticationType !== 'phone' && <AnonymousPurchaseWarning />}
-      <AvailableFareProducts
-        onBuySingleFareProduct={onBuySingleFareProduct}
-        onBuyPeriodFareProduct={onBuyPeriodFareProduct}
-        onBuyHour24FareProduct={onBuyHour24FareProduct}
-        containerStyle={
-          hasRecentFareContracts
-            ? {
-                backgroundColor:
-                  theme.static.background.background_2.background,
-              }
-            : undefined
-        }
-      />
+      {hasRecentFareContracts && <RecentFareContracts />}
+      <View
+        style={{
+          backgroundColor: hasRecentFareContracts
+            ? theme.static.background.background_2.background
+            : undefined,
+        }}
+      >
+        {authenticationType !== 'phone' && <AnonymousPurchaseWarning />}
+        <AvailableFareProducts
+          onBuySingleFareProduct={onBuySingleFareProduct}
+          onBuyPeriodFareProduct={onBuyPeriodFareProduct}
+          onBuyHour24FareProduct={onBuyHour24FareProduct}
+        />
+      </View>
     </ScrollView>
   ) : null;
 };

--- a/src/screens/Ticketing/Purchase/AnonymousPurchaseWarning.tsx
+++ b/src/screens/Ticketing/Purchase/AnonymousPurchaseWarning.tsx
@@ -30,7 +30,7 @@ const AnonymousPurchaseWarning = () => {
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   warning: {
-    marginTop: theme.spacings.large,
+    marginTop: theme.spacings.xLarge,
     paddingHorizontal: theme.spacings.medium,
   },
 }));


### PR DESCRIPTION
ref. https://github.com/AtB-AS/kundevendt/issues/2333#issuecomment-1285218487 (and also previous PR https://github.com/AtB-AS/mittatb-app/pull/3018)

Fixes an inconsistency with [sketches](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?node-id=10194%3A48114) where the warning message for anonymous users was shown in the same section as recent tickets.

Now the ticketing screen looks like this:

![collage](https://user-images.githubusercontent.com/1774972/197178550-ac340513-ca64-4b25-8caa-4a4e4e2cba5f.png)
