### PR TITLE
fix: update section margins in QuaySection

### DIFF
--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -160,5 +160,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginBottom: theme.spacings.medium,
     paddingHorizontal: theme.spacings.medium,
   },
-  quayData: {flex: 1, marginTop: theme.spacings.small},
+  quayData: {flex: 1},
 }));

--- a/src/screens/Departures/StopPlaceView.tsx
+++ b/src/screens/Departures/StopPlaceView.tsx
@@ -260,7 +260,7 @@ function publicCodeCompare(a?: string, b?: string): number {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   headerWithNavigation: {
-    paddingVertical: theme.spacings.medium,
+    paddingTop: theme.spacings.medium,
     marginHorizontal: theme.spacings.medium,
   },
   headerWithoutNavigation: {

--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -81,7 +81,7 @@ export default function QuaySection({
 
   return (
     <View testID={testID}>
-      <Sections.Section withPadding withBottomPadding>
+      <Sections.Section style={styles.section}>
         <Sections.GenericClickableItem
           onPress={() => {
             setIsMinimized(!isMinimized);
@@ -250,6 +250,10 @@ function compareByLineNameAndDesc(
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginHorizontal: theme.spacings.medium,
+    marginVertical: theme.spacings.medium,
+  },
   stopPlaceHeader: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
Adds medium padding above and below QuaySection, instead of "large-ish" just below (Using `withPadding withBottomPadding` was slightly more padding than in the design system). This way we don't have to handle padding in PlaceScreen, which is also used in the add favorites flow.


https://user-images.githubusercontent.com/1774972/206169537-bb5406cc-a3e0-4ad5-8f09-3cb5a473c478.mp4



fixes https://github.com/AtB-AS/kundevendt/issues/3020