### PR TITLE
refactor: Remove expand option in ActionSectionItem

### DIFF
--- a/src/components/sections/items/ActionSectionItem.tsx
+++ b/src/components/sections/items/ActionSectionItem.tsx
@@ -7,9 +7,8 @@ import {
 } from 'react-native';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
-import {SectionTexts, useTranslation} from '@atb/translations';
 import {ThemeText} from '@atb/components/text';
-import {NavigationIcon, ThemeIcon} from '@atb/components/theme-icon';
+import {ThemeIcon} from '@atb/components/theme-icon';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
@@ -18,7 +17,7 @@ import {FixedSwitch} from '@atb/components/switch';
 import {InteractiveColor} from '@atb/theme/colors';
 import {SvgProps} from 'react-native-svg';
 
-type ActionModes = 'check' | 'toggle' | 'heading-expand';
+type ActionModes = 'check' | 'toggle';
 type Props = SectionItemProps<{
   text: string;
   subtext?: string;
@@ -94,9 +93,7 @@ export function ActionSectionItem({
       {leftIcon && <ThemeIcon svg={leftIcon} style={styles.leftIcon} />}
       <View style={{flexShrink: 1}}>
         <ThemeText
-          type={
-            mode === 'heading-expand' ? 'body__primary--bold' : 'body__primary'
-          }
+          type="body__primary"
           style={[
             contentContainer,
             interactiveColor ? {color: interactiveColor.text} : undefined,
@@ -128,8 +125,6 @@ function ActionModeIcon({
   checked,
   color,
 }: Pick<Props, 'mode' | 'checked' | 'color'>) {
-  const styles = useStyles();
-  const {t} = useTranslation();
   const {theme} = useTheme();
 
   switch (mode) {
@@ -142,23 +137,6 @@ function ActionModeIcon({
             : undefined)}
           fillOpacity={checked ? 1 : 0}
         />
-      );
-    }
-    case 'heading-expand': {
-      const text = checked
-        ? t(SectionTexts.actionSectionItem.headingExpand.toggle.contract)
-        : t(SectionTexts.actionSectionItem.headingExpand.toggle.expand);
-      const icon = checked ? 'expand-less' : 'expand-more';
-      return (
-        <View style={styles.headerExpandIconGroup}>
-          <ThemeText
-            style={styles.headerExpandIconGroup__text}
-            type="body__secondary"
-          >
-            {text}
-          </ThemeText>
-          <NavigationIcon mode={icon} />
-        </View>
       );
     }
   }

--- a/src/departure-list/DeparturesList.tsx
+++ b/src/departure-list/DeparturesList.tsx
@@ -1,17 +1,16 @@
 import {StopPlaceGroup} from '@atb/api/departures/types';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
-import {ActionSectionItem} from '@atb/components/sections';
+import {ExpandableSectionItem} from '@atb/components/sections';
 import {Location} from '@atb/favorites/types';
 import {MessageBox} from '@atb/components/message-box';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {NearbyTexts, useTranslation} from '@atb/translations';
-import {animateNextChange} from '@atb/utils/animation';
 import React, {useEffect, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
-import QuaySection from './section-items/quay-section';
 import {hasNoGroupsWithDepartures, hasNoQuaysWithDepartures} from './utils';
 import {StopPlace} from '@atb/api/types/trips';
 import DeparturesTexts from '@atb/translations/screens/Departures';
+import QuaySection from '@atb/departure-list/section-items/quay-section';
 
 type DeparturesListProps = {
   departures: StopPlaceGroup[] | null;
@@ -142,7 +141,6 @@ const StopDepartures = React.memo(function StopDepartures({
   searchDate,
   testID,
 }: StopDeparturesProps) {
-  const {t} = useTranslation();
   const [expanded, setExpanded] = useState(
     defaultExpanded || disableCollapsing,
   );
@@ -159,25 +157,17 @@ const StopDepartures = React.memo(function StopDepartures({
   }
 
   return (
-    <View accessibilityState={{expanded}} testID={testID}>
+    <View testID={testID}>
       {!disableCollapsing && (
-        <ActionSectionItem
+        <ExpandableSectionItem
           transparent
           text={stopPlaceGroup.stopPlace.name}
-          mode="heading-expand"
-          onPress={() => {
-            animateNextChange();
-            setExpanded(!expanded);
-          }}
-          checked={expanded}
-          accessibility={{
-            accessibilityHint: t(
-              NearbyTexts.results.stops.header[
-                expanded ? 'hintHide' : 'hintShow'
-              ],
-            ),
-          }}
+          textType="body__primary--bold"
+          onPress={() => setExpanded(!expanded)}
+          initiallyExpanded={defaultExpanded}
           testID={testID + 'HideAction'}
+          showIconText={true}
+          expanded={expanded}
         />
       )}
 

--- a/src/translations/components/Section.ts
+++ b/src/translations/components/Section.ts
@@ -14,12 +14,14 @@ const SectionTexts = {
   timeInput: {
     label: _('Tid', 'Time'),
   },
-  actionSectionItem: {
-    headingExpand: {
-      toggle: {
-        expand: _('Vis', 'Show'),
-        contract: _('Skjul', 'Hide'),
-      },
+  expandableSectionItem: {
+    a11yHint: {
+      expand: _('Aktiver for å vise', 'Activate to show'),
+      contract: _('Aktiver for å skjule', 'Activate to hide'),
+    },
+    iconText: {
+      expand: _('Vis', 'Show'),
+      contract: _('Skjul', 'Hide'),
     },
   },
   textInput: {


### PR DESCRIPTION
Two main reasons:
- The ActionSectionItem was quite large and complex, with options for expandable, checkable and toggleable. It is better if these are seperate components.
- We already have the ExpandableSectionItem which should instead be used for this.

### Acceptance criteria
This affects two places, the FAQ in SelectTokenScreen, and the expandable stop place name in v1 departures.

- [ ] Should look and feel as before
- [ ] Should work good with screen reader