### PR TITLE
fix: Add missing t:card translations for NFK

### DIFF
--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -1,5 +1,6 @@
 import {translation as _} from '../commons';
 import orgSpecificTranslations from '@atb/translations/utils';
+
 const TravelTokenBoxTexts = {
   tcard: {
     title: _('t:kort', 't:card'),
@@ -59,8 +60,22 @@ export default orgSpecificTranslations(TravelTokenBoxTexts, {
 
       a11yLabel: _(
         'Du bruker nå reisekort. Ta med deg reisekortet når du er ute og reiser',
-        'Yoú are using travelcard. Remember to bring your travel card when you travel',
+        'You are using travel card. Remember to bring your travel card when you travel',
       ),
     },
+    errorMessages: {
+      tokensNotLoadedTitle: _(
+        'Klarer ikke hente informasjon om reisekort / mobil.',
+        'Unable to retrieve information about your travel card / phone.',
+      ),
+      tokensNotLoaded: _(
+        'Billetter må brukes på enten et reisekort eller en mobil, men akkurat nå klarer vi ikke finne ut hvor den er i bruk. Sjekk at du har tilgang på nett der du er.',
+        `Tickets must be used on either a travel card or phone, but right now we are unable to find where the ticket is in use. Check that you have internet access.`,
+      ),
+      noInspectableToken: _(
+        'Billetter må brukes på enten et reisekort eller en mobil, og det ser ikke ut som du har valgt en av dem.\n\nGå til **Min profil, Bytt mellom reisekort / mobil** for å velge.',
+        `Tickets must be used on either a travel card or a phone, and it looks like you haven't chosen one. Go to **My profile, switch between travel card / phone** to select`,
+      ),
+    }
   },
 });

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -76,6 +76,6 @@ export default orgSpecificTranslations(TravelTokenBoxTexts, {
         'Billetter må brukes på enten et reisekort eller en mobil, og det ser ikke ut som du har valgt en av dem.\n\nGå til **Min profil, Bytt mellom reisekort / mobil** for å velge.',
         `Tickets must be used on either a travel card or a phone, and it looks like you haven't chosen one. Go to **My profile, switch between travel card / phone** to select`,
       ),
-    }
+    },
   },
 });

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -1,6 +1,6 @@
 import {TransportMode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {translation as _} from '../commons';
-import orgSpecificTranslations from "@atb/translations/utils";
+import orgSpecificTranslations from '@atb/translations/utils';
 
 const FareContractTexts = {
   organizationName: _('AtB', 'AtB'),
@@ -182,8 +182,8 @@ export default orgSpecificTranslations(FareContractTexts, {
             'Du bruker billetten på ditt reisekort. Husk å ta det med deg når du reiser.\nDu kan alltid bytte til en mobil ved å gå til **Min profil**.',
             `Seems like you\'re using your ticket on your travel card. Remember to bring it with you while traveling.\nYou can always switch to your phone by heading over to **My profile**.`,
           ),
-        }
-      }
+        },
+      },
     },
     warning: {
       unableToRetrieveToken: _(
@@ -206,6 +206,6 @@ export default orgSpecificTranslations(FareContractTexts, {
         'Merk at billetter du kjøper nå vil være tilknyttet ditt reisekort. Om du heller vil bruke billett på denne mobilen kan du endre det fra **Min profil**.',
         'This ticket will be connected to your travel card. If you would rather use tickets on this phone, you can switch to this device from **My profile**.',
       ),
-    }
-  }
-})
+    },
+  },
+});

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -1,5 +1,6 @@
 import {TransportMode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {translation as _} from '../commons';
+import orgSpecificTranslations from "@atb/translations/utils";
 
 const FareContractTexts = {
   organizationName: _('AtB', 'AtB'),
@@ -116,7 +117,7 @@ const FareContractTexts = {
   warning: {
     unableToRetrieveToken: _(
       'Feil ved uthenting av t:kort / mobil',
-      'Error retrieving  t:card / phone',
+      'Error retrieving t:card / phone',
     ),
     noInspectableTokenFound: _(
       'Du må bruke billett på t:kort eller mobil',
@@ -167,4 +168,44 @@ const FareContractTexts = {
   },
 };
 
-export default FareContractTexts;
+export default orgSpecificTranslations(FareContractTexts, {
+  nfk: {
+    details: {
+      barcodeErrors: {
+        notInspectableDevice: {
+          wrongDevice: (deviceName: string) =>
+            _(
+              `Du bruker billetter på din mobil, "${deviceName}". Husk å ta den med deg når du reiser.\nDu kan alltid bytte til reisekort eller en annen mobil ved å gå til **Min profil**.`,
+              `Seems like you\'re using your ticket on your phone, "${deviceName}". Remember to bring it with you while traveling.\nYou can always switch to a travel card or a different phone by heading over to **My profile**.`,
+            ),
+          tCard: _(
+            'Du bruker billetten på ditt reisekort. Husk å ta det med deg når du reiser.\nDu kan alltid bytte til en mobil ved å gå til **Min profil**.',
+            `Seems like you\'re using your ticket on your travel card. Remember to bring it with you while traveling.\nYou can always switch to your phone by heading over to **My profile**.`,
+          ),
+        }
+      }
+    },
+    warning: {
+      unableToRetrieveToken: _(
+        'Feil ved uthenting av reisekort / mobil',
+        'Error retrieving travel card / phone',
+      ),
+      noInspectableTokenFound: _(
+        'Du må bruke billett på reisekort eller mobil',
+        'You must use a ticket on travel card or phone',
+      ),
+      travelCardAstoken: _(
+        'Bruk reisekort når du reiser',
+        'Bring your travel card when you travel',
+      ),
+      carnetWarning: _(
+        'Vennligst bytt til reisekort for å kunne bruke dette klippekortet.',
+        'Please switch to travel card to be able to use this punch card.',
+      ),
+      tcardIsInspectableWarning: _(
+        'Merk at billetter du kjøper nå vil være tilknyttet ditt reisekort. Om du heller vil bruke billett på denne mobilen kan du endre det fra **Min profil**.',
+        'This ticket will be connected to your travel card. If you would rather use tickets on this phone, you can switch to this device from **My profile**.',
+      ),
+    }
+  }
+})

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -16,7 +16,7 @@ const OnboardingTexts = {
       ),
       part3: _(
         'Du vil også kunne administrere billetter og eventuelle t:kort på den nye nettbutikken med samme konto.',
-        'You will also be able to manage your tickets and t:kort on the webshop with the same account',
+        'You will also be able to manage your tickets and t:card on the webshop with the same account',
       ),
     },
     mainButton: _('Neste', 'Next'),
@@ -42,7 +42,7 @@ export default orgSpecificTranslations(OnboardingTexts, {
         ),
         part3: _(
           'Du vil også kunne administrere billetter og eventuelle reisekort på den nye nettbutikken med samme konto.',
-          'You will also be able to manage your tickets and travelcards on the webshop with the same account',
+          'You will also be able to manage your tickets and travel cards on the webshop with the same account',
         ),
       },
     },

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from "@atb/translations/utils";
+import orgSpecificTranslations from '@atb/translations/utils';
 
 const ProfileTexts = {
   header: {
@@ -158,10 +158,10 @@ export default orgSpecificTranslations(ProfileTexts, {
             label: _(
               'Bruk billett på reisekort / mobil',
               'Use ticket on travel card / phone',
-            )
+            ),
           },
         },
       },
-    }
+    },
   }
 })

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -1,4 +1,5 @@
 import {translation as _} from '../commons';
