### PR TITLE
fix: screen reader issues ticket assistant

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
@@ -43,6 +43,10 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
     (config) => config.configuration.requiresLogin,
   );
 
+  const title = t(TicketingTexts.ticketAssistantTile.title);
+  const description = t(TicketingTexts.ticketAssistantTile.description);
+  const accessibilityLabel = [title, 'Beta', description].join('. ');
+
   return (
     <View
       style={[
@@ -55,6 +59,8 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
         <TouchableOpacity
           onPress={() => onPress(requiresLoginConfig)}
           accessible={true}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint={t(TicketingTexts.ticketAssistantTile.a11yHint)}
           style={styles.spreadContent}
         >
           <View style={styles.contentContainer}>
@@ -67,7 +73,11 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
                   testID={testID}
                 />
               </View>
-              <ThemeText type="label__uppercase" color={'secondary'}>
+              <ThemeText
+                type="label__uppercase"
+                accessible={false}
+                color={'secondary'}
+              >
                 {t(TicketingTexts.ticketAssistantTile.label)}
               </ThemeText>
             </View>
@@ -78,7 +88,7 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
                 color={themeColor}
                 testID={testID + 'Title'}
               >
-                {t(TicketingTexts.ticketAssistantTile.title)}
+                {title}
               </ThemeText>
               <BetaTag style={styles.betaTag} />
             </View>

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/Root_TicketAssistantStack.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/Root_TicketAssistantStack.tsx
@@ -46,6 +46,7 @@ export const Root_TicketAssistantStack = ({navigation}: Props) => {
               }
         }
         rightButton={{type: 'chat'}}
+        setFocusOnLoad={false}
       />
       <Tab.Navigator
         tabBar={(props: MaterialTopTabBarProps) => {

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -72,7 +72,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
         style={styles.scrollView}
         contentContainerStyle={styles.contentContainer}
       >
-        <View ref={focusRef}>
+        <View ref={focusRef} accessible={true}>
           <ThemeText
             type={'heading--big'}
             style={styles.header}
@@ -136,6 +136,12 @@ export const TicketAssistant_CategoryPickerScreen = ({
         ) : (
           <>
             {selectableTravellers.map((u, index) => {
+              const title = getReferenceDataName(u, language);
+              const description = getTextForLanguage(
+                u.alternativeDescriptions,
+                language,
+              );
+              const accessibilityLabel = [title, description].join('. ');
               return (
                 <View key={index} style={styles.a11yCategoryCards}>
                   <TouchableOpacity
@@ -147,6 +153,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
                       navigation.navigate('TicketAssistant_FrequencyScreen');
                     }}
                     accessible={true}
+                    accessibilityLabel={accessibilityLabel}
                     accessibilityHint={t(
                       TicketAssistantTexts.categoryPicker.a11yChooseButtonHint({
                         value: getReferenceDataName(u, language),
@@ -159,17 +166,14 @@ export const TicketAssistant_CategoryPickerScreen = ({
                         type={'body__primary--bold'}
                         isMarkdown={true}
                       >
-                        {getReferenceDataName(u, language)}
+                        {title}
                       </ThemeText>
                       <ThemeText
                         type={'body__tertiary'}
                         style={styles.expandedContent}
                         isMarkdown={true}
                       >
-                        {getTextForLanguage(
-                          u.alternativeDescriptions,
-                          language,
-                        )}
+                        {description}
                       </ThemeText>
                     </View>
                   </TouchableOpacity>

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -19,6 +19,7 @@ import {useAccessibilityContext} from '@atb/AccessibilityContext';
 import {Traveller} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/types';
 import {useTicketAssistantState} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistantContext';
 import {ExpandableSectionItem, Section} from '@atb/components/sections';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
 type CategoryPickerProps =
   TicketAssistantScreenProps<'TicketAssistant_CategoryPickerScreen'>;
@@ -28,6 +29,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
   const styles = useThemeStyles();
   const {t, language} = useTranslation();
   const a11yContext = useAccessibilityContext();
+  const focusRef = useFocusOnLoad();
 
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
@@ -70,14 +72,17 @@ export const TicketAssistant_CategoryPickerScreen = ({
         style={styles.scrollView}
         contentContainerStyle={styles.contentContainer}
       >
-        <ThemeText
-          type={'heading--big'}
-          style={styles.header}
-          color={themeColor}
-          accessibilityLabel={t(TicketAssistantTexts.categoryPicker.title)}
-        >
-          {t(TicketAssistantTexts.categoryPicker.title)}
-        </ThemeText>
+        <View ref={focusRef}>
+          <ThemeText
+            type={'heading--big'}
+            style={styles.header}
+            accessibilityRole={'header'}
+            color={themeColor}
+            accessibilityLabel={t(TicketAssistantTexts.categoryPicker.title)}
+          >
+            {t(TicketAssistantTexts.categoryPicker.title)}
+          </ThemeText>
+        </View>
 
         {!a11yContext.isScreenReaderEnabled ? (
           <Section style={styles.categoriesContainer}>

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -146,10 +146,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
                 <View key={index} style={styles.a11yCategoryCards}>
                   <TouchableOpacity
                     onPress={() => {
-                      updateCategory({
-                        id: u.userTypeString,
-                        userType: u.userTypeString,
-                      });
+                      setCurrentlyOpen(index);
                       navigation.navigate('TicketAssistant_FrequencyScreen');
                     }}
                     accessible={true}

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_DurationScreen/TicketAssistant_DurationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_DurationScreen/TicketAssistant_DurationScreen.tsx
@@ -10,6 +10,7 @@ import {TicketAssistantScreenProps} from '@atb/stacks-hierarchy/Root_TicketAssis
 import {useTicketAssistantState} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistantContext';
 import {DurationPicker} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_DurationScreen/durationPicker';
 import {daysInWeek} from 'date-fns';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 type DurationProps =
   TicketAssistantScreenProps<'TicketAssistant_DurationScreen'>;
 
@@ -17,6 +18,7 @@ export const TicketAssistant_DurationScreen = ({navigation}: DurationProps) => {
   const {inputParams, updateInputParams} = useTicketAssistantState();
   const styles = useThemeStyles();
   const {t} = useTranslation();
+  const focusRef = useFocusOnLoad();
 
   const [duration, setDuration] = useState(daysInWeek);
 
@@ -41,18 +43,21 @@ export const TicketAssistant_DurationScreen = ({navigation}: DurationProps) => {
       </View>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <View style={styles.mainView}>
-          <ThemeText
-            type={'heading--big'}
-            style={styles.header}
-            color={themeColor}
-            accessibilityLabel={t(
-              TicketAssistantTexts.duration.titleA11yLabel({
-                value: travelFrequency,
-              }),
-            )}
-          >
-            {t(TicketAssistantTexts.duration.title({value: travelFrequency}))}
-          </ThemeText>
+          <View ref={focusRef}>
+            <ThemeText
+              type={'heading--big'}
+              style={styles.header}
+              color={themeColor}
+              accessibilityRole={'header'}
+              accessibilityLabel={t(
+                TicketAssistantTexts.duration.titleA11yLabel({
+                  value: travelFrequency,
+                }),
+              )}
+            >
+              {t(TicketAssistantTexts.duration.title({value: travelFrequency}))}
+            </ThemeText>
+          </View>
           <DurationPicker setDuration={setDuration} duration={duration} />
         </View>
 

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_DurationScreen/TicketAssistant_DurationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_DurationScreen/TicketAssistant_DurationScreen.tsx
@@ -43,7 +43,7 @@ export const TicketAssistant_DurationScreen = ({navigation}: DurationProps) => {
       </View>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <View style={styles.mainView}>
-          <View ref={focusRef}>
+          <View ref={focusRef} accessible={true}>
             <ThemeText
               type={'heading--big'}
               style={styles.header}

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
@@ -97,8 +97,8 @@ export const TicketAssistant_FrequencyScreen = ({
                     key={number}
                     interactiveColor="interactive_2"
                     onPress={() => {
-                      navigation.navigate('TicketAssistant_DurationScreen');
                       setSliderValue(number);
+                      navigation.navigate('TicketAssistant_DurationScreen');
                     }}
                     text={number.toString()}
                     accessibilityHint={t(

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
@@ -11,6 +11,7 @@ import {TicketAssistantScreenProps} from '@atb/stacks-hierarchy/Root_TicketAssis
 import {useTicketAssistantState} from './TicketAssistantContext';
 import {useAccessibilityContext} from '@atb/AccessibilityContext';
 import {SectionSeparator} from '@atb/components/sections';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
 type FrequencyScreenProps =
   TicketAssistantScreenProps<'TicketAssistant_FrequencyScreen'>;
@@ -27,6 +28,7 @@ export const TicketAssistant_FrequencyScreen = ({
     inputParams.frequency ?? DEFAULT_SLIDER_VALUE,
   );
   const a11yContext = useAccessibilityContext();
+  const focusRef = useFocusOnLoad();
 
   const sliderMax = 14;
 
@@ -66,24 +68,27 @@ export const TicketAssistant_FrequencyScreen = ({
       </View>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <View style={styles.mainView}>
-          <ThemeText
-            type={'heading--big'}
-            style={styles.header}
-            color={themeColor}
-            accessibilityLabel={t(
-              TicketAssistantTexts.frequency.titleA11yLabel,
-            )}
-          >
-            {t(TicketAssistantTexts.frequency.title)}
-          </ThemeText>
-          <ThemeText
-            color={themeColor}
-            type={'body__secondary'}
-            style={styles.description}
-            accessibilityLabel={t(TicketAssistantTexts.frequency.description)}
-          >
-            {t(TicketAssistantTexts.frequency.description)}
-          </ThemeText>
+          <View ref={focusRef}>
+            <ThemeText
+              type={'heading--big'}
+              style={styles.header}
+              color={themeColor}
+              accessibilityRole={'header'}
+              accessibilityLabel={t(
+                TicketAssistantTexts.frequency.titleA11yLabel,
+              )}
+            >
+              {t(TicketAssistantTexts.frequency.title)}
+            </ThemeText>
+            <ThemeText
+              color={themeColor}
+              type={'body__secondary'}
+              style={styles.description}
+              accessibilityLabel={t(TicketAssistantTexts.frequency.description)}
+            >
+              {t(TicketAssistantTexts.frequency.description)}
+            </ThemeText>
+          </View>
           {a11yContext.isScreenReaderEnabled ? (
             <View style={styles.screenReaderButtons}>
               {numbers.map((number) => {
@@ -93,6 +98,7 @@ export const TicketAssistant_FrequencyScreen = ({
                     interactiveColor="interactive_2"
                     onPress={() => {
                       navigation.navigate('TicketAssistant_DurationScreen');
+                      setSliderValue(number);
                     }}
                     text={number.toString()}
                     accessibilityHint={t(

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
@@ -68,7 +68,7 @@ export const TicketAssistant_FrequencyScreen = ({
       </View>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <View style={styles.mainView}>
-          <View ref={focusRef}>
+          <View ref={focusRef} accessible={true}>
             <ThemeText
               type={'heading--big'}
               style={styles.header}

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
@@ -13,6 +13,7 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import SvgInfo from '@atb/assets/svg/color/icons/status/Info';
 import {useAuthState} from '@atb/auth';
 import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
 type SummaryProps = TicketAssistantScreenProps<'TicketAssistant_SummaryScreen'>;
 
@@ -22,6 +23,7 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
   const {authenticationType} = useAuthState();
   let {loading, inputParams, recommendedTicketSummary, error} =
     useTicketAssistantState();
+  const focusRef = useFocusOnLoad();
 
   const durationDays = inputParams.duration
     ? inputParams.duration * 24 * 60 * 60 * 1000
@@ -95,7 +97,7 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
       </View>
 
       {error ? (
-        <View>
+        <View ref={focusRef}>
           <ThemeText
             type={'heading--big'}
             color={themeColor}
@@ -112,22 +114,26 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
           </ThemeText>
         </View>
       ) : loading ? (
-        <View style={styles.loadingSpinner}>
+        <View style={styles.loadingSpinner} ref={focusRef}>
           <ActivityIndicator animating={true} size="large" />
         </View>
       ) : (
         <View style={styles.mainView}>
           <View>
-            <ThemeText
-              type={'heading--big'}
-              style={styles.header}
-              color={themeColor}
-              accessibilityLabel={t(
-                TicketAssistantTexts.summary.titleA11yLabel,
-              )}
-            >
-              {t(TicketAssistantTexts.summary.title)}
-            </ThemeText>
+            <View ref={focusRef} accessible={true}>
+              <ThemeText
+                type={'heading--big'}
+                style={styles.header}
+                color={themeColor}
+                accessibilityRole={'header'}
+                accessibilityLabel={t(
+                  TicketAssistantTexts.summary.titleA11yLabel,
+                )}
+              >
+                {t(TicketAssistantTexts.summary.title)}
+              </ThemeText>
+            </View>
+
             <ThemeText
               color={themeColor}
               type={'body__primary'}

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
@@ -97,7 +97,7 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
       </View>
 
       {error ? (
-        <View ref={focusRef}>
+        <View ref={focusRef} accessible={true}>
           <ThemeText
             type={'heading--big'}
             color={themeColor}
@@ -114,7 +114,7 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
           </ThemeText>
         </View>
       ) : loading ? (
-        <View style={styles.loadingSpinner} ref={focusRef}>
+        <View style={styles.loadingSpinner} ref={focusRef} accessible={true}>
           <ActivityIndicator animating={true} size="large" />
         </View>
       ) : (

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {Button} from '@atb/components/button';
 import {StaticColorByType} from '@atb/theme/colors';
 import {TicketAssistantScreenProps} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/navigation-types';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
 export const themeColor: StaticColorByType<'background'> =
   'background_accent_0';
@@ -19,19 +20,25 @@ export const TicketAssistant_WelcomeScreen = ({
   const {t} = useTranslation();
   const styles = useThemeStyles();
   const {width: windowWidth} = useWindowDimensions();
+  const focusRef = useFocusOnLoad();
+
   return (
     <ScrollView
       style={styles.container}
       contentContainerStyle={styles.contentContainer}
     >
-      <ThemeText
-        type="heading--big"
-        style={styles.header}
-        color={themeColor}
-        accessibilityLabel={t(TicketAssistantTexts.welcome.titleA11yLabel)}
-      >
-        {t(TicketAssistantTexts.welcome.title)}
-      </ThemeText>
+      <View ref={focusRef}>
+        <ThemeText
+          type="heading--big"
+          style={styles.header}
+          color={themeColor}
+          accessibilityRole={'header'}
+          accessibilityLabel={t(TicketAssistantTexts.welcome.titleA11yLabel)}
+        >
+          {t(TicketAssistantTexts.welcome.title)}
+        </ThemeText>
+      </View>
+
       <View style={styles.mainView}>
         <TicketSplash width={windowWidth} height={windowWidth / 2} />
 

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
@@ -27,7 +27,7 @@ export const TicketAssistant_WelcomeScreen = ({
       style={styles.container}
       contentContainerStyle={styles.contentContainer}
     >
-      <View ref={focusRef}>
+      <View ref={focusRef} accessible={true}>
         <ThemeText
           type="heading--big"
           style={styles.header}

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_ZonePickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_ZonePickerScreen.tsx
@@ -23,6 +23,7 @@ import {useOfferDefaults} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScree
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {useTicketAssistantState} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistantContext';
 import {useAccessibilityContext} from '@atb/AccessibilityContext';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
 type Props = TicketAssistantScreenProps<'TicketAssistant_ZonePickerScreen'>;
 export const TicketAssistant_ZonePickerScreen = ({
@@ -32,6 +33,7 @@ export const TicketAssistant_ZonePickerScreen = ({
   const styles = useThemeStyles();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
   const a11yContext = useAccessibilityContext();
+  const focusRef = useFocusOnLoad();
 
   const offerDefaults = useOfferDefaults(
     undefined,
@@ -96,16 +98,19 @@ export const TicketAssistant_ZonePickerScreen = ({
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.contentContainer}>
-        <ThemeText
-          type={'heading--big'}
-          style={styles.header}
-          color={themeColor}
-          accessibilityLabel={t(
-            TicketAssistantTexts.zonesSelector.titleA11yLabel,
-          )}
-        >
-          {t(TicketAssistantTexts.zonesSelector.title)}
-        </ThemeText>
+        <View ref={focusRef}>
+          <ThemeText
+            type={'heading--big'}
+            style={styles.header}
+            color={themeColor}
+            accessibilityRole={'header'}
+            accessibilityLabel={t(
+              TicketAssistantTexts.zonesSelector.titleA11yLabel,
+            )}
+          >
+            {t(TicketAssistantTexts.zonesSelector.title)}
+          </ThemeText>
+        </View>
         <View style={styles.zonesSelectorContainer}>
           <View style={styles.zonesSelectorButtonsContainer}>
             <TariffZonesSelectorButtons

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_ZonePickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_ZonePickerScreen.tsx
@@ -98,7 +98,7 @@ export const TicketAssistant_ZonePickerScreen = ({
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.contentContainer}>
-        <View ref={focusRef}>
+        <View ref={focusRef} accessible={true}>
           <ThemeText
             type={'heading--big'}
             style={styles.header}

--- a/src/translations/screens/TicketAssistant.ts
+++ b/src/translations/screens/TicketAssistant.ts
@@ -68,14 +68,14 @@ const TicketAssistantTexts = {
     ),
     a11yFrequencySelectionHint(amount: {value: number}) {
       return _(
-        `Aktiver om du reiser ${amount.value} ganer i uken`,
+        `Aktiver om du reiser ${amount.value} ganger i uken`,
         `Activate if you travel ${amount.value} times a week`,
       );
     },
   },
   zonesSelector: {
-    title: _('Hvor skal du reise?', 'Where are you traveling to?'),
-    titleA11yLabel: _('Hvor skal du reise?', 'Where do you travel?'),
+    title: _('Hvor skal du reise?', 'Where are you traveling?'),
+    titleA11yLabel: _('Hvor skal du reise?', 'Where are you traveling'),
     a11yNextHint: _('Aktiver for å gå videre', 'Activate to go to next page'),
   },
   duration: {

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -188,7 +188,7 @@ const TicketingTexts = {
     ),
     a11yHint: _(
       'Aktiver for å åpne billettveilederen',
-      'Activate to get tips and information about tickets',
+      'Activate to open the ticket assistant',
     ),
     label: _('FORSLAG', 'SUGGESTIONS'),
   },


### PR DESCRIPTION
Fixes several small bugs with screen readers for the ticket assistant:
- Now updates the frequency and category correctly with screen reader enabled
- Focus on headers when navigated to 
- Correct text is read by the screen reader on:
  - The ticket assistant tile in the ticket overview
  - Category on android
- Fix typo in norwegian: ganer -> ganger

Addressing: 
https://github.com/AtB-AS/kundevendt/issues/3917#issuecomment-1556861001
https://github.com/AtB-AS/kundevendt/issues/3917#issuecomment-1557051507