### PR TITLE
feat: show realtime icon and old time on departures

### DIFF
--- a/src/screens/Departures/components/EstimatedCallItem.tsx
+++ b/src/screens/Departures/components/EstimatedCallItem.tsx
@@ -12,17 +12,17 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {
+  formatLocaleTime,
   formatToClockOrLongRelativeMinutes,
   formatToClockOrRelativeMinutes,
   formatToSimpleDate,
 } from '@atb/utils/date';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
-import {EstimatedCall, StopPlace, Quay} from '@atb/api/types/departures';
 import {Mode as Mode_v2} from '@atb/api/types/generated/journey_planner_v3_types';
+import {EstimatedCall, Quay, StopPlace} from '@atb/api/types/departures';
 import useFontScale from '@atb/utils/use-font-scale';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {Error} from '@atb/assets/svg/color/icons/status';
 import ToggleFavouriteDeparture from '@atb/screens/Departures/components/ToggleFavouriteDeparture';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import {isToday, parseISO} from 'date-fns';
@@ -30,8 +30,11 @@ import {useOnMarkFavouriteDepartures} from '@atb/screens/Departures/components/u
 import {StopPlacesMode} from '@atb/screens/Departures/types';
 import {TouchableOpacityOrView} from '@atb/components/touchable-opacity-or-view';
 import {SvgProps} from 'react-native-svg';
-import {getSvgForMostCriticalSituation, SituationIcon} from '@atb/situations';
+import {getSvgForMostCriticalSituation} from '@atb/situations';
 import {getSituationA11yLabel} from '@atb/situations/utils';
