### PR TITLE
fix: new icon on widget

### DIFF
--- a/ios/departureWidget/Views/DepartureTimesView.swift
+++ b/ios/departureWidget/Views/DepartureTimesView.swift
@@ -36,7 +36,7 @@ struct DepartureTimesView: View {
 
             if let url = URL(string: deepLink) {
                 Link(destination: url) {
-                    Image(systemName: "ellipsis")
+                    Image(systemName: "chevron.right")
                         .frame(width: K.iconWidth)
                         .padding(8)
                         .foregroundColor(K.lineInformationColor)


### PR DESCRIPTION
Replaced the ellipsis icon(down right) with a right chevron after a talk with Sebastian, Christian and Øyvind.

New:
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-21 at 16 38 32](https://user-images.githubusercontent.com/70323886/226838072-98108d3f-b4c7-4fe8-80f9-4653e98071fc.png)

Old:
![IMG_5794](https://user-images.githubusercontent.com/70323886/226838112-e1ca1a6d-a4d1-4fd9-bc9c-c72e9e073ab7.png)