+import orgSpecificTranslations from "@atb/translations/utils";
 
 const ProfileTexts = {
   header: {
@@ -148,4 +149,19 @@ const ProfileTexts = {
     ),
   },
 };
-export default ProfileTexts;
+export default orgSpecificTranslations(ProfileTexts, {
+  nfk: {
+    sections: {
+      settings: {
+        linkSectionItems: {
+          travelToken: {
+            label: _(
+              'Bruk billett på reisekort / mobil',
+              'Use ticket on travel card / phone',
+            )
+          },
+        },
+      },
+    }
+  }
+})

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -163,5 +163,5 @@ export default orgSpecificTranslations(ProfileTexts, {
         },
       },
     },
-  }
-})
+  },
+});

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -188,12 +188,12 @@ export default orgSpecificTranslations(TicketingTexts, {
       illustrationa11yLabel: (travelCardId: string) =>
         _(
           `Illustrasjon av reisekort med kortnummer som inneholder ${travelCardId}`,
-          `Illustration of travelcard with card number that contains ${travelCardId}`,
+          `Illustration of travel card with card number that contains ${travelCardId}`,
         ),
-      cardType: _('reisekort', 'travelcard'),
+      cardType: _('reisekort', 'travel card'),
       onInspection: _(
         'I billettkontroll må du vise reisekortet ditt',
-        'In the event of an inspection, please present your travelcard',
+        'In the event of an inspection, please present your travel card',
       ),
     },
   },

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import orgSpecificTranslations from "@atb/translations/utils";
+import orgSpecificTranslations from '@atb/translations/utils';
 
 const MobileTokenOnboardingTexts = {
   flexibilityInfo: {
@@ -81,8 +81,7 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
         'Du kan bruke billetten din på et reisekort eller en mobil med appen AtB installert — men kun en av gangen.',
         'You can use your ticket on a travel card or a phone with the app AtB installed — but only one at a time.',
       ),
-    }
-    ,
+    },
     ticketSafetyInfo: {
       description: _(
         'Billetten din er trygt lagret på **Min profil**. Dermed vil du aldri miste den — selv om du mister reisekortet eller bytter mobil.',
@@ -91,7 +90,10 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
     },
     tCard: {
       label: _('Reisekort', 'Travel card'),
-      heading: _('Du bruker nå **reisekort**', 'You are now using your **travel card**'),
+      heading: _(
+        'Du bruker nå **reisekort**',
+        'You are now using your **travel card**'
+      ),
       reminder: _(
         'Ta med deg reisekortet når du er ute og reiser.',
         'Remember to bring your travel card while travelling.',
@@ -102,7 +104,10 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
         'Du kan alltid bytte til reisekort eller en annen mobil ved logge inn og gå til **Min profil**.',
         'You can always switch to a travel card or a different phone by logging in, and heading over to **My profile**.',
       ),
-      button: _('Bytt til reisekort eller annen mobil', 'Switch to travel card or phone'),
+      button: _(
+        'Bytt til reisekort eller annen mobil',
+        'Switch to travel card or phone'
+      ),
     },
     error: {
       description: _(
@@ -110,6 +115,6 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
         "We can't connect a travel card or phone to your profile. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact AtB service center.",
       ),
     },
-  }
-})
+  },
+});
 

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -92,7 +92,7 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
       label: _('Reisekort', 'Travel card'),
       heading: _(
         'Du bruker nå **reisekort**',
-        'You are now using your **travel card**'
+        'You are now using your **travel card**',
       ),
       reminder: _(
         'Ta med deg reisekortet når du er ute og reiser.',
@@ -106,7 +106,7 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
       ),
       button: _(
         'Bytt til reisekort eller annen mobil',
-        'Switch to travel card or phone'
+        'Switch to travel card or phone',
       ),
     },
     error: {
@@ -117,4 +117,3 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
     },
   },
 });
