### PR TITLE
refactor: Add ToggleSectionItem

### DIFF
--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -12,6 +12,7 @@ export {GenericClickableSectionItem} from './items/GenericClickableSectionItem';
 export {FavoriteSectionItem} from './items/FavoriteSectionItem';
 export {FavoriteDepartureSectionItem} from './items/FavoriteDepartureSectionItem';
 export {ExpandableSectionItem} from './items/ExpandableSectionItem';
+export {ToggleSectionItem} from './items/ToggleSectionItem';
 
 // Inputs
 export {TimeInputSectionItem} from './items/time-input';

--- a/src/components/sections/items/ActionSectionItem.tsx
+++ b/src/components/sections/items/ActionSectionItem.tsx
@@ -12,12 +12,10 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
-import {InternalLabeledSectionItem} from './InternalLabeledSectionItem';
-import {FixedSwitch} from '@atb/components/switch';
 import {InteractiveColor} from '@atb/theme/colors';
 import {SvgProps} from 'react-native-svg';
 
-type ActionModes = 'check' | 'toggle';
+type ActionModes = 'check';
 type Props = SectionItemProps<{
   text: string;
   subtext?: string;
@@ -48,26 +46,6 @@ export function ActionSectionItem({
   const {theme} = useTheme();
   const interactiveColor =
     color && checked ? theme.interactive[color].active : undefined;
-
-  if (mode === 'toggle') {
-    return (
-      <InternalLabeledSectionItem
-        label={text}
-        leftIcon={leftIcon}
-        accessibleLabel={false}
-        subtext={hideSubtext ? undefined : subtext}
-        {...props}
-      >
-        <FixedSwitch
-          value={checked}
-          onValueChange={(value) => onPress?.(value)}
-          accessibilityLabel={text + (subtext ? ',' + subtext : '')}
-          testID={testID}
-          {...accessibility}
-        />
-      </InternalLabeledSectionItem>
-    );
-  }
 
   const role: AccessibilityRole = mode === 'check' ? 'radio' : 'switch';
   const stateName = mode === 'check' ? 'selected' : 'expanded';

--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -1,0 +1,91 @@
+import React, {useEffect, useState} from 'react';
+import {AccessibilityProps, View} from 'react-native';
+import {StyleSheet, Theme} from '@atb/theme';
+import {ThemeText} from '@atb/components/text';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {useSectionItem} from '../use-section-item';
+import {SectionItemProps} from '../types';
+import {useSectionStyle} from '../use-section-style';
+import {Toggle} from '@atb/components/toggle';
+import {InteractiveColor} from '@atb/theme/colors';
+import {SvgProps} from 'react-native-svg';
+
+type Props = SectionItemProps<{
+  text: string;
+  subtext?: string;
+  onValueChange: (checked: boolean) => void;
+  value?: boolean;
+  leftIcon?: (props: SvgProps) => JSX.Element;
+  interactiveColor?: InteractiveColor;
+  accessibility?: AccessibilityProps;
+}>;
+export function ToggleSectionItem({
+  text,
+  subtext,
+  onValueChange,
+  leftIcon,
+  value = false,
+  accessibility,
+  testID,
+  interactiveColor,
+  ...props
+}: Props) {
+  const {topContainer} = useSectionItem(props);
+  const sectionStyle = useSectionStyle();
+  const styles = useStyles();
+
+  /*
+   Need to maintain a internal copy of the checked state for the accessibility
+   state to be read correctly. This is because we need an immediate rerender of
+   the component so the accessibilityState is updated before the screen reader
+   announces the value. This is also why we use the setTimeout-trick on the
+   onValueChange callback, so the rerender doesn't need to wait until that
+   method has finished execution.
+   */
+  const [checked, setChecked] = useState(value);
+  useEffect(() => setChecked(value), [value]);
+  const onChange = (v: boolean) => {
+    setChecked(v);
+    setTimeout(() => onValueChange(v), 0);
+  };
+
+  return (
+    <View
+      style={[sectionStyle.spaceBetween, topContainer]}
+      accessible={true}
+      accessibilityRole="switch"
+      accessibilityState={{checked: checked}}
+      accessibilityActions={[{name: 'activate'}]}
+      onAccessibilityAction={() => onChange(!checked)}
+      {...accessibility}
+    >
+      {leftIcon && <ThemeIcon svg={leftIcon} style={styles.leftIcon} />}
+      <View style={styles.textContainer}>
+        <ThemeText>{text}</ThemeText>
+        {subtext && (
+          <ThemeText
+            type="body__secondary"
+            color="secondary"
+            style={styles.subtext}
+          >
+            {subtext}
+          </ThemeText>
+        )}
+      </View>
+      <Toggle
+        importantForAccessibility={'no-hide-descendants'}
+        accessible={false}
+        value={checked}
+        onValueChange={onChange}
+        testID={testID}
+        interactiveColor={interactiveColor}
+      />
+    </View>
+  );
+}
+
+const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
+  leftIcon: {marginRight: theme.spacings.small},
+  textContainer: {flex: 1, marginRight: theme.spacings.small},
+  subtext: {marginTop: theme.spacings.small},
+}));

