### PR TITLE
fix: update departures realtime query when params change

### DIFF
--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -11,7 +11,7 @@ import {DeparturesRealtimeData} from '@atb/sdk';
 import {animateNextChange} from '@atb/utils/animation';
 import useInterval from '@atb/utils/use-interval';
 import {differenceInMinutes} from 'date-fns';
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import useReducerWithSideEffects, {
   NoUpdate,
   ReducerWithSideEffects,
@@ -246,7 +246,7 @@ export function useDeparturesData(
 ) {
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
   const {favoriteDepartures} = useFavorites();
-  let queryStartTime = startTime ?? new Date().toISOString();
+  const [queryStartTime, setQueryStartTime] = useState<string | undefined>();
   const activeFavoriteDepartures = showOnlyFavorites
     ? favoriteDepartures
     : undefined;
@@ -255,11 +255,12 @@ export function useDeparturesData(
   const timeout = useTimeoutRequest();
 
   const loadDepartures = useCallback(() => {
-    queryStartTime = startTime ?? new Date().toISOString();
+    const updatedQueryStartTime = startTime ?? new Date().toISOString();
+    setQueryStartTime(updatedQueryStartTime);
     dispatch({
       type: 'LOAD_INITIAL_DEPARTURES',
       quayIds,
-      startTime: queryStartTime,
+      startTime: updatedQueryStartTime,
       limitPerLine,
       limitPerQuay,
       timeRange,
@@ -268,19 +269,25 @@ export function useDeparturesData(
     });
   }, [JSON.stringify(quayIds), startTime, activeFavoriteDepartures, mode]);
 
-  const loadRealTimeData = useCallback(
-    () =>
-      dispatch({
-        type: 'LOAD_REALTIME_DATA',
-        quayIds,
-        startTime: queryStartTime,
-        limitPerLine,
-        limitPerQuay,
-        timeRange,
-        favoriteDepartures: activeFavoriteDepartures,
-      }),
-    [JSON.stringify(activeFavoriteDepartures)],
-  );
+  const loadRealTimeData = useCallback(() => {
+    if (!queryStartTime) return;
+    dispatch({
+      type: 'LOAD_REALTIME_DATA',
+      quayIds,
+      startTime: queryStartTime,
+      limitPerLine,
+      limitPerQuay,
+      timeRange,
+      favoriteDepartures: activeFavoriteDepartures,
+    });
+  }, [
+    JSON.stringify(quayIds),
+    queryStartTime,
+    limitPerLine,
+    limitPerQuay,
+    timeRange,
+    JSON.stringify(activeFavoriteDepartures),
+  ]);
 
   useEffect(() => {
     loadDepartures();

--- a/src/place-screen/utils.ts
+++ b/src/place-screen/utils.ts
@@ -15,7 +15,7 @@ export type SearchTime = {
 export const getLimitOfDeparturesPerLineByMode = (mode: StopPlacesMode) =>
   mode === 'Favourite' ? 1 : undefined;
 
-export const getTimeRangeByMode = (mode: StopPlacesMode, startTime: string) =>
+export const getTimeRangeByMode = (mode: StopPlacesMode, startTime?: string) =>
   mode === 'Favourite'
     ? ONE_WEEK_TIME_RANGE
     : getSecondsUntilMidnightOrMinimum(startTime, MIN_TIME_RANGE);
@@ -24,9 +24,10 @@ export const getTimeRangeByMode = (mode: StopPlacesMode, startTime: string) =>
  * Get seconds until midnight, but a minimum of `minimumSeconds`
  */
 function getSecondsUntilMidnightOrMinimum(
-  isoTime: string,
+  isoTime?: string,
   minimumSeconds: number = 0,
 ): number {
+  if (!isoTime) return minimumSeconds;
   const timeUntilMidnight = differenceInSeconds(
     addDays(parseISO(isoTime), 1).setHours(0, 0, 0),
     parseISO(isoTime),


### PR DESCRIPTION
Updates use-departures-data to fix realtime queries when search params change.

- Updates `loadRealTimeData` dependency list
- More resilient handling of `startTime` param, to prevent it from being out of sync between initial and realtime request.

fixes https://github.com/AtB-AS/kundevendt/issues/3654#issuecomment-1484886323