### PR TITLE
feat: Make boarding info less intrusive

### DIFF
--- a/src/components/accessible-text/AccessibleText.tsx
+++ b/src/components/accessible-text/AccessibleText.tsx
@@ -6,7 +6,7 @@ type LabelProps = ThemeTextProps & {
   prefix?: string;
   suffix?: string;
   children?: string;
-  pause?: 'before' | 'after' | 'none';
+  pause?: 'before' | 'after' | 'both' | 'none';
 };
 
 const AccessibleText = ({
@@ -16,12 +16,14 @@ const AccessibleText = ({
   pause = 'after',
   ...props
 }: LabelProps) => {
+  const pauseBefore = pause === 'before' || pause === 'both';
+  const pauseAfter = pause === 'after' || pause === 'both';
   return (
     <ThemeText
-      accessibilityLabel={`${pause === 'before' ? screenReaderPause : ''} ${
+      accessibilityLabel={`${pauseBefore ? screenReaderPause : ''} ${
         prefix ?? ''
       } ${children ?? ''} ${suffix ?? ''} ${
-        pause === 'after' ? screenReaderPause : ''
+        pauseAfter ? screenReaderPause : ''
       }`}
       {...props}
     >

--- a/src/components/accessible-text/AccessibleText.tsx
+++ b/src/components/accessible-text/AccessibleText.tsx
@@ -6,21 +6,23 @@ type LabelProps = ThemeTextProps & {
   prefix?: string;
   suffix?: string;
   children?: string;
-  pauseAfter?: boolean;
+  pause?: 'before' | 'after' | 'none';
 };
 
 const AccessibleText = ({
   prefix,
   suffix,
   children,
-  pauseAfter = true,
+  pause = 'after',
   ...props
 }: LabelProps) => {
   return (
     <ThemeText
-      accessibilityLabel={`${prefix ?? ''} : ${children ?? ''} ${
-        suffix ?? ''
-      } ${pauseAfter ? screenReaderPause : ' '}`}
+      accessibilityLabel={`${pause === 'before' ? screenReaderPause : ''} ${
+        prefix ?? ''
+      } ${children ?? ''} ${suffix ?? ''} ${
+        pause === 'after' ? screenReaderPause : ''
+      }`}
       {...props}
     >
       {children ?? ' '}

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -15,7 +15,7 @@ import ThemeIcon from '@atb/components/theme-icon';
 import {usePreferenceItems} from '@atb/preferences';
 import CancelledDepartureMessage from '@atb/screens/TripDetails/components/CancelledDepartureMessage';
 import PaginatedDetailsHeader from '@atb/screens/TripDetails/components/PaginatedDetailsHeader';
-import {SituationOrNoticeIcon, SituationMessageBox} from '@atb/situations';
+import {SituationMessageBox, SituationOrNoticeIcon} from '@atb/situations';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {DepartureDetailsTexts, useTranslation} from '@atb/translations';
 import {animateNextChange} from '@atb/utils/animation';
@@ -35,6 +35,7 @@ import useDepartureData, {
 } from './use-departure-data';
 import {TicketingMessages} from '@atb/screens/TripDetails/components/DetailsMessages';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
+import AccessibleText from '@atb/components/accessible-text';
 
 export type DepartureDetailsRouteParams = {
   items: ServiceJourneyDeparture[];
@@ -307,31 +308,36 @@ function EstimatedCallRow({
         onPress={() => handleQuayPress(call.quay)}
         testID={'legType_' + group}
       >
-        <ThemeText testID="quayName">{getQuayName(call.quay)} </ThemeText>
+        <ThemeText testID="quayName">{getQuayName(call.quay)}</ThemeText>
+        {!call.forAlighting && !call.metadata.isStartOfServiceJourney && (
+          <AccessibleText
+            type="body__secondary"
+            color="secondary"
+            style={styles.boardingInfo}
+            pause="before"
+          >
+            {t(DepartureDetailsTexts.messages.noAlighting)}
+          </AccessibleText>
+        )}
+        {!call.forBoarding && !call.metadata.isEndOfServiceJourney && (
+          <AccessibleText
+            type="body__secondary"
+            color="secondary"
+            style={styles.boardingInfo}
+            pause="before"
+          >
+            {t(DepartureDetailsTexts.messages.noBoarding)}
+          </AccessibleText>
+        )}
       </TripRow>
       {situations.map((situation) => (
-        <TripRow rowLabel={<SituationOrNoticeIcon situation={situation} />}>
+        <TripRow
+          rowLabel={<SituationOrNoticeIcon situation={situation} />}
+          style={styles.situationTripRow}
+        >
           <SituationMessageBox noStatusIcon={true} situation={situation} />
         </TripRow>
       ))}
-      {!call.forAlighting && (
-        <TripRow>
-          <MessageBox
-            noStatusIcon={true}
-            type="info"
-            message={t(DepartureDetailsTexts.messages.noAlighting)}
-          />
-        </TripRow>
-      )}
-      {!call.forBoarding && (
-        <TripRow>
-          <MessageBox
-            noStatusIcon={true}
-            type="info"
-            message={t(DepartureDetailsTexts.messages.noBoarding)}
-          />
-        </TripRow>
-      )}
 
       {collapseButton}
     </View>
@@ -428,9 +434,6 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   middleRow: {
     minHeight: 60,
   },
-  situationsContainer: {
-    marginBottom: theme.spacings.small,
-  },
   estimatedCallRows: {
     backgroundColor: theme.static.background.background_0.background,
     marginBottom: theme.spacings.xLarge,
@@ -444,6 +447,13 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   scrollView__content: {
     padding: theme.spacings.medium,
     paddingBottom: theme.spacings.large,
+  },
+  boardingInfo: {
+    marginTop: theme.spacings.xSmall,
+  },
+  situationTripRow: {
+    paddingTop: 0,
+    paddingBottom: theme.spacings.xLarge,
   },
 }));
 


### PR DESCRIPTION
Instead of using message boxes, just have the boarding info as secondary text under the quay name. Also skip redundant boarding info on first and last stop of service journey.

Also fixed som padding on the TripRow for situation message, so it is a little closer to the quay name above.

Resolves https://github.com/AtB-AS/kundevendt/issues/2992

Before/After:
<div>
<img width=400 src="https://user-images.githubusercontent.com/675421/206253222-0c6a4ed8-49fd-4ef8-9920-0ff08d169c38.png" />
<img width=400 src="https://user-images.githubusercontent.com/675421/206253235-3909dab5-a87a-4b22-ac22-49df5b5aa222.png" />
</div>