### PR TITLE
fix: remove train notices for FRAM

### DIFF
--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -51,6 +51,7 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
       firstTravelRight.endDateTime.toMillis(),
       fc.state,
     ) === 'valid' &&
+    !!firstTravelRight.tariffZoneRefs?.length &&
     firstTravelRight.tariffZoneRefs?.every(
       (val: string) => val === 'ATB:TariffZone:1',
     ) === true;


### PR DESCRIPTION
Currently the notice "Periodebilletter i sone A kan også brukes på tog i sone A" is shown for FRAM's "fylkesbilletter". This is because these travel rights don't have any zones and the `shouldShowValidOnTrainNotice`-check returns true. I've updated it to handle travel rights where the `tariffZoneRefs` is an empty array. 

Fixes https://github.com/AtB-AS/kundevendt/issues/4077