### PR TITLE
fix: Correct filter outline color for NFK app

### DIFF
--- a/src/anonymous-purchase-consequences-screen/components/Actions.tsx
+++ b/src/anonymous-purchase-consequences-screen/components/Actions.tsx
@@ -27,7 +27,7 @@ export const Actions = ({
         testID="loginButton"
       />
       <Button
-        interactiveColor="interactive_1"
+        interactiveColor="interactive_0"
         mode="secondary"
         onPress={secondaryAction}
         text={t(AnonymousPurchasesTexts.consequences.button.accept.label)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -330,7 +330,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 <Button
                   text={t(TripSearchTexts.filterButton.text)}
                   accessibilityHint={t(TripSearchTexts.filterButton.a11yHint)}
-                  interactiveColor="interactive_1"
+                  interactiveColor="interactive_0"
                   mode="secondary"
                   type="inline"
                   compact={true}


### PR DESCRIPTION
There were inconsistencies in the use of interactive colors on the filter menu, whereas one used interactive_0 and the other _1. This makes it consistent. It doesn't look like it affects AtB in any way.


Fixes https://github.com/AtB-AS/kundevendt/issues/3930

<img width="704" alt="Screenshot 2023-05-22 at 07 58 10" src="https://github.com/AtB-AS/mittatb-app/assets/606374/90b7dbcc-1ffb-43d5-a9ae-1f0cdfc8ca01">

<img width="704" alt="Screenshot 2023-05-22 at 07 59 32" src="https://github.com/AtB-AS/mittatb-app/assets/606374/c033f251-8bde-4ccf-89c8-474c4d467438">

