### PR TITLE
test: add testid for e2e

### DIFF
--- a/src/components/transportation-icon/TransportationIcon.tsx
+++ b/src/components/transportation-icon/TransportationIcon.tsx
@@ -17,6 +17,7 @@ export type TransportationIconProps = {
   size?: keyof Theme['icon']['size'];
   style?: StyleProp<ViewStyle>;
   disabled?: boolean;
+  testID?: string;
 };
 
 export const TransportationIcon: React.FC<TransportationIconProps> = ({
@@ -26,6 +27,7 @@ export const TransportationIcon: React.FC<TransportationIconProps> = ({
   size = 'normal',
   style,
   disabled,
+  testID,
 }) => {
   const {t} = useTranslation();
   const {theme} = useTheme();
@@ -65,6 +67,7 @@ export const TransportationIcon: React.FC<TransportationIconProps> = ({
         svg={svg}
         colorType={themeColor}
         accessibilityLabel={t(getTranslatedModeName(mode))}
+        testID={testID}
       />
       {lineNumberElement}
     </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -79,7 +79,11 @@ const ResultItemHeader: React.FC<{
 
   return (
     <View style={styles.resultHeader}>
-      <ThemeText style={styles.fromPlaceText} type={'body__secondary--bold'}>
+      <ThemeText
+        style={styles.fromPlaceText}
+        type={'body__secondary--bold'}
+        testID="resultDeparturePlace"
+      >
         {startName
           ? t(
               TripSearchTexts.results.resultItem.header.title(
@@ -221,7 +225,11 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                         />
                       )}
                       <View style={styles.departureTimes}>
-                        <ThemeText type="body__tertiary" color="primary">
+                        <ThemeText
+                          type="body__tertiary"
+                          color="primary"
+                          testID={'schTime' + i}
+                        >
                           {formatToClock(
                             leg.expectedStartTime,
                             language,
@@ -233,6 +241,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                             style={styles.scheduledTime}
                             type="body__tertiary--strike"
                             color="secondary"
+                            testID={'aimTime' + i}
                           >
                             {formatToClock(
                               leg.aimedStartTime,
@@ -266,7 +275,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
           <View>
             <DestinationIcon style={styles.iconContainer} />
             <View style={styles.departureTimes}>
-              <ThemeText type="body__tertiary" color="primary">
+              <ThemeText type="body__tertiary" color="primary" testID="endTime">
                 {formatToClock(tripPattern.expectedEndTime, language, 'ceil')}
               </ThemeText>
             </View>
@@ -488,6 +497,7 @@ const TransportationLeg = ({
       mode={leg.mode}
       subMode={leg.line?.transportSubmode}
       lineNumber={leg.line?.publicCode}
+      testID="trLeg"
     />
   );
 };


### PR DESCRIPTION
The new travel search was missing some test-ids that is beneficial for the E2E-tests once they're up and running again.

From https://github.com/AtB-AS/kundevendt/issues/3288