### PR TITLE
feat: upgrade theme package to get new NFK colours

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "link-assets": "react-native link"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.1.0-alpha.1",
+    "@atb-as/theme": "^6.1.3-alpha.1",
     "@bugsnag/react-native": "^7.17.3",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-client-sdk": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "link-assets": "react-native link"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.1.3-alpha.1",
+    "@atb-as/theme": "^6.1.3",
     "@bugsnag/react-native": "^7.17.3",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-client-sdk": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,10 +29,10 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
-"@atb-as/theme@^6.1.3-alpha.1":
-  version "6.1.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.1.3-alpha.1.tgz#01cdd3d45dcb9fb1dbb1c800dbe98daadd44328f"
-  integrity sha512-BR20duyUB6mgnhv1voGi4m5n7VqcAHUmlVJj+9S+jJOQ5YSXUvM9ZLG89R+xpfbb32B7YuNtEZaG+qk+Xc0zCQ==
+"@atb-as/theme@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.1.3.tgz#f151c6708e20cc64a216745224b20aed05492010"
+  integrity sha512-/Yb4PP+7ZeJtysPOsIUgnHY+l7NLR+bAEaDhzulEdy3e1HU39ZkY6xJtZ+02EiLkMPFPrjAz9ZmOuFxWjyblew==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,14 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
+"@atb-as/theme@^6.1.3-alpha.1":
+  version "6.1.3-alpha.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.1.3-alpha.1.tgz#01cdd3d45dcb9fb1dbb1c800dbe98daadd44328f"
+  integrity sha512-BR20duyUB6mgnhv1voGi4m5n7VqcAHUmlVJj+9S+jJOQ5YSXUvM9ZLG89R+xpfbb32B7YuNtEZaG+qk+Xc0zCQ==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@~7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"


### PR DESCRIPTION
Updating theme package, to include new NFK destructive interactive colours in the 1.28 version of app.

Should include the following changes in the theme package (only NFK colours as far as I can see):

- https://github.com/AtB-AS/design-system/commit/395f3eaa76b380ae6111892afd68310047acc3de
- https://github.com/AtB-AS/design-system/commit/734ffae25faa33fd6b66fa3d3c0638d3bce58996
- https://github.com/AtB-AS/design-system/commit/9ddd692faa9d76987823f766ea779eb52cf6b673