### PR TITLE
refactor: Only proved quay id to PlaceScreen

### DIFF
--- a/src/screens/Departures/PlaceScreen.tsx
+++ b/src/screens/Departures/PlaceScreen.tsx
@@ -16,7 +16,7 @@ import {StopPlaceAndQuaySelection} from '@atb/screens/Departures/components/Stop
 
 export type PlaceScreenParams = {
   place: StopPlace;
-  selectedQuay?: Quay;
+  selectedQuayId?: string;
   showOnlyFavoritesByDefault?: boolean;
   mode: StopPlacesMode;
   onCloseRoute?: string;
@@ -28,7 +28,7 @@ export default function PlaceScreen({
   route: {
     params: {
       place,
-      selectedQuay,
+      selectedQuayId,
       showOnlyFavoritesByDefault,
       mode,
       onCloseRoute,
@@ -77,15 +77,19 @@ export default function PlaceScreen({
   const navigateToQuay = (quay: Quay) => {
     if (mode === 'Favourite') {
       navigation.push('PlaceScreen', {
-        selectedQuay: quay,
+        selectedQuayId: quay.id,
         mode: mode,
         place: place,
       });
     } else {
-      navigation.setParams({selectedQuay: quay});
+      navigation.setParams({selectedQuayId: quay.id});
     }
   };
   const isFocused = useIsFocused();
+
+  const selectedQuay = selectedQuayId
+    ? place.quays?.find((q) => q.id === selectedQuayId)
+    : undefined;
 
   return (
     <View style={styles.container}>
@@ -94,7 +98,7 @@ export default function PlaceScreen({
         <StopPlaceAndQuaySelection
           place={place}
           selectedQuay={selectedQuay}
-          navigation={navigation}
+          onPress={(quayId) => navigation.setParams({selectedQuayId: quayId})}
         />
       )}
 

--- a/src/screens/Departures/components/StopPlaceAndQuaySelection.tsx
+++ b/src/screens/Departures/components/StopPlaceAndQuaySelection.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {StopPlace, Quay} from '@atb/api/types/departures';
-import {NavigationProp} from '@react-navigation/native';
 
 type quayChipData = {
   item: Quay;
@@ -15,11 +14,11 @@ type quayChipData = {
 const StopPlaceAndQuaySelection = ({
   place,
   selectedQuay,
-  navigation,
+  onPress,
 }: {
   place: StopPlace;
   selectedQuay?: Quay;
-  navigation: NavigationProp<any>;
+  onPress: (selectedQuayId?: string) => void;
 }) => {
   const styles = useStyles();
   const {theme} = useTheme();
@@ -40,9 +39,7 @@ const StopPlaceAndQuaySelection = ({
             <ActivityIndicator size="large" />
           ) : (
             <Button
-              onPress={() => {
-                navigation.setParams({selectedQuay: undefined});
-              }}
+              onPress={() => onPress()}
               text={t(DeparturesTexts.quayChips.allStops)}
               interactiveColor="interactive_1"
               active={!selectedQuay}
@@ -55,9 +52,7 @@ const StopPlaceAndQuaySelection = ({
       }
       renderItem={({item}: quayChipData) => (
         <Button
-          onPress={() => {
-            navigation.setParams({selectedQuay: item});
-          }}
+          onPress={() => onPress(item.id)}
           text={getQuayName(item)}
           interactiveColor="interactive_1"
           active={selectedQuay?.id === item.id}

--- a/src/screens/Map/MapScreen.tsx
+++ b/src/screens/Map/MapScreen.tsx
@@ -13,7 +13,7 @@ export const MapScreen = ({navigation}: MapScreenProps<'MapScreen'>) => {
   const navigateToQuay = (place: StopPlace, quay: Quay) => {
     navigation.navigate('PlaceScreen', {
       place,
-      selectedQuay: quay,
+      selectedQuayId: quay.id,
       mode: 'Departure',
     });
   };

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -353,7 +353,7 @@ function EstimatedCallRow({
           id: stopPlace.id,
           name: stopPlace.name,
         },
-        selectedQuay: {...quay, situations: []},
+        selectedQuayId: quay?.id,
         mode: 'Departure',
       });
     } else {

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -240,7 +240,7 @@ const TripSection: React.FC<TripSectionProps> = ({
           id: stopPlace.id,
           name: stopPlace.name,
         },
-        selectedQuay: quay,
+        selectedQuayId: quay?.id,
         mode: 'Departure',
       });
     } else {


### PR DESCRIPTION
The parameter selectedQuay to the PlaceScreen was an object. This was not beneficial as it is better that the PlaceScreen itself is in charge of what data is shown. Now when just passing the id, then the quay data from the stop-departures query are shown, and not the quay data available at the screen where it linked to the PlaceScreen.