### PR TITLE
fix: update handling of departures query variables

### DIFF
--- a/src/api/departures/departure-group.ts
+++ b/src/api/departures/departure-group.ts
@@ -31,6 +31,7 @@ export type DepartureRealtimeQuery = {
   limit: number;
   limitPerLine?: number;
   lineIds?: string[];
+  timeRange?: number;
 };
 
 export type DepartureFavoritesQuery = CursoredQuery<{

--- a/src/place-screen/components/QuayView.tsx
+++ b/src/place-screen/components/QuayView.tsx
@@ -15,6 +15,8 @@ import DeparturesTexts from '@atb/translations/screens/Departures';
 import {dictionary, useTranslation} from '@atb/translations';
 import {useIsFocused} from '@react-navigation/native';
 
+const NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 1000;
+
 export type QuayViewParams = {
   quay: Quay;
 };
@@ -58,6 +60,7 @@ export default function QuayView({
 
   const {state, forceRefresh} = useDeparturesData(
     [quay.id],
+    NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW,
     showOnlyFavorites,
     isFocused,
     mode,

--- a/src/place-screen/components/StopPlaceView.tsx
+++ b/src/place-screen/components/StopPlaceView.tsx
@@ -21,7 +21,8 @@ import {Walk} from '@atb/assets/svg/mono-icons/transportation';
 import {useHumanizeDistance} from '@atb/utils/location';
 import {useDeparturesData} from '../hooks/use-departures-data';
 
-const DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
+const NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
+const NUMBER_OF_DEPARTURES_IN_BUFFER = 5;
 
 type StopPlaceViewProps = {
   stopPlace: StopPlace;
@@ -80,6 +81,7 @@ export const StopPlaceView = (props: StopPlaceViewProps) => {
     searchTime?.option !== 'now' ? searchTime.date : undefined;
   const {state, forceRefresh} = useDeparturesData(
     stopPlace.quays?.map((q) => q.id) ?? [],
+    NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW + NUMBER_OF_DEPARTURES_IN_BUFFER,
     showOnlyFavorites,
     isFocused,
     mode,
@@ -216,7 +218,7 @@ export const StopPlaceView = (props: StopPlaceViewProps) => {
         <>
           <QuaySection
             quay={item}
-            departuresPerQuay={DEFAULT_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW}
+            departuresPerQuay={NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW}
             data={state.data}
             didLoadingDataFail={didLoadingDataFail}
             navigateToDetails={navigateToDetails}

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -26,8 +26,7 @@ import {TimeoutRequest, useTimeoutRequest} from '@atb/api/client';
 import {AxiosRequestConfig} from 'axios';
 import {useRefreshOnFocus} from '@atb/utils/use-refresh-on-focus';
 import {flatMap} from '@atb/utils/array';
-
-const MAX_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 1000;
+import {DepartureRealtimeQuery} from '@atb/api/departures/departure-group';
 
 // Used to re-trigger full refresh after N minutes.
 // To repopulate the view when we get fewer departures.
@@ -39,20 +38,14 @@ export type DepartureDataState = {
   error?: {type: ErrorType};
   locationId?: string[];
   isLoading: boolean;
-  queryInput: QueryInput;
   lastRefreshTime: Date;
 };
 
-const initialQueryInput = {
-  numberOfDepartures: MAX_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW,
-  startTime: new Date().toISOString(),
-};
 const initialState: DepartureDataState = {
   data: null,
   error: undefined,
   locationId: undefined,
   isLoading: false,
-  queryInput: initialQueryInput,
   lastRefreshTime: new Date(),
 
   // Store date as update tick to know when to rerender
@@ -64,7 +57,8 @@ type DepartureDataActions =
   | {
       type: 'LOAD_INITIAL_DEPARTURES';
       quayIds: string[];
-      startTime?: string;
+      startTime: string;
+      limitPerQuay: number;
       favoriteDepartures?: UserFavoriteDepartures;
       limitPerLine?: number;
       timeRange?: number;
@@ -73,6 +67,10 @@ type DepartureDataActions =
   | {
       type: 'LOAD_REALTIME_DATA';
       quayIds: string[];
+      startTime: string;
+      limitPerQuay: number;
+      limitPerLine?: number;
+      timeRange: number;
       favoriteDepartures?: UserFavoriteDepartures;
     }
   | {
@@ -107,8 +105,8 @@ const reducer: ReducerWithSideEffects<
       // is a fresh fetch. We should fetch the latest information.
       const queryInput: DeparturesVariables = {
         ids: action.quayIds,
-        numberOfDepartures: MAX_NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW,
-        startTime: action.startTime ?? new Date().toISOString(),
+        numberOfDepartures: action.limitPerQuay,
+        startTime: action.startTime,
         limitPerLine: action.limitPerLine,
         timeRange: action.timeRange,
       };
@@ -118,14 +116,12 @@ const reducer: ReducerWithSideEffects<
           ...state,
           isLoading: true,
           error: undefined,
-          queryInput,
         },
         async (_, dispatch) => {
           try {
             action.timeout.start();
             const result = await fetchEstimatedCalls(
               queryInput,
-              action.quayIds,
               action.favoriteDepartures,
               {
                 signal: action.timeout.signal,
@@ -156,20 +152,19 @@ const reducer: ReducerWithSideEffects<
 
     case 'LOAD_REALTIME_DATA': {
       if (!state.data?.length) return NoUpdate();
-
+      const lineIds = action.favoriteDepartures?.map((f) => f.lineId);
+      const queryInput: DepartureRealtimeQuery = {
+        quayIds: action.quayIds,
+        startTime: action.startTime,
+        limit: action.limitPerQuay,
+        limitPerLine: action.limitPerLine,
+        timeRange: action.timeRange,
+        lineIds,
+      };
       return SideEffect<DepartureDataState, DepartureDataActions>(
         async (_, dispatch) => {
-          // Use same query input with same startTime to ensure that
-          // we get the same result.
           try {
-            const lineIds = action.favoriteDepartures?.map((f) => f.lineId);
-            const realtimeData = await getRealtimeDepartures({
-              quayIds: action.quayIds,
-              lineIds,
-              limit: state.queryInput.numberOfDepartures,
-              startTime: state.queryInput.startTime,
-            });
-
+            const realtimeData = await getRealtimeDepartures(queryInput);
             dispatch({
               type: 'UPDATE_REALTIME',
               realtimeData,
@@ -239,6 +234,7 @@ const reducer: ReducerWithSideEffects<
 
 export function useDeparturesData(
   quayIds: string[],
+  limitPerQuay: number,
   showOnlyFavorites: boolean,
   isFocused: boolean,
   mode: StopPlacesMode,
@@ -248,29 +244,37 @@ export function useDeparturesData(
 ) {
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
   const {favoriteDepartures} = useFavorites();
+  let queryStartTime = startTime ?? new Date().toISOString();
   const activeFavoriteDepartures = showOnlyFavorites
     ? favoriteDepartures
     : undefined;
+  const limitPerLine = getLimitOfDeparturesPerLineByMode(mode);
+  const timeRange = getTimeRangeByMode(mode, queryStartTime);
   const timeout = useTimeoutRequest();
 
   const loadDepartures = useCallback(() => {
-    const limitPerLine = getLimitOfDeparturesPerLineByMode(mode);
-    const timeRange = getTimeRangeByMode(mode, startTime);
+    queryStartTime = startTime ?? new Date().toISOString();
     dispatch({
       type: 'LOAD_INITIAL_DEPARTURES',
       quayIds,
-      startTime,
-      favoriteDepartures: activeFavoriteDepartures,
+      startTime: queryStartTime,
       limitPerLine,
+      limitPerQuay,
       timeRange,
+      favoriteDepartures: activeFavoriteDepartures,
       timeout,
     });
   }, [JSON.stringify(quayIds), startTime, activeFavoriteDepartures, mode]);
+
   const loadRealTimeData = useCallback(
     () =>
       dispatch({
         type: 'LOAD_REALTIME_DATA',
-        quayIds: quayIds,
+        quayIds,
+        startTime: queryStartTime,
+        limitPerLine,
+        limitPerQuay,
+        timeRange,
         favoriteDepartures: activeFavoriteDepartures,
       }),
     [JSON.stringify(activeFavoriteDepartures)],
@@ -280,7 +284,6 @@ export function useDeparturesData(
     loadDepartures();
     return () => timeout.abort();
   }, [loadDepartures]);
-
   useEffect(() => {
     if (!state.tick) {
       return;
@@ -317,30 +320,12 @@ export function useDeparturesData(
   };
 }
 
-type QueryInput = {
-  numberOfDepartures: number;
-  startTime: string;
-  timeRange?: number;
-  limitPerLine?: number;
-};
-
 async function fetchEstimatedCalls(
-  queryInput: QueryInput,
-  quayIds: string[],
+  queryInput: DeparturesVariables,
   favoriteDepartures?: UserFavoriteDepartures,
   opts?: AxiosRequestConfig,
 ): Promise<DepartureTypes.EstimatedCall[]> {
-  const result = await getDepartures(
-    {
-      ids: quayIds,
-      startTime: queryInput.startTime,
-      numberOfDepartures: queryInput.numberOfDepartures,
-      timeRange: queryInput.timeRange,
-      limitPerLine: queryInput.limitPerLine,
-    },
-    favoriteDepartures,
-    opts,
-  );
+  const result = await getDepartures(queryInput, favoriteDepartures, opts);
   return flatMap(
     result.quays,
     (q) => q.estimatedCalls,

--- a/src/place-screen/utils.ts
+++ b/src/place-screen/utils.ts
@@ -15,16 +15,13 @@ export type SearchTime = {
 export const getLimitOfDeparturesPerLineByMode = (mode: StopPlacesMode) =>
   mode === 'Favourite' ? 1 : undefined;
 
-export const getTimeRangeByMode = (mode: StopPlacesMode, startTime?: string) =>
+export const getTimeRangeByMode = (mode: StopPlacesMode, startTime: string) =>
   mode === 'Favourite'
     ? ONE_WEEK_TIME_RANGE
-    : getSecondsUntilMidnightOrMinimum(
-        startTime ?? new Date().toISOString(),
-        MIN_TIME_RANGE,
-      );
+    : getSecondsUntilMidnightOrMinimum(startTime, MIN_TIME_RANGE);
 
 /**
- * Get seconds until midnight, but a minimum of `minSeconds`
+ * Get seconds until midnight, but a minimum of `minimumSeconds`
  */
 function getSecondsUntilMidnightOrMinimum(
   isoTime: string,


### PR DESCRIPTION
- Adds `timeRange` query variable to realtime query (added to BFF here https://github.com/AtB-AS/atb-bff/pull/241)
- Adds `limitPerQuay` param to `useDeparturesData` to limit amount of departures per screen. This fixes https://github.com/AtB-AS/kundevendt/issues/3654#issuecomment-1476060960
- Refactors how `queryInput` is sent BFF endpoints, to make it easier to track where each variable is set, and synchronize between the realtime and initial departures, which is important for cache.