### PR TITLE
refactor: Purchase screen texts from FireStore

### DIFF
--- a/src/screens/Ticketing/FareProducts/PurchaseTab.tsx
+++ b/src/screens/Ticketing/FareProducts/PurchaseTab.tsx
@@ -37,7 +37,7 @@ export const PurchaseTab: React.FC<Props> = ({navigation}) => {
             params: {
               screen: 'PurchaseOverview',
               params: {
-                selectableProductType: fareProductTypeConfig.type,
+                fareProductTypeConfig,
               },
             },
           },
@@ -47,7 +47,7 @@ export const PurchaseTab: React.FC<Props> = ({navigation}) => {
       navigation.navigate('Purchase', {
         screen: 'PurchaseOverview',
         params: {
-          selectableProductType: fareProductTypeConfig.type,
+          fareProductTypeConfig: fareProductTypeConfig,
         },
       });
     }

--- a/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
+++ b/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
@@ -11,10 +11,14 @@ import ThemeIcon from '@atb/components/theme-icon';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
 
 type RecentFareContractProps = {
   recentFareContract: RecentFareContract;
-  onSelect: (rfc: RecentFareContract) => void;
+  onSelect: (
+    rfc: RecentFareContract,
+    fareProductTypeConfig: FareProductTypeConfig,
+  ) => void;
   testID: string;
 };
 
