### PR TITLE
refactor: Fix updating trip patterns

### DIFF
--- a/src/api/trips_v2.ts
+++ b/src/api/trips_v2.ts
@@ -1,6 +1,6 @@
 import client from './client';
 import {AxiosRequestConfig} from 'axios';
-import {TripsQuery} from '@atb/api/types/trips';
+import {TripPattern, TripsQuery} from '@atb/api/types/trips';
 import {TripsQueryVariables} from '@atb/api/types/generated/TripsQuery';
 import Bugsnag from '@bugsnag/react-native';
 
@@ -40,17 +40,17 @@ export async function tripsSearch(
 }
 
 export async function singleTripSearch(
-  queryString: string | null,
+  queryString?: string,
   opts?: AxiosRequestConfig,
-): Promise<TripsQuery | null> {
+): Promise<TripPattern | undefined> {
   if (!queryString) {
-    return null;
+    return undefined;
   }
   const url = '/bff/v2/singleTrip';
   const query = {
     compressedQuery: queryString,
   };
-  return await post<TripsQuery>(url, query, opts);
+  return await post<TripPattern>(url, query, opts);
 }
 
 async function post<T>(

--- a/src/screens/TripDetails/Details/use-current-trip-pattern-with-updates.ts
+++ b/src/screens/TripDetails/Details/use-current-trip-pattern-with-updates.ts
@@ -1,0 +1,68 @@
+import {TripPattern} from '@atb/api/types/trips';
+import {AxiosError} from 'axios';
+import {useCallback, useEffect, useState} from 'react';
+import {singleTripSearch} from '@atb/api/trips_v2';
+import usePollableResource from '@atb/utils/use-pollable-resource';
+import {useIsFocused} from '@react-navigation/native';
+
+type TripPatternUpdate = {
+  tp?: TripPattern;
+  error?: AxiosError;
+};
+
+/**
+ * Hook for using the current trip pattern with updated data. The current trip
+ * pattern is based on the current index, and every 30 seconds the trip pattern
+ * is updated with a query to the single trip search endpoint.
+ *
+ * The updated data for all trip patterns is persisted in the state, so it
+ * doesn't go back to the original outdated trip pattern when navigating between
+ * indexes.
+ */
+export const useCurrentTripPatternWithUpdates = (
+  currentIndex: number,
+  originalTripPatterns: TripPattern[],
+) => {
+  const isFocused = useIsFocused();
+  const [tripPatternUpdates, setTripPatternUpdates] = useState<
+    TripPatternUpdate[]
+  >(originalTripPatterns.map(() => ({})));
+
+  const fetchTripPattern = useCallback(
+    (signal?: AbortSignal) =>
+      singleTripSearch(originalTripPatterns[currentIndex].compressedQuery, {
+        signal,
+      }),
+    [originalTripPatterns, currentIndex],
+  );
+
+  const [updatedTripPattern, , , error] = usePollableResource<
+    TripPattern | undefined,
+    AxiosError
+  >(fetchTripPattern, {
+    initialValue: originalTripPatterns[currentIndex],
+    pollingTimeInSeconds: 30,
+    disabled: !isFocused,
+  });
+
+  useEffect(() => {
+    const updated = tripPatternUpdates.map((existingUpdate, index) => {
+      if (index === currentIndex) {
+        if (error) {
+          return {...existingUpdate, error};
+        } else {
+          return {tp: updatedTripPattern, error: undefined};
+        }
+      }
+      return existingUpdate;
+    });
+
+    setTripPatternUpdates(updated);
+  }, [updatedTripPattern, error]);
+
+  return {
+    tripPattern:
+      tripPatternUpdates[currentIndex].tp ?? originalTripPatterns[currentIndex],
+    error: tripPatternUpdates[currentIndex].error,
+  };
+};


### PR DESCRIPTION
- It was not working at all because of wrong expected data type from single trip query endpoint.
- Keeps updated state for each trip pattern, so changing index by navigating left or right doesn't reset to the orignal trip pattern
- Hide loading indicator to make it feel more "snappy". The user don't need to know that it is updating behind the scenes.
- Not update a trip pattern with wrong data. This is done by utilizing the AbortController signal so when the index change the old request is aborted.
- Moved complexity into its own hook, to make the main Details component a little cleaner.
- Changed according to coding guidelines.