### PR TITLE
feat: configurable default tariff zone

### DIFF
--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -60,6 +60,7 @@ type ConfigurationContextState = {
   travelSearchFilters: TravelSearchFiltersType | undefined;
   appTexts: AppTexts | undefined;
   configurableLinks: ConfigurableLinks | undefined;
+  defaultTariffZone: TariffZone | undefined;
 };
 
 const defaultConfigurationContextState: ConfigurationContextState = {
@@ -74,6 +75,7 @@ const defaultConfigurationContextState: ConfigurationContextState = {
   travelSearchFilters: undefined,
   appTexts: undefined,
   configurableLinks: undefined,
+  defaultTariffZone: undefined,
 };
 
 const FirestoreConfigurationContext = createContext<ConfigurationContextState>(
@@ -100,6 +102,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   const [appTexts, setAppTexts] = useState<AppTexts>();
   const [configurableLinks, setConfigurableLinks] =
     useState<ConfigurableLinks>();
+  const [defaultTariffZone, setDefaultTariffZone] = useState<TariffZone>();
 
   useEffect(() => {
     firestore()
@@ -164,6 +167,15 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
           if (configurableLinks) {
             setConfigurableLinks(configurableLinks);
           }
+
+          const defaultTariffZoneId =
+            getDefaultTariffZoneFromSnapshot(snapshot);
+          if (defaultTariffZoneId && tariffZones) {
+            const defaultTariffZone = tariffZones.find(
+              (tariffZone) => tariffZone.id == defaultTariffZoneId,
+            );
+            setDefaultTariffZone(defaultTariffZone);
+          }
         },
         (error) => {
           Bugsnag.leaveBreadcrumb(
@@ -187,6 +199,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       travelSearchFilters,
       appTexts,
       configurableLinks,
+      defaultTariffZone,
     };
   }, [
     preassignedFareProducts,
@@ -200,6 +213,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     travelSearchFilters,
     appTexts,
     configurableLinks,
+    defaultTariffZone,
   ]);
 
   return (
@@ -406,4 +420,12 @@ function getConfigurableLinksFromSnapshot(
     termsInfo,
     inspectionInfo,
   };
+}
+
+function getDefaultTariffZoneFromSnapshot(
+  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
+): string | undefined {
+  return snapshot.docs
+    .find((doc) => doc.id == 'other')
+    ?.get<string>('defaultTariffZone');
 }

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -60,7 +60,6 @@ type ConfigurationContextState = {
   travelSearchFilters: TravelSearchFiltersType | undefined;
   appTexts: AppTexts | undefined;
   configurableLinks: ConfigurableLinks | undefined;
-  defaultTariffZone: TariffZone | undefined;
 };
 
 const defaultConfigurationContextState: ConfigurationContextState = {
@@ -75,7 +74,6 @@ const defaultConfigurationContextState: ConfigurationContextState = {
   travelSearchFilters: undefined,
   appTexts: undefined,
   configurableLinks: undefined,
-  defaultTariffZone: undefined,
 };
 
 const FirestoreConfigurationContext = createContext<ConfigurationContextState>(
@@ -102,7 +100,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   const [appTexts, setAppTexts] = useState<AppTexts>();
   const [configurableLinks, setConfigurableLinks] =
     useState<ConfigurableLinks>();
-  const [defaultTariffZone, setDefaultTariffZone] = useState<TariffZone>();
 
   useEffect(() => {
     firestore()
@@ -167,15 +164,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
           if (configurableLinks) {
             setConfigurableLinks(configurableLinks);
           }
-
-          const defaultTariffZoneId =
-            getDefaultTariffZoneFromSnapshot(snapshot);
-          if (defaultTariffZoneId && tariffZones) {
-            const defaultTariffZone = tariffZones.find(
-              (tariffZone) => tariffZone.id == defaultTariffZoneId,
-            );
-            setDefaultTariffZone(defaultTariffZone);
-          }
         },
         (error) => {
           Bugsnag.leaveBreadcrumb(
@@ -199,7 +187,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       travelSearchFilters,
       appTexts,
       configurableLinks,
-      defaultTariffZone,
     };
   }, [
     preassignedFareProducts,
@@ -213,7 +200,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     travelSearchFilters,
     appTexts,
     configurableLinks,
-    defaultTariffZone,
   ]);
 
   return (
@@ -420,12 +406,4 @@ function getConfigurableLinksFromSnapshot(
     termsInfo,
     inspectionInfo,
   };
-}
-
-function getDefaultTariffZoneFromSnapshot(
-  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
-): string | undefined {
-  return snapshot.docs
-    .find((doc) => doc.id == 'other')
-    ?.get<string>('defaultTariffZone');
 }

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -39,6 +39,7 @@ export type TariffZone = {
   name: LanguageAndTextType;
   version: string;
   geometry: Omit<Polygon, 'type'> & {type: any};
+  isDefault?: boolean;
 };
 
 export type CityZone = {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -105,23 +105,26 @@ const useTravellersWithPreselectedCounts = (
 
 /**
  * Get the default tariff zone, either based on current location, default tariff
- * zone set in firestore configuration or else the first tariff zone in the
+ * zone set on tariff zone in reference data or else the first tariff zone in the
  * provided tariff zones list.
  */
 const useDefaultTariffZone = (
   tariffZones: TariffZone[],
 ): TariffZoneWithMetadata => {
-  const {defaultTariffZone} = useFirestoreConfiguration();
   const tariffZoneFromLocation = useTariffZoneFromLocation(tariffZones);
   return useMemo<TariffZoneWithMetadata>(() => {
     if (tariffZoneFromLocation) {
       return {...tariffZoneFromLocation, resultType: 'geolocation'};
     }
 
+    const defaultTariffZone = tariffZones.find(
+      (tariffZone) => tariffZone.isDefault,
+    );
+
     if (defaultTariffZone) {
       return {...defaultTariffZone, resultType: 'zone'};
     }
 
     return {...tariffZones[0], resultType: 'zone'};
-  }, [tariffZones, tariffZoneFromLocation, defaultTariffZone]);
+  }, [tariffZones, tariffZoneFromLocation]);
 };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -104,18 +104,24 @@ const useTravellersWithPreselectedCounts = (
 };
 
 /**
- * Get the default tariff zone, either based on current location or else the
- * first tariff zone in the provided tariff zones list.
+ * Get the default tariff zone, either based on current location, default tariff
+ * zone set in firestore configuration or else the first tariff zone in the
+ * provided tariff zones list.
  */
 const useDefaultTariffZone = (
   tariffZones: TariffZone[],
 ): TariffZoneWithMetadata => {
+  const {defaultTariffZone} = useFirestoreConfiguration();
   const tariffZoneFromLocation = useTariffZoneFromLocation(tariffZones);
-  return useMemo<TariffZoneWithMetadata>(
-    () =>
-      tariffZoneFromLocation
-        ? {...tariffZoneFromLocation, resultType: 'geolocation'}
-        : {...tariffZones[0], resultType: 'zone'},
-    [tariffZones, tariffZoneFromLocation],
-  );
+  return useMemo<TariffZoneWithMetadata>(() => {
+    if (tariffZoneFromLocation) {
+      return {...tariffZoneFromLocation, resultType: 'geolocation'};
+    }
+
+    if (defaultTariffZone) {
+      return {...defaultTariffZone, resultType: 'zone'};
+    }
+
+    return {...tariffZones[0], resultType: 'zone'};
+  }, [tariffZones, tariffZoneFromLocation, defaultTariffZone]);
 };


### PR DESCRIPTION
This change allows us to configure the default tariff zone using the Firestore configuration. This has already been implemented in the webshop as NFK and FRAM do not want the default tariff zone to be the first from the list of tariff zones. 

The order for selecting a tariff zone is 
geolocation > default tariff zone from Firestore configuration > first tariff zone in the list of tariff zones.

Closes https://github.com/AtB-AS/kundevendt/issues/3659