### PR TITLE
fix: add missing preAssigned-type in route param

### DIFF
--- a/src/stacks-hierarchy/Root_TicketAssistantStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/navigation-types.ts
@@ -3,11 +3,13 @@ import {CompositeScreenProps, NavigationProp} from '@react-navigation/native';
 import {StackScreenProps} from '@react-navigation/stack';
 import {TariffZoneWithMetadata} from '@atb/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen';
 import {FareProductTypeConfig} from '@atb/configuration';
+import {PreassignedFareProduct} from '@atb/reference-data/types';
 
 export type TicketAssistant_ZonePickerScreenParams = {
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
   fareProductTypeConfig: FareProductTypeConfig;
+  preassignedFareProduct: PreassignedFareProduct;
 };
 
 export type TicketAssistantStackProps =


### PR DESCRIPTION
Fixes tsc error from https://github.com/AtB-AS/mittatb-app/pull/3520

Error in question: https://github.com/AtB-AS/mittatb-app/actions/runs/4977991584/jobs/8907818405#step:8:5