### PR TITLE
fix: set max font scale in navbar to 1.7

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -18,6 +18,7 @@ export type ThemeTextProps = TextProps & {
   type?: TextNames;
   color?: ColorType;
   isMarkdown?: boolean;
+  maxFontScale?: number;
 };
 
 export const ThemeText: React.FC<ThemeTextProps> = ({
@@ -26,6 +27,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   isMarkdown = false,
   style,
   children,
+  maxFontScale,
   ...props
 }) => {
   const {theme, useAndroidSystemFont} = useTheme();
@@ -55,7 +57,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   return (
     <Text
       style={[textStyle, style]}
-      maxFontSizeMultiplier={MAX_FONT_SCALE}
+      maxFontSizeMultiplier={maxFontScale ?? MAX_FONT_SCALE}
       {...props}
     >
       {content}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -33,6 +33,8 @@ import {dictionary, useTranslation} from '@atb/translations';
 
 const Tab = createBottomTabNavigator<TabNavigatorStackParams>();
 
+const MAX_FONT_SCALE = 1.7;
+
 export const Root_TabNavigatorStack = () => {
   const {theme} = useTheme();
   const {t} = useTranslation();
@@ -150,6 +152,7 @@ function tabSettings(
         style={{color, textAlign: 'center', lineHeight}}
         accessibilityLabel={tabBarA11yLabel}
         testID={testID}
+        maxFontScale={MAX_FONT_SCALE}
       >
         {tabBarLabel}
       </ThemeText>


### PR DESCRIPTION
ref. https://github.com/AtB-AS/mittatb-app/pull/3246#issuecomment-1405077929

Sets the navbar text scale to maximum 170%. Needed to add a `maxFontScale` param to `ThemeText` to make this possible.

Not sure if this is actually a good thing to do according to WCAG, but it was easy enough to implement, hence the PR. Open for comments.


### Text size 200% vs 170%
<div>
<img width="300px" src="https://user-images.githubusercontent.com/1774972/215119166-28fd23ed-fc97-469f-a0e5-86519b7ee529.png">


<img width="300px" src="https://user-images.githubusercontent.com/1774972/215118994-0cb6a8c6-c4b3-46b3-a84e-c015b996dd42.png">
</div>
