### PR TITLE
fix: Enable flipper on iOS

### DIFF
--- a/ios/Configs/Debug.xcconfig
+++ b/ios/Configs/Debug.xcconfig
@@ -3,4 +3,4 @@
 #include "Config.xcconfig"
 #include "../Pods/Target Support Files/Pods-app/Pods-app.debug.xcconfig"
 CODE_SIGN_IDENTITY=iPhone Developer
-GCC_PREPROCESSOR_DEFINITIONS = $(inherit) IS_WIDGET_ENABLE=$(ENABLE_WIDGET) DEBUG=1
+GCC_PREPROCESSOR_DEFINITIONS = $(inherit) IS_WIDGET_ENABLE=$(ENABLE_WIDGET) DEBUG=1 FB_SONARKIT_ENABLED=1


### PR DESCRIPTION
Flipper debugger was disabled for iOS on debug mode.

![image](https://user-images.githubusercontent.com/43450882/228535262-234d06ff-35c7-4172-8a56-bd83642378e8.png)
