### PR TITLE
fix: Stale animation caused wrong content on purchase tab

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/index.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/index.tsx
@@ -40,6 +40,7 @@ export default function TicketingTabs() {
       <Tab.Navigator
         tabBar={(props: MaterialTopTabBarProps) => <TabBar {...props} />}
         initialRouteName={initialRoute}
+        screenOptions={{animationEnabled: false}}
       >
         <Tab.Screen
           name="PurchaseTab"


### PR DESCRIPTION
There is a bug with the react-navigation material top tab library
on Android, where after navigating to it from other places in the
app (and also through deep linking to it) the animation is not
triggered when changing tab, meaning the selected tab is correct,
but the content shown is actually from the previously selected tab.

I did not find any other easy enough way to fix this except
disabling animation on the purchase tabs.

This fixes the issue described in this comment:
https://github.com/AtB-AS/mittatb-app/pull/3278#issuecomment-1427749363
