### PR TITLE
fix: Savings calculation for duration under 1 week

### DIFF
--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/TicketSummary.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/TicketSummary.tsx
@@ -48,9 +48,8 @@ export const TicketSummary = () => {
   const inputDuration = inputParams.duration || 0;
   const effectiveDuration = Math.min(ticket.duration, inputDuration);
 
-  const numberOfTravels = Math.ceil(
-    effectiveDuration * (frequency / daysInWeek),
-  );
+  const days = Math.min(inputDuration, daysInWeek);
+  const numberOfTravels = Math.ceil(effectiveDuration * (frequency / days));
 
   const savings =
     numberOfTravels * recommendedTicketSummary.singleTicketPrice - ticket.price;


### PR DESCRIPTION
When the input duration is shorter than one week, we need to calculate the amount of travels differently.

Addresses: https://github.com/AtB-AS/kundevendt/issues/3917#issuecomment-1549521933