### PR TITLE
test: e2e fix and optimization

### DIFF
--- a/e2e/tests/departuresV1.e2e.ts
+++ b/e2e/tests/departuresV1.e2e.ts
@@ -23,6 +23,7 @@ import {
   numberOfDepartureTimes,
   tapDepartureTime,
 } from '../utils/departures';
+import {toggleDeparturesV2} from '../utils/myprofile';
 
 describe('Departures v1', () => {
   beforeAll(async () => {
@@ -55,6 +56,12 @@ describe('Departures v1', () => {
     const departureQuay1 = 'Prinsens gate P2';
     const nextDepartureStop = 'Nidarosdomen';
 
+    // Enable v1
+    await goToTab('profile');
+    await toggleDeparturesV2(false);
+
+    // Go to departures
+    await goToTab('departures');
     // Do a departure search
     await departureSearch(departureStop);
 
@@ -107,10 +114,10 @@ describe('Departures v1', () => {
     await expectToBeVisibleByText(lineTitle);
     await expectToBeVisibleByText('Next');
     await expectToBeVisibleByText('Previous');
-    await expectToBeVisibleByText(departureQuay0 + ' ');
+    await expectToBeVisibleByText(departureQuay0);
 
     // Choose a stop place on the line
-    await tapByText(nextDepartureStop + ' ');
+    await tapByText(nextDepartureStop);
     await expectIdToHaveText('quaySection0Title', nextDepartureStop);
 
     // Go back
@@ -118,7 +125,10 @@ describe('Departures v1', () => {
     await goBack();
     await expectToBeVisibleByText('Departures');
   });
+});
 
+// Note! Place skipped tests in a separate 'describe' without app start-up to save run time
+xdescribe('Departures v1 - skipped', () => {
   xit('departure times should be sorted', async () => {
     /*
          1. Expect that the departure times per line is sorted

--- a/e2e/tests/departuresV2.e2e.ts
+++ b/e2e/tests/departuresV2.e2e.ts
@@ -21,8 +21,9 @@ import {
   departureSearch,
   numberOfDepartures,
   tapDeparture,
-  getLineTitleV2, ensureOnboardingIsConfirmed
-} from "../utils/departures";
+  getLineTitleV2,
+  ensureOnboardingIsConfirmed,
+} from '../utils/departures';
 import {expectGreaterThan, expectNumber} from '../utils/jestAssertions';
 
 describe('Departures v2', () => {
@@ -65,7 +66,7 @@ describe('Departures v2', () => {
     // Go to departures
     await goToTab('departures');
     //Confirm onboarding
-    await ensureOnboardingIsConfirmed()
+    await ensureOnboardingIsConfirmed();
 
     // Do a departure search
     await departureSearch(placeSearch);
@@ -130,10 +131,10 @@ describe('Departures v2', () => {
     await tapDeparture('quaySection0', 'departureItem0');
 
     await expectToBeVisibleByText(lineTitle);
-    await expectToBeVisibleByText(departureQuay0 + ' ');
+    await expectToBeVisibleByText(departureQuay0 + '');
 
     // Choose a stop place on the line
-    await tapByText(nextDepartureStop + ' ');
+    await tapByText(nextDepartureStop + '');
     await expectIdToHaveText('quaySectionName', nextDepartureStop);
 
     // Go back
@@ -158,7 +159,7 @@ describe('Departures v2', () => {
     // Go to departures
     await goToTab('departures');
     //Confirm onboarding
-    await ensureOnboardingIsConfirmed()
+    await ensureOnboardingIsConfirmed();
 
     // Do a departure search - that should automatically display the stop
     await departureSearch(departureStop);
@@ -195,7 +196,10 @@ describe('Departures v2', () => {
     let noDepTimesQuay1Expanded = await numberOfDepartures('quaySection1');
     expectGreaterThan(noDepTimesQuay1Expanded, 0);
   });
+});
 
+// Note! Place skipped tests in a separate 'describe' without app start-up to save run time
+xdescribe('Departures v2 - skipped', () => {
   xit('should show departures depending on given time', async () => {
     /*
          1. Set a different time in the date/time picker and assert

--- a/e2e/tests/myprofile.e2e.ts
+++ b/e2e/tests/myprofile.e2e.ts
@@ -103,15 +103,6 @@ describe('My profile', () => {
     await expectToBeVisibleByText('Log in');
   });
 
-  xit('Settings: should change the appearance', async () => {
-    /*
-        How to check change of appearance?
-        - Potentially possible to run device.captureViewHiarchy() and encode the stored file?
-        - Another crazy idea is to run device.takeScreenshot() and interpret the colours with ImageMagick or something?
-        - A third approach is to print the colour codes within the "Design system"-view and check that it is changed?
-        */
-  });
-
   // Validates language change
   it('Settings: should change language', async () => {
     await scrollToText('profileHomeScrollView', 'Settings', 'up');
@@ -235,6 +226,18 @@ describe('My profile', () => {
     await expectNumberOfFavourites(2);
 
     await goBack();
+  });
+});
+
+// Note! Place skipped tests in a separate 'describe' without app start-up to save run time
+describe('My profile - skipped', () => {
+  xit('Settings: should change the appearance', async () => {
+    /*
+        How to check change of appearance?
+        - Potentially possible to run device.captureViewHiarchy() and encode the stored file?
+        - Another crazy idea is to run device.takeScreenshot() and interpret the colours with ImageMagick or something?
+        - A third approach is to print the colour codes within the "Design system"-view and check that it is changed?
+        */
   });
 
   xit('should change start page', async () => {

--- a/e2e/tests/tickets.e2e.ts
+++ b/e2e/tests/tickets.e2e.ts
@@ -127,7 +127,10 @@ describe('Tickets anonymous', () => {
      */
     await goBack();
   });
+});
 
+// Note! Place skipped tests in a separate 'describe' without app start-up to save run time
+xdescribe('Tickets anonymous - skipped', () => {
   // TODO The app is crashing (https://github.com/AtB-AS/kundevendt/issues/1560#issuecomment-1252041408)
   xit('should be able to change zone on a single ticket', async () => {
     await tapById('purchaseTab');

--- a/e2e/tests/travelsearch.e2e.ts
+++ b/e2e/tests/travelsearch.e2e.ts
@@ -121,12 +121,12 @@ describe('Travel Search', () => {
     // Note space at the end
     await scrollContentToText(
       'departureDetailsContentView',
-      intermediateStop + ' ',
+      intermediateStop,
       'down',
     );
-    await tapByText(intermediateStop + ' ');
+    await tapByText(intermediateStop);
     await expectToBeVisibleByText(intermediateStop);
-    await expectIdToHaveText('quaySection0Title', intermediateStop);
+    await expectIdToHaveText('quaySectionName', intermediateStop);
 
     // Go back
     await goBack();
@@ -200,7 +200,10 @@ describe('Travel Search', () => {
       await expectEndLocationInTravelDetails(arrival);
     }
   });
+});
 
+// Note! Place skipped tests in a separate 'describe' without app start-up to save run time
+xdescribe('Travel Search - skipped', () => {
   // Check that the number of legs is correct on the suggestions
   // TODO An error in here (https://github.com/AtB-AS/kundevendt/issues/1560#issuecomment-1252057310)
   xit('should show correct number of legs', async () => {


### PR DESCRIPTION
There have been some test failures lately - due to a change on trip details and departures v2 as default. These are fixed here. In addition, I've moved skipped tests into a separate `describe` block that is skipped entirely. This way, skipped tests do not need to run `beforeEach` operations and the tests run a bit quicker.