### PR TITLE
fix: Show realtime even though before aimed time

### DIFF
--- a/src/screens/TripDetails/utils.ts
+++ b/src/screens/TripDetails/utils.ts
@@ -1,6 +1,5 @@
 import {secondsBetween} from '@atb/utils/date';
 
-// @TODO should be in external configuration at some point, or at least estimeted better.
 const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES = 1;
 
 export type TimeValues = {
@@ -24,8 +23,8 @@ export function getTimeRepresentationType({
   if (!expectedTime) {
     return 'no-significant-difference';
   }
-  return secondsBetween(aimedTime, expectedTime) <=
-    DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES * 60
+  const secondsDifference = Math.abs(secondsBetween(aimedTime, expectedTime));
+  return secondsDifference <= DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES * 60
     ? 'no-significant-difference'
     : 'significant-difference';
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -67,6 +67,10 @@ export function secondsToDuration(
   });
 }
 
+/**
+ * Return seconds between start and end. If end is before start the returned
+ * value will be negative.
+ */
 export function secondsBetween(
   start: string | Date,
   end: string | Date,


### PR DESCRIPTION
When the expected time was before aimed time, the aimed time was
shown. I am not sure if this was intentional or not. But when searching
for trips all legs of the trip is based on the realtime data, so we need
to show the expected time for all legs.

Resolves https://github.com/AtB-AS/kundevendt/issues/2928