### PR TITLE
fix: replace AtB kundesenter text for NFK

### DIFF
--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -111,8 +111,8 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
     },
     error: {
       description: _(
-        'Vi får ikke knyttet et reisekort eller en mobil til profilen din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nOm problemet vedvarer kan du ta kontakt med AtB kundesenter.',
-        "We can't connect a travel card or phone to your profile. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact AtB service center.",
+        'Vi får ikke knyttet et reisekort eller en mobil til profilen din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nTa kontakt med Reis Nordland kundeservice om problemet vedvarer.',
+        "We can't connect a travel card or phone to your profile. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact Reis Nordland customer service.",
       ),
     },
   },


### PR DESCRIPTION
Replaces this AtB reference when token does not work:

![image](https://user-images.githubusercontent.com/21310942/217847629-fa002da4-e899-4a68-a2fe-c04d2575d119.png)
