### PR TITLE
refactor: Support for AbortController in use-pollable-resource

### DIFF
--- a/src/utils/use-pollable-resource.ts
+++ b/src/utils/use-pollable-resource.ts
@@ -6,11 +6,11 @@ type PollableResourceOptions<T, E> = {
   initialValue: T;
   pollingTimeInSeconds?: number;
   disabled?: boolean;
-  filterError?(error: E): boolean;
 };
 
 /**
- * Pattern for creating a pollable resource as a hook. Pass data reciever function as first argument.
+ * Pattern for creating a pollable resource as a hook. Pass data receiver function as first argument. The
+ * receiver function may take an AbortSignal if it should be aborted when the callback function changes.
  * NOTE: callback should be cached as it is used as dependency in useEffect. Remember to use `useCallback`.
  *
  * Polling time of 0 equals no polling.
@@ -20,34 +20,31 @@ type PollableResourceOptions<T, E> = {
  * @returns [T, () => Promise<void>, boolean, E]
  */
 export default function usePollableResource<T, E extends Error = Error>(
-  callback: () => Promise<T>,
+  callback: (signal?: AbortSignal) => Promise<T>,
   opts: PollableResourceOptions<T, E>,
 ): [T, () => Promise<void>, boolean, E?] {
-  const {initialValue, pollingTimeInSeconds = 30, filterError} = opts;
+  const {initialValue, pollingTimeInSeconds = 30} = opts;
   const [isLoading, setIsLoading] = useIsLoading(false);
   const [error, setError] = useState<E | undefined>(undefined);
   const [state, setState] = useState<T>(initialValue);
+  const [abortController, setAbortController] = useState<AbortController>();
   const pollTime = pollingTimeInSeconds * 1000;
 
   const reload = useCallback(
     async function reload(
       loading: 'NO_LOADING' | 'WITH_LOADING' = 'WITH_LOADING',
+      abortController?: AbortController,
     ) {
       // Only fetch if there is a location and the screen is in focus.
-
       if (loading === 'WITH_LOADING') {
         setIsLoading(true);
       }
       try {
+        const newState = await callback(abortController?.signal);
         setError(undefined);
-        const newState = await callback();
         setState(newState);
       } catch (e: any) {
-        // only way to type guard e here is to have the consumer of
-        // use-pollable-resource send in a type guarding function
-        // or accept that arguments sent to filterError and setError
-        // can also be 'unknown'. So for simplicity we're setting e to 'any'
-        if (!filterError || filterError(e)) setError(e);
+        if (!abortController?.signal.aborted) setError(e);
       } finally {
         if (loading === 'WITH_LOADING') {
           setIsLoading(false);
@@ -58,10 +55,18 @@ export default function usePollableResource<T, E extends Error = Error>(
   );
 
   useEffect(() => {
-    reload('WITH_LOADING');
+    const abortController = new AbortController();
+    setAbortController(abortController);
+    reload('WITH_LOADING', abortController);
+    return () => abortController.abort();
   }, [reload]);
 
-  useInterval(() => reload('NO_LOADING'), pollTime, [reload], opts.disabled);
+  useInterval(
+    () => reload('NO_LOADING', abortController),
+    pollTime,
+    [reload],
+    opts.disabled,
+  );
 
   return [state, reload, isLoading, error];
 }


### PR DESCRIPTION
The reason for this is so the hook doesn't return outdated data. If something like the currently selected quay is changed on the screen using use-pollable-resource, then a request in progress for the previously selected quay should be aborted and not update state.

This functionality may be utilized by passing a data-retrieval function that takes in an AbortSignal as argument.