### PR TITLE
fix: bump generate-assets to include new nfk travelplanning svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^5.10.0",
+    "@atb-as/generate-assets": "^5.10.1",
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-env": "^7.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.10.0.tgz#dba29ed73e86f3325e1be58762b8ad7c1e10f38a"
-  integrity sha512-Hb3hZANtdaVtyiWvUikvqjBmjFKG1Ek7F9UIMbKVaAU0w3hj1T7wWtW1ev/IUcH09jwllCQ4hN1F3Os0QZgghg==
+"@atb-as/generate-assets@^5.10.1":
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-5.10.1.tgz#010f75f2a0ea5755062abb62e2dd1fb2e114e4c6"
+  integrity sha512-g/85JULcN+IpG6CPv1ugXZ26nXYLmfegQ+Wjh44i+GQ6ilzgUWZoDU/FlsN1K0lA7+NrNTX5CUZ5b+pV7WKJRg==
   dependencies:
     "@atb-as/theme" "^6.2.1"
     commander "^9.4.0"


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/3063

Uses changed SVG from https://github.com/AtB-AS/design-system/pull/101

![1277A87B-972F-45E5-9DD0-9E2380640B3D](https://user-images.githubusercontent.com/21310942/216251158-1b4ac217-fb0a-428a-92e1-9cea5df2a0a3.png)