### PR TITLE
feat: add realtime to trip details

### DIFF
--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -131,6 +131,13 @@ export type TripsQuery = {
           quay?: {name: string; id: string};
         }>;
         authority?: {id: string};
+        datedServiceJourney?: {
+          estimatedCalls?: Array<{
+            actualDepartureTime?: any;
+            predictionInaccurate: boolean;
+            quay?: {name: string};
+          }>;
+        };
       }>;
     }>;
   };

--- a/src/api/types/generated/journey_planner_v3_types.ts
+++ b/src/api/types/generated/journey_planner_v3_types.ts
@@ -14,27 +14,13 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** List of coordinates like: [[60.89, 11.12], [62.56, 12.10]] */
   Coordinates: any;
-  /** Local date using the ISO 8601 format: `YYYY-MM-DD`. Example: `2020-05-17`. */
   Date: any;
-  /**
-   * DateTime format accepting ISO 8601 dates with time zone offset.
-   *
-   * Format:  `YYYY-MM-DD'T'hh:mm[:ss](Z|±01:00)`
-   *
-   * Example: `2017-04-23T18:25:43+02:00` or `2017-04-23T16:25:43Z`
-   */
   DateTime: any;
-  /** A linear function to calculate a value(y) based on a parameter (x): `y = f(x) = a + bx`. It allows setting both a constant(a) and a coefficient(b) and the use those in the computation. Format: `a + b x`. Example: `1800 + 2.0 x` */
   DoubleFunction: any;
-  /** Duration in a lenient ISO-8601 duration format. Example P2DT2H12M40S, 2d2h12m40s or 1h */
   Duration: any;
-  /** Time using the format: HH:mm:SS. Example: 18:25:SS */
   LocalTime: any;
-  /** A 64-bit signed integer */
   Long: any;
-  /** Time using the format: `HH:MM:SS`. Example: `18:25:43` */
   Time: any;
 };
 