@@ -126,7 +130,7 @@ export const RecentFareContractComponent = ({
     <TouchableOpacity
       style={styles.container}
       accessible={true}
-      onPress={() => onSelect(recentFareContract)}
+      onPress={() => onSelect(recentFareContract, fareProductTypeConfig)}
       accessibilityLabel={currentAccessibilityLabel}
       accessibilityHint={t(RecentFareContractsTexts.repeatPurchase.a11yHint)}
       testID={testID}

--- a/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContracts.tsx
+++ b/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContracts.tsx
@@ -12,6 +12,7 @@ import useRecentFareContracts, {
 } from '../use-recent-fare-contracts';
 import {RecentFareContractComponent} from './RecentFareContractComponent';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
 
 export const RecentFareContracts = () => {
   const navigation = useNavigation<TicketingNavigationProps<'PurchaseTab'>>();
@@ -21,10 +22,14 @@ export const RecentFareContracts = () => {
   const {recentFareContracts, loading} = useRecentFareContracts();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
-  const onSelect = (rfc: RecentFareContract) => {
+  const onSelect = (
+    rfc: RecentFareContract,
+    fareProductTypeConfig: FareProductTypeConfig,
+  ) => {
     navigation.navigate('Purchase', {
       screen: 'PurchaseOverview',
       params: {
+        fareProductTypeConfig,
         preassignedFareProduct: rfc.preassignedFareProduct,
         userProfilesWithCount: rfc.userProfilesWithCount,
         fromTariffZone: {...rfc.fromTariffZone, resultType: 'zone'},

--- a/src/screens/Ticketing/Purchase/Confirmation/index.tsx
+++ b/src/screens/Ticketing/Purchase/Confirmation/index.tsx
@@ -8,7 +8,6 @@ import FullScreenHeader from '@atb/components/screen-header/full-header';
 import * as Sections from '@atb/components/sections';
 import ThemeText from '@atb/components/text';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
-import {useFareProductTypeConfig} from '@atb/configuration/utils';
 import {
   useHasEnabledMobileToken,
   useMobileTokenContextState,
@@ -23,7 +22,6 @@ import {
   useTranslation,
   getTextForLanguage,
 } from '@atb/translations';
-import MessageBoxTexts from '@atb/translations/components/MessageBox';
 import {formatToLongDateTime} from '@atb/utils/date';
 import {formatDecimalNumber} from '@atb/utils/numbers';
 import {addMinutes} from 'date-fns';
@@ -34,7 +32,10 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import {getOtherDeviceIsInspectableWarning} from '../../FareContracts/utils';
+import {
+  FareProductTypeConfig,
+  getOtherDeviceIsInspectableWarning,
+} from '../../FareContracts/utils';
 import useOfferState from '../Overview/use-offer-state';
 import {SelectPaymentMethod} from '../Payment';
 import {usePreviousPaymentMethod} from '../saved-payment-utils';
@@ -47,6 +48,7 @@ import {
 } from '../types';
 
 export type RouteParams = {
+  fareProductTypeConfig: FareProductTypeConfig;
   preassignedFareProduct: PreassignedFareProduct;
   fromTariffZone: TariffZone;
   toTariffZone: TariffZone;
@@ -121,6 +123,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
   );
 
   const {
+    fareProductTypeConfig,
     fromTariffZone,
     toTariffZone,
     preassignedFareProduct,
@@ -129,10 +132,8 @@ const Confirmation: React.FC<ConfirmationProps> = ({
     headerLeftButton,
   } = params;
 
-  const {configuration: fareProductTypeConfiguration} =
-    useFareProductTypeConfig(preassignedFareProduct.type);
   const {travellerSelectionMode, zoneSelectionMode, offerEndpoint} =
-    fareProductTypeConfiguration;
+    fareProductTypeConfig.configuration;
 
   const {
     offerSearchTime,
@@ -259,9 +260,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
   return (
     <View style={styles.container}>
       <FullScreenHeader
-        title={t(
-          PurchaseConfirmationTexts.header.title[preassignedFareProduct.type],
-        )}
+        title={getTextForLanguage(fareProductTypeConfig.name, language)}
         leftButton={headerLeftButton}
         globalMessageContext="app-ticketing"
       />

--- a/src/screens/Ticketing/Purchase/Overview/components/Summary.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Summary.tsx
@@ -52,6 +52,7 @@ export default function Summary({
 
   const toPaymentFunction = () => {
     navigation.navigate('Confirmation', {
+      fareProductTypeConfig,
       fromTariffZone,
       toTariffZone,
       userProfilesWithCount,

--- a/src/screens/Ticketing/Purchase/Overview/components/ZonesSelection.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/ZonesSelection.tsx
@@ -1,7 +1,9 @@
 import {screenReaderPause} from '@atb/components/accessible-text';
 import * as Sections from '@atb/components/sections';
 import ThemeText from '@atb/components/text';
-import {ZoneSelectionMode} from '@atb/screens/Ticketing/FareContracts/utils';
+import {
+  FareProductTypeConfig,
+} from '@atb/screens/Ticketing/FareContracts/utils';
 import {StyleSheet} from '@atb/theme';
 import {
   PurchaseOverviewTexts,
@@ -19,16 +21,16 @@ import {
 import {OverviewNavigationProps} from '../types';
 
 type ZonesSelectionProps = {
-  selectionMode: ZoneSelectionMode;
+  fareProductTypeConfig: FareProductTypeConfig;
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
   style?: StyleProp<ViewStyle>;
 };
 
 export default function ZonesSelection({
+  fareProductTypeConfig,
   fromTariffZone,
   toTariffZone,
-  selectionMode,
   style,
 }: ZonesSelectionProps) {
   const itemStyle = useStyles();
@@ -43,6 +45,8 @@ export default function ZonesSelection({
       screenReaderPause,
     accessibilityHint: t(PurchaseOverviewTexts.tariffZones.a11yHint),
   };
+
+  const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
 
   if (selectionMode === 'none') {
     return <></>;
@@ -75,7 +79,7 @@ export default function ZonesSelection({
             navigation.push('TariffZones', {
               fromTariffZone,
               toTariffZone,
-              selectionMode,
+              fareProductTypeConfig,
             });
           }}
           testID="selectZonesButton"

--- a/src/screens/Ticketing/Purchase/Overview/components/ZonesSelection.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/ZonesSelection.tsx
@@ -1,9 +1,7 @@
 import {screenReaderPause} from '@atb/components/accessible-text';
 import * as Sections from '@atb/components/sections';
 import ThemeText from '@atb/components/text';
-import {
-  FareProductTypeConfig,
-} from '@atb/screens/Ticketing/FareContracts/utils';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
 import {StyleSheet} from '@atb/theme';
 import {
   PurchaseOverviewTexts,

--- a/src/screens/Ticketing/Purchase/Overview/index.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/index.tsx
@@ -1,15 +1,14 @@
 import {MessageBox} from '@atb/components/message-box';
 import FullScreenFooter from '@atb/components/screen-footer/full-footer';
 import FullScreenHeader from '@atb/components/screen-header/full-header';
-import {useFareProductTypeConfig} from '@atb/configuration/utils';
 import {PreassignedFareProduct} from '@atb/reference-data/types';
 import {StyleSheet} from '@atb/theme';
 import {
   dictionary,
+  getTextForLanguage,
   PurchaseOverviewTexts,
   useTranslation,
 } from '@atb/translations';
-import MessageBoxTexts from '@atb/translations/components/MessageBox';
 import React, {useEffect, useState} from 'react';
 import {ScrollView, View} from 'react-native';
 import {PurchaseScreenProps} from '../types';
@@ -29,7 +28,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
   route: {params},
 }) => {
   const styles = useStyles();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const {
     preassignedFareProduct,
@@ -38,7 +37,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
     toTariffZone,
   } = useOfferDefaults(
     params.preassignedFareProduct,
-    params.selectableProductType,
+    params.fareProductTypeConfig.type,
     params.userProfilesWithCount,
     params.fromTariffZone,
     params.toTariffZone,
@@ -53,16 +52,13 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
     useState(selectableTravellers);
   const hasSelection = travellerSelection.some((u) => u.count);
   const [travelDate, setTravelDate] = useState<string | undefined>();
-  const fareProductTypeConfig = useFareProductTypeConfig(
-    preassignedFareProduct.type,
-  );
+
   const {
     timeSelectionMode,
     productSelectionMode,
     travellerSelectionMode,
-    zoneSelectionMode,
     offerEndpoint,
-  } = fareProductTypeConfig.configuration;
+  } = params.fareProductTypeConfig.configuration;
 
   const {isSearchingOffer, error, totalPrice, refreshOffer} = useOfferState(
     offerEndpoint,
@@ -90,9 +86,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
   return (
     <View style={styles.container}>
       <FullScreenHeader
-        title={t(
-          PurchaseOverviewTexts.header.title[preassignedFareProduct.type],
-        )}
+        title={getTextForLanguage(params.fareProductTypeConfig.name, language)}
         leftButton={{
           type: 'cancel',
           onPress: closeModal,
@@ -134,7 +128,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             fromTariffZone={fromTariffZone}
             toTariffZone={toTariffZone}
             style={styles.selectionComponent}
-            selectionMode={zoneSelectionMode}
+            fareProductTypeConfig={params.fareProductTypeConfig}
           />
 
           <StartTimeSelection
@@ -164,7 +158,7 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             preassignedFareProduct={preassignedFareProduct}
             travelDate={travelDate}
             style={styles.summary}
-            fareProductTypeConfig={fareProductTypeConfig}
+            fareProductTypeConfig={params.fareProductTypeConfig}
           />
         </FullScreenFooter>
       </ScrollView>

--- a/src/screens/Ticketing/Purchase/TariffZones/index.tsx
+++ b/src/screens/Ticketing/Purchase/TariffZones/index.tsx
@@ -37,7 +37,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {PurchaseScreenProps} from '../types';
 import {zoomIn, zoomOut} from '@atb/components/map/utils';
 import {flyToLocation} from '@atb/components/map/hooks/use-trigger-camera-move-effect';
-import {ZoneSelectionMode} from '../../FareContracts/utils';
+import {FareProductTypeConfig} from '../../FareContracts/utils';
 
 type TariffZonesRouteName = 'TariffZones';
 const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
@@ -45,7 +45,7 @@ const TariffZonesRouteNameStatic: TariffZonesRouteName = 'TariffZones';
 export type RouteParams = {
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
-  selectionMode: Exclude<ZoneSelectionMode, 'none'>;
+  fareProductTypeConfig: FareProductTypeConfig;
 };
 
 export type TariffZoneResultType = 'venue' | 'geolocation' | 'zone';
@@ -216,7 +216,8 @@ const TariffZones: React.FC<TariffZonesProps> = ({
   navigation,
   route: {params},
 }) => {
-  const {fromTariffZone, toTariffZone, selectionMode} = params;
+  const {fromTariffZone, toTariffZone, fareProductTypeConfig} = params;
+  const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
   const isApplicableOnSingleZoneOnly = selectionMode === 'single';
   const [regionEvent, setRegionEvent] = useState<RegionEvent>();
   const {tariffZones} = useFirestoreConfiguration();
@@ -274,6 +275,7 @@ const TariffZones: React.FC<TariffZonesProps> = ({
     navigation.navigate({
       name: 'PurchaseOverview',
       params: {
+        fareProductTypeConfig,
         fromTariffZone: selectedZones.from,
         toTariffZone: isApplicableOnSingleZoneOnly
           ? selectedZones.from

--- a/src/screens/Ticketing/Purchase/types.ts
+++ b/src/screens/Ticketing/Purchase/types.ts
@@ -1,8 +1,5 @@
 import {RootNavigationProps, RootStackScreenProps} from '@atb/navigation/types';
-import {
-  PreassignedFareProduct,
-  PreassignedFareProductType,
-} from '@atb/reference-data/types';
+import {PreassignedFareProduct} from '@atb/reference-data/types';
 import {PaymentType, ReserveOffer} from '@atb/ticketing';
 import {
   CompositeNavigationProp,
@@ -16,6 +13,7 @@ import {
 } from './TariffZones';
 import {RouteParams as TariffZoneSearchParams} from './TariffZones/search';
 import {UserProfileWithCount} from './Travellers/use-user-count-state';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
 
 export type CardPaymentMethod =
   | {paymentType: PaymentType.Visa | PaymentType.Mastercard; save: boolean}
@@ -61,9 +59,9 @@ export type SavedPaymentOption =
 
 type PurchaseOverviewParams = {
   refreshOffer?: boolean;
+  fareProductTypeConfig: FareProductTypeConfig;
   preassignedFareProduct?: PreassignedFareProduct;
   userProfilesWithCount?: UserProfileWithCount[];
-  selectableProductType?: PreassignedFareProductType;
   fromTariffZone?: TariffZoneWithMetadata;
   toTariffZone?: TariffZoneWithMetadata;
   travelDate?: string;

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -1,15 +1,6 @@
 import {translation as _} from '../../commons';
 
 const PurchaseConfirmationTexts = {
-  header: {
-    title: {
-      single: _('Enkeltbillett', 'Single ticket'),
-      night: _('Nattbillett', 'Night ticket'),
-      period: _('Periodebillett', 'Periodic ticket'),
-      carnet: _('Klippekort', 'Carnet ticket'),
-      hour24: _('24-timersbillett', '24 hour pass'),
-    },
-  },
   errorMessageBox: {
     title: _('Det oppstod en feil', 'An error occurred'),
     message: _(

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -2,15 +2,6 @@ import {translation as _} from '../../commons';
 import orgSpecificTranslations from '@atb/translations/utils';
 
 const PurchaseOverviewTexts = {
-  header: {
-    title: {
-      single: _('Enkeltbillett', 'Single ticket'),
-      night: _('Nattbillett', 'Night ticket'),
-      period: _('Periodebillett', 'Periodic ticket'),
-      carnet: _('Klippekort', 'Carnet ticket'),
-      hour24: _('24-timersbillett', '24 hour pass'),
-    },
-  },
   errorMessageBox: {
     title: _('Det oppstod en feil', 'An error occurred'),
     message: _(


### PR DESCRIPTION
Get the fare product type name during the purchase prosess from the new FareProductTypeConfigs in FireStore.