### PR TITLE
chore: move "try again" button to generic error message

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -114,10 +114,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                     getReferenceDataName(preassignedFareProduct, language),
                   ),
                 )}
-                onPressConfig={{
-                  action: refreshOffer,
-                  text: t(dictionary.retry),
-                }}
                 style={styles.selectionComponent}
               />
             ) : (
@@ -125,6 +121,10 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 type="error"
                 title={t(PurchaseOverviewTexts.errorMessageBox.title)}
                 message={t(PurchaseOverviewTexts.errorMessageBox.message)}
+                onPressConfig={{
+                  action: refreshOffer,
+                  text: t(dictionary.retry),
+                }}
                 style={styles.selectionComponent}
               />
             ))}


### PR DESCRIPTION
ref. https://github.com/AtB-AS/mittatb-app/pull/3425

Turns out I read the previous code wrong, and there shouldn't be a "Try again" button on the `isEmptyOffer` message, but instead on the generic one.

<div>
<img width="300px" src="https://user-images.githubusercontent.com/1774972/228203925-2c8ba312-292f-472a-8062-ba91ee4f0b72.PNG">

<img width="300px" src="https://user-images.githubusercontent.com/1774972/228204009-97a79bf0-62d7-4581-9e35-bd75f7bae67d.PNG">
</div>