+import Time from '@atb/screens/TripDetails/components/Time';
+import {getTimeRepresentationType} from '@atb/screens/TripDetails/utils';
+import {Realtime} from '@atb/assets/svg/color/icons/status';
 
 type EstimatedCallItemProps = {
   departure: EstimatedCall;
@@ -62,15 +65,6 @@ export default function EstimatedCallItem({
   const styles = useStyles();
 
   const line = departure.serviceJourney?.line;
-
-  const time = formatToClockOrRelativeMinutes(
-    departure.expectedDepartureTime,
-    language,
-    t(dictionary.date.units.now),
-  );
-  const timeWithRealtimePrefix = departure.realtime
-    ? time
-    : t(dictionary.missingRealTimePrefix) + time;
 
   const isTripCancelled = departure.cancellation;
 
@@ -139,11 +133,15 @@ export default function EstimatedCallItem({
             {departure.destinationDisplay?.frontText}
           </ThemeText>
           {mode === 'Departure' || mode === 'Map' ? (
-            <DepartureTime
-              isTripCancelled={isTripCancelled}
-              timeWithRealtimePrefix={timeWithRealtimePrefix}
-              testID={testID}
-            />
+            <>
+              <DepartureTime
+                isRealtime={departure.realtime}
+                isTripCancelled={isTripCancelled}
+                expectedTime={departure.expectedDepartureTime}
+                aimedTime={departure.aimedDepartureTime}
+                testID={testID}
+              />
+            </>
           ) : null}
         </View>
       </TouchableOpacity>
@@ -162,25 +160,64 @@ export default function EstimatedCallItem({
 
 const DepartureTime = ({
   isTripCancelled,
-  timeWithRealtimePrefix,
+  expectedTime,
+  aimedTime,
   testID,
+  isRealtime,
 }: {
   isTripCancelled: boolean;
-  timeWithRealtimePrefix: string;
+  expectedTime: string;
+  aimedTime: string;
   testID: string;
+  isRealtime: boolean;
 }) => {
   const styles = useStyles();
-  return (
-    <>
-      <ThemeText
-        type="body__primary--bold"
-        testID={testID + 'Time'}
-        style={isTripCancelled && styles.strikethrough}
-      >
-        {timeWithRealtimePrefix}
-      </ThemeText>
-    </>
+  const {t, language} = useTranslation();
+  const timeRepresentationType = getTimeRepresentationType({
+    expectedTime: expectedTime,
+    aimedTime: aimedTime,
+    missingRealTime: !isRealtime,
+  });
+  const readableExpectedTime = formatToClockOrRelativeMinutes(
+    expectedTime,
+    language,
+    t(dictionary.date.units.now),
   );
+  const readableAimedTime = formatLocaleTime(aimedTime, language);
+  const ExpectedText = (
+    <ThemeText
+      type="body__primary--bold"
+      testID={testID + 'Time'}
+      style={isTripCancelled && styles.strikethrough}
+    >
+      {readableExpectedTime}
+    </ThemeText>
+  );
+  const RealtimeWithIcon = (
+    <View style={styles.realtime}>
+      <ThemeIcon style={styles.realtimeIcon} svg={Realtime}></ThemeIcon>
+      {ExpectedText}
+    </View>
+  );
+  switch (timeRepresentationType) {
+    case 'significant-difference':
+      return (
+        <View style={styles.delayedRealtime}>
+          {RealtimeWithIcon}
+          <ThemeText
+            type="body__tertiary--strike"
+            color={'secondary'}
+            testID={testID + 'Time'}
+          >
+            {readableAimedTime}
+          </ThemeText>
+        </View>
+      );
+    case 'no-significant-difference':
+      return RealtimeWithIcon;
+    case 'no-realtime':
+      return ExpectedText;
+  }
 };
 
 function getA11yDeparturesLabel(
@@ -190,15 +227,39 @@ function getA11yDeparturesLabel(
 ) {
   let a11yDateInfo = '';
   if (departure.expectedDepartureTime) {
-    const a11yClock = formatToClockOrLongRelativeMinutes(
+    const a11yClockExpected = formatToClockOrLongRelativeMinutes(
       departure.expectedDepartureTime,
       language,
       t(dictionary.date.units.now),
       9,
     );
-    const a11yTimeWithRealtimePrefix = departure.realtime
-      ? a11yClock
-      : t(dictionary.a11yMissingRealTimePrefix) + a11yClock;
+    const a11yClockAimed = formatLocaleTime(
+      departure.aimedDepartureTime,
+      language,
+    );
+    const timeRepresentationType = getTimeRepresentationType({
+      expectedTime: departure.expectedDepartureTime,
+      aimedTime: departure.aimedDepartureTime,
+      missingRealTime: !departure.realtime,
+    });
+    let a11yTimeWithRealtimePrefix;
+    switch (timeRepresentationType) {
+      case 'significant-difference':
+        a11yTimeWithRealtimePrefix =
+          t(dictionary.a11yRealTimePrefix) +
+          a11yClockExpected +
+          ',' +
+          t(dictionary.a11yRouteTimePrefix) +
+          a11yClockAimed;
+        break;
+      case 'no-significant-difference':
+        a11yTimeWithRealtimePrefix =
+          t(dictionary.a11yRealTimePrefix) + a11yClockExpected;
+        break;
+      case 'no-realtime':
+        a11yTimeWithRealtimePrefix =
+          t(dictionary.a11yRouteTimePrefix) + a11yClockExpected;
+    }
     const parsedDepartureTime = parseISO(departure.expectedDepartureTime);
     const a11yDate = !isToday(parsedDepartureTime)
       ? formatToSimpleDate(parsedDepartureTime, language) + ','
@@ -301,6 +362,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexShrink: 1,
     marginRight: theme.spacings.xLarge,
   },
+  realtimeIcon: {
+    marginRight: theme.spacings.xSmall / 2,
+  },
   lineChip: {
     padding: theme.spacings.small,
     borderRadius: theme.border.radius.regular,
@@ -318,6 +382,13 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   strikethrough: {
     textDecorationLine: 'line-through',
+  },
+  delayedRealtime: {
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+  },
+  realtime: {
+    flexDirection: 'row',
   },
   warningIcon: {
     marginRight: theme.spacings.small,

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -1,6 +1,5 @@
 import {Platform} from 'react-native';
 import {translation as _} from './commons';
-import orgSpecificTranslations from './utils';
 
 const softhyphen = Platform.OS === 'ios' ? '\u00AD' : '\u200B';
 
@@ -21,7 +20,8 @@ const dictionary = {
     profile_a11y: _('Min profil', 'My profile'),
   },
   missingRealTimePrefix: _('ca. ', 'ca. '),
-  a11yMissingRealTimePrefix: _('cirka ', 'circa '),
+  a11yRouteTimePrefix: _('rutetid ', 'route time '),
+  a11yRealTimePrefix: _('sanntid ', 'realtime '),
   travel: {
     legModes: {
       bus: _('Buss', 'Bus'),


### PR DESCRIPTION
Show realtime icon and old time on departures, and update screenreader to match logic.

<details>
<summary>Screenshots</summary>

![Simulator Screen Shot - iPhone 14 - 2022-12-06 at 14 52 07](https://user-images.githubusercontent.com/85479566/205930355-d16b474f-ee22-4289-8edd-27d43489a7e7.png)

![Simulator Screen Shot - iPhone 14 - 2022-12-06 at 14 52 59](https://user-images.githubusercontent.com/85479566/205930466-1096a90f-3a91-4966-b325-564b3b0a1fa3.png)
</details>

Close https://github.com/AtB-AS/kundevendt/issues/2950