### PR TITLE
feat: Add onboarding for mobile token without travelcard

### DIFF
--- a/scripts/register-local-app-version.sh
+++ b/scripts/register-local-app-version.sh
@@ -7,7 +7,7 @@
 echo "Loading all env variables from .env file"
 export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
 
-credentials=$(gcloud secrets versions access --project fram-staging-dc00 --secret=entur-client-credentials-publish latest)
+credentials=$(gcloud secrets versions access --project atb-staging-c420 --secret=entur-client-credentials-publish latest)
 
 export APP_ENVIRONMENT=staging
 export ENTUR_CLIENT_ID=$(echo $credentials | jq '.clientId' -r)

--- a/scripts/register-local-app-version.sh
+++ b/scripts/register-local-app-version.sh
@@ -7,7 +7,7 @@
 echo "Loading all env variables from .env file"
 export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
 
-credentials=$(gcloud secrets versions access --project atb-staging-c420 --secret=entur-client-credentials-publish latest)
+credentials=$(gcloud secrets versions access --project fram-staging-dc00 --secret=entur-client-credentials-publish latest)
 
 export APP_ENVIRONMENT=staging
 export ENTUR_CLIENT_ID=$(echo $credentials | jq '.clientId' -r)

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -18,6 +18,7 @@ enum storeKey {
   previousBuildNumber = '@ATB_previous_build_number',
   ticketing = '@ATB_ticket_informational_accepted',
   mobileTokenOnboarding = '@ATB_mobile_token_onboarded',
+  mobileTokenWithoutTravelcardOnboarding = '@ATB_mobile_token_without_travelcard_onboarded',
 }
 type AppState = {
   isLoading: boolean;
@@ -25,6 +26,7 @@ type AppState = {
   ticketingAccepted: boolean;
   newBuildSincePreviousLaunch: boolean;
   mobileTokenOnboarded: boolean;
+  mobileTokenWithoutTravelcardOnboarded: boolean;
 };
 
 type AppReducerAction =
@@ -34,13 +36,16 @@ type AppReducerAction =
       ticketingAccepted: boolean;
       newBuildSincePreviousLaunch: boolean;
       mobileTokenOnboarded: boolean;
+      mobileTokenWithoutTravelcardOnboarded: boolean;
     }
   | {type: 'COMPLETE_ONBOARDING'}
   | {type: 'RESTART_ONBOARDING'}
   | {type: 'ACCEPT_TICKETING'}
   | {type: 'RESET_TICKETING'}
   | {type: 'COMPLETE_MOBILE_TOKEN_ONBOARDING'}
