### PR TITLE
feat: Show notices on Departure Details

### DIFF
--- a/__tests__/utils-test.ts
+++ b/__tests__/utils-test.ts
@@ -3,9 +3,8 @@ import {addMinutes} from 'date-fns';
 import {Leg} from '@atb/api/types/trips';
 import {TIME_LIMIT_IN_MINUTES} from '../src/screens/TripDetails/Details/utils';
 import {hasShortWaitTime} from '../src/screens/TripDetails/components/utils';
-import {defaultPreassignedFareProducts} from '@atb/reference-data/defaults';
-import {productIsSellableInApp} from '@atb/reference-data/utils';
 import {Flattened, flattenObject} from '@atb/utils/object';
+import {onlyUniques, onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
 
 describe('IterateWithNext', () => {
   it('iterates correctly', () => {
@@ -88,28 +87,6 @@ describe('Short wait time evaluator', () => {
   });
 });
 
-describe('Default Fareproducts', () => {
-  it('can be filtered by distribution channel', () => {
-    const defaultsHaveproductsWithoutAppChannel =
-      defaultPreassignedFareProducts.some((product) => {
-        const productHasAppChannel = product.distributionChannel.some(
-          (channel) => channel === 'app',
-        );
-        return !productHasAppChannel;
-      });
-
-    expect(defaultsHaveproductsWithoutAppChannel).toBe(true);
-
-    const filteredByAppChannel = defaultPreassignedFareProducts.filter(
-      productIsSellableInApp,
-    );
-
-    expect(
-      defaultPreassignedFareProducts.length - filteredByAppChannel.length,
-    ).toBeGreaterThan(0);
-  });
-});
-
 describe('Function flattenObject()', () => {
   const inputObj = {
     a: 1,
@@ -135,5 +112,32 @@ describe('Function flattenObject()', () => {
 
   it('has expected type', () => {
     expect(flatObj as ExpectedObj).toBeTruthy();
+  });
+});
+
+describe('Function onlyUnique', () => {
+  const input = [1, 'a', 3, 'k', 3, 'a'];
+  const expected = [1, 'a', 3, 'k'];
+
+  it('only contains unique values', () => {
+    expect(input.filter(onlyUniques).sort()).toEqual(expected.sort());
+  });
+});
+
+describe('Function onlyUniqueBasedOnField', () => {
+  const input = [
+    {field1: 'test1', field2: 'what'},
+    {field1: 'test1', field2: 'what'},
+    {field1: 'test2', field2: 'what'},
+  ];
+  const expected = [
+    {field1: 'test1', field2: 'what'},
+    {field1: 'test2', field2: 'what'},
+  ];
+
+  it('only contains unique values', () => {
+    expect(input.filter(onlyUniquesBasedOnField('field1')).sort()).toEqual(
+      expected.sort(),
+    );
   });
 });

--- a/src/api/serviceJourney.ts
+++ b/src/api/serviceJourney.ts
@@ -3,22 +3,19 @@ import client from './client';
 import qs from 'query-string';
 import {stringifyUrl} from './utils';
 import {ServiceJourneyMapInfoData_v3} from '@atb/api/types/serviceJourney';
-import {ServiceJourneyEstimatedCallFragment} from './types/generated/serviceJourney';
+import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 
-type ServiceJourneyDepartures = {
-  value: ServiceJourneyEstimatedCallFragment[];
-};
-
-export async function getDepartures(
+export async function getServiceJourneyWithEstimatedCalls(
   id: string,
-  date?: Date,
-): Promise<ServiceJourneyEstimatedCallFragment[]> {
-  let url = `bff/v2/servicejourney/${encodeURIComponent(id)}/departures`;
-  if (date) {
-    url = url + `?date=${formatISO(date, {representation: 'date'})}`;
-  }
-  const response = await client.get<ServiceJourneyDepartures>(url);
-  return response.data?.value ?? [];
+  date: Date,
+): Promise<ServiceJourneyWithEstCallsFragment> {
+  const encodedId = encodeURIComponent(id);
+  const formattedDate = formatISO(date, {representation: 'date'});
+  let url = `bff/v2/servicejourney/${encodedId}/calls?date=${formattedDate}`;
+  const response = await client.get<{
+    value: ServiceJourneyWithEstCallsFragment;
+  }>(url);
+  return response.data?.value;
 }
 
 export async function getServiceJourneyMapLegs(

--- a/src/api/types/generated/ServiceJourneyWithEstimatedCallsQuery.ts
+++ b/src/api/types/generated/ServiceJourneyWithEstimatedCallsQuery.ts
@@ -1,0 +1,53 @@
+import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type ServiceJourneyWithEstimatedCallsQuery = {
+  serviceJourney?: {
+    id: string;
+    transportMode?: Types.TransportMode;
+    transportSubmode?: Types.TransportSubmode;
+    publicCode?: string;
+    line: {publicCode?: string};
+    notices: Array<{text?: string}>;
+    estimatedCalls?: Array<{
+      actualArrivalTime?: any;
+      actualDepartureTime?: any;
+      aimedArrivalTime: any;
+      aimedDepartureTime: any;
+      cancellation: boolean;
+      date?: any;
+      expectedDepartureTime: any;
+      expectedArrivalTime: any;
+      forAlighting: boolean;
+      forBoarding: boolean;
+      realtime: boolean;
+      destinationDisplay?: {frontText?: string};
+      quay?: {
+        id: string;
+        name: string;
+        publicCode?: string;
+        situations: Array<{
+          id: string;
+          situationNumber?: string;
+          reportType?: Types.ReportType;
+          summary: Array<{language?: string; value: string}>;
+          description: Array<{language?: string; value: string}>;
+        }>;
+        stopPlace?: {
+          id: string;
+          name: string;
+          latitude?: number;
+          longitude?: number;
+        };
+        tariffZones: Array<{id: string; name?: string}>;
+      };
+      notices: Array<{text?: string}>;
+      situations: Array<{
+        id: string;
+        situationNumber?: string;
+        reportType?: Types.ReportType;
+        summary: Array<{language?: string; value: string}>;
+        description: Array<{language?: string; value: string}>;
+      }>;
+    }>;
+  };
+};

--- a/src/api/types/generated/fragments/estimated-calls.ts
+++ b/src/api/types/generated/fragments/estimated-calls.ts
@@ -1,0 +1,36 @@
+import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type EstimatedCallWithQuayFragment = {
+  actualArrivalTime?: any;
+  actualDepartureTime?: any;
+  aimedArrivalTime: any;
+  aimedDepartureTime: any;
+  cancellation: boolean;
+  date?: any;
+  expectedDepartureTime: any;
+  expectedArrivalTime: any;
+  forAlighting: boolean;
+  forBoarding: boolean;
+  realtime: boolean;
+  destinationDisplay?: {frontText?: string};
+  quay?: {
+    id: string;
+    name: string;
+    publicCode?: string;
+    stopPlace?: {
+      id: string;
+      name: string;
+      latitude?: number;
+      longitude?: number;
+    };
+    tariffZones: Array<{id: string; name?: string}>;
+  };
+  notices: Array<{id: string; text?: string}>;
+  situations: Array<{
+    id: string;
+    situationNumber?: string;
+    reportType?: Types.ReportType;
+    summary: Array<{language?: string; value: string}>;
+    description: Array<{language?: string; value: string}>;
+  }>;
+};

--- a/src/api/types/generated/fragments/notices.ts
+++ b/src/api/types/generated/fragments/notices.ts
@@ -1,0 +1,1 @@
+export type NoticeFragment = {id: string; text?: string};

--- a/src/api/types/generated/fragments/quays.ts
+++ b/src/api/types/generated/fragments/quays.ts
@@ -1,0 +1,24 @@
+import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type QuayFragment = {
+  id: string;
+  name: string;
+  publicCode?: string;
+  stopPlace?: {id: string; name: string; latitude?: number; longitude?: number};
+  tariffZones: Array<{id: string; name?: string}>;
+};
+
+export type QuayWithSituationsFragment = {
+  id: string;
+  name: string;
+  publicCode?: string;
+  situations: Array<{
+    id: string;
+    situationNumber?: string;
+    reportType?: Types.ReportType;
+    summary: Array<{language?: string; value: string}>;
+    description: Array<{language?: string; value: string}>;
+  }>;
+  stopPlace?: {id: string; name: string; latitude?: number; longitude?: number};
+  tariffZones: Array<{id: string; name?: string}>;
+};

--- a/src/api/types/generated/fragments/service-journeys.ts
+++ b/src/api/types/generated/fragments/service-journeys.ts
@@ -1,0 +1,45 @@
+import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type ServiceJourneyWithEstCallsFragment = {
+  id: string;
+  transportMode?: Types.TransportMode;
+  transportSubmode?: Types.TransportSubmode;
+  publicCode?: string;
+  line: {publicCode?: string; notices: Array<{id: string; text?: string}>};
+  journeyPattern?: {notices: Array<{id: string; text?: string}>};
+  notices: Array<{id: string; text?: string}>;
+  estimatedCalls?: Array<{
+    actualArrivalTime?: any;
+    actualDepartureTime?: any;
+    aimedArrivalTime: any;
+    aimedDepartureTime: any;
+    cancellation: boolean;
+    date?: any;
+    expectedDepartureTime: any;
+    expectedArrivalTime: any;
+    forAlighting: boolean;
+    forBoarding: boolean;
+    realtime: boolean;
+    destinationDisplay?: {frontText?: string};
+    quay?: {
+      id: string;
+      name: string;
+      publicCode?: string;
+      stopPlace?: {
+        id: string;
+        name: string;
+        latitude?: number;
+        longitude?: number;
+      };
+      tariffZones: Array<{id: string; name?: string}>;
+    };
+    notices: Array<{id: string; text?: string}>;
+    situations: Array<{
+      id: string;
+      situationNumber?: string;
+      reportType?: Types.ReportType;
+      summary: Array<{language?: string; value: string}>;
+      description: Array<{language?: string; value: string}>;
+    }>;
+  }>;
+};

--- a/src/api/types/generated/fragments/stop-places.ts
+++ b/src/api/types/generated/fragments/stop-places.ts
@@ -1,0 +1,8 @@
+import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type StopPlaceFragment = {
+  id: string;
+  name: string;
+  latitude?: number;
+  longitude?: number;
+};

--- a/src/api/types/generated/serviceJourney.ts
+++ b/src/api/types/generated/serviceJourney.ts
@@ -110,36 +110,12 @@ export type ServiceJourneyEstimatedCallFragment = {
   }>;
 };
 
-export type NoticeFragment = {text?: string};
-
-export type QuayFragment = {
-  id: string;
-  name: string;
-  publicCode?: string;
-  situations: Array<{
-    id: string;
-    situationNumber?: string;
-    reportType?: Types.ReportType;
-    summary: Array<{language?: string; value: string}>;
-    description: Array<{language?: string; value: string}>;
-  }>;
-  stopPlace?: {id: string; name: string; latitude?: number; longitude?: number};
-  tariffZones: Array<{id: string; name?: string}>;
-};
-
 export type LineFragment = {
   id: string;
   name?: string;
   publicCode?: string;
   transportMode?: Types.TransportMode;
   transportSubmode?: Types.TransportSubmode;
-};
-
-export type StopPlaceFragment = {
-  id: string;
-  name: string;
-  latitude?: number;
-  longitude?: number;
 };
 
 export type ServiceJourneyFragment = {

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -3,9 +3,8 @@ import {
   TransportMode,
   TransportSubmode,
 } from '@atb/api/types/generated/journey_planner_v3_types';
-import {QuayFragment} from '@atb/api/types/generated/serviceJourney';
+import {QuayFragment} from '@atb/api/types/generated/fragments/quays';
 import {ServiceJourneyMapInfoData_v3} from '@atb/api/types/serviceJourney';
-import {Info} from '@atb/assets/svg/color/icons/status';
 import {ExpandLess, ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
 import ContentWithDisappearingHeader from '@atb/components/disappearing-header/content';
 import {MessageBox} from '@atb/components/message-box';
@@ -35,6 +34,7 @@ import useDepartureData, {
   EstimatedCallWithMetadata,
 } from './use-departure-data';
 import {TicketingMessages} from '@atb/screens/TripDetails/components/DetailsMessages';
+import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 
 export type DepartureDetailsRouteParams = {
   items: ServiceJourneyDeparture[];
@@ -56,7 +56,7 @@ export default function DepartureDetails({navigation, route}: Props) {
 
   const isFocused = useIsFocused();
   const [
-    {estimatedCallsWithMetadata, title, mode, subMode, situations},
+    {estimatedCallsWithMetadata, title, mode, subMode, situations, notices},
     isLoading,
   ] = useDepartureData(activeItem, 30, !isFocused);
   const mapData = useMapData(activeItem);
@@ -65,6 +65,10 @@ export default function DepartureDetails({navigation, route}: Props) {
     animateNextChange();
     setActiveItem(newPage - 1);
   };
+
+  const alreadyShownSituationNumbers = situations
+    .map((s) => s.situationNumber)
+    .filter((s): s is string => !!s);
 
   return (
     <View style={styles.container}>
@@ -118,6 +122,16 @@ export default function DepartureDetails({navigation, route}: Props) {
               style={styles.messageBox}
             />
           ))}
+          {notices.map(
+            (notice) =>
+              notice.text && (
+                <MessageBox
+                  type="info"
+                  message={notice.text}
+                  style={styles.messageBox}
+                />
+              ),
+          )}
 
           {isLoading && (
             <View>
@@ -144,6 +158,8 @@ export default function DepartureDetails({navigation, route}: Props) {
             calls={estimatedCallsWithMetadata}
             mode={mode}
             subMode={subMode}
+            toQuayId={activeItem.toQuayId}
+            alreadyShownSituationNumbers={alreadyShownSituationNumbers}
           />
         </View>
       </ContentWithDisappearingHeader>
@@ -155,9 +171,17 @@ type CallGroupProps = {
   calls: EstimatedCallWithMetadata[];
   mode?: TransportMode;
   subMode?: TransportSubmode;
+  toQuayId?: string;
+  alreadyShownSituationNumbers: string[];
 };
 
-function EstimatedCallRows({calls, mode, subMode}: CallGroupProps) {
+function EstimatedCallRows({
+  calls,
+  mode,
+  subMode,
+  toQuayId,
+  alreadyShownSituationNumbers,
+}: CallGroupProps) {
   const styles = useStopsStyle();
   const passedCalls = calls.filter((c) => c.metadata.group === 'passed');
   const showCollapsable = passedCalls.length > 1;
@@ -189,33 +213,63 @@ function EstimatedCallRows({calls, mode, subMode}: CallGroupProps) {
     <View style={styles.estimatedCallRows}>
       {estimatedCallsToShow.map((call) => (
         <EstimatedCallRow
-          // Quay and ServiceJourney ID is not a unique key if a ServiceJourney
-          // passes by the same stop several times, (e.g. Ringen in Oslo)
-          // which is why it is used in combination with aimedDepartureTime.
-          key={`${call.quay?.id} ${call.serviceJourney?.id} ${call.aimedDepartureTime}`}
+          // Quay ID is not a unique key if a ServiceJourney passes by the
+          // same stop several times, (e.g. Ringen in Oslo) which is why it
+          // is used in combination with aimedDepartureTime.
+          key={`${call.quay?.id}-${call.aimedDepartureTime}`}
           call={call}
           mode={mode}
           subMode={subMode}
           collapseButton={
             call.metadata.isStartOfServiceJourney ? collapseButton : null
           }
+          situations={getSituationsToShowForCall(
+            call,
+            alreadyShownSituationNumbers,
+            toQuayId,
+          )}
         />
       ))}
     </View>
   );
 }
 
+/**
+ * Get the situations to show for an estimated call. Based on the following
+ * rules:
+ * - We don't show situations on passed calls or calls which are after the trip
+ * - We don't show situations which are already shown at the top, above the
+ *   service journey
+ * - If the trip have an end quay we only show situations on the end quay of the
+ *   trip, or else we show situations on all intermediate quays on the trip
+ */
+const getSituationsToShowForCall = (
+  {situations, metadata: {group, isEndOfGroup}}: EstimatedCallWithMetadata,
+  alreadyShownSituationNumbers: string[],
+  toQuayId?: string,
+) => {
+  if (group === 'passed' || group === 'after') return [];
+  if (toQuayId && !isEndOfGroup) return [];
+  return situations.filter(
+    (s) =>
+      !s.situationNumber ||
+      !alreadyShownSituationNumbers.includes(s.situationNumber),
+  );
+};
+
 type TripItemProps = {
   call: EstimatedCallWithMetadata;
   mode: TransportMode | undefined;
   subMode: TransportSubmode | undefined;
   collapseButton: JSX.Element | null;
+  situations: SituationFragment[];
 };
 function EstimatedCallRow({
   call,
   mode,
   subMode,
   collapseButton,
+  situations,
 }: TripItemProps) {
   const navigation = useNavigation<Props['navigation']>();
   const {t} = useTranslation();
@@ -255,35 +309,26 @@ function EstimatedCallRow({
       >
         <ThemeText testID="quayName">{getQuayName(call.quay)} </ThemeText>
       </TripRow>
-      {group === 'trip'
-        ? call.quay?.situations.map((situation) => (
-            <TripRow rowLabel={<SituationIcon situation={situation} />}>
-              <SituationMessageBox noStatusIcon={true} situation={situation} />
-            </TripRow>
-          ))
-        : null}
-      {call.notices &&
-        call.notices.map((notice, index) => {
-          if (!notice.text) return null;
-          return (
-            <TripRow
-              key={'notice-' + index}
-              rowLabel={<ThemeIcon svg={Info} />}
-            >
-              <MessageBox
-                noStatusIcon={true}
-                type="info"
-                message={notice.text}
-              />
-            </TripRow>
-          );
-        })}
+      {situations.map((situation) => (
+        <TripRow rowLabel={<SituationIcon situation={situation} />}>
+          <SituationMessageBox noStatusIcon={true} situation={situation} />
+        </TripRow>
+      ))}
       {!call.forAlighting && (
         <TripRow>
           <MessageBox
             noStatusIcon={true}
             type="info"
             message={t(DepartureDetailsTexts.messages.noAlighting)}
+          />
+        </TripRow>
+      )}
+      {!call.forBoarding && (
+        <TripRow>
+          <MessageBox
+            noStatusIcon={true}
+            type="info"
+            message={t(DepartureDetailsTexts.messages.noBoarding)}
           />
         </TripRow>
       )}
@@ -302,7 +347,7 @@ function EstimatedCallRow({
           id: stopPlace.id,
           name: stopPlace.name,
         },
-        selectedQuay: quay,
+        selectedQuay: {...quay, situations: []},
         mode: 'Departure',
       });
     } else {

--- a/src/screens/TripDetails/components/DetailsMessages.tsx
+++ b/src/screens/TripDetails/components/DetailsMessages.tsx
@@ -25,8 +25,8 @@ import {hasShortWaitTime} from '@atb/screens/TripDetails/components/utils';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
 import {ServiceJourneyDeparture} from '@atb/screens/TripDetails/DepartureDetails/types';
-import {ServiceJourneyEstimatedCallFragment} from '@atb/api/types/generated/serviceJourney';
 import {StyleSheet} from '@atb/theme';
+import {EstimatedCallWithMetadata} from '@atb/screens/TripDetails/DepartureDetails/use-departure-data';
 
 type TripMessagesProps = {
   tripPattern: TripPattern;
@@ -120,7 +120,7 @@ function someLegsAreByTrain(tripPattern: TripPattern): boolean {
 
 type TicketingMessagesProps = {
   item: ServiceJourneyDeparture;
-  trip: ServiceJourneyEstimatedCallFragment[];
+  trip: EstimatedCallWithMetadata[];
   mode: TransportMode | undefined;
   subMode: TransportSubmode | undefined;
 };

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -12,6 +12,7 @@ const DepartureDetailsTexts = {
   messages: {
     loading: _('Laster detaljer', 'Loading details'),
     noAlighting: _('Ingen avstigning', 'No disembarking'),
+    noBoarding: _('Ingen påstigning', 'No boarding'),
     noActiveItem: _(
       'Ojda! Noe gikk galt med lasting av detaljer for denne reisen.',
       'Oops! We had some issues loading the details for this journey.',

--- a/src/utils/only-uniques.ts
+++ b/src/utils/only-uniques.ts
@@ -1,0 +1,7 @@
+export const onlyUniques = <T>(value: T, index: number, self: T[]) =>
+  self.indexOf(value) === index;
+
+export const onlyUniquesBasedOnField =
+  <T>(field: keyof T) =>
+  (element: T, index: number, array: T[]) =>
+    array.findIndex((el) => el[field] === element[field]) === index;

--- a/src/utils/transportation-names.ts
+++ b/src/utils/transportation-names.ts
@@ -2,6 +2,7 @@ import {EstimatedCall, Leg, Quay} from '../sdk';
 import {Quay as Quay_v2} from '../api/types/trips';
 import {TranslatedString, dictionary} from '../translations';
 import {AnyMode} from '@atb/components/transportation-icon';
+import {QuayFragment} from '@atb/api/types/generated/fragments/quays';
 
 export function getLineName(leg: Leg) {
   return leg.line
@@ -52,7 +53,9 @@ export function getTranslatedModeName(mode?: AnyMode): TranslatedString {
   }
 }
 
-export function getQuayName(quay?: Quay | Quay_v2): string | undefined {
+export function getQuayName(
+  quay?: Quay | Quay_v2 | QuayFragment,
+): string | undefined {
   if (!quay) return;
   if (!quay.publicCode) return quay.name;
   return `${quay.name} ${quay.publicCode}`;


### PR DESCRIPTION
To enable this we use the new serviceJourney/{id}/calls endpoint in the bff. This also gets the relevant notices on service journey, journey pattern and line level. In addition show the situations on each estimated call, but filter out those who are shown at the top. This is for removing line- and serviceJourney-level situations which are duplicated for each estimated call.