### PR TITLE
fix: add close button to error screen in assistant

### DIFF
--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistantContext.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistantContext.tsx
@@ -40,7 +40,7 @@ const TicketAssistantContextProvider: React.FC = ({children}) => {
 
   const [recommendedTicketSummary, setRecommendedTicketSummary] =
     useState<RecommendedTicketSummary>();
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
   const updateInputParams = (newData: InputParams) => {
     setInputParams((prevState) => {
@@ -69,10 +69,12 @@ const TicketAssistantContextProvider: React.FC = ({children}) => {
               fareProductTypeConfigs,
             ),
           );
-          setLoading(false);
         })
         .catch(() => {
           setError(true);
+        })
+        .finally(() => {
+          setLoading(false);
         });
     };
     if (

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
@@ -95,30 +95,29 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
       <View style={styles.backdrop}>
         <DashboardBackground width={'100%'} height={'100%'} />
       </View>
-
-      {error ? (
-        <View ref={focusRef} accessible={true}>
-          <ThemeText
-            type={'heading--big'}
-            color={themeColor}
-            style={styles.header}
-          >
-            {t(TicketAssistantTexts.summary.crashedHeader)}
-          </ThemeText>
-          <ThemeText
-            type={'body__primary'}
-            color={themeColor}
-            style={styles.description}
-          >
-            {t(TicketAssistantTexts.summary.crashedDescription)}
-          </ThemeText>
-        </View>
-      ) : loading ? (
-        <View style={styles.loadingSpinner} ref={focusRef} accessible={true}>
-          <ActivityIndicator animating={true} size="large" />
-        </View>
-      ) : (
-        <View style={styles.mainView}>
+      <View style={styles.mainView}>
+        {error ? (
+          <View ref={focusRef} accessible={true}>
+            <ThemeText
+              type={'heading--big'}
+              color={themeColor}
+              style={styles.header}
+            >
+              {t(TicketAssistantTexts.summary.crashedHeader)}
+            </ThemeText>
+            <ThemeText
+              type={'body__primary'}
+              color={themeColor}
+              style={styles.description}
+            >
+              {t(TicketAssistantTexts.summary.crashedDescription)}
+            </ThemeText>
+          </View>
+        ) : loading ? (
+          <View style={styles.loadingSpinner} ref={focusRef} accessible={true}>
+            <ActivityIndicator animating={true} size="large" />
+          </View>
+        ) : (
           <View>
             <View ref={focusRef} accessible={true}>
               <ThemeText
@@ -170,6 +169,8 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
               </View>
             )}
           </View>
+        )}
+        {(error || !loading) && (
           <Button
             style={styles.feedback}
             interactiveColor="interactive_0"
@@ -179,8 +180,8 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
               navigation.popToTop();
             }}
           />
-        </View>
-      )}
+        )}
+      </View>
     </ScrollView>
   );
 };


### PR DESCRIPTION
Added the close button to the error screen swell after suggestion from @tormoseng.

Also made it so that loading is true by default, incase a user swipes thru very fast. If not it will show the summary screen before starting the load. 