### PR TITLE
fix: skip error logging on singleTrip 410 responses

### DIFF
--- a/src/api/trips_v2.ts
+++ b/src/api/trips_v2.ts
@@ -60,6 +60,7 @@ async function post<T>(
 ) {
   const response = await client.post<T>(url, query, {
     ...opts,
+    skipErrorLogging: (error) => error.response?.status === 410,
   });
 
   return response.data;


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/2451

Following https://github.com/AtB-AS/atb-bff/pull/169, skip error logging to bugsnag for 410 responses from the singleTrip BFF endpoint.

I have tested that in the simulator on iOS, there is no "bugsnag-popup" when we get a 410 response.