### PR TITLE
fix: decouple unit tests from env variables

### DIFF
--- a/src/translations/components/DetailsMessages.ts
+++ b/src/translations/components/DetailsMessages.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '@atb/translations';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const DetailsMessages = {
   messages: {

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '../utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const ScreenHeaderTexts = {
   headerButton: {

--- a/src/translations/components/ServiceDisruptions.ts
+++ b/src/translations/components/ServiceDisruptions.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '../utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const ServiceDisruptionsTexts = {
   header: {

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const TravelTokenBoxTexts = {
   tcard: {

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -10,6 +10,7 @@ export {
 
 export type {LanguageAndTextType} from './types';
 export {getTextForLanguage} from './utils';
+export {orgSpecificTranslations} from './orgSpecificTranslations';
 
 export {default as FavoriteTexts} from './components/FavoriteChips';
 export {default as PaginationTexts} from './components/Pagination';

--- a/src/translations/orgSpecificTranslations.ts
+++ b/src/translations/orgSpecificTranslations.ts
@@ -1,0 +1,15 @@
+import merge from 'lodash.merge';
+import {AppOrgs} from '../../types/app-orgs';
+import {APP_ORG} from '@env';
+
+export type Overrides<T> = {
+  [P in keyof T]?: Overrides<T[P]>;
+};
+export function orgSpecificTranslations<T>(
+  translationTexts: T,
+  overrides: Partial<{
+    [org in AppOrgs]: Overrides<T>;
+  }>,
+) {
+  return merge(translationTexts, overrides[APP_ORG]);
+}

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -1,6 +1,6 @@
 import {TransportMode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const FareContractTexts = {
   organizationName: _('AtB', 'AtB'),

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '../utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const OnboardingTexts = {
   welcome: {

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const ProfileTexts = {
   header: {

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -1,4 +1,4 @@
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 import {translation as _} from '../commons';
 
 const bulletPoint = '\u2022';

--- a/src/translations/screens/TicketingSplash.ts
+++ b/src/translations/screens/TicketingSplash.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import orgSpecificTranslations from '../utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const TicketingSplashTexts = {
   header: {

--- a/src/translations/screens/subscreens/ContactSheet.ts
+++ b/src/translations/screens/subscreens/ContactSheet.ts
@@ -1,4 +1,4 @@
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 import {translation as _} from '../../commons';
 const ContactSheetTexts = {
   header: {

--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const DeleteProfileTexts = {
   header: {

--- a/src/translations/screens/subscreens/Information.ts
+++ b/src/translations/screens/subscreens/Information.ts
@@ -1,4 +1,4 @@
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 import {translation as _} from '../../commons';
 
 const bulletPoint = '\u2022';

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const MobileTokenOnboardingTexts = {
   flexibilityInfo: {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const PurchaseOverviewTexts = {
   errorMessageBox: {

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import orgSpecificTranslations from '@atb/translations/utils';
+import {orgSpecificTranslations} from '@atb/translations';
 
 const SelectTravelTokenTexts = {
   travelToken: {

--- a/src/translations/utils.ts
+++ b/src/translations/utils.ts
@@ -1,18 +1,5 @@
-import merge from 'lodash.merge';
-import {AppOrgs} from '../../types/app-orgs';
-import {APP_ORG} from '@env';
 import {Language, useTranslation} from './commons';
 import {LanguageAndTextLanguagesEnum, LanguageAndTextType} from './types';
-
-type Overrides<T> = {
-  [P in keyof T]?: Overrides<T[P]>;
-};
-export default function orgSpecificTranslations<T>(
-  translationTexts: T,
-  overrides: Partial<{[org in AppOrgs]: Overrides<T>}>,
-) {
-  return merge(translationTexts, overrides[APP_ORG]);
-}
 
 /**
  * Get the text in the requested language. If English is requested, it will

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -21,7 +21,7 @@ import {
 import en from 'date-fns/locale/en-GB';
 import nb from 'date-fns/locale/nb';
 import humanizeDuration from 'humanize-duration';
-import {DEFAULT_LANGUAGE, Language} from '../translations';
+import {DEFAULT_LANGUAGE, Language} from '../translations/commons';
 
 const humanizer = humanizeDuration.humanizer({});
 


### PR DESCRIPTION
Unit tests were failing because they attempted to load env variable `APP_ORG`, which isn't initialized when running unit tests. Moving `orgSpecificTranslations()` to its own file and not importing from `index.ts` solves this.