### PR TITLE
fix: Update chip info colors on discount info

### DIFF
--- a/src/components/info-chip/InfoChip.tsx
+++ b/src/components/info-chip/InfoChip.tsx
@@ -5,7 +5,7 @@ import {InteractiveColor} from '@atb/theme/colors';
 
 type Props = {
   text: string;
-  interactiveColor?: InteractiveColor;
+  interactiveColor: InteractiveColor;
   style?: StyleProp<ViewStyle>;
   testID?: string;
 };
@@ -16,7 +16,7 @@ type Props = {
  */
 export const InfoChip = ({
   text,
-  interactiveColor = 'interactive_0',
+  interactiveColor,
   style = {},
   testID = '',
 }: Props) => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Overview/components/FlexTicketDiscountInfo.tsx
@@ -81,9 +81,13 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                   <View style={styles.infoChips}>
                     <InfoChip
                       style={styles.infoChips_first}
+                      interactiveColor={'interactive_2'}
                       text={discountText}
                     />
-                    <InfoChip text={priceText} />
+                    <InfoChip
+                      text={priceText}
+                      interactiveColor={'interactive_2'}
+                    />
                   </View>
                 </View>
               </Sections.GenericSectionItem>


### PR DESCRIPTION
This is changed so they are the same as on recent fare products and fare contracts.

This only affects dark mode. 

Before:
![Screenshot 2023-02-03 at 10 32 39](https://user-images.githubusercontent.com/675421/216564561-8762412a-4577-4fb9-88f1-3772c3ab82e1.png)
After:
![Screenshot 2023-02-03 at 10 32 14](https://user-images.githubusercontent.com/675421/216564566-8662d2f4-08ef-4089-a18f-479642ecef83.png)
