### PR TITLE
fix: handle undefined firestore feedback values

### DIFF
--- a/src/components/feedback/index.tsx
+++ b/src/components/feedback/index.tsx
@@ -106,7 +106,7 @@ export const Feedback = ({
   const incrementCounterAndSetDisplayStats = async () => {
     if (feedbackConfig) {
       const defaultDisplayStatObject: VersionStats = {
-        answeredAtDisplayCount: undefined,
+        answeredAtDisplayCount: 1,
         doNotShowAgain: false,
         displayCount: 1,
         surveyVersion: feedbackConfig.surveyVersion,
@@ -216,7 +216,7 @@ export const Feedback = ({
       const organization = APP_ORG;
       const submitTime = Date.now();
       const displayCount = currentVersionStats.displayCount;
-      const isReprompt = currentVersionStats?.answeredAtDisplayCount;
+      const isReprompt = currentVersionStats.answeredAtDisplayCount || 1;
 
       const dataToServer = {
         submitTime,

--- a/src/components/feedback/index.tsx
+++ b/src/components/feedback/index.tsx
@@ -106,7 +106,7 @@ export const Feedback = ({
   const incrementCounterAndSetDisplayStats = async () => {
     if (feedbackConfig) {
       const defaultDisplayStatObject: VersionStats = {
-        answeredAtDisplayCount: 1,
+        answeredAtDisplayCount: undefined,
         doNotShowAgain: false,
         displayCount: 1,
         surveyVersion: feedbackConfig.surveyVersion,
@@ -216,7 +216,7 @@ export const Feedback = ({
       const organization = APP_ORG;
       const submitTime = Date.now();
       const displayCount = currentVersionStats.displayCount;
-      const isReprompt = currentVersionStats.answeredAtDisplayCount || 1;
+      const isReprompt = currentVersionStats.answeredAtDisplayCount;
 
       const dataToServer = {
         submitTime,
@@ -231,7 +231,9 @@ export const Feedback = ({
         metadata,
       };
 
-      const submittedFeedbackDoc = await firestore()
+      const db = firestore();
+      await db.settings({ignoreUndefinedProperties: true});
+      const submittedFeedbackDoc = await db
         .collection('feedback')
         .add(dataToServer);
       setFirebaseId(submittedFeedbackDoc.id);


### PR DESCRIPTION
Fixes an error when submitting feedback, caused by `isReprompt` / `answeredAtDisplayCount` was undefined, which isn't supported in firestore, unless `ignoreUndefinedProperties` is set to true.

~Fixed by initializing the value to `1`, and providing a fallback. I could have set `answeredAtDisplayCount` to be required [here](https://github.com/AtB-AS/mittatb-app/blob/rosvik/1996-error-in-feedback-components-for-ios/src/components/feedback/index.tsx#L81) in `VersionStats` as well, but since there is data saved to user's devices where it is undefined, I think we should still support it, and rather use a fallback.~

fixes https://github.com/AtB-AS/kundevendt/issues/1996