### PR TITLE
fix: use new colors for zone selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "unimported": "npx unimported"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.2.1",
+    "@atb-as/theme": "^6.2.2",
     "@bugsnag/react-native": "^7.18.2",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-client-sdk": "^1.1.6",

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/AvailableFareProducts/AvailableFareProducts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/AvailableFareProducts/AvailableFareProducts.tsx
@@ -44,7 +44,10 @@ export const AvailableFareProducts = ({
       </ThemeText>
 
       {groupedConfigs.map(([firstConfig, secondConfig]) => (
-        <View style={styles.fareProductsContainer}>
+        <View
+          style={styles.fareProductsContainer}
+          key={firstConfig.type + secondConfig?.type}
+        >
           <FareProductTile
             onPress={() => onProductSelect(firstConfig)}
             testID={`${firstConfig.type}FareProduct`}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/TariffZones/index.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/TariffZones/index.tsx
@@ -457,10 +457,13 @@ const TariffZones: React.FC<TariffZonesProps> = ({
                     // Mapbox Expression syntax
                     'case',
                     ['==', selectedZones.from.id, ['id']],
-                    hexToRgba(theme.static.status.valid.background, 0.6),
+                    hexToRgba(theme.static.zone_selection.from.background, 0.6),
                     ['==', selectedZones.to.id, ['id']],
                     !isApplicableOnSingleZoneOnly
-                      ? hexToRgba(theme.static.status.info.background, 0.6)
+                      ? hexToRgba(
+                          theme.static.zone_selection.to.background,
+                          0.6,
+                        )
                       : 'transparent',
                     'transparent',
                   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,14 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
+"@atb-as/theme@^6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.2.2.tgz#66b41d5504aaf628ec7963dd7f410fdada681a72"
+  integrity sha512-GeOLUogYciMK2SEHCA0sQCy83CeGfd45hN4CeHiuS9LQwSd89HYmfnj4/p2NpbqFzmCAakMwn37ijFegFN9LSQ==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@~7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"


### PR DESCRIPTION
Use the new colors added for zone selection. These colors were added to fix the low contrast colors for NFK. The AtB colors are still the same as before.

New NFK colors:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/14045515/218121318-6318bb93-c0da-4e15-b54f-2b4da3b0bfc0.png">



Fixes https://github.com/AtB-AS/kundevendt/issues/3060