### PR TITLE
fix: Update scooter onbarding text and image

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^6.0.11",
+    "@atb-as/generate-assets": "^6.0.13",
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-env": "^7.20.2",

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_ScooterOnboardingScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_ScooterOnboardingScreen.tsx
@@ -10,7 +10,7 @@ import {storage, StorageModelKeysEnum} from '@atb/storage';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {ScooterOnboarding} from '@atb/assets/svg/color/images';
 import {MapScreenProps} from './navigation-types';
-import {ScooterTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -36,7 +36,7 @@ export const Map_ScooterOnboardingScreen = ({navigation}: Props) => {
       >
         <View
           accessible={true}
-          accessibilityLabel={t(ScooterTexts.onboarding.a11yLabel)}
+          accessibilityLabel={t(MobilityTexts.onboarding.a11yLabel)}
           ref={focusRef}
         >
           <ThemeText
@@ -44,17 +44,17 @@ export const Map_ScooterOnboardingScreen = ({navigation}: Props) => {
             color={themeColor}
             type="heading--big"
           >
-            {t(ScooterTexts.onboarding.title)}
+            {t(MobilityTexts.onboarding.title)}
           </ThemeText>
           <View style={styles.illustration}>
             <ScooterOnboarding />
           </View>
           <ThemeText color={themeColor} style={styles.body}>
-            {t(ScooterTexts.onboarding.body)}
+            {t(MobilityTexts.onboarding.body)}
           </ThemeText>
         </View>
         <Button
-          text={t(ScooterTexts.onboarding.button)}
+          text={t(MobilityTexts.onboarding.button)}
           onPress={async () => {
             await setOnboardingCompleted();
             navigation.goBack();

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -33,6 +33,21 @@ export const MobilityTexts = {
       ),
     button: _('OK', 'OK'),
   },
+  onboarding: {
+    title: _(
+      'Elsparkesykler og bysykler i kartet 🎉',
+      'Electrical scooters and city bikes in map 🎉',
+    ),
+    body: _(
+      'Se elsparkesykler og bysykler i Trondheim på ett sted. Skru på tjenesten i kartet.',
+      'See electric scooters and city bikes in Trondheim in one app. Enable this feature through the map.',
+    ),
+    button: _('Den er grei!', 'Sounds good!'),
+    a11yLabel: _(
+      'Se elsparkesykler og bysykler i Trondheim på ett sted. Skru på tjenesten i kartet.',
+      'See electric scooters and city bikes in Trondheim in one app. Enable this feature through the map.',
+    ),
+  },
 };
 
 export const ScooterTexts = {
@@ -43,18 +58,6 @@ export const ScooterTexts = {
       price > 0
         ? _(`+ ${price} kr for oppstart`, `+ ${price} kr to unlock`)
         : _('Ingen oppstartskostnad', 'Free to unlock'),
-  },
-  onboarding: {
-    title: _('El-sparkesykler i kartet 🎉', 'Electrical scooters in map 🎉'),
-    body: _(
-      'Nå kan du se alle sparkesyklene i byen på ett sted! Skru på tjenesten i kartet',
-      'You can now see all electric scooters in town in one app! Enable this feature through the map.',
-    ),
-    button: _('Den er grei!', 'Sounds good!'),
-    a11yLabel: _(
-      'Nå kan du se alle el-sparkesyklene i byen på ett sted! Skru på tjenesten i kartet',
-      'You can now see all electric scooters in town in one app! Enable this feature through the map.',
-    ),
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,30 +9,30 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^6.0.11":
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-6.0.11.tgz#ae97451aa570b387530c05d90a6185dd734fc15c"
-  integrity sha512-9zyEY6Ig4SPtzO78GKtklpj68o20PjyPvf4P8PGt9k/AMbIUhOg/illkDXAN/u5EykYT7HWzpdCl0JmW8Xp7QQ==
+"@atb-as/generate-assets@^6.0.13":
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-6.0.13.tgz#3bf6d0adf4d0f8c577154e196d64e75902a6c46b"
+  integrity sha512-mFi0iRYJn3aLXaC/O8W8DSypDj9s28MK3vNka21YN6N7ELlWahZoXNbBaAkF/rgXDX2mN1trtmToTI3OrmMfbw==
   dependencies:
-    "@atb-as/theme" "^6.5.0"
+    "@atb-as/theme" "^6.5.2"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.5.0.tgz#b02b6ae600d78cdee07528e8ad6dd3bb036ba9e5"
-  integrity sha512-IEHIhOit6jU7dAHMJ6zpGRVMQyRvBQ4UQfU6ODC8upEFkmPd1Mdn1l3AFvVTU3UyjRf1CH9fTbOEvt4wYLwiig==
-  dependencies:
-    hex-to-rgba "^2.0.1"
-    ts-deepmerge "^4.0.0"
-
 "@atb-as/theme@^6.5.1":
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.5.1.tgz#b252b2a95a23f63fd0c2e9452b01111115abc6d0"
   integrity sha512-CT9xlSqosmdrYu47Y38d1n7KkPZpmz+PFcZl3i5fhFygk+wAf9+jEx7zWM00mu5R1GAXtDFxrEHq0eJrRqji0w==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
+"@atb-as/theme@^6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.5.2.tgz#c18ef67f6fbf24afbda268f5d562d19e7994e9a6"
+  integrity sha512-k/1jcp+Z+3oM4eGgc8PVL6NctqeY8r5xiFmOZw1RfrjfBffC8NwCkHhFI23U8UZz7NBWEebkHN/+S/HhMm4mZg==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"


### PR DESCRIPTION
This should have been split into two (three?) different onboarding screens - one for vehicles and one for city bikes (and possibly a third for both). Given the time constraints before release, it's considered sufficient to just update the text.