### PR TITLE
fix: remove tram on nfk summary page

### DIFF
--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -123,5 +123,11 @@ export default orgSpecificTranslations(PurchaseOverviewTexts, {
       'Når du er ute og reiser må du ha med reisekortet som er registrert på din profil.',
       'When traveling, you need to bring the travel card registered on your profile.',
     ),
+    summary: {
+      messageInZone: _(
+        `Gjelder for buss i valgte soner`,
+        `Applies for bus in selected zones`,
+      ),
+    },
   },
 });


### PR DESCRIPTION
Removes tram for summary text in NFK app. Should be unchanged for AtB, and ideally it should use the dynamic message based on actually included transport methods in the product, so hopefully won't be used for too long.

![image](https://user-images.githubusercontent.com/21310942/217914004-0192edf8-0b2a-4b37-a72a-6be25ca0ce76.png)
