### PR TITLE
feat: support external links for ticketing info in my profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ vendor/bundle
 assets/design-assets
 src/assets/svg
 
+# Information files
+src/assets/information-data
+
 # Yalc
 .yalc/
 yalc.lock

--- a/.gitignore
+++ b/.gitignore
@@ -95,9 +95,6 @@ vendor/bundle
 assets/design-assets
 src/assets/svg
 
-# Information files
-src/assets/information-data
-
 # Yalc
 .yalc/
 yalc.lock

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -39,7 +39,7 @@ export type AppTexts = {
   discountInfo: LanguageAndTextType[];
 };
 
-type ProfileInfoUrls = {
+type ConfigurableLinks = {
   ticketingInfo: LanguageAndTextType[];
   termsInfo: LanguageAndTextType[];
   inspectionInfo: LanguageAndTextType[];
@@ -55,7 +55,7 @@ type ConfigurationContextState = {
   fareProductTypeConfigs: FareProductTypeConfig[];
   travelSearchFilters: TravelSearchFiltersType | undefined;
   appTexts: AppTexts | undefined;
-  profileInfoUrls: ProfileInfoUrls | undefined;
+  configurableLinks: ConfigurableLinks | undefined;
 };
 
 const defaultConfigurationContextState: ConfigurationContextState = {
@@ -68,7 +68,7 @@ const defaultConfigurationContextState: ConfigurationContextState = {
   fareProductTypeConfigs: defaultFareProductTypeConfig,
   travelSearchFilters: undefined,
   appTexts: undefined,
-  profileInfoUrls: undefined,
+  configurableLinks: undefined,
 };
 
 const FirestoreConfigurationContext = createContext<ConfigurationContextState>(
@@ -92,7 +92,8 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   const [travelSearchFilters, setTravelSearchFilters] =
     useState<TravelSearchFiltersType>();
   const [appTexts, setAppTexts] = useState<AppTexts>();
-  const [profileInfoUrls, setProfileInfoUrls] = useState<ProfileInfoUrls>();
+  const [configurableLinks, setConfigurableLinks] =
+    useState<ConfigurableLinks>();
 
   useEffect(() => {
     firestore()
@@ -148,9 +149,9 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
             setAppTexts(appTexts);
           }
 
-          const profileInfoUrls = getProfileInfoUrlsFromSnapshot(snapshot);
-          if (profileInfoUrls) {
-            setProfileInfoUrls(profileInfoUrls);
+          const configurableLinks = getConfigurableLinksFromSnapshot(snapshot);
+          if (configurableLinks) {
+            setConfigurableLinks(configurableLinks);
           }
         },
         (error) => {
@@ -173,7 +174,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       fareProductTypeConfigs,
       travelSearchFilters,
       appTexts,
-      profileInfoUrls,
+      configurableLinks,
     };
   }, [
     preassignedFareProducts,
@@ -185,7 +186,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     fareProductTypeConfigs,
     travelSearchFilters,
     appTexts,
-    profileInfoUrls,
+    configurableLinks,
   ]);
 
   return (
@@ -351,9 +352,9 @@ function getAppTextsFromSnapshot(
   return {discountInfo};
 }
 
-function getProfileInfoUrlsFromSnapshot(
+function getConfigurableLinksFromSnapshot(
   snapshot: FirebaseFirestoreTypes.QuerySnapshot,
-): ProfileInfoUrls | undefined {
+): ConfigurableLinks | undefined {
   const urls = snapshot.docs.find((doc) => doc.id == 'urls');
 
   const ticketingInfo = mapLanguageAndTextType(urls?.get('ticketingInfo'));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_GenericWebsiteInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_GenericWebsiteInformationScreen.tsx
@@ -2,9 +2,25 @@ import React from 'react';
 import {useTranslation} from '@atb/translations';
 import {ThemeText} from '@atb/components/text';
 import GenericWebsiteInformationScreen from '@atb/translations/screens/subscreens/GenericWebsiteInformationScreen';
+import {View} from 'react-native';
+import {FullScreenHeader} from '@atb/components/screen-header';
+import {Section} from '@atb/components/sections';
 
 export const Profile_GenericWebsiteInformationScreen = () => {
   const {t} = useTranslation();
 
-  return <ThemeText>{t(GenericWebsiteInformationScreen.message)}</ThemeText>;
+  return (
+    <View>
+      <FullScreenHeader
+        title={t(GenericWebsiteInformationScreen.title)}
+        leftButton={{type: 'back'}}
+      />
+
+      <View>
+        <Section withTopPadding withPadding>
+          <ThemeText>{t(GenericWebsiteInformationScreen.message)}</ThemeText>
+        </Section>
+      </View>
+    </View>
+  );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_GenericWebsiteInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_GenericWebsiteInformationScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {useTranslation} from '@atb/translations';
+import {ThemeText} from '@atb/components/text';
+import GenericWebsiteInformationScreen from '@atb/translations/screens/subscreens/GenericWebsiteInformationScreen';
+
+export const Profile_GenericWebsiteInformationScreen = () => {
+  const {t} = useTranslation();
+
+  return <ThemeText>{t(GenericWebsiteInformationScreen.message)}</ThemeText>;
+};

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_GenericWebsiteInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_GenericWebsiteInformationScreen.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {useTranslation} from '@atb/translations';
-import {ThemeText} from '@atb/components/text';
-import GenericWebsiteInformationScreen from '@atb/translations/screens/subscreens/GenericWebsiteInformationScreen';
 import {View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {Section} from '@atb/components/sections';
+import {useTranslation} from '@atb/translations';
+import GenericWebsiteInformationScreen from '@atb/translations/screens/subscreens/GenericWebsiteInformationScreen';
 
 export const Profile_GenericWebsiteInformationScreen = () => {
   const {t} = useTranslation();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -83,15 +83,15 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const isDeparturesV2Enabled = useDeparturesV2Enabled();
   const showMapPage = useMapPage();
 
-  const {profileInfoUrls} = useFirestoreConfiguration();
-  const ticketingInfo = profileInfoUrls?.ticketingInfo
-    ? profileInfoUrls?.ticketingInfo
+  const {configurableLinks} = useFirestoreConfiguration();
+  const ticketingInfo = configurableLinks?.ticketingInfo
+    ? configurableLinks?.ticketingInfo
     : undefined;
-  const termsInfo = profileInfoUrls?.termsInfo
-    ? profileInfoUrls?.termsInfo
+  const termsInfo = configurableLinks?.termsInfo
+    ? configurableLinks?.termsInfo
     : undefined;
-  const inspectionInfo = profileInfoUrls?.inspectionInfo
-    ? profileInfoUrls?.inspectionInfo
+  const inspectionInfo = configurableLinks?.inspectionInfo
+    ? configurableLinks?.inspectionInfo
     : undefined;
   const ticketingInfoUrl = getTextForLanguage(ticketingInfo, language);
   const termsInfoUrl = getTextForLanguage(termsInfo, language);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -15,6 +15,7 @@ import {
   useHasEnabledMobileToken,
   useMobileTokenContextState,
 } from '@atb/mobile-token/MobileTokenContext';
+import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {usePreferences} from '@atb/preferences';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import SelectFavouritesBottomSheet from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet';
@@ -24,7 +25,11 @@ import {
   filterActiveOrCanBeUsedFareContracts,
   useTicketingState,
 } from '@atb/ticketing';
-import {ProfileTexts, useTranslation} from '@atb/translations';
+import {
+  getTextForLanguage,
+  ProfileTexts,
+  useTranslation,
+} from '@atb/translations';
 import DeleteProfileTexts from '@atb/translations/screens/subscreens/DeleteProfile';
 import {numberToAccessibilityString} from '@atb/utils/accessibility';
 import useCopyWithOpacityFade from '@atb/utils/use-copy-with-countdown';
@@ -59,7 +64,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const {wipeToken} = useMobileTokenContextState();
   const style = useProfileHomeStyle();
   const {clearHistory} = useSearchHistory();
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const {authenticationType, signOut, user, customerNumber} = useAuthState();
   const config = useLocalConfig();
 
@@ -77,6 +82,9 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const {setPreference} = usePreferences();
   const isDeparturesV2Enabled = useDeparturesV2Enabled();
   const showMapPage = useMapPage();
+
+  const {profileInfoUrls} = useFirestoreConfiguration();
+  const {ticketingInfo, termsInfo, inspectionInfo} = profileInfoUrls;
 
   const {enable_departures_v2_as_default} = useRemoteConfig();
   const setDeparturesV2Enabled = (value: boolean) => {
@@ -449,35 +457,81 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             <Sections.HeaderSectionItem
               text={t(ProfileTexts.sections.information.heading)}
             />
-            <Sections.LinkSectionItem
-              text={t(
-                ProfileTexts.sections.information.linkSectionItems.ticketing
-                  .label,
-              )}
-              testID="ticketingInfoButton"
-              onPress={() =>
-                navigation.navigate('Profile_TicketingInformationScreen')
-              }
-            />
-            <Sections.LinkSectionItem
-              text={t(
-                ProfileTexts.sections.information.linkSectionItems.terms.label,
-              )}
-              testID="termsInfoButton"
-              onPress={() =>
-                navigation.navigate('Profile_TermsInformationScreen')
-              }
-            />
-            <Sections.LinkSectionItem
-              text={t(
-                ProfileTexts.sections.information.linkSectionItems.inspection
-                  .label,
-              )}
-              testID="inspectionInfoButton"
-              onPress={() =>
-                navigation.navigate('Profile_TicketInspectionInformationScreen')
-              }
-            />
+            {ticketingInfo ? (
+              <Sections.LinkSectionItem
+                icon={<ThemeIcon svg={ExternalLink} />}
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.ticketing
+                    .label,
+                )}
+                testID="ticketingInfoButton"
+                onPress={() =>
+                  Linking.openURL(getTextForLanguage(ticketingInfo, language))
+                }
+              />
+            ) : (
+              <Sections.LinkSectionItem
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.ticketing
+                    .label,
+                )}
+                testID="ticketingInfoButton"
+                onPress={() =>
+                  navigation.navigate('Profile_TicketingInformationScreen')
+                }
+              />
+            )}
+            {termsInfo ? (
+              <Sections.LinkSectionItem
+                icon={<ThemeIcon svg={ExternalLink} />}
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.terms
+                    .label,
+                )}
+                testID="termsInfoButton"
+                onPress={() =>
+                  Linking.openURL(getTextForLanguage(termsInfo, language))
+                }
+              />
+            ) : (
+              <Sections.LinkSectionItem
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.terms
+                    .label,
+                )}
+                testID="termsInfoButton"
+                onPress={() =>
+                  navigation.navigate('Profile_TermsInformationScreen')
+                }
+              />
+            )}
+
+            {inspectionInfo ? (
+              <Sections.LinkSectionItem
+                icon={<ThemeIcon svg={ExternalLink} />}
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.inspection
+                    .label,
+                )}
+                testID="inspectionInfoButton"
+                onPress={() =>
+                  Linking.openURL(getTextForLanguage(inspectionInfo, language))
+                }
+              />
+            ) : (
+              <Sections.LinkSectionItem
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.inspection
+                    .label,
+                )}
+                testID="inspectionInfoButton"
+                onPress={() =>
+                  navigation.navigate(
+                    'Profile_TicketInspectionInformationScreen',
+                  )
+                }
+              />
+            )}
           </Sections.Section>
         )}
         {(!!JSON.parse(IS_QA_ENV || 'false') ||

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -35,7 +35,7 @@ import {numberToAccessibilityString} from '@atb/utils/accessibility';
 import useCopyWithOpacityFade from '@atb/utils/use-copy-with-countdown';
 import useLocalConfig from '@atb/utils/use-local-config';
 import Bugsnag from '@bugsnag/react-native';
-import {IS_QA_ENV} from '@env';
+import {APP_ORG, IS_QA_ENV} from '@env';
 import parsePhoneNumber from 'libphonenumber-js';
 import React from 'react';
 import {Linking, View} from 'react-native';
@@ -477,7 +477,11 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
                 testID="ticketingInfoButton"
                 onPress={() =>
-                  navigation.navigate('Profile_TicketingInformationScreen')
+                  navigation.navigate(
+                    APP_ORG === 'atb'
+                      ? 'Profile_TicketingInformationScreen'
+                      : 'Profile_GenericWebsiteInformationScreen',
+                  )
                 }
               />
             )}
