### PR TITLE
feat: add purchaseMessage from FareProductTypeConfig

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/PurchaseMessages.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/PurchaseMessages.tsx
@@ -5,11 +5,16 @@ import {
 } from '@atb/mobile-token/MobileTokenContext';
 import {StyleSheet} from '@atb/theme';
 import {useTicketingState} from '@atb/ticketing';
-import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import {
+  getTextForLanguage,
+  PurchaseOverviewTexts,
+  useTranslation,
+} from '@atb/translations';
 import React from 'react';
 import {getOtherDeviceIsInspectableWarning} from '../../../fare-contracts/utils';
 import {getValidOnTrainNoticeText} from '../../Root_TabNavigatorStack/TabNav_TicketingStack/utils';
 import {TariffZoneWithMetadata} from '../../Root_PurchaseTariffZonesSearchByMapScreen';
+import {useFirestoreConfiguration} from '@atb/configuration';
 
 export type PurchaseWarningsProps = {
   preassignedFareProductType: string;
@@ -22,7 +27,7 @@ export const PurchaseMessages: React.FC<PurchaseWarningsProps> = ({
   fromTariffZone,
   toTariffZone,
 }) => {
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const styles = useStyles();
 
   const {
@@ -42,6 +47,14 @@ export const PurchaseMessages: React.FC<PurchaseWarningsProps> = ({
     t,
     remoteTokens,
     deviceIsInspectable,
+  );
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+  const purchaseMessageFromFareProductTypeConfig = fareProductTypeConfigs.find(
+    (config) => config.type === preassignedFareProductType,
+  )?.description;
+  const localizedFareProductTypePurchaseMessage = getTextForLanguage(
+    purchaseMessageFromFareProductTypeConfig,
+    language,
   );
 
   const shouldShowValidTrainTicketNotice =
@@ -74,6 +87,14 @@ export const PurchaseMessages: React.FC<PurchaseWarningsProps> = ({
         <MessageBox
           style={styles.warning}
           message={getValidOnTrainNoticeText(t, preassignedFareProductType)}
+          type="info"
+        />
+      )}
+
+      {localizedFareProductTypePurchaseMessage && (
+        <MessageBox
+          style={styles.warning}
+          message={localizedFareProductTypePurchaseMessage}
           type="info"
         />
       )}


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/3947

Related PR in FareProductTypeConfig:

https://github.com/AtB-AS/fare-product-type-configs/pull/3

DRAFT: requires merge of PR above before types can be corrected.

## Description

Introducing a PurchaseMessage field in Firestore for FareProductTypeConfig. This makes it possible to display a message to the user before confirming purchase of a ticket in the app. 

The message can be customized for every FareProductTypeConfig, meaning that the message can be different for single tickets, 24 hour tickets, period tickets and possibly also carnet tickets. 

Having the message stored in the FareProductTypeConfig means that it also can be changed in real time, not requiring app updates (and people actually updating) to add the latest information. At NFK for instance, they are planning to include night bus in a ticket that does not have night bus included at this time, so the message should be possible to change without app update.

### Caveats

This proposal does not make it possible to specify specific tariffZones or modes of transport that could have made it possible to also replace the info about trains in zone A in AtB. Suggestions on how this could be included is of course very welcome, however, I could not see any way to do this that does not dramatically increase the complexity.