### PR TITLE
feat: add fare product type configurations from firestore

### DIFF
--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -25,6 +25,8 @@ import {
   defaultModesWeSellTicketsFor,
 } from '@atb/configuration/defaults';
 import {PaymentType} from '@atb/ticketing';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
+import {mapToFareProductTypeConfigs} from './converters';
 
 type ConfigurationContextState = {
   preassignedFareProducts: PreassignedFareProduct[];
@@ -59,6 +61,9 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   );
   const [paymentTypes, setPaymentTypes] = useState(defaultPaymentTypes);
   const [vatPercent, setVatPercent] = useState(defaultVatPercent);
+  const [fareProductTypeConfigs, setFareProductTypeConfigs] = useState<
+    FareProductTypeConfig[]
+  >([]);
 
   useEffect(() => {
     firestore()
@@ -96,6 +101,12 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
           if (vatPercent) {
             setVatPercent(vatPercent);
           }
+
+          const fareProductTypeConfigs =
+            getFareProductTypeConfigsFromSnapshot(snapshot);
+          if (fareProductTypeConfigs) {
+            setFareProductTypeConfigs(fareProductTypeConfigs);
+          }
         },
         (error) => {
           Bugsnag.leaveBreadcrumb(
@@ -114,6 +125,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       modesWeSellTicketsFor,
       paymentTypes,
       vatPercent,
+      fareProductTypeConfigs,
     };
   }, [
     preassignedFareProducts,
@@ -122,6 +134,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     modesWeSellTicketsFor,
     paymentTypes,
     vatPercent,
+    fareProductTypeConfigs,
   ]);
 
   return (
@@ -236,4 +249,16 @@ function mapPaymentTypeStringsToEnums(
     }
   }
   return paymentTypes;
+}
+
+function getFareProductTypeConfigsFromSnapshot(
+  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
+): FareProductTypeConfig[] | undefined {
+  const fareProductTypeConfigs = snapshot.docs
+    .find((doc) => doc.id == 'fareProductTypesConfigs')
+    ?.get('fareProductTypesConfigs');
+  if (fareProductTypeConfigs !== undefined) {
+    return mapToFareProductTypeConfigs(fareProductTypeConfigs);
+  }
+  return undefined;
 }

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -66,7 +66,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   const [vatPercent, setVatPercent] = useState(defaultVatPercent);
   const [fareProductTypeConfigs, setFareProductTypeConfigs] = useState<
     FareProductTypeConfig[]
