### PR TITLE
test: handle departure onboarding and ticket change

### DIFF
--- a/e2e/tests/departuresV2.e2e.ts
+++ b/e2e/tests/departuresV2.e2e.ts
@@ -21,8 +21,8 @@ import {
   departureSearch,
   numberOfDepartures,
   tapDeparture,
-  getLineTitleV2,
-} from '../utils/departures';
+  getLineTitleV2, ensureOnboardingIsConfirmed
+} from "../utils/departures";
 import {expectGreaterThan, expectNumber} from '../utils/jestAssertions';
 
 describe('Departures v2', () => {
@@ -64,6 +64,8 @@ describe('Departures v2', () => {
 
     // Go to departures
     await goToTab('departures');
+    //Confirm onboarding
+    await ensureOnboardingIsConfirmed()
 
     // Do a departure search
     await departureSearch(placeSearch);
@@ -155,6 +157,8 @@ describe('Departures v2', () => {
 
     // Go to departures
     await goToTab('departures');
+    //Confirm onboarding
+    await ensureOnboardingIsConfirmed()
 
     // Do a departure search - that should automatically display the stop
     await departureSearch(departureStop);

--- a/e2e/tests/tickets.e2e.ts
+++ b/e2e/tests/tickets.e2e.ts
@@ -65,7 +65,7 @@ describe('Tickets anonymous', () => {
 
   it('should get an offer for a single ticket', async () => {
     await expectToBeVisibleByText('Buy');
-    await expectToBeVisibleByText('Valid');
+    await expectToBeVisibleByText('Active');
     await tapById('purchaseTab');
     await expectToBeVisibleByText('Single ticket');
     //await expectToBeVisibleByText('Periodic ticket');

--- a/e2e/utils/departures.ts
+++ b/e2e/utils/departures.ts
@@ -1,7 +1,7 @@
 import {by, element, expect} from 'detox';
 import {tapById} from './interactionHelpers';
 import {expectIdToHaveText, expectToBeVisibleByText} from './expectHelpers';
-import { chooseSearchResult, idExists, setInputById } from "./commonHelpers";
+import {chooseSearchResult, idExists, setInputById} from './commonHelpers';
 
 // Do a departure search
 export const departureSearch = async (departure: string) => {
@@ -14,7 +14,9 @@ export const departureSearch = async (departure: string) => {
 
 // Check if departure onboarding is done
 export const ensureOnboardingIsConfirmed = async () => {
-  const haveToConfirmOnboarding = await idExists(by.id('departuresOnboardingConfirmButton'));
+  const haveToConfirmOnboarding = await idExists(
+    by.id('departuresOnboardingConfirmButton'),
+  );
   if (haveToConfirmOnboarding) {
     await tapById('departuresOnboardingConfirmButton');
   }

--- a/e2e/utils/departures.ts
+++ b/e2e/utils/departures.ts
@@ -1,7 +1,7 @@
 import {by, element, expect} from 'detox';
 import {tapById} from './interactionHelpers';
 import {expectIdToHaveText, expectToBeVisibleByText} from './expectHelpers';
-import {chooseSearchResult, setInputById} from './commonHelpers';
+import { chooseSearchResult, idExists, setInputById } from "./commonHelpers";
 
 // Do a departure search
 export const departureSearch = async (departure: string) => {
@@ -10,6 +10,14 @@ export const departureSearch = async (departure: string) => {
   await chooseSearchResult('locationSearchItem0');
 
   await expectToBeVisibleByText('Departures');
+};
+
+// Check if departure onboarding is done
+export const ensureOnboardingIsConfirmed = async () => {
+  const haveToConfirmOnboarding = await idExists(by.id('departuresOnboardingConfirmButton'));
+  if (haveToConfirmOnboarding) {
+    await tapById('departuresOnboardingConfirmButton');
+  }
 };
 
 // v2: Choose bus stop

--- a/src/screens/Departures/DeparturesOnboardingScreen.tsx
+++ b/src/screens/Departures/DeparturesOnboardingScreen.tsx
@@ -61,6 +61,7 @@ export const DeparturesOnboardingScreen = ({navigation}: Props) => {
             navigation.goBack();
           }}
           style={styles.button}
+          testID="departuresOnboardingConfirmButton"
         />
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
The new departure onboarding has to be clicked in order to run the departure v2 tests. In addition, the ticket tab is renamed "Active" from previous "Valid".