### PR TITLE
refactor: Add new section message tem

### DIFF
--- a/src/components/message-box/index.tsx
+++ b/src/components/message-box/index.tsx
@@ -13,6 +13,7 @@ import MessageBoxTexts from '@atb/translations/components/MessageBox';
 import {useTranslation} from '@atb/translations';
 import {Close} from '@atb/assets/svg/mono-icons/actions';
 import {screenReaderPause} from '@atb/components/accessible-text';
+import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
 
 type WithMessage = {
   message: string;
@@ -61,7 +62,7 @@ const MessageBox: React.FC<MessageBoxProps> = ({
     typeof icon !== 'undefined' ? (
       icon
     ) : (
-      <ThemeIcon fill={textColor} svg={typeToIcon(type)} />
+      <ThemeIcon fill={textColor} svg={messageTypeToIcon(type)} />
     );
   const child = message ? (
     <>
@@ -176,16 +177,3 @@ const useBoxStyle = StyleSheet.createThemeHook((theme) => ({
     marginBottom: theme.spacings.small,
   },
 }));
-
-function typeToIcon(type: MessageBoxProps['type']) {
-  switch (type) {
-    case 'warning':
-      return Warning;
-    case 'error':
-      return ErrorIcon;
-    case 'valid':
-      return Check;
-    default:
-      return Info;
-  }
-}

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -20,3 +20,6 @@ export {default as PhoneInput} from './phone-input';
 export {default as LocationInput} from './location-input';
 export {default as ButtonInput} from './button-input';
 export {default as CounterInput} from './counter-input';
+
+// Info
+export {default as MessageItem} from './message-item';

--- a/src/components/sections/message-item.tsx
+++ b/src/components/sections/message-item.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {View} from 'react-native';
+import {SectionItem, useSectionItem} from './section-utils';
+import ThemeText from '@atb/components/text';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {Statuses} from '@atb-as/theme';
+import ThemeIcon from '@atb/components/theme-icon';
+import {dictionary, useTranslation} from '@atb/translations';
+import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
+
+export type MessageItemProps = SectionItem<{
+  messageType: Statuses;
+  title?: string;
+  message: string;
+}>;
+
+export default function MessageItem({
+  messageType,
+  title,
+  message,
+  ...props
+}: MessageItemProps) {
+  const {topContainer} = useSectionItem(props);
+  const styles = useStyles();
+  const {theme} = useTheme();
+  const a11yLabel = useA11yLabel(messageType, title, message);
+
+  const themeColor = theme.static.status[messageType];
+
+  return (
+    <View
+      accessible={true}
+      accessibilityLabel={a11yLabel}
+      style={[
+        topContainer,
+        {backgroundColor: themeColor.background},
+        styles.container,
+      ]}
+    >
+      <ThemeIcon
+        style={styles.icon}
+        fill={themeColor.text}
+        svg={messageTypeToIcon(messageType)}
+      />
+      <View>
+        {title && (
+          <ThemeText
+            type="body__primary--bold"
+            style={styles.title}
+            color={messageType}
+          >
+            {title}
+          </ThemeText>
+        )}
+        <ThemeText style={styles.message} color={messageType}>
+          {message}
+        </ThemeText>
+      </View>
+    </View>
+  );
+}
+
+const useA11yLabel = (
+  messageType: Statuses,
+  title: string | undefined,
+  message: string,
+) => {
+  const {t} = useTranslation();
+  return `
+    ${t(dictionary.messageTypes[messageType])}
+    ${title ? title : ''}
+    ${message}
+  `;
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {flexDirection: 'row'},
+  icon: {marginRight: theme.spacings.medium},
+  title: {marginBottom: theme.spacings.small},
+  message: {flex: 1},
+}));

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -314,6 +314,32 @@ export default function DesignSystem() {
           </Sections.GenericItem>
         </Sections.Section>
 
+        <Sections.Section withPadding withTopPadding>
+          <Sections.HeaderItem text="Message section items" />
+
+          <Sections.MessageItem
+            messageType="info"
+            title="Information message!"
+            message="An information message with title"
+          />
+
+          <Sections.MessageItem
+            messageType="valid"
+            message="A success message without title"
+          />
+
+          <Sections.MessageItem
+            messageType="warning"
+            title="Warning message!"
+            message="A warning message with title"
+          />
+
+          <Sections.MessageItem
+            messageType="error"
+            message="An error message without title"
+          />
+        </Sections.Section>
+
         <View style={style.buttons}>
           <ButtonGroup>{buttons}</ButtonGroup>
         </View>

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -64,6 +64,12 @@ const dictionary = {
     km: _('km', 'km'),
     m: _('m', 'm'),
   },
+  messageTypes: {
+    info: _('Til info', 'Info'),
+    warning: _('Advarsel', 'Warning'),
+    valid: _('Suksess', 'Success'),
+    error: _('Feil', 'Error'),
+  },
 };
 
 export default dictionary;

--- a/src/utils/message-type-to-icon.ts
+++ b/src/utils/message-type-to-icon.ts
@@ -1,0 +1,15 @@
+import {Check, Error, Info, Warning} from '../assets/svg/mono-icons/status';
+import {Statuses} from '@atb/theme';
+
+export const messageTypeToIcon = (messageType: Statuses) => {
+  switch (messageType) {
+    case 'warning':
+      return Warning;
+    case 'error':
+      return Error;
+    case 'valid':
+      return Check;
+    default:
+      return Info;
+  }
+};


### PR DESCRIPTION
Support title and message, and the screen reader will read the status message type before reading the text content.

This is to be used when adding situation messages on departures v2.

Resolves https://github.com/AtB-AS/kundevendt/issues/147

![Screenshot 2022-11-09 at 10 24 16](https://user-images.githubusercontent.com/675421/200816678-45d7538f-a14b-4be8-813f-23ed27ded0e5.png)
