### PR TITLE
feat: deeplink from each departure on medium widget

### DIFF
--- a/ios/departureWidget/DepartureWidget.swift
+++ b/ios/departureWidget/DepartureWidget.swift
@@ -17,7 +17,7 @@ struct DepartureWidgetEntryView: View {
         ZStack {
             Color("WidgetBackgroundColor")
             WidgetInfoView(widgetFamily: family, viewModel: viewModel)
-        }.widgetURL(URL(string: viewModel.deepLink))
+        }.widgetURL(URL(string: viewModel.deepLink(departure: nil)))
     }
 }
 

--- a/ios/departureWidget/Structs.swift
+++ b/ios/departureWidget/Structs.swift
@@ -264,6 +264,7 @@ struct DepartureTime: Codable {
     let realtime: Bool
     let situations: [SituationElement]
     let serviceJourneyId: String
+    let serviceDate: String
 }
 
 struct SituationElement: Codable {
@@ -317,6 +318,11 @@ struct QuayWithLocation: Codable {
         longitude = try container.decode(Double.self, forKey: .longitude)
         latitude = try container.decode(Double.self, forKey: .latitude)
     }
+}
+
+struct DepartureLinkLabel: Hashable {
+    let label: String
+    let link: String
 }
 
 struct FavouriteDeparture: Codable {
@@ -419,7 +425,8 @@ extension QuayGroup {
                         predictionInaccurate: false,
                         realtime: false,
                         situations: [],
-                        serviceJourneyId: ""
+                        serviceJourneyId: "",
+                        serviceDate: ""
                     )
                 }
             ),

--- a/ios/departureWidget/Views/ChipView.swift
+++ b/ios/departureWidget/Views/ChipView.swift
@@ -1,15 +1,17 @@
 import SwiftUI
 
 struct ChipView: View {
-    let label: String
+    let departure: DepartureLinkLabel
 
     var body: some View {
-        Text(label)
-            .lineLimit(1)
-            .fixedSize()
-            .padding(8)
-            .background(Color("TimeTileBackgroundColor"))
-            .cornerRadius(8)
-            .font(DefaultFonts.bold)
+        Link(destination: URL(string: departure.link)!) {
+            Text(departure.label)
+                .lineLimit(1)
+                .fixedSize()
+                .padding(8)
+                .background(Color("TimeTileBackgroundColor"))
+                .cornerRadius(8)
+                .font(DefaultFonts.bold)
+        }
     }
 }

