### PR TITLE
fix: Fix departure details header wrap

### DIFF
--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -251,7 +251,7 @@ function LastPassedStop({realtimeText}: {realtimeText: string}) {
       <ThemeText
         type="body__secondary"
         color="background_accent_0"
-        style={{flexShrink: 1}}
+        style={styles.passedText}
       >
         {realtimeText}
       </ThemeText>
@@ -524,18 +524,23 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
     paddingTop: theme.spacings.medium,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    flexWrap: 'wrap',
   },
   border: {
     borderColor: theme.static.background.background_3.background,
     marginVertical: theme.spacings.medium,
   },
   passedSection: {
-    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'center',
+    minWidth: '60%',
+    flex: 1,
   },
   passedSectionRealtimeIcon: {
     marginRight: theme.spacings.xSmall,
+  },
+  passedText: {
+    flexShrink: 1,
   },
   startPlace: {
     marginTop: theme.spacings.medium,


### PR DESCRIPTION
Wrap header content on departure details

![Simulator Screen Shot - iPhone 14 Pro - 2023-05-09 at 15 43 35](https://github.com/AtB-AS/mittatb-app/assets/85479566/16e57d7c-f51c-4c5c-8676-0471561b7658)
![Simulator Screen Shot - iPhone 14 Pro - 2023-05-09 at 15 43 52](https://github.com/AtB-AS/mittatb-app/assets/85479566/4e7180c9-efad-4393-97e2-a077d5e2dc68)


https://github.com/AtB-AS/kundevendt/issues/3679#issuecomment-1539913245