### PR TITLE
feat: update zone selection component

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -10,10 +10,10 @@ import {
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {
-  tariffZonesDescription,
   tariffZonesSummary,
   TariffZoneWithMetadata,
 } from '../../Root_PurchaseTariffZonesSearchByMapScreen';
+import {getReferenceDataName} from '@atb/reference-data/utils';
 
 type ZonesSelectionProps = {
   fareProductTypeConfig: FareProductTypeConfig;
@@ -34,7 +34,7 @@ export default function ZonesSelection({
   onSelect,
   style,
 }: ZonesSelectionProps) {
-  const itemStyle = useStyles();
+  const styles = useStyles();
   const {t, language} = useTranslation();
 
   const accessibility: AccessibilityProps = {
@@ -57,37 +57,73 @@ export default function ZonesSelection({
       <ThemeText
         type="body__secondary"
         color="secondary"
-        style={itemStyle.sectionText}
+        style={styles.sectionText}
         accessibilityLabel={t(
-          PurchaseOverviewTexts.zones.label[selectionMode].a11yLabel,
+          PurchaseOverviewTexts.zones.title[selectionMode].a11yLabel,
         )}
       >
-        {t(PurchaseOverviewTexts.zones.label[selectionMode].text)}
+        {t(PurchaseOverviewTexts.zones.title[selectionMode].text)}
       </ThemeText>
       <Sections.Section {...accessibility}>
-        <Sections.ButtonSectionItem
-          label={t(TariffZonesTexts.zoneTitle)}
-          value={tariffZonesDescription(
-            fromTariffZone,
-            toTariffZone,
-            language,
-            t,
-          )}
-          highlighted={true}
-          inlineValue={false}
-          onPress={() => {
+        <Sections.GenericClickableSectionItem
+          onPress={() =>
             onSelect({
               fromTariffZone,
               toTariffZone,
               fareProductTypeConfig,
-            });
-          }}
+            })
+          }
           testID="selectZonesButton"
-        />
+        >
+          {selectionMode === 'single' ? (
+            <ZoneLabel tariffZone={fromTariffZone} />
+          ) : (
+            <>
+              <View style={styles.fromZone}>
+                <ThemeText
+                  color="secondary"
+                  type="body__secondary"
+                  style={styles.toFromLabel}
+                >
+                  {t(PurchaseOverviewTexts.zones.label.from)}
+                </ThemeText>
+                <ZoneLabel tariffZone={fromTariffZone} />
+              </View>
+              <View style={styles.toZone}>
+                <ThemeText
+                  color="secondary"
+                  type="body__secondary"
+                  style={styles.toFromLabel}
+                >
+                  {t(PurchaseOverviewTexts.zones.label.to)}
+                </ThemeText>
+                <ZoneLabel tariffZone={toTariffZone} />
+              </View>
+            </>
+          )}
+        </Sections.GenericClickableSectionItem>
       </Sections.Section>
     </View>
   );
 }
+
+const ZoneLabel = ({tariffZone}: {tariffZone: TariffZoneWithMetadata}) => {
+  const {t, language} = useTranslation();
+  const zoneName = t(
+    TariffZonesTexts.zoneName(getReferenceDataName(tariffZone, language)),
+  );
+
+  return tariffZone.venueName ? (
+    <ThemeText style={{flexShrink: 1}}>
+      <ThemeText type="body__primary--bold">
+        {tariffZone.venueName + ' '}
+      </ThemeText>
+      ({zoneName})
+    </ThemeText>
+  ) : (
+    <ThemeText type="body__primary--bold">{zoneName}</ThemeText>
+  );
+};
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   subtitleStyle: {
@@ -95,5 +131,16 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   sectionText: {
     marginBottom: theme.spacings.medium,
+  },
+  fromZone: {
+    flexDirection: 'row',
+  },
+  toZone: {
+    flexDirection: 'row',
+    marginTop: theme.spacings.small,
+  },
+  toFromLabel: {
+    minWidth: 36,
+    marginRight: theme.spacings.small,
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -48,6 +48,10 @@ export default function ZonesSelection({
     return <></>;
   }
 
+  const displayAsOneZone =
+    fromTariffZone.id === toTariffZone.id &&
+    fromTariffZone.venueName === toTariffZone.venueName;
+
   return (
     <View style={style}>
       <ThemeText
@@ -71,7 +75,7 @@ export default function ZonesSelection({
           }
           testID="selectZonesButton"
         >
-          {selectionMode === 'single' ? (
+          {displayAsOneZone ? (
             <ZoneLabel tariffZone={fromTariffZone} />
           ) : (
             <>
@@ -135,7 +139,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginTop: theme.spacings.small,
   },
   toFromLabel: {
-    minWidth: 36,
+    minWidth: 40,
     marginRight: theme.spacings.small,
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -2,11 +2,7 @@ import {screenReaderPause, ThemeText} from '@atb/components/text';
 import * as Sections from '@atb/components/sections';
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {StyleSheet} from '@atb/theme';
-import {
-  PurchaseOverviewTexts,
-  TariffZonesTexts,
-  useTranslation,
-} from '@atb/translations';
+import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {
@@ -109,19 +105,18 @@ export default function ZonesSelection({
 
 const ZoneLabel = ({tariffZone}: {tariffZone: TariffZoneWithMetadata}) => {
   const {t, language} = useTranslation();
-  const zoneName = t(
-    TariffZonesTexts.zoneName(getReferenceDataName(tariffZone, language)),
-  );
+  const zoneName = getReferenceDataName(tariffZone, language);
+  const zoneLabel = t(PurchaseOverviewTexts.zones.zoneName(zoneName));
 
   return tariffZone.venueName ? (
     <ThemeText style={{flexShrink: 1}}>
       <ThemeText type="body__primary--bold">
         {tariffZone.venueName + ' '}
       </ThemeText>
-      ({zoneName})
+      ({zoneLabel})
     </ThemeText>
   ) : (
-    <ThemeText type="body__primary--bold">{zoneName}</ThemeText>
+    <ThemeText type="body__primary--bold">{zoneLabel}</ThemeText>
   );
 };
 

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -80,28 +80,6 @@ export const tariffZonesSummary = (
   }
 };
 
-export const tariffZonesDescription = (
-  fromTariffZone: TariffZone,
-  toTariffZone: TariffZone,
-  language: Language,
-  t: TranslateFunction,
-): string => {
-  if (fromTariffZone.id === toTariffZone.id) {
-    return t(
-      TariffZonesTexts.zoneDescription.text.singleZone(
-        getReferenceDataName(fromTariffZone, language),
-      ),
-    );
-  } else {
-    return t(
-      TariffZonesTexts.zoneDescription.text.multipleZone(
-        getReferenceDataName(fromTariffZone, language),
-        getReferenceDataName(toTariffZone, language),
-      ),
-    );
-  }
-};
-
 const departurePickerAccessibilityLabel = (
   fromTariffZone: TariffZoneWithMetadata,
   language: Language,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -73,6 +73,7 @@ const PurchaseOverviewTexts = {
       from: _('Fra', 'From'),
       to: _('Til', 'To'),
     },
+    zoneName: (zoneName: string) => _(`Sone ${zoneName}`, `Zone ${zoneName}`),
   },
   productSelection: {
     title: _('Velg billett', 'Select a ticket'),

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -56,15 +56,22 @@ const PurchaseOverviewTexts = {
     ),
   },
   zones: {
-    label: {
+    title: {
       single: {
-        text: _('Velg sone (kun én)', 'Select zone (only one)'),
-        a11yLabel: _('Velg sone (kun én)', 'Select zone (only one)'),
+        text: _('Velg holdeplass/sone (kun én)', 'Select stop/zone (only one)'),
+        a11yLabel: _(
+          'Velg holdeplass eller sone (kun én)',
+          'Select stop or zone (only one)',
+        ),
       },
       multiple: {
-        text: _('Velg sone(r)', 'Select zone(s)'),
-        a11yLabel: _('Velg soner', 'Select zones'),
+        text: _('Velg holdeplass/sone(r)', 'Select stop/zone(s)'),
+        a11yLabel: _('Velg holeplass eller soner', 'Select stop or zones'),
       },
+    },
+    label: {
+      from: _('Fra', 'From'),
+      to: _('Til', 'To'),
     },
   },
   productSelection: {

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -20,17 +20,7 @@ const TariffZonesTexts = {
     },
   },
   zoneTitle: _(`Reisesone(r)`, `Travel zone(s)`),
-  zoneDescription: {
-    text: {
-      singleZone: (zoneName: string) =>
-        _(`Sone ${zoneName}`, `Zone ${zoneName}`),
-      multipleZone: (zoneNameFrom: string, zoneNameTo: string) =>
-        _(
-          `Sone ${zoneNameFrom} til sone ${zoneNameTo}`,
-          `Zone ${zoneNameFrom} to zone ${zoneNameTo}`,
-        ),
-    },
-  },
+  zoneName: (zoneName: string) => _(`Sone ${zoneName}`, `Zone ${zoneName}`),
 
   location: {
     singleZone: {

--- a/src/translations/screens/subscreens/TariffZones.ts
+++ b/src/translations/screens/subscreens/TariffZones.ts
@@ -20,8 +20,6 @@ const TariffZonesTexts = {
     },
   },
   zoneTitle: _(`Reisesone(r)`, `Travel zone(s)`),
-  zoneName: (zoneName: string) => _(`Sone ${zoneName}`, `Zone ${zoneName}`),
-
   location: {
     singleZone: {
       label: _('Reise i ', 'Travel in '),


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/3536

Updates the zone selection component to show selected stop places. If from and to zone and stop place are the same, show only one line, if not split into two lines with "From" and "To" labels. If there's only one zone selectable, only one line is shown.

https://user-images.githubusercontent.com/1774972/223431288-19b49cbd-bc4c-478f-ac7a-f27bd85328d2.mp4