### PR TITLE
fix: filter realtime departures by line

### DIFF
--- a/src/api/departures/departure-group.ts
+++ b/src/api/departures/departure-group.ts
@@ -25,6 +25,14 @@ export type DepartureGroupsQuery = CursoredQuery<{
   limitPerLine: number;
 }>;
 
+export type DepartureRealtimeQuery = {
+  quayIds: string[];
+  startTime: string;
+  limit: number;
+  limitPerLine?: number;
+  lineIds?: string[];
+};
+
 export type DepartureFavoritesQuery = CursoredQuery<{
   startTime: string;
   limitPerLine: number;

--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -10,7 +10,8 @@ import {
   DeparturesRealtimeData,
   PaginationInput,
 } from '@atb/sdk';
-import {flatMap, uniqueItems} from '@atb/utils/array';
+import {flatMap} from '@atb/utils/array';
+import {onlyUniques} from '@atb/utils/only-uniques';
 import client from '../client';
 import {
   DepartureFavoritesQuery,
@@ -71,8 +72,8 @@ export async function getRealtimeDepartures(
 
   const params = build({
     ...query,
-    quayIds: uniqueItems(query.quayIds),
-    lineIds: query.lineIds ? uniqueItems(query.lineIds) : undefined,
+    quayIds: query.quayIds.filter(onlyUniques),
+    lineIds: query.lineIds?.filter(onlyUniques),
   });
   const url = `bff/v2/departures/realtime?${params}`;
 

--- a/src/place-screen/hooks/use-quay-data.ts
+++ b/src/place-screen/hooks/use-quay-data.ts
@@ -78,6 +78,7 @@ type DepartureDataActions =
   | {
       type: 'LOAD_REALTIME_DATA';
       quay: DepartureTypes.Quay;
+      favoriteDepartures?: UserFavoriteDepartures;
     }
   | {
       type: 'STOP_LOADER';
@@ -166,10 +167,11 @@ const reducer: ReducerWithSideEffects<
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            const quayIds = [action.quay.id];
-
-            const realtimeData = await getRealtimeDepartures(quayIds, {
-              limitPerLine: state.queryInput.numberOfDepartures,
+            const lineIds = action.favoriteDepartures?.map((f) => f.lineId);
+            const realtimeData = await getRealtimeDepartures({
+              quayIds: [action.quay.id],
+              lineIds,
+              limit: state.queryInput.numberOfDepartures,
               startTime: state.queryInput.startTime,
             });
 
@@ -251,6 +253,9 @@ export function useQuayData(
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
   const isFocused = useIsFocused();
   const {favoriteDepartures} = useFavorites();
+  const activeFavoriteDepartures = showOnlyFavorites
+    ? favoriteDepartures
+    : undefined;
   const timeout = useTimeoutRequest();
 
   const loadDepartures = useCallback(() => {
@@ -260,12 +265,12 @@ export function useQuayData(
       type: 'LOAD_INITIAL_DEPARTURES',
       quay,
       startTime,
-      favoriteDepartures: showOnlyFavorites ? favoriteDepartures : undefined,
+      favoriteDepartures: activeFavoriteDepartures,
       limitPerLine,
       timeRange,
       timeout,
     });
-  }, [quay, startTime, showOnlyFavorites, favoriteDepartures, mode]);
+  }, [quay, startTime, activeFavoriteDepartures, mode]);
 
   useEffect(() => {
     loadDepartures();
@@ -283,7 +288,12 @@ export function useQuayData(
     }
   }, [state.tick, state.lastRefreshTime]);
   useInterval(
-    () => dispatch({type: 'LOAD_REALTIME_DATA', quay: quay}),
+    () =>
+      dispatch({
+        type: 'LOAD_REALTIME_DATA',
+        quay: quay,
+        favoriteDepartures: activeFavoriteDepartures,
+      }),
     updateFrequencyInSeconds * 1000,
     [quay.id],
     !isFocused || mode !== 'Departure',
@@ -298,7 +308,15 @@ export function useQuayData(
     state.tick,
     HARD_REFRESH_LIMIT_IN_MINUTES * 60,
     loadDepartures,
-    useCallback(() => dispatch({type: 'LOAD_REALTIME_DATA', quay}), []),
+    useCallback(
+      () =>
+        dispatch({
+          type: 'LOAD_REALTIME_DATA',
+          quay,
+          favoriteDepartures: activeFavoriteDepartures,
+        }),
+      [],
+    ),
   );
 
   return {

--- a/src/place-screen/hooks/use-stop-place-state.ts
+++ b/src/place-screen/hooks/use-stop-place-state.ts
@@ -75,6 +75,7 @@ type DepartureDataActions =
   | {
       type: 'LOAD_REALTIME_DATA';
       stopPlace: StopPlace;
+      favoriteDepartures?: UserFavoriteDepartures;
     }
   | {
       type: 'STOP_LOADER';
@@ -155,15 +156,18 @@ const reducer: ReducerWithSideEffects<
     }
 
     case 'LOAD_REALTIME_DATA': {
-      if (!state.data?.length) return NoUpdate();
+      if (!state.data?.length || !action.stopPlace.quays) return NoUpdate();
       return SideEffect<DepartureDataState, DepartureDataActions>(
         async (_, dispatch) => {
           // Use same query input with same startTime to ensure that
           // we get the same result.
           try {
-            const quayIds = action.stopPlace.quays?.map((q) => q.id);
-            const realtimeData = await getRealtimeDepartures(quayIds, {
-              limitPerLine: state.queryInput.numberOfDepartures,
+            const quayIds = action.stopPlace.quays?.map((q) => q.id) ?? [];
+            const lineIds = action.favoriteDepartures?.map((f) => f.lineId);
+            const realtimeData = await getRealtimeDepartures({
+              quayIds,
+              lineIds,
+              limit: state.queryInput.numberOfDepartures,
               startTime: state.queryInput.startTime,
             });
             dispatch({
@@ -244,6 +248,9 @@ export function useStopPlaceData(
 ) {
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
   const {favoriteDepartures} = useFavorites();
+  const activeFavoriteDepartures = showOnlyFavorites
+    ? favoriteDepartures
+    : undefined;
   const timeout = useTimeoutRequest();
 
   const loadDepartures = useCallback(() => {
@@ -255,10 +262,10 @@ export function useStopPlaceData(
       startTime,
       timeRange,
       limitPerLine,
-      favoriteDepartures: showOnlyFavorites ? favoriteDepartures : undefined,
+      favoriteDepartures: activeFavoriteDepartures,
       timeOut: timeout,
     });
-  }, [stopPlace, startTime, showOnlyFavorites, favoriteDepartures, mode]);
+  }, [stopPlace, startTime, activeFavoriteDepartures, mode]);
 
   useEffect(() => {
     loadDepartures();
@@ -277,7 +284,12 @@ export function useStopPlaceData(
   }, [state.tick, state.lastRefreshTime]);
 
   useInterval(
-    () => dispatch({type: 'LOAD_REALTIME_DATA', stopPlace}),
+    () =>
+      dispatch({
+        type: 'LOAD_REALTIME_DATA',
+        stopPlace,
+        favoriteDepartures: activeFavoriteDepartures,
+      }),
     updateFrequencyInSeconds * 1000,
     [stopPlace.id],
     !isFocused || mode !== 'Departure',
@@ -292,7 +304,15 @@ export function useStopPlaceData(
     state.tick,
     HARD_REFRESH_LIMIT_IN_MINUTES * 60,
     loadDepartures,
-    useCallback(() => dispatch({type: 'LOAD_REALTIME_DATA', stopPlace}), []),
+    useCallback(
+      () =>
+        dispatch({
+          type: 'LOAD_REALTIME_DATA',
+          stopPlace,
+          favoriteDepartures: activeFavoriteDepartures,
+        }),
+      [],
+    ),
   );
 
   return {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
@@ -69,6 +69,7 @@ type DepartureDataActions =
     }
   | {
       type: 'LOAD_REALTIME_DATA';
+      favoriteDepartureIds: string[];
     }
   | {
       type: 'STOP_LOADER';
@@ -155,7 +156,11 @@ const reducer: ReducerWithSideEffects<
           try {
             const realtimeData = await getStopPlaceGroupRealtime(
               state.data ?? [],
-              state.queryInput,
+              {
+                limitPerLine: state.queryInput.limitPerLine,
+                startTime: state.queryInput.startTime,
+                lineIds: action.favoriteDepartureIds,
+              },
             );
             dispatch({
               type: 'UPDATE_REALTIME',
@@ -264,6 +269,15 @@ export function useFavoriteDepartureData(
       }),
     [JSON.stringify(dashboardFavoriteIds)],
   );
+  const dashboardFavoriteLineIds = dashboardFavorites.map((f) => f.lineId);
+  const loadRealTimeData = useCallback(
+    () =>
+      dispatch({
+        type: 'LOAD_REALTIME_DATA',
+        favoriteDepartureIds: dashboardFavoriteLineIds,
+      }),
+    [JSON.stringify(dashboardFavoriteLineIds)],
+  );
 
   useEffect(() => {
     if (!state.tick) {
@@ -279,11 +293,11 @@ export function useFavoriteDepartureData(
     state.tick,
     HARD_REFRESH_LIMIT_IN_MINUTES * 60,
     loadInitialDepartures,
-    useCallback(() => dispatch({type: 'LOAD_REALTIME_DATA'}), []),
+    loadRealTimeData,
   );
 
   useInterval(
-    () => dispatch({type: 'LOAD_REALTIME_DATA'}),
+    loadRealTimeData,
     updateFrequencyInSeconds * 1000,
     [],
     !isFocused,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/use-departure-data.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/use-departure-data.ts
@@ -232,7 +232,10 @@ const reducer: ReducerWithSideEffects<
           try {
             const realtimeData = await getStopPlaceGroupRealtime(
               state.data ?? [],
-              state.queryInput,
+              {
+                limitPerLine: state.queryInput.limitPerLine,
+                startTime: state.queryInput.startTime,
+              },
             );
             dispatch({
               type: 'UPDATE_REALTIME',

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -35,3 +35,10 @@ export function iterateWithNext<T>(
   }
   return [...generator(iterable)];
 }
+
+/**
+ * Returns an array with duplicates removed
+ */
+export function uniqueItems<T>(iterable: T[]) {
+  return [...new Set(iterable)];
+}

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -35,10 +35,3 @@ export function iterateWithNext<T>(
   }
   return [...generator(iterable)];
 }
-
-/**
- * Returns an array with duplicates removed
- */
-export function uniqueItems<T>(iterable: T[]) {
-  return [...new Set(iterable)];
-}


### PR DESCRIPTION
Together with https://github.com/AtB-AS/atb-bff/pull/224, this PR adds filtering on lines when fetching realtime departures on the dashboard, and when favorites are toggled in departures. (Also a bit of related refactoring)

resolves https://github.com/AtB-AS/kundevendt/issues/3252