### PR TITLE
feat: replace quay name with "see more departures"

### DIFF
--- a/src/screens/Departures/components/QuaySection.tsx
+++ b/src/screens/Departures/components/QuaySection.tsx
@@ -1,4 +1,4 @@
-import {EstimatedCall, StopPlace, Quay} from '@atb/api/types/departures';
+import {EstimatedCall, Quay, StopPlace} from '@atb/api/types/departures';
 import {ExpandLess, ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
 import * as Sections from '@atb/components/sections';
 import SectionSeparator from '@atb/components/sections/section-separator';
@@ -202,9 +202,7 @@ export default function QuaySection({
         {shouldShowMoreItemsLink && (
           <Sections.LinkItem
             icon="arrow-right"
-            text={
-              quay.publicCode ? quay.name + ' ' + quay.publicCode : quay.name
-            }
+            text={t(DeparturesTexts.quaySection.moreDepartures)}
             textType="body__primary--bold"
             onPress={() => navigateToQuay(quay)}
             accessibility={{

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -61,6 +61,7 @@ const DeparturesTexts = {
       'Aktiver for å vise flere avganger',
       'Activate to show more departures',
     ),
+    moreDepartures: _('Se flere avganger', 'See more departures'),
   },
   line: _('Linje', 'Line'),
   a11yViewDepartureDetailsHint: _(


### PR DESCRIPTION
Replace quay name with "see more departures"

<details>
<summary>Screenshot</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-16 at 15 12 35](https://user-images.githubusercontent.com/85479566/208117610-2800bcbf-03b5-4788-93e1-d816a6491b1c.png)
</details>


Close https://github.com/AtB-AS/kundevendt/issues/2953