### PR TITLE
fix: Norwegian text when English language selected in travel search details

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,12 +72,12 @@ export const App = () => {
                     <FavoritesContextProvider>
                       <FiltersContextProvider>
                         <SearchHistoryContextProvider>
-                          <GeolocationContextProvider>
-                            <RemoteConfigContextProvider>
-                              <FirestoreConfigurationContextProvider>
-                                <TicketingContextProvider>
-                                  <MobileTokenContextProvider>
-                                    <AppLanguageProvider>
+                          <RemoteConfigContextProvider>
+                            <FirestoreConfigurationContextProvider>
+                              <TicketingContextProvider>
+                                <MobileTokenContextProvider>
+                                  <AppLanguageProvider>
+                                    <GeolocationContextProvider>
                                       <GlobalMessagesContextProvider>
                                         <BottomSheetProvider>
                                           <FeedbackQuestionsProvider>
@@ -85,12 +85,12 @@ export const App = () => {
                                           </FeedbackQuestionsProvider>
                                         </BottomSheetProvider>
                                       </GlobalMessagesContextProvider>
-                                    </AppLanguageProvider>
-                                  </MobileTokenContextProvider>
-                                </TicketingContextProvider>
-                              </FirestoreConfigurationContextProvider>
-                            </RemoteConfigContextProvider>
-                          </GeolocationContextProvider>
+                                    </GeolocationContextProvider>
+                                  </AppLanguageProvider>
+                                </MobileTokenContextProvider>
+                              </TicketingContextProvider>
+                            </FirestoreConfigurationContextProvider>
+                          </RemoteConfigContextProvider>
                         </SearchHistoryContextProvider>
                       </FiltersContextProvider>
                     </FavoritesContextProvider>

--- a/src/translations/components/Section.ts
+++ b/src/translations/components/Section.ts
@@ -2,8 +2,8 @@ import {translation as _} from '../commons';
 
 const SectionTexts = {
   LocationInputSectionItem: {
-    myPosition: _('Min posisjon', 'My current position'),
-    updatingLocation: _('Oppdaterer posisjon', 'Updating current location'),
+    myPosition: _('Min posisjon', 'My position'),
+    updatingLocation: _('Oppdaterer posisjon', 'Updating location'),
     placeholder: _('Sted eller adresse', 'Place or address'),
     a11yValue: (currentLocation: string) =>
       _(`${currentLocation} er valgt.`, `${currentLocation} is selected.`),

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -5,7 +5,7 @@ import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations
 const softhyphen = Platform.OS === 'ios' ? '\u00AD' : '\u200B';
 
 const dictionary = {
-  myPosition: _('Min posisjon', 'My current position'),
+  myPosition: _('Min posisjon', 'My position'),
   fromPlace: _('Avreisested', 'Place of departure'),
   toPlace: _('Destinasjon', 'Destination'),
   navigation: {

--- a/src/translations/screens/Nearby.ts
+++ b/src/translations/screens/Nearby.ts
@@ -51,9 +51,9 @@ const NearbyTexts = {
       ),
     },
     locationButton: {
-      a11yLabel: _('Bruk min posisjon', 'Use my current location'),
+      a11yLabel: _('Bruk min posisjon', 'Use my location'),
     },
-    updatingLocation: _('Oppdaterer posisjon', 'Updating current location'),
+    updatingLocation: _('Oppdaterer posisjon', 'Updating location'),
   },
   dateInput: {
     departureNow: (time: string) =>
@@ -84,7 +84,7 @@ const NearbyTexts = {
   stateAnnouncements: {
     updatingLocation: _(
       'Oppdaterer posisjon for å finne avganger i nærheten.',
-      'Updating your current location to find nearby departures',
+      'Updating your location to find nearby departures',
     ),
     loadingFromCurrentLocation: _(
       'Laster avganger i nærheten av gjeldende posisjon',

--- a/src/translations/screens/TripSearch.ts
+++ b/src/translations/screens/TripSearch.ts
@@ -57,7 +57,7 @@ const TripSearchTexts = {
     locationButton: {
       a11yLabel: {
         update: _('Oppdater posisjon', 'Update position'),
-        use: _('Bruk min posisjon', 'Use my current location'),
+        use: _('Bruk min posisjon', 'Use my location'),
       },
     },
     swapButton: {


### PR DESCRIPTION
Moved the geoLocationContext inside the appLanguangeProvider

![Simulator Screenshot - iPhone 14 - 2023-04-28 at 13 59 19](https://user-images.githubusercontent.com/70323886/235141873-2adc5c68-cae3-41c9-b5cc-502283f00eb3.png)
