### PR TITLE
refactor: Add support for notification on icons

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -12,7 +12,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import {ThemeIcon} from '@atb/components/theme-icon';
+import {ThemeIcon, ThemeIconProps} from '@atb/components/theme-icon';
 
 type ButtonMode = 'primary' | 'secondary' | 'tertiary';
 
@@ -44,6 +44,7 @@ type ButtonTypeAwareProps =
 type ButtonIconProps = {
   svg: ({fill}: {fill: string}) => JSX.Element;
   size?: keyof Theme['icon']['size'];
+  notificationColor?: ThemeIconProps['notificationColor'];
 };
 
 export type ButtonProps = {
@@ -166,11 +167,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
         >
           {leftIcon && (
             <View style={leftStyling}>
-              <ThemeIcon
-                svg={leftIcon.svg}
-                fill={textColor}
-                size={leftIcon.size}
-              />
+              <ThemeIcon fill={textColor} {...leftIcon} />
             </View>
           )}
           {text && (
@@ -189,11 +186,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
           )}
           {rightIcon && (
             <View style={rightStyling}>
-              <ThemeIcon
-                svg={rightIcon.svg}
-                fill={textColor}
-                size={rightIcon.size}
-              />
+              <ThemeIcon fill={textColor} {...rightIcon} />
             </View>
           )}
         </TouchableOpacity>

--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -1,0 +1,71 @@
+import {StyleSheet, Theme, useTheme} from '@atb/theme';
+import {View} from 'react-native';
+import {ThemeIconProps} from './ThemeIcon';
+import {
+  flatStaticColors,
+  isInteractiveColor,
+  isStaticColor,
+  isStatusColor,
+  Mode,
+} from '@atb/theme/colors';
+import type {NotificationColor} from './types';
+
+export const NotificationIndicator = ({
+  color,
+  iconSize,
+}: {
+  color: NotificationColor;
+  iconSize: ThemeIconProps['size'];
+}) => {
+  const {theme, themeName} = useTheme();
+  const notificationColor = getNotificationColor(theme, themeName, color);
+  const styles = useStyles();
+  const indicatorSize = getIndicatorSize(iconSize);
+  return (
+    <View
+      style={{
+        ...styles.indicator,
+        backgroundColor: notificationColor,
+        height: indicatorSize,
+        width: indicatorSize,
+      }}
+    />
+  );
+};
+
+function getNotificationColor(
+  theme: Theme,
+  themeType: Mode,
+  colorType: NotificationColor,
+): string {
+  if (isStatusColor(colorType)) {
+    return theme.static.status[colorType].background;
+  } else if (isStaticColor(colorType)) {
+    return flatStaticColors[themeType][colorType].background;
+  } else if (isInteractiveColor(colorType)) {
+    return theme.interactive[colorType].outline.background;
+  } else {
+    return theme.text.colors[colorType];
+  }
+}
+
+const getIndicatorSize = (size: ThemeIconProps['size']) => {
+  switch (size) {
+    case 'small':
+      return 4;
+    case 'large':
+      return 8;
+    default:
+      return 6;
+  }
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  indicator: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    borderRadius: theme.border.radius.circle,
+    zIndex: 10,
+  },
+}));

