### PR TITLE
fix: don't round minutes when showing seconds

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -90,7 +90,7 @@ export function formatToClock(
   showSeconds?: boolean,
 ) {
   const parsed = parseIfNeeded(isoDate);
-  const rounded = roundMinute(parsed, roundingMethod);
+  const rounded = !showSeconds ? roundMinute(parsed, roundingMethod) : parsed;
   const seconds = showSeconds ? ':' + format(parsed, 'ss') : '';
 
   return formatLocaleTime(rounded, language) + seconds;


### PR DESCRIPTION
follow up to https://github.com/AtB-AS/kundevendt/issues/3219

Fixes issue found by @HanneLH, where minutes were rounded when seconds are shown:

https://user-images.githubusercontent.com/1774972/217524138-8db08d45-b175-4758-a1eb-81648e75815c.MP4


