### PR TITLE
refactor: Transportation modes from Firestore

### DIFF
--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -11,6 +11,7 @@ import {
 import {LanguageAndTextType} from '@atb/translations/types';
 import Bugsnag from '@bugsnag/react-native';
 import {isArray} from 'lodash';
+import {TransportModeType} from '@atb/configuration/types';
 
 export function mapToFareProductTypeConfigs(
   config: any,
@@ -42,7 +43,7 @@ function mapToFareProductTypeConfig(
     return;
   }
 
-  const fcTypes = ['single', 'period', 'hour24', 'night'];
+  const fcTypes = ['single', 'period', 'hour24', 'night', 'carnet'];
   const fcType = mapToStringAlternatives<FareProductType>(config.type, fcTypes);
   if (!fcType) {
     return;
@@ -71,9 +72,12 @@ function mapToFareProductTypeConfig(
     );
     return;
   }
-  if (!config.transportModes.every((value: any) => typeof value === 'string')) {
+
+  const transportModes = mapTransportModeTypes(config.transportModes);
+
+  if (!transportModes) {
     Bugsnag.notify(
-      `fare product of type: "${fcType}", one or more of the "transportModes" values is not of type "string"`,
+      `fare product of type: "${fcType}", "transportModes" should conform: "TransportModeType"`,
     );
     return;
   }
@@ -88,7 +92,7 @@ function mapToFareProductTypeConfig(
     type: fcType,
     name,
     description,
-    transportModes: config.transportModes,
+    transportModes,
     configuration,
   };
 }
@@ -198,4 +202,18 @@ function mapLanguageAndTextType(text: any[]) {
     return;
 
   return text as LanguageAndTextType[];
+}
+
+function mapTransportModeTypes(transportModes: any[]) {
+  if (
+    !transportModes.every(
+      (item: any) =>
+        typeof item === 'object' &&
+        'mode' in item &&
+        typeof item.mode === 'string',
+    )
+  )
+    return;
+
+  return transportModes as TransportModeType[];
 }

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -1,0 +1,9 @@
+import {
+  TransportMode,
+  TransportSubmode,
+} from '@atb/api/types/generated/journey_planner_v3_types';
+
+export type TransportModeType = {
+  mode: TransportMode;
+  subMode?: TransportSubmode;
+};

--- a/src/reference-data/defaults/fare-product-type-config.json
+++ b/src/reference-data/defaults/fare-product-type-config.json
@@ -122,5 +122,36 @@
       "productSelectionMode": "product",
       "offerEndpoint": "authority"
     }
+  },
+  {
+    "type": "carnet",
+    "name": [
+      {
+        "lang": "nob",
+        "value": "Klippekort"
+      },
+      {
+        "lang": "eng",
+        "value": "Punch card"
+      }
+    ],
+    "transportModes": ["bus"],
+    "description": [
+      {
+        "lang": "nob",
+        "value": "10 forhåndskjøpte enkeltbilletter som må aktiveres før du går om bord"
+      },
+      {
+        "lang": "eng",
+        "value": "10 pre-purchased tickets that you have to validate before boarding"
+      }
+    ],
+    "configuration": {
+      "zoneSelectionMode": "multiple",
+      "travellerSelectionMode": "single",
+      "timeSelectionMode": "none",
+      "productSelectionMode": "none",
+      "offerEndpoint": "zones"
+    }
   }
 ]

--- a/src/reference-data/defaults/fare-product-type-config.json
+++ b/src/reference-data/defaults/fare-product-type-config.json
@@ -11,7 +11,10 @@
         "value": "Single ticket bus/tram"
       }
     ],
-    "transportModes": ["bus"],
+    "transportModes": [
+      {"mode": "bus", "subMode": "localBus"},
+      {"mode": "tram"}
+    ],
     "description": [
       {
         "lang": "nob",
@@ -42,7 +45,10 @@
         "value": "Periodic ticket"
       }
     ],
-    "transportModes": ["bus"],
+    "transportModes": [
+      {"mode": "bus", "subMode": "localBus"},
+      {"mode": "tram"}
+    ],
     "description": [
       {
         "lang": "nob",
@@ -73,7 +79,10 @@
         "value": "24 hour pass"
       }
     ],
-    "transportModes": ["bus"],
+    "transportModes": [
+      {"mode": "bus", "subMode": "localBus"},
+      {"mode": "tram"}
+    ],
     "description": [
       {
         "lang": "nob",
@@ -104,7 +113,10 @@
         "value": "Night ticket"
       }
     ],
