### PR TITLE
feat: add dark realtime icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^5.5.1",
+    "@atb-as/generate-assets": "^5.6.0",
     "@babel/core": "^7.18.13",
     "@babel/runtime": "^7.18.9",
     "@entur-private/abt-token-server-javascript-interface": "1.1.5",

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -26,7 +26,7 @@ import {StoredType} from '@atb/favorites/storage';
 import {FavoriteDeparture} from '@atb/favorites/types';
 import {NearbyScreenProps} from '@atb/screens/Nearby/types';
 import {ServiceJourneyDeparture} from '@atb/screens/TripDetails/DepartureDetails/types';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {
   dictionary,
   Language,
@@ -54,7 +54,8 @@ import {
 } from 'react-native';
 import {hasNoDeparturesOnGroup, isValidDeparture} from '../utils';
 import {getSvgForMostCriticalSituationOrNotice} from '@atb/situations';
-import {Realtime} from '@atb/assets/svg/color/icons/status';
+import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
+import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 import {filterNotices} from '@atb/screens/TripDetails/utils';
 
 type RootProps = NearbyScreenProps<'NearbyRoot'>;
@@ -261,6 +262,7 @@ function DepartureTimeItem({
 }: DepartureTimeItemProps) {
   const styles = useItemStyles();
   const {t, language} = useTranslation();
+  const {themeName} = useTheme();
 
   const notices = filterNotices(departure.notices || []);
 
@@ -268,7 +270,11 @@ function DepartureTimeItem({
     departure.situations,
     notices,
   );
-  const leftIcon = departure.realtime ? Realtime : undefined;
+  const leftIcon = departure.realtime
+    ? themeName === 'dark'
+      ? RealtimeDark
+      : RealtimeLight
+    : undefined;
 
   if (!isValidDeparture(departure)) {
     return null;

--- a/src/screens/Departures/components/EstimatedCallItem.tsx
+++ b/src/screens/Departures/components/EstimatedCallItem.tsx
@@ -37,7 +37,8 @@ import {
   getNoticesForEstimatedCall,
   getTimeRepresentationType,
 } from '@atb/screens/TripDetails/utils';
-import {Realtime} from '@atb/assets/svg/color/icons/status';
+import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
+import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 
 type EstimatedCallItemProps = {
@@ -179,6 +180,8 @@ const DepartureTime = ({
 }) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const {themeName} = useTheme();
+
   const timeRepresentationType = getTimeRepresentationType({
     expectedTime: expectedTime,
     aimedTime: aimedTime,
@@ -201,7 +204,11 @@ const DepartureTime = ({
   );
   const RealtimeWithIcon = (
     <View style={styles.realtime}>
-      <ThemeIcon style={styles.realtimeIcon} svg={Realtime}></ThemeIcon>
+      <ThemeIcon
+        style={styles.realtimeIcon}
+        svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
+        size={'small'}
+      ></ThemeIcon>
       {ExpectedText}
     </View>
   );
@@ -373,7 +380,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginRight: theme.spacings.xLarge,
   },
   realtimeIcon: {
-    marginRight: theme.spacings.xSmall / 2,
+    marginRight: theme.spacings.xSmall,
   },
   lineChip: {
     padding: theme.spacings.small,
@@ -399,6 +406,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   realtime: {
     flexDirection: 'row',
+    alignItems: 'center',
   },
   warningIcon: {
     marginRight: theme.spacings.small,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.5.1.tgz#61b26c55a34a63d62cee01d1659c8834174f2cc5"
-  integrity sha512-IC1NSDUyN4s3lzr/cE9Lb+HLlv0F9/zfSnte5JMCcEkGcAY3dx120W0+hcJrZDzzAVBBnyHy2MBkFMCNxd/wBw==
+"@atb-as/generate-assets@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.6.0.tgz#7678b2a625bbdf7e3617c4ed4cd223f4ca8db4a2"
+  integrity sha512-BNposchvZ7UpAd4z88+uIjPPV89wRX/HVYMNmhsMjqXtTCaM/e2Z1+aCNkwAhVD9v+/VavYEU4ZKQxpFPYn9wg==
   dependencies:
     "@atb-as/theme" "^6.1.3"
     commander "^9.4.0"


### PR DESCRIPTION
Add dark mode version of realtime icon

<details>
<summary>Screenshots dark mode</summary>

![image](https://user-images.githubusercontent.com/85479566/206466296-60eb27ec-1df1-48dc-8fda-59ecf0ffa81c.png)
![image](https://user-images.githubusercontent.com/85479566/206466371-2ed4d6bf-741f-47e0-a184-ef509edd96f3.png)
</details>
<details>
<summary>Screenshots light mode</summary>

![image](https://user-images.githubusercontent.com/85479566/206466565-707906c3-ff34-41d4-ade6-077978f0acb1.png)
![image](https://user-images.githubusercontent.com/85479566/206466490-1d7d27e7-5ead-4ccd-ae0b-5fa7a47ba44f.png)
</details>

https://github.com/AtB-AS/design-system/pull/92

https://github.com/AtB-AS/kundevendt/issues/2947
https://github.com/AtB-AS/kundevendt/issues/2950
