### PR TITLE
feat: Remote config to disable vehicle operator logos

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -35,6 +35,7 @@ export type RemoteConfig = {
   enable_new_travel_search: boolean;
   enable_from_travel_search_to_ticket: boolean;
   enable_vehicles_in_map: boolean;
+  enable_vehicle_operator_logo: boolean;
   enable_realtime_map: boolean;
 };
 
@@ -72,6 +73,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_new_travel_search: false,
   enable_from_travel_search_to_ticket: false,
   enable_vehicles_in_map: false,
+  enable_vehicle_operator_logo: false,
   enable_realtime_map: false,
 };
 
@@ -173,6 +175,10 @@ export function getConfig(): RemoteConfig {
     values['enable_vehicles_in_map']?.asBoolean() ??
     defaultRemoteConfig.enable_vehicles_in_map;
 
+  const enable_vehicle_operator_logo =
+    values['enable_vehicle_operator_logo']?.asBoolean() ??
+    defaultRemoteConfig.enable_vehicle_operator_logo;
+
   const enable_realtime_map =
     values['enable_realtime_map']?.asBoolean() ??
     defaultRemoteConfig.enable_realtime_map;
@@ -210,7 +216,8 @@ export function getConfig(): RemoteConfig {
     enable_travel_search_filters,
     enable_new_travel_search,
     enable_from_travel_search_to_ticket,
-    enable_vehicles_in_map: enable_vehicles_in_map,
+    enable_vehicles_in_map,
+    enable_vehicle_operator_logo,
     enable_realtime_map,
   };
 }

--- a/src/vehicles/components/OperatorLogo.tsx
+++ b/src/vehicles/components/OperatorLogo.tsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import {Image, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 type OperatorLogoProps = {
   operatorName: string;
   logoUrl: string | undefined;
 };
-export const OperatorLogo = ({operatorName, logoUrl}: OperatorLogoProps) => (
-  <View style={{flex: 1, alignItems: 'center'}}>
-    {logoUrl ? (
-      <Image
-        source={{uri: logoUrl}}
-        style={{height: 50, width: 120}}
-        resizeMode="contain"
-      />
-    ) : (
-      <ThemeText type={'body__primary--big--bold'}>{operatorName}</ThemeText>
-    )}
-  </View>
-);
+export const OperatorLogo = ({operatorName, logoUrl}: OperatorLogoProps) => {
+  const {enable_vehicle_operator_logo} = useRemoteConfig();
+  return (
+    <View style={{flex: 1, alignItems: 'center'}}>
+      {logoUrl && enable_vehicle_operator_logo ? (
+        <Image
+          source={{uri: logoUrl}}
+          style={{height: 50, width: 120}}
+          resizeMode="contain"
+        />
+      ) : (
+        <ThemeText type={'body__primary--big--bold'}>{operatorName}</ThemeText>
+      )}
+    </View>
+  );
+};


### PR DESCRIPTION
Since we don't know yet how operators will provide logos through Entur we add a remote config to disable logos if they don't behave as expected.