-    "transportModes": ["bus"],
+    "transportModes": [
+      {"mode": "bus", "subMode": "localBus"},
+      {"mode": "tram"}
+    ],
     "description": [
       {
         "lang": "nob",
@@ -135,7 +147,10 @@
         "value": "Punch card"
       }
     ],
-    "transportModes": ["bus"],
+    "transportModes": [
+      {"mode": "bus", "subMode": "localBus"},
+      {"mode": "tram"}
+    ],
     "description": [
       {
         "lang": "nob",

--- a/src/screens/Ticketing/FareContracts/Carnet/UsedAccessValidityHeader.tsx
+++ b/src/screens/Ticketing/FareContracts/Carnet/UsedAccessValidityHeader.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import {View} from 'react-native';
 import {UsedAccessStatus} from './types';
 import TransportMode from '@atb/screens/Ticketing/FareContracts/Component/TransportMode';
+import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 type Props = {
   now: number;
@@ -24,14 +25,20 @@ function UsedAccessValidityHeader(props: Props) {
   const styles = useStyles();
   const {t, language} = useTranslation();
   const usedAccessValidityText = getUsedAccessValidityText(props, t, language);
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === 'carnet',
+  );
 
   return (
     <View style={styles.validityHeader}>
       <View style={styles.validityContainer}>
-        <TransportMode
-          fareProductType={'carnet'}
-          disabled={props.status === 'inactive'}
-        />
+        {fareProductTypeConfig && (
+          <TransportMode
+            modes={fareProductTypeConfig?.transportModes}
+            disabled={props.status === 'inactive'}
+          />
+        )}
         <ThemeText
           style={styles.label}
           type="body__secondary"

--- a/src/screens/Ticketing/FareContracts/Component/TransportMode.tsx
+++ b/src/screens/Ticketing/FareContracts/Component/TransportMode.tsx
@@ -1,18 +1,17 @@
 import {View} from 'react-native';
-import {getTransportationModes} from '@atb/screens/Ticketing/FareContracts/utils';
 import TransportationIcon from '@atb/components/transportation-icon';
 import ThemeText from '@atb/components/text';
-import {TicketingTexts, useTranslation} from '@atb/translations';
+import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
-import {PreassignedFareProductType} from '@atb/reference-data/types';
 import {StyleSheet, Theme} from '@atb/theme';
+import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 
 const TransportMode = ({
-  fareProductType,
+  modes,
   iconSize,
   disabled,
 }: {
-  fareProductType: PreassignedFareProductType | 'summerPass';
+  modes: Mode[];
   iconSize?: keyof Theme['icon']['size'];
   disabled?: boolean;
 }) => {
@@ -20,19 +19,16 @@ const TransportMode = ({
   const {t} = useTranslation();
   return (
     <View style={styles.transportationMode}>
-      {getTransportationModes(fareProductType)?.map((mode: any) => (
+      {modes.map((mode: Mode) => (
         <TransportationIcon
           key={mode}
-          mode={mode.mode}
-          subMode={mode.subMode}
+          mode={mode}
           size={iconSize}
           disabled={disabled}
         />
       ))}
       <ThemeText type="label__uppercase" color={'secondary'}>
-        {t(
-          TicketingTexts.availableFareProducts[fareProductType].transportModes,
-        )}
+        {modes.map((tm) => t(FareContractTexts.transportMode(tm))).join('/')}
       </ThemeText>
     </View>
   );

--- a/src/screens/Ticketing/FareContracts/Component/TransportMode.tsx
+++ b/src/screens/Ticketing/FareContracts/Component/TransportMode.tsx
@@ -4,14 +4,14 @@ import ThemeText from '@atb/components/text';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {StyleSheet, Theme} from '@atb/theme';
-import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {TransportModeType} from '@atb/configuration/types';
 
 const TransportMode = ({
   modes,
   iconSize,
   disabled,
 }: {
-  modes: Mode[];
+  modes: TransportModeType[];
   iconSize?: keyof Theme['icon']['size'];
   disabled?: boolean;
 }) => {
@@ -19,16 +19,19 @@ const TransportMode = ({
   const {t} = useTranslation();
   return (
     <View style={styles.transportationMode}>
-      {modes.map((mode: Mode) => (
+      {modes.map(({mode, subMode}) => (
         <TransportationIcon
-          key={mode}
+          key={mode + subMode}
           mode={mode}
+          subMode={subMode}
           size={iconSize}
           disabled={disabled}
         />
       ))}
       <ThemeText type="label__uppercase" color={'secondary'}>
-        {modes.map((tm) => t(FareContractTexts.transportMode(tm))).join('/')}
+        {modes
+          .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
+          .join('/')}
       </ThemeText>
     </View>
   );

--- a/src/screens/Ticketing/FareContracts/ValidityHeader.tsx
+++ b/src/screens/Ticketing/FareContracts/ValidityHeader.tsx
@@ -17,6 +17,7 @@ import {
 import {PreassignedFareProductType} from '@atb/reference-data/types';
 import TransportMode from '@atb/screens/Ticketing/FareContracts/Component/TransportMode';
 import FareContractStatusSymbol from '@atb/screens/Ticketing/FareContracts/Component/FareContractStatusSymbol';
+import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 const ValidityHeader: React.FC<{
   status: ValidityStatus;
@@ -28,6 +29,10 @@ const ValidityHeader: React.FC<{
 }> = ({status, now, validFrom, validTo, isInspectable, fareProductType}) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === fareProductType,
+  );
 
   const validityTime: string = validityTimeText(
     status,
@@ -42,7 +47,9 @@ const ValidityHeader: React.FC<{
     <View style={styles.validityHeader}>
       <View style={styles.validityContainer}>
         {isValidFareContract(status) ? (
-          fareProductType && <TransportMode fareProductType={fareProductType} />
+          fareProductTypeConfig && (
+            <TransportMode modes={fareProductTypeConfig.transportModes} />
+          )
         ) : (
           <FareContractStatusSymbol status={status} />
         )}

--- a/src/screens/Ticketing/FareContracts/utils.ts
+++ b/src/screens/Ticketing/FareContracts/utils.ts
@@ -1,5 +1,4 @@
 import {FareContractState} from '@atb/ticketing';
-import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {
   PreassignedFareProductType,
   UserProfile,
@@ -22,6 +21,7 @@ import {
   isMobileToken,
   isTravelCardToken,
 } from '@atb/mobile-token/utils';
+import {TransportModeType} from '@atb/configuration/types';
 
 export type RelativeValidityStatus = 'upcoming' | 'valid' | 'expired';
 
@@ -37,7 +37,7 @@ export type ValidityStatus =
 export type FareProductTypeConfig = {
   type: FareProductType;
   name: LanguageAndTextType[];
-  transportModes: Mode[];
+  transportModes: TransportModeType[];
   description: LanguageAndTextType[];
   configuration: FareProductTypeConfigSettings;
 };

--- a/src/screens/Ticketing/FareContracts/utils.ts
+++ b/src/screens/Ticketing/FareContracts/utils.ts
@@ -1,8 +1,5 @@
 import {FareContractState} from '@atb/ticketing';
-import {
-  Mode,
-  TransportSubmode,
-} from '@atb/api/types/generated/journey_planner_v3_types';
+import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {
   PreassignedFareProductType,
   UserProfile,
@@ -51,6 +48,7 @@ export type FareProductTypeConfigSettings = {
   timeSelectionMode: TimeSelectionMode;
   productSelectionMode: ProductSelectionMode;
   offerEndpoint: OfferEndpoint;
+  requiresLogin: boolean;
 };
 
 export type FareProductType =
@@ -94,25 +92,6 @@ export function getValidityStatus(
   if (state === FareContractState.Refunded) return 'refunded';
   return getRelativeValidity(now, validFrom, validTo);
 }
-
-export const getTransportationModes = (fareProductType?: string) => {
-  switch (fareProductType) {
-    case 'single':
-    case 'hour24':
-    case 'period':
-    case 'night':
-    case 'carnet':
-      return [{mode: Mode.Bus, subMode: TransportSubmode.LocalBus}];
-    case 'summerPass': //TODO cross check this value
-      return [
-        {mode: Mode.Bus, subMode: TransportSubmode.LocalBus},
-        {mode: Mode.Rail},
-        {mode: Mode.Water},
-      ];
-    default:
-      return null;
-  }
-};
 
 export const mapToUserProfilesWithCount = (
   userProfileRefs: string[],

--- a/src/screens/Ticketing/FareProducts/AvailableFareProducts/FareProductTile.tsx
+++ b/src/screens/Ticketing/FareProducts/AvailableFareProducts/FareProductTile.tsx
@@ -34,7 +34,7 @@ const FareProductTile = ({
   const title = useTextForLanguage(config.name);
   const description = useTextForLanguage(config.description);
   const transportModesText = config.transportModes
-    .map((tm) => t(FareContractTexts.transportMode(tm)))
+    .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
     .join('/');
   const accessibilityLabel = [title, transportModesText, description].join(
     '. ',

--- a/src/screens/Ticketing/FareProducts/AvailableFareProducts/FareProductTile.tsx
+++ b/src/screens/Ticketing/FareProducts/AvailableFareProducts/FareProductTile.tsx
@@ -57,7 +57,7 @@ const FareProductTile = ({
         style={styles.spreadContent}
       >
         <View style={styles.contentContainer}>
-          <TransportMode fareProductType={config.type} iconSize={'small'} />
+          <TransportMode modes={config.transportModes} iconSize={'small'} />
           <ThemeText
             type="body__secondary--bold"
             style={styles.title}

--- a/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
+++ b/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
@@ -9,9 +9,9 @@ import {getReferenceDataName} from '@atb/reference-data/utils';
 import TransportationIcon from '@atb/components/transportation-icon';
 import ThemeIcon from '@atb/components/theme-icon';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
-import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
+import {TransportModeType} from '@atb/configuration/types';
 
 type RecentFareContractProps = {
   recentFareContract: RecentFareContract;
@@ -78,7 +78,7 @@ export const RecentFareContractComponent = ({
   if (!fareProductTypeConfig) return null;
 
   type ModeNameProps = {
-    modes: Mode[];
+    modes: TransportModeType[];
     joinSymbol?: string;
   };
 
@@ -88,7 +88,7 @@ export const RecentFareContractComponent = ({
       return t(RecentFareContractsTexts.severalTransportModes);
     else
       return modes
-        .map((mode) => t(FareContractTexts.transportMode(mode)))
+        .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
         .join(joinSymbol);
   };
 
@@ -137,8 +137,13 @@ export const RecentFareContractComponent = ({
     >
       <View style={[styles.upperPart, {minWidth: width * 0.6}]}>
         <View style={styles.travelModeWrapper}>
-          {fareProductTypeConfig.transportModes.map((mode) => (
-            <TransportationIcon mode={mode} key={mode} size="small" />
+          {fareProductTypeConfig.transportModes.map(({mode, subMode}) => (
+            <TransportationIcon
+              mode={mode}
+              subMode={subMode}
+              key={mode + subMode}
+              size="small"
+            />
           ))}
 
           <ThemeText type="label__uppercase">

--- a/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContracts.tsx
+++ b/src/screens/Ticketing/FareProducts/RecentFareProducts/RecentFareContracts.tsx
@@ -76,7 +76,7 @@ export const RecentFareContracts = () => {
         </View>
       )}
 
-      {!loading && !!recentFareContracts.length && (
+      {!loading && !!memoizedRecentFareContracts.length && (
         <>
           <ThemeText type="body__secondary" style={styles.header}>
             {t(RecentFareContractsTexts.repeatPurchase.label)}

--- a/src/screens/Ticketing/Purchase/Overview/components/Summary.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/Summary.tsx
@@ -63,7 +63,7 @@ export default function Summary({
   };
 
   const transportModesText = fareProductTypeConfig.transportModes
-    .map((tm) => t(FareContractTexts.transportMode(tm)))
+    .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
     .filter(Boolean)
     .join('/');
 

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -1,4 +1,4 @@
-import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {TransportMode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {translation as _} from '../commons';
 
 const FareContractTexts = {
@@ -146,35 +146,23 @@ const FareContractTexts = {
     ),
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },
-  transportMode: (mode: Mode) => {
+  transportMode: (mode: TransportMode) => {
     switch (mode) {
-      case Mode.Bus:
+      case TransportMode.Bus:
+      case TransportMode.Coach:
         return _('buss', 'bus');
-      case Mode.Rail:
+      case TransportMode.Rail:
         return _('tog', 'train');
-      case Mode.Tram:
+      case TransportMode.Tram:
         return _('trikk', 'tram');
-      case Mode.Water:
+      case TransportMode.Water:
         return _('båt', 'boat');
-      case Mode.Air:
+      case TransportMode.Air:
         return _('fly', 'plane');
-      case Mode.Foot:
-        return _('gange', 'walk');
-      case Mode.Metro:
+      case TransportMode.Metro:
         return _('T-bane', 'metro');
       default:
         return _('ukjent transportmiddel', 'unknown transport');
-      /*
-                bus: _('buss', 'bus'),
-                rail: _('tog', 'train'),
-                tram: _('trikk', 'tram'),
-                water: _('båt', 'boat'),
-                air: _('fly', 'plane'),
-                foot: _('gange', 'walk'),
-                metro: _('T-bane', 'metro'),
-                unknown: _('ukjent transportmiddel', 'unknown transport'),
-                several: _('Flere reisemåter', 'Several transport modes'),
-                */
     }
   },
 };


### PR DESCRIPTION
Show transportation mode icons based on the new
FareProductTypeConfigs in FireStore.