### PR TITLE
feat: update zone selection a11y label

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -5,10 +5,7 @@ import {StyleSheet} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
-import {
-  tariffZonesSummary,
-  TariffZoneWithMetadata,
-} from '../../Root_PurchaseTariffZonesSearchByMapScreen';
+import {TariffZoneWithMetadata} from '../../Root_PurchaseTariffZonesSearchByMapScreen';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 
 type ZonesSelectionProps = {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -2,7 +2,12 @@ import {screenReaderPause, ThemeText} from '@atb/components/text';
 import * as Sections from '@atb/components/sections';
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {StyleSheet} from '@atb/theme';
-import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import {
+  Language,
+  PurchaseOverviewTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {TariffZoneWithMetadata} from '../../Root_PurchaseTariffZonesSearchByMapScreen';
@@ -34,9 +39,8 @@ export default function ZonesSelection({
     accessible: true,
     accessibilityRole: 'button',
     accessibilityLabel:
-      tariffZonesSummary(fromTariffZone, toTariffZone, language, t) +
-      screenReaderPause,
-    accessibilityHint: t(PurchaseOverviewTexts.tariffZones.a11yHint),
+      a11yLabel(fromTariffZone, toTariffZone, language, t) + screenReaderPause,
+    accessibilityHint: t(PurchaseOverviewTexts.zones.a11yHint),
   };
 
   const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
@@ -119,6 +123,35 @@ const ZoneLabel = ({tariffZone}: {tariffZone: TariffZoneWithMetadata}) => {
   ) : (
     <ThemeText type="body__primary--bold">{zoneLabel}</ThemeText>
   );
+};
+
+const a11yLabel = (
+  from: TariffZoneWithMetadata,
+  to: TariffZoneWithMetadata,
+  language: Language,
+  t: TranslateFunction,
+): string => {
+  const displayAsOneZone = from.id === to.id && from.venueName === to.venueName;
+
+  const getZoneText = (tz: TariffZoneWithMetadata) => {
+    const venueName = tz.venueName ? `${tz.venueName}, ` : '';
+    const zoneName = getReferenceDataName(tz, language);
+    return venueName + t(PurchaseOverviewTexts.zones.zoneName(zoneName));
+  };
+
+  if (displayAsOneZone) {
+    const prefix = t(PurchaseOverviewTexts.zones.a11yLabelPrefixSingle);
+    return `${prefix} ${getZoneText(from)}`;
+  } else {
+    const prefix = t(PurchaseOverviewTexts.zones.a11yLabelPrefixMultiple);
+    const fromLabel = `${t(
+      PurchaseOverviewTexts.zones.label.from,
+    )} ${getZoneText(from)}`;
+    const toLabel = `${t(PurchaseOverviewTexts.zones.label.to)} ${getZoneText(
+      to,
+    )}`;
+    return `${prefix} ${fromLabel}, ${toLabel}`;
+  }
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -58,28 +58,6 @@ type TariffZoneSelection = {
 
 type Props = RootStackScreenProps<'Root_PurchaseTariffZonesSearchByMapScreen'>;
 
-export const tariffZonesSummary = (
-  fromTariffZone: TariffZone,
-  toTariffZone: TariffZone,
-  language: Language,
-  t: TranslateFunction,
-): string => {
-  if (fromTariffZone.id === toTariffZone.id) {
-    return t(
-      TariffZonesTexts.zoneSummary.text.singleZone(
-        getReferenceDataName(fromTariffZone, language),
-      ),
-    );
-  } else {
-    return t(
-      TariffZonesTexts.zoneSummary.text.multipleZone(
-        getReferenceDataName(fromTariffZone, language),
-        getReferenceDataName(toTariffZone, language),
-      ),
-    );
-  }
-};
-
 const departurePickerAccessibilityLabel = (
   fromTariffZone: TariffZoneWithMetadata,
   language: Language,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/CompactFareContractInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/CompactFareContractInfo.tsx
@@ -4,10 +4,10 @@ import {StyleSheet} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {AccessibilityProps, View} from 'react-native';
-import {tariffZonesSummary} from '@atb/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen';
 import {
   getNonInspectableTokenWarning,
   isValidFareContract,
+  tariffZonesSummary,
   userProfileCountAndName,
 } from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/FareContractInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/FareContractInfo.tsx
@@ -26,7 +26,6 @@ import {
 import React from 'react';
 import {View} from 'react-native';
 import {UserProfileWithCount} from '../../../Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
-import {tariffZonesSummary} from '@atb/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen';
 import {
   getNonInspectableTokenWarning,
   isValidFareContract,
@@ -34,6 +33,7 @@ import {
   ValidityStatus,
   userProfileCountAndName,
   getValidityStatus,
+  tariffZonesSummary,
 } from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {screenReaderPause} from '@atb/components/text';
 import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils.ts
@@ -1,5 +1,5 @@
 import {FareContractState} from '@atb/ticketing';
-import {UserProfile} from '@atb/reference-data/types';
+import {UserProfile, TariffZone} from '@atb/reference-data/types';
 import {UserProfileWithCount} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
 import {
   findReferenceDataById,
@@ -11,6 +11,7 @@ import {
   Language,
   LanguageAndTextType,
   TranslateFunction,
+  TariffZonesTexts,
 } from '@atb/translations';
 import {
   findInspectable,
@@ -173,3 +174,25 @@ export const getOtherDeviceIsInspectableWarning = (
 
 export const isValidFareContract = (status: ValidityStatus) =>
   status === 'valid';
+
+export function tariffZonesSummary(
+  fromTariffZone: TariffZone,
+  toTariffZone: TariffZone,
+  language: Language,
+  t: TranslateFunction,
+): string {
+  if (fromTariffZone.id === toTariffZone.id) {
+    return t(
+      TariffZonesTexts.zoneSummary.text.singleZone(
+        getReferenceDataName(fromTariffZone, language),
+      ),
+    );
+  } else {
+    return t(
+      TariffZonesTexts.zoneSummary.text.multipleZone(
+        getReferenceDataName(fromTariffZone, language),
+        getReferenceDataName(toTariffZone, language),
+      ),
+    );
+  }
+}

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -28,9 +28,6 @@ const PurchaseOverviewTexts = {
       `Activate to select travellers`,
     ),
   },
-  tariffZones: {
-    a11yHint: _('Aktivér for å velge soner', 'Activate to select zones'),
-  },
   product: {
     a11yHint: _(
       'Aktivér for å velge billettype',
@@ -74,6 +71,9 @@ const PurchaseOverviewTexts = {
       to: _('Til', 'To'),
     },
     zoneName: (zoneName: string) => _(`Sone ${zoneName}`, `Zone ${zoneName}`),
+    a11yLabelPrefixSingle: _('Valgt sone:', 'Selected zone:'),
+    a11yLabelPrefixMultiple: _('Valgte soner:', 'Selected zones:'),
+    a11yHint: _('Aktivér for å velge soner', 'Activate to select zones'),
   },
   productSelection: {
     title: _('Velg billett', 'Select a ticket'),


### PR DESCRIPTION
Updates a11y label to reflect what the zone selection component displays after https://github.com/AtB-AS/mittatb-app/pull/3346, e.g. "Selected zones: From Prinsens gate, zone A, to Zone B1.

Also moves `tariffZonesSummary` to closer to where it's being used now.

closes https://github.com/AtB-AS/kundevendt/issues/3536