### PR TITLE
build: Copy .netrc in ios setup

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -47,9 +47,14 @@ runs:
         uses: maxim-lobanov/setup-xcode@v1.3.0
         with:
           xcode-version: "13.1"
-      - name: LS NETRC
+      - name: LS NETRC 1
         shell: bash
-        run: ls -al ~/.netrc
+        run: |
+          ls -al .netrc
+      - name: LS NETRC 2
+        shell: bash
+        run: |
+          ls -al ~/.netrc
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -47,6 +47,9 @@ runs:
         uses: maxim-lobanov/setup-xcode@v1.3.0
         with:
           xcode-version: "13.1"
+      - name: LS NETRC
+        shell: bash
+        run: ls -al ~/.netrc
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -47,14 +47,11 @@ runs:
         uses: maxim-lobanov/setup-xcode@v1.3.0
         with:
           xcode-version: "13.1"
-      - name: LS NETRC 1
+      - name: Copy .netrc to fetch mapbox sdk pod
         shell: bash
         run: |
-          ls -al .netrc
-      - name: LS NETRC 2
-        shell: bash
-        run: |
-          ls -al ~/.netrc
+          cat .netrc >> ~/.netrc
+          chmod 600 ~/.netrc
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -47,7 +47,7 @@ runs:
         uses: maxim-lobanov/setup-xcode@v1.3.0
         with:
           xcode-version: "13.1"
-      - name: Copy .netrc to fetch mapbox sdk pod
+      - name: Copy .netrc
         shell: bash
         run: |
           cat .netrc >> ~/.netrc

--- a/scripts/ios/override-config-files.sh
+++ b/scripts/ios/override-config-files.sh
@@ -2,6 +2,7 @@
 
 # copy file mapbox api download token
 echo "Copy .netrc file for mapbox api token"
+ls .netrc
 cat .netrc >> ~/.netrc
 chmod 600 ~/.netrc
 ls -al ~/.netrc

--- a/scripts/ios/override-config-files.sh
+++ b/scripts/ios/override-config-files.sh
@@ -2,10 +2,8 @@
 
 # copy file mapbox api download token
 echo "Copy .netrc file for mapbox api token"
-ls .netrc
 cat .netrc >> ~/.netrc
 chmod 600 ~/.netrc
-ls -al ~/.netrc
 
 echo "Installing pre-build dependencies"
 brew install findutils # for git-crypt

--- a/scripts/ios/override-config-files.sh
+++ b/scripts/ios/override-config-files.sh
@@ -4,6 +4,7 @@
 echo "Copy .netrc file for mapbox api token"
 cat .netrc >> ~/.netrc
 chmod 600 ~/.netrc
+ls -al ~/.netrc
 
 echo "Installing pre-build dependencies"
 brew install findutils # for git-crypt


### PR DESCRIPTION
I have no idea why this is now necessary, but wasn't before 🤔 Or to be more precise, I don't fully understand why it was working before without copying .netrc before installing pods.

I see the macos-12 runner changed version from 20221121.1 to 20221127.5 when this started happening, but don't see anything relevant in the changelogs that could have caused this.

It seems like the build started failing exactly on the day two years after the mapbox token was created was just a coincidence.

