### PR TITLE
fix: use theme color for login spinner

### DIFF
--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -1,5 +1,5 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {LoginTexts, useTranslation} from '@atb/translations';
 import React, {useState} from 'react';
 import {
@@ -34,6 +34,7 @@ export default function PhoneInput({
 }) {
   const {t} = useTranslation();
   const styles = useThemeStyles();
+  const {theme} = useTheme();
   const {signInWithPhoneNumber} = useAuthState();
   const [phoneNumber, setPhoneNumber] = useState('');
   const [prefix, setPrefix] = useState('47');
@@ -134,6 +135,7 @@ export default function PhoneInput({
               <ActivityIndicator
                 style={styles.activityIndicator}
                 size="large"
+                color={theme.text.colors.primary}
               />
             )}
 

--- a/src/translations/screens/subscreens/Login.ts
+++ b/src/translations/screens/subscreens/Login.ts
@@ -61,7 +61,7 @@ const LoginTexts = {
       'Log in with a one-time code sent to your phone',
     ),
     input: {
-      heading: _('Mobilnummer', 'phone number'),
+      heading: _('Mobilnummer', 'Phone number'),
       label: _('+47', '+47'),
       placeholder: _(
         'Skriv inn ditt telefonnummer',


### PR DESCRIPTION
There was no color defined for the spinner, so it defaulted to a gray color. I set the color to the primary text color since that has been used for the spinner in other places as well.

I also fixed the casing of the phone input heading, in english.

Android:

![image](https://user-images.githubusercontent.com/14045515/216092926-fe41e8df-e124-40ef-b56c-df05e15adf2a.png)
![image](https://user-images.githubusercontent.com/14045515/216092946-46463cc2-cd52-4e27-a303-1d8855210841.png) (😅)


iOS:

![image](https://user-images.githubusercontent.com/14045515/216092989-4d218594-e6be-41b0-889e-63ca2e200f18.png)
![image](https://user-images.githubusercontent.com/14045515/216092997-853a3da6-e732-4823-b6bb-069a85211fca.png)


Fixes https://github.com/AtB-AS/kundevendt/issues/3059