### PR TITLE
refactor: Whether product requires login from Firestore

### DIFF
--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -172,13 +172,22 @@ function mapToFareProductConfigSettings(
     return;
   }
 
+  const requiresLogin = settings.requiresLogin;
+  if (requiresLogin === undefined) {
+    Bugsnag.notify(
+      `fare product of type: "${fareProductType}" is missing 'requiresLogin' in configuration`,
+    );
+    return;
+  }
+
   return {
     zoneSelectionMode,
     travellerSelectionMode,
     timeSelectionMode,
     productSelectionMode,
     offerEndpoint,
-  } as FareProductTypeConfigSettings;
+    requiresLogin,
+  };
 }
 
 function notifyWrongConfigurationType(

--- a/src/login/LoginOnboarding.tsx
+++ b/src/login/LoginOnboarding.tsx
@@ -11,11 +11,13 @@ import useFocusOnLoad from '@atb/utils/use-focus-on-load';
 import {StaticColorByType} from '@atb/theme/colors';
 import {useNavigation} from '@react-navigation/native';
 import {Psst} from '@atb/assets/svg/color/illustrations';
-import {Periodebillett} from '@atb/assets/svg/color/images';
+import {Ticket} from '@atb/assets/svg/color/images';
 import {
   filterActiveOrCanBeUsedFareContracts,
   useTicketingState,
 } from '@atb/ticketing';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
+import {useTextForLanguage} from '@atb/translations/utils';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -23,10 +25,12 @@ export default function LoginOnboarding({
   headerLeftButton,
   doAfterSubmit,
   headerRightButton,
+  fareProductTypeConfig,
 }: {
   doAfterSubmit: (hasActiveFareContracts: boolean) => void;
   headerLeftButton?: LeftButtonProps;
   headerRightButton?: RightButtonProps;
+  fareProductTypeConfig: FareProductTypeConfig;
 }) {
   const {t} = useTranslation();
   const navigation = useNavigation();
@@ -39,6 +43,8 @@ export default function LoginOnboarding({
   const onNext = async () => {
     doAfterSubmit(activeFareContracts.length > 0);
   };
+
+  const productName = useTextForLanguage(fareProductTypeConfig.name);
 
   return (
     <View style={styles.container}>
@@ -56,7 +62,7 @@ export default function LoginOnboarding({
             style={styles.title}
             color={themeColor}
           >
-            {t(LoginTexts.onboarding.title)}
+            {productName + ' - ' + t(LoginTexts.onboarding.title)}
           </ThemeText>
         </View>
         <View accessible={true}>
@@ -64,7 +70,7 @@ export default function LoginOnboarding({
             {t(LoginTexts.onboarding.description)}
           </ThemeText>
         </View>
-        <Periodebillett style={styles.illustation} />
+        <Ticket style={styles.illustration} />
         <View style={styles.buttonView}>
           <Button
             interactiveColor="interactive_0"
@@ -128,7 +134,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   buttonView: {
     marginTop: theme.spacings.medium,
   },
-  illustation: {
+  illustration: {
     alignSelf: 'center',
     marginVertical: theme.spacings.medium,
   },

--- a/src/login/in-app/LoginOnboarding.tsx
+++ b/src/login/in-app/LoginOnboarding.tsx
@@ -4,9 +4,11 @@ import LoginOnboarding from '@atb/login/LoginOnboarding';
 import {AfterLoginParams} from '@atb/login/types';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {LoginInAppScreenProps} from '../types';
+import {FareProductTypeConfig} from '@atb/screens/Ticketing/FareContracts/utils';
 
 export type LoginOnboardingInAppRouteParams = {
   afterLogin: AfterLoginParams<'TabNavigator'> | AfterLoginParams<'Purchase'>;
+  fareProductTypeConfig: FareProductTypeConfig;
 };
 
 type LoginOnboardingProps = LoginInAppScreenProps<'LoginOnboardingInApp'>;
@@ -14,12 +16,13 @@ type LoginOnboardingProps = LoginInAppScreenProps<'LoginOnboardingInApp'>;
 export const LoginOnboardingInApp = ({
   navigation,
   route: {
-    params: {afterLogin},
+    params: {fareProductTypeConfig, afterLogin},
   },
 }: LoginOnboardingProps) => {
   const {enable_vipps_login} = useRemoteConfig();
   return (
     <LoginOnboarding
+      fareProductTypeConfig={fareProductTypeConfig}
       doAfterSubmit={(hasActiveFareContracts: boolean) => {
         if (hasActiveFareContracts) {
           navigation.navigate('activeFareContractPromptInApp', {

--- a/src/reference-data/defaults/fare-product-type-config.json
+++ b/src/reference-data/defaults/fare-product-type-config.json
@@ -170,7 +170,8 @@
       "travellerSelectionMode": "single",
       "timeSelectionMode": "none",
       "productSelectionMode": "none",
-      "offerEndpoint": "zones"
+      "offerEndpoint": "zones",
+      "requiresLogin": true
     }
   }
 ]

--- a/src/reference-data/defaults/fare-product-type-config.json
+++ b/src/reference-data/defaults/fare-product-type-config.json
@@ -30,7 +30,8 @@
       "travellerSelectionMode": "multiple",
       "timeSelectionMode": "none",
       "productSelectionMode": "none",
-      "offerEndpoint": "zones"
+      "offerEndpoint": "zones",
+      "requiresLogin": false
     }
   },
   {
@@ -64,7 +65,8 @@
       "travellerSelectionMode": "single",
       "timeSelectionMode": "datetime",
       "productSelectionMode": "duration",
-      "offerEndpoint": "zones"
+      "offerEndpoint": "zones",
+      "requiresLogin": true
     }
   },
   {
@@ -98,7 +100,8 @@
       "travellerSelectionMode": "single",
       "timeSelectionMode": "datetime",
       "productSelectionMode": "none",
-      "offerEndpoint": "zones"
+      "offerEndpoint": "zones",
+      "requiresLogin": false
     }
   },
   {
@@ -132,7 +135,8 @@
       "travellerSelectionMode": "none",
       "timeSelectionMode": "none",
       "productSelectionMode": "product",
-      "offerEndpoint": "authority"
+      "offerEndpoint": "authority",
+      "requiresLogin": false
     }
   },
   {

--- a/src/screens/Ticketing/FareProducts/PurchaseTab.tsx
+++ b/src/screens/Ticketing/FareProducts/PurchaseTab.tsx
@@ -26,12 +26,13 @@ export const PurchaseTab: React.FC<Props> = ({navigation}) => {
 
   const onProductSelect = (fareProductTypeConfig: FareProductTypeConfig) => {
     if (
-      fareProductTypeConfig.type === 'period' &&
+      fareProductTypeConfig.configuration.requiresLogin &&
       authenticationType !== 'phone'
     ) {
       navigation.navigate('LoginInApp', {
         screen: 'LoginOnboardingInApp',
         params: {
+          fareProductTypeConfig,
           afterLogin: {
             screen: 'Purchase',
             params: {

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -29,13 +29,10 @@ const LoginTexts = {
     continueButton: _('Jeg vil logge inn likevel', 'I want to log in anyway'),
   },
   onboarding: {
-    title: _(
-      'Nå kan du kjøpe periodebilletter!',
-      'Periodic tickets – available now!',
-    ),
+    title: _('Logg inn for å kjøpe!', 'Log in to purchase!'),
     description: _(
-      'Når du logger inn kan du kjøpe periodebilletter på 7, 30, 60, 90 eller 180 dagers varighet.',
-      'Log in to purchase 7, 30, 60, 90 or 180-day tickets.',
+      'Denne billetten krever at du er innlogget for å kunne kjøpe.',
+      'This ticket requires that you are logged in to purchase.',
     ),
     button: _('Ta meg til innlogging', 'Take me to login'),
     laterButton: _('Jeg vil logge inn senere', 'I want to log in later'),


### PR DESCRIPTION
Whether a product requires login or not is now based on the field 'requiresLogin' in the new FareProductTypeConfigs in FireStore.

Also made the login-onboarding screen with "you need to login" warning to be more generic.