### PR TITLE
fix: Update firebase_app_distribution plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-appcenter (2.0.0)
-    fastlane-plugin-firebase_app_distribution (0.4.0)
+    fastlane-plugin-firebase_app_distribution (0.4.2)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)


### PR DESCRIPTION
The version 0.4.0 has been yanked (removed) from the RubyGems.
https://rubygems.org/gems/fastlane-plugin-firebase_app_distribution/versions
