### PR TITLE
fix: Set appGroupName in storage as it is necessary on iOS

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,11 +2,14 @@ import auth from '@react-native-firebase/auth';
 import Bugsnag from '@bugsnag/react-native';
 import {v4 as uuid} from 'uuid';
 
+import {APP_GROUP_NAME} from '@env';
+
 import {setInstallId as setApiInstallId} from './api/client';
 import {loadLocalConfig} from './local-config';
 import storage from './storage';
 
 export async function setupConfig() {
+  await storage.setAppGroupName(APP_GROUP_NAME);
   await ensureFirstTimeSetup();
   const {installId} = await loadLocalConfig();
   Bugsnag.setUser(installId);

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Bugsnag from '@bugsnag/react-native';
+import {Platform} from 'react-native';
 
 export enum StorageModelKeysEnum {
   HasReadDeparturesV2Onboarding = '@ATB_has_read_departures_v2_onboarding',
@@ -56,6 +57,12 @@ const leaveBreadCrumb = (
 export type KeyValuePair = [string, string | null];
 
 const storage = {
+  /** Necessary for communication between App and iOS Widget */
+  setAppGroupName: async (groupName?: string) => {
+    if (Platform.OS === 'ios') {
+      await AsyncStorage.setAppGroupName(groupName).catch(errorHandler);
+    }
+  },
   get: async (key: string) => {
     const value = await AsyncStorage.getItem(key).catch(errorHandler);
     leaveBreadCrumb('read-single', key, value);


### PR DESCRIPTION
Readding usage of the `setAppGroupName`. It was recently removed as it gave an error on Android, but is now added again as it is necessary to do on iOS.