-  | {type: 'RESTART_MOBILE_TOKEN_ONBOARDING'};
+  | {type: 'RESTART_MOBILE_TOKEN_ONBOARDING'}
+  | {type: 'COMPLETE_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'}
+  | {type: 'RESTART_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'};
 
 type AppContextState = AppState & {
   completeOnboarding: () => void;
@@ -49,6 +54,8 @@ type AppContextState = AppState & {
   resetTicketing: () => void;
   completeMobileTokenOnboarding: () => void;
   restartMobileTokenOnboarding: () => void;
+  completeMobileTokenWithoutTravelcardOnboarding: () => void;
+  restartMobileTokenWithoutTravelcardOnboarding: () => void;
 };
 const AppContext = createContext<AppContextState | undefined>(undefined);
 const AppDispatch = createContext<Dispatch<AppReducerAction> | undefined>(
@@ -67,6 +74,8 @@ const appReducer: AppReducer = (prevState, action) => {
         newBuildSincePreviousLaunch: action.newBuildSincePreviousLaunch,
         isLoading: false,
         mobileTokenOnboarded: action.mobileTokenOnboarded,
+        mobileTokenWithoutTravelcardOnboarded:
+          action.mobileTokenWithoutTravelcardOnboarded,
       };
     case 'COMPLETE_ONBOARDING':
       return {
@@ -98,6 +107,16 @@ const appReducer: AppReducer = (prevState, action) => {
         ...prevState,
         mobileTokenOnboarded: false,
       };
+    case 'COMPLETE_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING':
+      return {
+        ...prevState,
+        mobileTokenWithoutTravelcardOnboarded: true,
+      };
+    case 'RESTART_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING':
+      return {
+        ...prevState,
+        mobileTokenWithoutTravelcardOnboarded: false,
+      };
   }
 };
 
@@ -107,6 +126,7 @@ const defaultAppState: AppState = {
   ticketingAccepted: false,
   newBuildSincePreviousLaunch: false,
   mobileTokenOnboarded: false,
+  mobileTokenWithoutTravelcardOnboarded: false,
 };
 
 export const AppContextProvider: React.FC = ({children}) => {
@@ -122,12 +142,20 @@ export const AppContextProvider: React.FC = ({children}) => {
         ? false
         : JSON.parse(savedTicketingAccepted);
 
-      const savedmobileTokenOnboarded = await storage.get(
+      const savedMobileTokenOnboarded = await storage.get(
         storeKey.mobileTokenOnboarding,
       );
-      const mobileTokenOnboarded = !savedmobileTokenOnboarded
+      const mobileTokenOnboarded = !savedMobileTokenOnboarded
         ? false
-        : JSON.parse(savedmobileTokenOnboarded);
+        : JSON.parse(savedMobileTokenOnboarded);
+
+      const savedMobileTokenWithoutTravelcardOnboarded = await storage.get(
+        storeKey.mobileTokenWithoutTravelcardOnboarding,
+      );
+      const mobileTokenWithoutTravelcardOnboarded =
+        !savedMobileTokenWithoutTravelcardOnboarded
+          ? false
+          : JSON.parse(savedMobileTokenWithoutTravelcardOnboarded);
 
       const previousBuildNumber = await storage.get(
         storeKey.previousBuildNumber,
@@ -149,6 +177,7 @@ export const AppContextProvider: React.FC = ({children}) => {
         ticketingAccepted,
         newBuildSincePreviousLaunch,
         mobileTokenOnboarded,
+        mobileTokenWithoutTravelcardOnboarded,
       });
 
       RNBootSplash.hide({fade: true});
@@ -163,6 +192,8 @@ export const AppContextProvider: React.FC = ({children}) => {
     resetTicketing,
     completeMobileTokenOnboarding,
     restartMobileTokenOnboarding,
+    completeMobileTokenWithoutTravelcardOnboarding,
+    restartMobileTokenWithoutTravelcardOnboarding,
   } = useMemo(
     () => ({
       completeOnboarding: async () => {
@@ -192,6 +223,20 @@ export const AppContextProvider: React.FC = ({children}) => {
         );
         dispatch({type: 'RESTART_MOBILE_TOKEN_ONBOARDING'});
       },
+      completeMobileTokenWithoutTravelcardOnboarding: async () => {
+        await storage.set(
+          storeKey.mobileTokenWithoutTravelcardOnboarding,
+          JSON.stringify(true),
+        );
+        dispatch({type: 'COMPLETE_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'});
+      },
+      restartMobileTokenWithoutTravelcardOnboarding: async () => {
+        await storage.set(
+          storeKey.mobileTokenWithoutTravelcardOnboarding,
+          JSON.stringify(false),
+        );
+        dispatch({type: 'RESTART_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'});
+      },
     }),
     [],
   );
@@ -206,6 +251,8 @@ export const AppContextProvider: React.FC = ({children}) => {
         resetTicketing,
         completeMobileTokenOnboarding,
         restartMobileTokenOnboarding,
+        completeMobileTokenWithoutTravelcardOnboarding,
+        restartMobileTokenWithoutTravelcardOnboarding,
       }}
     >
       <AppDispatch.Provider value={dispatch}>{children}</AppDispatch.Provider>

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -66,7 +66,20 @@ export const shouldOnboardMobileToken = (
   hasEnabledMobileToken: boolean,
   authenticationType: string,
   mobileTokenOnboarded: boolean,
+  disableTravelcard: boolean,
 ) =>
   hasEnabledMobileToken &&
   authenticationType === 'phone' &&
-  !mobileTokenOnboarded;
+  !mobileTokenOnboarded &&
+  !disableTravelcard;
+
+export const shouldOnboardMobileTokenWithoutTravelcard = (
+  hasEnabledMobileToken: boolean,
+  authenticationType: string,
+  mobileTokenWithoutTravelcardOnboarded: boolean,
+  disableTravelcard: boolean,
+) =>
+  hasEnabledMobileToken &&
+  authenticationType === 'phone' &&
+  !mobileTokenWithoutTravelcardOnboarded &&
+  disableTravelcard;

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -47,6 +47,7 @@ export type RemoteConfig = {
   use_flexible_on_directMode: boolean;
   use_flexible_on_egressMode: boolean;
   use_trygg_overgang_qr_code: boolean;
+  disable_travelcard: boolean;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -99,6 +100,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   use_flexible_on_directMode: true,
   use_flexible_on_egressMode: true,
   use_trygg_overgang_qr_code: false,
+  disable_travelcard: false,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -248,6 +250,10 @@ export function getConfig(): RemoteConfig {
     values['use_trygg_overgang_qr_code']?.asBoolean() ??
     defaultRemoteConfig.use_trygg_overgang_qr_code;
 
+  const disable_travelcard =
+    values['disable_travelcard']?.asBoolean() ??
+    defaultRemoteConfig.disable_travelcard;
+
   return {
     enable_network_logging,
     enable_ticketing,
@@ -294,6 +300,7 @@ export function getConfig(): RemoteConfig {
     use_flexible_on_directMode,
     use_flexible_on_egressMode,
     use_trygg_overgang_qr_code,
+    disable_travelcard,
   };
 }
 

--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -25,6 +25,7 @@ import React, {useCallback, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {RadioGroupSection, Section} from '@atb/components/sections';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 type Props = {onAfterSave: () => void};
 
@@ -33,6 +34,7 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
   const {t} = useTranslation();
 
   const {fareContracts} = useTicketingState();
+  const {disable_travelcard} = useRemoteConfig();
 
   const {token, remoteTokens, toggleToken} = useMobileTokenContextState();
   const inspectableToken = findInspectable(remoteTokens);
@@ -77,7 +79,11 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
   return (
     <View style={styles.container}>
       <FullScreenHeader
-        title={t(TravelTokenTexts.toggleToken.title)}
+        title={
+          disable_travelcard
+            ? t(TravelTokenTexts.toggleToken.titleWithoutTravelcard)
+            : t(TravelTokenTexts.toggleToken.title)
+        }
         leftButton={{type: 'back'}}
       />
       <ScrollView
@@ -85,25 +91,29 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
         testID="selectTokenScrollView"
       >
         <View style={styles.radioArea}>
-          <RadioBox
-            title={t(TravelTokenTexts.toggleToken.radioBox.tCard.title)}
-            description={t(
-              TravelTokenTexts.toggleToken.radioBox.tCard.description,
-            )}
-            a11yLabel={t(TravelTokenTexts.toggleToken.radioBox.tCard.a11yLabel)}
-            a11yHint={t(TravelTokenTexts.toggleToken.radioBox.tCard.a11yHint)}
-            disabled={false}
-            selected={selectedType === 'travelCard'}
-            icon={<ThemedTokenTravelCard />}
-            type="spacious"
-            onPress={() => {
-              animateNextChange();
-              setSelectedType('travelCard');
-              setSelectedToken(travelCardToken);
-            }}
-            style={styles.leftRadioBox}
-            testID="selectTravelcard"
-          />
+          {!disable_travelcard && (
+            <RadioBox
+              title={t(TravelTokenTexts.toggleToken.radioBox.tCard.title)}
+              description={t(
+                TravelTokenTexts.toggleToken.radioBox.tCard.description,
+              )}
+              a11yLabel={t(
+                TravelTokenTexts.toggleToken.radioBox.tCard.a11yLabel,
+              )}
+              a11yHint={t(TravelTokenTexts.toggleToken.radioBox.tCard.a11yHint)}
+              disabled={false}
+              selected={selectedType === 'travelCard'}
+              icon={<ThemedTokenTravelCard />}
+              type="spacious"
+              onPress={() => {
+                animateNextChange();
+                setSelectedType('travelCard');
+                setSelectedToken(travelCardToken);
+              }}
+              style={styles.leftRadioBox}
+              testID="selectTravelcard"
+            />
+          )}
           <RadioBox
             title={t(TravelTokenTexts.toggleToken.radioBox.phone.title)}
             description={t(

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -40,6 +40,7 @@ import {Root_TipsAndInformation} from '@atb/stacks-hierarchy/Root_TipsAndInforma
 import {Root_FareContractDetailsScreen} from '@atb/stacks-hierarchy/Root_FareContractDetailsScreen';
 import {Root_CarnetDetailsScreen} from '@atb/stacks-hierarchy/Root_CarnetDetailsScreen';
 import {Root_ReceiptScreen} from '@atb/stacks-hierarchy/Root_ReceiptScreen';
+import {Root_MobileTokenWithoutTravelcardOnboardingStack} from '@atb/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding';
 import {AnalyticsContextProvider} from '@atb/analytics';
 
 type ResultState = PartialState<NavigationState> & {
@@ -321,6 +322,10 @@ export const RootStack = () => {
                   <Stack.Screen
                     name="Root_MobileTokenOnboardingStack"
                     component={Root_MobileTokenOnboardingStack}
+                  />
+                  <Stack.Screen
+                    name="Root_MobileTokenWithoutTravelcardOnboardingStack"
+                    component={Root_MobileTokenWithoutTravelcardOnboardingStack}
                   />
                   <Stack.Screen
                     name="Root_AddEditFavoritePlaceScreen"

--- a/src/stacks-hierarchy/Root_MobileTokenOnboarding/utils.ts
+++ b/src/stacks-hierarchy/Root_MobileTokenOnboarding/utils.ts
@@ -1,25 +1,42 @@
 import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
 import {useAuthState} from '@atb/auth';
 import {useAppState} from '@atb/AppContext';
-import {shouldOnboardMobileToken} from '@atb/api/utils';
+import {
+  shouldOnboardMobileToken,
+  shouldOnboardMobileTokenWithoutTravelcard,
+} from '@atb/api/utils';
 import {useNavigation} from '@react-navigation/native';
 import {useEffect} from 'react';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 export const useGoToMobileTokenOnboardingWhenNecessary = () => {
   const hasEnabledMobileToken = useHasEnabledMobileToken();
   const {authenticationType} = useAuthState();
-  const {mobileTokenOnboarded} = useAppState();
+  const {mobileTokenOnboarded, mobileTokenWithoutTravelcardOnboarded} =
+    useAppState();
+  const {disable_travelcard} = useRemoteConfig();
+  const navigation = useNavigation<RootNavigationProps>();
+
   const shouldOnboard = shouldOnboardMobileToken(
     hasEnabledMobileToken,
     authenticationType,
     mobileTokenOnboarded,
+    disable_travelcard,
   );
-  const navigation = useNavigation<RootNavigationProps>();
+  const shouldOnboardWithoutTravelcard =
+    shouldOnboardMobileTokenWithoutTravelcard(
+      hasEnabledMobileToken,
+      authenticationType,
+      mobileTokenWithoutTravelcardOnboarded,
+      disable_travelcard,
+    );
 
   useEffect(() => {
-    if (shouldOnboard) {
+    if (shouldOnboardWithoutTravelcard) {
+      navigation.navigate('Root_MobileTokenWithoutTravelcardOnboardingStack');
+    } else if (shouldOnboard) {
       navigation.navigate('Root_MobileTokenOnboardingStack');
     }
-  }, [shouldOnboard]);
+  }, [shouldOnboardWithoutTravelcard, shouldOnboard]);
 };

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen.tsx
@@ -1,0 +1,37 @@
+import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';
+import {findInspectable} from '@atb/mobile-token/utils';
+import {InspectableTokenInfo} from './components/InspectableTokenInfo';
+import {NoTokenInfo} from './components/NoTokenInfo';
+import React from 'react';
+import {MobileTokenWithoutTravelcardOnboardingScreenProps} from './navigation_types';
+
+type Props =
+  MobileTokenWithoutTravelcardOnboardingScreenProps<'MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen'>;
+export const MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen = ({
+  navigation,
+}: Props) => {
+  const {remoteTokens, isLoading, isError} = useMobileTokenContextState();
+
+  const close = () => navigation.pop();
+
+  if (isLoading) return <NoTokenInfo close={close} />;
+  if (isError) return <NoTokenInfo close={close} />;
+
+  const inspectableToken = findInspectable(remoteTokens);
+
+  if (!inspectableToken) {
+    return <NoTokenInfo close={close} />;
+  }
+
+  return (
+    <InspectableTokenInfo
+      inspectableToken={inspectableToken}
+      close={close}
+      navigateToSelectToken={() =>
+        navigation.navigate(
+          'MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen',
+        )
+      }
+    />
+  );
+};

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen.tsx
@@ -1,0 +1,116 @@
+import TravelPlanning from '@atb/assets/svg/color/images/light/TravelPlanning';
+import {Button} from '@atb/components/button';
+import {ThemeText} from '@atb/components/text';
+import {StyleSheet} from '@atb/theme';
+import {StaticColorByType} from '@atb/theme/colors';
+import {useTranslation} from '@atb/translations';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import React from 'react';
+import {ScrollView, View} from 'react-native';
+import {MobileTokenWithoutTravelcardOnboardingScreenProps} from './navigation_types';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import MobileTokenWithoutTravelcardOnboardingTexts from '@atb/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding';
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export type FlexibilityInfoProps =
+  MobileTokenWithoutTravelcardOnboardingScreenProps<'MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen'>;
+
+export const MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen = ({
+  navigation,
+}: FlexibilityInfoProps): JSX.Element => {
+  const styles = useThemeStyles();
+  const {t} = useTranslation();
+  const focusRef = useFocusOnLoad();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.containerContent}>
+        <View style={styles.viewContent}>
+          <View style={styles.mainView}>
+            <View accessible={true} ref={focusRef}>
+              <ThemeText
+                type="heading--jumbo"
+                style={styles.header}
+                color={themeColor}
+              >
+                {t(
+                  MobileTokenWithoutTravelcardOnboardingTexts.flexibilityInfo
+                    .heading,
+                )}
+              </ThemeText>
+            </View>
+            <View style={styles.illustration}>
+              <TravelPlanning />
+            </View>
+            <ThemeText color={themeColor} style={styles.description}>
+              {t(
+                MobileTokenWithoutTravelcardOnboardingTexts.flexibilityInfo
+                  .description,
+              )}
+            </ThemeText>
+          </View>
+          <View style={styles.buttons}>
+            <Button
+              interactiveColor="interactive_0"
+              onPress={() => {
+                navigation.navigate(
+                  'MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen',
+                );
+              }}
+              text={t(MobileTokenWithoutTravelcardOnboardingTexts.next)}
+              testID="nextButton"
+              accessibilityHint={t(
+                MobileTokenWithoutTravelcardOnboardingTexts.a11yNextPageHint,
+              )}
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    backgroundColor: theme.static.background[themeColor].background,
+    flex: 1,
+    paddingHorizontal: theme.spacings.xLarge,
+  },
+  containerContent: {
+    paddingTop: theme.spacings.xLarge,
+    flexGrow: 1,
+  },
+  viewContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  mainView: {
+    justifyContent: 'space-between',
+  },
+  header: {
+    marginBottom: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  illustration: {
+    minHeight: 180,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: theme.spacings.xLarge,
+  },
+  cardOrPhoneIllustration: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+  },
+  cardOrPhoneText: {
+    marginTop: theme.spacings.xLarge,
+    marginHorizontal: theme.spacings.xLarge,
+  },
+  description: {
+    marginTop: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  buttons: {
+    marginVertical: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen.tsx
@@ -1,0 +1,120 @@
+import {MobileTokenWithoutTravelcardOnboardingScreenProps} from './navigation_types';
+import {useTranslation} from '@atb/translations';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {ScrollView, View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import {ThemedTokenPhone} from '@atb/theme/ThemedAssets';
+import {Button} from '@atb/components/button';
+import React from 'react';
+import {StyleSheet} from '@atb/theme';
+import {StaticColorByType} from '@atb/theme/colors';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import MobileTokenWithoutTravelcardOnboardingTexts from '@atb/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding';
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export type OptionsInfoScreenProps =
+  MobileTokenWithoutTravelcardOnboardingScreenProps<'MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen'>;
+
+export const MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen = ({
+  navigation,
+}: OptionsInfoScreenProps): JSX.Element => {
+  const styles = useThemeStyles();
+  const {t} = useTranslation();
+  const focusRef = useFocusOnLoad();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.containerContent}>
+        <View style={styles.viewContent}>
+          <View style={styles.mainView}>
+            <View accessible={true} ref={focusRef}>
+              <ThemeText
+                type="heading--jumbo"
+                style={styles.header}
+                color={themeColor}
+              >
+                {t(
+                  MobileTokenWithoutTravelcardOnboardingTexts.optionsInfo
+                    .heading,
+                )}
+              </ThemeText>
+            </View>
+
+            <View style={styles.illustration}>
+              <View style={styles.cardOrPhoneIllustration}>
+                <ThemedTokenPhone />
+              </View>
+            </View>
+            <ThemeText color={themeColor} style={styles.description}>
+              {t(
+                MobileTokenWithoutTravelcardOnboardingTexts.optionsInfo
+                  .description,
+              )}
+            </ThemeText>
+          </View>
+
+          <View style={styles.buttons}>
+            <Button
+              interactiveColor="interactive_0"
+              onPress={() => {
+                navigation.navigate(
+                  'MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen',
+                );
+              }}
+              text={t(MobileTokenWithoutTravelcardOnboardingTexts.next)}
+              testID="nextButton"
+              accessibilityHint={t(
+                MobileTokenWithoutTravelcardOnboardingTexts.a11yNextPageHint,
+              )}
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    backgroundColor: theme.static.background[themeColor].background,
+    flex: 1,
+    paddingHorizontal: theme.spacings.xLarge,
+  },
+  containerContent: {
+    paddingTop: theme.spacings.xLarge,
+    flexGrow: 1,
+  },
+  viewContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  mainView: {
+    justifyContent: 'space-between',
+  },
+  header: {
+    marginBottom: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  illustration: {
+    minHeight: 180,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: theme.spacings.xLarge,
+  },
+  cardOrPhoneIllustration: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+  },
+  cardOrPhoneText: {
+    marginTop: theme.spacings.xLarge,
+    marginHorizontal: theme.spacings.xLarge,
+  },
+  description: {
+    marginTop: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  buttons: {
+    marginVertical: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen.tsx
@@ -1,0 +1,11 @@
+import {SelectTravelTokenScreenComponent} from '@atb/select-travel-token-screen';
+import {MobileTokenWithoutTravelcardOnboardingScreenProps} from '@atb/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/navigation_types';
+
+type Props =
+  MobileTokenWithoutTravelcardOnboardingScreenProps<'MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen'>;
+
+export const MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen = ({
+  navigation,
+}: Props) => (
+  <SelectTravelTokenScreenComponent onAfterSave={navigation.goBack} />
+);

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen.tsx
@@ -1,0 +1,119 @@
+import {MobileTokenWithoutTravelcardOnboardingScreenProps} from './navigation_types';
+import {useTranslation} from '@atb/translations';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {ScrollView, View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import MobileTokenWithoutTravelcardOnboardingTexts from '@atb/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding';
+import {Cloud} from '@atb/assets/svg/color/illustrations';
+import {Button} from '@atb/components/button';
+import {StyleSheet} from '@atb/theme';
+import React from 'react';
+import {StaticColorByType} from '@atb/theme/colors';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export type TicketSafetyInfoProps =
+  MobileTokenWithoutTravelcardOnboardingScreenProps<'MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen'>;
+
+export const MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen = ({
+  navigation,
+}: TicketSafetyInfoProps): JSX.Element => {
+  const styles = useThemeStyles();
+  const {t} = useTranslation();
+  const focusRef = useFocusOnLoad();
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.containerContent}>
+        <View style={styles.viewContent}>
+          <View style={styles.mainView}>
+            <View accessible={true} ref={focusRef}>
+              <ThemeText
+                type="heading--jumbo"
+                style={styles.header}
+                color={themeColor}
+              >
+                {t(
+                  MobileTokenWithoutTravelcardOnboardingTexts.ticketSafetyInfo
+                    .heading,
+                )}
+              </ThemeText>
+            </View>
+            <View style={styles.illustration}>
+              <Cloud />
+            </View>
+            <ThemeText
+              color={themeColor}
+              style={styles.description}
+              isMarkdown={true}
+            >
+              {t(
+                MobileTokenWithoutTravelcardOnboardingTexts.ticketSafetyInfo
+                  .description,
+              )}
+            </ThemeText>
+          </View>
+          <View style={styles.buttons}>
+            <Button
+              interactiveColor="interactive_0"
+              onPress={() => {
+                navigation.navigate(
+                  'MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen',
+                );
+              }}
+              text={t(MobileTokenWithoutTravelcardOnboardingTexts.next)}
+              testID="nextButton"
+              accessibilityHint={t(
+                MobileTokenWithoutTravelcardOnboardingTexts.a11yNextPageHint,
+              )}
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    backgroundColor: theme.static.background[themeColor].background,
+    flex: 1,
+    paddingHorizontal: theme.spacings.xLarge,
+  },
+  containerContent: {
+    paddingTop: theme.spacings.xLarge,
+    flexGrow: 1,
+  },
+  viewContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  mainView: {
+    justifyContent: 'space-between',
+  },
+  header: {
+    marginBottom: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  illustration: {
+    minHeight: 180,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: theme.spacings.xLarge,
+  },
+  cardOrPhoneIllustration: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+  },
+  cardOrPhoneText: {
+    marginTop: theme.spacings.xLarge,
+    marginHorizontal: theme.spacings.xLarge,
+  },
+  description: {
+    marginTop: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  buttons: {
+    marginVertical: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/Root_MobileTokenWithoutTravelcardOnboardingStack.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/Root_MobileTokenWithoutTravelcardOnboardingStack.tsx
@@ -1,0 +1,75 @@
+import {StyleSheet} from '@atb/theme';
+import {
+  createMaterialTopTabNavigator,
+  MaterialTopTabBarProps,
+} from '@react-navigation/material-top-tabs';
+import React from 'react';
+import {PageIndicator} from '@atb/components/page-indicator';
+import {StaticColorByType} from '@atb/theme/colors';
+import {MobileTokenWithoutTravelcardOnboardingParams} from './navigation_types';
+import {MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen} from './MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen';
+import {MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen} from './MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen';
+import {MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen} from './MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen';
+import {MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen} from './MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen';
+import {MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen} from './MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen';
+import {View} from 'react-native';
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+const Tab =
+  createMaterialTopTabNavigator<MobileTokenWithoutTravelcardOnboardingParams>();
+
+export const Root_MobileTokenWithoutTravelcardOnboardingStack = () => {
+  const styles = useStyles();
+  return (
+    <View style={styles.container}>
+      <Tab.Navigator
+        tabBar={(props: MaterialTopTabBarProps) => {
+          return <PageIndicator {...props} />;
+        }}
+        tabBarPosition="bottom"
+        initialRouteName="MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen"
+        backBehavior="order"
+      >
+        <Tab.Screen
+          name="MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen"
+          key="MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen"
+          component={
+            MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen
+          }
+        />
+        <Tab.Screen
+          name="MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen"
+          key="MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen"
+          component={MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen}
+        />
+        <Tab.Screen
+          name="MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen"
+          key="MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen"
+          component={
+            MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen
+          }
+        />
+        <Tab.Screen
+          name="MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen"
+          key="MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen"
+          component={MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen}
+        />
+        <Tab.Screen
+          name="MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen"
+          key="MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen"
+          component={
+            MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen
+          }
+        />
+      </Tab.Navigator>
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.static.background[themeColor].background,
+  },
+}));

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/components/InspectableTokenInfo.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/components/InspectableTokenInfo.tsx
@@ -1,0 +1,118 @@
+import {useTranslation} from '@atb/translations';
+import {ScrollView, View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import {Button} from '@atb/components/button';
+import {StyleSheet} from '@atb/theme';
+import React from 'react';
+import {StaticColorByType} from '@atb/theme/colors';
+import {TravelTokenBox} from '@atb/travel-token-box';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import MobileTokenWithoutTravelcardOnboardingTexts from '@atb/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding';
+import {RemoteToken} from '@atb/mobile-token/types';
+import {useAppState} from '@atb/AppContext';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export function InspectableTokenInfo({
+  close,
+  navigateToSelectToken,
+}: {
+  inspectableToken: RemoteToken;
+  close: () => void;
+  navigateToSelectToken: () => void;
+}): JSX.Element {
+  const styles = useThemeStyles();
+  const {t} = useTranslation();
+  const focusRef = useFocusOnLoad();
+  const {completeMobileTokenWithoutTravelcardOnboarding} = useAppState();
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.containerContent}>
+        <View style={styles.viewContent}>
+          <View style={styles.mainView}>
+            <View accessible={true} ref={focusRef}>
+              <ThemeText
+                type="heading--jumbo"
+                style={styles.header}
+                color={themeColor}
+                isMarkdown={true}
+              >
+                {t(MobileTokenWithoutTravelcardOnboardingTexts.phone.heading)}
+              </ThemeText>
+            </View>
+            <View style={styles.illustration}>
+              <TravelTokenBox showIfThisDevice={true} alwaysShowErrors={true} />
+            </View>
+            <ThemeText
+              style={styles.description}
+              color={themeColor}
+              isMarkdown={true}
+            >
+              {t(MobileTokenWithoutTravelcardOnboardingTexts.phone.description)}
+            </ThemeText>
+          </View>
+          <View style={styles.buttons}>
+            <Button
+              onPress={() => {
+                completeMobileTokenWithoutTravelcardOnboarding();
+                close();
+              }}
+              text={t(MobileTokenWithoutTravelcardOnboardingTexts.ok)}
+              testID="nextButton"
+              style={styles.okButton}
+            />
+            <Button
+              interactiveColor="interactive_1"
+              mode="secondary"
+              onPress={() => {
+                completeMobileTokenWithoutTravelcardOnboarding();
+                navigateToSelectToken();
+              }}
+              text={t(MobileTokenWithoutTravelcardOnboardingTexts.phone.button)}
+              testID="switchButton"
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    paddingHorizontal: theme.spacings.xLarge,
+    flex: 1,
+    backgroundColor: theme.static.background[themeColor].background,
+  },
+  containerContent: {
+    paddingTop: theme.spacings.xLarge,
+    flexGrow: 1,
+  },
+  viewContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  mainView: {
+    justifyContent: 'space-between',
+  },
+  header: {
+    marginBottom: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  illustration: {
+    minHeight: 180,
+    justifyContent: 'center',
+    marginVertical: theme.spacings.xLarge,
+  },
+  description: {
+    marginTop: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  buttons: {
+    marginVertical: theme.spacings.medium,
+  },
+  okButton: {
+    marginBottom: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/components/NoTokenInfo.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/components/NoTokenInfo.tsx
@@ -1,0 +1,90 @@
+import {useTranslation} from '@atb/translations';
+import {ScrollView, View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import MobileTokenWithoutTravelcardOnboarding from '@atb/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding';
+import {Button} from '@atb/components/button';
+import {StyleSheet} from '@atb/theme';
+import React from 'react';
+import {StaticColorByType} from '@atb/theme/colors';
+import {CrashSmall} from '@atb/assets/svg/color/images';
+import {useAppState} from '@atb/AppContext';
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export function NoTokenInfo({close}: {close: () => void}): JSX.Element {
+  const styles = useThemeStyles();
+  const {t} = useTranslation();
+  const {completeMobileTokenWithoutTravelcardOnboarding} = useAppState();
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.containerContent}
+    >
+      <View style={styles.viewContent}>
+        <View style={styles.mainView}>
+          <ThemeText
+            type="heading--jumbo"
+            style={styles.header}
+            color={themeColor}
+          >
+            {t(MobileTokenWithoutTravelcardOnboarding.error.heading)}
+          </ThemeText>
+          <View style={styles.illustration}>
+            <CrashSmall width="185px" height="185px" />
+          </View>
+          <ThemeText style={styles.description} color={themeColor}>
+            {t(MobileTokenWithoutTravelcardOnboarding.error.description)}
+          </ThemeText>
+        </View>
+        <View style={styles.buttons}>
+          <Button
+            interactiveColor="interactive_0"
+            onPress={() => {
+              completeMobileTokenWithoutTravelcardOnboarding();
+              close();
+            }}
+            text={t(MobileTokenWithoutTravelcardOnboarding.next)}
+            testID="nextButton"
+          />
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    paddingHorizontal: theme.spacings.xLarge,
+    backgroundColor: theme.static.background[themeColor].background,
+    flex: 1,
+  },
+  containerContent: {
+    paddingTop: theme.spacings.xLarge,
+    flexGrow: 1,
+  },
+  viewContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  mainView: {
+    justifyContent: 'space-between',
+  },
+  header: {
+    marginBottom: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  illustration: {
+    minHeight: 180,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: theme.spacings.xLarge,
+  },
+  description: {
+    marginTop: theme.spacings.xLarge,
+    textAlign: 'center',
+  },
+  buttons: {
+    marginVertical: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/index.tsx
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/index.tsx
@@ -1,0 +1,1 @@
+export {Root_MobileTokenWithoutTravelcardOnboardingStack} from './Root_MobileTokenWithoutTravelcardOnboardingStack';

--- a/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/navigation_types.ts
+++ b/src/stacks-hierarchy/Root_MobileTokenWithoutTravelcardOnboarding/navigation_types.ts
@@ -1,0 +1,21 @@
+import {RootStackScreenProps} from '@atb/stacks-hierarchy';
+import {CompositeScreenProps} from '@react-navigation/native';
+import {StackScreenProps} from '@react-navigation/stack';
+
+export type MobileTokenWithoutTravelcardOnboardingParams = {
+  MobileTokenWithoutTravelcardOnboarding_FlexibilityInfoScreen: undefined;
+  MobileTokenWithoutTravelcardOnboarding_OptionsInfoScreen: undefined;
+  MobileTokenWithoutTravelcardOnboarding_TicketSafetyInfoScreen: undefined;
+  MobileTokenWithoutTravelcardOnboarding_CurrentTokenScreen: undefined;
+  MobileTokenWithoutTravelcardOnboarding_SelectTravelTokenScreen: undefined;
+};
+
+export type MobileTokenWithoutTravelcardOnboardingRootProps =
+  RootStackScreenProps<'Root_MobileTokenWithoutTravelcardOnboardingStack'>;
+
+export type MobileTokenWithoutTravelcardOnboardingScreenProps<
+  T extends keyof MobileTokenWithoutTravelcardOnboardingParams,
+> = CompositeScreenProps<
+  StackScreenProps<MobileTokenWithoutTravelcardOnboardingParams, T>,
+  MobileTokenWithoutTravelcardOnboardingRootProps
+>;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -54,7 +54,10 @@ function setClipboard(content: string) {
 export const Profile_DebugInfoScreen = () => {
   const style = useProfileHomeStyle();
   const appDispatch = useAppDispatch();
-  const {restartMobileTokenOnboarding} = useAppState();
+  const {
+    restartMobileTokenOnboarding,
+    restartMobileTokenWithoutTravelcardOnboarding,
+  } = useAppState();
   const {resetDismissedGlobalMessages} = useGlobalMessagesState();
   const {user, abtCustomerId} = useAuthState();
   const [idToken, setIdToken] = useState<
@@ -171,6 +174,10 @@ export const Profile_DebugInfoScreen = () => {
           <LinkSectionItem
             text="Set mobile token onboarded to false"
             onPress={restartMobileTokenOnboarding}
+          />
+          <LinkSectionItem
+            text="Set mobile token without travelcard onboarded to false"
+            onPress={restartMobileTokenWithoutTravelcardOnboarding}
           />
           <LinkSectionItem
             text="Reset dismissed Global messages"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -51,7 +51,6 @@ import {
   Section,
   ToggleSectionItem,
 } from '@atb/components/sections';
-import {BetaTag} from '@atb/components/beta-tag';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -97,7 +96,8 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const termsInfoUrl = getTextForLanguage(termsInfo, language);
   const inspectionInfoUrl = getTextForLanguage(inspectionInfo, language);
 
-  const {enable_departures_v2_as_default} = useRemoteConfig();
+  const {enable_departures_v2_as_default, disable_travelcard} =
+    useRemoteConfig();
   const setDeparturesV2Enabled = (value: boolean) => {
     if (enable_departures_v2_as_default) {
       updateMetadata({
@@ -300,10 +300,17 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
 
           {authenticationType === 'phone' && hasEnabledMobileToken && (
             <LinkSectionItem
-              text={t(
-                ProfileTexts.sections.settings.linkSectionItems.travelToken
-                  .label,
-              )}
+              text={
+                disable_travelcard
+                  ? t(
+                      ProfileTexts.sections.settings.linkSectionItems
+                        .travelToken.labelWithoutTravelcard,
+                    )
+                  : t(
+                      ProfileTexts.sections.settings.linkSectionItems
+                        .travelToken.label,
+                    )
+              }
               label={'new'}
               onPress={() => navigation.navigate('Profile_TravelTokenScreen')}
               testID="travelTokenButton"
@@ -341,7 +348,14 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               <ThemeText type="heading__component">
                 {t(ProfileTexts.sections.newFeatures.heading)}
               </ThemeText>
-              <BetaTag style={style.betaTag} />
+              <View style={style.betaLabel}>
+                <ThemeText
+                  color="background_accent_3"
+                  style={style.betaLabelText}
+                >
+                  BETA
+                </ThemeText>
+              </View>
             </View>
           </GenericSectionItem>
           <ToggleSectionItem
@@ -591,9 +605,6 @@ const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     backgroundColor: theme.static.background.background_1.background,
     flex: 1,
   },
-  betaTag: {
-    marginHorizontal: theme.spacings.small,
-  },
   customerNumberHeading: {
     marginBottom: theme.spacings.xSmall,
   },
@@ -607,5 +618,16 @@ const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   betaSectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  betaLabel: {
+    backgroundColor: theme.static.background.background_accent_3.background,
+    marginHorizontal: theme.spacings.small,
+    paddingHorizontal: theme.spacings.small,
+    paddingVertical: theme.spacings.small,
+    borderRadius: theme.border.radius.regular,
+  },
+  betaLabelText: {
+    fontSize: 8,
+    lineHeight: 9,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/ChangeTokenAction.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/ChangeTokenAction.tsx
@@ -18,6 +18,7 @@ import {
   LinkSectionItem,
   Section,
 } from '@atb/components/sections';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 const ChangeTokenAction = ({
   onChange,
@@ -31,6 +32,7 @@ const ChangeTokenAction = ({
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {isError, isLoading} = useMobileTokenContextState();
+  const {disable_travelcard} = useRemoteConfig();
   const now = new Date();
   const nextMonthStartDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
   const countRenewalDate = formatToShortDateWithYear(
@@ -78,7 +80,11 @@ const ChangeTokenAction = ({
     <Section style={styles.changeTokenButton}>
       <LinkSectionItem
         type="spacious"
-        text={t(TravelTokenTexts.travelToken.changeTokenButton)}
+        text={
+          disable_travelcard
+            ? t(TravelTokenTexts.travelToken.changeTokenWithoutTravelcardButton)
+            : t(TravelTokenTexts.travelToken.changeTokenButton)
+        }
         disabled={isError || isLoading || toggleLimit === 0}
         onPress={onChange}
         testID="switchTokenButton"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/FaqSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/FaqSection.tsx
@@ -7,10 +7,12 @@ import {
   HeaderSectionItem,
   Section,
 } from '@atb/components/sections';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 const FaqSection = ({toggleMaxLimit}: {toggleMaxLimit?: number}) => {
   const {t} = useTranslation();
   const styles = useStyles();
+  const {disable_travelcard} = useRemoteConfig();
 
   return (
     <Section style={styles.faqSection}>
@@ -30,8 +32,12 @@ const FaqSection = ({toggleMaxLimit}: {toggleMaxLimit?: number}) => {
           }
         />
       ) : null}
-      {/*eslint-disable-next-line rulesdir/translations-warning*/}
-      {TravelTokenTexts.travelToken.faqs.map(({question, answer}, index) => (
+      {(disable_travelcard
+        ? // eslint-disable-next-line rulesdir/translations-warning
+          TravelTokenTexts.travelToken.faqsWithoutTravelcard
+        : // eslint-disable-next-line rulesdir/translations-warning
+          TravelTokenTexts.travelToken.faqs
+      ).map(({question, answer}, index) => (
         <ExpandableSectionItem
           key={index}
           text={t(question)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/Profile_TravelTokenScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/Profile_TravelTokenScreen.tsx
@@ -11,6 +11,7 @@ import {ChangeTokenAction} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/Ta
 import {useMobileTokenContextState} from '@atb/mobile-token/MobileTokenContext';
 import {useIsFocused} from '@react-navigation/native';
 import {useTokenToggleDetails} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/use-token-toggle-details';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 type Props = ProfileScreenProps<'Profile_TravelTokenScreen'>;
 
@@ -19,6 +20,7 @@ export const Profile_TravelTokenScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
   const {isError, isLoading} = useMobileTokenContextState();
   const screenHasFocus = useIsFocused();
+  const {disable_travelcard} = useRemoteConfig();
   const shouldFetchTokenDetails = screenHasFocus && !isError && !isLoading;
   const {shouldShowLoader, toggleLimit, maxToggleLimit} = useTokenToggleDetails(
     shouldFetchTokenDetails,
@@ -26,7 +28,11 @@ export const Profile_TravelTokenScreen = ({navigation}: Props) => {
   return (
     <View style={styles.container}>
       <FullScreenHeader
-        title={t(TravelTokenTexts.travelToken.header.title)}
+        title={
+          disable_travelcard
+            ? t(TravelTokenTexts.travelToken.header.titleWithoutTravelcard)
+            : t(TravelTokenTexts.travelToken.header.title)
+        }
         leftButton={{type: 'back'}}
       />
       <ScrollView style={styles.scrollView}>

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -70,6 +70,7 @@ export type RootStackParamList = {
   };
   Root_PurchasePaymentWithVippsScreen: PaymentParams;
   Root_MobileTokenOnboardingStack: undefined;
+  Root_MobileTokenWithoutTravelcardOnboardingStack: undefined;
   Root_FareContractDetailsScreen: FareContractDetailsRouteParams;
   Root_CarnetDetailsScreen: CarnetDetailsRouteParams;
   Root_ReceiptScreen: ReceiptScreenRouteParams;

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -56,6 +56,10 @@ const ProfileTexts = {
             'Bruk billett på t:kort / mobil',
             'Use ticket on t:card / phone',
           ),
+          labelWithoutTravelcard: _(
+            'Bruk billett på mobil',
+            'Use ticket on phone',
+          ),
         },
         appearance: {
           label: _('Utseende', 'Appearance'),

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -161,7 +161,7 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
     },
     error: {
       description: _(
-        'Vi får ikke knyttet et reisekort eller en mobil til bruker din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nTa kontakt med FRAM kundeservice om problemet vedvarer.',
+        'Vi får ikke knyttet et reisekort eller en mobil til brukeren din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nTa kontakt med FRAM kundeservice om problemet vedvarer.',
         "We can't connect a travel card or phone to your user. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact FRAM customer service.",
       ),
     },

--- a/src/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenWithoutTravelcardOnboarding.ts
@@ -1,0 +1,116 @@
+import {translation as _} from '../../commons';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
+
+const MobileTokenWithoutTravelcardOnboardingTexts = {
+  flexibilityInfo: {
+    heading: _('En mer fleksibel reisehverdag', 'More flexibility'),
+    description: _(
+      'Du velger selv hvordan du vil bruke og vise frem billetten din.',
+      'Choose how to use and show your ticket.',
+    ),
+  },
+  optionsInfo: {
+    heading: _('Bruk din mobil', 'Use your phone'),
+    description: _(
+      'Du kan bruke billetten din på en mobil med appen AtB installert — men kun en av gangen.',
+      'You can use your ticket on a phone with the app AtB installed — but only one at a time.',
+    ),
+  },
+  ticketSafetyInfo: {
+    heading: _('Vi tar vare på billetten din', 'Your ticket is safe with us'),
+    description: _(
+      'Billetten din er trygt lagret på **Min profil**. Dermed vil du aldri miste den — selv om du mister eller bytter mobil.',
+      "Your ticket is safely stored on **My profile**. That way you won't lose your ticket even if you lose or switch phones.",
+    ),
+  },
+  phone: {
+    heading: _('Du bruker nå **mobil**', 'You are now using your **phone**'),
+    description: _(
+      'Du kan alltid bytte til en annen mobil ved logge inn og gå til **Min profil**.',
+      'You can always switch to a different phone by logging in, and heading over to **My profile**.',
+    ),
+    button: _('Bytt til en annen mobil', 'Switch to a different phone'),
+    reminder: _(
+      'Ta med deg mobilen når du er ute og reiser.',
+      'Remember to bring your phone while travelling. ',
+    ),
+  },
+  error: {
+    heading: _(
+      'Det ser ut som det tar litt tid...',
+      "It looks like it's taking a while...",
+    ),
+    description: _(
+      'Vi får ikke knyttet en mobil til brukeren din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nTa kontakt med AtB kundesenter.',
+      "We can't connect a phone to your user. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact AtB service center.",
+    ),
+  },
+  next: _('Neste', 'Next'),
+  ok: _('OK', 'OK'),
+  or: _('eller', 'or'),
+  a11yNextPageHint: _(
+    'Aktiver for å gå til neste side',
+    'Activate to go to next page',
+  ),
+};
+export default orgSpecificTranslations(
+  MobileTokenWithoutTravelcardOnboardingTexts,
+  {
+    nfk: {
+      optionsInfo: {
+        heading: _('Bruk din mobil', 'Use your phone'),
+        description: _(
+          'Du kan bruke billetten din på en mobil med Reis-appen installert — men kun en av gangen.',
+          'You can use your ticket on a phone with the Reis app installed — but only one at a time.',
+        ),
+      },
+      ticketSafetyInfo: {
+        description: _(
+          'Billetten din er trygt lagret på **Min profil**. Dermed vil du aldri miste den — selv om du mister eller bytter mobil.',
+          "Your ticket is safely stored on **My profile**. That way you won't lose your ticket even if you lose or switch phones.",
+        ),
+      },
+      phone: {
+        description: _(
+          'Du kan alltid bytte til en annen mobil ved logge inn og gå til **Min profil**.',
+          'You can always switch to a different phone by logging in, and heading over to **My profile**.',
+        ),
+        button: _('Bytt til en annen mobil', 'Switch to a different phone'),
+      },
+      error: {
+        description: _(
+          'Vi får ikke knyttet en mobil til profilen din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nTa kontakt med Reis Nordland kundeservice om problemet vedvarer.',
+          "We can't connect a phone to your profile. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact Reis Nordland customer service.",
+        ),
+      },
+    },
+    fram: {
+      optionsInfo: {
+        heading: _('Bruk din mobil', 'Use your phone'),
+        description: _(
+          'Du kan bruke billetten din på en mobil med FRAM-appen installert — men kun en av gangen.',
+          'You can use your ticket on a phone with the FRAM app installed — but only one at a time.',
+        ),
+      },
+      ticketSafetyInfo: {
+        description: _(
+          'Billetten din er trygt lagret på **Min bruker**. Dermed vil du aldri miste den — selv om du mister eller bytter mobil.',
+          "Your ticket is safely stored on **My user**. That way you won't lose your ticket even if you lose or switch phones.",
+        ),
+      },
+      phone: {
+        description: _(
+          'Du kan alltid bytte til en annen mobil ved logge inn og gå til **Min bruker**.',
+          'You can always switch to a different phone by logging in, and heading over to **My user**.',
+        ),
+        button: _('Bytt til en annen mobil', 'Switch to a different phone'),
+      },
+      error: {
+        description: _(
+          'Vi får ikke knyttet en mobil til brukeren din. Sjekk at du har tilgang på nett.\n\nHvis du ikke er på nett, vil appen prøve på nytt når du er koblet på igjen.\n\nTa kontakt med FRAM kundeservice om problemet vedvarer.',
+          "We can't connect a phone to your user. Check your internet connection.\n\nIf you are not online, the app will try again when you are connected.\n\nIf the problem persists, please contact FRAM customer service.",
+        ),
+      },
+    },
+  },
+);

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -8,10 +8,15 @@ const SelectTravelTokenTexts = {
         'Bruk billett på t:kort / mobil',
         'Use ticket on t:card / phone',
       ),
+      titleWithoutTravelcard: _('Bruk billett mobil', 'Use ticket on phone'),
     },
     changeTokenButton: _(
       'Bytt mellom t:kort / mobil',
       'Switch between t:card / phone',
+    ),
+    changeTokenWithoutTravelcardButton: _(
+      'Bytt mellom mobiler',
+      'Switch between phones',
     ),
     toggleCountLimitInfo: (
       remainingToggleCount: number,
@@ -86,6 +91,58 @@ const SelectTravelTokenTexts = {
         ),
       },
     ],
+    faqsWithoutTravelcard: [
+      {
+        question: _(
+          'Hva skjer om jeg mister mobilen?',
+          'What happens if I lose my phone?',
+        ),
+        answer: _(
+          'Billetten din ligger trygt lagret i Min profil. Velg å bruke billetten på en annen mobil.',
+          'Your ticket is safely stored in My profile. Switch to use the ticket on another mobile phone.',
+        ),
+      },
+      {
+        question: _(
+          'Kan jeg bruke billetten på flere mobiler samtidig?',
+          'Can I use the ticket on several mobile phones at the same time?',
+        ),
+        answer: _(
+          'Nei, du kan kun bruke en av gangen, og billetten kan ikke deles med andre reisende.',
+          'No, you can only use one at a time and the ticket cannot be shared with other travellers.',
+        ),
+      },
+      {
+        question: _(
+          'Kan jeg reise uten mobil?',
+          'Can I travel without my phone?',
+        ),
+        answer: _(
+          'Du må alltid ha med deg det mobilen du har valgt å bruke billetten på.',
+          'You must always travel with the mobile phone you have chosen to use the ticket on.',
+        ),
+      },
+      {
+        question: _(
+          `Jeg får ikke logget inn i appen AtB med e-post`,
+          `I can not log into the AtB app with e-mail`,
+        ),
+        answer: _(
+          `Det er ikke mulig å logge inn i appen med e-post per i dag. Du kan fortsette å bruke t:kort eller opprette en ny brukerprofil med mobilnummer som innlogging. Merk at billettene ikke vil bli overført til din nye brukerprofil. Du kan kontakte kundesenteret vedrørende refusjon dersom du likevel vil lage en ny brukerprofil i appen.`,
+          `It is not possible to log into the app with e-mail as of today. You can continue to use your t:card or create a new user profile with a mobile number as login. Note that the tickets will not be transferred to your new user profile. You can contact customer service regarding a refund if you still want to create a new user profile in the app.`,
+        ),
+      },
+      {
+        question: _(
+          `Har du flere spørsmål om billettkjøp?`,
+          `Do you have any other questions about ticket purchases?`,
+        ),
+        answer: _(
+          `Se flere måter å kontakte oss på atb.no/kontakt`,
+          `See how to contact us at atb.no/en/contact`,
+        ),
+      },
+    ],
     tokenToggleFaq: {
       question: _(
         `Hvor mange ganger kan jeg bytte?`,
@@ -100,6 +157,7 @@ const SelectTravelTokenTexts = {
   },
   toggleToken: {
     title: _('Bytt mellom t:kort / mobil', 'Switch between t:card / phone'),
+    titleWithoutTravelcard: _('Bytt mellom mobiler', 'Switch between phones'),
     radioBox: {
       tCard: {
         title: _('t:kort', 't:card'),
@@ -292,6 +350,58 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
           answer: _(
             `Det er ikke mulig å logge inn i appen med e-post per i dag. Du kan fortsette å bruke reisekort eller opprette en ny brukerprofil med mobilnummer som innlogging. Merk at billettene ikke vil bli overført til din nye bruker. Du kan kontakte kundesenteret vedrørende refusjon dersom du likevel vil lage en ny bruker i appen.`,
             `It is not possible to log into the app with e-mail as of today. You can continue to use your travel card or create a new user profile with a mobile number as login. Note that the tickets will not be transferred to your new user. You can contact customer service regarding a refund if you still want to create a new user in the app.`,
+          ),
+        },
+        {
+          question: _(
+            `Har du flere spørsmål om billettkjøp?`,
+            `Do you have any other questions about ticket purchases?`,
+          ),
+          answer: _(
+            `Se flere måter å kontakte oss på frammr.no/kontakt-oss`,
+            `See how to contact us at en.frammr.no/contact-us`,
+          ),
+        },
+      ],
+      faqsWithoutTravelcard: [
+        {
+          question: _(
+            'Hva skjer om jeg mister mobilen?',
+            'What happens if I lose my phone?',
+          ),
+          answer: _(
+            'Billetten din ligger trygt lagret i Min profil. Velg å bruke billetten på en annen mobil.',
+            'Your ticket is safely stored in My profile. Switch to use the ticket on another mobile phone.',
+          ),
+        },
+        {
+          question: _(
+            'Kan jeg bruke billetten på flere mobiler samtidig?',
+            'Can I use the ticket on several mobile phones at the same time?',
+          ),
+          answer: _(
+            'Nei, du kan kun bruke en av gangen, og billetten kan ikke deles med andre reisende.',
+            'No, you can only use one at a time and the ticket cannot be shared with other travellers.',
+          ),
+        },
+        {
+          question: _(
+            'Kan jeg reise uten mobil?',
+            'Can I travel without my phone?',
+          ),
+          answer: _(
+            'Du må alltid ha med deg det mobilen du har valgt å bruke billetten på.',
+            'You must always travel with the mobile phone you have chosen to use the ticket on.',
+          ),
+        },
+        {
+          question: _(
+            `Jeg får ikke logget inn i appen AtB med e-post`,
+            `I can not log into the AtB app with e-mail`,
+          ),
+          answer: _(
+            `Det er ikke mulig å logge inn i appen med e-post per i dag. Du kan opprette en ny brukerprofil med mobilnummer som innlogging. Merk at billettene ikke vil bli overført til din nye bruker. Du kan kontakte kundesenteret vedrørende refusjon dersom du likevel vil lage en ny bruker i appen.`,
+            `It is not possible to log into the app with e-mail as of today. You can create a new user profile with a mobile number as login. Note that the tickets will not be transferred to your new user. You can contact customer service regarding a refund if you still want to create a new user in the app.`,
           ),
         },
         {

--- a/src/translations/screens/subscreens/TravelToken.ts
+++ b/src/translations/screens/subscreens/TravelToken.ts
@@ -396,8 +396,8 @@ export default orgSpecificTranslations(SelectTravelTokenTexts, {
         },
         {
           question: _(
-            `Jeg får ikke logget inn i appen AtB med e-post`,
-            `I can not log into the AtB app with e-mail`,
+            `Jeg får ikke logget inn i FRAM-appen med e-post`,
+            `I can not log into the FRAM app with e-mail`,
           ),
           answer: _(
             `Det er ikke mulig å logge inn i appen med e-post per i dag. Du kan opprette en ny brukerprofil med mobilnummer som innlogging. Merk at billettene ikke vil bli overført til din nye bruker. Du kan kontakte kundesenteret vedrørende refusjon dersom du likevel vil lage en ny bruker i appen.`,


### PR DESCRIPTION
FRAM is not going to use or refer to travelcards in the app before we are all over on a new system and not using both an old and a new one. We are still going to utilize mobile token and the advantages that come with that, but we don't want to show information about travelcards. As a result of that I duplicated the existing onboarding for mobile token and called it MobileTokenWithoutTravelcardOnboarding, and removed references to travelcard. The SelectTravelTokenScreenComponent I did not duplicate, but I did a check for `disable_travelcard` (which is a new variable in remote config to control this) to see if the choice for travelcard should be hidden, in addition to using the correct translations.

Screenshots:

![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/678e644c-610a-4604-93fa-58465fe54567)
![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/290cbdec-526e-47bb-8741-dfaeacb86877)
![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/9edf72d3-cc8a-42f3-b28f-a200856d892e)
![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/0b966ca5-aebc-4f85-921d-2b74e3fd86a4)
![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/c9fd26b7-9032-4ebb-8fc0-292e8b453857)
![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/df60fc32-24df-43de-9af6-b34720af1ab9)
![image](https://github.com/AtB-AS/mittatb-app/assets/14045515/a09946dd-a8e7-476d-8dec-e1585ff9dc50)


The illustrations are updated with correct colors in https://github.com/AtB-AS/design-system/pull/131
