### PR TITLE
build: Fix Android dependency error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -335,6 +335,8 @@ android {
 
 dependencies {
     implementation 'com.facebook.soloader:soloader:0.9.0+'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0"
 
     implementation project(":tokencore")
 


### PR DESCRIPTION
Two kotlin dependencies were picked up as two different transitive dependencies, but with mis-matching version numbers. Adding them as specific dependencies in our build.gradle should fix this.