### PR TITLE
fix: remove incorrect traveler description texts for FRAM

### DIFF
--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -23,6 +23,12 @@ const SpecificExtensions = orgSpecificTranslations(SpecificExtensionsInternal, {
     singleChild: _('', ''),
     periodAdult: _('Gyldig på nattbuss.', 'Valid for night bus.'),
   },
+  fram: {
+    singleChild: _('', ''),
+    periodChild: _('', ''),
+    periodStudent: _('', ''),
+    periodSenior: _('', ''),
+  },
 });
 
 function specificOverrides(


### PR DESCRIPTION
I've removed the bike and night bus references in the traveler descriptions for FRAM. 

Fixes https://github.com/AtB-AS/kundevendt/issues/4053