-

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -1,4 +1,6 @@
 import {translation as _} from '../../commons';
+import orgSpecificTranslations from "@atb/translations/utils";
+
 const MobileTokenOnboardingTexts = {
   flexibilityInfo: {
     heading: _('En mer fleksibel reisehverdag', 'More flexibility'),
@@ -68,4 +70,46 @@ const MobileTokenOnboardingTexts = {
     'Activate to go to next page',
   ),
 };
-export default MobileTokenOnboardingTexts;
+export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
+  nfk: {
+    optionsInfo: {
+      heading: _(
+        'Velg mellom reisekort eller mobil',
+        'Choose between travel card or phone',
+      ),
+      description: _(
+        'Du kan bruke billetten din på et reisekort eller en mobil med appen AtB installert — men kun en av gangen.',
+        'You can use your ticket on a travel card or a phone with the app AtB installed — but only one at a time.',
+      ),
+    }
+    ,
+    ticketSafetyInfo: {
+      description: _(
+        'Billetten din er trygt lagret på **Min profil**. Dermed vil du aldri miste den — selv om du mister reisekortet eller bytter mobil.',
+        "Your ticket is safely stored on **My profile**. That way you won't lose your ticket even if you lose your travel card or switch phones.",
+      ),
+    },
+    tCard: {
+      label: _('Reisekort', 'Travel card'),
+      heading: _('Du bruker nå **reisekort**', 'You are now using your **travel card**'),
+      reminder: _(
+        'Ta med deg reisekortet når du er ute og reiser.',
+        'Remember to bring your travel card while travelling.',
+      ),
+    },
+    phone: {
+      description: _(
+        'Du kan alltid bytte til reisekort eller en annen mobil ved logge inn og gå til **Min profil**.',
+        'You can always switch to a travel card or a different phone by logging in, and heading over to **My profile**.',
+      ),
+      button: _('Bytt til reisekort eller annen mobil', 'Switch to travel card or phone'),
+    },
+    error: {
+      description: _(
+        'Vi får ikke knyttet et reisekort eller en mobil til profilen din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nOm problemet vedvarer kan du ta kontakt med AtB kundesenter.',
+        "We can't connect a travel card or phone to your profile. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact AtB service center.",
+      ),
+    },
+  }
+})
+

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -78,8 +78,8 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
         'Choose between travel card or phone',
       ),
       description: _(
-        'Du kan bruke billetten din på et reisekort eller en mobil med appen AtB installert — men kun en av gangen.',
-        'You can use your ticket on a travel card or a phone with the app AtB installed — but only one at a time.',
+        'Du kan bruke billetten din på et reisekort eller en mobil med Reis-appen installert — men kun en av gangen.',
+        'You can use your ticket on a travel card or a phone with the Reis app installed — but only one at a time.',
       ),
     },
     ticketSafetyInfo: {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -118,7 +118,7 @@ export default orgSpecificTranslations(PurchaseOverviewTexts, {
   nfk: {
     warning: _(
       'Når du er ute og reiser må du ha med reisekortet som er registrert på din profil.',
-      'When traveling, you need to bring the travelcard registered on your profile.',
+      'When traveling, you need to bring the travel card registered on your profile.',
     ),
   },
 });

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import orgSpecificTranslations from "@atb/translations/utils";
+import orgSpecificTranslations from '@atb/translations/utils';
 
 const SelectTravelTokenTexts = {
   travelToken: {
@@ -211,10 +211,13 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
             `See how to contact us at atb.no/en/contact`,
           ),
         },
-      ]
+      ],
     },
     toggleToken: {
-      title: _('Bytt mellom reisekort / mobil', 'Switch between travel card / phone'),
+      title: _(
+        'Bytt mellom reisekort / mobil',
+        'Switch between travel card / phone'
+      ),
       radioBox: {
         tCard: {
           title: _('reisekort', 'travel card'),
@@ -233,7 +236,6 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
         'Du har ikke et reisekort registrert. Hvis du ønsker å bruke reisekort kan du legge til dette på din profil i [nettbutikken](https://nettbutikk.atb.no).',
         'You have no travel card registered, if you wish to use travel card as travel token you may add this to your profile in the [webshop](https://nettbutikk.atb.no).',
       ),
-    }
-  }
-})
-
+    },
+  },
+});

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -220,7 +220,7 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
       ),
       radioBox: {
         tCard: {
-          title: _('reisekort', 'travel card'),
+          title: _('Reisekort', 'Travel card'),
           description: _(
             'Les av reisekortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
             'Validate your travel card at the bus stop or on board. The card will be scanned in a ticket inspection.',

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -216,7 +216,7 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
     toggleToken: {
       title: _(
         'Bytt mellom reisekort / mobil',
-        'Switch between travel card / phone'
+        'Switch between travel card / phone',
       ),
       radioBox: {
         tCard: {
@@ -229,7 +229,10 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
             'reisekort. Les av reisekortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
             'travel card. Validate your travel card at the bus stop or on board. The card will be scanned in a ticket inspection.',
           ),
-          a11yHint: _('Aktivér for å velge reisekort.', 'Activate to select travel card'),
+          a11yHint: _(
+            'Aktivér for å velge reisekort.',
+            'Activate to select travel card',
+          ),
         },
       },
       noTravelCard: _(

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -1,4 +1,5 @@
 import {translation as _} from '../../commons';
+import orgSpecificTranslations from "@atb/translations/utils";
 
 const SelectTravelTokenTexts = {
   travelToken: {
@@ -107,7 +108,7 @@ const SelectTravelTokenTexts = {
           'Validate your t:card at the bus stop or on board. The card will be scanned in a ticket inspection.',
         ),
         a11yLabel: _(
-          't:kort. Les av t-kortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
+          't:kort. Les av t:kortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
           't:card. Validate your t:card at the bus stop or on board. The card will be scanned in a ticket inspection.',
         ),
         a11yHint: _('Aktivér for å velge t:kort.', 'Activate to select t:card'),
@@ -133,7 +134,7 @@ const SelectTravelTokenTexts = {
     errorMessage: _('Noe gikk galt', 'Something went wrong'),
     noTravelCard: _(
       'Du har ikke et t:kort registrert. Hvis du ønsker å bruke t:kort kan du legge til dette på din profil i [nettbutikken](https://nettbutikk.atb.no).',
-      'You have no t:card registered, If you wish to use t:card as travel token you may add this to your profile in the [webshop](https://nettbutikk.atb.no).',
+      'You have no t:card registered, if you wish to use t:card as travel token you may add this to your profile in the [webshop](https://nettbutikk.atb.no).',
     ),
     noMobileToken: _(
       'Vi forsøker å klargjøre din mobil til å kunne bruke billettene på den, men det ser ut som det tar litt tid. Du kan sjekke om du har nettilgang og hvis ikke så vil appen forsøke på nytt neste gang du får tilgang.',
@@ -146,4 +147,93 @@ const SelectTravelTokenTexts = {
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },
 };
-export default SelectTravelTokenTexts;
+export default orgSpecificTranslations(SelectTravelTokenTexts, {
+  nfk: {
+    travelToken: {
+      header: {
+        title: _(
+          'Bruk billett på reisekort / mobil',
+          'Use ticket on travel card / phone',
+        ),
+      },
+      changeTokenButton: _(
+        'Bytt mellom reisekort / mobil',
+        'Switch between travel card / phone',
+      ),
+      faqs: [
+        {
+          question: _(
+            'Hva skjer om jeg mister reisekortet eller mobilen?',
+            'What happens if I lose my travel card or phone?',
+          ),
+          answer: _(
+            'Billetten din ligger trygt lagret i Min profil. Velg å bruke billetten på en annen mobil eller reisekort.',
+            'Your ticket is safely stored in My profile. Switch to use the ticket on another mobile phone or travel card.',
+          ),
+        },
+        {
+          question: _(
+            'Kan jeg bruke billetten på både reisekort og mobil samtidig?',
+            'Can I use the ticket on both travel card and mobile phone at the same time?',
+          ),
+          answer: _(
+            'Nei, du kan kun bruke en av gangen, og billetten kan ikke deles med andre reisende.',
+            'No, you can only use one at a time and the ticket cannot be shared with other travellers.',
+          ),
+        },
+        {
+          question: _(
+            'Kan jeg reise uten reisekort eller mobil?',
+            'Can I travel without my travel card or phone?',
+          ),
+          answer: _(
+            'Du må alltid ha med deg det reisekortet eller mobilen du har valgt å bruke billetten på.',
+            'You must always travel with the travel card or mobile phone you have chosen to use the ticket on.',
+          ),
+        },
+        {
+          question: _(
+            `Jeg får ikke logget inn i appen AtB med e-post`,
+            `I can not log into the AtB app with e-mail`,
+          ),
+          answer: _(
+            `Det er ikke mulig å logge inn i appen med e-post per i dag. Du kan fortsette å bruke reisekort eller opprette en ny brukerprofil med mobilnummer som innlogging. Merk at billettene ikke vil bli overført til din nye brukerprofil. Du kan kontakte kundesenteret vedrørende refusjon dersom du likevel vil lage en ny brukerprofil i appen.`,
+            `It is not possible to log into the app with e-mail as of today. You can continue to use your travel card or create a new user profile with a mobile number as login. Note that the tickets will not be transferred to your new user profile. You can contact customer service regarding a refund if you still want to create a new user profile in the app.`,
+          ),
+        },
+        {
+          question: _(
+            `Har du flere spørsmål om billettkjøp?`,
+            `Do you have any other questions about ticket purchases?`,
+          ),
+          answer: _(
+            `Se flere måter å kontakte oss på atb.no/kontakt`,
+            `See how to contact us at atb.no/en/contact`,
+          ),
+        },
+      ]
+    },
+    toggleToken: {
+      title: _('Bytt mellom reisekort / mobil', 'Switch between travel card / phone'),
+      radioBox: {
+        tCard: {
+          title: _('reisekort', 'travel card'),
+          description: _(
+            'Les av reisekortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
+            'Validate your travel card at the bus stop or on board. The card will be scanned in a ticket inspection.',
+          ),
+          a11yLabel: _(
+            'reisekort. Les av reisekortet ditt på holdeplass eller om bord. Kortet leses av ved kontroll.',
+            'travel card. Validate your travel card at the bus stop or on board. The card will be scanned in a ticket inspection.',
+          ),
+          a11yHint: _('Aktivér for å velge reisekort.', 'Activate to select travel card'),
+        },
+      },
+      noTravelCard: _(
+        'Du har ikke et reisekort registrert. Hvis du ønsker å bruke reisekort kan du legge til dette på din profil i [nettbutikken](https://nettbutikk.atb.no).',
+        'You have no travel card registered, if you wish to use travel card as travel token you may add this to your profile in the [webshop](https://nettbutikk.atb.no).',
+      ),
+    }
+  }
+})
+


### PR DESCRIPTION
https://github.com/AtB-AS/mittatb-app/pull/3220 2.0

Fixes t:kort references and AtB references in ticketing related screens for Reis.

Mostly work of Adrian.