### PR TITLE
refactor: Date change didn't refresh departure search

### DIFF
--- a/src/screens/Departures/QuayView.tsx
+++ b/src/screens/Departures/QuayView.tsx
@@ -55,7 +55,7 @@ export default function QuayView({
   const {favoriteDepartures} = useFavorites();
   const searchStartTime =
     searchTime?.option !== 'now' ? searchTime.date : undefined;
-  const {state, refresh, forceRefresh} = useQuayData(
+  const {state, forceRefresh} = useQuayData(
     quay,
     showOnlyFavorites,
     mode,
@@ -76,10 +76,6 @@ export default function QuayView({
   useEffect(() => {
     if (!placeHasFavorites) setShowOnlyFavorites(false);
   }, [favoriteDepartures]);
-
-  useEffect(() => {
-    refresh();
-  }, [quay]);
 
   return (
     <SectionList
@@ -118,10 +114,7 @@ export default function QuayView({
         </>
       }
       refreshControl={
-        <RefreshControl
-          refreshing={state.isLoading}
-          onRefresh={didLoadingDataFail ? forceRefresh : refresh}
-        />
+        <RefreshControl refreshing={state.isLoading} onRefresh={forceRefresh} />
       }
       sections={quayListData}
       testID={testID}

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -59,7 +59,7 @@ export default function StopPlaceView({
   const {t} = useTranslation();
   const searchStartTime =
     searchTime?.option !== 'now' ? searchTime.date : undefined;
-  const {state, refresh, forceRefresh} = useStopPlaceData(
+  const {state, forceRefresh} = useStopPlaceData(
     stopPlace,
     showOnlyFavorites,
     isFocused,
@@ -82,10 +82,6 @@ export default function StopPlaceView({
   useEffect(() => {
     if (!placeHasFavorites) setShowOnlyFavorites(false);
   }, [favoriteDepartures]);
-
-  useEffect(() => {
-    refresh();
-  }, [stopPlace]);
 
   useMemo(
     () =>
@@ -140,10 +136,7 @@ export default function StopPlaceView({
         </>
       }
       refreshControl={
-        <RefreshControl
-          refreshing={state.isLoading}
-          onRefresh={didLoadingDataFail ? forceRefresh : refresh}
-        />
+        <RefreshControl refreshing={state.isLoading} onRefresh={forceRefresh} />
       }
       sections={quayListData}
       testID={testID}


### PR DESCRIPTION
Restructured the logic in quay-state and stop-place-state so (hopefully) only one effect for reloading state is fired when anything changes.

Resolves https://github.com/AtB-AS/kundevendt/issues/2875