### PR TITLE
fix: Fix several warnings

### DIFF
--- a/src/diagnostics/bugsnagConfig.ts
+++ b/src/diagnostics/bugsnagConfig.ts
@@ -1,5 +1,11 @@
 import Bugsnag, {Event} from '@bugsnag/react-native';
 
+/**
+ * Set to true if you want Bugsnag breadcrumbs to be written to console.log
+ * locally
+ * */
+const LOG_BREADCRUMBS_LOCALLY = false;
+
 export default function configureAndStartBugsnag() {
   if (!__DEV__) {
     Bugsnag.start();
@@ -31,9 +37,12 @@ export default function configureAndStartBugsnag() {
       onError?.(event, () => {});
       console.error('[BUGSNAG]', error, JSON.stringify(metadata, null, 2));
     };
-    Bugsnag.leaveBreadcrumb = (message, metadata) =>
-      // eslint-disable-next-line
-      console.log(message, metadata || "");
+    Bugsnag.leaveBreadcrumb = (message, metadata) => {
+      if (LOG_BREADCRUMBS_LOCALLY) {
+        // eslint-disable-next-line
+        console.log(message, metadata || '');
+      }
+    };
     Bugsnag.setUser = () => {};
   }
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,14 +1,12 @@
 import auth from '@react-native-firebase/auth';
 import Bugsnag from '@bugsnag/react-native';
 import {v4 as uuid} from 'uuid';
-import {APP_GROUP_NAME} from '@env';
 
 import {setInstallId as setApiInstallId} from './api/client';
 import {loadLocalConfig} from './local-config';
 import storage from './storage';
 
 export async function setupConfig() {
-  await storage.setAppGroupName(APP_GROUP_NAME);
   await ensureFirstTimeSetup();
   const {installId} = await loadLocalConfig();
   Bugsnag.setUser(installId);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -172,10 +172,9 @@ export default function useOfferState(
             });
           }
         } catch (err) {
-          console.warn(err);
-
           const errorType = getAxiosErrorType(err);
           if (errorType !== 'cancel') {
+            console.warn(err);
             dispatch({
               type: 'SET_ERROR',
               error: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
@@ -84,6 +84,7 @@ const CompactFareContracts: React.FC<Props> = ({
           );
           return (
             <CompactFareContractInfo
+              key={fareContract.id}
               {...fareContractInfoDetailsProps}
               now={now}
               onPressDetails={() => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -217,11 +217,12 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
               }}
             >
               <View style={styles.legOutput}>
-                {interpose(
-                  legs.map((leg, i) => (
-                    <View
-                      key={tripPattern.compressedQuery + leg.aimedStartTime}
-                    >
+                {legs.map((leg, i) => (
+                  <View
+                    key={tripPattern.compressedQuery + leg.aimedStartTime}
+                    style={styles.legAndDash}
+                  >
+                    <View>
                       {leg.mode === 'foot' ? (
                         <FootLeg leg={leg} nextLeg={tripPattern.legs[i + 1]} />
                       ) : (
@@ -262,11 +263,13 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                         )}
                       </View>
                     </View>
-                  )),
-                  <View style={[styles.dashContainer, iconHeight]}>
-                    <LegDash />
-                  </View>,
-                )}
+                    {i < legs.length - 1 ? (
+                      <View style={[styles.dashContainer, iconHeight]}>
+                        <LegDash />
+                      </View>
+                    ) : null}
+                  </View>
+                ))}
               </View>
               {collapsedLegs.length ? (
                 <View style={[styles.dashContainer, iconHeight]}>
@@ -410,6 +413,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   legOutput: {
     flexDirection: 'row',
   },
+  legAndDash: {flexDirection: 'row'},
   departureTimes: {
     flexDirection: 'row',
     justifyContent: 'flex-start',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -17,7 +17,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {screenReaderHidden} from '@atb/utils/accessibility';
-import {flatMap, interpose} from '@atb/utils/array';
+import {flatMap} from '@atb/utils/array';
 import {
   formatToClock,
   isInThePast,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -332,7 +332,7 @@ export const Profile_DebugInfoScreen = () => {
             expandContent={
               <View>
                 {Object.entries(user?.toJSON() ?? {}).map(([key, value]) => (
-                  <MapEntry title={key} value={value} />
+                  <MapEntry key={key} title={key} value={value} />
                 ))}
               </View>
             }
@@ -347,7 +347,7 @@ export const Profile_DebugInfoScreen = () => {
               <View>
                 {!!idToken ? (
                   Object.entries(idToken).map(([key, value]) => (
-                    <MapEntry title={key} value={value} />
+                    <MapEntry key={key} title={key} value={value} />
                   ))
                 ) : (
                   <ThemeText>No id token</ThemeText>
@@ -366,6 +366,7 @@ export const Profile_DebugInfoScreen = () => {
                 <View>
                   {Object.keys(remoteConfig).map((key) => (
                     <MapEntry
+                      key={key}
                       title={key}
                       value={
                         remoteConfig[key as keyof RemoteConfigContextState]
@@ -390,7 +391,7 @@ export const Profile_DebugInfoScreen = () => {
                 {storedValues && (
                   <View>
                     {storedValues.map(([key, value]) => (
-                      <MapEntry title={key} value={value} />
+                      <MapEntry key={key} title={key} value={value} />
                     ))}
                   </View>
                 )}
@@ -411,6 +412,7 @@ export const Profile_DebugInfoScreen = () => {
                   </ThemeText>
                   {Object.keys(preferences).map((key) => (
                     <TouchableOpacity
+                      key={key}
                       onPress={() => setPreference({[key]: undefined})}
                     >
                       <MapEntry
@@ -530,7 +532,7 @@ function MapValue({value}: {value: any}) {
         <View style={{flexDirection: 'column'}}>
           {entries.length ? (
             Object.entries(value).map(([key, value]) => (
-              <MapEntry title={key} value={value} />
+              <MapEntry key={key} title={key} value={value} />
             ))
           ) : (
             <ThemeText color="secondary">Empty object</ThemeText>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -111,6 +111,7 @@ export const Profile_DesignSystemScreen = () => {
 
   const radioSegments = Object.keys(theme.interactive).map((color) => (
     <RadioSegments
+      key={color}
       activeIndex={segmentedSelection}
       style={{
         marginTop: theme.spacings.small,
@@ -207,6 +208,7 @@ export const Profile_DesignSystemScreen = () => {
               />
               {Object.values(LegMode).map((mode) => (
                 <TransportationIcon
+                  key={mode}
                   style={style.transportationIcon}
                   mode={mode}
                 />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/CompactFareContractInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/CompactFareContractInfo.tsx
@@ -86,7 +86,7 @@ const CompactFareContractInfoTexts = (
         {timeUntilExpire}
       </ThemeText>
       {userProfilesWithCount.map((u) => (
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText key={u.id} type="body__secondary" color="secondary">
           {userProfileCountAndName(u, omitUserProfileCount, language)}
         </ThemeText>
       ))}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -56,9 +56,6 @@ const leaveBreadCrumb = (
 export type KeyValuePair = [string, string | null];
 
 const storage = {
-  setAppGroupName: async (groupName?: string) => {
-    await AsyncStorage.setAppGroupName(groupName).catch(errorHandler);
-  },
   get: async (key: string) => {
     const value = await AsyncStorage.getItem(key).catch(errorHandler);
     leaveBreadCrumb('read-single', key, value);

--- a/src/translations/components/CancelledDeparture.ts
+++ b/src/translations/components/CancelledDeparture.ts
@@ -1,4 +1,4 @@
-import {translation as _} from '@atb/translations';
+import {translation as _} from '../commons';
 
 const CancelledDepartureTexts = {
   message: _(

--- a/src/translations/components/DetailsMessages.ts
+++ b/src/translations/components/DetailsMessages.ts
@@ -1,5 +1,5 @@
-import {translation as _} from '@atb/translations';
-import {orgSpecificTranslations} from '@atb/translations';
+import {translation as _} from '../commons';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const DetailsMessages = {
   messages: {

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const ScreenHeaderTexts = {
   headerButton: {

--- a/src/translations/components/ServiceDisruptions.ts
+++ b/src/translations/components/ServiceDisruptions.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const ServiceDisruptionsTexts = {
   header: {

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const TravelTokenBoxTexts = {
   tcard: {

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -10,7 +10,6 @@ export {
 
 export type {LanguageAndTextType} from './types';
 export {getTextForLanguage} from './utils';
-export {orgSpecificTranslations} from './orgSpecificTranslations';
 
 export {default as FavoriteTexts} from './components/FavoriteChips';
 export {default as PaginationTexts} from './components/Pagination';

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -1,6 +1,6 @@
 import {TransportMode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const FareContractTexts = {
   organizationName: _('AtB', 'AtB'),

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const OnboardingTexts = {
   welcome: {

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const ProfileTexts = {
   header: {

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -1,4 +1,4 @@
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 import {translation as _} from '../commons';
 
 const bulletPoint = '\u2022';

--- a/src/translations/screens/TicketingSplash.ts
+++ b/src/translations/screens/TicketingSplash.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const TicketingSplashTexts = {
   header: {

--- a/src/translations/screens/subscreens/ContactSheet.ts
+++ b/src/translations/screens/subscreens/ContactSheet.ts
@@ -1,4 +1,4 @@
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 import {translation as _} from '../../commons';
 const ContactSheetTexts = {
   header: {

--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 
 const DeleteProfileTexts = {
   header: {

--- a/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
+++ b/src/translations/screens/subscreens/GenericWebsiteInformationScreen.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 
 const GenericWebsiteInformationScreenTextsInternal = {
   title: _('Informasjon', 'Information'),

--- a/src/translations/screens/subscreens/Information.ts
+++ b/src/translations/screens/subscreens/Information.ts
@@ -1,4 +1,4 @@
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 import {translation as _} from '../../commons';
 
 const bulletPoint = '\u2022';

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 
 const MobileTokenOnboardingTexts = {
   flexibilityInfo: {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 
 const PurchaseOverviewTexts = {
   travelSearchInfo: _(

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -1,5 +1,5 @@
 import {translation as _} from '../../commons';
-import {orgSpecificTranslations} from '@atb/translations';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 
 const SelectTravelTokenTexts = {
   travelToken: {

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -379,6 +379,7 @@ function EstimatedCallRow({
       </TripRow>
       {situations.map((situation) => (
         <TripRow
+          key={situation.situationNumber}
           rowLabel={<SituationOrNoticeIcon situation={situation} />}
           style={styles.situationTripRow}
         >


### PR DESCRIPTION
### Solution
Some errors which shows up in the Metro when running up the simulator locally are fixed. These are mainly:
- React unique keys errors
- Removed usage of "setAppGroupName" in AsyncStorage since it gave "undefined is not a function". This method was no longer supported by the AsyncStorage lib, and also the error was spamming Bugsnag for every user.
- Removed some cyclical dependencies in the translations module.
- Turned off logging breadcrumbs to console when developing locally. This can easily be overrided in the `bugsnagConfig.ts`.

### Acceptance criteria
The app should work as before. Mainly two things in the app can be affected by this change, which is:
- [ ] Travel search results should look and behave as before, especially the horizontal list of buses/trains with the double dash (`--`) between.
- [ ] Local storage should work as before, and still be persisted when this change is applied.
