### PR TITLE
refactor: added eslint rule no-restricted-syntax to restrict wildcard imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,14 @@ module.exports = {
 
     'no-restricted-imports': ['warn', {patterns: ['@atb/components/*/']}],
 
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: ":matches(ImportNamespaceSpecifier[local.name!='React'])",
+        message: 'No wildcard imports',
+      },
+    ],
+
     // React-Hooks Plugin
     // The following rules are made available via `eslint-plugin-react-hooks`
     'react-hooks/rules-of-hooks': 2, // early error
@@ -75,6 +83,12 @@ module.exports = {
           'error',
           {restrictDefaultExports: {direct: false}},
         ],
+      },
+    },
+    {
+      files: ['src/api/types/**'],
+      rules: {
+        'no-restricted-syntax': 'off',
       },
     },
   ],

--- a/src/LocaleProvider.tsx
+++ b/src/LocaleProvider.tsx
@@ -1,4 +1,4 @@
-import * as RNLocalize from 'react-native-localize';
+import RNLocalize from 'react-native-localize';
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import {Language} from '@atb/translations';
 import {usePreferences} from '@atb/preferences';

--- a/src/components/icon-box/utils.ts
+++ b/src/components/icon-box/utils.ts
@@ -1,7 +1,16 @@
-import * as TransportIcons from '@atb/assets/svg/mono-icons/transportation';
-import * as EnturTransportIcons from '@atb/assets/svg/mono-icons/transportation-entur';
 import {AnyMode, AnySubMode} from './types';
 import {TransportSubmode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {
+  Bus,
+  Flexible,
+  Tram,
+  Train,
+  Boat,
+  Ferry,
+  Walk,
+  Unknown,
+} from '@atb/assets/svg/mono-icons/transportation';
+import {Plane, Subway} from '@atb/assets/svg/mono-icons/transportation-entur';
 
 const TRANSPORT_SUB_MODES_BOAT: AnySubMode[] = [
   TransportSubmode.HighSpeedPassengerService,
@@ -14,26 +23,26 @@ const TRANSPORT_SUB_MODES_BOAT: AnySubMode[] = [
 export function getTransportModeSvg(mode?: AnyMode, subMode?: AnySubMode) {
   switch (mode) {
     case 'flex':
-      return TransportIcons.Flexible;
+      return Flexible;
     case 'bus':
     case 'coach':
-      return TransportIcons.Bus;
+      return Bus;
     case 'tram':
-      return TransportIcons.Tram;
+      return Tram;
     case 'rail':
-      return TransportIcons.Train;
+      return Train;
     case 'air':
-      return EnturTransportIcons.Plane;
+      return Plane;
     case 'water':
       return subMode && TRANSPORT_SUB_MODES_BOAT.includes(subMode)
-        ? TransportIcons.Boat
-        : TransportIcons.Ferry;
+        ? Boat
+        : Ferry;
     case 'foot':
-      return TransportIcons.Walk;
+      return Walk;
     case 'metro':
-      return EnturTransportIcons.Subway;
+      return Subway;
     case 'unknown':
     default:
-      return TransportIcons.Unknown;
+      return Unknown;
   }
 }

--- a/src/components/location-icon/LocationIcon.tsx
+++ b/src/components/location-icon/LocationIcon.tsx
@@ -1,11 +1,16 @@
 import {Pin} from '@atb/assets/svg/mono-icons/map';
 import {Location as LocationMonoIcon} from '@atb/assets/svg/mono-icons/places';
-import * as TransportationIcons from '@atb/assets/svg/mono-icons/transportation';
-import * as EnturTransportationIcons from '@atb/assets/svg/mono-icons/transportation-entur';
 import {Location} from '@atb/favorites';
 import React from 'react';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {getVenueIconTypes} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
+import {
+  Bus,
+  Ferry,
+  Train,
+  Tram,
+} from '@atb/assets/svg/mono-icons/transportation';
+import {Plane} from '@atb/assets/svg/mono-icons/transportation-entur';
 
 export const LocationIcon = ({
   location,
@@ -43,43 +48,27 @@ const mapTypeToIconComponent = (iconType: VenueIconType) => {
   switch (iconType) {
     case 'bus':
       return (
-        <ThemeIcon
-          svg={TransportationIcons.Bus}
-          accessibilityLabel="Bussholdeplass"
-          key="bus"
-        />
+        <ThemeIcon svg={Bus} accessibilityLabel="Bussholdeplass" key="bus" />
       );
     case 'tram':
       return (
         <ThemeIcon
-          svg={TransportationIcons.Tram}
+          svg={Tram}
           accessibilityLabel="Trikkeholdeplass"
           key="tram"
         />
       );
     case 'rail':
       return (
-        <ThemeIcon
-          svg={TransportationIcons.Train}
-          accessibilityLabel="Togstasjon"
-          key="rail"
-        />
+        <ThemeIcon svg={Train} accessibilityLabel="Togstasjon" key="rail" />
       );
     case 'airport':
       return (
-        <ThemeIcon
-          svg={EnturTransportationIcons.Plane}
-          accessibilityLabel="Flyplass"
-          key="airport"
-        />
+        <ThemeIcon svg={Plane} accessibilityLabel="Flyplass" key="airport" />
       );
     case 'boat':
       return (
-        <ThemeIcon
-          svg={TransportationIcons.Ferry}
-          accessibilityLabel="Fergeleie"
-          key="boat"
-        />
+        <ThemeIcon svg={Ferry} accessibilityLabel="Fergeleie" key="boat" />
       );
     case 'unknown':
     default:

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -16,8 +16,8 @@ import {useControlPositionsStyle} from './hooks/use-control-styles';
 import {MapCameraConfig, MapViewConfig} from './MapConfig';
 import {PositionArrow} from './components/PositionArrow';
 import {shadows} from './components/shadows';
-import * as Mobility from './components/mobility';
 import {MapFilter} from './components/filter/MapFilter';
+import {Stations, Vehicles} from '@atb/components/map/components/mobility';
 
 export const Map = (props: MapProps) => {
   const {initialLocation} = props;
@@ -114,14 +114,14 @@ export const Map = (props: MapProps) => {
             </MapboxGL.PointAnnotation>
           )}
           {props.vehicles && (
-            <Mobility.Vehicles
+            <Vehicles
               mapCameraRef={mapCameraRef}
               vehicles={props.vehicles.vehicles}
               onPress={props.vehicles.onPress}
             />
           )}
           {props.stations && (
-            <Mobility.Stations
+            <Stations
               mapCameraRef={mapCameraRef}
               stations={props.stations.stations}
               onPress={props.stations.onPress}

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -5,7 +5,7 @@ import {
   QuayGroup,
   StopPlaceGroup,
 } from '@atb/api/departures/types';
-import * as DepartureTypes from '@atb/api/types/departures';
+import {EstimatedCall} from '@atb/api/types/departures';
 import {DepartureRealtimeData, DeparturesRealtimeData} from '@atb/sdk';
 import {isNumberOfMinutesInThePast} from '@atb/utils/date';
 
@@ -102,9 +102,9 @@ function updateDeparturesWithRealtime(
 }
 
 export function updateDeparturesWithRealtimeV2(
-  estimatedCalls: DepartureTypes.EstimatedCall[] | null,
+  estimatedCalls: EstimatedCall[] | null,
   realtime?: DeparturesRealtimeData,
-): DepartureTypes.EstimatedCall[] | null {
+): EstimatedCall[] | null {
   if (!estimatedCalls) return null;
   if (!realtime) return estimatedCalls;
 

--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -13,9 +13,9 @@ import {
 import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';
 import {secondsToDuration} from '@atb/utils/date';
 import {FareContractInfoDetailsProps} from './FareContractInfo';
-import * as Sections from '@atb/components/sections';
 import {screenReaderPause} from '@atb/components/text';
 import {InspectionSymbol} from '@atb/fare-contracts/components/InspectionSymbol';
+import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 
 type CompactFareContractInfoProps = FareContractInfoDetailsProps & {
   onPressDetails?: () => void;
@@ -54,16 +54,16 @@ export const CompactFareContractInfo = (
   };
 
   return (
-    <Sections.Section withPadding {...accessibility}>
-      <Sections.GenericClickableSectionItem onPress={props.onPressDetails}>
+    <Section withPadding {...accessibility}>
+      <GenericClickableSectionItem onPress={props.onPressDetails}>
         <View style={styles.container}>
           <View style={styles.ticketDetails}>
             <CompactFareContractInfoTexts {...fareContractInfoTextsProps} />
             {isValid && <InspectionSymbol {...props} isLoading={isLoading} />}
           </View>
         </View>
-      </Sections.GenericClickableSectionItem>
-    </Sections.Section>
+      </GenericClickableSectionItem>
+    </Section>
   );
 };
 

--- a/src/fare-contracts/PreActivatedFareContractInfo.tsx
+++ b/src/fare-contracts/PreActivatedFareContractInfo.tsx
@@ -1,4 +1,3 @@
-import * as Sections from '@atb/components/sections';
 import {FareContractState, PreActivatedTravelRight} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
@@ -8,6 +7,11 @@ import {ValidityLine} from './ValidityLine';
 import {getValidityStatus} from '@atb/fare-contracts/utils';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {findReferenceDataById} from '@atb/reference-data/utils';
+import {
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = {
   fareContractState: FareContractState;
@@ -47,8 +51,8 @@ export const PreActivatedFareContractInfo: React.FC<Props> = ({
     fareContractState,
   );
   return (
-    <Sections.Section withBottomPadding testID={testID}>
-      <Sections.GenericSectionItem>
+    <Section withBottomPadding testID={testID}>
+      <GenericSectionItem>
         <ValidityHeader
           status={validityStatus}
           isInspectable={isInspectable}
@@ -72,9 +76,9 @@ export const PreActivatedFareContractInfo: React.FC<Props> = ({
           testID={testID}
           fareProductType={preassignedFareProduct?.type}
         />
-      </Sections.GenericSectionItem>
+      </GenericSectionItem>
       {!hideDetails && (
-        <Sections.LinkSectionItem
+        <LinkSectionItem
           text={t(
             validityStatus === 'valid' && isInspectable
               ? FareContractTexts.detailsLink.valid
@@ -84,6 +88,6 @@ export const PreActivatedFareContractInfo: React.FC<Props> = ({
           testID={testID + 'Details'}
         />
       )}
-    </Sections.Section>
+    </Section>
   );
 };

--- a/src/fare-contracts/UnknownFareContract.tsx
+++ b/src/fare-contracts/UnknownFareContract.tsx
@@ -1,26 +1,26 @@
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {FareContract} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ValidityLine} from './ValidityLine';
+import {GenericSectionItem, Section} from '@atb/components/sections';
 
 export function UnknownFareContract({fc}: {fc: FareContract}) {
   const {t} = useTranslation();
 
   return (
-    <Sections.Section withBottomPadding>
-      <Sections.GenericSectionItem>
+    <Section withBottomPadding>
+      <GenericSectionItem>
         <ValidityLine status="unknown" />
         <ThemeText>
           {t(FareContractTexts.unknownFareContract.message)}
         </ThemeText>
-      </Sections.GenericSectionItem>
-      <Sections.GenericSectionItem>
+      </GenericSectionItem>
+      <GenericSectionItem>
         <ThemeText>
           {t(FareContractTexts.unknownFareContract.orderId(fc.orderId))}
         </ThemeText>
-      </Sections.GenericSectionItem>
-    </Sections.Section>
+      </GenericSectionItem>
+    </Section>
   );
 }

--- a/src/fare-contracts/carnet/CarnetDetailedView.tsx
+++ b/src/fare-contracts/carnet/CarnetDetailedView.tsx
@@ -1,10 +1,14 @@
-import * as Sections from '@atb/components/sections';
 import {FareContract, isCarnetTravelRight} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {OrderDetails} from '@atb/fare-contracts/details/OrderDetails';
 import {UnknownFareContractDetails} from '@atb/fare-contracts/details/UnknownFareContractDetails';
 import {CarnetDetails} from '@atb/fare-contracts/carnet/CarnetDetails';
+import {
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = {
   fareContract: FareContract;
@@ -23,23 +27,23 @@ export const CarnetDetailedView: React.FC<Props> = ({
   const firstTravelRight = fc.travelRights[0];
   if (isCarnetTravelRight(firstTravelRight)) {
     return (
-      <Sections.Section withBottomPadding>
+      <Section withBottomPadding>
         <CarnetDetails
           now={now}
           inspectable={isInspectable}
           travelRights={fc.travelRights.filter(isCarnetTravelRight)}
           fareContract={fc}
         />
-        <Sections.GenericSectionItem>
+        <GenericSectionItem>
           <OrderDetails fareContract={fc} />
-        </Sections.GenericSectionItem>
-        <Sections.LinkSectionItem
+        </GenericSectionItem>
+        <LinkSectionItem
           text={t(FareContractTexts.details.askForReceipt)}
           onPress={onReceiptNavigate}
           accessibility={{accessibilityRole: 'button'}}
           testID="receiptButton"
         />
-      </Sections.Section>
+      </Section>
     );
   } else {
     return <UnknownFareContractDetails fc={fc} />;

--- a/src/fare-contracts/carnet/CarnetDetails.tsx
+++ b/src/fare-contracts/carnet/CarnetDetails.tsx
@@ -5,12 +5,11 @@ import {
   flattenCarnetTravelRightAccesses,
 } from '@atb/ticketing';
 import {getValidityStatus} from '@atb/fare-contracts/utils';
-import * as Sections from '@atb/components/sections';
 import {ValidityHeader} from '@atb/fare-contracts/ValidityHeader';
 import {UsedAccessValidityHeader} from '@atb/fare-contracts/carnet/UsedAccessValidityHeader';
 import {ValidityLine} from '@atb/fare-contracts/ValidityLine';
 import {View} from 'react-native';
-import {SectionSeparator} from '@atb/components/sections';
+import {GenericSectionItem, SectionSeparator} from '@atb/components/sections';
 import {FareContractInfo} from '@atb/fare-contracts/FareContractInfo';
 import {CarnetFooter} from '@atb/fare-contracts/carnet/CarnetFooter';
 import React from 'react';
@@ -46,7 +45,7 @@ export function CarnetDetails(props: {
 
   return (
     <>
-      <Sections.GenericSectionItem radius="top">
+      <GenericSectionItem radius="top">
         {fareContractValidityStatus !== 'valid' ? (
           <ValidityHeader
             now={now}
@@ -87,14 +86,14 @@ export function CarnetDetails(props: {
           testID={props.testID}
           fareProductType={'carnet'}
         />
-      </Sections.GenericSectionItem>
-      <Sections.GenericSectionItem>
+      </GenericSectionItem>
+      <GenericSectionItem>
         <CarnetFooter
           active={usedAccessValidityStatus === 'valid'}
           maximumNumberOfAccesses={maximumNumberOfAccesses}
           numberOfUsedAccesses={numberOfUsedAccesses}
         />
-      </Sections.GenericSectionItem>
+      </GenericSectionItem>
     </>
   );
 }

--- a/src/fare-contracts/carnet/CarnetFareContractInfo.tsx
+++ b/src/fare-contracts/carnet/CarnetFareContractInfo.tsx
@@ -1,10 +1,10 @@
-import * as Sections from '@atb/components/sections';
 import {RootStackParamList} from '@atb/stacks-hierarchy';
 import {CarnetDetails} from '@atb/fare-contracts/carnet/CarnetDetails';
 import {CarnetTravelRight, FareContract} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import React from 'react';
+import {LinkSectionItem, Section} from '@atb/components/sections';
 
 type Props = {
   fareContract: FareContract;
@@ -27,7 +27,7 @@ export const CarnetFareContractInfo: React.FC<Props> = ({
   const navigation = useNavigation<RootNavigationProp>();
 
   return (
-    <Sections.Section withBottomPadding testID={testID}>
+    <Section withBottomPadding testID={testID}>
       <CarnetDetails
         now={now}
         inspectable={isInspectable}
@@ -35,7 +35,7 @@ export const CarnetFareContractInfo: React.FC<Props> = ({
         testID={testID}
         fareContract={fareContract}
       />
-      <Sections.LinkSectionItem
+      <LinkSectionItem
         text={t(FareContractTexts.detailsLink.notValid)}
         onPress={() =>
           navigation.navigate({
@@ -48,6 +48,6 @@ export const CarnetFareContractInfo: React.FC<Props> = ({
         }
         testID={testID + 'Details'}
       />
-    </Sections.Section>
+    </Section>
   );
 };

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -1,5 +1,4 @@
 import {ValidityStatus} from '@atb/fare-contracts/utils';
-import * as Sections from '@atb/components/sections';
 import {ActivityIndicator, View} from 'react-native';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {SvgXml} from 'react-native-svg';
@@ -18,6 +17,7 @@ import {
 } from '@atb/mobile-token/utils';
 import {FareContract} from '@atb/ticketing';
 import {renderAztec} from '@entur-private/abt-mobile-client-sdk';
+import {GenericSectionItem} from '@atb/components/sections';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import QRCode from 'qrcode';
 
@@ -107,7 +107,7 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
   }
 
   return (
-    <Sections.GenericSectionItem>
+    <GenericSectionItem>
       <View style={{alignItems: 'center'}}>
         <View
           style={styles.aztecCode}
@@ -118,7 +118,7 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
           <SvgXml xml={aztecXml} width="100%" height="100%" />
         </View>
       </View>
-    </Sections.GenericSectionItem>
+    </GenericSectionItem>
   );
 };
 
@@ -126,7 +126,7 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
 //   const {t} = useTranslation();
 //
 //   return (
-//     <Sections.GenericSectionItem>
+//     <GenericSectionItem>
 //       <MessageBox
 //         type={'error'}
 //         title={t(TicketTexts.details.barcodeErrors.generic.title)}
@@ -134,7 +134,7 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
 //         onPress={retry && (() => retry(true))}
 //         onPressText={retry && t(TicketTexts.details.barcodeErrors.generic.retry)}
 //       />
-//     </Sections.GenericSectionItem>
+//     </GenericSectionItem>
 //   );
 // };
 
@@ -155,7 +155,7 @@ const DeviceNotInspectable = () => {
         ),
       );
   return (
-    <Sections.GenericSectionItem>
+    <GenericSectionItem>
       <MessageBox
         type={'warning'}
         title={t(
@@ -164,18 +164,18 @@ const DeviceNotInspectable = () => {
         message={message}
         isMarkdown={true}
       />
-    </Sections.GenericSectionItem>
+    </GenericSectionItem>
   );
 };
 
 const LoadingBarcode = () => {
   const {theme} = useTheme();
   return (
-    <Sections.GenericSectionItem>
+    <GenericSectionItem>
       <View style={{flex: 1}}>
         <ActivityIndicator animating={true} color={theme.text.colors.primary} />
       </View>
-    </Sections.GenericSectionItem>
+    </GenericSectionItem>
   );
 };
 
@@ -193,7 +193,7 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
   if (!aztecXml) return null;
 
   return (
-    <Sections.GenericSectionItem>
+    <GenericSectionItem>
       <View
         style={styles.aztecCode}
         accessible={true}
@@ -202,7 +202,7 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
       >
         <SvgXml xml={aztecXml} width="100%" height="100%" />
       </View>
-    </Sections.GenericSectionItem>
+    </GenericSectionItem>
   );
 };
 
@@ -220,7 +220,7 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
   if (!qrCodeSvg) return null;
 
   return (
-    <Sections.GenericSectionItem>
+    <GenericSectionItem>
       <View
         style={styles.aztecCode}
         accessible={true}
@@ -229,7 +229,7 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
       >
         <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
       </View>
-    </Sections.GenericSectionItem>
+    </GenericSectionItem>
   );
 };
 

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -1,11 +1,10 @@
-import * as Sections from '@atb/components/sections';
+import React from 'react';
 import {
   FareContract,
   isInspectableTravelRight,
   isPreActivatedTravelRight,
 } from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
-import React from 'react';
 import {FareContractInfo} from '../FareContractInfo';
 import {ValidityHeader} from '../ValidityHeader';
 import {ValidityLine} from '../ValidityLine';
@@ -17,6 +16,11 @@ import {
 import {OrderDetails} from '@atb/fare-contracts/details/OrderDetails';
 import {UnknownFareContractDetails} from '@atb/fare-contracts/details/UnknownFareContractDetails';
 import {PreassignedFareProduct} from '@atb/reference-data/types';
+import {
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = {
   fareContract: FareContract;
@@ -57,8 +61,8 @@ export const DetailsContent: React.FC<Props> = ({
 
     const validityStatus = getValidityStatus(now, validFrom, validTo, fc.state);
     return (
-      <Sections.Section withBottomPadding>
-        <Sections.GenericSectionItem>
+      <Section withBottomPadding>
+        <GenericSectionItem>
           <ValidityHeader
             status={validityStatus}
             now={now}
@@ -82,17 +86,17 @@ export const DetailsContent: React.FC<Props> = ({
             fareContract={fc}
             fareProductType={preassignedFareProduct?.type}
           />
-        </Sections.GenericSectionItem>
-        <Sections.GenericSectionItem>
+        </GenericSectionItem>
+        <GenericSectionItem>
           <OrderDetails fareContract={fc} />
-        </Sections.GenericSectionItem>
-        <Sections.LinkSectionItem
+        </GenericSectionItem>
+        <LinkSectionItem
           text={t(FareContractTexts.details.askForReceipt)}
           onPress={onReceiptNavigate}
           accessibility={{accessibilityRole: 'button'}}
           testID="receiptButton"
         />
-      </Sections.Section>
+      </Section>
     );
   } else {
     return <UnknownFareContractDetails fc={fc} />;

--- a/src/fare-contracts/details/UnknownFareContractDetails.tsx
+++ b/src/fare-contracts/details/UnknownFareContractDetails.tsx
@@ -1,22 +1,22 @@
 import {FareContract} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
-import * as Sections from '@atb/components/sections';
 import {ValidityLine} from '@atb/fare-contracts/ValidityLine';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
+import {GenericSectionItem, Section} from '@atb/components/sections';
 
 export function UnknownFareContractDetails({fc}: {fc: FareContract}) {
   const {t} = useTranslation();
   return (
-    <Sections.Section withBottomPadding>
-      <Sections.GenericSectionItem>
+    <Section withBottomPadding>
+      <GenericSectionItem>
         <ValidityLine status="unknown" />
-      </Sections.GenericSectionItem>
-      <Sections.GenericSectionItem>
+      </GenericSectionItem>
+      <GenericSectionItem>
         <ThemeText>
           {t(FareContractTexts.details.orderId(fc.orderId))}
         </ThemeText>
-      </Sections.GenericSectionItem>
-    </Sections.Section>
+      </GenericSectionItem>
+    </Section>
   );
 }

--- a/src/favorite-departures/FavoriteDeparturesScreenComponent.tsx
+++ b/src/favorite-departures/FavoriteDeparturesScreenComponent.tsx
@@ -1,4 +1,3 @@
-import * as Sections from '@atb/components/sections';
 import {useFavorites} from '@atb/favorites';
 import {StoredFavoriteDeparture} from '@atb/favorites';
 import {StyleSheet, Theme} from '@atb/theme';
@@ -10,6 +9,11 @@ import {FullScreenHeader} from '@atb/components/screen-header';
 import {animateNextChange} from '@atb/utils/animation';
 import {Add} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
+import {
+  FavoriteDepartureSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = {onPressAddFavorite: () => void};
 
@@ -48,9 +52,9 @@ export const FavoriteDeparturesScreenComponent = ({
       />
 
       <ScrollView>
-        <Sections.Section withFullPadding testID="favoritesList">
+        <Section withFullPadding testID="favoritesList">
           {favoriteDepartures.map((favorite) => (
-            <Sections.FavoriteDepartureSectionItem
+            <FavoriteDepartureSectionItem
               key={favorite.id}
               favorite={favorite}
               accessibility={{
@@ -62,15 +66,15 @@ export const FavoriteDeparturesScreenComponent = ({
               testID={`deleteFavorite${favoriteDepartures.indexOf(favorite)}`}
             />
           ))}
-        </Sections.Section>
-        <Sections.Section withPadding>
-          <Sections.LinkSectionItem
+        </Section>
+        <Section withPadding>
+          <LinkSectionItem
             text={t(FavoriteDeparturesTexts.favoriteItemAdd.label)}
             onPress={onPressAddFavorite}
             testID="addFavoriteDeparture"
             icon={<ThemeIcon svg={Add} />}
           />
-        </Sections.Section>
+        </Section>
       </ScrollView>
     </View>
   );

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -5,15 +5,18 @@ import {Quay, StopPlace} from '@atb/api/types/departures';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
 import React, {useRef} from 'react';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
-import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+import {
+  TransportSubmode,
+  TransportMode,
+} from '@atb/api/types/generated/journey_planner_v3_types';
 import {animateNextChange} from '@atb/utils/animation';
 
 type FavouriteDepartureLine = {
   id?: string;
   description?: string;
   lineNumber?: string;
-  transportMode?: Types.TransportMode;
-  transportSubmode?: Types.TransportSubmode;
+  transportMode?: TransportMode;
+  transportSubmode?: TransportSubmode;
   lineName?: string;
 };
 

--- a/src/login/ConfirmCode.tsx
+++ b/src/login/ConfirmCode.tsx
@@ -9,7 +9,6 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import * as Sections from '@atb/components/sections';
 import {Button} from '@atb/components/button';
 import {useAuthState} from '@atb/auth';
 import {
@@ -22,6 +21,7 @@ import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {StaticColorByType} from '@atb/theme/colors';
 import {loginConfirmCodeInputId} from '@atb/test-ids';
+import {Section, TextInputSectionItem} from '@atb/components/sections';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -103,8 +103,8 @@ export const ConfirmCode = ({
               {t(LoginTexts.confirmCode.description(phoneNumber))}
             </ThemeText>
           </View>
-          <Sections.Section>
-            <Sections.TextInputSectionItem
+          <Section>
+            <TextInputSectionItem
               label={t(LoginTexts.confirmCode.input.label)}
               placeholder={t(LoginTexts.confirmCode.input.placeholder)}
               onChangeText={setCode}
@@ -116,7 +116,7 @@ export const ConfirmCode = ({
               autoFocus={true}
               testID={loginConfirmCodeInputId}
             />
-          </Sections.Section>
+          </Section>
           <View style={styles.buttonView}>
             {isLoading && (
               <ActivityIndicator

--- a/src/login/LoginOptionsScreen.tsx
+++ b/src/login/LoginOptionsScreen.tsx
@@ -8,7 +8,6 @@ import {useAuthState} from '@atb/auth';
 import {VippsSignInErrorCode} from '@atb/auth/AuthContext';
 import {MessageBox} from '@atb/components/message-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {VippsLoginButton} from '@atb/components/vipps-login-button';
 import {AfterLoginParams, LoginInAppScreenProps} from '@atb/login/types';
@@ -23,6 +22,7 @@ import {ActivityIndicator, Linking, ScrollView, View} from 'react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {parseUrl} from 'query-string/base';
+import {LinkSectionItem, Section} from '@atb/components/sections';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -176,8 +176,8 @@ export const LoginOptionsScreen = ({
         <ThemeText style={styles.description} color={themeColor}>
           {t(LoginTexts.logInOptions.or)}
         </ThemeText>
-        <Sections.Section>
-          <Sections.LinkSectionItem
+        <Section>
+          <LinkSectionItem
             text={t(LoginTexts.logInOptions.options.phoneAndCode)}
             onPress={() => {
               navigation.navigate('LoginInApp', {
@@ -188,7 +188,7 @@ export const LoginOptionsScreen = ({
             disabled={isLoading}
             testID="chooseLoginPhone"
           />
-        </Sections.Section>
+        </Section>
       </ScrollView>
     </View>
   );

--- a/src/login/PhoneInput.tsx
+++ b/src/login/PhoneInput.tsx
@@ -8,7 +8,6 @@ import {
   ScrollView,
   View,
 } from 'react-native';
-import * as Sections from '@atb/components/sections';
 import {Button} from '@atb/components/button';
 import {useAuthState} from '@atb/auth';
 import {ThemeText} from '@atb/components/text';
@@ -20,6 +19,7 @@ import {LeftButtonProps, RightButtonProps} from '@atb/components/screen-header';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {StaticColorByType} from '@atb/theme/colors';
 import phone from 'phone';
+import {PhoneInputSectionItem, Section} from '@atb/components/sections';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -116,8 +116,8 @@ export const PhoneInput = ({
               {t(LoginTexts.phoneInput.description)}
             </ThemeText>
           </View>
-          <Sections.Section>
-            <Sections.PhoneInputSectionItem
+          <Section>
+            <PhoneInputSectionItem
               label={t(LoginTexts.phoneInput.input.heading)}
               value={phoneNumber}
               onChangeText={setPhoneNumber}
@@ -129,7 +129,7 @@ export const PhoneInput = ({
               autoFocus={true}
               textContentType="telephoneNumber"
             />
-          </Sections.Section>
+          </Section>
           <View style={styles.buttonView}>
             {isSubmitting && (
               <ActivityIndicator

--- a/src/nearby-stop-places/components/StopPlaceItem.tsx
+++ b/src/nearby-stop-places/components/StopPlaceItem.tsx
@@ -3,7 +3,6 @@ import {useTranslation} from '@atb/translations';
 import React from 'react';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
-import * as Sections from '@atb/components/sections';
 import {getTransportModeSvg} from '@atb/components/icon-box';
 import {NearestStopPlaceNode, StopPlace} from '@atb/api/types/departures';
 import DeparturesTexts from '@atb/translations/screens/Departures';
@@ -16,6 +15,7 @@ import {
 } from '@atb/situations';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
+import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 
 type StopPlaceItemProps = {
   stopPlaceNode: NearestStopPlaceNode;
@@ -61,8 +61,8 @@ export const StopPlaceItem = ({
     .join(',');
 
   return (
-    <Sections.Section withPadding>
-      <Sections.GenericClickableSectionItem
+    <Section withPadding>
+      <GenericClickableSectionItem
         onPress={() => onPress(place)}
         accessibilityLabel={a11yLabel}
         accessibilityHint={t(
@@ -93,8 +93,8 @@ export const StopPlaceItem = ({
             />
           ))}
         </View>
-      </Sections.GenericClickableSectionItem>
-    </Sections.Section>
+      </GenericClickableSectionItem>
+    </Section>
   );
 };
 

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -18,7 +18,10 @@ import {
   formatToSimpleDate,
 } from '@atb/utils/date';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
-import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
+import {
+  TransportMode,
+  TransportSubmode,
+} from '@atb/api/types/generated/journey_planner_v3_types';
 import {Mode as Mode_v2} from '@atb/api/types/generated/journey_planner_v3_types';
 import {EstimatedCall, Quay, StopPlace} from '@atb/api/types/departures';
 import {useFontScale} from '@atb/utils/use-font-scale';
@@ -327,8 +330,8 @@ function getLineA11yLabel(departure: EstimatedCall, t: TranslateFunction) {
 
 type LineChipProps = {
   publicCode?: string;
-  transportMode?: Types.TransportMode;
-  transportSubmode?: Types.TransportSubmode;
+  transportMode?: TransportMode;
+  transportSubmode?: TransportSubmode;
   icon?: (props: SvgProps) => JSX.Element;
   testID?: string;
 };

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -1,7 +1,12 @@
 import {EstimatedCall, Quay, StopPlace} from '@atb/api/types/departures';
 import {ExpandLess, ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
-import * as Sections from '@atb/components/sections';
-import {SectionSeparator} from '@atb/components/sections';
+import {
+  GenericClickableSectionItem,
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+  SectionSeparator,
+} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useFavorites} from '@atb/favorites';
@@ -89,8 +94,8 @@ export function QuaySection({
 
   return (
     <View testID={testID}>
-      <Sections.Section style={styles.section}>
-        <Sections.GenericClickableSectionItem
+      <Section style={styles.section}>
+        <GenericClickableSectionItem
           onPress={() => {
             setIsMinimized(!isMinimized);
           }}
@@ -125,7 +130,7 @@ export function QuaySection({
             </View>
             <ThemeIcon svg={isMinimized ? ExpandMore : ExpandLess} />
           </View>
-        </Sections.GenericClickableSectionItem>
+        </GenericClickableSectionItem>
         {!isMinimized &&
           /*
            This is under its own 'isMinimized' as nesting section items in React
@@ -140,7 +145,7 @@ export function QuaySection({
               departuresToDisplay.slice(0, departuresPerQuay)
             }
             renderItem={({item: departure, index}: EstimatedCallRenderItem) => (
-              <Sections.GenericSectionItem
+              <GenericSectionItem
                 radius={
                   index === departuresToDisplay.length - 1 &&
                   !shouldShowMoreItemsLink
@@ -161,7 +166,7 @@ export function QuaySection({
                   allowFavouriteSelection={allowFavouriteSelection}
                   mode={mode}
                 />
-              </Sections.GenericSectionItem>
+              </GenericSectionItem>
             )}
             keyExtractor={(item: EstimatedCall) =>
               // ServiceJourney ID is not a unique key if a ServiceJourney
@@ -172,7 +177,7 @@ export function QuaySection({
             ListEmptyComponent={
               <>
                 {data && !isLoading && (
-                  <Sections.GenericSectionItem
+                  <GenericSectionItem
                     radius={!shouldShowMoreItemsLink ? 'bottom' : undefined}
                   >
                     <ThemeText
@@ -184,30 +189,30 @@ export function QuaySection({
                         ? t(DeparturesTexts.noDeparturesForFavorites)
                         : t(DeparturesTexts.noDepartures)}
                     </ThemeText>
-                  </Sections.GenericSectionItem>
+                  </GenericSectionItem>
                 )}
               </>
             }
           />
         )}
         {!isMinimized && didLoadingDataFail && !isLoading && (
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <View style={styles.messageBox}>
               <ThemeText type="body__secondary" color="secondary">
                 {t(DeparturesTexts.message.noData)}
               </ThemeText>
             </View>
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
         )}
         {isLoading && !isMinimized && (
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <View style={{width: '100%'}}>
               <ActivityIndicator></ActivityIndicator>
             </View>
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
         )}
         {shouldShowMoreItemsLink && (
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             icon="arrow-right"
             text={t(DeparturesTexts.quaySection.moreDepartures)}
             textType="body__primary--bold"
@@ -216,9 +221,9 @@ export function QuaySection({
               accessibilityHint: t(DeparturesTexts.quaySection.a11yToQuayHint),
             }}
             testID={testID + 'More'}
-          ></Sections.LinkSectionItem>
+          ></LinkSectionItem>
         )}
-      </Sections.Section>
+      </Section>
     </View>
   );
 }

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -3,7 +3,7 @@ import {
   DeparturesVariables,
   getDepartures,
 } from '@atb/api/departures/stops-nearest';
-import * as DepartureTypes from '@atb/api/types/departures';
+import {EstimatedCall} from '@atb/api/types/departures';
 import {ErrorType, getAxiosErrorType} from '@atb/api/utils';
 import {useFavorites, UserFavoriteDepartures} from '@atb/favorites';
 import {DeparturesRealtimeData} from '@atb/sdk';
@@ -32,7 +32,7 @@ import {DepartureRealtimeQuery} from '@atb/api/departures/departure-group';
 const HARD_REFRESH_LIMIT_IN_MINUTES = 10;
 
 export type DepartureDataState = {
-  data: DepartureTypes.EstimatedCall[] | null;
+  data: EstimatedCall[] | null;
   tick?: Date;
   error?: {type: ErrorType};
   locationId?: string[];
@@ -79,7 +79,7 @@ type DepartureDataActions =
       type: 'UPDATE_DEPARTURES';
       locationId?: string[];
       reset?: boolean;
-      result: DepartureTypes.EstimatedCall[];
+      result: EstimatedCall[];
     }
   | {
       type: 'SET_ERROR';
@@ -332,10 +332,7 @@ async function fetchEstimatedCalls(
   queryInput: DeparturesVariables,
   favoriteDepartures?: UserFavoriteDepartures,
   opts?: AxiosRequestConfig,
-): Promise<DepartureTypes.EstimatedCall[]> {
+): Promise<EstimatedCall[]> {
   const result = await getDepartures(queryInput, favoriteDepartures, opts);
-  return flatMap(
-    result.quays,
-    (q) => q.estimatedCalls,
-  ) as DepartureTypes.EstimatedCall[];
+  return flatMap(result.quays, (q) => q.estimatedCalls) as EstimatedCall[];
 }

--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -2,7 +2,6 @@ import {Button} from '@atb/components/button';
 import {MessageBox} from '@atb/components/message-box';
 import {RadioBox} from '@atb/components/radio';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';
 import {RemoteToken} from '@atb/mobile-token/types';
 import {
@@ -25,6 +24,7 @@ import {flatMap} from '@atb/utils/array';
 import React, {useCallback, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
+import {RadioGroupSection, Section} from '@atb/components/sections';
 
 type Props = {onAfterSave: () => void};
 
@@ -159,8 +159,8 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
           )}
 
         {selectedType === 'mobile' && mobileTokens?.length && (
-          <Sections.Section type="spacious" style={styles.selectDeviceSection}>
-            <Sections.RadioGroupSection<RemoteToken>
+          <Section type="spacious" style={styles.selectDeviceSection}>
+            <RadioGroupSection<RemoteToken>
               items={mobileTokens}
               keyExtractor={(rt) => rt.id}
               itemToText={(rt) =>
@@ -179,7 +179,7 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
                 TravelTokenTexts.toggleToken.radioBox.phone.selection.heading,
               )}
             />
-          </Sections.Section>
+          </Section>
         )}
 
         {saveState.error && (

--- a/src/service-disruptions/ServiceDisruptionSheet.tsx
+++ b/src/service-disruptions/ServiceDisruptionSheet.tsx
@@ -2,7 +2,6 @@ import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {
   ScreenHeaderTexts,
   ServiceDisruptionsTexts,
@@ -11,6 +10,7 @@ import {
 import React, {forwardRef} from 'react';
 import {Linking, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
+import {Section} from '@atb/components/sections';
 
 type Props = {
   close: () => void;
@@ -35,11 +35,11 @@ export const ServiceDisruptionSheet = forwardRef<View, Props>(
           setFocusOnLoad={false}
         />
 
-        <Sections.Section withFullPadding>
+        <Section withFullPadding>
           <View ref={focusRef} accessible>
             <ThemeText>{t(ServiceDisruptionsTexts.body)}</ThemeText>
           </View>
-        </Sections.Section>
+        </Section>
 
         <FullScreenFooter>
           <Button

--- a/src/situations/SituationBottomSheet.tsx
+++ b/src/situations/SituationBottomSheet.tsx
@@ -16,12 +16,12 @@ import {Linking, TouchableOpacity, View} from 'react-native';
 import {InfoLinkFragment} from '@atb/api/types/generated/fragments/shared';
 import {StyleSheet} from '@atb/theme';
 import {SituationType} from './types';
-import * as Sections from '@atb/components/sections';
 import {SituationOrNoticeIcon} from './SituationOrNoticeIcon';
 import {daysBetween, formatToLongDateTime} from '@atb/utils/date';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Time} from '@atb/assets/svg/mono-icons/time';
 import {screenReaderPause} from '@atb/components/text';
+import {GenericSectionItem, Section} from '@atb/components/sections';
 
 type Props = {
   situation: SituationType;
@@ -53,8 +53,8 @@ export const SituationBottomSheet = forwardRef<View, Props>(
 
         <ScrollView centerContent={true}>
           <View>
-            <Sections.Section style={styles.section}>
-              <Sections.GenericSectionItem type="spacious">
+            <Section style={styles.section}>
+              <GenericSectionItem type="spacious">
                 <View
                   accessibilityLabel={[summary, description, advice].join(
                     screenReaderPause,
@@ -104,8 +104,8 @@ export const SituationBottomSheet = forwardRef<View, Props>(
                     </ThemeText>
                   </View>
                 )}
-              </Sections.GenericSectionItem>
-            </Sections.Section>
+              </GenericSectionItem>
+            </Section>
           </View>
         </ScrollView>
         <FullScreenFooter>

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -7,7 +7,6 @@ import {MessageBox} from '@atb/components/message-box';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useFavorites} from '@atb/favorites';
@@ -18,6 +17,12 @@ import React, {useEffect, useState} from 'react';
 import {Alert, Keyboard, ScrollView, View} from 'react-native';
 import {EmojiSheet} from './EmojiSheet';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
+import {
+  ButtonSectionItem,
+  LocationInputSectionItem,
+  Section,
+  TextInputSectionItem,
+} from '@atb/components/sections';
 
 export type Props = RootStackScreenProps<'Root_AddEditFavoritePlaceScreen'>;
 
@@ -150,8 +155,8 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
           />
         )}
 
-        <Sections.Section withPadding>
-          <Sections.LocationInputSectionItem
+        <Section withPadding>
+          <LocationInputSectionItem
             label={t(AddEditFavoriteTexts.fields.location.label)}
             location={location}
             onPress={() =>
@@ -165,10 +170,10 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
             }
             testID="locationSearchButton"
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding>
-          <Sections.TextInputSectionItem
+        <Section withPadding>
+          <TextInputSectionItem
             label={t(AddEditFavoriteTexts.fields.name.label)}
             onChangeText={setName}
             value={name}
@@ -178,10 +183,10 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
             placeholder={t(AddEditFavoriteTexts.fields.name.placeholder)}
             testID="nameInput"
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding>
-          <Sections.ButtonSectionItem
+        <Section withPadding>
+          <ButtonSectionItem
             onPress={openEmojiPopup}
             accessibilityLabel={t(AddEditFavoriteTexts.fields.icon.a11yLabel)}
             accessibilityHint={t(AddEditFavoriteTexts.fields.icon.a11yHint)}
@@ -197,7 +202,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
             }
             testID="iconButton"
           />
-        </Sections.Section>
+        </Section>
       </ScrollView>
 
       <FullScreenFooter avoidKeyboard={true}>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -4,7 +4,6 @@ import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {MessageBox} from '@atb/components/message-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {
@@ -43,6 +42,7 @@ import {usePreviousPaymentMethod} from '../saved-payment-utils';
 import {CardPaymentMethod, PaymentMethod, SavedPaymentOption} from '../types';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import analytics from '@react-native-firebase/analytics';
+import {GenericSectionItem, Section} from '@atb/components/sections';
 
 function getPreviousPaymentMethod(
   previousPaymentMethod: SavedPaymentOption | undefined,
@@ -265,8 +265,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
               style={styles.errorMessage}
             />
           )}
-          <Sections.Section>
-            <Sections.GenericSectionItem>
+          <Section>
+            <GenericSectionItem>
               <View accessible={true}>
                 <ThemeText>
                   {getReferenceDataName(preassignedFareProduct, language)}
@@ -310,13 +310,13 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   {travelDateText}
                 </ThemeText>
               </View>
-            </Sections.GenericSectionItem>
-          </Sections.Section>
+            </GenericSectionItem>
+          </Section>
         </View>
 
-        <Sections.Section style={styles.paymentSummaryContainer}>
+        <Section style={styles.paymentSummaryContainer}>
           {travellerSelectionMode !== 'none' && (
-            <Sections.GenericSectionItem>
+            <GenericSectionItem>
               {userProfilesWithCountAndOffer.map((u, i) => (
                 <PricePerUserProfile
                   key={u.id}
@@ -324,9 +324,9 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   style={i != 0 ? styles.smallTopMargin : undefined}
                 />
               ))}
-            </Sections.GenericSectionItem>
+            </GenericSectionItem>
           )}
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <View style={styles.totalPaymentContainer} accessible={true}>
               <View style={styles.totalContainerHeadings}>
                 <ThemeText type="body__primary">
@@ -354,8 +354,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                 />
               )}
             </View>
-          </Sections.GenericSectionItem>
-        </Sections.Section>
+          </GenericSectionItem>
+        </Section>
 
         <MessageBox
           type="info"

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -1,5 +1,4 @@
-import * as Sections from '@atb/components/sections';
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {ThemeText} from '@atb/components/text';
 import {Linking, StyleProp, View, ViewStyle} from 'react-native';
 import {InfoChip} from '@atb/components/info-chip';
@@ -14,6 +13,12 @@ import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurati
 import {formatDecimalNumber} from '@atb/utils/numbers';
 import {StyleSheet} from '@atb/theme';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {
+  ExpandableSectionItem,
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = {
   userProfiles: UserProfileWithCountAndOffer[];
@@ -41,17 +46,17 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
       >
         {t(PurchaseOverviewTexts.flexDiscount.heading)}
       </ThemeText>
-      <Sections.Section>
-        <Sections.ExpandableSectionItem
+      <Section>
+        <ExpandableSectionItem
           text={t(PurchaseOverviewTexts.flexDiscount.expandableLabel)}
           textType="heading__component"
           expanded={expanded}
           onPress={setExpanded}
         />
         {expanded && (
-          <Sections.GenericSectionItem accessibility={{accessible: true}}>
+          <GenericSectionItem accessibility={{accessible: true}}>
             <ThemeText>{description}</ThemeText>
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
         )}
         {expanded &&
           [...userProfiles].map((u) => {
@@ -73,7 +78,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
               ) + ' kr';
 
             return (
-              <Sections.GenericSectionItem
+              <GenericSectionItem
                 accessibility={{
                   accessible: true,
                   accessibilityLabel: `${userProfileName}, ${discountText}, ${priceText}`,
@@ -100,11 +105,11 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                     />
                   </View>
                 </View>
-              </Sections.GenericSectionItem>
+              </GenericSectionItem>
             );
           })}
         {expanded && (
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(PurchaseOverviewTexts.flexDiscount.link)}
             icon={'external-link'}
             onPress={() => Linking.openURL(flex_ticket_url)}
@@ -113,7 +118,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
             }}
           />
         )}
-      </Sections.Section>
+      </Section>
     </View>
   );
 };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -11,11 +11,11 @@ import {
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {PreassignedFareProduct} from '@atb/reference-data/types';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
-import * as Sections from '../../../components/sections';
 import {ThemeText} from '@atb/components/text';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 import {StyleSheet} from '@atb/theme';
+import {RadioGroupSection, Section} from '@atb/components/sections';
 
 type ProductSelectionByProductsProps = {
   selectedProduct: PreassignedFareProduct;
@@ -48,8 +48,8 @@ export function ProductSelectionByProducts({
       <ThemeText type="body__secondary" color="secondary" style={styles.title}>
         {title || t(PurchaseOverviewTexts.productSelection.title)}
       </ThemeText>
-      <Sections.Section>
-        <Sections.RadioGroupSection<PreassignedFareProduct>
+      <Section>
+        <RadioGroupSection<PreassignedFareProduct>
           items={selectableProducts}
           keyExtractor={(u) => u.id}
           itemToText={(fp) => getReferenceDataName(fp, language)}
@@ -79,7 +79,7 @@ export function ProductSelectionByProducts({
             PurchaseOverviewTexts.productSelection.a11yTitle,
           )}
         />
-      </Sections.Section>
+      </Section>
     </View>
   );
 }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -8,10 +8,10 @@ import {
   Language,
   getTextForLanguage,
 } from '@atb/translations';
-import * as Sections from '../../../../components/sections';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {useScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {usePreferences} from '@atb/preferences';
+import {CounterSectionItem, Section} from '@atb/components/sections';
 
 export function MultipleTravellersSelection({
   userProfilesWithCount,
@@ -42,9 +42,9 @@ export function MultipleTravellersSelection({
   );
 
   return (
-    <Sections.Section>
+    <Section>
       {userProfilesWithCount.map((u) => (
-        <Sections.CounterSectionItem
+        <CounterSectionItem
           key={u.userTypeString}
           text={getReferenceDataName(u, language)}
           count={u.count}
@@ -65,7 +65,7 @@ export function MultipleTravellersSelection({
           ].join(' ')}
         />
       ))}
-    </Sections.Section>
+    </Section>
   );
 }
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -6,9 +6,9 @@ import {
   PurchaseOverviewTexts,
   getTextForLanguage,
 } from '@atb/translations';
-import * as Sections from '../../../../components/sections';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {usePreferences} from '@atb/preferences';
+import {RadioGroupSection, Section} from '@atb/components/sections';
 
 export function SingleTravellerSelection({
   userProfilesWithCount,
@@ -38,8 +38,8 @@ export function SingleTravellerSelection({
   }
 
   return (
-    <Sections.Section>
-      <Sections.RadioGroupSection<UserProfileWithCount>
+    <Section>
+      <RadioGroupSection<UserProfileWithCount>
         items={userProfilesWithCount}
         keyExtractor={(u) => u.userTypeString}
         itemToText={(u) => getReferenceDataName(u, language)}
@@ -50,6 +50,6 @@ export function SingleTravellerSelection({
         color="interactive_2"
         accessibilityHint={t(PurchaseOverviewTexts.travellerSelection.a11yHint)}
       />
-    </Sections.Section>
+    </Section>
   );
 }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -1,5 +1,4 @@
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-import * as Sections from '@atb/components/sections';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {
@@ -12,6 +11,7 @@ import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {TariffZoneWithMetadata} from '../../Root_PurchaseTariffZonesSearchByMapScreen';
 import {getReferenceDataName} from '@atb/reference-data/utils';
+import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 
 type ZonesSelectionProps = {
   fareProductTypeConfig: FareProductTypeConfig;
@@ -73,8 +73,8 @@ export function ZonesSelection({
       >
         {t(PurchaseOverviewTexts.zones.title[selectionMode].text)}
       </ThemeText>
-      <Sections.Section {...accessibility}>
-        <Sections.GenericClickableSectionItem
+      <Section {...accessibility}>
+        <GenericClickableSectionItem
           onPress={() =>
             onSelect({
               fromTariffZone,
@@ -110,8 +110,8 @@ export function ZonesSelection({
               </View>
             </>
           )}
-        </Sections.GenericClickableSectionItem>
-      </Sections.Section>
+        </GenericClickableSectionItem>
+      </Section>
     </View>
   );
 }

--- a/src/stacks-hierarchy/Root_ReceiptScreen.tsx
+++ b/src/stacks-hierarchy/Root_ReceiptScreen.tsx
@@ -2,7 +2,6 @@ import {useAccessibilityContext} from '@atb/AccessibilityContext';
 import {Button} from '@atb/components/button';
 import {MessageBox, MessageBoxProps} from '@atb/components/message-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {StyleSheet} from '@atb/theme';
 import {sendReceipt} from '@atb/ticketing';
 import {
@@ -14,6 +13,7 @@ import {validateEmail} from '@atb/utils/validation';
 import React, {useState} from 'react';
 import {View} from 'react-native';
 import {RootStackScreenProps} from '../stacks-hierarchy/navigation-types';
+import {Section, TextInputSectionItem} from '@atb/components/sections';
 
 type Props = RootStackScreenProps<'Root_ReceiptScreen'>;
 
@@ -70,8 +70,8 @@ export function Root_ReceiptScreen({route}: Props) {
             {...translateStateToMessage(state, t, email, reference)}
           />
         </View>
-        <Sections.Section withTopPadding withBottomPadding>
-          <Sections.TextInputSectionItem
+        <Section withTopPadding withBottomPadding>
+          <TextInputSectionItem
             label={t(FareContractTexts.receipt.inputLabel)}
             value={email}
             onChangeText={setEmail}
@@ -81,7 +81,7 @@ export function Root_ReceiptScreen({route}: Props) {
             autoCorrect={false}
             autoFocus={!a11yContext.isScreenReaderEnabled}
           />
-        </Sections.Section>
+        </Section>
         <Button
           text={t(FareContractTexts.receipt.sendButton)}
           onPress={onSend}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -18,9 +18,13 @@ import haversineDistance from 'haversine-distance';
 import React, {useEffect, useRef} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {useFavoriteDepartureData} from '../use-favorite-departure-data';
-import * as Sections from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemedNoFavouriteDepartureImage} from '@atb/theme/ThemedAssets';
+import {
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = {
   onEditFavouriteDeparture: () => void;
@@ -71,8 +75,8 @@ export const DeparturesWidget = ({
       </ThemeText>
 
       {!favoriteDepartures.length && (
-        <Sections.Section>
-          <Sections.GenericSectionItem>
+        <Section>
+          <GenericSectionItem>
             <View style={styles.noFavouritesView}>
               <ThemedNoFavouriteDepartureImage />
               <View style={styles.noFavouritesTextContainer}>
@@ -86,15 +90,15 @@ export const DeparturesWidget = ({
                 </ThemeText>
               </View>
             </View>
-          </Sections.GenericSectionItem>
-          <Sections.LinkSectionItem
+          </GenericSectionItem>
+          <LinkSectionItem
             textType="body__secondary"
             text={t(FavoriteDeparturesTexts.favoriteItemAdd.label)}
             onPress={onAddFavouriteDeparture}
             icon={<ThemeIcon svg={Add} />}
             testID="addFavoriteDeparture"
           />
-        </Sections.Section>
+        </Section>
       )}
 
       {state.isLoading && (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
@@ -7,7 +7,6 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {Button} from '@atb/components/button';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
@@ -21,6 +20,12 @@ import type {
 import {useFilters} from '@atb/travel-search-filters';
 import {ThemeText} from '@atb/components/text';
 import {Checkbox} from '@atb/components/checkbox';
+import {
+  GenericClickableSectionItem,
+  HeaderSectionItem,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 
 export const TravelSearchFiltersBottomSheet = forwardRef<
   any,
@@ -66,11 +71,11 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
         setFocusOnLoad={false}
       />
       <ScrollView style={styles.filtersContainer} ref={focusRef}>
-        <Sections.Section>
-          <Sections.HeaderSectionItem
+        <Section>
+          <HeaderSectionItem
             text={t(TripSearchTexts.filters.bottomSheet.modes.heading)}
           />
-          <Sections.ToggleSectionItem
+          <ToggleSectionItem
             text={t(TripSearchTexts.filters.bottomSheet.modes.all)}
             value={allModesSelected}
             onValueChange={(checked) => {
@@ -89,7 +94,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
               language,
             );
             return text ? (
-              <Sections.ToggleSectionItem
+              <ToggleSectionItem
                 key={option.id}
                 text={text}
                 leftIcon={getTransportModeSvg(
@@ -110,9 +115,9 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
               />
             ) : null;
           })}
-        </Sections.Section>
-        <Sections.Section style={styles.saveFiltersContainer}>
-          <Sections.GenericClickableSectionItem
+        </Section>
+        <Section style={styles.saveFiltersContainer}>
+          <GenericClickableSectionItem
             onPress={() => {
               setSaveFilters(!saveFilters);
             }}
@@ -134,8 +139,8 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
                 {t(TripSearchTexts.filters.bottomSheet.saveFilters.text)}
               </ThemeText>
             </View>
-          </Sections.GenericClickableSectionItem>
-        </Sections.Section>
+          </GenericClickableSectionItem>
+        </Section>
       </ScrollView>
 
       <FullScreenFooter>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
@@ -1,10 +1,13 @@
 import {TravelSearchTransportModes} from '@atb-as/config-specs';
 import {CancelToken, isCancel} from '@atb/api';
 import {tripsSearch} from '@atb/api/trips_v2';
-import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
 import {
+  Modes,
   InputMaybe,
   StreetMode,
+  TransportModes,
+  TransportSubmode,
+  TransportMode,
 } from '@atb/api/types/generated/journey_planner_v3_types';
 import {TripsQueryVariables} from '@atb/api/types/generated/TripsQuery';
 import {TripPattern} from '@atb/api/types/trips';
@@ -214,7 +217,7 @@ async function doSearch(
   cancelToken: CancelTokenSource,
   tripSearchPreferences: TripSearchPreferences | undefined,
   travelSearchFiltersSelection: TravelSearchFiltersSelectionType | undefined,
-  journeySearchModes: Types.Modes,
+  journeySearchModes: Modes,
 ) {
   const from = {
     ...fromLocation,
@@ -316,9 +319,7 @@ function filterDuplicateTripPatterns(
   });
 }
 
-function useJourneySearchModes(
-  defaultValue: InputMaybe<StreetMode>,
-): Types.Modes {
+function useJourneySearchModes(defaultValue: InputMaybe<StreetMode>): Modes {
   const {
     preferences: {
       flexibleTransport,
@@ -371,16 +372,13 @@ function useJourneySearchModes(
 
 function transportModeToEnum(
   modes: TravelSearchTransportModes[],
-): Types.TransportModes[] {
+): TransportModes[] {
   return modes.map((internal) => {
     return {
-      transportMode: enumFromString(
-        Types.TransportMode,
-        internal.transportMode,
-      ),
+      transportMode: enumFromString(TransportMode, internal.transportMode),
       transportSubModes: internal.transportSubModes
-        ?.map((submode) => enumFromString(Types.TransportSubmode, submode))
-        .filter(Boolean) as Types.TransportSubmode[],
+        ?.map((submode) => enumFromString(TransportSubmode, submode))
+        .filter(Boolean) as TransportSubmode[],
     };
   });
 }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -1,5 +1,4 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, Theme} from '@atb/theme';
 import React, {useEffect, useState} from 'react';
@@ -36,6 +35,14 @@ import {useMapDebugOverride} from '@atb/components/map';
 import {useTicketingAssistantDebugOverride} from '../../Root_TicketAssistantStack/use-ticketing-assistant-enabled';
 import {useTipsAndInformationDebugOverride} from '@atb/stacks-hierarchy/Root_TipsAndInformation/use-tips-and-information-enabled';
 import {useCityBikesInMapDebugOverride} from '@atb/mobility/use-city-bikes-enabled';
+import {
+  ExpandableSectionItem,
+  GenericSectionItem,
+  HeaderSectionItem,
+  LinkSectionItem,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -136,67 +143,67 @@ export const Profile_DebugInfoScreen = () => {
       />
 
       <ScrollView testID="debugInfoScrollView">
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ToggleSectionItem
+        <Section withPadding withTopPadding>
+          <ToggleSectionItem
             text="Toggle test-ID"
             value={showTestIds}
             onValueChange={(showTestIds) => {
               setPreference({showTestIds});
             }}
           />
-          <Sections.ToggleSectionItem
+          <ToggleSectionItem
             text="Display seconds in trip planner"
             value={debugShowSeconds}
             onValueChange={(debugShowSeconds) => {
               setPreference({debugShowSeconds});
             }}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Restart onboarding"
             onPress={() => {
               appDispatch({type: 'RESTART_ONBOARDING'});
             }}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Set mobile token onboarded to false"
             onPress={restartMobileTokenOnboarding}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Reset dismissed Global messages"
             onPress={resetDismissedGlobalMessages}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Copy link to customer in Firestore (staging)"
             icon="arrow-upleft"
             onPress={() => copyFirestoreLink()}
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Force refresh id token"
             onPress={() => auth().currentUser?.getIdToken(true)}
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Force refresh remote config"
             onPress={remoteConfig.refresh}
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Reset feedback displayStats"
             onPress={() => storage.set('@ATB_feedback_display_stats', '')}
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Reset frontpage favourite departures"
             onPress={() => storage.set('@ATB_user_frontpage_departures', '[]')}
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Reset user map filters"
             onPress={() => storage.set('@ATB_user_map_filters', '')}
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Reset has read filter onboarding"
             onPress={() =>
               storage.set(
@@ -205,7 +212,7 @@ export const Profile_DebugInfoScreen = () => {
               )
             }
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Reset has read scooter onboarding"
             onPress={() =>
               storage.set(
@@ -214,123 +221,123 @@ export const Profile_DebugInfoScreen = () => {
               )
             }
           />
-        </Sections.Section>
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem
+        </Section>
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem
             text="Flexible transport"
             subtitle={
               'If undefined, the value from Remote Config will be used. Works when the app is either QA or Debug, ONLY!.\n\nNOTE: When enabled, this value has more preference than remote config.'
             }
           />
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MapEntry
               title="Flexible transport enabled"
               value={flexibleTransport}
             />
-          </Sections.GenericSectionItem>
-          <Sections.ToggleSectionItem
+          </GenericSectionItem>
+          <ToggleSectionItem
             text="Flexible transport enabled"
             value={flexibleTransport}
             onValueChange={(flexibleTransport) => {
               setPreference({flexibleTransport});
             }}
           />
-        </Sections.Section>
+        </Section>
         {flexibleTransport && (
-          <Sections.Section withPadding withTopPadding>
-            <Sections.HeaderSectionItem
+          <Section withPadding withTopPadding>
+            <HeaderSectionItem
               text="Flexible transport modes"
               subtitle={
                 'If `Flexible transport is enabled`, these values will take effect when the app is either QA or Debug ONLY!.\n\nThe default values are `Foot`.'
               }
             />
-            <Sections.ToggleSectionItem
+            <ToggleSectionItem
               text="Use Flexible on AccessMode"
               value={useFlexibleTransportOnAccessMode}
               onValueChange={(useFlexibleTransportOnAccessMode) => {
                 setPreference({useFlexibleTransportOnAccessMode});
               }}
             />
-            <Sections.ToggleSectionItem
+            <ToggleSectionItem
               text="Use Flexible on DirectMode"
               value={useFlexibleTransportOnDirectMode}
               onValueChange={(useFlexibleTransportOnDirectMode) => {
                 setPreference({useFlexibleTransportOnDirectMode});
               }}
             />
-            <Sections.ToggleSectionItem
+            <ToggleSectionItem
               text="Use Flexible on EgreessMode"
               value={useFlexibleTransportOnEgressMode}
               onValueChange={(useFlexibleTransportOnEgressMode) => {
                 setPreference({useFlexibleTransportOnEgressMode});
               }}
             />
-          </Sections.Section>
+          </Section>
         )}
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem
             text="Remote config override"
             subtitle="If undefined the value
         from Remote Config will be used. Needs reload of app after change."
           />
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable travel search filter."
               override={travelSearchDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable new travel search."
               override={newTravelSearchDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable from travel search to ticket purchase."
               override={fromTravelSearchToTicketDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable vehicles in map."
               override={vehiclesInMapDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable city bike stations in map."
               override={cityBikesInMapDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable realtime positions in map."
               override={realtimeMapDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable map"
               override={mapDebugOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable ticketing assistant"
               override={ticketingAssistantOverride}
             />
-          </Sections.GenericSectionItem>
-          <Sections.GenericSectionItem>
+          </GenericSectionItem>
+          <GenericSectionItem>
             <DebugOverride
               description="Enable tips and information for tickets"
               override={tipsAndInformationOverride}
             />
-          </Sections.GenericSectionItem>
-        </Sections.Section>
+          </GenericSectionItem>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text={'Trip search parameters'}
             showIconText={true}
             expandContent={
@@ -398,10 +405,10 @@ export const Profile_DebugInfoScreen = () => {
               </View>
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text="Firebase Auth user info"
             showIconText={true}
             expandContent={
@@ -412,10 +419,10 @@ export const Profile_DebugInfoScreen = () => {
               </View>
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text="Firebase Auth user claims"
             showIconText={true}
             expandContent={
@@ -430,10 +437,10 @@ export const Profile_DebugInfoScreen = () => {
               </View>
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text="Remote config"
             showIconText={true}
             expandContent={
@@ -452,10 +459,10 @@ export const Profile_DebugInfoScreen = () => {
               )
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text="Storage"
             showIconText={true}
             expandContent={
@@ -473,10 +480,10 @@ export const Profile_DebugInfoScreen = () => {
               </>
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text="Preferences"
             showIconText={true}
             expandContent={
@@ -500,10 +507,10 @@ export const Profile_DebugInfoScreen = () => {
               )
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ExpandableSectionItem
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
             text="Mobile token state"
             showIconText={true}
             expandContent={
@@ -554,7 +561,7 @@ export const Profile_DebugInfoScreen = () => {
                       onPress={renewToken}
                     />
                   )}
-                  <Sections.ExpandableSectionItem
+                  <ExpandableSectionItem
                     text="Remote tokens"
                     showIconText={true}
                     expandContent={remoteTokens?.map((token) => (
@@ -577,7 +584,7 @@ export const Profile_DebugInfoScreen = () => {
               )
             }
           />
-        </Sections.Section>
+        </Section>
       </ScrollView>
     </View>
   );
@@ -689,7 +696,7 @@ function LabeledSlider({
   const [pref, setPref] = useState(initialValue || defaultValue);
 
   return (
-    <Sections.GenericSectionItem>
+    <GenericSectionItem>
       <ThemeText
         onPress={
           defaultValue
@@ -711,7 +718,7 @@ function LabeledSlider({
         onValueChange={setPref}
         onSlidingComplete={onSetValue}
       />
-    </Sections.GenericSectionItem>
+    </GenericSectionItem>
   );
 }
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -3,7 +3,6 @@ import {Delete} from '@atb/assets/svg/mono-icons/actions';
 import {useAuthState} from '@atb/auth';
 import {MessageBox} from '@atb/components/message-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet, Theme} from '@atb/theme';
 import {
@@ -16,6 +15,7 @@ import React, {useEffect, useState} from 'react';
 import {Alert, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {ProfileScreenProps} from './navigation-types';
+import {LinkSectionItem, Section} from '@atb/components/sections';
 
 type DeleteProfileScreenProps =
   ProfileScreenProps<'Profile_DeleteProfileScreen'>;
@@ -91,8 +91,8 @@ export const Profile_DeleteProfileScreen = ({
           />
         )}
 
-        <Sections.Section withPadding>
-          <Sections.LinkSectionItem
+        <Section withPadding>
+          <LinkSectionItem
             subtitle={`${customerNumber}`}
             text={t(DeleteProfileTexts.customerNumber)}
             accessibility={{
@@ -104,7 +104,7 @@ export const Profile_DeleteProfileScreen = ({
             disabled={activeFareContracts}
             icon={<ThemeIcon svg={Delete} colorType="error" />}
           />
-        </Sections.Section>
+        </Section>
       </ScrollView>
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -6,7 +6,6 @@ import {Button, ButtonGroup} from '@atb/components/button';
 import {MessageBox} from '@atb/components/message-box';
 import {RadioSegments} from '@atb/components/radio';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {TransportationIconBox} from '@atb/components/icon-box';
@@ -25,6 +24,19 @@ import {dictionary, useTranslation} from '@atb/translations';
 import {Bus} from '@atb/assets/svg/mono-icons/transportation';
 import {useFontScale} from '@atb/utils/use-font-scale';
 import {InfoChip} from '@atb/components/info-chip';
+import {
+  ActionSectionItem,
+  ButtonSectionItem,
+  ExpandableSectionItem,
+  GenericSectionItem,
+  HeaderSectionItem,
+  LinkSectionItem,
+  LocationInputSectionItem,
+  MessageSectionItem,
+  Section,
+  TextInputSectionItem,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 
 export const Profile_DesignSystemScreen = () => {
   const style = useProfileHomeStyle();
@@ -132,15 +144,15 @@ export const Profile_DesignSystemScreen = () => {
       />
 
       <ScrollView>
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem
             text={'Current font scale: ' + fontScale.toFixed(3)}
           />
-        </Sections.Section>
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem text="Icons" />
+        </Section>
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem text="Icons" />
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <View style={style.icons}>
               <ThemeIcon svg={Check} />
               <ThemeIcon svg={Check} colorType="info" />
@@ -214,41 +226,41 @@ export const Profile_DesignSystemScreen = () => {
                 />
               ))}
             </View>
-          </Sections.GenericSectionItem>
-        </Sections.Section>
+          </GenericSectionItem>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem text="Messages" />
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem text="Messages" />
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox type="info" message="This is a message" />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               type="info"
               message="This is a message with title"
               title="Title"
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               message="This is a warning"
               title="Title"
               type="warning"
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               message="This is a success message"
               title="Title"
               type="valid"
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               message="This is an error with retry link"
               title="Title"
@@ -258,27 +270,27 @@ export const Profile_DesignSystemScreen = () => {
                 text: t(dictionary.retry),
               }}
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               type="info"
               isMarkdown={true}
               title="Markdown"
               message={`This is a message with markdown,\nSupporting **bold** and *italics*\nand special characters like ', " + æøå`}
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               type="info"
               title="With dismiss"
               onDismiss={() => Alert.alert('Closed')}
               message={`This is a message with dismiss button`}
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               type="warning"
               title="With dismiss and action"
@@ -289,9 +301,9 @@ export const Profile_DesignSystemScreen = () => {
               }}
               message={`This is a message with dismiss and action`}
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               type="error"
               title="With dismiss and link"
@@ -302,9 +314,9 @@ export const Profile_DesignSystemScreen = () => {
               }}
               message={`This is a message with dismiss and link`}
             />
-          </Sections.GenericSectionItem>
+          </GenericSectionItem>
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             <MessageBox
               type="valid"
               isMarkdown={true}
@@ -312,11 +324,11 @@ export const Profile_DesignSystemScreen = () => {
               noStatusIcon={true}
               message={`This is a message without status icon`}
             />
-          </Sections.GenericSectionItem>
-        </Sections.Section>
+          </GenericSectionItem>
+        </Section>
 
-        <Sections.Section style={style.section}>
-          <Sections.ExpandableSectionItem
+        <Section style={style.section}>
+          <ExpandableSectionItem
             text={'InfoChip'}
             showIconText={false}
             textType={'heading__title'}
@@ -363,10 +375,10 @@ export const Profile_DesignSystemScreen = () => {
               </View>
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section style={style.section}>
-          <Sections.ExpandableSectionItem
+        <Section style={style.section}>
+          <ExpandableSectionItem
             text={'Buttons'}
             showIconText={false}
             textType={'heading__title'}
@@ -1133,10 +1145,10 @@ export const Profile_DesignSystemScreen = () => {
               </View>
             }
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ActionSectionItem
+        <Section withPadding withTopPadding>
+          <ActionSectionItem
             text="Some very long text over here which goes over multiple lines"
             subtext="With a subtext"
             mode="check"
@@ -1144,12 +1156,12 @@ export const Profile_DesignSystemScreen = () => {
             leftIcon={Bus}
             checked
           />
-          <Sections.ToggleSectionItem
+          <ToggleSectionItem
             text="Some short text"
             leftIcon={Bus}
             onValueChange={() => {}}
           />
-          <Sections.ActionSectionItem
+          <ActionSectionItem
             text="Some short text"
             mode="check"
             checked
@@ -1157,58 +1169,58 @@ export const Profile_DesignSystemScreen = () => {
             leftIcon={Bus}
             onPress={() => {}}
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.LocationInputSectionItem
+        <Section withPadding withTopPadding>
+          <LocationInputSectionItem
             label="Label"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onPress={() => {}}
           />
-          <Sections.LocationInputSectionItem
+          <LocationInputSectionItem
             label="Label"
             placeholder="Short"
             onPress={() => {}}
             type="compact"
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.ButtonSectionItem
+        <Section withPadding withTopPadding>
+          <ButtonSectionItem
             label="Label"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onPress={() => {}}
             icon="arrow-left"
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Some longer text"
             onPress={() => {}}
             disabled
             icon={<ThemeIcon svg={Edit} />}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Some longer text"
             onPress={() => {}}
             icon={<ThemeIcon svg={Edit} />}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Dangerous Link Item"
             subtitle="Subtitle text"
             onPress={() => {}}
             icon={<ThemeIcon svg={Delete} colorType="error" />}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text="Disabled Dangerous Link Item text"
             subtitle="Disabled Subtitle text"
             disabled={true}
             onPress={() => {}}
             icon={<ThemeIcon svg={Delete} colorType="error" />}
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.TextInputSectionItem
+        <Section withPadding withTopPadding>
+          <TextInputSectionItem
             label="Input"
             placeholder="My very long placeholder over here. Yes over multiple lines"
             onChangeText={() => {}}
@@ -1218,7 +1230,7 @@ export const Profile_DesignSystemScreen = () => {
             inlineLabel={false}
           />
 
-          <Sections.TextInputSectionItem
+          <TextInputSectionItem
             label="Input"
             placeholder="Short placeholder"
             onChangeText={() => {}}
@@ -1227,12 +1239,12 @@ export const Profile_DesignSystemScreen = () => {
             showClear={true}
             inlineLabel={false}
           />
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem text="Texts" />
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem text="Texts" />
 
-          <Sections.GenericSectionItem>
+          <GenericSectionItem>
             {textNames.map(function (t: TextNames) {
               return (
                 <ThemeText type={t} key={t}>
@@ -1240,24 +1252,24 @@ export const Profile_DesignSystemScreen = () => {
                 </ThemeText>
               );
             })}
-          </Sections.GenericSectionItem>
-        </Sections.Section>
+          </GenericSectionItem>
+        </Section>
 
-        <Sections.Section withPadding withTopPadding>
-          <Sections.HeaderSectionItem text="Message section items" />
+        <Section withPadding withTopPadding>
+          <HeaderSectionItem text="Message section items" />
 
-          <Sections.MessageSectionItem
+          <MessageSectionItem
             messageType="info"
             title="Information message!"
             message="An information message with title"
           />
 
-          <Sections.MessageSectionItem
+          <MessageSectionItem
             messageType="valid"
             message="A success message without title"
           />
 
-          <Sections.MessageSectionItem
+          <MessageSectionItem
             messageType="warning"
             title="Warning message!"
             message="A warning message with title link"
@@ -1267,7 +1279,7 @@ export const Profile_DesignSystemScreen = () => {
             }}
           />
 
-          <Sections.MessageSectionItem
+          <MessageSectionItem
             messageType="error"
             message="An error message without title and with action"
             onPressConfig={{
@@ -1275,7 +1287,7 @@ export const Profile_DesignSystemScreen = () => {
               text: t(dictionary.retry),
             }}
           />
-        </Sections.Section>
+        </Section>
 
         <View style={style.section}>
           <ButtonGroup>{buttons}</ButtonGroup>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
@@ -2,7 +2,6 @@ import {Add} from '@atb/assets/svg/mono-icons/actions';
 import SvgReorder from '@atb/assets/svg/mono-icons/actions/Reorder';
 import {MessageBox} from '@atb/components/message-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import * as Sections from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StoredLocationFavorite, useFavorites} from '@atb/favorites';
 import {StyleSheet, Theme} from '@atb/theme';
@@ -11,6 +10,11 @@ import React from 'react';
 import {View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {ProfileScreenProps} from './navigation-types';
+import {
+  FavoriteSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 type Props = ProfileScreenProps<'Profile_FavoriteListScreen'>;
 
@@ -44,9 +48,9 @@ export const Profile_FavoriteListScreen = ({navigation}: Props) => {
           />
         )}
 
-        <Sections.Section withTopPadding withPadding>
+        <Section withTopPadding withPadding>
           {items.map((favorite, i) => (
-            <Sections.FavoriteSectionItem
+            <FavoriteSectionItem
               key={favorite.id}
               favorite={favorite}
               accessibility={{
@@ -56,24 +60,24 @@ export const Profile_FavoriteListScreen = ({navigation}: Props) => {
               testID={'favorite' + i}
             />
           ))}
-        </Sections.Section>
+        </Section>
 
-        <Sections.Section withPadding>
+        <Section withPadding>
           {!!items.length && (
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text={t(FavoriteListTexts.buttons.changeOrder)}
               onPress={onSortClick}
               icon={<ThemeIcon svg={SvgReorder} />}
               testID="changeOrderButton"
             />
           )}
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(FavoriteListTexts.buttons.addFavorite)}
             onPress={onAddButtonClick}
             icon={<ThemeIcon svg={Add} />}
             testID="addFavoriteButton"
           />
-        </Sections.Section>
+        </Section>
       </ScrollView>
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -7,7 +7,6 @@ import {ActivityIndicatorOverlay} from '@atb/components/activity-indicator-overl
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {LoginInAppStackParams} from '@atb/login/types';
@@ -45,6 +44,13 @@ import {ProfileScreenProps} from './navigation-types';
 import {destructiveAlert} from './utils';
 import {useIsLoading} from '@atb/utils/use-is-loading';
 import {useDeparturesV2Enabled} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack';
+import {
+  GenericSectionItem,
+  HeaderSectionItem,
+  LinkSectionItem,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -139,22 +145,22 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
         testID="profileHomeScrollView"
       >
         {enable_login ? (
-          <Sections.Section withPadding>
-            <Sections.HeaderSectionItem
+          <Section withPadding>
+            <HeaderSectionItem
               text={t(ProfileTexts.sections.account.heading)}
             />
             {authenticationType === 'phone' && (
-              <Sections.GenericSectionItem>
+              <GenericSectionItem>
                 <ThemeText style={style.customerNumberHeading}>
                   {t(ProfileTexts.sections.account.infoItems.phoneNumber)}
                 </ThemeText>
                 <ThemeText type="body__secondary" color="secondary">
                   {phoneNumber?.formatInternational()}
                 </ThemeText>
-              </Sections.GenericSectionItem>
+              </GenericSectionItem>
             )}
             {customerNumber && (
-              <Sections.GenericSectionItem>
+              <GenericSectionItem>
                 <ThemeText style={style.customerNumberHeading}>
                   {t(ProfileTexts.sections.account.infoItems.customerNumber)}
                 </ThemeText>
@@ -167,11 +173,11 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 >
                   {customerNumber}
                 </ThemeText>
-              </Sections.GenericSectionItem>
+              </GenericSectionItem>
             )}
 
             {authenticationType == 'phone' && (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.account.linkSectionItems.paymentOptions
                     .label,
@@ -179,10 +185,10 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 onPress={() =>
                   navigation.navigate('Profile_PaymentOptionsScreen')
                 }
-              ></Sections.LinkSectionItem>
+              ></LinkSectionItem>
             )}
 
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text={t(
                 ProfileTexts.sections.account.linkSectionItems.ticketHistory
                   .label,
@@ -191,7 +197,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               testID="ticketHistoryButton"
             />
             {authenticationType !== 'phone' && (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.account.linkSectionItems.login.label,
                 )}
@@ -221,7 +227,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               />
             )}
             {authenticationType === 'phone' && (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(DeleteProfileTexts.header.title)}
                 onPress={() =>
                   navigation.navigate('Profile_DeleteProfileScreen')
@@ -229,7 +235,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               />
             )}
             {authenticationType === 'phone' && (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.account.linkSectionItems.logout.label,
                 )}
@@ -274,14 +280,12 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 testID="logoutButton"
               />
             )}
-          </Sections.Section>
+          </Section>
         ) : null}
-        <Sections.Section withPadding>
-          <Sections.HeaderSectionItem
-            text={t(ProfileTexts.sections.settings.heading)}
-          />
+        <Section withPadding>
+          <HeaderSectionItem text={t(ProfileTexts.sections.settings.heading)} />
           {enable_ticketing ? (
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text={t(
                 ProfileTexts.sections.settings.linkSectionItems.userProfile
                   .label,
@@ -294,7 +298,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
           ) : null}
 
           {authenticationType === 'phone' && hasEnabledMobileToken && (
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text={t(
                 ProfileTexts.sections.settings.linkSectionItems.travelToken
                   .label,
@@ -307,14 +311,14 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               testID="travelTokenButton"
             />
           )}
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.appearance.label,
             )}
             onPress={() => navigation.navigate('Profile_AppearanceScreen')}
             testID="appearanceButton"
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.startScreen.label,
             )}
@@ -324,7 +328,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             testID="startScreenButton"
           />
           {enable_i18n && (
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text={t(
                 ProfileTexts.sections.settings.linkSectionItems.language.label,
               )}
@@ -332,9 +336,9 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               testID="languageButton"
             />
           )}
-        </Sections.Section>
-        <Sections.Section withPadding>
-          <Sections.GenericSectionItem>
+        </Section>
+        <Section withPadding>
+          <GenericSectionItem>
             <View style={style.betaSectionHeader}>
               <ThemeText type="heading__component">
                 {t(ProfileTexts.sections.newFeatures.heading)}
@@ -348,27 +352,27 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 </ThemeText>
               </View>
             </View>
-          </Sections.GenericSectionItem>
-          <Sections.ToggleSectionItem
+          </GenericSectionItem>
+          <ToggleSectionItem
             text={t(ProfileTexts.sections.newFeatures.departures)}
             value={isDeparturesV2Enabled}
             onValueChange={setDeparturesV2Enabled}
             testID="newDeparturesToggle"
           />
 
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.enrollment.label,
             )}
             onPress={() => navigation.navigate('Profile_EnrollmentScreen')}
             testID="invitationCodeButton"
           />
-        </Sections.Section>
-        <Sections.Section withPadding>
-          <Sections.HeaderSectionItem
+        </Section>
+        <Section withPadding>
+          <HeaderSectionItem
             text={t(ProfileTexts.sections.favorites.heading)}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.favorites.linkSectionItems.places.label,
             )}
@@ -381,7 +385,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             testID="favoriteLocationsButton"
             onPress={() => navigation.navigate('Profile_FavoriteListScreen')}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.favorites.linkSectionItems.departures.label,
             )}
@@ -396,12 +400,10 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               navigation.navigate('Profile_FavoriteDeparturesScreen')
             }
           />
-        </Sections.Section>
-        <Sections.Section withPadding>
-          <Sections.HeaderSectionItem
-            text={t(ProfileTexts.sections.privacy.heading)}
-          />
-          <Sections.LinkSectionItem
+        </Section>
+        <Section withPadding>
+          <HeaderSectionItem text={t(ProfileTexts.sections.privacy.heading)} />
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.privacy.linkSectionItems.privacy.label,
             )}
@@ -414,7 +416,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             testID="privacyButton"
             onPress={() => Linking.openURL(privacy_policy_url)}
           />
-          <Sections.LinkSectionItem
+          <LinkSectionItem
             text={t(
               ProfileTexts.sections.privacy.linkSectionItems.clearHistory.label,
             )}
@@ -446,14 +448,14 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               })
             }
           />
-        </Sections.Section>
+        </Section>
         {enable_ticketing && (
-          <Sections.Section withPadding>
-            <Sections.HeaderSectionItem
+          <Section withPadding>
+            <HeaderSectionItem
               text={t(ProfileTexts.sections.information.heading)}
             />
             {ticketingInfoUrl ? (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.ticketing
@@ -463,7 +465,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 onPress={() => Linking.openURL(ticketingInfoUrl)}
               />
             ) : (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.ticketing
                     .label,
@@ -479,7 +481,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               />
             )}
             {termsInfoUrl ? (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.terms
@@ -489,7 +491,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 onPress={() => Linking.openURL(termsInfoUrl)}
               />
             ) : (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.terms
                     .label,
@@ -506,7 +508,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             )}
 
             {inspectionInfoUrl ? (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.inspection
@@ -516,7 +518,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 onPress={() => Linking.openURL(inspectionInfoUrl)}
               />
             ) : (
-              <Sections.LinkSectionItem
+              <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.inspection
                     .label,
@@ -531,14 +533,14 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 }
               />
             )}
-          </Sections.Section>
+          </Section>
         )}
         {(!!JSON.parse(IS_QA_ENV || 'false') ||
           __DEV__ ||
           customerProfile?.debug) && (
-          <Sections.Section withPadding>
-            <Sections.HeaderSectionItem text="Developer menu" />
-            <Sections.LinkSectionItem
+          <Section withPadding>
+            <HeaderSectionItem text="Developer menu" />
+            <LinkSectionItem
               text={t(
                 ProfileTexts.sections.favorites.linkSectionItems
                   .frontpageFavourites.label,
@@ -552,17 +554,17 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               testID="favoriteDeparturesButton"
               onPress={selectFavourites}
             />
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text="Design system"
               testID="designSystemButton"
               onPress={() => navigation.navigate('Profile_DesignSystemScreen')}
             />
-            <Sections.LinkSectionItem
+            <LinkSectionItem
               text="Debug"
               testID="debugButton"
               onPress={() => navigation.navigate('Profile_DebugInfoScreen')}
             />
-          </Sections.Section>
+          </Section>
         )}
         <View style={style.debugInfoContainer}>
           <ThemeText>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/ChangeTokenAction.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/ChangeTokenAction.tsx
@@ -8,12 +8,16 @@ import React from 'react';
 import Warning from '@atb/assets/svg/color/icons/status/Warning';
 import Info from '@atb/assets/svg/color/icons/status/Info';
 import Error from '@atb/assets/svg/color/icons/status/Error';
-import * as Sections from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Swap} from '@atb/assets/svg/mono-icons/actions';
 import {ActivityIndicator, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, Theme} from '@atb/theme';
+import {
+  GenericSectionItem,
+  LinkSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 const ChangeTokenAction = ({
   onChange,
@@ -71,8 +75,8 @@ const ChangeTokenAction = ({
   };
 
   return (
-    <Sections.Section style={styles.changeTokenButton}>
-      <Sections.LinkSectionItem
+    <Section style={styles.changeTokenButton}>
+      <LinkSectionItem
         type="spacious"
         text={t(TravelTokenTexts.travelToken.changeTokenButton)}
         disabled={isError || isLoading || toggleLimit === 0}
@@ -82,11 +86,11 @@ const ChangeTokenAction = ({
       />
 
       {shouldShowLoader ? (
-        <Sections.GenericSectionItem>
+        <GenericSectionItem>
           <ActivityIndicator style={styles.loader} />
-        </Sections.GenericSectionItem>
+        </GenericSectionItem>
       ) : toggleLimit !== undefined ? (
-        <Sections.GenericSectionItem>
+        <GenericSectionItem>
           <View style={styles.tokenInfoView}>
             <ThemeIcon svg={getToggleInfoIcon(toggleLimit)} />
             <ThemeText
@@ -100,9 +104,9 @@ const ChangeTokenAction = ({
               {getToggleInfo(toggleLimit, countRenewalDate)}
             </ThemeText>
           </View>
-        </Sections.GenericSectionItem>
+        </GenericSectionItem>
       ) : null}
-    </Sections.Section>
+    </Section>
   );
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/FaqSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/FaqSection.tsx
@@ -1,20 +1,22 @@
 import {TravelTokenTexts, useTranslation} from '@atb/translations';
-import * as Sections from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {StyleSheet, Theme} from '@atb/theme';
+import {
+  ExpandableSectionItem,
+  HeaderSectionItem,
+  Section,
+} from '@atb/components/sections';
 
 const FaqSection = ({toggleMaxLimit}: {toggleMaxLimit?: number}) => {
   const {t} = useTranslation();
   const styles = useStyles();
 
   return (
-    <Sections.Section style={styles.faqSection}>
-      <Sections.HeaderSectionItem
-        text={t(TravelTokenTexts.travelToken.faq.title)}
-      />
+    <Section style={styles.faqSection}>
+      <HeaderSectionItem text={t(TravelTokenTexts.travelToken.faq.title)} />
       {toggleMaxLimit ? (
-        <Sections.ExpandableSectionItem
+        <ExpandableSectionItem
           text={t(TravelTokenTexts.travelToken.tokenToggleFaq.question)}
           showIconText={false}
           expandContent={
@@ -30,14 +32,14 @@ const FaqSection = ({toggleMaxLimit}: {toggleMaxLimit?: number}) => {
       ) : null}
       {/*eslint-disable-next-line rulesdir/translations-warning*/}
       {TravelTokenTexts.travelToken.faqs.map(({question, answer}, index) => (
-        <Sections.ExpandableSectionItem
+        <ExpandableSectionItem
           key={index}
           text={t(question)}
           showIconText={false}
           expandContent={<ThemeText isMarkdown={true}>{t(answer)}</ThemeText>}
         />
       ))}
-    </Sections.Section>
+    </Section>
   );
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration.tsx
@@ -1,7 +1,9 @@
 import {useTheme} from '@atb/theme';
 import React from 'react';
+/* eslint-disable no-restricted-syntax, no-param-reassign */
 import * as Light from '@atb/assets/svg/color/illustrations/ticket-type/light';
 import * as Dark from '@atb/assets/svg/color/illustrations/ticket-type/dark';
+/* eslint-enable no-restricted-syntax, no-param-reassign */
 import {SvgProps} from 'react-native-svg';
 import {FareProductTypeConfig} from '@atb/configuration';
 

--- a/src/stacks-hierarchy/Root_TipsAndInformation/Root_TipsAndInformation.tsx
+++ b/src/stacks-hierarchy/Root_TipsAndInformation/Root_TipsAndInformation.tsx
@@ -5,7 +5,7 @@ import {TipsAndInformationTexts, useTranslation} from '@atb/translations';
 import {StyleSheet, Theme} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {themeColor} from '@atb/stacks-hierarchy/Root_OnboardingStack/Onboarding_WelcomeScreen';
-import * as Sections from '@atb/components/sections';
+import {ExpandableSectionItem, Section} from '@atb/components/sections';
 import {Button} from '@atb/components/button';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 
@@ -29,10 +29,10 @@ export const Root_TipsAndInformation = ({navigation}: Props) => {
       </ThemeText>
 
       <View style={styles.innerContainer}>
-        <Sections.Section style={styles.tipsContainer}>
+        <Section style={styles.tipsContainer}>
           {/* eslint-disable-next-line rulesdir/translations-warning */}
           {TipsAndInformationTexts.tips.map(({title, tip}, index) => (
-            <Sections.ExpandableSectionItem
+            <ExpandableSectionItem
               key={index}
               textType="body__primary--bold"
               text={t(title)}
@@ -48,7 +48,7 @@ export const Root_TipsAndInformation = ({navigation}: Props) => {
               }
             />
           ))}
-          <Sections.ExpandableSectionItem
+          <ExpandableSectionItem
             textType="body__primary--bold"
             text={t(TipsAndInformationTexts.ticketAssistantTip.title)}
             showIconText={false}
@@ -71,7 +71,7 @@ export const Root_TipsAndInformation = ({navigation}: Props) => {
               </View>
             }
           />
-        </Sections.Section>
+        </Section>
       </View>
     </View>
   );


### PR DESCRIPTION
I suggest we stop using wildcard import as they are considered an anti-pattern. The code becomes clearer when you explicitly import from a module, ref. https://app.deepsource.com/directory/analyzers/javascript/issues/JS-C1003 . 

Now introducing a new eslint rule to check for this and removing all wildcard imports in our project 👩🏼‍🚀 

