### PR TITLE
feat: Add flex discount info

### DIFF
--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -61,20 +61,23 @@ export function ExpandableSectionItem({
   };
 
   return (
-    <View style={topContainer}>
+    <View
+      style={topContainer}
+      accessible={true}
+      accessibilityLabel={text}
+      accessibilityHint={
+        expanded
+          ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
+          : t(SectionTexts.expandableSectionItem.a11yHint.expand)
+      }
+      accessibilityRole="button"
+      accessibilityState={{
+        expanded: expanded,
+      }}
+    >
       <TouchableOpacity
         onPress={onPress}
         style={sectionStyle.spaceBetween}
-        accessibilityLabel={text}
-        accessibilityHint={
-          expanded
-            ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
-            : t(SectionTexts.expandableSectionItem.a11yHint.expand)
-        }
-        accessibilityRole="button"
-        accessibilityState={{
-          expanded: expanded,
-        }}
         testID={testID}
         {...accessibility}
       >

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -15,23 +15,29 @@ import {
 } from '@atb/reference-data/types';
 import Bugsnag from '@bugsnag/react-native';
 import {
+  defaultFareProductTypeConfig,
   defaultPreassignedFareProducts,
   defaultTariffZones,
   defaultUserProfiles,
-  defaultFareProductTypeConfig,
 } from '@atb/reference-data/defaults';
 import {
-  defaultVatPercent,
-  defaultPaymentTypes,
   defaultModesWeSellTicketsFor,
+  defaultPaymentTypes,
+  defaultVatPercent,
 } from '@atb/configuration/defaults';
 import {PaymentType} from '@atb/ticketing';
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {
+  mapLanguageAndTextType,
   mapToFareProductTypeConfigs,
   mapToTransportModeFilterOptions,
 } from './converters';
 import type {TravelSearchFiltersType} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/types';
+import {LanguageAndTextType} from '@atb/translations';
+
+export type AppTexts = {
+  discountInfo: LanguageAndTextType[];
+};
 
 type ConfigurationContextState = {
   preassignedFareProducts: PreassignedFareProduct[];
@@ -42,6 +48,7 @@ type ConfigurationContextState = {
   vatPercent: number;
   fareProductTypeConfigs: FareProductTypeConfig[];
   travelSearchFilters: TravelSearchFiltersType | undefined;
+  appTexts: AppTexts | undefined;
 };
 
 const defaultConfigurationContextState: ConfigurationContextState = {
@@ -53,6 +60,7 @@ const defaultConfigurationContextState: ConfigurationContextState = {
   vatPercent: defaultVatPercent,
   fareProductTypeConfigs: defaultFareProductTypeConfig,
   travelSearchFilters: undefined,
+  appTexts: undefined,
 };
 
 const FirestoreConfigurationContext = createContext<ConfigurationContextState>(
@@ -75,6 +83,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   >(defaultFareProductTypeConfig);
   const [travelSearchFilters, setTravelSearchFilters] =
     useState<TravelSearchFiltersType>();
+  const [appTexts, setAppTexts] = useState<AppTexts>();
 
   useEffect(() => {
     firestore()
@@ -124,6 +133,11 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
           if (travelSearchFilters) {
             setTravelSearchFilters(travelSearchFilters);
           }
+
+          const appTexts = getAppTextsFromSnapshot(snapshot);
+          if (appTexts) {
+            setAppTexts(appTexts);
+          }
         },
         (error) => {
           Bugsnag.leaveBreadcrumb(
@@ -144,6 +158,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       vatPercent,
       fareProductTypeConfigs,
       travelSearchFilters,
+      appTexts,
     };
   }, [
     preassignedFareProducts,
@@ -154,6 +169,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     vatPercent,
     fareProductTypeConfigs,
     travelSearchFilters,
+    appTexts,
   ]);
 
   return (
@@ -300,4 +316,21 @@ function getTravelSearchFiltersFromSnapshot(
   }
 
   return undefined;
+}
+
+function getAppTextsFromSnapshot(
+  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
+): AppTexts | undefined {
+  const appTextsRaw = snapshot.docs.find((doc) => doc.id == 'appTexts');
+  if (!appTextsRaw) return undefined;
+
+  const discountInfo = mapLanguageAndTextType(appTextsRaw.get('discountInfo'));
+  if (!discountInfo) {
+    Bugsnag.notify(
+      `App text field "discountInfo" should conform: "LanguageAndTextType"`,
+    );
+    return undefined;
+  }
+
+  return {discountInfo};
 }

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -310,7 +310,7 @@ function mapToStringAlternatives<T>(value: any, alternatives: string[]) {
   return value as T;
 }
 
-function mapLanguageAndTextType(text?: any[]) {
+export function mapLanguageAndTextType(text?: any) {
   if (!text) return;
   if (!text.every((item: any) => ['lang', 'value'].every((f) => f in item)))
     return;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/components/FlexTicketDiscountInfo.tsx
@@ -1,0 +1,98 @@
+import * as Sections from '@atb/components/sections';
+import {useState} from 'react';
+import {ThemeText} from '@atb/components/text';
+import {StyleProp, View, ViewStyle} from 'react-native';
+import {InfoChip} from '@atb/components/info-chip';
+import {
+  getTextForLanguage,
+  PurchaseOverviewTexts,
+  useTranslation,
+} from '@atb/translations';
+import {UserProfileWithCountAndOffer} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/use-offer-state';
+import {getReferenceDataName} from '@atb/reference-data/utils';
+import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
+import {formatDecimalNumber} from '@atb/utils/numbers';
+
+type Props = {
+  userProfiles: UserProfileWithCountAndOffer[];
+  style: StyleProp<ViewStyle>;
+};
+
+export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
+  const {t, language} = useTranslation();
+  const [expanded, setExpanded] = useState(true);
+  const {appTexts} = useFirestoreConfiguration();
+
+  if (!userProfiles.some((u) => u.offer.flex_discount_ladder)) return null;
+  const description =
+    getTextForLanguage(appTexts?.discountInfo, language) ||
+    t(PurchaseOverviewTexts.flexDiscount.description);
+
+  return (
+    <View style={style}>
+      <ThemeText
+        type="body__secondary"
+        color="secondary"
+        style={{marginBottom: 12}}
+      >
+        {t(PurchaseOverviewTexts.flexDiscount.heading)}
+      </ThemeText>
+      <Sections.Section>
+        <Sections.ExpandableSectionItem
+          text={t(PurchaseOverviewTexts.flexDiscount.expandableLabel)}
+          textType="heading__component"
+          expanded={expanded}
+          onPress={setExpanded}
+        />
+        {expanded && (
+          <Sections.GenericSectionItem accessibility={{accessible: true}}>
+            <ThemeText>{description}</ThemeText>
+          </Sections.GenericSectionItem>
+        )}
+        {expanded &&
+          [...userProfiles].map((u) => {
+            const ladder = u.offer.flex_discount_ladder;
+            const discountPercent = ladder?.steps[ladder.current].discount;
+            if (!discountPercent) return null;
+
+            const userProfileName = getReferenceDataName(u, language);
+            const discountText = discountPercent.toFixed(0) + ' %';
+            const priceText =
+              formatDecimalNumber(
+                u.offer.prices[0].amount_float || 0,
+                language,
+                2,
+              ) + ' kr';
+
+            return (
+              <Sections.GenericSectionItem
+                accessibility={{
+                  accessible: true,
+                  accessibilityLabel: `${userProfileName}, ${discountText}, ${priceText}`,
+                }}
+                key={userProfileName}
+              >
+                <View
+                  style={{
+                    flex: 1,
+                    flexWrap: 'wrap',
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <ThemeText type="body__secondary" color="secondary">
+                    {userProfileName}
+                  </ThemeText>
+                  <View style={{flexDirection: 'row'}}>
+                    <InfoChip style={{marginRight: 8}} text={discountText} />
+                    <InfoChip text={priceText} />
+                  </View>
+                </View>
+              </Sections.GenericSectionItem>
+            );
+          })}
+      </Sections.Section>
+    </View>
+  );
+};

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/components/FlexTicketDiscountInfo.tsx
@@ -12,6 +12,7 @@ import {UserProfileWithCountAndOffer} from '@atb/stacks-hierarchy/Root_TabNaviga
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {formatDecimalNumber} from '@atb/utils/numbers';
+import {StyleSheet} from '@atb/theme';
 
 type Props = {
   userProfiles: UserProfileWithCountAndOffer[];
@@ -21,6 +22,7 @@ type Props = {
 export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
   const {t, language} = useTranslation();
   const [expanded, setExpanded] = useState(true);
+  const styles = useStyles();
   const {appTexts} = useFirestoreConfiguration();
 
   if (!userProfiles.some((u) => u.offer.flex_discount_ladder)) return null;
@@ -33,7 +35,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
       <ThemeText
         type="body__secondary"
         color="secondary"
-        style={{marginBottom: 12}}
+        style={styles.heading}
       >
         {t(PurchaseOverviewTexts.flexDiscount.heading)}
       </ThemeText>
@@ -72,20 +74,15 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                 }}
                 key={userProfileName}
               >
-                <View
-                  style={{
-                    flex: 1,
-                    flexWrap: 'wrap',
-                    flexDirection: 'row',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                  }}
-                >
+                <View style={styles.userProfileDiscountInfo}>
                   <ThemeText type="body__secondary" color="secondary">
                     {userProfileName}
                   </ThemeText>
-                  <View style={{flexDirection: 'row'}}>
-                    <InfoChip style={{marginRight: 8}} text={discountText} />
+                  <View style={styles.infoChips}>
+                    <InfoChip
+                      style={styles.infoChips_first}
+                      text={discountText}
+                    />
                     <InfoChip text={priceText} />
                   </View>
                 </View>
@@ -96,3 +93,16 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
     </View>
   );
 };
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  heading: {marginBottom: theme.spacings.medium},
+  userProfileDiscountInfo: {
+    flex: 1,
+    flexWrap: 'wrap',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  infoChips: {flexDirection: 'row'},
+  infoChips_first: {marginRight: theme.spacings.small},
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/index.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/index.tsx
@@ -21,6 +21,7 @@ import TravellerSelection from './components/TravellerSelection';
 import ZonesSelection from './components/ZonesSelection';
 import {useOfferDefaults} from './use-offer-defaults';
 import useOfferState from './use-offer-state';
+import {FlexTicketDiscountInfo} from './components/FlexTicketDiscountInfo';
 
 type OverviewProps = PurchaseScreenProps<'PurchaseOverview'>;
 
@@ -57,7 +58,13 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
   const {timeSelectionMode, travellerSelectionMode, zoneSelectionMode} =
     params.fareProductTypeConfig.configuration;
 
-  const {isSearchingOffer, error, totalPrice, refreshOffer} = useOfferState(
+  const {
+    isSearchingOffer,
+    error,
+    totalPrice,
+    refreshOffer,
+    userProfilesWithCountAndOffer,
+  } = useOfferState(
     zoneSelectionMode === 'none' ? 'authority' : 'zones',
     preassignedFareProduct,
     fromTariffZone,
@@ -148,6 +155,11 @@ const PurchaseOverview: React.FC<OverviewProps> = ({
             travelDate={travelDate}
             setTravelDate={setTravelDate}
             validFromTime={travelDate}
+            style={styles.selectionComponent}
+          />
+
+          <FlexTicketDiscountInfo
+            userProfiles={userProfilesWithCountAndOffer}
             style={styles.selectionComponent}
           />
         </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/use-offer-state.ts
@@ -1,7 +1,12 @@
 import {CancelToken as CancelTokenStatic} from '@atb/api';
 import {ErrorType, getAxiosErrorType} from '@atb/api/utils';
 import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
-import {Offer, OfferPrice, searchOffers} from '@atb/ticketing';
+import {
+  FlexDiscountLadder,
+  Offer,
+  OfferPrice,
+  searchOffers,
+} from '@atb/ticketing';
 import {CancelToken} from 'axios';
 import {useCallback, useEffect, useMemo, useReducer} from 'react';
 import {UserProfileWithCount} from '../Travellers/use-user-count-state';
@@ -20,6 +25,7 @@ type OfferState = {
   totalPrice: number;
   error?: OfferError;
   userProfilesWithCountAndOffer: UserProfileWithCountAndOffer[];
+  flexDiscountLadder?: FlexDiscountLadder;
 };
 
 type OfferReducerAction =

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -118,6 +118,14 @@ export type PaymentResponse = {
   status: PaymentStatus;
 };
 
+export type FlexDiscountLadder = {
+  current: number;
+  steps: {
+    expires: string;
+    discount: number; // The discount percentage
+  }[];
+};
+
 export type OfferPrice = {
   amount?: string;
   amount_float?: number;
@@ -133,6 +141,7 @@ export type Offer = {
   offer_id: string;
   traveller_id: string;
   prices: OfferPrice[];
+  flex_discount_ladder?: FlexDiscountLadder;
 };
 
 export type OfferSearchResponse = Offer[];

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -107,6 +107,14 @@ const PurchaseOverviewTexts = {
       _(`Gjelder for ${text}`, `Applies for ${text}`),
     button: _('Til betaling', 'To payment'),
   },
+  flexDiscount: {
+    heading: _('Rabatt', 'Discount'),
+    expandableLabel: _('Din rabatt og pris', 'Your discount and price'),
+    description: _(
+      'Voksen får rabatt i sone A basert på antall kjøp de siste 14 dagene',
+      'Adult get a discount in Zone A based on number of purchases the last 14 days',
+    ),
+  },
 };
 
 export default orgSpecificTranslations(PurchaseOverviewTexts, {


### PR DESCRIPTION
When the field `flexDiscountLadder` is returned in the offer response, the flex discount info is shown. Although we only have flex discount for adult now, the app supports discounts on multiple user profile types.

The expandable with the info is as of now always expanded at start of the purchase process. Might do something about this later, like storing the state of the expandable on the device storage.

The description text has a reference to a specific zone and number of days. Because of this it is made overrideable by specifying a 'discountInfo' under 'appTexts' in Firestore Configuration.

Also a minor change to the ExpandableSectionItem which makes the full height/width of the expandable heading be focusable for the screen reader.