### PR TITLE
fix: Show walking minutes with correct rounding

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -23,6 +23,7 @@ import {
   secondsBetween,
   secondsToDuration,
   secondsToDurationShort,
+  secondsToMinutes,
 } from '@atb/utils/date';
 import {
   getQuayName,
@@ -53,7 +54,6 @@ import {Destination} from '@atb/assets/svg/mono-icons/places';
 import {CollapsedLegs} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CollapsedLegs';
 import useFontScale from '@atb/utils/use-font-scale';
 import TripDetails from '@atb/translations/screens/subscreens/TripDetails';
-import {secondsToMinutes} from 'date-fns';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -463,6 +463,7 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
 
   const mustWalk = significantWalkTime(leg.duration);
   const mustWait = showWaitTime && significantWaitTime(waitTimeInSeconds);
+  const walkMinutes = secondsToMinutes(leg.duration);
 
   const a11yText =
     mustWalk && mustWait
@@ -479,7 +480,7 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
   return (
     <View style={styles.walkContainer}>
       <ThemeIcon accessibilityLabel={a11yText} testID="fLeg" svg={Walk} />
-      <Text style={styles.walkDuration}>{secondsToMinutes(leg.duration)}</Text>
+      <Text style={styles.walkDuration}>{walkMinutes}</Text>
     </View>
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -463,7 +463,6 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
 
   const mustWalk = significantWalkTime(leg.duration);
   const mustWait = showWaitTime && significantWaitTime(waitTimeInSeconds);
-  const walkMinutes = secondsToMinutes(leg.duration);
 
   const a11yText =
     mustWalk && mustWait
@@ -480,7 +479,7 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
   return (
     <View style={styles.walkContainer}>
       <ThemeIcon accessibilityLabel={a11yText} testID="fLeg" svg={Walk} />
-      <Text style={styles.walkDuration}>{walkMinutes}</Text>
+      <Text style={styles.walkDuration}>{secondsToMinutes(leg.duration)}</Text>
     </View>
   );
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -38,6 +38,10 @@ export function secondsToDurationShort(
     round: true,
   });
 }
+// Translates seconds to minutes without postfix. Returns minimum 1
+export function secondsToMinutes(seconds: number): string {
+  return Math.max(Math.round(seconds / 60), 1).toString();
+}
 
 export function secondsToMinutesShort(
   seconds: number,
@@ -49,7 +53,10 @@ export function secondsToMinutesShort(
   });
 }
 
-export function secondsToMinutes(seconds: number, language: Language): string {
+export function secondsToMinutesLong(
+  seconds: number,
+  language: Language,
+): string {
   return getHumanizer(seconds * 1000, language, {
     units: ['m'],
     round: true,
@@ -147,7 +154,7 @@ export function formatToClockOrLongRelativeMinutes(
     return now;
   }
 
-  return secondsToMinutes(diff, language);
+  return secondsToMinutesLong(diff, language);
 }
 
 export function isRelativeButNotNow(


### PR DESCRIPTION
Fix minutes in walk icon to match trip details and avoid 0 minutes in icon

https://github.com/AtB-AS/kundevendt/issues/3288#issuecomment-1434420975