### PR TITLE
feat: Notify errors when sign in fails

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -137,7 +137,7 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
         ) {
           return 'invalid_code';
         }
-        if (isAuthError(error)) Bugsnag.notify(error);
+        Bugsnag.notify(error as any);
         return 'unknown_error';
       }
     },
@@ -221,7 +221,7 @@ export default function AuthContextProvider({children}: PropsWithChildren<{}>) {
         if (isAuthError(error) && error.code === ERROR_INVALID_PHONE_NUMBER) {
           return 'invalid_phone';
         }
-        console.warn(error);
+        Bugsnag.notify(error as any);
         return 'unknown_error';
       }
     },

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -143,7 +143,7 @@ export default function PhoneInput({
               <MessageBox
                 style={styles.errorMessage}
                 type="error"
-                message={t(LoginTexts.phoneInput.errors.invalid_phone)}
+                message={t(LoginTexts.phoneInput.errors[error])}
               />
             )}
 


### PR DESCRIPTION
### Background
We only sent errors to Bugsnag when confirm code failed, but we
also want to do it when sending in phone number fails.

This change was requested by @Sebstorvik when he asked to find a login-error in Bugsnag. We found out that the logging was recently added, but just to the confirm code step, while the login-error he found was in the phone input step. Since finding this error took as long time as fixing it, I just created a PR.
