### PR TITLE
chore: upgrade theme package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "unimported": "npx unimported"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.1.3",
+    "@atb-as/theme": "^6.2.1",
     "@bugsnag/react-native": "^7.17.3",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-client-sdk": "^1.1.6",

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -55,7 +55,7 @@ export default function DesignSystem() {
         padding: theme.spacings.medium,
       }}
     >
-      {name}
+      {name} {color.text} / {color.background}
     </ThemeText>
   );
 
@@ -77,6 +77,20 @@ export default function DesignSystem() {
     const staticColor =
       theme.static.status[color as StaticColorByType<'status'>];
     return <Swatch color={staticColor} name={color} key={color} />;
+  });
+
+  const textSwatches = Object.keys(theme.text.colors).map((color) => {
+    const textColors = theme.text.colors;
+    return (
+      <Swatch
+        color={{
+          text: theme.static.background.background_0.background,
+          background: textColors[color as keyof typeof textColors],
+        }}
+        name={color}
+        key={color}
+      />
+    );
   });
 
   const radioSegmentsOptions = [
@@ -422,6 +436,10 @@ export default function DesignSystem() {
         <View style={style.swatchGroup}>{backgroundSwatches}</View>
         <View style={style.swatchGroup}>{transportSwatches}</View>
         <View style={style.swatchGroup}>{statusSwatches}</View>
+        <View style={style.swatchGroup}>
+          <ThemeText>Text colors:</ThemeText>
+          {textSwatches}
+        </View>
 
         <View style={{margin: theme.spacings.medium}}>
           <ThemeText>Segmented controls:</ThemeText>

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,14 +21,6 @@
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.1.3.tgz#f151c6708e20cc64a216745224b20aed05492010"
-  integrity sha512-/Yb4PP+7ZeJtysPOsIUgnHY+l7NLR+bAEaDhzulEdy3e1HU39ZkY6xJtZ+02EiLkMPFPrjAz9ZmOuFxWjyblew==
-  dependencies:
-    hex-to-rgba "^2.0.1"
-    ts-deepmerge "^4.0.0"
-
 "@atb-as/theme@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.2.1.tgz#820e3e7cee8814d02e28b9366b88d1f24095ecc8"


### PR DESCRIPTION
Upgrades theme package to include new secondary text color in dark mode. Also adds text colors to the design system page, and displays color codes on swatches.

<img width="400px" src="https://user-images.githubusercontent.com/1774972/210349381-9115da0d-6905-4071-b143-8a032088ab75.png">

closes https://github.com/AtB-AS/kundevendt/issues/3040