### PR TITLE
fix: adjust margin to fit design

### DIFF
--- a/src/screens/Departures/components/EstimatedCallItem.tsx
+++ b/src/screens/Departures/components/EstimatedCallItem.tsx
@@ -377,7 +377,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   lineName: {
     flexGrow: 1,
     flexShrink: 1,
-    marginRight: theme.spacings.xLarge,
+    marginRight: theme.spacings.medium,
   },
   realtimeIcon: {
     marginRight: theme.spacings.xSmall,


### PR DESCRIPTION
Adjust margin size to fit sketches in figma and avoid breaking for longer names.

https://github.com/AtB-AS/kundevendt/issues/2950#issuecomment-1344210716