### PR TITLE
fix: various departures fixes

### DIFF
--- a/src/nearby-stop-places/components/StopPlaces.tsx
+++ b/src/nearby-stop-places/components/StopPlaces.tsx
@@ -30,7 +30,7 @@ export const StopPlaces = ({
       )}
       {stopPlaces.map((node: NearestStopPlaceNode) => (
         <StopPlaceItem
-          key={node?.place?.id}
+          key={node.place.id}
           stopPlaceNode={node}
           onPress={navigateToPlace}
           testID={'stopPlaceItem' + stopPlaces.indexOf(node)}

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -19,6 +19,7 @@ type QuaySectionProps = {
   quay: Quay;
   departuresPerQuay?: number;
   data: EstimatedCall[] | null;
+  isLoading: boolean;
   didLoadingDataFail: boolean;
   testID?: 'quaySection' | string;
   navigateToQuay?: (arg0: Quay) => void;
@@ -46,6 +47,7 @@ export default function QuaySection({
   quay,
   departuresPerQuay,
   data,
+  isLoading,
   didLoadingDataFail,
   testID,
   navigateToQuay,
@@ -169,7 +171,7 @@ export default function QuaySection({
             }
             ListEmptyComponent={
               <>
-                {data && (
+                {data && !isLoading && (
                   <Sections.GenericSectionItem
                     radius={!shouldShowMoreItemsLink ? 'bottom' : undefined}
                   >
@@ -188,7 +190,7 @@ export default function QuaySection({
             }
           />
         )}
-        {!isMinimized && didLoadingDataFail && (
+        {!isMinimized && didLoadingDataFail && !isLoading && (
           <Sections.GenericSectionItem>
             <View style={styles.messageBox}>
               <ThemeText type="body__secondary" color="secondary">
@@ -197,7 +199,7 @@ export default function QuaySection({
             </View>
           </Sections.GenericSectionItem>
         )}
-        {!data && !isMinimized && !didLoadingDataFail && (
+        {isLoading && !isMinimized && (
           <Sections.GenericSectionItem>
             <View style={{width: '100%'}}>
               <ActivityIndicator></ActivityIndicator>

--- a/src/place-screen/components/QuayView.tsx
+++ b/src/place-screen/components/QuayView.tsx
@@ -129,7 +129,8 @@ export default function QuayView({
         <QuaySection
           quay={item}
           data={state.data}
-          didLoadingDataFail={!!state.error}
+          isLoading={state.isLoading}
+          didLoadingDataFail={didLoadingDataFail}
           navigateToDetails={navigateToDetails}
           testID={'quaySection'}
           stopPlace={stopPlace}

--- a/src/place-screen/components/StopPlaceView.tsx
+++ b/src/place-screen/components/StopPlaceView.tsx
@@ -218,6 +218,7 @@ export const StopPlaceView = (props: StopPlaceViewProps) => {
         <>
           <QuaySection
             quay={item}
+            isLoading={state.isLoading}
             departuresPerQuay={NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW}
             data={state.data}
             didLoadingDataFail={didLoadingDataFail}

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -299,7 +299,7 @@ export function useDeparturesData(
   useInterval(
     loadRealTimeData,
     updateFrequencyInSeconds * 1000,
-    JSON.stringify(quayIds),
+    [JSON.stringify(quayIds)],
     !isFocused || mode === 'Favourite',
   );
   useInterval(

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -297,7 +297,7 @@ export function useDeparturesData(
   useInterval(
     loadRealTimeData,
     updateFrequencyInSeconds * 1000,
-    quayIds,
+    JSON.stringify(quayIds),
     !isFocused || mode === 'Favourite',
   );
   useInterval(

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -101,6 +101,8 @@ const reducer: ReducerWithSideEffects<
 > = (state, action) => {
   switch (action.type) {
     case 'LOAD_INITIAL_DEPARTURES': {
+      if (!action.quayIds.length) return NoUpdate();
+
       // Update input data with new date as this
       // is a fresh fetch. We should fetch the latest information.
       const queryInput: DeparturesVariables = {


### PR DESCRIPTION
Fixes some issues related to departures

- a useEffect dependency list could vary in length.
- a BFF request was sent without required quayIds, that caused an error message to pop up for a split second.
- updated logic for showing loading indicator, by adding an `isLoading` param to to QuaySection

fixes https://github.com/AtB-AS/kundevendt/issues/3654#issuecomment-1482609501