### PR TITLE
refactor: Not accessible empty header title

### DIFF
--- a/src/components/screen-header/index.tsx
+++ b/src/components/screen-header/index.tsx
@@ -135,6 +135,7 @@ const BaseHeader = ({
         ref={focusRef}
       >
         <ThemeText
+          accessible={false}
           onLayout={setLayoutFor('title')}
           type="body__primary--bold"
           color={themeColor}


### PR DESCRIPTION
Using 'accessible: false' on the Text child component so it isn't accessible in the instances where the parent view has
'accessible: false'.