### PR TITLE
feat: Show night ticket and handle different states

### DIFF
--- a/src/screens/Ticketing/FareContracts/Component/InspectionSymbol.tsx
+++ b/src/screens/Ticketing/FareContracts/Component/InspectionSymbol.tsx
@@ -65,7 +65,7 @@ const InspectableContent = ({
 }) => {
   const {language} = useTranslation();
   const styles = useStyles();
-  if (!fromTariffZone || !toTariffZone) return null;
+
   const shouldFill =
     preassignedFareProduct?.type === 'period' ||
     preassignedFareProduct?.type === 'hour24';
@@ -79,15 +79,17 @@ const InspectableContent = ({
         },
       ]}
     >
-      <ThemeText
-        type="body__primary--bold"
-        allowFontScaling={false}
-        color={shouldFill ? themeColor : undefined}
-      >
-        {getReferenceDataName(fromTariffZone, language)}
-        {fromTariffZone.id !== toTariffZone.id &&
-          '-' + getReferenceDataName(toTariffZone, language)}
-      </ThemeText>
+      {fromTariffZone && toTariffZone && (
+        <ThemeText
+          type="body__primary--bold"
+          allowFontScaling={false}
+          color={shouldFill ? themeColor : undefined}
+        >
+          {getReferenceDataName(fromTariffZone, language)}
+          {fromTariffZone.id !== toTariffZone.id &&
+            '-' + getReferenceDataName(toTariffZone, language)}
+        </ThemeText>
+      )}
       <ThemeIcon
         svg={Bus}
         fill={shouldFill ? themeColor.text : undefined}

--- a/src/screens/Ticketing/FareContracts/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/FareContracts/Details/DetailsScreen.tsx
@@ -56,10 +56,9 @@ export default function DetailsScreen({navigation, route}: Props) {
       firstTravelRight.endDateTime.toMillis(),
       fc.state,
     ) === 'valid' &&
-    firstTravelRight.tariffZoneRefs.every(
+    firstTravelRight.tariffZoneRefs?.every(
       (val: string) => val === 'ATB:TariffZone:1',
-    ) &&
-    preassignedFareProduct?.type !== 'night';
+    );
 
   return (
     <View style={styles.container}>

--- a/src/screens/Ticketing/FareContracts/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/FareContracts/Details/DetailsScreen.tsx
@@ -58,7 +58,8 @@ export default function DetailsScreen({navigation, route}: Props) {
     ) === 'valid' &&
     firstTravelRight.tariffZoneRefs.every(
       (val: string) => val === 'ATB:TariffZone:1',
-    );
+    ) &&
+    preassignedFareProduct?.type !== 'night';
 
   return (
     <View style={styles.container}>

--- a/src/screens/Ticketing/FareContracts/Details/DetailsScreen.tsx
+++ b/src/screens/Ticketing/FareContracts/Details/DetailsScreen.tsx
@@ -47,8 +47,8 @@ export default function DetailsScreen({navigation, route}: Props) {
       orderVersion: fc.version,
     });
 
