### PR TITLE
fix: add space before unit of measurement in distance

### DIFF
--- a/src/departure-list/section-items/quay-header.tsx
+++ b/src/departure-list/section-items/quay-header.tsx
@@ -96,9 +96,9 @@ function Distance({distance}: DistanceProps) {
 }
 const humanizeDistance = (meters: number, t: TFunc<typeof Language>) => {
   if (meters >= 1000) {
-    return `${Math.round(meters / 1000)}${t(dictionary.distance.km)}`;
+    return `${Math.round(meters / 1000)} ${t(dictionary.distance.km)}`;
   }
-  return `${Math.round(meters)}${t(dictionary.distance.m)}`;
+  return `${Math.round(meters)} ${t(dictionary.distance.m)}`;
 };
 const useItemStyles = StyleSheet.createThemeHook((theme) => ({
   situations: {


### PR DESCRIPTION
https://www.sprakradet.no/sprakhjelp/Skriveregler/Mellomrom/
"Det skal vere mellomrom mellom tal og (forkorta) nemningar anten nemninga står framfor talet eller etter det.

10 kr, 5,68 kg, 25 l, 5 m, 10 min"