### PR TITLE
build: add FRAM to ios-staging GH action

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        org: [atb, nfk]
+        org: [atb, nfk, fram]
     environment: ${{ matrix.org }}
     timeout-minutes: 360
     runs-on: macOS-12
@@ -81,7 +81,7 @@ jobs:
           APP_NAME: 'AtB.app'
 
       - name: Distribute to Firebase app distribution
-        if: matrix.org == 'nfk'
+        if: 'matrix.org == "nfk" || matrix.org == "fram"'
         run: |
           echo ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIALS}} | base64 --decode > google-services.json
           bundle exec fastlane ios firebase_distribution_staging


### PR DESCRIPTION
We want to play whack-a-mole with the errors that will eventually hit us with the creation of the new FRAM app. 

I guess this is the best way to do that?

All staging builds jobs will send out an email that the job failed for some days, but if we've understood how matrixes works it will only affect the FRAM build job.