--- a/ios/departureWidget/Views/ChipView.swift
+++ b/ios/departureWidget/Views/ChipView.swift
@@ -4,14 +4,16 @@ struct ChipView: View {
     let departure: DepartureLinkLabel
 
     var body: some View {
-        Link(destination: URL(string: departure.link)!) {
-            Text(departure.label)
-                .lineLimit(1)
-                .fixedSize()
-                .padding(8)
-                .background(Color("TimeTileBackgroundColor"))
-                .cornerRadius(8)
-                .font(DefaultFonts.bold)
+        if let url = URL(string: departure.link) {
+            Link(destination: url) {
+                Text(departure.label)
+                    .lineLimit(1)
+                    .fixedSize()
+                    .padding(8)
+                    .background(Color("TimeTileBackgroundColor"))
+                    .cornerRadius(8)
+                    .font(DefaultFonts.bold)
+            }
         }
     }
 }

--- a/ios/departureWidget/Views/DepartureTimesView.swift
+++ b/ios/departureWidget/Views/DepartureTimesView.swift
@@ -2,12 +2,12 @@ import Foundation
 import SwiftUI
 
 struct DepartureTimesView: View {
-    var aimedTimes: [String]
+    var departures: [DepartureLinkLabel]
 
     var body: some View {
         HStack {
-            ForEach(aimedTimes, id: \.self) {
-                ChipView(label: $0)
+            ForEach(departures, id: \.self) {
+                ChipView(departure: $0)
             }
         }.clipShape(Rectangle())
     }

--- a/ios/departureWidget/Views/WidgetInfoView.swift
+++ b/ios/departureWidget/Views/WidgetInfoView.swift
@@ -23,7 +23,7 @@ struct WidgetInfoView: View {
         widgetFamily == .systemMedium ? 6 : 3
     }
 
-    private var aimedTimes: [String] {
+    private var departures: [DepartureLinkLabel] {
         viewModel.getDepartureAimedTimes(limit: numberOfDepartures)
     }
 
@@ -87,13 +87,13 @@ struct WidgetInfoView: View {
                         Spacer()
 
                         if viewModel.entry.state == .noDepartureQuays {
-                              Text("no_departures").font(DefaultFonts.bold).frame(maxWidth: .infinity)
+                            Text("no_departures").font(DefaultFonts.bold).frame(maxWidth: .infinity)
                                 .lineLimit(1)
                                 .padding(8)
                                 .background(Color("TimeTileBackgroundColor"))
                                 .cornerRadius(8)
                         } else {
-                            DepartureTimesView(aimedTimes: aimedTimes)
+                            DepartureTimesView(departures: departures)
                         }
                     }
                     .padding(K.padding)

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -63,7 +63,43 @@ export const RootStack = () => {
     const params = parse(path);
     let destination: PartialRoute<any>[] | undefined;
 
-    if (departuresV2Enabled) {
+    if (path.includes('details')) {
+      destination = [
+        {
+          // Index is needed so that the user can go back after
+          // opening the app with the widget when it was not open previously
+          index: 0,
+          name: 'Departures_NearbyStopPlacesScreen',
+        },
+        {
+          name: 'Departures_PlaceScreen',
+          index: 1,
+          params: {
+            place: {
+              name: params.stopName,
+              id: params.stopId,
+            },
+            selectedQuayId: params.quayId,
+            showOnlyFavoritesByDefault: true,
+            mode: 'Departure',
+          },
+        },
+        {
+          name: 'Departures_DepartureDetailsScreen',
+          params: {
+            activeItemIndex: 0,
+            items: [
+              {
+                serviceJourneyId: params.serviceJourneyId,
+                serviceDate: params.serviceDate,
+                date: new Date(),
+                fromQuayId: params.quayId,
+              },
+            ],
+          },
+        },
+      ];
+    } else if (departuresV2Enabled) {
       destination = [
         {
           // Index is needed so that the user can go back after

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -63,7 +63,7 @@ export const RootStack = () => {
     const params = parse(path);
     let destination: PartialRoute<any>[] | undefined;
 
-    if (path.includes('details')) {
+    if (departuresV2Enabled) {
       destination = [
         {
           // Index is needed so that the user can go back after
@@ -84,46 +84,12 @@ export const RootStack = () => {
             mode: 'Departure',
           },
         },
-        {
-          name: 'Departures_DepartureDetailsScreen',
-          params: {
-            activeItemIndex: 0,
-            items: [
-              {
-                serviceJourneyId: params.serviceJourneyId,
-                serviceDate: params.serviceDate,
-                date: new Date(),
-                fromQuayId: params.quayId,
-              },
-            ],
-          },
-        },
-      ];
-    } else if (departuresV2Enabled) {
-      destination = [
-        {
-          // Index is needed so that the user can go back after
-          // opening the app with the widget when it was not open previously
-          index: 0,
-          name: 'Departures_NearbyStopPlacesScreen',
-        },
-        {
-          name: 'Departures_PlaceScreen',
-          params: {
-            place: {
-              name: params.stopName,
-              id: params.stopId,
-            },
-            selectedQuayId: params.quayId,
-            showOnlyFavoritesByDefault: true,
-            mode: 'Departure',
-          },
-        },
       ];
     } else {
       destination = [
         {
-          name: 'NearbyRoot',
+          name: 'Nearby_RootScreen',
+          index: 0,
           params: {
             location: {
               id: params.stopId,
@@ -139,6 +105,24 @@ export const RootStack = () => {
           },
         },
       ];
+    }
+    if (path.includes('details')) {
+      destination.push({
+        name: departuresV2Enabled
+          ? 'Departures_DepartureDetailsScreen'
+          : 'Nearby_DepartureDetailsScreen',
+        params: {
+          activeItemIndex: 0,
+          items: [
+            {
+              serviceJourneyId: params.serviceJourneyId,
+              serviceDate: params.serviceDate,
+              date: new Date(),
+              fromQuayId: params.quayId,
+            },
+          ],
+        },
+      });
     }
 
     return {


### PR DESCRIPTION
Deeplinks in medium widget:
1. Can now click individual departures on the medium widget. 
2. This redirects you to the details screen of the clicked departure.

Closes https://github.com/AtB-AS/kundevendt/issues/3289