### PR TITLE
fix: Update Debug.xcconfig to allow build from Dev machines

### DIFF
--- a/ios/Configs/Debug.xcconfig
+++ b/ios/Configs/Debug.xcconfig
@@ -3,4 +3,4 @@
 #include "Config.xcconfig"
 #include "../Pods/Target Support Files/Pods-app/Pods-app.debug.xcconfig"
 CODE_SIGN_IDENTITY=iPhone Developer
-GCC_PREPROCESSOR_DEFINITIONS = $(inherit) IS_WIDGET_ENABLE=$(ENABLE_WIDGET)
+GCC_PREPROCESSOR_DEFINITIONS = $(inherit) IS_WIDGET_ENABLE=$(ENABLE_WIDGET) DEBUG=1


### PR DESCRIPTION
When adding GCC_PREPROCESSOR_DEFINITIONS to Xcode config seems like it rewrites internal Xcode settings for debugging even dough it uses the $(inherit), this PR brings back DEBUG macro.