### PR TITLE
refactor: Correct mode on PlaceScreen in Dashboard stack

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_PlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_PlaceScreen.tsx
@@ -12,7 +12,8 @@ export const Dashboard_PlaceScreen = ({navigation, route}: Props) => (
         : navigation.push('Dashboard_PlaceScreen', {
             place: stopPlace,
             selectedQuayId: quayId,
-            mode: 'Departure',
+            mode: route.params.mode,
+            onCloseRoute: route.params.onCloseRoute,
           })
     }
     onPressDeparture={(items, activeItemIndex) =>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_PlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_PlaceScreen.tsx
@@ -12,7 +12,7 @@ export const Departures_PlaceScreen = ({navigation, route}: Props) => (
         : navigation.push('Departures_PlaceScreen', {
             place: stopPlace,
             selectedQuayId: quayId,
-            mode: 'Departure',
+            mode: route.params.mode,
           })
     }
     onPressDeparture={(items, activeItemIndex) =>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_PlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_PlaceScreen.tsx
@@ -12,7 +12,7 @@ export const Map_PlaceScreen = ({navigation, route}: Props) => (
         : navigation.push('Map_PlaceScreen', {
             place: stopPlace,
             selectedQuayId: quayId,
-            mode: 'Departure',
+            mode: route.params.mode,
           })
     }
     onPressDeparture={(items, activeItemIndex) =>


### PR DESCRIPTION
In the Dashboard-stack the PlaceScreen mode can be both 'Departures' and 'Favorites'. This mode should be forwarded when pushing new PlaceScreen on the stack.