### PR TITLE
refactor: Fix QuaySection border bottom error

### DIFF
--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -131,8 +131,7 @@ export default function QuaySection({
             renderItem={({item: departure, index}: EstimatedCallRenderItem) => (
               <Sections.GenericItem
                 radius={
-                  (!navigateToQuay &&
-                    index === departuresToDisplay.length - 1) ||
+                  index === departuresToDisplay.length - 1 &&
                   !shouldShowMoreItemsLink
                     ? 'bottom'
                     : undefined


### PR DESCRIPTION
There was an error where not only the last item of a QuaySection had bottom border-radius.

Before/After
<div>
<img width=400 src="https://user-images.githubusercontent.com/675421/202445346-698cc5d6-e43d-4c66-929b-0b4ac689a45d.jpeg"/>
<img width=400 src="https://user-images.githubusercontent.com/675421/202445339-149e8eae-d471-4d00-9caf-10411d93df07.PNG"/>
</div>
