### PR TITLE
fix: Fix hooks order error in ThemeIcon

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -45,6 +45,7 @@ type ButtonIconProps = {
   svg: ({fill}: {fill: string}) => JSX.Element;
   size?: keyof Theme['icon']['size'];
   notification?: ThemeIconProps['notification'];
+  loading?: boolean;
 };
 
 export type ButtonProps = {

--- a/src/components/map/components/filter/MapFilter.tsx
+++ b/src/components/map/components/filter/MapFilter.tsx
@@ -6,7 +6,6 @@ import {MapFilterType} from '@atb/components/map/types';
 import {StyleSheet} from '@atb/theme';
 import {shadows} from '@atb/components/map';
 import {Filter} from '@atb/assets/svg/mono-icons/actions';
-import {LoadingSpinner} from '@atb/components/loading';
 
 type MapFilterProps = {
   onFilterChange: (filter: MapFilterType) => void;
@@ -33,7 +32,7 @@ export const MapFilter = ({onFilterChange, isLoading}: MapFilterProps) => {
       interactiveColor="interactive_2"
       accessibilityRole="button"
       onPress={onPress}
-      leftIcon={{svg: isLoading ? LoadingSpinner : Filter}}
+      leftIcon={{svg: Filter, loading: isLoading}}
     />
   );
 };

--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -14,12 +14,14 @@ import {
   NotificationIndicator,
   NotificationIndicatorProps,
 } from '@atb/components/theme-icon/NotificationIndicator';
+import {LoadingSpinner} from '@atb/components/loading';
 
 export type ThemeIconProps = {
   svg(props: SvgProps): JSX.Element;
   colorType?: IconColor;
   size?: keyof Theme['icon']['size'];
   notification?: Omit<NotificationIndicatorProps, 'iconSize'>;
+  loading?: boolean;
 } & SvgProps;
 
 export const ThemeIcon = ({
@@ -29,6 +31,7 @@ export const ThemeIcon = ({
   fill,
   notification,
   style,
+  loading,
   ...props
 }: ThemeIconProps): JSX.Element => {
   const {theme, themeName} = useTheme();
@@ -47,9 +50,15 @@ export const ThemeIcon = ({
 
   return (
     <View style={style}>
-      {svg(settings)}
-      {notification && (
-        <NotificationIndicator {...notification} iconSize={size} />
+      {loading ? (
+        <LoadingSpinner />
+      ) : (
+        <>
+          {svg(settings)}
+          {notification && (
+            <NotificationIndicator {...notification} iconSize={size} />
+          )}
+        </>
       )}
     </View>
   );


### PR DESCRIPTION
The error happenend because the provided svg to ThemeIcon is called
as a function, which doesn't work with the LoadingSpinnger
component.

This was fixed by making the loading a flag on ThemeIcon, which now
internally handles correct showing of LoadingSpinner.

The warning that was shown:
```
Warning: React has detected a change in the order of Hooks called by ThemeIcon. This will lead to bugs
and errors if not fixed. For more information, read the Rules of Hooks: 
https://reactjs.org/link/rules-of-hooks

   Previous render            Next render
   ------------------------------------------------------
1. useContext                 useContext
2. useState                   useState
3. useEffect                  useEffect
4. undefined                  useContext
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    in ThemeIcon
    in RCTView (created by View)
    in View
    in RCTView (created by View)
    in View (created by AnimatedComponent)
    in AnimatedComponent
    in AnimatedComponentWrapper (created by TouchableOpacity)
    in TouchableOpacity (created by TouchableOpacity)
    in TouchableOpacity
    in RCTView (created by View)
    in View (created by AnimatedComponent)
    in AnimatedComponent
    in AnimatedComponentWrapper
    in Unknown (created by MapFilter)
    in MapFilter (created by Map)
```