--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -73,7 +73,7 @@ export function ToggleSectionItem({
         )}
       </View>
       <Toggle
-        importantForAccessibility={'no-hide-descendants'}
+        importantForAccessibility="no-hide-descendants"
         accessible={false}
         value={checked}
         onValueChange={onChange}

--- a/src/components/switch/index.ts
+++ b/src/components/switch/index.ts
@@ -1,1 +1,0 @@
-export {FixedSwitch} from './FixedSwitch';

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -12,7 +12,7 @@ type Props = Pick<SwitchProps, 'value' | 'onValueChange' | 'testID'> & {
 // A bug in RN borks Switch animations when Switch is used inside react navigation
 // for Android. A small delay to render and setting value through state
 // seems to mitigate the bug
-export function FixedSwitch({
+export function Toggle({
   value,
   onValueChange,
   interactiveColor = 'interactive_1',

--- a/src/components/toggle/index.ts
+++ b/src/components/toggle/index.ts
@@ -1,0 +1,1 @@
+export {Toggle} from './Toggle';

--- a/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
+++ b/src/screens/Dashboard/SelectFavouritesBottomSheet.tsx
@@ -3,7 +3,7 @@ import {ScrollView, View} from 'react-native';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {Button, ButtonGroup} from '@atb/components/button';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
-import {FixedSwitch} from '@atb/components/switch';
+import {Toggle} from '@atb/components/toggle';
 import {ThemeText} from '@atb/components/text';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
@@ -82,7 +82,7 @@ const SelectableFavouriteDeparture = ({
       </View>
 
       <View>
-        <FixedSwitch
+        <Toggle
           importantForAccessibility="no"
           value={active}
           onValueChange={(value) => handleSwitchFlip(favouriteId, value)}

--- a/src/screens/Dashboard/TravelSearchFiltersBottomSheet.tsx
+++ b/src/screens/Dashboard/TravelSearchFiltersBottomSheet.tsx
@@ -60,11 +60,10 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
           <Sections.HeaderSectionItem
             text={t(TripSearchTexts.filters.modes.heading)}
           />
-          <Sections.ActionSectionItem
-            mode="toggle"
+          <Sections.ToggleSectionItem
             text={t(TripSearchTexts.filters.modes.all)}
-            checked={selectedModes?.length === filters.transportModes?.length}
-            onPress={(checked) => {
+            value={selectedModes?.length === filters.transportModes?.length}
+            onValueChange={(checked) => {
               setSelectedModes(checked ? filters.transportModes : []);
             }}
           />
@@ -75,9 +74,8 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
               language,
             );
             return text ? (
-              <Sections.ActionSectionItem
+              <Sections.ToggleSectionItem
                 key={option.id}
-                mode="toggle"
                 text={text}
                 leftIcon={
                   getTransportModeSvg(
@@ -86,8 +84,8 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
                   ) || Add
                 }
                 subtext={description}
-                checked={selectedModes?.some(({id}) => id === option.id)}
-                onPress={(checked) => {
+                value={selectedModes?.some(({id}) => id === option.id)}
+                onValueChange={(checked) => {
                   setSelectedModes(
                     checked
                       ? selectedModes?.concat(option)

--- a/src/screens/Departures/components/FavoriteToggle.tsx
+++ b/src/screens/Departures/components/FavoriteToggle.tsx
@@ -1,4 +1,4 @@
-import {ActionSectionItem} from '@atb/components/sections';
+import {ToggleSectionItem} from '@atb/components/sections';
 import {useTranslation} from '@atb/translations';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import React from 'react';
@@ -15,12 +15,11 @@ export default function FavoriteToggle({
   const {t} = useTranslation();
 
   return (
-    <ActionSectionItem
+    <ToggleSectionItem
       transparent
       text={t(DeparturesTexts.favorites.toggle)}
-      mode="toggle"
-      checked={enabled}
-      onPress={setEnabled}
+      value={enabled}
+      onValueChange={setEnabled}
       testID="showOnlyFavoritesButton"
     />
   );

--- a/src/screens/Nearby/Nearby.tsx
+++ b/src/screens/Nearby/Nearby.tsx
@@ -6,9 +6,9 @@ import {Button} from '@atb/components/button';
 import {SimpleDisappearingHeader} from '@atb/components/disappearing-header';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {
-  ActionSectionItem,
   LocationInputSectionItem,
   Section,
+  ToggleSectionItem,
 } from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import DeparturesList from '@atb/departure-list/DeparturesList';
@@ -253,12 +253,11 @@ const NearbyOverview: React.FC<Props> = ({
 
       {data !== null && (
         <View style={styles.container}>
-          <ActionSectionItem
+          <ToggleSectionItem
             transparent
             text={t(NearbyTexts.favorites.toggle)}
-            mode="toggle"
-            checked={showOnlyFavorites}
-            onPress={toggleShowFavorites}
+            value={showOnlyFavorites}
+            onValueChange={toggleShowFavorites}
             testID="showOnlyFavoritesButton"
           />
         </View>

--- a/src/screens/Profile/Appearance/index.tsx
+++ b/src/screens/Profile/Appearance/index.tsx
@@ -1,4 +1,4 @@
-import {ActionSectionItem, Section} from '@atb/components/sections';
+import {Section, ToggleSectionItem} from '@atb/components/sections';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {AppearanceSettingsTexts, useTranslation} from '@atb/translations';
 import React from 'react';
@@ -27,19 +27,17 @@ export default function Appearance() {
 
       <ScrollView>
         <Section withTopPadding withPadding>
-          <ActionSectionItem
-            mode="toggle"
+          <ToggleSectionItem
             text={t(AppearanceSettingsTexts.actions.usePhoneTheme)}
-            checked={!overrideSystemAppearance}
-            onPress={(checked) => overrideOSThemePreference(!checked)}
+            value={!overrideSystemAppearance}
+            onValueChange={(checked) => overrideOSThemePreference(!checked)}
           />
 
           {overrideSystemAppearance && (
-            <ActionSectionItem
-              mode="toggle"
+            <ToggleSectionItem
               text={t(AppearanceSettingsTexts.actions.darkMode)}
-              checked={storedColorScheme === 'dark'}
-              onPress={(checked) =>
+              value={storedColorScheme === 'dark'}
+              onValueChange={(checked) =>
                 updateThemePreference(checked ? 'dark' : 'light')
               }
             />
@@ -47,11 +45,10 @@ export default function Appearance() {
         </Section>
         {Platform.OS === 'android' && (
           <Section withTopPadding withPadding>
-            <ActionSectionItem
-              mode="toggle"
+            <ToggleSectionItem
               text={t(AppearanceSettingsTexts.actions.useSystemFont)}
-              checked={useAndroidSystemFont}
-              onPress={(checked) => updateAndroidFontOverride(checked)}
+              value={useAndroidSystemFont}
+              onValueChange={(checked) => updateAndroidFontOverride(checked)}
             />
           </Section>
         )}

--- a/src/screens/Profile/DebugInfo/index.tsx
+++ b/src/screens/Profile/DebugInfo/index.tsx
@@ -112,11 +112,10 @@ export default function DebugInfo() {
 
       <ScrollView testID="debugInfoScrollView">
         <Sections.Section withPadding withTopPadding>
-          <Sections.ActionSectionItem
-            mode="toggle"
+          <Sections.ToggleSectionItem
             text="Toggle test-ID"
-            checked={showTestIds}
-            onPress={(showTestIds) => {
+            value={showTestIds}
+            onValueChange={(showTestIds) => {
               setPreference({showTestIds});
             }}
           />

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -306,11 +306,10 @@ export default function DesignSystem() {
             leftIcon={Bus}
             checked
           />
-          <Sections.ActionSectionItem
+          <Sections.ToggleSectionItem
             text="Some short text"
-            mode="toggle"
             leftIcon={Bus}
-            onPress={() => {}}
+            onValueChange={() => {}}
           />
           <Sections.ActionSectionItem
             text="Some short text"

--- a/src/screens/Profile/Home/index.tsx
+++ b/src/screens/Profile/Home/index.tsx
@@ -329,20 +329,18 @@ export default function ProfileHome({navigation}: ProfileProps) {
               </View>
             </View>
           </Sections.GenericSectionItem>
-          <Sections.ActionSectionItem
-            mode="toggle"
+          <Sections.ToggleSectionItem
             text={t(ProfileTexts.sections.newFeatures.departures)}
-            checked={isDeparuresV2Enabled}
-            onPress={setDeparturesV2Enabled}
+            value={isDeparuresV2Enabled}
+            onValueChange={setDeparturesV2Enabled}
             testID="newDeparturesToggle"
           />
           {enable_map_page ? (
-            <Sections.ActionSectionItem
-              mode="toggle"
+            <Sections.ToggleSectionItem
               text={t(ProfileTexts.sections.newFeatures.map)}
-              checked={showMapPage}
+              value={showMapPage}
               testID="enableMapPageToggle"
-              onPress={(enableMapPage) => {
+              onValueChange={(enableMapPage) => {
                 setPreference({enableMapPage: enableMapPage});
               }}
             />

--- a/src/screens/Profile/Language/index.tsx
+++ b/src/screens/Profile/Language/index.tsx
@@ -1,7 +1,7 @@
 import {
-  ActionSectionItem,
   RadioGroupSection,
   Section,
+  ToggleSectionItem,
 } from '@atb/components/sections';
 import {Preference_Language, usePreferences} from '@atb/preferences';
 import {StyleSheet, Theme} from '@atb/theme';
@@ -36,11 +36,10 @@ export default function Language() {
       />
       <ScrollView>
         <Section withPadding withTopPadding>
-          <ActionSectionItem
-            mode="toggle"
+          <ToggleSectionItem
             text={t(LanguageSettingsTexts.usePhoneSettings)}
-            checked={useSystemLanguage}
-            onPress={(checked) => {
+            value={useSystemLanguage}
+            onValueChange={(checked) => {
               setPreference({
                 useSystemLanguage: checked,
                 language: language || DEFAULT_LANGUAGE,

--- a/src/screens/Ticketing/Purchase/Overview/components/InfoToggle.tsx
+++ b/src/screens/Ticketing/Purchase/Overview/components/InfoToggle.tsx
@@ -1,4 +1,4 @@
-import {FixedSwitch} from '@atb/components/switch';
+import {Toggle} from '@atb/components/toggle';
 import {ThemeText} from '@atb/components/text';
 import {usePreferences} from '@atb/preferences';
 import React from 'react';
@@ -37,7 +37,7 @@ export default function InfoToggle({
         >
           {t(PurchaseOverviewTexts.infoToggle.label)}
         </ThemeText>
-        <FixedSwitch
+        <Toggle
           value={!hideDescriptions}
           onValueChange={(checked) => {
             setPreference({hideTravellerDescriptions: !checked});


### PR DESCRIPTION
The old 'toggle' mode on ActionSectionItem had some screen reader challenges. This is fixed in this commit, alongside some restructuring.

- Created a new ToggleSectionItem instead of using ActionSectionItem.
- Renamed FixedSwitch to Toggle. This is because toggle is used as the word for the component in design-sketches/Figma, and it is slightly more intuitive.
- Parameter names are now 'value' and 'onValueChange' so it is the same parameters as using the Toggle (previously FixedSwitch) directly.
- When using screen reader the whole section item is now selected, and some extra measures has been added to ensure the accessibility state is read correctly.