### PR TITLE
fix: Create theme and fix image colors for FRAM

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^6.0.13",
+    "@atb-as/generate-assets": "^7.0.0",
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-env": "^7.20.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "unimported": "npx unimported"
   },
   "dependencies": {
-    "@atb-as/theme": "^6.5.1",
+    "@atb-as/theme": "^6.5.2",
     "@bugsnag/react-native": "^7.18.2",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-client-sdk": "^1.1.6",

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -1,6 +1,5 @@
 import {Add, Edit} from '@atb/assets/svg/mono-icons/actions';
 import {StopPlaceInfo} from '@atb/api/departures/types';
-import {NoFavouriteDeparture} from '@atb/assets/svg/color/images/';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
@@ -21,6 +20,7 @@ import {ActivityIndicator, View} from 'react-native';
 import {useFavoriteDepartureData} from '../use-favorite-departure-data';
 import * as Sections from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
+import {ThemedNoFavouriteDepartureImage} from '@atb/theme/ThemedAssets';
 
 type Props = {
   onEditFavouriteDeparture: () => void;
@@ -74,7 +74,7 @@ export const DeparturesWidget = ({
         <Sections.Section>
           <Sections.GenericSectionItem>
             <View style={styles.noFavouritesView}>
-              <NoFavouriteDeparture />
+              <ThemedNoFavouriteDepartureImage />
               <View style={styles.noFavouritesTextContainer}>
                 <ThemeText
                   type="body__secondary"

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -5,6 +5,8 @@ import {Phone as DarkPhone} from '@atb/assets/svg/color/illustrations/token/mobi
 import {Phone as LightPhone} from '@atb/assets/svg/color/illustrations/token/mobile/light/';
 import {Map as LightMap} from '@atb/assets/svg/color/images/light';
 import {Map as DarkMap} from '@atb/assets/svg/color/images/dark';
+import {NoFavouriteDeparture as LightNoFavouriteDeparture} from '@atb/assets/svg/color/images/light';
+import {NoFavouriteDeparture as DarkNoFavouriteDeparture} from '@atb/assets/svg/color/images/dark';
 import {useTheme} from '@atb/theme/ThemeContext';
 
 export const ThemedTokenTravelCard = () => {
@@ -23,4 +25,11 @@ export const ThemedMapImage = () => {
   const {themeName} = useTheme();
   const Map = themeName === 'dark' ? DarkMap : LightMap;
   return <Map />;
+};
+
+export const ThemedNoFavouriteDepartureImage = () => {
+  const {themeName} = useTheme();
+  const NoFavouriteDeparture =
+    themeName === 'dark' ? DarkNoFavouriteDeparture : LightNoFavouriteDeparture;
+  return <NoFavouriteDeparture />;
 };

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -15,13 +15,24 @@ import {
   ThemeVariant,
 } from '@atb-as/theme';
 import {Flattened, flattenObject} from '@atb/utils/object';
+import {AppOrgs} from '../../types/app-orgs';
 
 export type {Statuses, Mode, TextColor, ContrastColor, RadiusSizes, TextNames};
 export {textNames};
 
-const mainThemes = createThemesFor(
-  APP_ORG == 'nfk' ? ThemeVariant.Nfk : ThemeVariant.AtB,
-);
+const appOrgToThemeVariant = (appOrg: AppOrgs): ThemeVariant => {
+  switch (appOrg) {
+    case 'nfk':
+      return ThemeVariant.Nfk;
+    case 'fram':
+      return ThemeVariant.FRAM;
+    case 'atb':
+    default:
+      return ThemeVariant.AtB;
+  }
+};
+
+const mainThemes = createThemesFor(appOrgToThemeVariant(APP_ORG));
 
 // Override semibold with bold to avoid Android Roboto bold bug.
 // See ttps://github.com/facebook/react-native/issues/25696

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@atb-as/generate-assets@^6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-6.0.13.tgz#3bf6d0adf4d0f8c577154e196d64e75902a6c46b"
-  integrity sha512-mFi0iRYJn3aLXaC/O8W8DSypDj9s28MK3vNka21YN6N7ELlWahZoXNbBaAkF/rgXDX2mN1trtmToTI3OrmMfbw==
+"@atb-as/generate-assets@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.0.0.tgz#3da3478a61a75004fdeb69a7fd0697dfee764e93"
+  integrity sha512-yE2LRGo0LWF4zzK5mM8qhXBacVFDA+3Mw4CkvuqOG6zh5SLvDycL34Z3uSbDIfKE+k9sotE7qdGWlWa8mZO3jw==
   dependencies:
     "@atb-as/theme" "^6.5.2"
     commander "^9.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,14 +21,6 @@
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^6.5.1":
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.5.1.tgz#b252b2a95a23f63fd0c2e9452b01111115abc6d0"
-  integrity sha512-CT9xlSqosmdrYu47Y38d1n7KkPZpmz+PFcZl3i5fhFygk+wAf9+jEx7zWM00mu5R1GAXtDFxrEHq0eJrRqji0w==
-  dependencies:
-    hex-to-rgba "^2.0.1"
-    ts-deepmerge "^4.0.0"
-
 "@atb-as/theme@^6.5.2":
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.5.2.tgz#c18ef67f6fbf24afbda268f5d562d19e7994e9a6"


### PR DESCRIPTION
Add changes to theme creation such that a theme for FRAM is created. Updated the package `@atb-as/generate-assets` to get the updated images with the correct colors.

Fixes https://github.com/AtB-AS/kundevendt/issues/3773