### PR TITLE
fix: Show departures more than 3 hours in the future

### DIFF
--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -246,30 +246,33 @@ export function useDeparturesData(
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
   const {favoriteDepartures} = useFavorites();
   const [queryStartTime, setQueryStartTime] = useState<string | undefined>();
+  const [timeRange, setTimeRange] = useState<number | undefined>();
   const activeFavoriteDepartures = showOnlyFavorites
     ? favoriteDepartures
     : undefined;
   const limitPerLine = getLimitOfDeparturesPerLineByMode(mode);
-  const timeRange = getTimeRangeByMode(mode, queryStartTime);
+
   const timeout = useTimeoutRequest();
 
   const loadDepartures = useCallback(() => {
     const updatedQueryStartTime = startTime ?? new Date().toISOString();
     setQueryStartTime(updatedQueryStartTime);
+    const updatedTimeRange = getTimeRangeByMode(mode, updatedQueryStartTime);
+    setTimeRange(updatedTimeRange);
     dispatch({
       type: 'LOAD_INITIAL_DEPARTURES',
       quayIds,
       startTime: updatedQueryStartTime,
       limitPerLine,
       limitPerQuay,
-      timeRange,
+      timeRange: updatedTimeRange,
       favoriteDepartures: activeFavoriteDepartures,
       timeout,
     });
   }, [JSON.stringify(quayIds), startTime, activeFavoriteDepartures, mode]);
 
   const loadRealTimeData = useCallback(() => {
-    if (!queryStartTime) return;
+    if (!queryStartTime || !timeRange) return;
     dispatch({
       type: 'LOAD_REALTIME_DATA',
       quayIds,


### PR DESCRIPTION
Fix issue with departures only showing up to 3 hours in advance. Also fix unexpected behaviour where we get more or less departures by switching between days.

Close https://github.com/AtB-AS/kundevendt/issues/3983