### PR TITLE
fix: Duplicate key on recent fare contracts

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
@@ -79,16 +79,9 @@ export const RecentFareContracts = ({onSelect}: Props) => {
             testID="recentTicketsScrollView"
           >
             {memoizedRecentFareContracts.map((rfc) => {
-              const componentKey =
-                rfc.preassignedFareProduct.id +
-                rfc.userProfilesWithCount
-                  .map((traveller) => {
-                    return traveller.count + traveller.userTypeString;
-                  })
-                  .join();
               return (
                 <RecentFareContractComponent
-                  key={componentKey}
+                  key={rfc.id}
                   recentFareContract={rfc}
                   onSelect={onSelect}
                   testID={'recent' + memoizedRecentFareContracts.indexOf(rfc)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/types.ts
@@ -2,6 +2,11 @@ import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
 import {UserProfileWithCount} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
 
 export type RecentFareContract = {
+  /**
+   * An id created from the underlying fields. Can be used to check for uniques
+   * and as react key.
+   */
+  id: string;
   preassignedFareProduct: PreassignedFareProduct;
   fromTariffZone?: TariffZone;
   toTariffZone?: TariffZone;


### PR DESCRIPTION
The react component key for recent fare contracts only used fare
product and travellers, and not zones. Which ment that we got a
duplicate key error if a user had two recent fare contracts
with same product and travellers, but different zones.

When doing this the logic for the key ended up being almost a
duplicate of checking for unique fare contracts. So now we use the
underlying fields for the recent fare contract to create an id
which can be used both as react key and for filtering out
duplicates.

Example of error we got before this fix:
```
ERROR Warning: Encountered two children with the same key, `ATB:PreassignedFareProduct:8808c3601ADULT`. 
Keys should be unique so that components maintain their identity across updates. 
Non-unique keys may cause children to be duplicated and/or omitted — the behavior
is unsupported and could change in a future version.
    in RCTScrollContentView (created by ScrollView)
    in RCTScrollView (created by ScrollView)
    in ScrollView (created by ScrollView)
    in ScrollView (created by RecentFareContracts)
    in RCTView (created by View)
    in View (created by RecentFareContracts)
    in RecentFareContracts (created by TicketTabNav_PurchaseTabScreen)
    in RCTScrollContentView (created by ScrollView)
    in RCTScrollView (created by ScrollView)
    in ScrollView (created by ScrollView)
    in ScrollView (created by TicketTabNav_PurchaseTabScreen)
    in TicketTabNav_PurchaseTabScreen (created by SceneView
```

### Acceptance criteria
- [ ] Recent fare contracts should work as before. Only show the three latest unique purchases. Check by changing product, travellers and tariff zones.
