### PR TITLE
fix: Screen reader with parallax scroll

### DIFF
--- a/src/components/parallax-scroll/ParallaxScroll.tsx
+++ b/src/components/parallax-scroll/ParallaxScroll.tsx
@@ -36,17 +36,19 @@ export function ParallaxScroll({header, children, refreshControl}: Props) {
         <View onLayout={onHeaderContentLayout}>{header}</View>
       </Animated.View>
 
-      <Animated.ScrollView
-        scrollEventThrottle={10}
-        refreshControl={refreshControl}
-        onScroll={Animated.event(
-          [{nativeEvent: {contentOffset: {y: scrollYRef}}}],
-          {useNativeDriver: false},
-        )}
-        contentContainerStyle={{paddingTop: contentHeight}}
-      >
-        {children}
-      </Animated.ScrollView>
+      <View style={{paddingTop: contentHeight}}>
+        <Animated.ScrollView
+          scrollEventThrottle={10}
+          refreshControl={refreshControl}
+          onScroll={Animated.event(
+            [{nativeEvent: {contentOffset: {y: scrollYRef}}}],
+            {useNativeDriver: false},
+          )}
+          style={styles.children}
+        >
+          {children}
+        </Animated.ScrollView>
+      </View>
     </View>
   );
 }
@@ -66,5 +68,8 @@ const useThemeStyles = StyleSheet.createThemeHook(() => ({
     zIndex: 2,
     elevation: 4,
     justifyContent: 'space-between',
+  },
+  children: {
+    overflow: 'visible',
   },
 }));


### PR DESCRIPTION
The VoiceOver on the parallex scroll content was messed up because
of absolute positioning not making it clear the navigation order of
the components. By wrapping the parallax scroll children in a View
and placing the top padding there, VoiceOver behaves correctly.

Fixes:
https://github.com/AtB-AS/mittatb-app/pull/3509#issuecomment-1541390219

### Acceptance criteria
- [ ] Parallax scroll works correctly on TripSearchScreen, TripDetailsScreen and DepartureDetailsScreen, on both Android and iOS.
- [ ] Screen reader works correctly with the parallax scroll content on TripSearchScreen, TripDetailsScreen and DepartureDetailsScreen, on both Android and iOS.
