### PR TITLE
chore: adds FRAM firebase id to info.plist allowed urls

### DIFF
--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -45,6 +45,7 @@
 			<array>
 				<string>com.googleusercontent.apps.939812594010-cb697rhj3ifghgjq3flv7e67l1a18jma</string>
 				<string>com.googleusercontent.apps.793301954236-2umj9ofp91902ra1p816dtlh15gf7lev</string>
+				<string>com.googleusercontent.apps.312905478211-4aitnn8g8qom68g669ckedsvvvgl4o0j</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Adds missing allowed URL for recaptcha and local login.

Fixes https://github.com/AtB-AS/kundevendt/issues/3774 and allows for logging in for FRAM locally