### PR TITLE
build(changelog): Fix grep for latest release tag

### DIFF
--- a/tools/release/changelog.config.js
+++ b/tools/release/changelog.config.js
@@ -1,7 +1,7 @@
 const {execSync} = require('child_process');
 
 const latestReleaseTag = execSync(
-  `git tag --sort=creatordate |  grep -E '(^alpha-.*)|(^v.*)' | tail -1`,
+  `git tag --sort=creatordate | grep -E '(^alpha-.*)|(^v.*)' | grep -vE '(atb|nfk|fram)' | tail -1`,
 )
   .toString('utf-8')
   .trim();


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/2508

Negative lookahead is not supported in [POSIX Extented Regular Expressions](https://en.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions), which is what's used with `grep -E`. A possible solution to this is to chain two `grep` expressions, where one of them inverts the match. As it is now it matches the organization ID wherever it is in the tag, but I don't see that as an issue.

I also went ahead and added `fram` to the expression, since that will potentialle be needed in the near future.
