### PR TITLE
Fix: Remove comma from trip details time

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -36,6 +36,7 @@ export function secondsToDurationShort(
   return getShortHumanizer(seconds * 1000, language, {
     units: ['d', 'h', 'm'],
     round: true,
+    conjunction: " ",
   });
 }
 // Translates seconds to minutes without postfix. Returns minimum 1

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -36,7 +36,7 @@ export function secondsToDurationShort(
   return getShortHumanizer(seconds * 1000, language, {
     units: ['d', 'h', 'm'],
     round: true,
-    conjunction: " ",
+    conjunction: ' ',
   });
 }
 // Translates seconds to minutes without postfix. Returns minimum 1


### PR DESCRIPTION
Force " " as conjunction char instead of default ","

No comma between "3 t" and "31 min":

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/7fb5f92d-85fa-4840-9f5f-fe4cd350aba7" />



