### PR TITLE
fix: Not log GRPC errors in axios client

### DIFF
--- a/src/mobile-token/mobileTokenClient.ts
+++ b/src/mobile-token/mobileTokenClient.ts
@@ -1,6 +1,4 @@
 import {useCallback, useEffect, useMemo} from 'react';
-// import {NoTokenError} from '@entur/abt-mobile-client-sdk/token/token-state-react-native-lib/src/native/errors';
-// import {Token} from '@entur/abt-mobile-client-sdk/token/token-core-javascript-lib';
 import {
   AbtClient,
   encodeAsSecureContainer,
@@ -10,7 +8,6 @@ import {
   ActivatedToken,
 } from '@entur-private/abt-mobile-client-sdk';
 import Bugsnag from '@bugsnag/react-native';
-// import {ActivatedToken} from '@entur/atb-mobile-client-sdk/token/token-core-javascript-lib/src';
 
 export default function useMobileTokenClient(
   abtClient: AbtClient,

--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -1,6 +1,7 @@
 import {
   ActivatedToken,
   GrpcError,
+  GrpcErrorType,
   handleReattest,
   handleRemoteError,
   RemoteTokenServiceWithInitiate,
@@ -44,11 +45,14 @@ export type TokenService = RemoteTokenServiceWithInitiate & {
   getTokenToggleDetails: () => Promise<TokenLimitResponse>;
 };
 
+const isGrpcErrorType = (errorData: any): errorData is GrpcErrorType =>
+  errorData && 'grpcErrorCode' in errorData;
+
 const grpcErrorHandler = (err: any) => {
   if (axios.isAxiosError(err)) {
     const errorData = err.response?.data as any;
-    if (errorData && 'grpcErrorCode' in errorData) {
-      return Promise.reject(new GrpcError('TEST', errorData));
+    if (isGrpcErrorType(errorData)) {
+      return Promise.reject(new GrpcError(errorData.message, errorData));
     }
   }
   return Promise.reject(err);
@@ -67,6 +71,7 @@ const service: TokenService = {
           [IsEmulatorHeaderName]: String(isEmulator),
         },
         authWithIdToken: true,
+        skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
         timeout: 15000,
       })
       .then((res) => res.data.pendingTokenDetails)
@@ -80,6 +85,7 @@ const service: TokenService = {
         },
         authWithIdToken: true,
         timeout: 15000,
+        skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
       })
       .then((res) => res.data.activeTokenDetails)
       .catch(grpcErrorHandler),
@@ -94,6 +100,7 @@ const service: TokenService = {
         },
         authWithIdToken: true,
         timeout: 15000,
+        skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
       })
       .then((res) => res.data.pendingTokenDetails)
       .catch(grpcErrorHandler),
@@ -114,6 +121,7 @@ const service: TokenService = {
         },
         authWithIdToken: true,
         timeout: 15000,
+        skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
       })
       .then((res) => res.data.activeTokenDetails)
       .catch(grpcErrorHandler),
@@ -128,6 +136,7 @@ const service: TokenService = {
         },
         authWithIdToken: true,
         timeout: 15000,
+        skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
       })
       .then((res) => res.data.activeTokenDetails)
       .catch(grpcErrorHandler),
@@ -143,6 +152,7 @@ const service: TokenService = {
             },
             authWithIdToken: true,
             timeout: 15000,
+            skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
           },
         )
         .then((res) => res.data.removed)
@@ -157,6 +167,7 @@ const service: TokenService = {
           },
           authWithIdToken: true,
           timeout: 15000,
+          skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
         })
         .then((res) => res.data.tokens)
         .catch(grpcErrorHandler),
@@ -173,6 +184,7 @@ const service: TokenService = {
             },
             authWithIdToken: true,
             timeout: 15000,
+            skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
           },
         )
         .then((res) => res.data.tokens)
@@ -184,6 +196,7 @@ const service: TokenService = {
         .get<TokenLimitResponse>('/tokens/v3/toggle/details', {
           authWithIdToken: true,
           timeout: 15000,
+          skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
         })
         .then((res) => res.data)
         .catch(grpcErrorHandler),
@@ -201,6 +214,7 @@ const service: TokenService = {
             },
             authWithIdToken: true,
             timeout: 15000,
+            // skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
           })
           .catch(grpcErrorHandler),
       token,

--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -214,7 +214,7 @@ const service: TokenService = {
             },
             authWithIdToken: true,
             timeout: 15000,
-            // skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
+            skipErrorLogging: (err) => isGrpcErrorType(err.response?.data),
           })
           .catch(grpcErrorHandler),
       token,


### PR DESCRIPTION
Some GRPC errors are not errors per se, but a part of a normal expected flow, for example the error signifying that the token needs renewal. Other errors that really are errors should be handled and logged in the mobile token specific code.