### PR TITLE
refactor: 'compact' as own field on button

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -39,11 +39,8 @@ const DefaultModeStyles: {[key in ButtonMode]: ButtonSettings} = {
 };
 
 type ButtonTypeAwareProps =
-  | {text?: string; type: 'inline' | 'compact'}
-  | {
-      text: string;
-      type?: 'block';
-    };
+  | {text?: string; type: 'inline'}
+  | {text: string; type?: 'block'};
 
 type ButtonIconProps = {
   svg: ({fill}: {fill: string}) => JSX.Element;
@@ -60,6 +57,7 @@ export type ButtonProps = {
   leftIcon?: ButtonIconProps;
   rightIcon?: ButtonIconProps;
   active?: boolean;
+  compact?: boolean;
 } & ButtonTypeAwareProps &
   TouchableOpacityProps;
 
@@ -77,6 +75,7 @@ const Button = React.forwardRef<any, ButtonProps>(
       text,
       disabled,
       active,
+      compact = false,
       style,
       viewContainerStyle,
       textContainerStyle,
@@ -102,10 +101,9 @@ const Button = React.forwardRef<any, ButtonProps>(
       }).start();
     }, [disabled, fadeAnim]);
 
-    const isInline = type === 'compact' || type === 'inline';
+    const isInline = type === 'inline';
 
-    const spacing =
-      type === 'compact' ? theme.spacings.small : theme.spacings.medium;
+    const spacing = compact ? theme.spacings.small : theme.spacings.medium;
 
     const {background: backgroundColor, text: textColor} = themeColor
       ? theme.interactive[themeColor][active ? 'active' : 'default']

--- a/src/components/map/components/BackArrow.tsx
+++ b/src/components/map/components/BackArrow.tsx
@@ -10,7 +10,8 @@ const BackArrow: React.FC<{onBack(): void} & AccessibilityProps> = ({
 }) => {
   return (
     <Button
-      type="compact"
+      type="inline"
+      compact={true}
       interactiveColor="interactive_0"
       onPress={onBack}
       hitSlop={insets.symmetric(12, 20)}

--- a/src/components/map/components/MapControls.tsx
+++ b/src/components/map/components/MapControls.tsx
@@ -17,7 +17,8 @@ const MapControls: React.FC<Props> = ({zoomIn, zoomOut}) => {
   return (
     <View style={styles.zoomContainer}>
       <Button
-        type="compact"
+        type="inline"
+        compact={true}
         interactiveColor="interactive_2"
         accessibilityRole="button"
         accessibilityLabel={t(MapTexts.controls.zoomIn.a11yLabel)}
@@ -25,7 +26,8 @@ const MapControls: React.FC<Props> = ({zoomIn, zoomOut}) => {
         leftIcon={{svg: Add}}
       />
       <Button
-        type="compact"
+        type="inline"
+        compact={true}
         interactiveColor="interactive_2"
         accessibilityRole="button"
         accessibilityLabel={t(MapTexts.controls.zoomOut.a11yLabel)}

--- a/src/components/map/components/PositionArrow.tsx
+++ b/src/components/map/components/PositionArrow.tsx
@@ -13,7 +13,8 @@ const PositionArrow: React.FC<{onPress(): void} & AccessibilityProps> = ({
 
   return (
     <Button
-      type="compact"
+      type="inline"
+      compact={true}
       interactiveColor="interactive_0"
       onPress={onPress}
       hitSlop={insets.symmetric(12, 20)}

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -279,7 +279,8 @@ function DepartureTimeItem({
   return (
     <Button
       key={departure.serviceJourneyId}
-      type="compact"
+      type="inline"
+      compact={true}
       interactiveColor="interactive_2"
       onPress={() => onPress(departure)}
       text={formatTimeText(departure, searchDate, language, t)}

--- a/src/favorite-chips/index.tsx
+++ b/src/favorite-chips/index.tsx
@@ -135,7 +135,8 @@ const FavoriteChip: React.FC<ButtonProps> = (props) => {
       style={{
         marginRight: theme.spacings.small,
       }}
-      type="compact"
+      type="inline"
+      compact={true}
     />
   );
 };

--- a/src/screens/Departures/components/DateSelection.tsx
+++ b/src/screens/Departures/components/DateSelection.tsx
@@ -108,7 +108,8 @@ export default function DateSelection({
           ),
         )}
         accessibilityHint={t(DeparturesTexts.dateNavigation.a11yChangeDateHint)}
-        type="compact"
+        type="inline"
+        compact={true}
         mode="tertiary"
         rightIcon={{svg: DateIcon}}
         textStyle={{
@@ -123,7 +124,8 @@ export default function DateSelection({
           setSearchTime(changeDay(searchTime, 1));
         }}
         text={t(DeparturesTexts.dateNavigation.nextDay)}
-        type="compact"
+        type="inline"
+        compact={true}
         mode="tertiary"
         rightIcon={{svg: ArrowRight}}
         textStyle={{

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -247,11 +247,17 @@ export default function DesignSystem() {
               rightIcon={{svg: Delete}}
             />
             <Button text="Press me" onPress={presser} type="inline" />
-            <Button text="Press me" onPress={presser} type="compact" />
             <Button
               text="Press me"
               onPress={presser}
-              type="compact"
+              type="inline"
+              compact={true}
+            />
+            <Button
+              text="Press me"
+              onPress={presser}
+              type="inline"
+              compact={true}
               rightIcon={{svg: Delete}}
             />
             <Button

--- a/src/screens/TripDetails/components/PaginatedDetailsHeader.tsx
+++ b/src/screens/TripDetails/components/PaginatedDetailsHeader.tsx
@@ -35,7 +35,8 @@ const PaginatedDetailsHeader: React.FC<PaginatedDetailsHeader> = ({
         <View style={styles.container}>
           <View style={styles.buttonLeft}>
             <Button
-              type="compact"
+              type="inline"
+              compact={true}
               mode="tertiary"
               disabled={!hasPrevious}
               leftIcon={{svg: ArrowLeft}}
@@ -58,7 +59,8 @@ const PaginatedDetailsHeader: React.FC<PaginatedDetailsHeader> = ({
           </ThemeText>
           <View style={styles.buttonRight}>
             <Button
-              type="compact"
+              type="inline"
+              compact={true}
               mode="tertiary"
               disabled={!hasNext}
               rightIcon={{svg: ArrowRight}}


### PR DESCRIPTION
Type 'compact' mainly decided the internal padding of the button, but it also made the button behave as it had type 'inline'. The compact mode was extracted from the type field into its own field, so it is possible to specify compact mode both when the button type is 'inline' or 'block'.