### PR TITLE
fix: Fix Android dark mode toggle

### DIFF
--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -40,6 +40,7 @@ export function Toggle({
       onValueChange={(value) => handleValueChange(value)}
       trackColor={{
         true: theme.interactive[interactiveColor].outline.background,
+        false: theme.static.background.background_3.background,
       }}
       thumbColor="white"
       style={Platform.OS === 'android' ? styles.android : styles.ios}


### PR DESCRIPTION
Make Android toggles visible when dark mode is set in app but not on phone.
<details>
<summary>Screenshot</summary>

![Screenshot_1678702266](https://user-images.githubusercontent.com/85479566/224671692-9b6dde7d-baed-4357-b30c-4c0ed6536979.png)
</details>

Close https://github.com/AtB-AS/kundevendt/issues/2359