### PR TITLE
refactor: FixedSwitch improvements 

### DIFF
--- a/src/components/switch/FixedSwitch.tsx
+++ b/src/components/switch/FixedSwitch.tsx
@@ -1,12 +1,26 @@
 import useDelayGate from '@atb/utils/use-delay-gate';
 import React, {useEffect, useState} from 'react';
-import {Switch, SwitchProps} from 'react-native';
+import {AccessibilityProps, Switch, SwitchProps, Platform} from 'react-native';
+import {StyleSheet, useTheme} from '@atb/theme';
+import useFontScale from '@atb/utils/use-font-scale';
+import {InteractiveColor} from '@atb/theme/colors';
+
+type Props = Pick<SwitchProps, 'value' | 'onValueChange' | 'testID'> & {
+  interactiveColor?: InteractiveColor;
+} & AccessibilityProps;
 
 // A bug in RN borks Switch animations when Switch is used inside react navigation
 // for Android. A small delay to render and setting value through state
 // seems to mitigate the bug
-export function FixedSwitch({value, onValueChange, ...props}: SwitchProps) {
+export function FixedSwitch({
+  value,
+  onValueChange,
+  interactiveColor = 'interactive_1',
+  ...props
+}: Props) {
   const [checked, setChecked] = useState(value);
+  const {theme} = useTheme();
+  const styles = useStyles();
 
   // Preserve outside changes
   function handleValueChange(value: boolean) {
@@ -22,9 +36,26 @@ export function FixedSwitch({value, onValueChange, ...props}: SwitchProps) {
 
   return delayRender ? (
     <Switch
-      {...props}
       value={checked}
       onValueChange={(value) => handleValueChange(value)}
+      trackColor={{
+        true: theme.interactive[interactiveColor].outline.background,
+      }}
+      thumbColor="white"
+      style={Platform.OS === 'android' ? styles.android : styles.ios}
+      {...props}
     />
   ) : null;
 }
+
+const useStyles = StyleSheet.createThemeHook(() => {
+  const scale = useFontScale();
+  return {
+    android: {
+      transform: [{scale}],
+    },
+    ios: {
+      transform: [{scale: 0.7 * scale}],
+    },
+  };
+});

--- a/src/components/switch/FixedSwitch.tsx
+++ b/src/components/switch/FixedSwitch.tsx
@@ -49,7 +49,8 @@ export function FixedSwitch({
 }
 
 const useStyles = StyleSheet.createThemeHook(() => {
-  const scale = useFontScale();
+  const fontScale = useFontScale();
+  const scale = Math.max(fontScale, 1);
   return {
     android: {
       transform: [{scale}],

--- a/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Platform, ScrollView, View} from 'react-native';
+import {ScrollView, View} from 'react-native';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {Button, ButtonGroup} from '@atb/components/button';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
@@ -16,7 +16,6 @@ import {
 import SelectFavouriteDeparturesText from '@atb/translations/screens/subscreens/SelectFavouriteDeparturesTexts';
 import {TransportationIcon, AnyMode} from '@atb/components/transportation-icon';
 import {useFavorites} from '@atb/favorites';
-import useFontScale from '@atb/utils/use-font-scale';
 import {TransportSubmode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {LegMode} from '@entur/sdk';
 import {SectionSeparator} from '@atb/components/sections';

--- a/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
@@ -86,11 +86,7 @@ const SelectableFavouriteDeparture = ({
         <FixedSwitch
           importantForAccessibility="no"
           value={active}
-          onChange={() => handleSwitchFlip(favouriteId, !active)}
-          style={[
-            styles.toggle,
-            Platform.OS === 'android' ? styles.androidToggle : styles.iosToggle,
-          ]}
+          onValueChange={(value) => handleSwitchFlip(favouriteId, value)}
         />
       </View>
     </View>
@@ -224,7 +220,6 @@ const SelectFavouritesBottomSheet = ({
 export default SelectFavouritesBottomSheet;
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const scale = useFontScale();
   return {
     container: {
       flex: 1,
@@ -257,16 +252,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
     lineIdentiferText: {
       marginBottom: theme.spacings.small,
-    },
-    toggle: {
-      alignSelf: 'center',
-    },
-    androidToggle: {
-      transform: [{scale: scale}, {translateY: -6}],
-    },
-    iosToggle: {
-      marginLeft: theme.spacings.xSmall,
-      transform: [{scale: scale}],
     },
   };
 });

--- a/src/screens/Ticketing/Purchase/Overview/components/InfoToggle.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/InfoToggle.tsx
@@ -1,10 +1,9 @@
 import {FixedSwitch} from '@atb/components/switch';
 import {ThemeText} from '@atb/components/text';
 import {usePreferences} from '@atb/preferences';
-import useFontScale from '@atb/utils/use-font-scale';
 import React from 'react';
-import {View, Platform} from 'react-native';
-import {StyleSheet} from '@atb/theme';
+import {View} from 'react-native';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 
 export default function InfoToggle({
@@ -22,39 +21,23 @@ export default function InfoToggle({
   } = usePreferences();
 
   return (
-    <View
-      style={{flex: 1, flexDirection: 'row', justifyContent: 'space-between'}}
-    >
-      <View style={{flexGrow: 1}}>
-        <ThemeText
-          type="body__secondary"
-          color="secondary"
-          style={styles.title}
-        >
+    <View style={styles.container}>
+      <View style={{flexShrink: 1}}>
+        <ThemeText type="body__secondary" color="secondary">
           {title}
         </ThemeText>
       </View>
 
-      <View
-        style={{
-          flex: 1,
-          flexDirection: 'row',
-          flexGrow: 1,
-          justifyContent: 'flex-end',
-        }}
-      >
+      <View style={styles.switchAndLabel}>
         <ThemeText
           type="body__secondary"
           accessible={false}
           importantForAccessibility="no"
+          style={styles.label}
         >
           {t(PurchaseOverviewTexts.infoToggle.label)}
         </ThemeText>
         <FixedSwitch
-          style={[
-            styles.toggle,
-            Platform.OS === 'android' ? styles.androidToggle : styles.iosToggle,
-          ]}
           value={!hideDescriptions}
           onValueChange={(checked) => {
             setPreference({hideTravellerDescriptions: !checked});
@@ -67,20 +50,18 @@ export default function InfoToggle({
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const scale = useFontScale();
   return {
-    title: {
+    container: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
       marginBottom: theme.spacings.medium,
+      alignItems: 'center',
     },
-    toggle: {
-      alignSelf: 'center',
+    switchAndLabel: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
     },
-    androidToggle: {
-      transform: [{scale: scale}, {translateY: -6}],
-    },
-    iosToggle: {
-      marginLeft: theme.spacings.xSmall,
-      transform: [{scale: 0.7 * scale}, {translateY: -10}],
-    },
+    label: {marginRight: theme.spacings.xSmall},
   };
 });

--- a/src/screens/Ticketing/Purchase/Overview/components/InfoToggle.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/InfoToggle.tsx
@@ -3,7 +3,7 @@ import {ThemeText} from '@atb/components/text';
 import {usePreferences} from '@atb/preferences';
 import React from 'react';
 import {View} from 'react-native';
-import {StyleSheet, useTheme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 
 export default function InfoToggle({


### PR DESCRIPTION
Everywhere the FixedSwitch was used there was need for scaling it
with font scale etc. This is now moved into the FixedSwitch so the
scaling is done in just one place.

Also add the possibility for setting an interactive color for the
switch.

Affects mainly three places:
- The switch in select favourites
- The switch on InfoToggle (like on show travellers info text)
- The switches under "My profile"