### PR TITLE
feat: handle live position error states

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
 export {CancelToken, isCancel, client} from './client';
 export {autocomplete, reverse} from './geocoder';
 export {search} from './trips';
+export type {SubscriptionState} from './use-subscription';

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -47,6 +47,7 @@ export type RemoteConfig = {
   use_flexible_on_directMode: boolean;
   use_flexible_on_egressMode: boolean;
   use_trygg_overgang_qr_code: boolean;
+  live_vehicle_stale_threshold: number;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -99,6 +100,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   use_flexible_on_directMode: true,
   use_flexible_on_egressMode: true,
   use_trygg_overgang_qr_code: false,
+  live_vehicle_stale_threshold: 15,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -248,6 +250,10 @@ export function getConfig(): RemoteConfig {
     values['use_trygg_overgang_qr_code']?.asBoolean() ??
     defaultRemoteConfig.use_trygg_overgang_qr_code;
 
+  const live_vehicle_stale_threshold =
+    values['live_vehicle_stale_threshold']?.asNumber() ??
+    defaultRemoteConfig.live_vehicle_stale_threshold;
+
   return {
     enable_network_logging,
     enable_ticketing,
@@ -294,6 +300,7 @@ export function getConfig(): RemoteConfig {
     use_flexible_on_directMode,
     use_flexible_on_egressMode,
     use_trygg_overgang_qr_code,
+    live_vehicle_stale_threshold,
   };
 }
 

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -301,7 +301,7 @@ const LiveVehicleIcon = ({
   return <ThemeIcon svg={svg} fill={fillColor} />;
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
+const useStyles = StyleSheet.createThemeHook(() => ({
   mapView: {
     flex: 1,
   },

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -222,11 +222,12 @@ const LiveVehicle = ({
           theme.interactive.interactive_destructive.default.background,
         circleStrokeWidth: 2,
       };
-    if (isStale)
+    if (isLoading || isStale)
       return {
         circleColor: theme.interactive.interactive_1.disabled.background,
-        circleRadius: 22,
-        circleStrokeWidth: 0,
+        circleRadius: 20,
+        circleStrokeColor: theme.interactive.interactive_1.default.background,
+        circleStrokeWidth: 2,
       };
     return {
       circleColor,
@@ -281,8 +282,6 @@ const LiveVehicleIcon = ({
   const fillColor = useTransportationColor(mode, subMode, 'text');
   const svg = getTransportModeSvg(mode, subMode);
 
-  if (isLoading) return <ActivityIndicator color={fillColor} />;
-
   if (isError)
     return (
       <ThemeIcon
@@ -290,12 +289,10 @@ const LiveVehicleIcon = ({
         fill={theme.interactive.interactive_destructive.default.background}
       />
     );
-
-  if (isStale)
+  if (isLoading || isStale)
     return (
-      <ThemeIcon
-        svg={svg}
-        fill={theme.interactive.interactive_1.disabled.text}
+      <ActivityIndicator
+        color={theme.interactive.interactive_1.disabled.text}
       />
     );
 

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -17,6 +17,7 @@ import {
 } from '@atb/components/map';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useGeolocationState} from '@atb/GeolocationContext';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {useTheme, StyleSheet} from '@atb/theme';
 import {MapTexts, useTranslation} from '@atb/translations';
 import {Coordinates} from '@atb/utils/coordinates';
@@ -49,7 +50,6 @@ type Props = TravelDetailsMapScreenParams & {
 const FOLLOW_ZOOM_LEVEL = 14.5;
 const FOLLOW_MIN_ZOOM_LEVEL = 8;
 const FOLLOW_ANIMATION_DURATION = 500;
-const STALE_DATA_THRESHOLD_IN_SECONDS = 10;
 
 export const TravelDetailsMapScreenComponent = ({
   legs,
@@ -189,6 +189,7 @@ const LiveVehicle = ({
   zoomLevel,
 }: VehicleIconProps) => {
   const {theme} = useTheme();
+  const {live_vehicle_stale_threshold} = useRemoteConfig();
 
   const isError =
     subscriptionState === 'CLOSING' || subscriptionState === 'CLOSED';
@@ -202,7 +203,7 @@ const LiveVehicle = ({
         vehicle.lastUpdated,
         new Date(),
       );
-      setIsStale(STALE_DATA_THRESHOLD_IN_SECONDS < secondsSinceUpdate);
+      setIsStale(live_vehicle_stale_threshold < secondsSinceUpdate);
     },
     1000,
     [vehicle.lastUpdated],


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/3687

- Shows a gray icon when the data is more than 10 seconds old (not sure if this is the correct threshold, it does appear quite often when the update frequency also is 10s)
- Shows a red icon when the websocket is disconnected.
- Shows a spinner when the websocket is connecting. (This doesn't actually appear in practice for me, since the websocket seems to connect very quickly, but I guess it could happen on slower phones)

<div>
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/8778136e-c81c-481b-949e-e6e8fd9d2419">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/e4546232-2f80-4d23-83d0-05bbff0342f5">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/c2f82cc5-52a7-4cb8-94c9-062e05a4dc03">
</div>

https://github.com/AtB-AS/mittatb-app/assets/1774972/8859697f-38df-41a6-8624-34bf531a35eb