### PR TITLE
fix: Stretched compact map fix

### DIFF
--- a/src/components/disappearing-header/ContentWithDisappearingHeader.tsx
+++ b/src/components/disappearing-header/ContentWithDisappearingHeader.tsx
@@ -55,7 +55,7 @@ export function ContentWithDisappearingHeader({
         }
         onScroll={Animated.event(
           [{nativeEvent: {contentOffset: {y: scrollYRef}}}],
-          {useNativeDriver: true},
+          {useNativeDriver: false},
         )}
         contentContainerStyle={{
           paddingTop: Platform.OS === 'ios' ? 0 : contentHeight,

--- a/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -47,7 +47,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
       setTimeout(
         () =>
           cameraRef.current?.fitBounds(bounds.ne, bounds.sw, undefined, 100),
-        50,
+        100,
       );
     }
   }, [bounds]);


### PR DESCRIPTION
Setting `useNativeDriver` to `true` seems to work when testing on iPhone 12 mini emulator. I am not exactly sure why, and probably not worth investing more time into understanding it since the map is going to be removed from this animated header really soon.

This change should be tested to see if it works, and if the scroll animation is good enough without it. More info about the setting can be found here:
https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated

A specific note about what happens with the value set to false:
> without the native driver it will always run a frame behind of the gesture because of the async nature of React Native.

Since this is a delayed/parallax type of animation, it hopefully isn't noticeable for the user. Should probably compare side by side with old animation which uses native driver.

Also set timeout value to 100 instead of 50 to work more often on slower phones.
