### PR TITLE
build: register nfk app versions

### DIFF
--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -87,12 +87,10 @@ jobs:
           GOOGLE_PLAY_SERVICE_ACCOUNT_PATH: google-play-service-account.json
           ANDROID_PACKAGE_NAME: ${{ env.ANDROID_APPLICATION_ID }}
       - name: Upload bundle and source maps
-        if: matrix.org == 'atb'
         run: bash ./scripts/android/upload-sourcemaps.sh
         env:
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
       - name: Register app version
-        if: matrix.org == 'atb'
         run: bash ./scripts/android/register-app-version.sh
         env:
           ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_PRODUCTION}}

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run fastlane build
         run: bundle exec fastlane ios build
         env:
-          # A workaround for Github Actions which breaks for a timeout in some cases,
+          # A workaround for Github Actions which breaks for a timeout in some cases, 
           # so this sets a higher value for TIMEOUT and reduces the number of retries
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 1

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run fastlane build
         run: bundle exec fastlane ios build
         env:
-          # A workaround for Github Actions which breaks for a timeout in some cases, 
+          # A workaround for Github Actions which breaks for a timeout in some cases,
           # so this sets a higher value for TIMEOUT and reduces the number of retries
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 1
@@ -67,7 +67,6 @@ jobs:
         env:
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
       - name: Register app version
-        if: matrix.org == 'atb'
         run: sh ./scripts/ios/register-app-version.sh
         env:
           ENTUR_CLIENT_ID: ${{ secrets.ATB_ENTUR_CLIENT_ID_PRODUCTION}}


### PR DESCRIPTION
Registering NFK iOS and Android app versions with Entur, while also uploading source maps for NFK Android.