### PR TITLE
Fix: wrong calculations in ticket summary of ticket assistant

### DIFF
--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/TicketSummary.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/TicketSummary.tsx
@@ -45,12 +45,15 @@ export const TicketSummary = () => {
       : ''
   }`;
 
-  const inputDur = inputParams.duration || 0;
-  const compDur = Math.min(ticket.duration, inputDur);
+  const inputDuration = inputParams.duration || 0;
+  const effectiveDuration = Math.min(ticket.duration, inputDuration);
 
-  const numTickets = Math.ceil(compDur * (frequency / daysInWeek));
+  const numberOfTravels = Math.ceil(
+    effectiveDuration * (frequency / daysInWeek),
+  );
+
   const savings =
-    numTickets * recommendedTicketSummary.singleTicketPrice - ticket.price;
+    numberOfTravels * recommendedTicketSummary.singleTicketPrice - ticket.price;
 
   const ticketPriceString = `${formatDecimalNumber(
     ticket.price,
@@ -59,7 +62,7 @@ export const TicketSummary = () => {
   )} kr`;
 
   const perTripPrice = ticket.duration
-    ? ticket.price / numTickets
+    ? ticket.price / numberOfTravels
     : ticket.price;
 
   const perTripPriceString = `${formatDecimalNumber(
@@ -81,7 +84,7 @@ export const TicketSummary = () => {
               language,
               2,
             ),
-            alternative: numTickets.toString(),
+            alternative: numberOfTravels.toString(),
           })
       : TicketAssistantTexts.summary.singleTicketNotice,
   );

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/utils.ts
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/utils.ts
@@ -1,38 +1,11 @@
 import {TicketResponseData} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/types';
-import {daysInWeek} from 'date-fns';
-
-export function calculateSavings(
-  ticketPrice: number,
-  alternativePrice: number,
-): number {
-  return alternativePrice - ticketPrice;
-}
-
-export function calculateSingleTickets(
-  duration: number,
-  frequency: number,
-): number {
-  return Math.ceil((duration / daysInWeek) * frequency);
-}
 
 export function getLongestDurationTicket(
   tickets: TicketResponseData[],
 ): TicketResponseData {
-  let longestDuration = 0;
-  let longestDurationIndex = 0;
-  tickets.forEach((ticket, index) => {
-    if (ticket.duration > longestDuration) {
-      longestDuration = ticket.duration;
-      longestDurationIndex = index;
-    }
+  return tickets.reduce((longestTicket, currentTicket) => {
+    return currentTicket.duration > longestTicket.duration
+      ? currentTicket
+      : longestTicket;
   });
-  return tickets[longestDurationIndex];
-}
-
-export function perTripSavings(
-  savings: number,
-  duration: number,
-  frequency: number,
-): number {
-  return savings / ((duration / daysInWeek) * frequency);
 }


### PR DESCRIPTION
### Regarding @tormoseng's [comment](https://github.com/AtB-AS/kundevendt/issues/3917#issuecomment-1545248721):
Some code cleanup and now calculates savings like this:

1. If the recommended ticket's duration is longer than the user's specified duration, we should compare it with the specified period.
2. If the recommended ticket lasts shorter than the specified period, we should compare it with the ticket's duration.