### PR TITLE
refactor: Fix some filters design flaws

### DIFF
--- a/src/components/sections/items/InternalLabeledSectionItem.tsx
+++ b/src/components/sections/items/InternalLabeledSectionItem.tsx
@@ -55,12 +55,7 @@ export function InternalLabeledSectionItem({
 
 const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   icon: {marginRight: theme.spacings.small},
-  label: {
-    // @TODO Find a better way to do this.
-    minWidth: 60 - theme.spacings.medium,
-    flex: 1,
-    flexWrap: 'wrap',
-  },
+  label: {flex: 1},
   subtext: {
     marginTop: theme.spacings.small,
   },

--- a/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
@@ -142,9 +142,10 @@ const SelectFavouritesBottomSheet = ({
 
             <View>
               {updatedFavorites &&
-                updatedFavorites.map((favorite, index) => {
+                updatedFavorites.map((favorite) => {
                   return (
                     <View key={favorite.id}>
+                      <SectionSeparator />
                       <SelectableFavouriteDeparture
                         handleSwitchFlip={handleSwitchFlip}
                         favouriteId={favorite.id}
@@ -166,9 +167,6 @@ const SelectFavouritesBottomSheet = ({
                           favorite.lineTransportationSubMode
                         }
                       />
-                      {favouriteItems.length - 1 !== index && (
-                        <SectionSeparator />
-                      )}
                     </View>
                   );
                 })}

--- a/src/screens/Dashboard/TravelSearchFiltersBottomSheet.tsx
+++ b/src/screens/Dashboard/TravelSearchFiltersBottomSheet.tsx
@@ -42,6 +42,9 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
     close();
   };
 
+  const allModesSelected =
+    (selectedModes?.length || 0) >= (filters.transportModes?.length || 0);
+
   return (
     <BottomSheetContainer maxHeightValue={0.9}>
       <ScreenHeaderWithoutNavigation
@@ -63,7 +66,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
           <Sections.ActionSectionItem
             mode="toggle"
             text={t(TripSearchTexts.filters.modes.all)}
-            checked={selectedModes?.length === filters.transportModes?.length}
+            checked={allModesSelected}
             onPress={(checked) => {
               setSelectedModes(checked ? filters.transportModes : []);
             }}


### PR DESCRIPTION
- Add section seperator under heading for select favourites bottom sheet so it looks the same as the filters bottom sheet.
- Some changes to the internal section label so text doesn't overflow.
- Fixed a bug where removing a filter option from Firestore made the "all" button work incorrectly.