### PR TITLE
fix: use default traveller in ticket assistant

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.125.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.125.0

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -38,7 +38,12 @@ export const TicketAssistant_CategoryPickerScreen = ({
   const {updateInputParams} = useTicketAssistantState();
 
   const {selectableTravellers} = offerDefaults;
-  const [currentlyOpen, setCurrentlyOpen] = useState<number>(0);
+  const defaultTravellerIndex = selectableTravellers.findIndex(
+    (a) => a.count > 0,
+  );
+  const [currentlyOpen, setCurrentlyOpen] = useState<number>(
+    defaultTravellerIndex,
+  );
 
   function updateCategory(traveller: Traveller) {
     updateInputParams({traveller: traveller});

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -42,7 +42,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
     (a) => a.count > 0,
   );
   const [currentlyOpen, setCurrentlyOpen] = useState<number>(
-    defaultTravellerIndex,
+    defaultTravellerIndex > 0 ? defaultTravellerIndex : 0,
   );
 
   function updateCategory(traveller: Traveller) {


### PR DESCRIPTION
Now opens the default traveller in category selection in the ticket assistant.

With student as default: 
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/94e1841c-f818-48b2-9270-faa454947198">

Adresses: https://github.com/AtB-AS/kundevendt/issues/3917#issuecomment-1549178307