### PR TITLE
feat: Retry Remote Config fetch when the request failed

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -41,7 +41,7 @@ export type RemoteConfig = {
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
-  enable_network_logging: true,
+  enable_network_logging: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
   enable_intercom: true,
   enable_i18n: false,


### PR DESCRIPTION
- Will retry fetching remote config values every 15 seconds until a
  successful fetch.
- Will only notify error to Bugsnag if 'enable_network_logging' is
  true. If it is not true, a breadcrumb will be sent instead.
- The default value for 'enable_network_logging' was changed to
  false as this is the value that we have in production today.
