### PR TITLE
fix: Only put margin on icon in button if there is another element

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -145,13 +145,15 @@ export const Button = React.forwardRef<any, ButtonProps>(
     const leftStyling: ViewStyle = {
       position: isInline ? 'relative' : 'absolute',
       left: isInline ? undefined : spacing,
-      marginRight: isInline ? theme.spacings.xSmall : undefined,
+      marginRight:
+        isInline && (text || rightIcon) ? theme.spacings.xSmall : undefined,
     };
 
     const rightStyling: ViewStyle = {
       position: isInline ? 'relative' : 'absolute',
       right: isInline ? undefined : spacing,
-      marginLeft: isInline ? theme.spacings.xSmall : undefined,
+      marginLeft:
+        isInline && (text || leftIcon) ? theme.spacings.xSmall : undefined,
     };
 
     return (


### PR DESCRIPTION
Fix issue where there is a margin on right side of buttons on map

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-06 at 14 14 13](https://user-images.githubusercontent.com/85479566/223120252-47bf3ef3-0c9c-48ab-ba41-be055e9efbf9.png)