@@ -501,7 +505,11 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
                 testID="termsInfoButton"
                 onPress={() =>
-                  navigation.navigate('Profile_TermsInformationScreen')
+                  navigation.navigate(
+                    APP_ORG === 'atb'
+                      ? 'Profile_TermsInformationScreen'
+                      : 'Profile_GenericWebsiteInformationScreen',
+                  )
                 }
               />
             )}
@@ -527,7 +535,9 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 testID="inspectionInfoButton"
                 onPress={() =>
                   navigation.navigate(
-                    'Profile_TicketInspectionInformationScreen',
+                    APP_ORG === 'atb'
+                      ? 'Profile_TicketInspectionInformationScreen'
+                      : 'Profile_GenericWebsiteInformationScreen',
                   )
                 }
               />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -84,7 +84,18 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const showMapPage = useMapPage();
 
   const {profileInfoUrls} = useFirestoreConfiguration();
-  const {ticketingInfo, termsInfo, inspectionInfo} = profileInfoUrls;
+  const ticketingInfo = profileInfoUrls?.ticketingInfo
+    ? profileInfoUrls?.ticketingInfo
+    : undefined;
+  const termsInfo = profileInfoUrls?.termsInfo
+    ? profileInfoUrls?.termsInfo
+    : undefined;
+  const inspectionInfo = profileInfoUrls?.inspectionInfo
+    ? profileInfoUrls?.inspectionInfo
+    : undefined;
+  const ticketingInfoUrl = getTextForLanguage(ticketingInfo, language);
+  const termsInfoUrl = getTextForLanguage(termsInfo, language);
+  const inspectionInfoUrl = getTextForLanguage(inspectionInfo, language);
 
   const {enable_departures_v2_as_default} = useRemoteConfig();
   const setDeparturesV2Enabled = (value: boolean) => {
@@ -457,7 +468,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             <Sections.HeaderSectionItem
               text={t(ProfileTexts.sections.information.heading)}
             />
-            {ticketingInfo ? (
+            {ticketingInfoUrl ? (
               <Sections.LinkSectionItem
                 icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
@@ -465,9 +476,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                     .label,
                 )}
                 testID="ticketingInfoButton"
-                onPress={() =>
-                  Linking.openURL(getTextForLanguage(ticketingInfo, language))
-                }
+                onPress={() => Linking.openURL(ticketingInfoUrl)}
               />
             ) : (
               <Sections.LinkSectionItem
@@ -485,7 +494,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 }
               />
             )}
