### PR TITLE
feat: Adjusted icon size in ticket inspection and showing a maximum of two icons

### DIFF
--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -7,9 +7,8 @@ import {
   useTranslation,
 } from '@atb/translations';
 import React from 'react';
-import {StyleSheet, Theme, useTheme} from '@atb/theme';
+import {StyleSheet, Theme} from '@atb/theme';
 import {TransportModeType} from '@atb/configuration/types';
-import useFontScale from '@atb/utils/use-font-scale';
 
 const modesDisplayLimit: number = 2;
 
@@ -40,15 +39,10 @@ export const TransportModes = ({
   style?: ViewStyle;
 }) => {
   const styles = useStyles();
-  const {theme} = useTheme();
-  const fontScale = useFontScale();
   const {t} = useTranslation();
 
   const modesCount: number = modes.length;
   const modesToDisplay = modes.slice(0, modesDisplayLimit);
-  const boxHeight = {
-    height: theme.icon.size['small'] * fontScale + theme.spacings.xSmall * 2,
-  };
   const transportModeText: string = getTransportModeText(
     modes,
     t,
@@ -68,10 +62,11 @@ export const TransportModes = ({
         />
       ))}
       {modesCount > modesDisplayLimit && (
-        <View style={[styles.multipleModes, boxHeight]}>
+        <View style={styles.multipleModes}>
           <ThemeText
             color={'transport_other'}
             type="label__uppercase"
+            style={styles.additionalModesCounter}
             accessibilityLabel={t(
               FareContractTexts.transportModes.a11yLabelMultipleTravelModes(
                 modesCount,
@@ -104,9 +99,13 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   transportationIcon: {
     marginRight: theme.spacings.xSmall,
   },
+  additionalModesCounter: {
+    lineHeight: 10,
+  },
   multipleModes: {
     marginRight: theme.spacings.xSmall,
     paddingHorizontal: theme.spacings.xSmall,
+    paddingVertical: theme.spacings.xSmall,
     borderRadius: theme.border.radius.small,
     backgroundColor: theme.static.transport.transport_other.background,
   },

--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -1,4 +1,4 @@
-import {View} from 'react-native';
+import {View, ViewStyle} from 'react-native';
 import {TransportationIcon} from '@atb/components/transportation-icon';
 import {ThemeText} from '@atb/components/text';
 import {
@@ -28,14 +28,16 @@ export const getTransportModeText = (
     .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
     .join('/');
 };
-export const TransportMode = ({
+export const TransportModes = ({
   modes,
   iconSize,
   disabled,
+  style,
 }: {
   modes: TransportModeType[];
   iconSize?: keyof Theme['icon']['size'];
   disabled?: boolean;
+  style?: ViewStyle;
 }) => {
   const styles = useStyles();
   const {theme} = useTheme();
@@ -47,9 +49,14 @@ export const TransportMode = ({
   const boxHeight = {
     height: theme.icon.size['small'] * fontScale + theme.spacings.xSmall * 2,
   };
+  const transportModeText: string = getTransportModeText(
+    modes,
+    t,
+    modesDisplayLimit,
+  );
 
   return (
-    <View style={styles.transportationMode}>
+    <View style={[styles.transportationMode, style]}>
       {modesToDisplay.map(({mode, subMode}) => (
         <TransportationIcon
           style={styles.transportationIcon}
@@ -62,7 +69,15 @@ export const TransportMode = ({
       ))}
       {modesCount > modesDisplayLimit && (
         <View style={[styles.multipleModes, boxHeight]}>
-          <ThemeText color={'transport_other'} type="label__uppercase">
+          <ThemeText
+            color={'transport_other'}
+            type="label__uppercase"
+            accessibilityLabel={t(
+              FareContractTexts.transportModes.a11yLabelMultipleTravelModes(
+                modesCount,
+              ),
+            )}
+          >
             +{modesCount - modesDisplayLimit}
           </ThemeText>
         </View>
@@ -71,12 +86,10 @@ export const TransportMode = ({
         type="label__uppercase"
         color={'secondary'}
         accessibilityLabel={t(
-          FareContractTexts.transportModes.a11yLabel(
-            getTransportModeText(modesToDisplay, t, modesDisplayLimit),
-          ),
+          FareContractTexts.transportModes.a11yLabel(transportModeText),
         )}
       >
-        {getTransportModeText(modes, t, modesDisplayLimit)}
+        {transportModeText}
       </ThemeText>
     </View>
   );
@@ -84,7 +97,6 @@ export const TransportMode = ({
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   transportationMode: {
-    flex: 2,
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',

--- a/src/components/transportation-modes/index.ts
+++ b/src/components/transportation-modes/index.ts
@@ -1,0 +1,1 @@
+export {getTransportModeText, TransportModes} from './TransportModes';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/CarnetDetails.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/CarnetDetails.tsx
@@ -6,7 +6,7 @@ import {
 } from '@atb/ticketing';
 import {getValidityStatus} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import * as Sections from '@atb/components/sections';
-import ValidityHeader from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader';
+import {ValidityHeader} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader';
 import UsedAccessValidityHeader from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/UsedAccessValidityHeader';
 import ValidityLine from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityLine';
 import {View} from 'react-native';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/UsedAccessValidityHeader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/UsedAccessValidityHeader.tsx
@@ -10,7 +10,7 @@ import {secondsToDuration} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
 import {UsedAccessStatus} from './types';
-import TransportMode from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 type Props = {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/UsedAccessValidityHeader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Carnet/UsedAccessValidityHeader.tsx
@@ -10,7 +10,7 @@ import {secondsToDuration} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
 import {UsedAccessStatus} from './types';
-import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {TransportModes} from '@atb/components/transportation-modes';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 type Props = {
@@ -34,7 +34,7 @@ function UsedAccessValidityHeader(props: Props) {
     <View style={styles.validityHeader}>
       <View style={styles.validityContainer}>
         {fareProductTypeConfig && (
-          <TransportMode
+          <TransportModes
             modes={fareProductTypeConfig?.transportModes}
             disabled={props.status === 'inactive'}
           />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode.tsx
@@ -1,11 +1,33 @@
 import {View} from 'react-native';
 import {TransportationIcon} from '@atb/components/transportation-icon';
 import {ThemeText} from '@atb/components/text';
-import {FareContractTexts, useTranslation} from '@atb/translations';
+import {
+  FareContractTexts,
+  TranslateFunction,
+  useTranslation,
+} from '@atb/translations';
 import React from 'react';
-import {StyleSheet, Theme} from '@atb/theme';
+import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {TransportModeType} from '@atb/configuration/types';
+import useFontScale from '@atb/utils/use-font-scale';
 
+const modesDisplayLimit: number = 2;
+
+export const getTransportModeText = (
+  modes: TransportModeType[],
+  t: TranslateFunction,
+  modesDisplayLimit: number = 2,
+): string => {
+  const modesCount: number = modes.length;
+
+  if (!modes) return '';
+  if (modesCount > modesDisplayLimit) {
+    return t(FareContractTexts.transportModes.multipleTravelModes);
+  }
+  return modes
+    .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
+    .join('/');
+};
 export const TransportMode = ({
   modes,
   iconSize,
@@ -16,10 +38,16 @@ export const TransportMode = ({
   disabled?: boolean;
 }) => {
   const styles = useStyles();
+  const {theme} = useTheme();
+  const fontScale = useFontScale();
   const {t} = useTranslation();
-  const modesDisplayLimit: number = 2;
+
   const modesCount: number = modes.length;
   const modesToDisplay = modes.slice(0, modesDisplayLimit);
+  const boxHeight = {
+    height: theme.icon.size['small'] * fontScale + theme.spacings.xSmall * 2,
+  };
+
   return (
     <View style={styles.transportationMode}>
       {modesToDisplay.map(({mode, subMode}) => (
@@ -33,22 +61,22 @@ export const TransportMode = ({
         />
       ))}
       {modesCount > modesDisplayLimit && (
-        <View style={styles.multipleModes}>
-          <ThemeText
-            style={styles.fonts}
-            color={'transport_other'}
-            testID={'amountAdditionalModes'}
-          >
-            +{modesCount - 2}
+        <View style={[styles.multipleModes, boxHeight]}>
+          <ThemeText color={'transport_other'} type="label__uppercase">
+            +{modesCount - modesDisplayLimit}
           </ThemeText>
         </View>
       )}
-      <ThemeText type="label__uppercase" color={'secondary'}>
-        {modesCount <= modesDisplayLimit
-          ? modes
-              .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
-              .join('/')
-          : t(FareContractTexts.multipleTravelModes)}
+      <ThemeText
+        type="label__uppercase"
+        color={'secondary'}
+        accessibilityLabel={t(
+          FareContractTexts.transportModes.a11yLabel(
+            getTransportModeText(modesToDisplay, t, modesDisplayLimit),
+          ),
+        )}
+      >
+        {getTransportModeText(modes, t, modesDisplayLimit)}
       </ThemeText>
     </View>
   );
@@ -56,6 +84,7 @@ export const TransportMode = ({
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   transportationMode: {
+    flex: 2,
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
@@ -63,12 +92,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   transportationIcon: {
     marginRight: theme.spacings.xSmall,
   },
-  fonts: {
-    fontSize: 12,
-  },
   multipleModes: {
     marginRight: theme.spacings.xSmall,
-
     paddingHorizontal: theme.spacings.xSmall,
     borderRadius: theme.border.radius.small,
     backgroundColor: theme.static.transport.transport_other.background,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {StyleSheet, Theme} from '@atb/theme';
 import {TransportModeType} from '@atb/configuration/types';
 
-const TransportMode = ({
+export const TransportMode = ({
   modes,
   iconSize,
   disabled,
@@ -17,9 +17,12 @@ const TransportMode = ({
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
+  const modesDisplayLimit: number = 2;
+  const modesCount: number = modes.length;
+  const modesToDisplay = modes.slice(0, modesDisplayLimit);
   return (
     <View style={styles.transportationMode}>
-      {modes.map(({mode, subMode}) => (
+      {modesToDisplay.map(({mode, subMode}) => (
         <TransportationIcon
           style={styles.transportationIcon}
           key={mode + subMode}
@@ -29,10 +32,23 @@ const TransportMode = ({
           disabled={disabled}
         />
       ))}
+      {modesCount > modesDisplayLimit && (
+        <View style={styles.multipleModes}>
+          <ThemeText
+            style={styles.fonts}
+            color={'transport_other'}
+            testID={'amountAdditionalModes'}
+          >
+            +{modesCount - 2}
+          </ThemeText>
+        </View>
+      )}
       <ThemeText type="label__uppercase" color={'secondary'}>
-        {modes
-          .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
-          .join('/')}
+        {modesCount <= modesDisplayLimit
+          ? modes
+              .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
+              .join('/')
+          : t(FareContractTexts.multipleTravelModes)}
       </ThemeText>
     </View>
   );
@@ -47,6 +63,14 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   transportationIcon: {
     marginRight: theme.spacings.xSmall,
   },
-}));
+  fonts: {
+    fontSize: 12,
+  },
+  multipleModes: {
+    marginRight: theme.spacings.xSmall,
 
-export default TransportMode;
+    paddingHorizontal: theme.spacings.xSmall,
+    borderRadius: theme.border.radius.small,
+    backgroundColor: theme.static.transport.transport_other.background,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Details/DetailsContent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Details/DetailsContent.tsx
@@ -7,7 +7,7 @@ import {
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import FareContractInfo from '../FareContractInfo';
-import ValidityHeader from '../ValidityHeader';
+import {ValidityHeader} from '../ValidityHeader';
 import ValidityLine from '../ValidityLine';
 import {getValidityStatus} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/PreActivatedFareContractInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/PreActivatedFareContractInfo.tsx
@@ -3,7 +3,7 @@ import {FareContractState, PreActivatedTravelRight} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import FareContractInfo from './FareContractInfo';
-import ValidityHeader from './ValidityHeader';
+import {ValidityHeader} from './ValidityHeader';
 import ValidityLine from './ValidityLine';
 import {getValidityStatus} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader.tsx
@@ -14,7 +14,7 @@ import {
   isValidFareContract,
   ValidityStatus,
 } from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
-import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {TransportModes} from '@atb/components/transportation-modes';
 import FareContractStatusSymbol from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/FareContractStatusSymbol';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
@@ -47,9 +47,10 @@ export const ValidityHeader: React.FC<{
       <View style={styles.validityContainer}>
         {isValidFareContract(status) ? (
           fareProductTypeConfig && (
-            <TransportMode
+            <TransportModes
               modes={fareProductTypeConfig.transportModes}
               iconSize={'small'}
+              style={{flex: 2}}
             />
           )
         ) : (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader.tsx
@@ -145,7 +145,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
   },
   label: {
-    flex: 1,
+    flex: 3,
     textAlign: 'right',
     marginLeft: theme.spacings.xLarge,
   },

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/ValidityHeader.tsx
@@ -14,11 +14,11 @@ import {
   isValidFareContract,
   ValidityStatus,
 } from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
-import TransportMode from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
 import FareContractStatusSymbol from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/FareContractStatusSymbol';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
-const ValidityHeader: React.FC<{
+export const ValidityHeader: React.FC<{
   status: ValidityStatus;
   now: number;
   validFrom: number;
@@ -47,7 +47,10 @@ const ValidityHeader: React.FC<{
       <View style={styles.validityContainer}>
         {isValidFareContract(status) ? (
           fareProductTypeConfig && (
-            <TransportMode modes={fareProductTypeConfig.transportModes} />
+            <TransportMode
+              modes={fareProductTypeConfig.transportModes}
+              iconSize={'small'}
+            />
           )
         ) : (
           <FareContractStatusSymbol status={status} />
@@ -147,5 +150,3 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginLeft: theme.spacings.xLarge,
   },
 }));
-
-export default ValidityHeader;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/AvailableFareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/AvailableFareProducts/FareProductTile.tsx
@@ -9,7 +9,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {getStaticColor, StaticColor} from '@atb/theme/colors';
-import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {TransportModes} from '@atb/components/transportation-modes';
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {useTextForLanguage} from '@atb/translations/utils';
 
@@ -53,7 +53,7 @@ const FareProductTile = ({
         style={styles.spreadContent}
       >
         <View style={styles.contentContainer}>
-          <TransportMode modes={config.transportModes} iconSize={'small'} />
+          <TransportModes modes={config.transportModes} iconSize={'small'} />
           <ThemeText
             type="body__secondary--bold"
             style={styles.title}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/AvailableFareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/AvailableFareProducts/FareProductTile.tsx
@@ -9,7 +9,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {getStaticColor, StaticColor} from '@atb/theme/colors';
-import TransportMode from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {useTextForLanguage} from '@atb/translations/utils';
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import {ThemeText} from '@atb/components/text';
-import {FareContractTexts, useTranslation} from '@atb/translations';
+import {useTranslation} from '@atb/translations';
 import RecentFareContractsTexts from '@atb/translations/screens/subscreens/RecentFareContractsTexts';
 import {RecentFareContract} from '../use-recent-fare-contracts';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {Dimensions, TouchableOpacity, View} from 'react-native';
 import {getReferenceDataName} from '@atb/reference-data/utils';
-import {TransportationIcon} from '@atb/components/transportation-icon';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
-import {TransportModeType} from '@atb/configuration/types';
 import {InfoChip} from '@atb/components/info-chip';
 import {InteractiveColor} from '@atb/theme/colors';
+import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
 
 type RecentFareContractProps = {
   recentFareContract: RecentFareContract;
@@ -51,30 +50,11 @@ export const RecentFareContractComponent = ({
   );
 
   if (!fareProductTypeConfig) return null;
-
-  type ModeNameProps = {
-    modes: TransportModeType[];
-    joinSymbol?: string;
-  };
-
-  const modeNames = ({modes, joinSymbol = '/'}: ModeNameProps) => {
-    if (!modes) return null;
-    if (modes.length > 2)
-      return t(RecentFareContractsTexts.severalTransportModes);
-    else
-      return modes
-        .map((tm) => t(FareContractTexts.transportMode(tm.mode)))
-        .join(joinSymbol);
-  };
-
   const returnAccessibilityLabel = () => {
     const modeInfo = `${getReferenceDataName(
       preassignedFareProduct,
       language,
-    )}${t(RecentFareContractsTexts.a11yPreLabels.transportModes)} ${modeNames({
-      modes: fareProductTypeConfig.transportModes,
-      joinSymbol: t(RecentFareContractsTexts.a11yPreLabels.and),
-    })}`;
+    )}${t(RecentFareContractsTexts.a11yPreLabels.transportModes)}`;
 
     const travellerInfo = `${t(
       RecentFareContractsTexts.a11yPreLabels.travellers,
@@ -118,19 +98,10 @@ export const RecentFareContractComponent = ({
     >
       <View style={[styles.upperPart, {minWidth: width * 0.6}]}>
         <View style={styles.travelModeWrapper}>
-          {fareProductTypeConfig.transportModes.map(({mode, subMode}) => (
-            <TransportationIcon
-              style={styles.transportationIcon}
-              mode={mode}
-              subMode={subMode}
-              key={mode + subMode}
-              size="small"
-            />
-          ))}
-
-          <ThemeText type="label__uppercase" color={interactiveColor.default}>
-            {modeNames({modes: fareProductTypeConfig.transportModes})}
-          </ThemeText>
+          <TransportMode
+            iconSize={'small'}
+            modes={fareProductTypeConfig.transportModes}
+          />
         </View>
 
         <View style={styles.productName} testID={testID + 'Title'}>
@@ -243,9 +214,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   travelModeWrapper: {
     flexShrink: 1,
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
     marginBottom: theme.spacings.medium,
   },
   transportationIcon: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
@@ -12,7 +12,10 @@ import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurati
 import {FareProductTypeConfig} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/utils';
 import {InfoChip} from '@atb/components/info-chip';
 import {InteractiveColor} from '@atb/theme/colors';
-import {TransportMode} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+import {
+  getTransportModeText,
+  TransportMode,
+} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
 
 type RecentFareContractProps = {
   recentFareContract: RecentFareContract;
@@ -54,11 +57,13 @@ export const RecentFareContractComponent = ({
     const modeInfo = `${getReferenceDataName(
       preassignedFareProduct,
       language,
-    )}${t(RecentFareContractsTexts.a11yPreLabels.transportModes)}`;
+    )} ${t(
+      RecentFareContractsTexts.a11yPreLabels.transportModes,
+    )}${getTransportModeText(fareProductTypeConfig.transportModes, t)}`;
 
     const travellerInfo = `${t(
       RecentFareContractsTexts.a11yPreLabels.travellers,
-    )}: ${userProfilesWithCount
+    )}${userProfilesWithCount
       .map((u) => u.count + ' ' + getReferenceDataName(u, language))
       .join(', ')}`;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareProducts/RecentFareProducts/RecentFareContractComponent.tsx
@@ -14,8 +14,8 @@ import {InfoChip} from '@atb/components/info-chip';
 import {InteractiveColor} from '@atb/theme/colors';
 import {
   getTransportModeText,
-  TransportMode,
-} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/FareContracts/Component/TransportMode';
+  TransportModes,
+} from '@atb/components/transportation-modes';
 
 type RecentFareContractProps = {
   recentFareContract: RecentFareContract;
@@ -103,9 +103,10 @@ export const RecentFareContractComponent = ({
     >
       <View style={[styles.upperPart, {minWidth: width * 0.6}]}>
         <View style={styles.travelModeWrapper}>
-          <TransportMode
+          <TransportModes
             iconSize={'small'}
             modes={fareProductTypeConfig.transportModes}
+            style={{flex: 2}}
           />
         </View>
 

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -166,6 +166,7 @@ const FareContractTexts = {
         return _('ukjent transportmiddel', 'unknown transport');
     }
   },
+  multipleTravelModes: _('Flere reisemåter', 'Several travel modes'),
 };
 
 export default orgSpecificTranslations(FareContractTexts, {

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -147,6 +147,14 @@ const FareContractTexts = {
     ),
     unnamedDevice: _('Enhet uten navn', 'Unnamed device'),
   },
+  transportModes: {
+    multipleTravelModes: _('Flere reisemåter', 'Several travel modes'),
+    a11yLabel: (transportModes: string) =>
+      _(
+        `Billetten gjelder ${transportModes}`,
+        `Ticket is valid on ${transportModes}`,
+      ),
+  },
   transportMode: (mode: TransportMode) => {
     switch (mode) {
       case TransportMode.Bus:
@@ -166,7 +174,6 @@ const FareContractTexts = {
         return _('ukjent transportmiddel', 'unknown transport');
     }
   },
-  multipleTravelModes: _('Flere reisemåter', 'Several travel modes'),
 };
 
 export default orgSpecificTranslations(FareContractTexts, {

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -154,6 +154,8 @@ const FareContractTexts = {
         `Billetten gjelder ${transportModes}`,
         `Ticket is valid on ${transportModes}`,
       ),
+    a11yLabelMultipleTravelModes: (count: number) =>
+      _(`Totalt ${count} reisemåter`, `In total ${count} travel modes`),
   },
   transportMode: (mode: TransportMode) => {
     switch (mode) {

--- a/src/translations/screens/subscreens/RecentFareContractsTexts.ts
+++ b/src/translations/screens/subscreens/RecentFareContractsTexts.ts
@@ -25,7 +25,6 @@ const RecentFareContractsTexts = {
     travellers: _('for følgende reisende: ', 'for the following travellers: '),
     and: _(' og ', ' and '),
   },
-  severalTransportModes: _('ukjent transportmiddel', 'unknown transport'),
   options: {
     now: _('Nå', 'Now'),
     futureDate: _('Fremtidig starttidspunkt', 'Future start time'),


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/3154
* Adjusted icon size in ticket page / tabs to 'small'
* Added box with +xx for when there are more than 2 transport modes and text reflecting several travel modes
* Made use og common component TransportMode.tsx in RecentFareContractComponent.tsx
* Created a common function for formatting transport mode texts liks BUS/TRAM
![image](https://user-images.githubusercontent.com/126664682/225315090-c871df2c-3b6f-44a0-96ef-4ab351b19b75.png)