@@ -232,9 +218,9 @@ export type EstimatedCall = {
   expectedArrivalTime: Scalars['DateTime'];
   /** Expected time of departure from quay. Updated with real time information if available. Will be null if an actualDepartureTime exists */
   expectedDepartureTime: Scalars['DateTime'];
-  /** Whether vehicle may be alighted at quay according to the planned data. If the cancellation flag is set, alighting is not possible, even if this field is set to true. */
+  /** Whether vehicle may be alighted at quay. */
   forAlighting: Scalars['Boolean'];
-  /** Whether vehicle may be boarded at quay according to the planned data. If the cancellation flag is set, boarding is not possible, even if this field is set to true. */
+  /** Whether vehicle may be boarded at quay. */
   forBoarding: Scalars['Boolean'];
   notices: Array<Notice>;
   occupancyStatus: OccupancyStatus;
@@ -714,7 +700,7 @@ export type PtSituationElement = {
   lines: Array<Maybe<Line>>;
   /** Priority of this situation  */
   priority?: Maybe<Scalars['Int']>;
-  quays: Array<Maybe<Quay>>;
+  quays: Array<Quay>;
   /**
    * Authority that reported this situation
    * @deprecated Not yet officially supported. May be removed or renamed.
@@ -727,6 +713,7 @@ export type PtSituationElement = {
   severity?: Maybe<Severity>;
   /** Operator's internal id for this situation */
   situationNumber?: Maybe<Scalars['String']>;
+  stopPlaces: Array<StopPlace>;
   /** Summary of situation in all different translations available */
   summary: Array<MultilingualString>;
   /** Period this situation is in effect */
@@ -1028,10 +1015,12 @@ export type QueryTypeTripArgs = {
   includePlannedCancellations?: InputMaybe<Scalars['Boolean']>;
   itineraryFilters?: InputMaybe<ItineraryFilters>;
   locale?: InputMaybe<Locale>;
+  maximumAdditionalTransfers?: InputMaybe<Scalars['Int']>;
   maximumTransfers?: InputMaybe<Scalars['Int']>;
   modes?: InputMaybe<Modes>;
   numTripPatterns?: InputMaybe<Scalars['Int']>;
   pageCursor?: InputMaybe<Scalars['String']>;
+  relaxTransitSearchGeneralizedCostAtDestination?: InputMaybe<Scalars['Float']>;
   searchWindow?: InputMaybe<Scalars['Int']>;
   timetableView?: InputMaybe<Scalars['Boolean']>;
   to: Location;
@@ -1203,6 +1192,8 @@ export type RoutingParameters = {
   includedPlannedCancellations?: Maybe<Scalars['Boolean']>;
   /** @deprecated Parking is specified by modes */
   kissAndRide?: Maybe<Scalars['Boolean']>;
+  /** Maximum number of transfers allowed in addition to the result with least number of transfers */
+  maxAdditionalTransfers?: Maybe<Scalars['Int']>;
   /** This is the maximum duration in seconds for a direct street search. This is a performance limit and should therefore be set high. Use filters to limit what is presented to the client. */
   maxDirectStreetDuration?: Maybe<Scalars['Int']>;
   /** The maximum slope of streets for wheelchair trips. */
@@ -1444,10 +1435,14 @@ export type TimetabledPassingTime = {
   /** Scheduled time of departure from quay */
   departure?: Maybe<TimeAndDayOffset>;
   destinationDisplay?: Maybe<DestinationDisplay>;
+  /** Earliest possible departure time for a service journey with a service window. */
+  earliestDepartureTime?: Maybe<TimeAndDayOffset>;
   /** Whether vehicle may be alighted at quay. */
   forAlighting?: Maybe<Scalars['Boolean']>;
   /** Whether vehicle may be boarded at quay. */
   forBoarding?: Maybe<Scalars['Boolean']>;
+  /** Latest possible (planned) arrival time for a service journey with a service window. */
+  latestArrivalTime?: Maybe<TimeAndDayOffset>;
   notices: Array<Notice>;
   quay?: Maybe<Quay>;
   /** Whether vehicle will only stop on request. */

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -8,7 +8,6 @@ import {MessageBox} from '@atb/components/message-box';
 import ThemeText from '@atb/components/text';
 import ThemeIcon from '@atb/components/theme-icon/theme-icon';
 import TransportationIcon from '@atb/components/transportation-icon';
-import {usePreferenceItems} from '@atb/preferences';
 import {ServiceJourneyDeparture} from '@atb/screens/TripDetails/DepartureDetails/types';
 import {SituationMessageBox, SituationOrNoticeIcon} from '@atb/situations';
 import {StyleSheet, useTheme} from '@atb/theme';
@@ -43,7 +42,8 @@ import Time from './Time';
 import TripLegDecoration from './TripLegDecoration';
 import TripRow from './TripRow';
 import WaitSection, {WaitDetails} from './WaitSection';
-import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
+import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 import {useDeparturesV2Enabled} from '@atb/screens/Departures/use-departures-v2-enabled';
 
 type TripSectionProps = {
@@ -72,7 +72,7 @@ const TripSection: React.FC<TripSectionProps> = ({
 }) => {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
-  const {theme} = useTheme();
+  const {themeName} = useTheme();
   const departuresV2Enabled = useDeparturesV2Enabled();
 
   const isWalkSection = leg.mode === 'foot';
@@ -87,6 +87,10 @@ const TripSection: React.FC<TripSectionProps> = ({
   const navigation = useNavigation<TripDetailsRootNavigation<'Details'>>();
 
   const notices = getNoticesForLeg(leg);
+
+  const lastPassedStop = leg.datedServiceJourney?.estimatedCalls
+    ?.filter((a) => !a.predictionInaccurate && a.actualDepartureTime)
+    .pop();
 
   const sectionOutput = (
     <>
@@ -168,7 +172,25 @@ const TripSection: React.FC<TripSectionProps> = ({
             />
           </TripRow>
         )}
-
+        {lastPassedStop?.quay?.name && (
+          <TripRow>
+            <View style={style.realtime}>
+              <ThemeIcon
+                svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
+                size={'small'}
+                style={style.realtimeIcon}
+              ></ThemeIcon>
+              <ThemeText type={'body__secondary'} color={'secondary'}>
+                {t(
+                  TripDetailsTexts.trip.leg.lastPassedStop(
+                    lastPassedStop.quay.name,
+                    formatToClock(lastPassedStop.actualDepartureTime, language),
+                  ),
+                )}
+              </ThemeText>
+            </View>
+          </TripRow>
+        )}
         {leg.intermediateEstimatedCalls.length > 0 && (
           <IntermediateInfo {...leg} />
         )}
@@ -394,6 +416,13 @@ const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   },
   legLineName: {
     fontWeight: 'bold',
+  },
+  realtime: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  realtimeIcon: {
+    marginRight: theme.spacings.xSmall,
   },
 }));
 export default TripSection;

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -11,7 +11,11 @@ const TripDetailsTexts = {
           `Steg ${stepNumber}, ${travelMode}`,
           `Step ${stepNumber}, ${travelMode}`,
         ),
-
+      lastPassedStop: (stopPlaceName: string, time: string) =>
+        _(
+          `Passerte ${stopPlaceName} kl. ${time}`,
+          `Passed ${stopPlaceName} at ${time}`,
+        ),
       start: {
         a11yLabel: {
           noRealTime: (placeName: string, aimedTime: string) =>

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -11,11 +11,8 @@ const TripDetailsTexts = {
           `Steg ${stepNumber}, ${travelMode}`,
           `Step ${stepNumber}, ${travelMode}`,
         ),
-      lastPassedStop: (stopPlaceName: string, time: string) =>
-        _(
-          `Passerte ${stopPlaceName} kl. ${time}`,
-          `Passed ${stopPlaceName} at ${time}`,
-        ),
+      lastPassedStop: (quayName: string, time: string) =>
+        _(`Passerte ${quayName} kl. ${time}`, `Passed ${quayName} at ${time}`),
       start: {
         a11yLabel: {
           noRealTime: (placeName: string, aimedTime: string) =>


### PR DESCRIPTION
Add realtime with previously passed bus stop on trip details.

<details>
<summary>Screenshots</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 13 38 56](https://user-images.githubusercontent.com/85479566/207612581-98285e1f-4dcf-496d-8687-8880497b605a.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 13 38 31](https://user-images.githubusercontent.com/85479566/207612610-d04f2326-516d-449f-bbac-453096f83f4f.png)
</details>

https://github.com/AtB-AS/atb-bff/pull/197

Close https://github.com/AtB-AS/kundevendt/issues/2949