### PR TITLE
feat: Add realtime icon to trip leg times

### DIFF
--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -320,9 +320,12 @@ function EstimatedCallRow({
       <TripRow
         rowLabel={
           <Time
-            aimedTime={call.aimedDepartureTime}
-            expectedTime={call.expectedDepartureTime}
-            missingRealTime={!call.realtime && isStartOfServiceJourney}
+            timeValues={{
+              aimedTime: call.aimedDepartureTime,
+              expectedTime: call.expectedDepartureTime,
+              missingRealTime: !call.realtime && isStartOfServiceJourney,
+            }}
+            showRealtime={false}
           />
         }
         alignChildren={

--- a/src/screens/TripDetails/DepartureDetails/index.tsx
+++ b/src/screens/TripDetails/DepartureDetails/index.tsx
@@ -325,7 +325,7 @@ function EstimatedCallRow({
               expectedTime: call.expectedDepartureTime,
               missingRealTime: !call.realtime && isStartOfServiceJourney,
             }}
-            showRealtime={false}
+            showRealtimeIcon={false}
           />
         }
         alignChildren={

--- a/src/screens/TripDetails/components/Time.tsx
+++ b/src/screens/TripDetails/components/Time.tsx
@@ -5,24 +5,43 @@ import {formatToClock} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
 import {getTimeRepresentationType, TimeValues} from '../utils';
+import ThemeIcon from '@atb/components/theme-icon';
+import {useTheme} from '@atb/theme';
+import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
+import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 
-const Time: React.FC<TimeValues> = (timeValues) => {
+const Time: React.FC<{timeValues: TimeValues; showRealtime?: boolean}> = ({
+  timeValues,
+  showRealtime = true,
+}) => {
   const {t, language} = useTranslation();
+  const {themeName} = useTheme();
   const {aimedTime, expectedTime} = timeValues;
   const representationType = getTimeRepresentationType(timeValues);
   const scheduled = formatToClock(aimedTime, language);
   const expected = expectedTime ? formatToClock(expectedTime, language) : '';
 
+  const realtimeIcon = (
+    <ThemeIcon
+      svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
+      size="small"
+      style={{marginRight: 4}}
+    ></ThemeIcon>
+  );
+
   switch (representationType) {
     case 'significant-difference': {
       return (
         <View style={{flexDirection: 'column', alignItems: 'flex-end'}}>
-          <AccessibleText
-            prefix={t(dictionary.travel.time.expectedPrefix)}
-            testID="expTime"
-          >
-            {expected}
-          </AccessibleText>
+          <View style={{flexDirection: 'row', alignItems: 'center'}}>
+            {showRealtime && realtimeIcon}
+            <AccessibleText
+              prefix={t(dictionary.travel.time.expectedPrefix)}
+              testID="expTime"
+            >
+              {expected}
+            </AccessibleText>
+          </View>
           <AccessibleText
             type="body__tertiary"
             color="secondary"
@@ -36,15 +55,15 @@ const Time: React.FC<TimeValues> = (timeValues) => {
       );
     }
     case 'no-realtime': {
-      return (
-        <ThemeText testID="schCaTime">
-          <ThemeText>{t(dictionary.missingRealTimePrefix)}</ThemeText>
-          {scheduled}
-        </ThemeText>
-      );
+      return <ThemeText testID="schCaTime">{scheduled}</ThemeText>;
     }
     default: {
-      return <ThemeText testID="schTime">{scheduled}</ThemeText>;
+      return (
+        <View style={{flexDirection: 'row', alignItems: 'center'}}>
+          {showRealtime && realtimeIcon}
+          <ThemeText testID="schTime">{scheduled}</ThemeText>
+        </View>
+      );
     }
   }
 };

--- a/src/screens/TripDetails/components/Time.tsx
+++ b/src/screens/TripDetails/components/Time.tsx
@@ -15,7 +15,7 @@ const Time: React.FC<{timeValues: TimeValues; showRealtimeIcon?: boolean}> = ({
   showRealtimeIcon = true,
 }) => {
   const {t, language} = useTranslation();
-  const {themeName} = useTheme();
+  const {themeName, theme} = useTheme();
   const {aimedTime, expectedTime} = timeValues;
   const representationType = getTimeRepresentationType(timeValues);
   const scheduled = formatToClock(aimedTime, language);
@@ -25,7 +25,7 @@ const Time: React.FC<{timeValues: TimeValues; showRealtimeIcon?: boolean}> = ({
     <ThemeIcon
       svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
       size="small"
-      style={{marginRight: 4}}
+      style={{marginRight: theme.spacings.xSmall}}
     />
   );
 

--- a/src/screens/TripDetails/components/Time.tsx
+++ b/src/screens/TripDetails/components/Time.tsx
@@ -10,9 +10,9 @@ import {useTheme} from '@atb/theme';
 import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
 import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 
-const Time: React.FC<{timeValues: TimeValues; showRealtime?: boolean}> = ({
+const Time: React.FC<{timeValues: TimeValues; showRealtimeIcon?: boolean}> = ({
   timeValues,
-  showRealtime = true,
+  showRealtimeIcon = true,
 }) => {
   const {t, language} = useTranslation();
   const {themeName} = useTheme();
@@ -26,7 +26,7 @@ const Time: React.FC<{timeValues: TimeValues; showRealtime?: boolean}> = ({
       svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
       size="small"
       style={{marginRight: 4}}
-    ></ThemeIcon>
+    />
   );
 
   switch (representationType) {
@@ -34,7 +34,7 @@ const Time: React.FC<{timeValues: TimeValues; showRealtime?: boolean}> = ({
       return (
         <View style={{flexDirection: 'column', alignItems: 'flex-end'}}>
           <View style={{flexDirection: 'row', alignItems: 'center'}}>
-            {showRealtime && realtimeIcon}
+            {showRealtimeIcon && realtimeIcon}
             <AccessibleText
               prefix={t(dictionary.travel.time.expectedPrefix)}
               testID="expTime"
@@ -60,8 +60,8 @@ const Time: React.FC<{timeValues: TimeValues; showRealtime?: boolean}> = ({
     default: {
       return (
         <View style={{flexDirection: 'row', alignItems: 'center'}}>
-          {showRealtime && realtimeIcon}
-          <ThemeText testID="schTime">{scheduled}</ThemeText>
+          {showRealtimeIcon && realtimeIcon}
+          <ThemeText testID="schTime">{expected}</ThemeText>
         </View>
       );
     }

--- a/src/screens/TripDetails/components/TripSection.tsx
+++ b/src/screens/TripDetails/components/TripSection.tsx
@@ -121,7 +121,7 @@ const TripSection: React.FC<TripSectionProps> = ({
               language,
               t,
             )}
-            rowLabel={<Time {...startTimes} />}
+            rowLabel={<Time timeValues={startTimes} />}
             onPress={() => handleQuayPress(leg.fromPlace.quay)}
             testID="fromPlace"
           >
@@ -208,7 +208,7 @@ const TripSection: React.FC<TripSectionProps> = ({
               language,
               t,
             )}
-            rowLabel={<Time {...endTimes} />}
+            rowLabel={<Time timeValues={endTimes} />}
             onPress={() => handleQuayPress(leg.toPlace.quay)}
             testID="toPlace"
           >
@@ -359,7 +359,7 @@ export function getPlaceName(place: Place): string {
   return place.quay ? getQuayName(place.quay) ?? fallback : fallback;
 }
 export function mapLegToTimeValues(leg: Leg) {
-  const legIsMissingRealTime = !leg.realtime && leg.mode !== 'foot';
+  const legIsMissingRealTime = !leg.realtime;
   return {
     startTimes: {
       expectedTime: leg.expectedStartTime,

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -41,7 +41,7 @@ const dictionary = {
     },
     time: {
       aimedPrefix: _('Rutetid', 'Route time'),
-      expectedPrefix: _('Forventet tid', 'Time expected'),
+      expectedPrefix: _('Sanntid', 'Realtime'),
     },
   },
   date: {

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -17,13 +17,13 @@ const TripDetailsTexts = {
         a11yLabel: {
           noRealTime: (placeName: string, aimedTime: string) =>
             _(
-              `Fra ${placeName}, ca. klokken ${aimedTime}`,
-              `From ${placeName}, appr. time ${aimedTime}`,
+              `Fra ${placeName}, klokken ${aimedTime}`,
+              `From ${placeName}, time ${aimedTime}`,
             ),
           singularTime: (placeName: string, time: string) =>
             _(
-              `Fra ${placeName}, klokken ${time}`,
-              `From ${placeName}, time ${time}`,
+              `Fra ${placeName}, sanntid klokken ${time}`,
+              `From ${placeName}, realtime ${time}`,
             ),
           realAndAimed: (
             placeName: string,
@@ -31,8 +31,8 @@ const TripDetailsTexts = {
             aimedTime: string,
           ) =>
             _(
-              `Fra ${placeName}, forventet tid klokken ${realTime}. Rutetid klokken ${aimedTime}.`,
-              `From ${placeName}, expected time ${realTime}. Route time ${aimedTime}.`,
+              `Fra ${placeName}, sanntid tid klokken ${realTime}. Rutetid klokken ${aimedTime}.`,
+              `From ${placeName}, realtime ${realTime}. Route time ${aimedTime}.`,
             ),
         },
       },


### PR DESCRIPTION
Add realtime icon to trip leg times to remove "ca." and differenciate between no realtime and trip that has not passed any stops.

<details>
<summary>Screenshot</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-22 at 08 28 46](https://user-images.githubusercontent.com/85479566/209080624-d2664bde-4c69-40dc-85ba-1a1461329680.png)
</details>

https://github.com/AtB-AS/kundevendt/issues/2949