### PR TITLE
feat: update night ticket inspection symbol

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/InspectionSymbol.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/InspectionSymbol.tsx
@@ -8,6 +8,8 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import {Bus} from '@atb/assets/svg/mono-icons/transportation';
 import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
 import {ContrastColor} from '@atb-as/theme';
+import {Moon} from '@atb/assets/svg/mono-icons/ticketing';
+import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 export type InspectionSymbolProps = {
   preassignedFareProduct?: PreassignedFareProduct;
@@ -66,9 +68,15 @@ const InspectableContent = ({
   const {language} = useTranslation();
   const styles = useStyles();
 
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === preassignedFareProduct?.type,
+  );
   const shouldFill =
     preassignedFareProduct?.type === 'period' ||
     preassignedFareProduct?.type === 'hour24';
+  const InspectionSvg =
+    fareProductTypeConfig?.illustration === 'night' ? Moon : Bus;
 
   return (
     <View
@@ -91,7 +99,7 @@ const InspectableContent = ({
         </ThemeText>
       )}
       <ThemeIcon
-        svg={Bus}
+        svg={InspectionSvg}
         fill={shouldFill ? themeColor.text : undefined}
         size={'large'}
       />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/InspectionSymbol.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/InspectionSymbol.tsx
@@ -73,8 +73,8 @@ const InspectableContent = ({
     (c) => c.type === preassignedFareProduct?.type,
   );
   const shouldFill =
-    preassignedFareProduct?.type === 'period' ||
-    preassignedFareProduct?.type === 'hour24';
+    fareProductTypeConfig?.illustration === 'period' ||
+    fareProductTypeConfig?.illustration === 'hour24';
   const InspectionSvg =
     fareProductTypeConfig?.illustration === 'night' ? Moon : Bus;
 


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/3636

- Updates InspectionSymbol to show the "Moon" icon when `fareProductTypeConfig.illustration` is set to "night".
- Updates `shouldFill` to use the `illustration` field as well. (No visual changes, but could prevent things from breaking in the future)

<div>
<img width="300px" src="https://user-images.githubusercontent.com/1774972/224342760-90aac494-402a-4213-8d41-994cb73a0b0b.PNG">
<img width="300px" src="https://user-images.githubusercontent.com/1774972/224342772-cf33bda8-f081-44f4-a7c1-3d519b8d79fb.PNG">
</div>

