### PR TITLE
refactor: Change to bold quay name

### DIFF
--- a/src/departure-list/section-items/quay-header.tsx
+++ b/src/departure-list/section-items/quay-header.tsx
@@ -64,7 +64,9 @@ export default function QuayHeaderItem({
         accessibilityLabel={`${accessibilityLabel} ${label} ${screenReaderPause}`}
         accessibilityRole="header"
       >
-        <ThemeText testID={testID + 'Title'}>{title}</ThemeText>
+        <ThemeText type={'body__primary--bold'} testID={testID + 'Title'}>
+          {title}
+        </ThemeText>
         <Distance distance={humanized} />
       </View>
       {situations.map((situation) => (


### PR DESCRIPTION
Make quay header text on departures front page bold.

<details>
<summary>Screenshot</summary>

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-22 at 12 52 26](https://user-images.githubusercontent.com/85479566/209128863-aff0114f-132a-4548-8614-2b83741a2520.png)
</details>

https://github.com/AtB-AS/kundevendt/issues/2740