-  >([]);
+  >(defaultFareProductTypeConfig);
 
   useEffect(() => {
     firestore()

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -18,6 +18,7 @@ import {
   defaultPreassignedFareProducts,
   defaultTariffZones,
   defaultUserProfiles,
+  defaultFareProductTypeConfig,
 } from '@atb/reference-data/defaults';
 import {
   defaultVatPercent,
@@ -35,6 +36,7 @@ type ConfigurationContextState = {
   modesWeSellTicketsFor: string[];
   paymentTypes: PaymentType[];
   vatPercent: number;
+  fareProductTypeConfigs: FareProductTypeConfig[];
 };
 
 const defaultConfigurationContextState: ConfigurationContextState = {
@@ -44,6 +46,7 @@ const defaultConfigurationContextState: ConfigurationContextState = {
   modesWeSellTicketsFor: defaultModesWeSellTicketsFor,
   paymentTypes: defaultPaymentTypes,
   vatPercent: defaultVatPercent,
+  fareProductTypeConfigs: defaultFareProductTypeConfig,
 };
 
 const FirestoreConfigurationContext = createContext<ConfigurationContextState>(
@@ -255,10 +258,11 @@ function getFareProductTypeConfigsFromSnapshot(
   snapshot: FirebaseFirestoreTypes.QuerySnapshot,
 ): FareProductTypeConfig[] | undefined {
   const fareProductTypeConfigs = snapshot.docs
-    .find((doc) => doc.id == 'fareProductTypesConfigs')
-    ?.get('fareProductTypesConfigs');
+    .find((doc) => doc.id == 'fareProductTypeConfigs')
+    ?.get('fareProductTypeConfigs');
   if (fareProductTypeConfigs !== undefined) {
     return mapToFareProductTypeConfigs(fareProductTypeConfigs);
   }
+
   return undefined;
 }

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -51,6 +51,10 @@ function mapToFareProductTypeConfig(
   const configuration = mapToFareProductConfigSettings(config.configuration);
   if (!configuration) return;
 
+  if (!isArray(config.transportModes)) return;
+  if (!config.transportModes.every((value: any) => typeof value === 'string'))
+    return;
+
   return {
     type: fcType,
     name,

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -42,10 +42,9 @@ function mapToFareProductTypeConfig(
     return;
   }
 
-  const fcTypes = ['single', 'period', 'hour24', 'night', 'carnet'];
+  const fcTypes = ['single', 'period', 'hour24', 'night'];
   const fcType = mapToStringAlternatives<FareProductType>(config.type, fcTypes);
   if (!fcType) {
-    notifyWrongConfigurationType(config.type, 'type', fcTypes);
     return;
   }
 

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -42,7 +42,7 @@ function mapToFareProductTypeConfig(
     return;
   }
 
-  const fcTypes = ['single', 'period', 'hour24', 'night'];
+  const fcTypes = ['single', 'period', 'hour24', 'night', 'carnet'];
   const fcType = mapToStringAlternatives<FareProductType>(config.type, fcTypes);
   if (!fcType) {
     notifyWrongConfigurationType(config.type, 'type', fcTypes);

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -6,7 +6,9 @@ import {
   TimeSelectionMode,
   TravellerSelectionMode,
   ZoneSelectionMode,
+  FareProductType,
 } from '@atb/screens/Ticketing/FareContracts/utils';
+import {LanguageAndTextType} from '@atb/translations/types';
 import {isArray} from 'lodash';
 
 export function mapToFareProductTypeConfigs(
@@ -31,7 +33,14 @@ function mapToFareProductTypeConfig(
   ];
   if (!fields.every((f) => f in config)) return;
 
-  const fcType = mapToStringAlternatives<OfferEndpoint>(config.type, [
+  if (!isArray(config.name) || !isArray(config.description)) return;
+
+  let name = mapLanguageAndTextType(config.name);
+  let description = mapLanguageAndTextType(config.description);
+
+  if (!name || !description) return;
+
+  const fcType = mapToStringAlternatives<FareProductType>(config.type, [
     'single',
     'period',
     'hour24',
@@ -40,16 +49,14 @@ function mapToFareProductTypeConfig(
   if (!fcType) return;
 
   const configuration = mapToFareProductConfigSettings(config.configuration);
-
   if (!configuration) return;
-  if (typeof config.description !== 'string') return;
 
   return {
-    type: config.type,
-    name: config.name,
+    type: fcType,
+    name,
+    description,
     transportModes: config.transportModes,
-    description: config.description,
-    configuration: configuration,
+    configuration,
   };
 }
 
@@ -58,7 +65,7 @@ function mapToFareProductConfigSettings(
 ): FareProductTypeConfigSettings | undefined {
   const zoneSelectionMode = mapToStringAlternatives<ZoneSelectionMode>(
     settings.zoneSelectionMode,
-    ['single', 'two', 'none'],
+    ['single', 'multiple', 'none'],
   );
   const travellerSelectionMode =
     mapToStringAlternatives<TravellerSelectionMode>(
@@ -75,7 +82,7 @@ function mapToFareProductConfigSettings(
   );
   const offerEndpoint = mapToStringAlternatives<OfferEndpoint>(
     settings.offerEndpoint,
-    ['duration', 'product', 'none'],
+    ['zones', 'authority'],
   );
 
   if (
@@ -103,4 +110,11 @@ function mapToStringAlternatives<T>(value: any, alternatives: string[]) {
   if (typeof value !== 'string') return;
   if (!alternatives.includes(value)) return;
   return value as T;
+}
+
+function mapLanguageAndTextType(text: any[]) {
+  if (!text.every((item: any) => ['lang', 'value'].every((f) => f in item)))
+    return;
+
+  return text as LanguageAndTextType[];
 }

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -1,0 +1,106 @@
+import {
+  FareProductTypeConfigSettings,
+  FareProductTypeConfig,
+  OfferEndpoint,
+  ProductSelectionMode,
+  TimeSelectionMode,
+  TravellerSelectionMode,
+  ZoneSelectionMode,
+} from '@atb/screens/Ticketing/FareContracts/utils';
+import {isArray} from 'lodash';
+
+export function mapToFareProductTypeConfigs(
+  config: any,
+): FareProductTypeConfig[] | undefined {
+  if (!isArray(config)) return;
+
+  return config
+    .map((val) => mapToFareProductTypeConfig(val))
+    .filter(Boolean) as FareProductTypeConfig[];
+}
+
+function mapToFareProductTypeConfig(
+  config: any,
+): FareProductTypeConfig | undefined {
+  const fields = [
+    'type',
+    'name',
+    'transportModes',
+    'description',
+    'configuration',
+  ];
+  if (!fields.every((f) => f in config)) return;
+
+  const fcType = mapToStringAlternatives<OfferEndpoint>(config.type, [
+    'single',
+    'period',
+    'hour24',
+    'night',
+  ]);
+  if (!fcType) return;
+
+  const configuration = mapToFareProductConfigSettings(config.configuration);
+
+  if (!configuration) return;
+  if (typeof config.description !== 'string') return;
+
+  return {
+    type: config.type,
+    name: config.name,
+    transportModes: config.transportModes,
+    description: config.description,
+    configuration: configuration,
+  };
+}
+
+function mapToFareProductConfigSettings(
+  settings: any,
+): FareProductTypeConfigSettings | undefined {
+  const zoneSelectionMode = mapToStringAlternatives<ZoneSelectionMode>(
+    settings.zoneSelectionMode,
+    ['single', 'two', 'none'],
+  );
+  const travellerSelectionMode =
+    mapToStringAlternatives<TravellerSelectionMode>(
+      settings.travellerSelectionMode,
+      ['multiple', 'single', 'none'],
+    );
+  const timeSelectionMode = mapToStringAlternatives<TimeSelectionMode>(
+    settings.timeSelectionMode,
+    ['datetime', 'none'],
+  );
+  const productSelectionMode = mapToStringAlternatives<ProductSelectionMode>(
+    settings.productSelectionMode,
+    ['duration', 'product', 'none'],
+  );
+  const offerEndpoint = mapToStringAlternatives<OfferEndpoint>(
+    settings.offerEndpoint,
+    ['duration', 'product', 'none'],
+  );
+
+  if (
+    !(
+      zoneSelectionMode &&
+      travellerSelectionMode &&
+      timeSelectionMode &&
+      productSelectionMode &&
+      offerEndpoint
+    )
+  ) {
+    return;
+  }
+
+  return {
+    zoneSelectionMode,
+    travellerSelectionMode,
+    timeSelectionMode,
+    productSelectionMode,
+    offerEndpoint,
+  } as FareProductTypeConfigSettings;
+}
+
+function mapToStringAlternatives<T>(value: any, alternatives: string[]) {
+  if (typeof value !== 'string') return;
+  if (!alternatives.includes(value)) return;
+  return value as T;
+}

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -9,12 +9,16 @@ import {
   FareProductType,
 } from '@atb/screens/Ticketing/FareContracts/utils';
 import {LanguageAndTextType} from '@atb/translations/types';
+import Bugsnag from '@bugsnag/react-native';
 import {isArray} from 'lodash';
 
 export function mapToFareProductTypeConfigs(
   config: any,
 ): FareProductTypeConfig[] | undefined {
-  if (!isArray(config)) return;
+  if (!isArray(config)) {
+    Bugsnag.notify(`fare product configurations should be of type "array"`);
+    return;
+  }
 
   return config
     .map((val) => mapToFareProductTypeConfig(val))
@@ -31,29 +35,55 @@ function mapToFareProductTypeConfig(
     'description',
     'configuration',
   ];
-  if (!fields.every((f) => f in config)) return;
+  if (!fields.every((f) => f in config)) {
+    Bugsnag.notify(
+      `fare product is missing one or more of the following fields: ${fields}`,
+    );
+    return;
+  }
 
-  if (!isArray(config.name) || !isArray(config.description)) return;
+  const fcTypes = ['single', 'period', 'hour24', 'night'];
+  const fcType = mapToStringAlternatives<FareProductType>(config.type, fcTypes);
+  if (!fcType) {
+    notifyWrongConfigurationType(config.type, 'type', fcTypes);
+    return;
+  }
+
+  if (!isArray(config.name) || !isArray(config.description)) {
+    Bugsnag.notify(
+      `fare product type: "${fcType}", fields "name" or "description" should be defined as an array.`,
+    );
+    return;
+  }
 
   let name = mapLanguageAndTextType(config.name);
   let description = mapLanguageAndTextType(config.description);
 
-  if (!name || !description) return;
-
-  const fcType = mapToStringAlternatives<FareProductType>(config.type, [
-    'single',
-    'period',
-    'hour24',
-    'night',
-  ]);
-  if (!fcType) return;
-
-  const configuration = mapToFareProductConfigSettings(config.configuration);
-  if (!configuration) return;
-
-  if (!isArray(config.transportModes)) return;
-  if (!config.transportModes.every((value: any) => typeof value === 'string'))
+  if (!name || !description) {
+    Bugsnag.notify(
+      `fare product type: "${fcType}", "name" or "description" should conform: "LanguageAndTextType"`,
+    );
     return;
+  }
+
+  if (!isArray(config.transportModes)) {
+    Bugsnag.notify(
+      `fare product type: "${fcType}", "transportModes" should be of type "array"`,
+    );
+    return;
+  }
+  if (!config.transportModes.every((value: any) => typeof value === 'string')) {
+    Bugsnag.notify(
+      `fare product type: "${fcType}", one or more of the "transportModes" values is not of type "string"`,
+    );
+    return;
+  }
+
+  const configuration = mapToFareProductConfigSettings(
+    fcType,
+    config.configuration,
+  );
+  if (!configuration) return;
 
   return {
     type: fcType,
@@ -65,39 +95,77 @@ function mapToFareProductTypeConfig(
 }
 
 function mapToFareProductConfigSettings(
+  fareProductType: FareProductType,
   settings: any,
 ): FareProductTypeConfigSettings | undefined {
+  const zoneSelectionModeTypes = ['single', 'multiple', 'none'];
   const zoneSelectionMode = mapToStringAlternatives<ZoneSelectionMode>(
     settings.zoneSelectionMode,
-    ['single', 'multiple', 'none'],
+    zoneSelectionModeTypes,
   );
+  if (!zoneSelectionMode) {
+    notifyWrongConfigurationType(
+      fareProductType,
+      'zoneSelectionMode',
+      zoneSelectionModeTypes,
+    );
+    return;
+  }
+
+  const travellerSelectionModeTypes = ['multiple', 'single', 'none'];
   const travellerSelectionMode =
     mapToStringAlternatives<TravellerSelectionMode>(
       settings.travellerSelectionMode,
-      ['multiple', 'single', 'none'],
+      travellerSelectionModeTypes,
     );
+  if (!travellerSelectionMode) {
+    notifyWrongConfigurationType(
+      fareProductType,
+      'travellerSelectionMode',
+      travellerSelectionModeTypes,
+    );
+    return;
+  }
+
+  const timeSelectionModeTypes = ['datetime', 'none'];
   const timeSelectionMode = mapToStringAlternatives<TimeSelectionMode>(
     settings.timeSelectionMode,
-    ['datetime', 'none'],
+    timeSelectionModeTypes,
   );
+  if (!timeSelectionMode) {
+    notifyWrongConfigurationType(
+      fareProductType,
+      'timeSelectionMode',
+      timeSelectionModeTypes,
+    );
+    return;
+  }
+
+  const productSelectionModeTypes = ['duration', 'product', 'none'];
   const productSelectionMode = mapToStringAlternatives<ProductSelectionMode>(
     settings.productSelectionMode,
-    ['duration', 'product', 'none'],
+    productSelectionModeTypes,
   );
+  if (!productSelectionMode) {
+    notifyWrongConfigurationType(
+      fareProductType,
+      'productSelectionMode',
+      productSelectionModeTypes,
+    );
+    return;
+  }
+
+  const offerEndpointTypes = ['zones', 'authority'];
   const offerEndpoint = mapToStringAlternatives<OfferEndpoint>(
     settings.offerEndpoint,
-    ['zones', 'authority'],
+    offerEndpointTypes,
   );
-
-  if (
-    !(
-      zoneSelectionMode &&
-      travellerSelectionMode &&
-      timeSelectionMode &&
-      productSelectionMode &&
-      offerEndpoint
-    )
-  ) {
+  if (!offerEndpoint) {
+    notifyWrongConfigurationType(
+      fareProductType,
+      'offerEndpoint',
+      offerEndpointTypes,
+    );
     return;
   }
 
@@ -108,6 +176,16 @@ function mapToFareProductConfigSettings(
     productSelectionMode,
     offerEndpoint,
   } as FareProductTypeConfigSettings;
+}
+
+function notifyWrongConfigurationType(
+  fareProductType: string,
+  field: string,
+  types: string[],
+) {
+  Bugsnag.notify(
+    `fare product of type: "${fareProductType}", the "${field}" field, does not belong to any of the following types: "${types}"`,
+  );
 }
 
 function mapToStringAlternatives<T>(value: any, alternatives: string[]) {

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -51,7 +51,7 @@ function mapToFareProductTypeConfig(
 
   if (!isArray(config.name) || !isArray(config.description)) {
     Bugsnag.notify(
-      `fare product type: "${fcType}", fields "name" or "description" should be defined as an "array".`,
+      `fare product of type: "${fcType}", fields "name" or "description" should be defined as an "array".`,
     );
     return;
   }
@@ -61,20 +61,20 @@ function mapToFareProductTypeConfig(
 
   if (!name || !description) {
     Bugsnag.notify(
-      `fare product type: "${fcType}", "name" or "description" should conform: "LanguageAndTextType"`,
+      `fare product of type: "${fcType}", "name" or "description" should conform: "LanguageAndTextType"`,
     );
     return;
   }
 
   if (!isArray(config.transportModes)) {
     Bugsnag.notify(
-      `fare product type: "${fcType}", "transportModes" should be of type "array"`,
+      `fare product of type: "${fcType}", "transportModes" should be of type "array"`,
     );
     return;
   }
   if (!config.transportModes.every((value: any) => typeof value === 'string')) {
     Bugsnag.notify(
-      `fare product type: "${fcType}", one or more of the "transportModes" values is not of type "string"`,
+      `fare product of type: "${fcType}", one or more of the "transportModes" values is not of type "string"`,
     );
     return;
   }

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -51,7 +51,7 @@ function mapToFareProductTypeConfig(
 
   if (!isArray(config.name) || !isArray(config.description)) {
     Bugsnag.notify(
-      `fare product type: "${fcType}", fields "name" or "description" should be defined as an array.`,
+      `fare product type: "${fcType}", fields "name" or "description" should be defined as an "array".`,
     );
     return;
   }

--- a/src/reference-data/defaults.ts
+++ b/src/reference-data/defaults.ts
@@ -1,10 +1,14 @@
 import {PreassignedFareProduct, TariffZone, UserProfile} from './types';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
 import preassignedFareProducts from './defaults/preassigned-fare-products.json';
 import tariffZones from './defaults/tariff-zones.json';
 import userProfiles from './defaults/user-profiles.json';
+import fareProductTypeConfig from './defaults/fare-product-type-config.json';
 import {PaymentType} from '@atb/ticketing';
 
 export const defaultPreassignedFareProducts =
   preassignedFareProducts as PreassignedFareProduct[];
 export const defaultTariffZones: TariffZone[] = tariffZones;
 export const defaultUserProfiles: UserProfile[] = userProfiles;
+export const defaultFareProductTypeConfig =
+  fareProductTypeConfig as FareProductTypeConfig[];

--- a/src/reference-data/defaults/fare-product-type-config.json
+++ b/src/reference-data/defaults/fare-product-type-config.json
@@ -1,0 +1,126 @@
+[
+  {
+    "type": "single",
+    "name": [
+      {
+        "lang": "nob",
+        "value": "Enkeltbillett buss/trikk"
+      },
+      {
+        "lang": "eng",
+        "value": "Single ticket bus/tram"
+      }
+    ],
+    "transportModes": ["bus"],
+    "description": [
+      {
+        "lang": "nob",
+        "value": "Når du skal reise av og til"
+      },
+      {
+        "lang": "eng",
+        "value": "When you travel occasionally"
+      }
+    ],
+    "configuration": {
+      "zoneSelectionMode": "multiple",
+      "travellerSelectionMode": "multiple",
+      "timeSelectionMode": "none",
+      "productSelectionMode": "none",
+      "offerEndpoint": "zones"
+    }
+  },
+  {
+    "type": "period",
+    "name": [
+      {
+        "lang": "nob",
+        "value": "Periodebillett"
+      },
+      {
+        "lang": "eng",
+        "value": "Periodic ticket"
+      }
+    ],
+    "transportModes": ["bus"],
+    "description": [
+      {
+        "lang": "nob",
+        "value": "Når du reiser litt oftere"
+      },
+      {
+        "lang": "eng",
+        "value": "When you travel more frequently"
+      }
+    ],
+    "configuration": {
+      "zoneSelectionMode": "multiple",
+      "travellerSelectionMode": "single",
+      "timeSelectionMode": "datetime",
+      "productSelectionMode": "duration",
+      "offerEndpoint": "zones"
+    }
+  },
+  {
+    "type": "hour24",
+    "name": [
+      {
+        "lang": "nob",
+        "value": "24-timersbillett"
+      },
+      {
+        "lang": "eng",
+        "value": "24 hour pass"
+      }
+    ],
+    "transportModes": ["bus"],
+    "description": [
+      {
+        "lang": "nob",
+        "value": "Når du vil reise flere ganger på et døgn"
+      },
+      {
+        "lang": "eng",
+        "value": "For travelling several times in 24 hours"
+      }
+    ],
+    "configuration": {
+      "zoneSelectionMode": "single",
+      "travellerSelectionMode": "single",
+      "timeSelectionMode": "datetime",
+      "productSelectionMode": "none",
+      "offerEndpoint": "zones"
+    }
+  },
+  {
+    "type": "night",
+    "name": [
+      {
+        "lang": "nob",
+        "value": "Nattbillett"
+      },
+      {
+        "lang": "eng",
+        "value": "Night ticket"
+      }
+    ],
+    "transportModes": ["bus"],
+    "description": [
+      {
+        "lang": "nob",
+        "value": "Fra 00:30 til 04:00 på nattbuss og -trikk"
+      },
+      {
+        "lang": "eng",
+        "value": "From 00:30 to 04:00 for night bus and tram"
+      }
+    ],
+    "configuration": {
+      "zoneSelectionMode": "none",
+      "travellerSelectionMode": "none",
+      "timeSelectionMode": "none",
+      "productSelectionMode": "product",
+      "offerEndpoint": "authority"
+    }
+  }
+]

--- a/src/screens/Ticketing/FareContracts/utils.ts
+++ b/src/screens/Ticketing/FareContracts/utils.ts
@@ -17,6 +17,7 @@ import {
   Language,
   FareContractTexts,
   TranslateFunction,
+  LanguageAndTextType,
 } from '@atb/translations';
 import {
   findInspectable,
@@ -35,6 +36,28 @@ export type ValidityStatus =
   | 'inactive'
   | 'rejected'
   | 'approved';
+
+export type FareProductTypeConfig = {
+  type: 'single' | 'period' | 'hour24' | 'night';
+  name: LanguageAndTextType;
+  transportModes: Mode[];
+  description: LanguageAndTextType;
+  configuration: FareProductTypeConfigSettings;
+};
+
+export type FareProductTypeConfigSettings = {
+  zoneSelectionMode: ZoneSelectionMode;
+  travellerSelectionMode: TravellerSelectionMode;
+  timeSelectionMode: TimeSelectionMode;
+  productSelectionMode: ProductSelectionMode;
+  offerEndpoint: OfferEndpoint;
+};
+
+export type ZoneSelectionMode = 'single' | 'two' | 'none';
+export type TravellerSelectionMode = 'multiple' | 'single' | 'none';
+export type TimeSelectionMode = 'datetime' | 'none';
+export type ProductSelectionMode = 'duration' | 'product' | 'none';
+export type OfferEndpoint = 'zones' | 'authority';
 
 export function getRelativeValidity(
   now: number,

--- a/src/screens/Ticketing/FareContracts/utils.ts
+++ b/src/screens/Ticketing/FareContracts/utils.ts
@@ -38,10 +38,10 @@ export type ValidityStatus =
   | 'approved';
 
 export type FareProductTypeConfig = {
-  type: 'single' | 'period' | 'hour24' | 'night';
-  name: LanguageAndTextType;
+  type: FareProductType;
+  name: LanguageAndTextType[];
   transportModes: Mode[];
-  description: LanguageAndTextType;
+  description: LanguageAndTextType[];
   configuration: FareProductTypeConfigSettings;
 };
 
@@ -53,7 +53,13 @@ export type FareProductTypeConfigSettings = {
   offerEndpoint: OfferEndpoint;
 };
 
-export type ZoneSelectionMode = 'single' | 'two' | 'none';
+export type FareProductType =
+  | 'single'
+  | 'period'
+  | 'hour24'
+  | 'night'
+  | 'carnet';
+export type ZoneSelectionMode = 'single' | 'multiple' | 'none';
 export type TravellerSelectionMode = 'multiple' | 'single' | 'none';
 export type TimeSelectionMode = 'datetime' | 'none';
 export type ProductSelectionMode = 'duration' | 'product' | 'none';


### PR DESCRIPTION
Just a draft PR for now. Having problems with my development environment so haven't tested the implementation of this, but maybe enough to show how it'll be used.

closes https://github.com/AtB-AS/kundevendt/issues/2895