### PR TITLE
feat: refund information link

### DIFF
--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -43,10 +43,10 @@ export type AppTexts = {
 };
 
 type ConfigurableLinks = {
-  ticketingInfo: LanguageAndTextType[];
-  termsInfo: LanguageAndTextType[];
-  inspectionInfo: LanguageAndTextType[];
-  refundInfo: LanguageAndTextType[];
+  ticketingInfo?: LanguageAndTextType[];
+  termsInfo?: LanguageAndTextType[];
+  inspectionInfo?: LanguageAndTextType[];
+  refundInfo?: LanguageAndTextType[];
 };
 
 type ConfigurationContextState = {
@@ -400,9 +400,6 @@ function getConfigurableLinksFromSnapshot(
   const inspectionInfo = mapLanguageAndTextType(urls?.get('inspectionInfo'));
   const termsInfo = mapLanguageAndTextType(urls?.get('termsInfo'));
   const refundInfo = mapLanguageAndTextType(urls?.get('refundInfo'));
-
-  if (!ticketingInfo || !inspectionInfo || !termsInfo || !refundInfo)
-    return undefined;
 
   return {
     ticketingInfo,

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -46,6 +46,7 @@ type ConfigurableLinks = {
   ticketingInfo: LanguageAndTextType[];
   termsInfo: LanguageAndTextType[];
   inspectionInfo: LanguageAndTextType[];
+  refundInfo: LanguageAndTextType[];
 };
 
 type ConfigurationContextState = {
@@ -398,12 +399,15 @@ function getConfigurableLinksFromSnapshot(
   const ticketingInfo = mapLanguageAndTextType(urls?.get('ticketingInfo'));
   const inspectionInfo = mapLanguageAndTextType(urls?.get('inspectionInfo'));
   const termsInfo = mapLanguageAndTextType(urls?.get('termsInfo'));
+  const refundInfo = mapLanguageAndTextType(urls?.get('refundInfo'));
 
-  if (!ticketingInfo || !inspectionInfo || !termsInfo) return undefined;
+  if (!ticketingInfo || !inspectionInfo || !termsInfo || !refundInfo)
+    return undefined;
 
   return {
     ticketingInfo,
     termsInfo,
     inspectionInfo,
+    refundInfo,
   };
 }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -93,9 +93,13 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const inspectionInfo = configurableLinks?.inspectionInfo
     ? configurableLinks?.inspectionInfo
     : undefined;
+  const refundInfo = configurableLinks?.refundInfo
+    ? configurableLinks?.refundInfo
+    : undefined;
   const ticketingInfoUrl = getTextForLanguage(ticketingInfo, language);
   const termsInfoUrl = getTextForLanguage(termsInfo, language);
   const inspectionInfoUrl = getTextForLanguage(inspectionInfo, language);
+  const refundInfoUrl = getTextForLanguage(refundInfo, language);
 
   const {enable_departures_v2_as_default} = useRemoteConfig();
   const setDeparturesV2Enabled = (value: boolean) => {
@@ -522,6 +526,18 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                       : 'Profile_GenericWebsiteInformationScreen',
                   )
                 }
+              />
+            )}
+
+            {refundInfoUrl && (
+              <LinkSectionItem
+                icon={<ThemeIcon svg={ExternalLink} />}
+                text={t(
+                  ProfileTexts.sections.information.linkSectionItems.refund
+                    .label,
+                )}
+                testID="refundInfoButton"
+                onPress={() => Linking.openURL(refundInfoUrl)}
               />
             )}
           </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -449,17 +449,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             <HeaderSectionItem
               text={t(ProfileTexts.sections.information.heading)}
             />
-            {ticketingInfoUrl ? (
-              <LinkSectionItem
-                icon={<ThemeIcon svg={ExternalLink} />}
-                text={t(
-                  ProfileTexts.sections.information.linkSectionItems.ticketing
-                    .label,
-                )}
-                testID="ticketingInfoButton"
-                onPress={() => Linking.openURL(ticketingInfoUrl)}
-              />
-            ) : (
+            {APP_ORG === 'atb' ? (
               <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.ticketing
@@ -467,52 +457,49 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
                 testID="ticketingInfoButton"
                 onPress={() =>
-                  navigation.navigate(
-                    APP_ORG === 'atb'
-                      ? 'Profile_TicketingInformationScreen'
-                      : 'Profile_GenericWebsiteInformationScreen',
-                  )
+                  navigation.navigate('Profile_TicketingInformationScreen')
                 }
-              />
-            )}
-            {termsInfoUrl ? (
-              <LinkSectionItem
-                icon={<ThemeIcon svg={ExternalLink} />}
-                text={t(
-                  ProfileTexts.sections.information.linkSectionItems.terms
-                    .label,
-                )}
-                testID="termsInfoButton"
-                onPress={() => Linking.openURL(termsInfoUrl)}
               />
             ) : (
-              <LinkSectionItem
-                text={t(
-                  ProfileTexts.sections.information.linkSectionItems.terms
-                    .label,
-                )}
-                testID="termsInfoButton"
-                onPress={() =>
-                  navigation.navigate(
-                    APP_ORG === 'atb'
-                      ? 'Profile_TermsInformationScreen'
-                      : 'Profile_GenericWebsiteInformationScreen',
-                  )
-                }
-              />
+              ticketingInfoUrl && (
+                <LinkSectionItem
+                  icon={<ThemeIcon svg={ExternalLink} />}
+                  text={t(
+                    ProfileTexts.sections.information.linkSectionItems.ticketing
+                      .label,
+                  )}
+                  testID="ticketingInfoButton"
+                  onPress={() => Linking.openURL(ticketingInfoUrl)}
+                />
+              )
             )}
 
-            {inspectionInfoUrl ? (
+            {APP_ORG === 'atb' ? (
               <LinkSectionItem
-                icon={<ThemeIcon svg={ExternalLink} />}
                 text={t(
-                  ProfileTexts.sections.information.linkSectionItems.inspection
+                  ProfileTexts.sections.information.linkSectionItems.terms
                     .label,
                 )}
-                testID="inspectionInfoButton"
-                onPress={() => Linking.openURL(inspectionInfoUrl)}
+                testID="termsInfoButton"
+                onPress={() =>
+                  navigation.navigate('Profile_TermsInformationScreen')
+                }
               />
             ) : (
+              termsInfoUrl && (
+                <LinkSectionItem
+                  icon={<ThemeIcon svg={ExternalLink} />}
+                  text={t(
+                    ProfileTexts.sections.information.linkSectionItems.terms
+                      .label,
+                  )}
+                  testID="termsInfoButton"
+                  onPress={() => Linking.openURL(termsInfoUrl)}
+                />
+              )
+            )}
+
+            {APP_ORG === 'atb' ? (
               <LinkSectionItem
                 text={t(
                   ProfileTexts.sections.information.linkSectionItems.inspection
@@ -527,6 +514,18 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   )
                 }
               />
+            ) : (
+              inspectionInfoUrl && (
+                <LinkSectionItem
+                  icon={<ThemeIcon svg={ExternalLink} />}
+                  text={t(
+                    ProfileTexts.sections.information.linkSectionItems
+                      .inspection.label,
+                  )}
+                  testID="inspectionInfoButton"
+                  onPress={() => Linking.openURL(inspectionInfoUrl)}
+                />
+              )
             )}
 
             {refundInfoUrl && (

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -136,6 +136,9 @@ const ProfileTexts = {
         inspection: {
           label: _('Billettkontroll', 'Ticket inspection'),
         },
+        refund: {
+          label: _('Refusjon', 'Refund'),
+        },
       },
     },
   },


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/4004

FRAM would like to have a link to their refund form so I've extended the configurable links with `refundInfo`. 

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/8502f781-ce98-4f49-9ce7-194dc6be6956)