--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -1,4 +1,4 @@
-import {StyleSheet, Theme, useTheme} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {View} from 'react-native';
 import {ThemeIconProps} from './ThemeIcon';
 import {
@@ -6,7 +6,6 @@ import {
   isInteractiveColor,
   isStaticColor,
   isStatusColor,
-  Mode,
 } from '@atb/theme/colors';
 import type {NotificationColor} from './types';
 
@@ -17,9 +16,8 @@ export const NotificationIndicator = ({
   color: NotificationColor;
   iconSize: ThemeIconProps['size'];
 }) => {
-  const {theme, themeName} = useTheme();
-  const notificationColor = getNotificationColor(theme, themeName, color);
   const styles = useStyles();
+  const notificationColor = useNotificationColor(color);
   const indicatorSize = getIndicatorSize(iconSize);
   return (
     <View
@@ -33,19 +31,16 @@ export const NotificationIndicator = ({
   );
 };
 
-function getNotificationColor(
-  theme: Theme,
-  themeType: Mode,
-  colorType: NotificationColor,
-): string {
-  if (isStatusColor(colorType)) {
-    return theme.static.status[colorType].background;
-  } else if (isStaticColor(colorType)) {
-    return flatStaticColors[themeType][colorType].background;
-  } else if (isInteractiveColor(colorType)) {
-    return theme.interactive[colorType].outline.background;
+function useNotificationColor(color: NotificationColor): string {
+  const {theme, themeName} = useTheme();
+  if (isStatusColor(color)) {
+    return theme.static.status[color].background;
+  } else if (isStaticColor(color)) {
+    return flatStaticColors[themeName][color].background;
+  } else if (isInteractiveColor(color)) {
+    return theme.interactive[color].outline.background;
   } else {
-    return theme.text.colors[colorType];
+    return theme.text.colors[color];
   }
 }
 

--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -1,22 +1,22 @@
 import {useTheme} from '@atb/theme';
 import {
-  TextColor,
-  Theme,
-  Mode,
-  StaticColor,
-  isStaticColor,
   flatStaticColors,
+  isStaticColor,
   isStatusColor,
+  Mode,
+  Theme,
 } from '@atb/theme/colors';
 import {SvgProps} from 'react-native-svg';
 import useFontScale from '@atb/utils/use-font-scale';
+import {View} from 'react-native';
+import type {IconColor, NotificationColor} from './types';
+import {NotificationIndicator} from '@atb/components/theme-icon/NotificationIndicator';
 
-type IconColor = StaticColor | TextColor;
-
-type ThemeIconProps = {
+export type ThemeIconProps = {
   svg(props: SvgProps): JSX.Element;
   colorType?: IconColor;
   size?: keyof Theme['icon']['size'];
+  notificationColor?: NotificationColor;
 } & SvgProps;
 
 export const ThemeIcon = ({
@@ -24,6 +24,8 @@ export const ThemeIcon = ({
   colorType,
   size = 'normal',
   fill,
+  notificationColor,
+  style,
   ...props
 }: ThemeIconProps): JSX.Element => {
   const {theme, themeName} = useTheme();
@@ -39,7 +41,15 @@ export const ThemeIcon = ({
     width: iconSize,
     ...props,
   };
-  return svg(settings);
+
+  return (
+    <View style={style}>
+      {svg(settings)}
+      {notificationColor && (
+        <NotificationIndicator color={notificationColor} iconSize={size} />
+      )}
+    </View>
+  );
 };
 
 function getFill(theme: Theme, themeType: Mode, colorType?: IconColor): string {

--- a/src/components/theme-icon/index.ts
+++ b/src/components/theme-icon/index.ts
@@ -1,3 +1,4 @@
 export {ThemeIcon} from './ThemeIcon';
 export {NavigationIcon, isNavigationIcon} from './NavigationIcon';
+export type {ThemeIconProps} from './ThemeIcon';
 export type {NavigationIconTypes} from './NavigationIcon';

--- a/src/components/theme-icon/types.ts
+++ b/src/components/theme-icon/types.ts
@@ -1,0 +1,5 @@
+import {InteractiveColor, StaticColor, TextColor} from '@atb/theme/colors';
+
+export type IconColor = StaticColor | TextColor;
+
+export type NotificationColor = IconColor | InteractiveColor;

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -1,5 +1,5 @@
 import {ContrastColor} from '@atb-as/theme';
-import {Add, Delete, Edit} from '@atb/assets/svg/mono-icons/actions';
+import {Add, Delete, Edit, Feedback} from '@atb/assets/svg/mono-icons/actions';
 import {Check} from '@atb/assets/svg/mono-icons/status';
 import {Ticket} from '@atb/assets/svg/mono-icons/ticketing';
 import {Button, ButtonGroup} from '@atb/components/button';
@@ -137,8 +137,34 @@ export default function DesignSystem() {
               <ThemeIcon svg={Check} colorType="info" />
               <ThemeIcon svg={Check} colorType="warning" />
 
-              <ThemeIcon svg={Ticket} colorType="error" />
               <ThemeIcon svg={Ticket} colorType="disabled" size="small" />
+              <ThemeIcon svg={Ticket} colorType="error" />
+              <ThemeIcon svg={Ticket} size="large" />
+            </View>
+            <View style={style.icons}>
+              <ThemeText style={{marginRight: 12}}>
+                With notification indicators:
+              </ThemeText>
+
+              <ThemeIcon
+                style={{marginRight: 12}}
+                svg={Feedback}
+                size="small"
+                notificationColor="valid"
+              />
+              <ThemeIcon
+                style={{marginRight: 12}}
+                svg={Feedback}
+                colorType="error"
+                notificationColor="info"
+              />
+              <ThemeIcon
+                style={{marginRight: 12}}
+                svg={Feedback}
+                colorType="disabled"
+                size="large"
+                notificationColor="error"
+              />
             </View>
             <View style={style.icons}>
               <TransportationIcon
@@ -883,6 +909,17 @@ export default function DesignSystem() {
                     onPress={presser}
                     mode="primary"
                     interactiveColor={'interactive_0'}
+                    rightIcon={{
+                      svg: Delete,
+                      notificationColor: 'interactive_0',
+                    }}
+                    style={{margin: 4}}
+                  />
+                  <Button
+                    text="Example"
+                    onPress={presser}
+                    mode="primary"
+                    interactiveColor={'interactive_0'}
                     disabled={true}
                     leftIcon={{svg: Add}}
                     rightIcon={{svg: Delete}}
@@ -900,7 +937,7 @@ export default function DesignSystem() {
                       mode="primary"
                       type="inline"
                       interactiveColor={'interactive_0'}
-                      leftIcon={{svg: Add}}
+                      leftIcon={{svg: Add, notificationColor: 'valid'}}
                       style={{margin: 4}}
                     />
                     <Button

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -78,10 +78,9 @@ export type Theme = Themes['light'];
 export type InteractiveColor = keyof Theme['interactive'];
 
 export const isInteractiveColor = (
-  theme: Theme,
   color?: string,
 ): color is InteractiveColor => {
-  return !!color && color in theme.interactive;
+  return !!color && color in themes.light.interactive;
 };
 
 /**


### PR DESCRIPTION
Add the possibility to add a small notification indicator at the top
right of icons through specifying a notification color to the
ThemeIcon. Also possible to add on button icons.

Screenshots from in-app DesignSystem:
![Screenshot 2023-01-10 at 10 56 31](https://user-images.githubusercontent.com/675421/211519943-f394ad61-2ba5-45de-8a59-072c1c43b6dc.png)
(Button number 2 and 4 has notification indicator)


![Screenshot 2023-01-10 at 10 56 12](https://user-images.githubusercontent.com/675421/211519949-dede99c0-1e5d-48a4-892b-1b71a8a85d40.png)
