### PR TITLE
refactor: stop using bff/v1/departures-realtime for realtime

### DIFF
--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -37,26 +37,16 @@ export async function getDepartures(
   return response.data;
 }
 
-export async function getRealtimeDeparture(
+export async function getStopPlaceGroupRealtime(
   stops: StopPlaceGroup[],
   query: DepartureGroupsQuery,
   opts?: AxiosRequestConfig,
 ): Promise<DeparturesRealtimeData> {
   const quayIds = flatMap(stops, (s) => s.quays.map((q) => q.quay.id));
-  const startTime = query.startTime;
-
-  const params = build({
-    quayIds,
-    startTime,
-    limit: query.limitPerLine,
-  });
-
-  let url = `bff/v1/departures-realtime?${params}`;
-  const response = await client.get<DeparturesRealtimeData>(url, opts);
-  return response.data;
+  return getRealtimeDepartures(quayIds, query, opts);
 }
 
-export async function getRealtimeDepartureV2(
+export async function getRealtimeDepartures(
   quayIds: string[] | undefined,
   query: DepartureGroupsQuery,
   opts?: AxiosRequestConfig,

--- a/src/screens/Dashboard/state.ts
+++ b/src/screens/Dashboard/state.ts
@@ -9,7 +9,7 @@ import useReducerWithSideEffects, {
 } from 'use-reducer-with-side-effects';
 import {
   getFavouriteDepartures,
-  getRealtimeDepartureV2,
+  getStopPlaceGroupRealtime,
 } from '@atb/api/departures';
 import {
   DepartureFavoritesQuery,
@@ -23,7 +23,6 @@ import {differenceInMinutes} from 'date-fns';
 import useInterval from '@atb/utils/use-interval';
 import {updateStopsWithRealtime} from '../../departure-list/utils';
 import {SearchTime} from '../Nearby/types';
-import {flatMap} from '@atb/utils/array';
 import {animateNextChange} from '@atb/utils/animation';
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW = 7;
@@ -153,8 +152,8 @@ const reducer: ReducerWithSideEffects<
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            const realtimeData = await getRealtimeDepartureV2(
-              flatMap(state.data ?? [], (f) => f.quays.map((q) => q.quay.id)),
+            const realtimeData = await getStopPlaceGroupRealtime(
+              state.data ?? [],
               state.queryInput,
             );
             dispatch({

--- a/src/screens/Departures/state/quay-state.ts
+++ b/src/screens/Departures/state/quay-state.ts
@@ -1,4 +1,4 @@
-import {getRealtimeDepartureV2} from '@atb/api/departures';
+import {getRealtimeDepartures} from '@atb/api/departures';
 import {
   getQuayDepartures,
   QuayDeparturesVariables,
@@ -170,7 +170,7 @@ const reducer: ReducerWithSideEffects<
           try {
             const quayIds = [action.quay.id];
 
-            const realtimeData = await getRealtimeDepartureV2(quayIds, {
+            const realtimeData = await getRealtimeDepartures(quayIds, {
               limitPerLine: state.queryInput.numberOfDepartures,
               startTime: state.queryInput.startTime,
             });

--- a/src/screens/Departures/state/stop-place-state.ts
+++ b/src/screens/Departures/state/stop-place-state.ts
@@ -1,4 +1,4 @@
-import {getRealtimeDepartureV2} from '@atb/api/departures';
+import {getRealtimeDepartures} from '@atb/api/departures';
 import {getStopPlaceDepartures} from '@atb/api/departures/stops-nearest';
 import {EstimatedCall, StopPlace} from '@atb/api/types/departures';
 import {ErrorType, getAxiosErrorType} from '@atb/api/utils';
@@ -164,7 +164,7 @@ const reducer: ReducerWithSideEffects<
           // we get the same result.
           try {
             const quayIds = action.stopPlace.quays?.map((q) => q.id);
-            const realtimeData = await getRealtimeDepartureV2(quayIds, {
+            const realtimeData = await getRealtimeDepartures(quayIds, {
               limitPerLine: state.queryInput.numberOfDepartures,
               startTime: state.queryInput.startTime,
             });

--- a/src/screens/Nearby/state.ts
+++ b/src/screens/Nearby/state.ts
@@ -7,7 +7,10 @@ import useReducerWithSideEffects, {
   Update,
   UpdateWithSideEffect,
 } from 'use-reducer-with-side-effects';
-import {getDepartureGroups, getRealtimeDeparture} from '@atb/api/departures';
+import {
+  getDepartureGroups,
+  getStopPlaceGroupRealtime,
+} from '@atb/api/departures';
 import {
   DepartureFavoritesQuery,
   DepartureGroupMetadata,
@@ -227,7 +230,7 @@ const reducer: ReducerWithSideEffects<
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            const realtimeData = await getRealtimeDeparture(
+            const realtimeData = await getStopPlaceGroupRealtime(
               state.data ?? [],
               state.queryInput,
             );


### PR DESCRIPTION
After the upgrade of old endpoints to OTP2 (Issue https://github.com/AtB-AS/kundevendt/issues/3171 among others), the endpoints `bff/v1/departures-realtime` and `bff/v2/departures/realtime` are identical in functionality. Therefore it makes sense to stop using `bff/v1/departures-realtime`, and deprecate it.

I think it makes sense to test this later, as I'm also working on a larger BFF refactoring.