### PR TITLE
feat: notification indicator based on font size

### DIFF
--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -7,6 +7,7 @@ import {
   isStaticColor,
   isStatusColor,
 } from '@atb/theme/colors';
+import useFontScale from '@atb/utils/use-font-scale';
 import type {NotificationColor} from './types';
 
 export type NotificationIndicatorProps = {
@@ -28,12 +29,14 @@ export const NotificationIndicator = ({
   const styles = useStyles();
   const notificationColor = useNotificationColor(color);
   const borderColor = useNotificationColor(backgroundColor);
-  const indicatorSize = getIndicatorSize(iconSize, !!borderColor);
+  const fontScale = useFontScale();
+  const indicatorSize = getIndicatorSize(iconSize, !!borderColor, fontScale);
+  const borderWidth = (iconSize === 'small' ? 1 : 2) * fontScale;
   return (
     <View
       style={{
         ...styles.indicator,
-        borderWidth: borderColor ? (iconSize === 'small' ? 1 : 2) : 0,
+        borderWidth: borderColor ? borderWidth : 0,
         borderColor,
         height: indicatorSize,
         width: indicatorSize,
@@ -63,14 +66,18 @@ function useNotificationColor(color?: NotificationColor): string | undefined {
   }
 }
 
-const getIndicatorSize = (size: ThemeIconProps['size'], hasBorder: boolean) => {
+const getIndicatorSize = (
+  size: ThemeIconProps['size'],
+  hasBorder: boolean,
+  fontScale: number,
+) => {
   switch (size) {
     case 'small':
-      return hasBorder ? 6 : 4;
+      return (hasBorder ? 6 : 4) * fontScale;
     case 'large':
-      return hasBorder ? 12 : 8;
+      return (hasBorder ? 12 : 8) * fontScale;
     default:
-      return hasBorder ? 10 : 6;
+      return (hasBorder ? 10 : 6) * fontScale;
   }
 };
 


### PR DESCRIPTION
Makes notification icons, and the border around them adjust to font size.

### Small, default and large text

<div>
<img width="400px" src="https://user-images.githubusercontent.com/1774972/213402335-97188354-21e7-410f-8531-bd47795a2383.png">
<img width="400px" src="https://user-images.githubusercontent.com/1774972/213402330-b5888d37-8ab5-4912-978b-fccec3901e75.png">
<img width="400px" src="https://user-images.githubusercontent.com/1774972/213402323-a5c85b7e-802b-44a4-8e76-9146687d8d61.png">
</div>

closes https://github.com/AtB-AS/kundevendt/issues/3229