### PR TITLE
fix: wrong expiry date shown on payment card

### DIFF
--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -49,6 +49,6 @@ export function getExpireDate(iso: string): string {
   // This must be done since the expiry date stored is the date the card expires,
   // and the date that shows on the card is the month before the card expires
   // Example: The card expires the moment the date is 02.2021, but the date on the card is 01.2021
-  date.setMonth(date.getMonth() - 1);
+  date.setDate(date.getDate() - 1);
   return format(date, 'MM/yy');
 }

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -45,7 +45,7 @@ export function getPaymentTypeName(paymentType: PaymentType) {
 
 export function getExpireDate(iso: string): string {
   let date = parseISO(iso);
-  // Subtract one month to get the correct expiry date
+  // Subtract one day to get the correct expiry date
   // This must be done since the expiry date stored is the date the card expires,
   // and the date that shows on the card is the month before the card expires
   // Example: The card expires the moment the date is 02.2021, but the date on the card is 01.2021

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -46,7 +46,7 @@ export function getPaymentTypeName(paymentType: PaymentType) {
 export function getExpireDate(iso: string): string {
   let date = parseISO(iso);
   // Subtract one month to get the correct expiry date
-  // This must be done since the expiry date stored in the database is the date the card expires,
+  // This must be done since the expiry date stored is the date the card expires,
   // and the date that shows on the card is the month before the card expires
   // Example: The card expires the moment the date is 02.2021, but the date on the card is 01.2021
   date.setMonth(date.getMonth() - 1);

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -45,5 +45,10 @@ export function getPaymentTypeName(paymentType: PaymentType) {
 
 export function getExpireDate(iso: string): string {
   let date = parseISO(iso);
+  // Subtract one month to get the correct expiry date
+  // This must be done since the expiry date stored in the database is the date the card expires,
+  // and the date that shows on the card is the month before the card expires
+  // Example: The card expires the moment the date is 02.2021, but the date on the card is 01.2021
+  date.setMonth(date.getMonth() - 1);
   return format(date, 'MM/yy');
 }


### PR DESCRIPTION
When a cards shown expire date on the card is shown as 01.2024, it is valid thru the entire month of January and the expire date is technically 02.2024(this is how we store it).  I would say this is the correct way to store the expire date, and a simple fix is to do as I have done, subtract one month when getting the string to show. 

