### PR TITLE
fix: toggle FAQ translations for Reis

### DIFF
--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -1,4 +1,6 @@
 import {translation as _} from '../../commons';
+import orgSpecificTranslations from '@atb/translations/utils';
+
 const DeleteProfileTexts = {
   header: {
     title: _('Slett Min profil', 'Delete My profile'),
@@ -22,8 +24,8 @@ const DeleteProfileTexts = {
       }`,
     ),
   unableToDeleteWithFareContracts: _(
-    'Kan ikke slette Min profil mens du har aktive billetter. Kontakt Reis Nordland kundeservice for refusjon eller vent til billettene har utløpt.',
-    'Unable to delete My profile while you have active tickets. Please contact Reis Nordland customer support for refund or wait until tickets expire.',
+    'Kan ikke slette Min profil mens du har aktive billetter. Kontakt AtB kundeservice for refusjon eller vent til billettene har utløpt.',
+    'Unable to delete My profile while you have active tickets. Please contact customer support to refund or wait until tickets expire.',
   ),
   customerNumber: _('Kundenummer', 'Customer number'),
   deleteConfirmation: {
@@ -44,4 +46,11 @@ const DeleteProfileTexts = {
   },
 };
 
-export default DeleteProfileTexts;
+export default orgSpecificTranslations(DeleteProfileTexts, {
+  nfk: {
+    unableToDeleteWithFareContracts: _(
+      'Kan ikke slette Min profil mens du har aktive billetter. Kontakt Reis Nordland kundeservice for refusjon eller vent til billettene har utløpt.',
+      'Unable to delete My profile while you have active tickets. Please contact Reis Nordland customer support for refund or wait until tickets expire.',
+    ),
+  },
+});

--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -22,8 +22,8 @@ const DeleteProfileTexts = {
       }`,
     ),
   unableToDeleteWithFareContracts: _(
-    'Kan ikke slette Min profil mens du har aktive billetter. Kontakt AtB kundeservice for refusjon eller vent til billettene har utløpt.',
-    'Unable to delete My profile while you have active tickets. Please contact customer support to refund or wait until tickets expire.',
+    'Kan ikke slette Min profil mens du har aktive billetter. Kontakt Reis Nordland kundeservice for refusjon eller vent til billettene har utløpt.',
+    'Unable to delete My profile while you have active tickets. Please contact Reis Nordland customer support for refund or wait until tickets expire.',
   ),
   customerNumber: _('Kundenummer', 'Customer number'),
   deleteConfirmation: {

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -193,8 +193,8 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
         },
         {
           question: _(
-            `Jeg får ikke logget inn i appen AtB med e-post`,
-            `I can not log into the AtB app with e-mail`,
+            `Jeg får ikke logget inn i Reis-appen med e-post`,
+            `I can not log into the Reis app with e-mail`,
           ),
           answer: _(
             `Det er ikke mulig å logge inn i appen med e-post per i dag. Du kan fortsette å bruke reisekort eller opprette en ny brukerprofil med mobilnummer som innlogging. Merk at billettene ikke vil bli overført til din nye brukerprofil. Du kan kontakte kundesenteret vedrørende refusjon dersom du likevel vil lage en ny brukerprofil i appen.`,
@@ -207,8 +207,8 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
             `Do you have any other questions about ticket purchases?`,
           ),
           answer: _(
-            `Se flere måter å kontakte oss på atb.no/kontakt`,
-            `See how to contact us at atb.no/en/contact`,
+            `Se flere måter å kontakte oss på reisnordland.no/kontakt-oss`,
+            `See how to contact us at reisnordland.com/contact-us`,
           ),
         },
       ],


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/3022

Changes to Reis instead of AtB references in these views:

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/21310942/214009961-bea90245-9d88-4be3-8831-ac901b121996.png)
![image](https://user-images.githubusercontent.com/21310942/214009978-b96418b7-302d-4bb8-a8a1-b4c7f04b84c0.png)

</details>
