### PR TITLE
refactor: Add notification indicator spacing

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -44,7 +44,7 @@ type ButtonTypeAwareProps =
 type ButtonIconProps = {
   svg: ({fill}: {fill: string}) => JSX.Element;
   size?: keyof Theme['icon']['size'];
-  notificationColor?: ThemeIconProps['notificationColor'];
+  notification?: ThemeIconProps['notification'];
 };
 
 export type ButtonProps = {

--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -9,30 +9,49 @@ import {
 } from '@atb/theme/colors';
 import type {NotificationColor} from './types';
 
+export type NotificationIndicatorProps = {
+  color: NotificationColor;
+  /**
+   * An optional background color that will be applied as a border/spacing
+   * around the indicator. Use the same color as the background under the
+   * ThemeIcon to make the notification indicator "pop" out a little more.
+   */
+  backgroundColor?: NotificationColor;
+  iconSize: ThemeIconProps['size'];
+};
+
 export const NotificationIndicator = ({
   color,
+  backgroundColor,
   iconSize,
-}: {
-  color: NotificationColor;
-  iconSize: ThemeIconProps['size'];
-}) => {
+}: NotificationIndicatorProps) => {
   const styles = useStyles();
   const notificationColor = useNotificationColor(color);
-  const indicatorSize = getIndicatorSize(iconSize);
+  const borderColor = useNotificationColor(backgroundColor);
+  const indicatorSize = getIndicatorSize(iconSize, !!borderColor);
   return (
     <View
       style={{
         ...styles.indicator,
-        backgroundColor: notificationColor,
+        borderWidth: borderColor ? (iconSize === 'small' ? 1 : 2) : 0,
+        borderColor,
         height: indicatorSize,
         width: indicatorSize,
       }}
-    />
+    >
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: notificationColor,
+        }}
+      />
+    </View>
   );
 };
 
-function useNotificationColor(color: NotificationColor): string {
+function useNotificationColor(color?: NotificationColor): string | undefined {
   const {theme, themeName} = useTheme();
+  if (!color) return undefined;
   if (isStatusColor(color)) {
     return theme.static.status[color].background;
   } else if (isStaticColor(color)) {
@@ -44,14 +63,14 @@ function useNotificationColor(color: NotificationColor): string {
   }
 }
 
-const getIndicatorSize = (size: ThemeIconProps['size']) => {
+const getIndicatorSize = (size: ThemeIconProps['size'], hasBorder: boolean) => {
   switch (size) {
     case 'small':
-      return 4;
+      return hasBorder ? 6 : 4;
     case 'large':
-      return 8;
+      return hasBorder ? 12 : 8;
     default:
-      return 6;
+      return hasBorder ? 10 : 6;
   }
 };
 
@@ -62,5 +81,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     top: 0,
     borderRadius: theme.border.radius.circle,
     zIndex: 10,
+    overflow: 'hidden',
   },
 }));

--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -10,13 +10,16 @@ import {SvgProps} from 'react-native-svg';
 import useFontScale from '@atb/utils/use-font-scale';
 import {View} from 'react-native';
 import type {IconColor, NotificationColor} from './types';
-import {NotificationIndicator} from '@atb/components/theme-icon/NotificationIndicator';
+import {
+  NotificationIndicator,
+  NotificationIndicatorProps,
+} from '@atb/components/theme-icon/NotificationIndicator';
 
 export type ThemeIconProps = {
   svg(props: SvgProps): JSX.Element;
   colorType?: IconColor;
   size?: keyof Theme['icon']['size'];
-  notificationColor?: NotificationColor;
+  notification?: Omit<NotificationIndicatorProps, 'iconSize'>;
 } & SvgProps;
 
 export const ThemeIcon = ({
@@ -24,7 +27,7 @@ export const ThemeIcon = ({
   colorType,
   size = 'normal',
   fill,
-  notificationColor,
+  notification,
   style,
   ...props
 }: ThemeIconProps): JSX.Element => {
@@ -45,8 +48,8 @@ export const ThemeIcon = ({
   return (
     <View style={style}>
       {svg(settings)}
-      {notificationColor && (
-        <NotificationIndicator color={notificationColor} iconSize={size} />
+      {notification && (
+        <NotificationIndicator {...notification} iconSize={size} />
       )}
     </View>
   );

--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -9,7 +9,7 @@ import {
 import {SvgProps} from 'react-native-svg';
 import useFontScale from '@atb/utils/use-font-scale';
 import {View} from 'react-native';
-import type {IconColor, NotificationColor} from './types';
+import type {IconColor} from './types';
 import {
   NotificationIndicator,
   NotificationIndicatorProps,

--- a/src/screens/Profile/DesignSystem.tsx
+++ b/src/screens/Profile/DesignSystem.tsx
@@ -150,20 +150,45 @@ export default function DesignSystem() {
                 style={{marginRight: 12}}
                 svg={Feedback}
                 size="small"
-                notificationColor="valid"
+                notification={{color: 'valid'}}
               />
               <ThemeIcon
                 style={{marginRight: 12}}
                 svg={Feedback}
                 colorType="error"
-                notificationColor="info"
+                notification={{color: 'info'}}
               />
               <ThemeIcon
                 style={{marginRight: 12}}
                 svg={Feedback}
                 colorType="disabled"
                 size="large"
-                notificationColor="error"
+                notification={{color: 'error'}}
+              />
+            </View>
+            <View style={style.icons}>
+              <ThemeText style={{marginRight: 12}}>
+                And notification spacing:
+              </ThemeText>
+
+              <ThemeIcon
+                style={{marginRight: 12}}
+                svg={Feedback}
+                size="small"
+                notification={{color: 'valid', backgroundColor: 'background_0'}}
+              />
+              <ThemeIcon
+                style={{marginRight: 12}}
+                svg={Feedback}
+                colorType="error"
+                notification={{color: 'info', backgroundColor: 'background_0'}}
+              />
+              <ThemeIcon
+                style={{marginRight: 12}}
+                svg={Feedback}
+                colorType="disabled"
+                size="large"
+                notification={{color: 'error', backgroundColor: 'background_0'}}
               />
             </View>
             <View style={style.icons}>
@@ -911,7 +936,7 @@ export default function DesignSystem() {
                     interactiveColor={'interactive_0'}
                     rightIcon={{
                       svg: Delete,
-                      notificationColor: 'interactive_0',
+                      notification: {color: 'interactive_0'},
                     }}
                     style={{margin: 4}}
                   />
@@ -937,7 +962,7 @@ export default function DesignSystem() {
                       mode="primary"
                       type="inline"
                       interactiveColor={'interactive_0'}
-                      leftIcon={{svg: Add, notificationColor: 'valid'}}
+                      leftIcon={{svg: Add, notification: {color: 'valid'}}}
                       style={{margin: 4}}
                     />
                     <Button


### PR DESCRIPTION
After discussion with @ckbilstad regarding that the icons should "pop" a little more.

The code is getting more complex for the notification indicators, but I think it is worth it as it is quite a hassle to add these icons with indicators to the design-system repo as well. Adding them to the design-system requires there to be a version for light/dark (since they are not mono), and also NFK/Fram must add their own if they want another notification indicator color.

![Screenshot 2023-01-12 at 13 31 01](https://user-images.githubusercontent.com/675421/212073883-0c104b73-7d21-44dd-a557-e961ae9a9053.png)
