### PR TITLE
refactor: Not show err msg when doing new search

### DIFF
--- a/src/screens/Departures/state/quay-state.ts
+++ b/src/screens/Departures/state/quay-state.ts
@@ -147,10 +147,13 @@ const reducer: ReducerWithSideEffects<
               result: result,
             });
           } catch (e) {
+            const errorType = getAxiosErrorType(e, action.timeout.didTimeout);
+            // Not show error msg if the request was cancelled by a new search
+            if (errorType === 'cancel') return;
             dispatch({
               type: 'SET_ERROR',
               reset: false,
-              error: getAxiosErrorType(e, action.timeout.didTimeout),
+              error: errorType,
             });
           } finally {
             dispatch({type: 'STOP_LOADER'});

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -141,10 +141,13 @@ const reducer: ReducerWithSideEffects<
               result: result,
             });
           } catch (e) {
+            const errorType = getAxiosErrorType(e, action.timeOut.didTimeout);
+            // Not show error msg if the request was cancelled by a new search
+            if (errorType === 'cancel') return;
             dispatch({
               type: 'SET_ERROR',
               reset: action.stopPlace.id !== state.locationId,
-              error: getAxiosErrorType(e, action.timeOut.didTimeout),
+              error: errorType,
             });
           } finally {
             dispatch({type: 'STOP_LOADER'});


### PR DESCRIPTION
When a new departures search was fired, the old search was cancelled by the abort controller. This cancellation led to the action "SET_ERROR" was sent slightly after the new search was actually started. So the error message was shown to the user even though no error had happened.

Resolves https://github.com/AtB-AS/kundevendt/issues/2890