### PR TITLE
fix: ui changes to contact sheet and correct notification icon on chat

### DIFF
--- a/src/chat/ContactSheet.tsx
+++ b/src/chat/ContactSheet.tsx
@@ -12,11 +12,12 @@ import {AccessibilityProps, Linking, View} from 'react-native';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
-import {ChatUnread} from '@atb/assets/svg/color/icons/actions';
 import {useChatUnreadCount} from './use-chat-unread-count';
 import Intercom from 'react-native-intercom';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {screenReaderHidden} from '@atb/utils/accessibility';
+import {Chat} from '@atb/assets/svg/mono-icons/actions';
+import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 
 type Props = {
   close: () => void;
@@ -33,39 +34,25 @@ export const ContactSheet = forwardRef<View, Props>(({close}, focusRef) => {
 
   return (
     <BottomSheetContainer>
-      <View>
-        <ScreenHeaderWithoutNavigation
-          title={t(ContactSheetTexts.header.title)}
-          leftButton={{
-            type: 'cancel',
-            onPress: close,
-            text: t(ScreenHeaderTexts.headerButton.cancel.text),
-          }}
-          color={'background_1'}
-          setFocusOnLoad={false}
-        />
-      </View>
+      <ScreenHeaderWithoutNavigation
+        title={t(ContactSheetTexts.header.title)}
+        leftButton={{
+          type: 'close',
+          onPress: close,
+          text: t(ScreenHeaderTexts.headerButton.close.text),
+        }}
+        color={'background_1'}
+        setFocusOnLoad={false}
+      />
       <FullScreenFooter>
-        <ContactItem
-          title={t(ContactSheetTexts.customer_service.title)}
-          body={t(ContactSheetTexts.customer_service.body)}
-          buttonText={t(ContactSheetTexts.customer_service.button)}
-          focusRef={focusRef}
-          accessibilityHint={t(ContactSheetTexts.customer_service.a11yHint)}
-          onPress={() => {
-            Linking.openURL(customer_service_url);
-            close();
-          }}
-        />
-
         {showWebsiteFeedback ? (
           <ContactItem
-            title={t(ContactSheetTexts.customer_feedback_website.title)}
             body={t(ContactSheetTexts.customer_feedback_website.body)}
             buttonText={t(ContactSheetTexts.customer_feedback_website.button)}
             accessibilityHint={t(
               ContactSheetTexts.customer_feedback_website.a11yHint,
             )}
+            icon={() => <ThemeIcon svg={ExternalLink} />}
             onPress={() => {
               Linking.openURL(customer_feedback_url);
               close();
@@ -76,7 +63,6 @@ export const ContactSheet = forwardRef<View, Props>(({close}, focusRef) => {
         {showIntercomFeedback ? (
           <ContactItem
             screenReaderHidden={screenReaderHidden}
-            title={t(ContactSheetTexts.customer_feedback.title)}
             body={t(ContactSheetTexts.customer_feedback.body)}
             buttonText={t(ContactSheetTexts.customer_feedback.button)}
             accessibilityHint={t(ContactSheetTexts.customer_feedback.a11yHint)}
@@ -86,15 +72,27 @@ export const ContactSheet = forwardRef<View, Props>(({close}, focusRef) => {
                 : Intercom.displayConversationsList();
               close();
             }}
-            icon={() =>
-              unreadCount ? (
-                <ThemeIcon colorType="background_accent_3" svg={ChatUnread} />
-              ) : (
-                <></>
-              )
-            }
+            icon={() => (
+              <ThemeIcon
+                colorType="background_accent_3"
+                svg={Chat}
+                notification={unreadCount ? {color: 'valid'} : undefined}
+              />
+            )}
           />
         ) : undefined}
+        <ContactItem
+          body={t(ContactSheetTexts.customer_service.body)}
+          buttonText={t(ContactSheetTexts.customer_service.button)}
+          focusRef={focusRef}
+          accessibilityHint={t(ContactSheetTexts.customer_service.a11yHint)}
+          buttonMode={'secondary'}
+          icon={() => <ThemeIcon svg={ExternalLink} />}
+          onPress={() => {
+            Linking.openURL(customer_service_url);
+            close();
+          }}
+        />
       </FullScreenFooter>
     </BottomSheetContainer>
   );
@@ -103,36 +101,36 @@ export const ContactSheet = forwardRef<View, Props>(({close}, focusRef) => {
 type ContactProps = {
   onPress: () => void;
   icon?: () => JSX.Element;
-  title: string;
   body: string;
   buttonText: string;
   accessibilityHint: string;
   focusRef?: React.ForwardedRef<View>;
   screenReaderHidden?: AccessibilityProps;
+  buttonMode?: 'primary' | 'secondary';
 };
 
 const ContactItem: React.FC<ContactProps> = ({
   onPress,
   icon,
-  title,
   body,
   buttonText,
   accessibilityHint,
   focusRef,
   screenReaderHidden,
+  buttonMode = 'primary',
 }) => {
   const styles = useStyles();
 
   return (
-    <View {...screenReaderHidden}>
+    <View style={styles.container} {...screenReaderHidden}>
       <View style={styles.descriptionSection} ref={focusRef} accessible>
-        <ThemeText type="body__secondary" color="secondary">
-          {title}
-        </ThemeText>
         <ThemeText>{body}</ThemeText>
       </View>
       <Button
-        interactiveColor="interactive_0"
+        mode={buttonMode}
+        interactiveColor={
+          buttonMode == 'primary' ? 'interactive_0' : 'interactive_2'
+        }
         text={buttonText}
         accessibilityHint={accessibilityHint}
         onPress={onPress}
@@ -144,10 +142,9 @@ const ContactItem: React.FC<ContactProps> = ({
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
   return {
-    descriptionSection: {
-      margin: theme.spacings.medium,
-      marginBottom: theme.spacings.large,
-      marginTop: theme.spacings.xLarge,
+    descriptionSection: {marginBottom: theme.spacings.medium},
+    container: {
+      marginBottom: theme.spacings.medium,
     },
   };
 });

--- a/src/chat/ContactSheet.tsx
+++ b/src/chat/ContactSheet.tsx
@@ -1,4 +1,3 @@
-import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet} from '@atb/theme';
@@ -18,6 +17,7 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {screenReaderHidden} from '@atb/utils/accessibility';
 import {Chat} from '@atb/assets/svg/mono-icons/actions';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
+import {Button, ButtonProps} from '@atb/components/button';
 
 type Props = {
   close: () => void;
@@ -106,7 +106,7 @@ type ContactProps = {
   accessibilityHint: string;
   focusRef?: React.ForwardedRef<View>;
   screenReaderHidden?: AccessibilityProps;
-  buttonMode?: 'primary' | 'secondary';
+  buttonMode?: ButtonProps['mode'];
 };
 
 const ContactItem: React.FC<ContactProps> = ({

--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -1,5 +1,3 @@
-import {Chat} from '@atb/assets/svg/mono-icons/actions';
-import {ChatUnread} from '@atb/assets/svg/color/icons/actions';
 import {IconButtonProps} from '@atb/components/screen-header';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet} from '@atb/theme';
@@ -10,6 +8,7 @@ import {StaticColor, TextColor} from '@atb/theme/colors';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {ContactSheet} from '@atb/chat/ContactSheet';
 import {ScreenHeaderTexts, useTranslation} from '@atb/translations';
+import {Chat} from '@atb/assets/svg/mono-icons/actions';
 
 export const useChatIcon = (
   color?: StaticColor | TextColor,
@@ -29,11 +28,17 @@ export const useChatIcon = (
   return {
     children: (
       <View style={styles.chatContainer} testID={testID}>
-        {unreadCount ? (
-          <ThemeIcon colorType={color} svg={ChatUnread} />
-        ) : (
-          <ThemeIcon colorType={color} svg={Chat} />
-        )}
+        <ThemeIcon
+          colorType={color}
+          svg={Chat}
+          notification={
+            unreadCount
+              ? {
+                  color: 'valid',
+                }
+              : undefined
+          }
+        />
       </View>
     ),
     accessibilityHint: t(ScreenHeaderTexts.headerButton.chat.a11yHint),

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -7,6 +7,10 @@ const ScreenHeaderTexts = {
       text: _('Tilbake', 'Back'),
       a11yHint: _('Aktivér for å gå tilbake', 'Activate to go back'),
     },
+    cancel: {
+      text: _('Avbryt', 'Cancel'),
+      a11yHint: _('Aktivér for å avbryte', 'Activate to cancel'),
+    },
     close: {
       text: _('Lukk', 'Close'),
       a11yHint: _('Aktivér for å lukke', 'Activate to close'),

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -7,10 +7,6 @@ const ScreenHeaderTexts = {
       text: _('Tilbake', 'Back'),
       a11yHint: _('Aktivér for å gå tilbake', 'Activate to go back'),
     },
-    cancel: {
-      text: _('Avbryt', 'Cancel'),
-      a11yHint: _('Aktivér for å avbryte', 'Activate to cancel'),
-    },
     close: {
       text: _('Lukk', 'Close'),
       a11yHint: _('Aktivér for å lukke', 'Activate to close'),

--- a/src/translations/screens/subscreens/ContactSheet.ts
+++ b/src/translations/screens/subscreens/ContactSheet.ts
@@ -10,10 +10,7 @@ const ContactSheetTexts = {
       'Har du spørsmål eller trenger hjelp?',
       'Do you have questions or need help?',
     ),
-    button: _(
-      'Kontakt kundeservice (åpnes i nettleser)',
-      'Contact customer service (opens in browser)',
-    ),
+    button: _('Kontakt kundeservice', 'Contact customer service'),
     a11yHint: _(
       'Aktivér for å kontakte kundeservice, åpner side i nettleser',
       'Activate to contact customer service, opens page in browser',
@@ -37,8 +34,8 @@ const ContactSheetTexts = {
   customer_feedback: {
     title: _('Tilbakemelding om appen', 'Feedback about the app'),
     body: _(
-      'Vil du foreslå forbedringer til appen?',
-      'Do you have suggestions on how we can improve the app?',
+      'Vil du foreslå forbedringer eller rapportere feil i appen?',
+      'Would you like to suggest improvements or report errors in the app?',
     ),
     button: _('Forbedre appen', 'Improve the app'),
     a11yHint: _(

--- a/src/translations/screens/subscreens/ContactSheet.ts
+++ b/src/translations/screens/subscreens/ContactSheet.ts
@@ -5,7 +5,6 @@ const ContactSheetTexts = {
     title: _('Kontakt AtB', 'Contact AtB'),
   },
   customer_service: {
-    title: _('Spørsmål til kundeservice', 'Questions for customer service'),
     body: _(
       'Har du spørsmål eller trenger hjelp?',
       'Do you have questions or need help?',
@@ -17,7 +16,6 @@ const ContactSheetTexts = {
     ),
   },
   customer_feedback_website: {
-    title: _('Tilbakemelding om appen', 'Feedback about the app'),
     body: _(
       'Vil du foreslå forbedringer til appen?',
       'Do you have suggestions on how we can improve the app?',
@@ -32,7 +30,6 @@ const ContactSheetTexts = {
     ),
   },
   customer_feedback: {
-    title: _('Tilbakemelding om appen', 'Feedback about the app'),
     body: _(
       'Vil du foreslå forbedringer eller rapportere feil i appen?',
       'Would you like to suggest improvements or report errors in the app?',


### PR DESCRIPTION
Found that the contact sheet had no design in figma when looking into status disruption. Designed with øyvind in figma and applied the changes. Also fixed so that the chatIcon uses the correct notification. 

[Figma](https://www.figma.com/file/2QTjAdekdIPuLFovQhVrY3/01.-Components?node-id=4632-15731&t=csb2PQqfPviugacR-4)

![Simulator Screenshot - iPhone 14 - 2023-05-05 at 10 23 16](https://user-images.githubusercontent.com/70323886/236410168-3e29b93f-fbdc-4065-87cf-f8a0ee00ed20.png)