-            {termsInfo ? (
+            {termsInfoUrl ? (
               <Sections.LinkSectionItem
                 icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
@@ -493,9 +502,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                     .label,
                 )}
                 testID="termsInfoButton"
-                onPress={() =>
-                  Linking.openURL(getTextForLanguage(termsInfo, language))
-                }
+                onPress={() => Linking.openURL(termsInfoUrl)}
               />
             ) : (
               <Sections.LinkSectionItem
@@ -514,7 +521,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               />
             )}
 
-            {inspectionInfo ? (
+            {inspectionInfoUrl ? (
               <Sections.LinkSectionItem
                 icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
@@ -522,9 +529,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                     .label,
                 )}
                 testID="inspectionInfoButton"
-                onPress={() =>
-                  Linking.openURL(getTextForLanguage(inspectionInfo, language))
-                }
+                onPress={() => Linking.openURL(inspectionInfoUrl)}
               />
             ) : (
               <Sections.LinkSectionItem

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -17,6 +17,7 @@ import {Profile_NearbyStopPlacesScreen} from './Profile_NearbyStopPlacesScreen';
 import {Profile_FavoriteDeparturesScreen} from './Profile_FavoriteDeparturesScreen';
 import {Profile_TermsInformationScreen} from './Profile_TermsInformationScreen';
 import {Profile_TicketInspectionInformationScreen} from './Profile_TicketInspectionInformationScreen';
+import {Profile_GenericWebsiteInformationScreen} from './Profile_GenericWebsiteInformationScreen';
 import {Profile_DeleteProfileScreen} from './Profile_DeleteProfileScreen';
 import {Profile_TravelTokenScreen} from './Profile_TravelTokenScreen';
 import {Profile_SelectTravelTokenScreen} from './Profile_SelectTravelTokenScreen';
@@ -106,6 +107,10 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_TicketInspectionInformationScreen"
         component={Profile_TicketInspectionInformationScreen}
+      />
+      <Stack.Screen
+        name="Profile_GenericWebsiteInformationScreen"
+        component={Profile_GenericWebsiteInformationScreen}
       />
       <Stack.Screen
         name="Profile_NearbyStopPlacesScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -26,6 +26,7 @@ export type ProfileStackParams = {
   Profile_TicketingInformationScreen: undefined;
   Profile_TermsInformationScreen: undefined;
   Profile_TicketInspectionInformationScreen: undefined;
+  Profile_GenericWebsiteInformationScreen: undefined;
   Profile_NearbyStopPlacesScreen: NearbyStopPlacesScreenParams;
   Profile_PlaceScreen: PlaceScreenParams;
 };

--- a/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
+++ b/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
@@ -1,0 +1,21 @@
+import {translation as _} from '../../commons';
+import {orgSpecificTranslations} from '@atb/translations';
+
+const GenericWebsiteInformationScreenTextsInternal = {
+  message: _(
+    'Gjeldende informasjon finner du på www.atb.no',
+    'Current information can be found on atb.no',
+  ),
+};
+
+export default orgSpecificTranslations(
+  GenericWebsiteInformationScreenTextsInternal,
+  {
+    nfk: {
+      message: _(
+        'Gjeldende informasjon finner du på www.reisnordland.no',
+        'Current information can be found on reisnordland.com',
+      ),
+    },
+  },
+);

--- a/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
+++ b/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
@@ -4,7 +4,7 @@ import {orgSpecificTranslations} from '@atb/translations';
 const GenericWebsiteInformationScreenTextsInternal = {
   message: _(
     'Gjeldende informasjon finner du på www.atb.no',
-    'Current information can be found on atb.no',
+    'Current information can be found on www.atb.no/en',
   ),
 };
 
@@ -14,7 +14,7 @@ export default orgSpecificTranslations(
     nfk: {
       message: _(
         'Gjeldende informasjon finner du på www.reisnordland.no',
-        'Current information can be found on reisnordland.com',
+        'Current information can be found on www.reisnordland.com',
       ),
     },
   },

--- a/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
+++ b/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
@@ -2,6 +2,7 @@ import {translation as _} from '../../commons';
 import {orgSpecificTranslations} from '@atb/translations';
 
 const GenericWebsiteInformationScreenTextsInternal = {
+  title: _('Informasjon', 'Information'),
   message: _(
     'Gjeldende informasjon finner du på www.atb.no',
     'Current information can be found on www.atb.no/en',


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/3046

Makes it possible to provide urls in Firestore for the information that AtB are providing by embedding text into the code of the app. Should be unchanged for AtB if urls are not provided.

In the unlikely event that the app should function while being offline, a fallback generic page (found in Screenshots) have been implemented for other orgs than AtB.

<details>
<summary>Screenshots</summary>

NFK (notice external link icon):
![9357A8B1-9C44-48F9-B56C-D269863D7905](https://user-images.githubusercontent.com/21310942/218757273-8b352345-4836-498d-8319-69a4564e9964.jpeg)
AtB:
![0936704C-7C8A-4440-B699-BC59EBAD8055](https://user-images.githubusercontent.com/21310942/218757264-26b59fb5-918b-48e8-84b3-fee9e889b06e.jpeg)

Norwegian fallback page:
![9336CC3A-CC33-4A9F-A8AD-80F9C2C9B149](https://user-images.githubusercontent.com/21310942/218755598-b7995ca0-2396-47ac-ab95-80a800d826c1.png)
English fallback page:
![BD29850A-1D1F-40AF-90A0-F2232FC45B73](https://user-images.githubusercontent.com/21310942/218755607-40195980-5cd0-4d33-807c-b78d622e6580.png)

</details>