### PR TITLE
feat: Firestore traveler category description

### DIFF
--- a/src/reference-data/defaults/user-profiles.json
+++ b/src/reference-data/defaults/user-profiles.json
@@ -10,6 +10,16 @@
       "lang": "nob",
       "value": "Fra 20 til og med 66 år."
     },
+    "alternativeDescriptions": [
+      {
+        "lang": "eng",
+        "value": "20 to 66 years."
+      },
+      {
+        "lang": "nob",
+        "value": "20 til og med 66 år."
+      }
+    ],
     "alternativeNames": [
       {
         "lang": "eng",
@@ -36,6 +46,16 @@
       "lang": "nob",
       "value": "Fra 67 år, personer med norsk uføretrygd, blinde og døvblinde."
     },
+    "alternativeDescriptions": [
+      {
+        "lang": "eng",
+        "value": "Over 67 or with concessionary card."
+      },
+      {
+        "lang": "nob",
+        "value": "Over 67 eller med gyldig honnørbevis."
+      }
+    ],
     "alternativeNames": [
       {
         "lang": "eng",
@@ -62,6 +82,16 @@
       "lang": "nob",
       "value": "Fra 6 til og med 19 år. Kjøp barnebillett om du skal ha med sykkel."
     },
+    "alternativeDescriptions": [
+      {
+        "lang": "eng",
+        "value": "6 to 19 years."
+      },
+      {
+        "lang": "nob",
+        "value": "6 til og med 19 år."
+      }
+    ],
     "alternativeNames": [
       {
         "lang": "eng",
@@ -88,6 +118,16 @@
       "lang": "nob",
       "value": "Studenter og elever på videregående skole til og med 34 år."
     },
+    "alternativeDescriptions": [
+      {
+        "lang": "eng",
+        "value": "Fulltime students under 35."
+      },
+      {
+        "lang": "nob",
+        "value": "Fulltidsstudenter og elever under 35 år."
+      }
+    ],
     "alternativeNames": [
       {
         "lang": "eng",
@@ -114,6 +154,16 @@
       "lang": "nob",
       "value": "Fra 16 til og med 19 år."
     },
+    "alternativeDescriptions": [
+      {
+        "lang": "eng",
+        "value": "16 to 19 years."
+      },
+      {
+        "lang": "nob",
+        "value": "Fra 16 til og med 19 år"
+      }
+    ],
     "alternativeNames": [
       {
         "lang": "eng",
@@ -140,6 +190,16 @@
       "lang": "nob",
       "value": "Vernepliktig i norsk førstegangstjeneste."
     },
+    "alternativeDescriptions": [
+      {
+        "lang": "eng",
+        "value": "Soldiers in mandatory service."
+      },
+      {
+        "lang": "nob",
+        "value": "Vernepliktig i førstegangstjeneste."
+      }
+    ],
     "alternativeNames": [
       {
         "lang": "eng",

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -29,6 +29,7 @@ export type UserProfile = {
   name: LanguageAndTextType;
   alternativeNames: LanguageAndTextType[];
   description: LanguageAndTextType;
+  alternativeDescriptions: LanguageAndTextType[];
   version: string;
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Travellers/MultipleTravellersSelection.tsx
@@ -6,6 +6,7 @@ import {
   PurchaseOverviewTexts,
   TranslateFunction,
   Language,
+  getTextForLanguage,
 } from '@atb/translations';
 import * as Sections from '../../../../../components/sections';
 import {getReferenceDataName} from '@atb/reference-data/utils';
@@ -53,9 +54,15 @@ export default function MultipleTravellersSelection({
           testID={'counterInput_' + u.userTypeString.toLowerCase()}
           color="interactive_2"
           hideSubtext={hideTravellerDescriptions}
-          subtext={t(
-            TicketTravellerTexts.information(u.userTypeString, fareProductType),
-          )}
+          subtext={[
+            getTextForLanguage(u.alternativeDescriptions, language),
+            t(
+              TicketTravellerTexts.information(
+                u.userTypeString,
+                fareProductType,
+              ),
+            ),
+          ].join(' ')}
         />
       ))}
     </Sections.Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Purchase/Travellers/SingleTravellerSelection.tsx
@@ -4,6 +4,7 @@ import {
   useTranslation,
   TicketTravellerTexts,
   PurchaseOverviewTexts,
+  getTextForLanguage,
 } from '@atb/translations';
 import * as Sections from '../../../../../components/sections';
 import {getReferenceDataName} from '@atb/reference-data/utils';
@@ -29,11 +30,11 @@ export default function SingleTravellerSelection({
   };
 
   function travellerInfoByFareProductType(fareProductType: string | undefined) {
-    return (u: UserProfileWithCount) => {
-      return t(
-        TicketTravellerTexts.information(u.userTypeString, fareProductType),
-      );
-    };
+    return (u: UserProfileWithCount) =>
+      [
+        getTextForLanguage(u.alternativeDescriptions, language),
+        t(TicketTravellerTexts.information(u.userTypeString, fareProductType)),
+      ].join(' ');
   }
 
   return (

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -1,5 +1,6 @@
 import {translation as _} from '../../commons';
 import {APP_ORG} from '@env';
+import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
 
 enum TravellerType {
   adult = 'ADULT',
@@ -8,6 +9,21 @@ enum TravellerType {
   student = 'STUDENT',
   military = 'MILITARY',
 }
+
+const SpecificExtensionsInternal = {
+  singleChild: _('Sykkel.', 'Bike.'),
+  periodAdult: _('', ''),
+  periodChild: _('Gyldig på nattbuss.', 'Valid for night bus.'),
+  periodStudent: _('Gyldig på nattbuss.', 'Valid for night bus. '),
+  periodSenior: _('Gyldig på nattbuss.', 'Valid for night bus.'),
+};
+
+const SpecificExtensions = orgSpecificTranslations(SpecificExtensionsInternal, {
+  nfk: {
+    singleChild: _('', ''),
+    periodAdult: _('Gyldig på nattbuss.', 'Valid for night bus.'),
+  },
+});
 
 function specificOverrides(
   travellerType: string,
@@ -19,36 +35,25 @@ function specificOverrides(
     case 'single':
       switch (travellerType) {
         case TravellerType.child:
-          return _('6 til og med 19 år. Sykkel.', '6 to 19 years. Bike.');
+          return SpecificExtensions.singleChild;
         default:
-          return undefined;
+          return _('', '');
       }
     case 'period':
       switch (travellerType) {
+        case TravellerType.adult:
+          return SpecificExtensions.periodAdult;
         case TravellerType.child:
-          return _(
-            '6 til og med 19 år. Gyldig på nattbuss.',
-            '6 to 19 years. Valid for night bus.',
-          );
+          return SpecificExtensions.periodChild;
         case TravellerType.student:
-          if (APP_ORG === 'atb')
-            return _(
-              'Fulltidsstudenter og elever under 35 år. Gyldig på nattbuss.',
-              'Fulltime students under 35. Valid for night bus. ',
-            );
-          else
-            return _(
-              'Fulltidsstudenter og elever under 30 år.',
-              'Fulltime students under 30.',
-            );
+          return SpecificExtensions.periodStudent;
         case TravellerType.senior:
-          return _(
-            'Over 67 eller med gyldig honnørbevis. Gyldig på nattbuss.',
-            'Over 67 or with concessionary card. Valid for night bus.',
-          );
+          return SpecificExtensions.periodSenior;
         default:
-          return undefined;
+          return _('', '');
       }
+    default:
+      return _('', '');
   }
 }
 


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/3480 

Using the changes from https://github.com/AtB-AS/webshop2/pull/270, modified to work in the app. 

Ensures that passenger category descriptions for ticketing are used from Firestore referenceData if it exists.