### PR TITLE
feat: Show info icon if trip or call has notices

### DIFF
--- a/src/api/departures/types.ts
+++ b/src/api/departures/types.ts
@@ -3,6 +3,7 @@ import {
   TransportSubmode,
 } from '@atb/api/types/generated/journey_planner_v3_types';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
+import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 
 type Notice = {text?: string};
 
@@ -24,6 +25,7 @@ export type DepartureTime = {
   situations: SituationFragment[];
   serviceJourneyId?: string;
   serviceDate: string;
+  notices?: NoticeFragment[];
 };
 
 export type DepartureGroup = {

--- a/src/api/types/generated/QuayDeparturesQuery.ts
+++ b/src/api/types/generated/QuayDeparturesQuery.ts
@@ -22,7 +22,10 @@ export type QuayDeparturesQuery = {
           publicCode?: string;
           transportMode?: Types.TransportMode;
           transportSubmode?: Types.TransportSubmode;
+          notices: Array<{id: string; text?: string}>;
         };
+        journeyPattern?: {notices: Array<{id: string; text?: string}>};
+        notices: Array<{id: string; text?: string}>;
       };
       situations: Array<{
         id: string;
@@ -31,6 +34,7 @@ export type QuayDeparturesQuery = {
         summary: Array<{language?: string; value: string}>;
         description: Array<{language?: string; value: string}>;
       }>;
+      notices: Array<{id: string; text?: string}>;
     }>;
     situations: Array<{
       id: string;

--- a/src/api/types/generated/StopQuayDeparturesQuery.ts
+++ b/src/api/types/generated/StopQuayDeparturesQuery.ts
@@ -21,7 +21,10 @@ export type StopPlaceQuayDeparturesQuery = {
             publicCode?: string;
             transportMode?: Types.TransportMode;
             transportSubmode?: Types.TransportSubmode;
+            notices: Array<{id: string; text?: string}>;
           };
+          journeyPattern?: {notices: Array<{id: string; text?: string}>};
+          notices: Array<{id: string; text?: string}>;
         };
         situations: Array<{
           id: string;
@@ -30,6 +33,7 @@ export type StopPlaceQuayDeparturesQuery = {
           summary: Array<{language?: string; value: string}>;
           description: Array<{language?: string; value: string}>;
         }>;
+        notices: Array<{id: string; text?: string}>;
       }>;
       situations: Array<{
         id: string;

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -53,8 +53,9 @@ import {
   View,
 } from 'react-native';
 import {hasNoDeparturesOnGroup, isValidDeparture} from '../utils';
-import {getSvgForMostCriticalSituation} from '@atb/situations';
+import {getSvgForMostCriticalSituationOrNotice} from '@atb/situations';
 import {Realtime} from '@atb/assets/svg/color/icons/status';
+import {filterNotices} from '@atb/screens/TripDetails/utils';
 
 type RootProps = NearbyScreenProps<'NearbyRoot'>;
 
@@ -260,7 +261,7 @@ function DepartureTimeItem({
 }: DepartureTimeItemProps) {
   const styles = useItemStyles();
   const {t, language} = useTranslation();
-
+  const notices = filterNotices(departure.notices || []);
   if (!isValidDeparture(departure)) {
     return null;
   }
@@ -273,7 +274,10 @@ function DepartureTimeItem({
       text={formatTimeText(departure, searchDate, language, t)}
       style={styles.departure}
       textStyle={styles.departureText}
-      rightIcon={getSvgForMostCriticalSituation(departure.situations)}
+      rightIcon={getSvgForMostCriticalSituationOrNotice(
+        departure.situations,
+        notices,
+      )}
       leftIcon={departure.realtime ? Realtime : undefined}
       testID={testID}
     />

--- a/src/screens/Assistant/ResultItem.tsx
+++ b/src/screens/Assistant/ResultItem.tsx
@@ -11,7 +11,7 @@ import TransportationIcon, {
   CollapsedLegs,
 } from '@atb/components/transportation-icon';
 
-import {SituationIcon} from '@atb/situations';
+import {SituationOrNoticeIcon} from '@atb/situations';
 import {StyleSheet} from '@atb/theme';
 import {
   AssistantTexts,
@@ -116,7 +116,7 @@ const ResultItemHeader: React.FC<{
 
       <WarnWhenRailReplacementBus tripPattern={tripPattern} />
 
-      <SituationIcon
+      <SituationOrNoticeIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
         accessibilityLabel={t(
           AssistantTexts.results.resultItem.hasSituationsTip,

--- a/src/screens/Dashboard/ResultItem.tsx
+++ b/src/screens/Dashboard/ResultItem.tsx
@@ -11,7 +11,7 @@ import TransportationIcon, {
   CollapsedLegs,
 } from '@atb/components/transportation-icon';
 
-import {SituationIcon} from '@atb/situations';
+import {SituationOrNoticeIcon} from '@atb/situations';
 import {StyleSheet} from '@atb/theme';
 import {
   TripSearchTexts,
@@ -44,6 +44,7 @@ import {Leg, TripPattern} from '@atb/api/types/trips';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {SearchTime} from '@atb/screens/Dashboard/journey-date-picker';
 import WarnWhenRailReplacementBus from '@atb/components/rail-replacement-bus-message';
+import {getNoticesForLeg} from '@atb/screens/TripDetails/utils';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -116,8 +117,9 @@ const ResultItemHeader: React.FC<{
 
       <WarnWhenRailReplacementBus tripPattern={tripPattern} />
 
-      <SituationIcon
+      <SituationOrNoticeIcon
         situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
+        notices={flatMap(tripPattern.legs, getNoticesForLeg)}
         accessibilityLabel={t(
           TripSearchTexts.results.resultItem.hasSituationsTip,
         )}

--- a/src/screens/Departures/components/EstimatedCallItem.tsx
+++ b/src/screens/Departures/components/EstimatedCallItem.tsx
@@ -30,10 +30,13 @@ import {useOnMarkFavouriteDepartures} from '@atb/screens/Departures/components/u
 import {StopPlacesMode} from '@atb/screens/Departures/types';
 import {TouchableOpacityOrView} from '@atb/components/touchable-opacity-or-view';
 import {SvgProps} from 'react-native-svg';
-import {getSvgForMostCriticalSituation} from '@atb/situations';
+import {getSvgForMostCriticalSituationOrNotice} from '@atb/situations';
 import {getSituationA11yLabel} from '@atb/situations/utils';
 import Time from '@atb/screens/TripDetails/components/Time';
-import {getTimeRepresentationType} from '@atb/screens/TripDetails/utils';
+import {
+  getNoticesForEstimatedCall,
+  getTimeRepresentationType,
+} from '@atb/screens/TripDetails/utils';
 import {Realtime} from '@atb/assets/svg/color/icons/status';
 
 type EstimatedCallItemProps = {
@@ -70,6 +73,9 @@ export default function EstimatedCallItem({
 
   const lineName = departure.destinationDisplay?.frontText;
   const lineNumber = line?.publicCode;
+
+  const notices = getNoticesForEstimatedCall(departure);
+
   const {onMarkFavourite, existingFavorite, toggleFavouriteAccessibilityLabel} =
     useOnMarkFavouriteDepartures(
       {...line, lineNumber: lineNumber, lineName: lineName},
@@ -122,8 +128,9 @@ export default function EstimatedCallItem({
               publicCode={line.publicCode}
               transportMode={line.transportMode}
               transportSubmode={line.transportSubmode}
-              icon={getSvgForMostCriticalSituation(
+              icon={getSvgForMostCriticalSituationOrNotice(
                 departure.situations,
+                notices,
                 departure.cancellation,
               )}
               testID={testID}

--- a/src/screens/Departures/components/EstimatedCallItem.tsx
+++ b/src/screens/Departures/components/EstimatedCallItem.tsx
@@ -31,13 +31,14 @@ import {StopPlacesMode} from '@atb/screens/Departures/types';
 import {TouchableOpacityOrView} from '@atb/components/touchable-opacity-or-view';
 import {SvgProps} from 'react-native-svg';
 import {getSvgForMostCriticalSituationOrNotice} from '@atb/situations';
-import {getSituationA11yLabel} from '@atb/situations/utils';
+import {getSituationOrNoticeA11yLabel} from '@atb/situations/utils';
 import Time from '@atb/screens/TripDetails/components/Time';
 import {
   getNoticesForEstimatedCall,
   getTimeRepresentationType,
 } from '@atb/screens/TripDetails/utils';
 import {Realtime} from '@atb/assets/svg/color/icons/status';
+import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 
 type EstimatedCallItemProps = {
   departure: EstimatedCall;
@@ -118,7 +119,7 @@ export default function EstimatedCallItem({
         }
         accessibilityLabel={
           navigateToDetails
-            ? getA11yDeparturesLabel(departure, t, language)
+            ? getA11yDeparturesLabel(departure, notices, t, language)
             : undefined
         }
       >
@@ -227,6 +228,7 @@ const DepartureTime = ({
 
 function getA11yDeparturesLabel(
   departure: EstimatedCall,
+  notices: NoticeFragment[],
   t: TranslateFunction,
   language: Language,
 ) {
@@ -272,15 +274,18 @@ function getA11yDeparturesLabel(
     a11yDateInfo = `${a11yDate} ${a11yTimeWithRealtimePrefix}`;
   }
 
-  const a11yWarning = getSituationA11yLabel(
+  const a11yWarning = getSituationOrNoticeA11yLabel(
     departure.situations,
+    notices,
     departure.cancellation,
     t,
   );
 
   return `${
     departure.cancellation ? t(CancelledDepartureTexts.message) : ''
-  } ${getLineA11yLabel(departure, t)} ${a11yWarning} ${a11yDateInfo}`;
+  } ${getLineA11yLabel(departure, t)} ${
+    a11yWarning ? a11yWarning + ',' : ''
+  } ${a11yDateInfo}`;
 }
 
 function getLineA11yLabel(departure: EstimatedCall, t: TranslateFunction) {

--- a/src/screens/Departures/components/StopPlaceItem.tsx
+++ b/src/screens/Departures/components/StopPlaceItem.tsx
@@ -10,7 +10,7 @@ import {NearestStopPlaceNode, StopPlace} from '@atb/api/types/departures';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import {StyleSheet} from '@atb/theme';
 import {useHumanizeDistance} from '@atb/utils/location';
-import {SituationIcon} from '@atb/situations';
+import {SituationOrNoticeIcon} from '@atb/situations';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {getSituationA11yLabel} from '@atb/situations/utils';
@@ -78,7 +78,7 @@ export default function StopPlaceItem({
               </ThemeText>
             )}
           </View>
-          <SituationIcon situations={allQuaySituations} />
+          <SituationOrNoticeIcon situations={allQuaySituations} />
           {place.transportMode?.map((mode) => (
             <ThemeIcon
               key={mode}

--- a/src/screens/Departures/components/StopPlaceItem.tsx
+++ b/src/screens/Departures/components/StopPlaceItem.tsx
@@ -13,7 +13,7 @@ import {useHumanizeDistance} from '@atb/utils/location';
 import {SituationOrNoticeIcon} from '@atb/situations';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
-import {getSituationA11yLabel} from '@atb/situations/utils';
+import {getSituationOrNoticeA11yLabel} from '@atb/situations/utils';
 
 type StopPlaceItemProps = {
   stopPlaceNode: NearestStopPlaceNode;
@@ -47,7 +47,7 @@ export default function StopPlaceItem({
     place.name,
     description,
     humanizedDistance,
-    getSituationA11yLabel(allQuaySituations, false, t),
+    getSituationOrNoticeA11yLabel(allQuaySituations, [], false, t),
     place.transportMode
       ?.map((mode) => t(getTranslatedModeName(mode)))
       .join(','),

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -15,7 +15,7 @@ import ThemeIcon from '@atb/components/theme-icon';
 import {usePreferenceItems} from '@atb/preferences';
 import CancelledDepartureMessage from '@atb/screens/TripDetails/components/CancelledDepartureMessage';
 import PaginatedDetailsHeader from '@atb/screens/TripDetails/components/PaginatedDetailsHeader';
-import {SituationIcon, SituationMessageBox} from '@atb/situations';
+import {SituationOrNoticeIcon, SituationMessageBox} from '@atb/situations';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {DepartureDetailsTexts, useTranslation} from '@atb/translations';
 import {animateNextChange} from '@atb/utils/animation';
@@ -310,7 +310,7 @@ function EstimatedCallRow({
         <ThemeText testID="quayName">{getQuayName(call.quay)} </ThemeText>
       </TripRow>
       {situations.map((situation) => (
-        <TripRow rowLabel={<SituationIcon situation={situation} />}>
+        <TripRow rowLabel={<SituationOrNoticeIcon situation={situation} />}>
           <SituationMessageBox noStatusIcon={true} situation={situation} />
         </TripRow>
       ))}

--- a/src/screens/TripDetails/DepartureDetails/use-departure-data.ts
+++ b/src/screens/TripDetails/DepartureDetails/use-departure-data.ts
@@ -10,6 +10,7 @@ import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import {getNoticesForServiceJourney} from '@atb/screens/TripDetails/utils';
 
 export type DepartureData = {
   estimatedCallsWithMetadata: EstimatedCallWithMetadata[];
@@ -59,14 +60,10 @@ export default function useDepartureData(
         focusedEstimatedCall.destinationDisplay?.frontText || ''
       }`;
 
-      const notices = [
-        ...serviceJourney.notices,
-        ...(serviceJourney.journeyPattern?.notices || []),
-        ...serviceJourney.line.notices,
-        ...focusedEstimatedCall.notices,
-      ]
-        .filter(onlyUniquesBasedOnField<NoticeFragment>('id'))
-        .sort((n1, n2) => n1.id.localeCompare(n2.id));
+      const notices = getNoticesForServiceJourney(
+        serviceJourney,
+        activeItem.fromQuayId,
+      );
 
       const situations = focusedEstimatedCall.situations.sort((n1, n2) =>
         n1.id.localeCompare(n2.id),

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -10,7 +10,7 @@ import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 import TransportationIcon from '@atb/components/transportation-icon';
 import {usePreferenceItems} from '@atb/preferences';
 import {ServiceJourneyDeparture} from '@atb/screens/TripDetails/DepartureDetails/types';
-import {SituationMessageBox, SituationIcon} from '@atb/situations';
+import {SituationMessageBox, SituationOrNoticeIcon} from '@atb/situations';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
   Language,
@@ -34,7 +34,11 @@ import {
   significantWalkTime,
 } from '../Details/utils';
 import {TripDetailsRootNavigation} from '../types';
-import {getTimeRepresentationType, TimeValues} from '../utils';
+import {
+  getNoticesForLeg,
+  getTimeRepresentationType,
+  TimeValues,
+} from '../utils';
 import Time from './Time';
 import TripLegDecoration from './TripLegDecoration';
 import TripRow from './TripRow';
@@ -81,14 +85,7 @@ const TripSection: React.FC<TripSectionProps> = ({
 
   const navigation = useNavigation<TripDetailsRootNavigation<'Details'>>();
 
-  const notices = [
-    ...(leg.line?.notices || []),
-    ...(leg.serviceJourney?.notices || []),
-    ...(leg.serviceJourney?.journeyPattern?.notices || []),
-    ...(leg.fromEstimatedCall?.notices || []),
-  ]
-    .filter(onlyUniquesBasedOnField('id'))
-    .sort((s1, s2) => s1.id.localeCompare(s2.id));
+  const notices = getNoticesForLeg(leg);
 
   const sectionOutput = (
     <>
@@ -150,22 +147,15 @@ const TripSection: React.FC<TripSectionProps> = ({
           </TripRow>
         )}
         {leg.situations.map((situation) => (
-          <TripRow rowLabel={<SituationIcon situation={situation} />}>
+          <TripRow rowLabel={<SituationOrNoticeIcon situation={situation} />}>
             <SituationMessageBox noStatusIcon={true} situation={situation} />
           </TripRow>
         ))}
-        {notices.map(
-          (notice) =>
-            notice.text && (
-              <TripRow rowLabel={<ThemeIcon svg={Info} />}>
-                <MessageBox
-                  noStatusIcon={true}
-                  type="info"
-                  message={notice.text}
-                />
-              </TripRow>
-            ),
-        )}
+        {notices.map((notice) => (
+          <TripRow rowLabel={<ThemeIcon svg={Info} />}>
+            <MessageBox noStatusIcon={true} type="info" message={notice.text} />
+          </TripRow>
+        ))}
         {leg.transportSubmode === TransportSubmode.RailReplacementBus && (
           <TripRow rowLabel={<ThemeIcon svg={Warning} />}>
             <MessageBox

--- a/src/screens/TripDetails/utils.ts
+++ b/src/screens/TripDetails/utils.ts
@@ -1,4 +1,9 @@
 import {secondsBetween} from '@atb/utils/date';
+import {Leg} from '@atb/api/types/trips';
+import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
+import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
+import {EstimatedCall} from '@atb/api/types/departures';
 
 const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES = 1;
 
@@ -28,3 +33,49 @@ export function getTimeRepresentationType({
     ? 'no-significant-difference'
     : 'significant-difference';
 }
+
+export const getNoticesForLeg = (leg: Leg) =>
+  filterNotices([
+    ...(leg.line?.notices || []),
+    ...(leg.serviceJourney?.notices || []),
+    ...(leg.serviceJourney?.journeyPattern?.notices || []),
+    ...(leg.fromEstimatedCall?.notices || []),
+  ]);
+
+export const getNoticesForServiceJourney = (
+  serviceJourney: ServiceJourneyWithEstCallsFragment,
+  fromQuayId?: string,
+) => {
+  const focusedEstimatedCall =
+    serviceJourney.estimatedCalls?.find(
+      ({quay}) => quay?.id && quay.id === fromQuayId,
+    ) || serviceJourney.estimatedCalls?.[0];
+
+  return filterNotices([
+    ...serviceJourney.notices,
+    ...(serviceJourney.journeyPattern?.notices || []),
+    ...serviceJourney.line.notices,
+    ...(focusedEstimatedCall?.notices || []),
+  ]);
+};
+
+export const getNoticesForEstimatedCall = (estimatedCall: EstimatedCall) => {
+  return filterNotices([
+    ...estimatedCall.notices,
+    ...(estimatedCall.serviceJourney?.notices || []),
+    ...(estimatedCall.serviceJourney?.line.notices || []),
+    ...(estimatedCall.serviceJourney?.journeyPattern?.notices || []),
+  ]);
+};
+
+/**
+ * Filter notices by removing duplicates (by id), removing those without text,
+ * and also sorting them since the order from Entur may change on each request.
+ */
+export const filterNotices = (
+  notices: NoticeFragment[],
+): Required<NoticeFragment>[] =>
+  notices
+    .filter((n): n is Required<NoticeFragment> => !!n.text)
+    .filter(onlyUniquesBasedOnField('id'))
+    .sort((s1, s2) => s1.id.localeCompare(s2.id));

--- a/src/situations/SituationOrNoticeIcon.tsx
+++ b/src/situations/SituationOrNoticeIcon.tsx
@@ -1,19 +1,32 @@
-import {Warning} from '@atb/assets/svg/color/icons/status';
+import {Info, Warning} from '@atb/assets/svg/color/icons/status';
 import React, {ComponentProps} from 'react';
-import {getSvgForMostCriticalSituation} from './utils';
+import {getSvgForMostCriticalSituationOrNotice} from './utils';
 import {SituationType} from '@atb/situations/types';
 import ThemeIcon from '@atb/components/theme-icon';
+import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 
 type Props = {
   style?: ComponentProps<typeof Warning>['style'];
   accessibilityLabel?: string;
+  notices?: NoticeFragment[];
+  cancellation?: boolean;
 } & ({situations: SituationType[]} | {situation: SituationType});
 
-export const SituationIcon = ({style, accessibilityLabel, ...props}: Props) => {
+export const SituationOrNoticeIcon = ({
+  style,
+  accessibilityLabel,
+  notices,
+  cancellation,
+  ...props
+}: Props) => {
   const situations =
     'situation' in props ? [props.situation] : props.situations;
 
-  const svg = getSvgForMostCriticalSituation(situations);
+  const svg = getSvgForMostCriticalSituationOrNotice(
+    situations,
+    notices,
+    cancellation,
+  );
   if (!svg) return null;
 
   return (

--- a/src/situations/index.tsx
+++ b/src/situations/index.tsx
@@ -1,4 +1,4 @@
 export {SituationMessageBox} from './SituationMessageBox';
 export {SituationSectionItem} from './SituationSectionItem';
-export {SituationIcon} from './SituationIcon';
-export {getSvgForMostCriticalSituation} from './utils';
+export {SituationOrNoticeIcon} from './SituationOrNoticeIcon';
+export {getSvgForMostCriticalSituationOrNotice} from './utils';

--- a/src/situations/utils.ts
+++ b/src/situations/utils.ts
@@ -68,13 +68,16 @@ export const getSvgForMostCriticalSituationOrNotice = (
     .reduce((svg, msgType) => (msgType === 'warning' ? Warning : svg), Info);
 };
 
-export const getSituationA11yLabel = (
+export const getSituationOrNoticeA11yLabel = (
   situations: SituationType[],
+  notices: NoticeFragment[],
   cancellation: boolean = false,
   t: TranslateFunction,
 ): string => {
   if (cancellation) return t(SituationsTexts.a11yLabel.error);
-  if (!situations.length) return '';
+  if (!situations.length) {
+    return notices.length ? t(SituationsTexts.a11yLabel.info) : '';
+  }
   const messageType = situations
     .map(getMessageTypeForSituation)
     .reduce(

--- a/src/situations/utils.ts
+++ b/src/situations/utils.ts
@@ -8,6 +8,7 @@ import {
 } from '@atb/translations';
 import {Error, Info, Warning} from '@atb/assets/svg/color/icons/status';
 import {SvgProps} from 'react-native-svg';
+import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 
 export const getUniqueSituations = (situations: SituationType[] = []) => {
   let seenIds: string[] = [];
@@ -53,12 +54,15 @@ export const getSvgForSituation = (
   }
 };
 
-export const getSvgForMostCriticalSituation = (
+export const getSvgForMostCriticalSituationOrNotice = (
   situations: SituationType[],
+  notices?: NoticeFragment[],
   cancellation: boolean = false,
 ) => {
   if (cancellation) return Error;
-  if (!situations.length) return undefined;
+  if (!situations.length) {
+    return notices?.length ? Info : undefined;
+  }
   return situations
     .map(getMessageTypeForSituation)
     .reduce((svg, msgType) => (msgType === 'warning' ? Warning : svg), Info);


### PR DESCRIPTION
On trip and estimated call we show a blue or yellow info icon if it has any situations. Now if the trip or estimated call has any notices the blue icon will show.

This is fixed for Assistant on the new frontpage (but not the old one), on departures v2, and on departures v1 on the frontpage.