### PR TITLE
fix: replace FRAM ios reversed id

### DIFF
--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -62,8 +62,6 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MBXAccessToken</key>
-	<string>$(MAPBOX_PUBLIC_TOKEN)</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Vi må bruke NFC for sikkerhetsformål.</string>
 	<key>NSAppTransportSecurity</key>

--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -45,7 +45,7 @@
 			<array>
 				<string>com.googleusercontent.apps.939812594010-cb697rhj3ifghgjq3flv7e67l1a18jma</string>
 				<string>com.googleusercontent.apps.793301954236-2umj9ofp91902ra1p816dtlh15gf7lev</string>
-				<string>com.googleusercontent.apps.312905478211-4aitnn8g8qom68g669ckedsvvvgl4o0j</string>
+				<string>com.googleusercontent.apps.312905478211-ssn46s3h6kp0o7p5s1pohdvhhuu7cqse</string>
 			</array>
 		</dict>
 	</array>
@@ -62,6 +62,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>MBXAccessToken</key>
+	<string>$(MAPBOX_PUBLIC_TOKEN)</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Vi må bruke NFC for sikkerhetsformål.</string>
 	<key>NSAppTransportSecurity</key>
@@ -113,7 +115,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>MBXAccessToken</key>
-	<string>$(MAPBOX_PUBLIC_TOKEN)</string>
 </dict>
 </plist>

--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -115,5 +115,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>MBXAccessToken</key>
+	<string>$(MAPBOX_PUBLIC_TOKEN)</string>
 </dict>
 </plist>


### PR DESCRIPTION
Replaces FRAM Google ID after recreating app with new identifier.