### PR TITLE
chore: upgrade design-system dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@atb-as/config-specs": "^3.1.0",
-    "@atb-as/theme": "^6.5.3",
+    "@atb-as/theme": "^6.6.0",
     "@bugsnag/react-native": "^7.18.2",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-client-sdk": "^1.1.6",
@@ -102,7 +102,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^7.1.0",
+    "@atb-as/generate-assets": "^7.2.0",
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-env": "^7.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,22 +22,22 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.1.0.tgz#1768b49172f8d4411f741d030052db2d4344f721"
-  integrity sha512-VbQjyteQi1v3SFKGimSiB0zkbANP4MCPYkwTjrS6Uw1CTSVthlMpVGCz8p10g6wGsdDoJlIRQcdj06hqSeM6Cw==
+"@atb-as/generate-assets@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.2.0.tgz#c9683a6f450798d711c9b5dc21c781e961fd5079"
+  integrity sha512-ilQWyxzBxII9K+rchfFBm3DMsnBYalyLXjLbf+Kt+rmtROsLJRAclpoI6WteTfhss6LrXuu9H1YpzB4VNjasIA==
   dependencies:
-    "@atb-as/theme" "^6.5.3"
+    "@atb-as/theme" "^6.6.0"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^6.5.3":
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.5.3.tgz#1c038b8f55a8ed1c588a7de4561a825837f5397a"
-  integrity sha512-rFeVNEoEo4QQSOa/VZkLGoYDzzWbkfJM8biI7eI9ni2cs368QHOb+W6WtqXE21caqh1K59+Sg2Ml/XHlCaHv8Q==
+"@atb-as/theme@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.6.0.tgz#f97a6e3543c910114b504f4ea0c32ea89eebbce5"
+  integrity sha512-NssmilsVvvh7TzF0ggXIqnziUZe+X32buN9nfaSSmOqfk3vFNz5pGhZwaNzO+L1ihoS5zj8U8G5Pt27vUMOs5g==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"


### PR DESCRIPTION
Upgrade @atb-as/theme and @atb-as/generate-assets to include the new FRAM theme (https://github.com/AtB-AS/design-system/pull/132)

Closes https://github.com/AtB-AS/kundevendt/issues/3892