### PR TITLE
fix: use aimedDepartureTime for pagination header

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -80,7 +80,7 @@ export default function LineItem({
 
   const items = group.departures.map<ServiceJourneyDeparture>((dep) => ({
     serviceJourneyId: dep.serviceJourneyId!,
-    date: dep.time,
+    date: dep.aimedTime,
     fromQuayId: group.lineInfo?.quayId,
     serviceDate: dep.serviceDate,
   }));

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -106,7 +106,7 @@ export default function EstimatedCallItem({
             navigateToDetails(
               departure.serviceJourney?.id,
               departure.date,
-              departure.expectedDepartureTime,
+              departure.aimedDepartureTime,
               departure.quay?.id,
               departure.cancellation,
             );

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -93,7 +93,7 @@ export const TripDetailsScreenComponent = ({
                 totalPages={tripPatterns.length}
                 onNavigate={navigate}
                 style={styles.pagination}
-                currentDate={tripPattern.legs[0]?.expectedStartTime}
+                currentDate={tripPattern.legs[0]?.aimedStartTime}
               />
             )}
             <Trip


### PR DESCRIPTION
related to https://github.com/AtB-AS/kundevendt/issues/3219

Use aimed departure time (rutetid) in the paginated header instead of expected time, to prevent header going out of sync after realtime updates. This affects both trip details and departure details.


### Screenshots (see date and time compared to first leg / departure)

<div>
<img width="300px" src="https://user-images.githubusercontent.com/1774972/215504533-6a176856-8358-40e8-96eb-4ccd6efab0f3.png">
<img width="300px" src="https://user-images.githubusercontent.com/1774972/215504608-5d12ab1f-4bd6-4d36-af9d-aac97df702a6.png">
<img width="300px" src="https://user-images.githubusercontent.com/1774972/215504652-f69dbd71-23bc-4d0d-a00f-4cd3a632ddd3.png">
</div>