### PR TITLE
fix: change AppTeamIdentifier into dynamic value

### DIFF
--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -5,7 +5,7 @@
 	<key>NFCReaderUsageDescription</key>
 	<string>Vi må bruke NFC for sikkerhetsformål.</string>
 	<key>AppTeamIdentifier</key>
-	<string>CSV447Q97L</string>
+	<string>$(IOS_DEVELOPMENT_TEAM_ID)</string>
 	<key>AppEnvironment</key>
 	<string>PRODUCTION</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>


### PR DESCRIPTION
Changed value together with Jorge. Most likely just a field that was dynamic at some point, but become hardcoded for testing at some point.

Hopefully solves https://github.com/AtB-AS/kundevendt/issues/3257