### PR TITLE
feat: add single zone flag on referenceData

### DIFF
--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -14,7 +14,7 @@ export type PreassignedFareProduct = {
   productAlias?: LanguageAndTextType[];
   distributionChannel: DistributionChannel[];
   alternativeNames: LanguageAndTextType[];
-  zoneSelectionMode: ZoneSelectionMode;
+  zoneSelectionMode?: ZoneSelectionMode;
   limitations: {
     userProfileRefs: string[];
     appVersionMin: string | undefined;

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -13,6 +13,7 @@ export type PreassignedFareProduct = {
   productAlias?: LanguageAndTextType[];
   distributionChannel: DistributionChannel[];
   alternativeNames: LanguageAndTextType[];
+  isApplicableOnSingleZoneOnly: boolean;
   limitations: {
     userProfileRefs: string[];
     appVersionMin: string | undefined;

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -1,5 +1,6 @@
 import {Polygon} from 'geojson';
 import {LanguageAndTextType} from '@atb/translations';
+import {ZoneSelectionMode} from '@atb-as/config-specs';
 
 export type DistributionChannel = 'web' | 'app';
 
@@ -13,7 +14,7 @@ export type PreassignedFareProduct = {
   productAlias?: LanguageAndTextType[];
   distributionChannel: DistributionChannel[];
   alternativeNames: LanguageAndTextType[];
-  isApplicableOnSingleZoneOnly: boolean;
+  zoneSelectionMode: ZoneSelectionMode;
   limitations: {
     userProfileRefs: string[];
     appVersionMin: string | undefined;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -148,6 +148,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             fromTariffZone={fromTariffZone}
             toTariffZone={toTariffZone}
             fareProductTypeConfig={params.fareProductTypeConfig}
+            preassignedFareProduct={preassignedFareProduct}
             onSelect={(t) =>
               navigation.push('Root_PurchaseTariffZonesSearchByMapScreen', t)
             }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -38,7 +38,6 @@ export function ZonesSelection({
 }: ZonesSelectionProps) {
   const styles = useStyles();
   const {t, language} = useTranslation();
-  console.log('preass', preassignedFareProduct);
 
   const accessibility: AccessibilityProps = {
     accessible: true,
@@ -59,9 +58,7 @@ export function ZonesSelection({
     selectionMode = 'multiple';
   }
   if (
-    preassignedFareProduct.zoneSelectionMode === 'single' ||
-    preassignedFareProduct.zoneSelectionMode === 'single-stop' ||
-    preassignedFareProduct.zoneSelectionMode === 'single-zone' ||
+    preassignedFareProduct.zoneSelectionMode?.includes('single') ||
     selectionMode == 'single-stop' ||
     selectionMode == 'single-zone'
   ) {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -12,11 +12,13 @@ import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {TariffZoneWithMetadata} from '../../Root_PurchaseTariffZonesSearchByMapScreen';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
+import {PreassignedFareProduct} from '@atb/reference-data/types';
 
 type ZonesSelectionProps = {
   fareProductTypeConfig: FareProductTypeConfig;
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
+  preassignedFareProduct: PreassignedFareProduct;
   onSelect: (t: {
     fromTariffZone: TariffZoneWithMetadata;
     toTariffZone: TariffZoneWithMetadata;
@@ -29,6 +31,7 @@ export function ZonesSelection({
   fareProductTypeConfig,
   fromTariffZone,
   toTariffZone,
+  preassignedFareProduct,
   onSelect,
   style,
 }: ZonesSelectionProps) {
@@ -53,7 +56,11 @@ export function ZonesSelection({
   if (selectionMode == 'multiple-stop' || selectionMode == 'multiple-zone') {
     selectionMode = 'multiple';
   }
-  if (selectionMode == 'single-stop' || selectionMode == 'single-zone') {
+  if (
+    preassignedFareProduct.isApplicableOnSingleZoneOnly ||
+    selectionMode == 'single-stop' ||
+    selectionMode == 'single-zone'
+  ) {
     selectionMode = 'single';
   }
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -38,6 +38,7 @@ export function ZonesSelection({
 }: ZonesSelectionProps) {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  console.log('preass', preassignedFareProduct);
 
   const accessibility: AccessibilityProps = {
     accessible: true,
@@ -58,7 +59,9 @@ export function ZonesSelection({
     selectionMode = 'multiple';
   }
   if (
-    preassignedFareProduct.isApplicableOnSingleZoneOnly ||
+    preassignedFareProduct.zoneSelectionMode === 'single' ||
+    preassignedFareProduct.zoneSelectionMode === 'single-stop' ||
+    preassignedFareProduct.zoneSelectionMode === 'single-zone' ||
     selectionMode == 'single-stop' ||
     selectionMode == 'single-zone'
   ) {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -23,6 +23,7 @@ type ZonesSelectionProps = {
     fromTariffZone: TariffZoneWithMetadata;
     toTariffZone: TariffZoneWithMetadata;
     fareProductTypeConfig: FareProductTypeConfig;
+    preassignedFareProduct: PreassignedFareProduct;
   }) => void;
   style?: StyleProp<ViewStyle>;
 };
@@ -87,6 +88,7 @@ export function ZonesSelection({
               fromTariffZone,
               toTariffZone,
               fareProductTypeConfig,
+              preassignedFareProduct,
             })
           }
           testID="selectZonesButton"

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -37,7 +37,6 @@ export const Root_PurchaseTariffZonesSearchByMapScreen = ({
     fareProductTypeConfig,
     preassignedFareProduct,
   } = route.params;
-  console.log('preassproduct', preassignedFareProduct);
   const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
   const isApplicableOnSingleZoneOnly =
     preassignedFareProduct.isApplicableOnSingleZoneOnly ||

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -31,9 +31,17 @@ export const Root_PurchaseTariffZonesSearchByMapScreen = ({
   navigation,
   route,
 }: Props) => {
-  const {fromTariffZone, toTariffZone, fareProductTypeConfig} = route.params;
+  const {
+    fromTariffZone,
+    toTariffZone,
+    fareProductTypeConfig,
+    preassignedFareProduct,
+  } = route.params;
+  console.log('preassproduct', preassignedFareProduct);
   const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
-  const isApplicableOnSingleZoneOnly = selectionMode === 'single';
+  const isApplicableOnSingleZoneOnly =
+    preassignedFareProduct.isApplicableOnSingleZoneOnly ||
+    selectionMode === 'single';
   const [selectedZones, setSelectedZones] = useState<TariffZoneSelection>({
     from: fromTariffZone,
     to: toTariffZone,

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -39,7 +39,7 @@ export const Root_PurchaseTariffZonesSearchByMapScreen = ({
   } = route.params;
   const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
   const isApplicableOnSingleZoneOnly =
-    preassignedFareProduct.isApplicableOnSingleZoneOnly ||
+    preassignedFareProduct.zoneSelectionMode === 'single' ||
     selectionMode === 'single';
   const [selectedZones, setSelectedZones] = useState<TariffZoneSelection>({
     from: fromTariffZone,

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -39,7 +39,7 @@ export const Root_PurchaseTariffZonesSearchByMapScreen = ({
   } = route.params;
   const selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
   const isApplicableOnSingleZoneOnly =
-    preassignedFareProduct.zoneSelectionMode === 'single' ||
+    preassignedFareProduct.zoneSelectionMode?.includes('single') ||
     selectionMode === 'single';
   const [selectedZones, setSelectedZones] = useState<TariffZoneSelection>({
     from: fromTariffZone,

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -22,6 +22,7 @@ export type Root_PurchaseTariffZonesSearchByMapScreenParams = {
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
   fareProductTypeConfig: FareProductTypeConfig;
+  preassignedFareProduct: PreassignedFareProduct;
 };
 
 export type Root_LocationSearchByMapScreenParams = {


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/3946

Makes three day ticket at NFK only selectable in a single zone using a `isApplicableOnSingleZoneOnly` flag that exists in the code from before (but not on the referenceData).