-  const shouldShowValidOnTrainNotice =
-    fc &&
+  const shouldShowValidOnTrainNotice: boolean =
+    fc !== undefined &&
     isPreActivatedTravelRight(firstTravelRight) &&
     getValidityStatus(
       now,
@@ -58,7 +58,7 @@ export default function DetailsScreen({navigation, route}: Props) {
     ) === 'valid' &&
     firstTravelRight.tariffZoneRefs?.every(
       (val: string) => val === 'ATB:TariffZone:1',
-    );
+    ) === true;
 
   return (
     <View style={styles.container}>

--- a/src/screens/Ticketing/FareContracts/FareContractInfo.tsx
+++ b/src/screens/Ticketing/FareContracts/FareContractInfo.tsx
@@ -84,8 +84,8 @@ const FareContractInfo = ({
 
   const firstTravelRight = travelRights[0];
   const {fareProductRef: productRef, tariffZoneRefs} = firstTravelRight;
-  const [firstZone] = tariffZoneRefs;
-  const [lastZone] = tariffZoneRefs.slice(-1);
+  const [firstZone] = tariffZoneRefs ?? [];
+  const [lastZone] = tariffZoneRefs?.slice(-1) ?? [];
 
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
@@ -177,7 +177,7 @@ const FareContractInfoHeader = ({
             {productName}
           </ThemeText>
         )}
-        {producDescription && preassignedFareProduct?.type === 'night' && (
+        {producDescription && (
           <ThemeText
             type="body__secondary"
             style={styles.product}
@@ -220,7 +220,7 @@ const FareContractInfoDetails = (props: FareContractInfoDetailsProps) => {
               userProfileCountAndName(u, omitUserProfileCount, language),
             )}
           />
-          {tariffZoneSummary && preassignedFareProduct?.type !== 'night' && (
+          {tariffZoneSummary && (
             <FareContractDetail
               header={t(FareContractTexts.label.zone)}
               children={[tariffZoneSummary]}
@@ -271,8 +271,8 @@ export const getFareContractInfoDetails = (
     fareContractState,
   );
 
-  const [firstZone] = tariffZoneRefs;
-  const [lastZone] = tariffZoneRefs.slice(-1);
+  const [firstZone] = tariffZoneRefs ?? [];
+  const [lastZone] = tariffZoneRefs?.slice(-1) ?? [];
   const fromTariffZone = findReferenceDataById(tariffZones, firstZone);
   const toTariffZone = findReferenceDataById(tariffZones, lastZone);
   const preassignedFareProduct = findReferenceDataById(

--- a/src/screens/Ticketing/FareContracts/FareContractInfo.tsx
+++ b/src/screens/Ticketing/FareContracts/FareContractInfo.tsx
@@ -19,7 +19,11 @@ import {
   NormalTravelRight,
   PreActivatedTravelRight,
 } from '@atb/ticketing';
-import {FareContractTexts, useTranslation} from '@atb/translations';
+import {
+  FareContractTexts,
+  getTextForLanguage,
+  useTranslation,
+} from '@atb/translations';
 import React from 'react';
 import {View} from 'react-native';
 import {UserProfileWithCount} from '../Purchase/Travellers/use-user-count-state';
@@ -146,6 +150,9 @@ const FareContractInfoHeader = ({
   const productName = preassignedFareProduct
     ? getReferenceDataName(preassignedFareProduct, language)
     : undefined;
+  const producDescription = preassignedFareProduct
+    ? getTextForLanguage(preassignedFareProduct.description, language)
+    : undefined;
   const {isError, remoteTokens, fallbackEnabled} = useMobileTokenContextState();
   const {t} = useTranslation();
   const warning = getNonInspectableTokenWarning(
@@ -170,6 +177,16 @@ const FareContractInfoHeader = ({
             {productName}
           </ThemeText>
         )}
+        {producDescription && preassignedFareProduct?.type === 'night' && (
+          <ThemeText
+            type="body__secondary"
+            style={styles.product}
+            accessibilityLabel={producDescription + screenReaderPause}
+            testID={testID + 'ProductDescription'}
+          >
+            {producDescription}
+          </ThemeText>
+        )}
       </View>
       {status === 'valid' && warning && <WarningMessage message={warning} />}
     </View>
@@ -183,6 +200,7 @@ const FareContractInfoDetails = (props: FareContractInfoDetailsProps) => {
     userProfilesWithCount,
     omitUserProfileCount,
     status,
+    preassignedFareProduct,
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
@@ -202,7 +220,7 @@ const FareContractInfoDetails = (props: FareContractInfoDetailsProps) => {
               userProfileCountAndName(u, omitUserProfileCount, language),
             )}
           />
-          {tariffZoneSummary && (
+          {tariffZoneSummary && preassignedFareProduct?.type !== 'night' && (
             <FareContractDetail
               header={t(FareContractTexts.label.zone)}
               children={[tariffZoneSummary]}
@@ -306,9 +324,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginBottom: theme.spacings.medium,
   },
   fareContractHeader: {
-    flexDirection: 'row',
+    flexDirection: 'column',
     justifyContent: 'space-between',
-    alignItems: 'center',
     marginTop: theme.spacings.xSmall,
   },
 }));

--- a/src/screens/Ticketing/FareContracts/FareContractInfo.tsx
+++ b/src/screens/Ticketing/FareContracts/FareContractInfo.tsx
@@ -84,15 +84,19 @@ const FareContractInfo = ({
 
   const firstTravelRight = travelRights[0];
   const {fareProductRef: productRef, tariffZoneRefs} = firstTravelRight;
-  const [firstZone] = tariffZoneRefs ?? [];
-  const [lastZone] = tariffZoneRefs?.slice(-1) ?? [];
+  const firstZone = tariffZoneRefs?.[0];
+  const lastZone = tariffZoneRefs?.slice(-1)?.[0];
 
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
     productRef,
   );
-  const fromTariffZone = findReferenceDataById(tariffZones, firstZone);
-  const toTariffZone = findReferenceDataById(tariffZones, lastZone);
+  const fromTariffZone = firstZone
+    ? findReferenceDataById(tariffZones, firstZone)
+    : undefined;
+  const toTariffZone = lastZone
+    ? findReferenceDataById(tariffZones, lastZone)
+    : undefined;
 
   const userProfilesWithCount = mapToUserProfilesWithCount(
     travelRights.map((tr) => tr.userProfileRef),
@@ -271,10 +275,14 @@ export const getFareContractInfoDetails = (
     fareContractState,
   );
 
-  const [firstZone] = tariffZoneRefs ?? [];
-  const [lastZone] = tariffZoneRefs?.slice(-1) ?? [];
-  const fromTariffZone = findReferenceDataById(tariffZones, firstZone);
-  const toTariffZone = findReferenceDataById(tariffZones, lastZone);
+  const firstZone = tariffZoneRefs?.[0];
+  const lastZone = tariffZoneRefs?.slice(-1)?.[0];
+  const fromTariffZone = firstZone
+    ? findReferenceDataById(tariffZones, firstZone)
+    : undefined;
+  const toTariffZone = lastZone
+    ? findReferenceDataById(tariffZones, lastZone)
+    : undefined;
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
     productRef,

--- a/src/screens/Ticketing/FareContracts/index.tsx
+++ b/src/screens/Ticketing/FareContracts/index.tsx
@@ -2,6 +2,7 @@ import {
   FareContract,
   isCarnetTravelRight,
   isInspectableTravelRight,
+  isNightTravelRight,
   isPreActivatedTravelRight,
 } from '@atb/ticketing';
 import React from 'react';
@@ -51,6 +52,18 @@ const SimpleFareContract: React.FC<Props> = ({
       <PreActivatedFareContractInfo
         fareContractState={fc.state}
         travelRights={fc.travelRights.filter(isPreActivatedTravelRight)}
+        now={now}
+        isInspectable={isInspectable}
+        hideDetails={hideDetails}
+        onPressDetails={onPressDetails}
+        testID={testID}
+      />
+    );
+  } else if (isNightTravelRight(firstTravelRight)) {
+    return (
+      <PreActivatedFareContractInfo
+        fareContractState={fc.state}
+        travelRights={fc.travelRights.filter(isNightTravelRight)}
         now={now}
         isInspectable={isInspectable}
         hideDetails={hideDetails}

--- a/src/screens/Ticketing/FareContracts/index.tsx
+++ b/src/screens/Ticketing/FareContracts/index.tsx
@@ -2,7 +2,6 @@ import {
   FareContract,
   isCarnetTravelRight,
   isInspectableTravelRight,
-  isNightTravelRight,
   isPreActivatedTravelRight,
 } from '@atb/ticketing';
 import React from 'react';
@@ -52,18 +51,6 @@ const SimpleFareContract: React.FC<Props> = ({
       <PreActivatedFareContractInfo
         fareContractState={fc.state}
         travelRights={fc.travelRights.filter(isPreActivatedTravelRight)}
-        now={now}
-        isInspectable={isInspectable}
-        hideDetails={hideDetails}
-        onPressDetails={onPressDetails}
-        testID={testID}
-      />
-    );
-  } else if (isNightTravelRight(firstTravelRight)) {
-    return (
-      <PreActivatedFareContractInfo
-        fareContractState={fc.state}
-        travelRights={fc.travelRights.filter(isNightTravelRight)}
         now={now}
         isInspectable={isInspectable}
         hideDetails={hideDetails}

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -34,7 +34,7 @@ export type NormalTravelRight = TravelRight & {
   endDateTime: Timestamp;
   usageValidityPeriodRef: string;
   userProfileRef: string;
-  tariffZoneRefs: string[];
+  tariffZoneRefs: string[] | undefined;
 };
 
 export type PreActivatedTravelRight = NormalTravelRight;

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -22,6 +22,7 @@ export type TravelRight = {
     | 'PreActivatedSingleTicket'
     | 'PreActivatedPeriodTicket'
     | 'CarnetTicket'
+    | 'NightTicket'
     | 'UnknownTicket';
 };
 

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -24,14 +24,9 @@ export function isPreActivatedTravelRight(
 ): travelRight is PreActivatedTravelRight {
   return (
     travelRight?.type === 'PreActivatedSingleTicket' ||
-    travelRight?.type === 'PreActivatedPeriodTicket'
+    travelRight?.type === 'PreActivatedPeriodTicket' ||
+    travelRight?.type === 'NightTicket'
   );
-}
-
-export function isNightTravelRight(
-  travelRight: TravelRight | undefined,
-): travelRight is PreActivatedTravelRight {
-  return travelRight?.type === 'NightTicket';
 }
 
 export function isSingleTravelRight(
@@ -80,8 +75,6 @@ export function isValidRightNowFareContract(f: FareContract): boolean {
 
   const firstTravelRight = f.travelRights?.[0];
   if (isPreActivatedTravelRight(firstTravelRight)) {
-    return isValidPreActivatedTravelRight(firstTravelRight);
-  } else if (isNightTravelRight(firstTravelRight)) {
     return isValidPreActivatedTravelRight(firstTravelRight);
   } else if (isCarnetTravelRight(firstTravelRight)) {
     return hasValidCarnetTravelRight(
@@ -145,8 +138,6 @@ function isActiveFareContractNowOrCanBeUsed(f: FareContract): boolean {
 
   const firstTravelRight = f.travelRights?.[0];
   if (isPreActivatedTravelRight(firstTravelRight)) {
-    return isValidPreActivatedTravelRight(firstTravelRight);
-  } else if (isNightTravelRight(firstTravelRight)) {
     return isValidPreActivatedTravelRight(firstTravelRight);
   } else if (isCarnetTravelRight(firstTravelRight)) {
     return hasActiveOrUsableCarnetTravelRight(

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -28,6 +28,12 @@ export function isPreActivatedTravelRight(
   );
 }
 
+export function isNightTravelRight(
+  travelRight: TravelRight | undefined,
+): travelRight is PreActivatedTravelRight {
+  return travelRight?.type === 'NightTicket';
+}
+
 export function isSingleTravelRight(
   travelRight: TravelRight | undefined,
 ): travelRight is PreActivatedSingleTravelRight {
@@ -74,6 +80,8 @@ export function isValidRightNowFareContract(f: FareContract): boolean {
 
   const firstTravelRight = f.travelRights?.[0];
   if (isPreActivatedTravelRight(firstTravelRight)) {
+    return isValidPreActivatedTravelRight(firstTravelRight);
+  } else if (isNightTravelRight(firstTravelRight)) {
     return isValidPreActivatedTravelRight(firstTravelRight);
   } else if (isCarnetTravelRight(firstTravelRight)) {
     return hasValidCarnetTravelRight(
@@ -137,6 +145,8 @@ function isActiveFareContractNowOrCanBeUsed(f: FareContract): boolean {
 
   const firstTravelRight = f.travelRights?.[0];
   if (isPreActivatedTravelRight(firstTravelRight)) {
+    return isValidPreActivatedTravelRight(firstTravelRight);
+  } else if (isNightTravelRight(firstTravelRight)) {
     return isValidPreActivatedTravelRight(firstTravelRight);
   } else if (isCarnetTravelRight(firstTravelRight)) {
     return hasActiveOrUsableCarnetTravelRight(


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/2731

In order to test please buy a normal single ticket and in the firestore configuration please add the type as `NightTicket`. Please also remove the `tariffZoneRefs` field. Together with all that please also in the `fareProductRef` add either:

- ATB:PreassignedFareProduct:8f351521
- ATB:PreassignedFareProduct:877baeff
- ATB:PreassignedFareProduct:e317a807

Example of one night ticket:

```json
{
  "created": {
    "nanoseconds": 17154000,
    "seconds": 1671009490
  },
  "customerAccountId": "ATB:CustomerAccount:aONCHMcM0TOSJaVvts3BZmtfn9I3",
  "eventTimestamp": {
    "nanoseconds": 860808000,
    "seconds": 1671009490
  },
  "id": "ATB:FareContract:4KB3B8B4-aONCHMcM0TOSJaVvts3BZmtfn9I3",
  "minimumSecurityLevel": -200,
  "orderId": "4KB3B8B4",
  "paymentType": [
    "VISA"
  ],
  "paymentTypeGroup": [
    "PAYMENTCARD"
  ],
  "qrCode": "........JhcoCMAE=",
  "state": 2,
  "totalAmount": "42.00",
  "totalTaxAmount": "4.50",
  "travelRights": [
    {
      "authorityRef": "ATB:Authority:2",
      "customerAccountId": "ATB:CustomerAccount:aONCHMcM0TOSJaVvts3BZmtfn9I3",
      "endDateTime": [
        FirestoreTimestamp
      ],
      "fareContract": [
        FirestoreDocumentReference
      ],
      "fareProductRef": "ATB:PreassignedFareProduct:8808c360",
      "id": "ATB:CustomerPurchasePackage:54791f19-714d-4c02-bbdb-fab5e3355c71",
      "startDateTime": [
        FirestoreTimestamp
      ],
      "status": 5,
      "type": "NightTicket",
      "usageValidityPeriodRef": "",
      "userProfileRef": "ATB:UserProfile:8ee842e3"
    }
  ],
  "version": "1"
}
```