### PR TITLE
fix: top border color on tab navigator

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -53,6 +53,8 @@ export const Root_TabNavigatorStack = () => {
           theme.interactive.interactive_2.outline.background,
         tabBarInactiveTintColor: theme.text.colors.secondary,
         tabBarStyle: {
+          borderTopWidth: theme.border.width.slim,
+          borderTopColor: theme.border.primary,
           backgroundColor: theme.interactive.interactive_2.default.background,
           ...useBottomNavigationStyles(),
         },


### PR DESCRIPTION
Set color of tabBar to primary

new:

![old-dark](https://user-images.githubusercontent.com/70323886/235153412-da16309f-805a-4b14-aeab-328754a42c3c.PNG)
![old-light](https://user-images.githubusercontent.com/70323886/235153422-8fea9605-b47e-4397-81ae-e5501638ffa6.PNG)

old:
![Simulator Screenshot - iPhone 14 - 2023-04-28 at 14 53 22](https://user-images.githubusercontent.com/70323886/235153461-65805a4c-d32e-4963-bb09-21ef78a9becd.png)
![Simulator Screenshot - iPhone 14 - 2023-04-28 at 14 52 56](https://user-images.githubusercontent.com/70323886/235153469-9f5a8780-8b9f-4f75-a636-34e570a9e536.png)
