### PR TITLE
fix: update departures focus logic to not cause infinite loops

### DIFF
--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -302,6 +302,8 @@ export function useDeparturesData(
     const timeSinceLastRealtimeRefresh = differenceInSeconds(
       state.tick,
       state.lastRealtimeRefreshTime,
+      // Rounding up makes ticks 10, 20 and 30s instead of 9, 19, and 29
+      {roundingMethod: 'ceil'},
     );
 
     if (timeSinceLastHardRefresh >= HARD_REFRESH_LIMIT_IN_MINUTES) {

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -23,7 +23,6 @@ import {StopPlacesMode} from '@atb/nearby-stop-places';
 import {getLimitOfDeparturesPerLineByMode, getTimeRangeByMode} from '../utils';
 import {TimeoutRequest, useTimeoutRequest} from '@atb/api/client';
 import {AxiosRequestConfig} from 'axios';
-import {useRefreshOnFocus} from '@atb/utils/use-refresh-on-focus';
 import {flatMap} from '@atb/utils/array';
 import {DepartureRealtimeQuery} from '@atb/api/departures/departure-group';
 
@@ -304,7 +303,7 @@ export function useDeparturesData(
     if (diff >= HARD_REFRESH_LIMIT_IN_MINUTES) {
       loadDepartures();
     }
-  }, [state.tick, state.lastRefreshTime]);
+  }, [state.tick]);
   useInterval(
     loadRealTimeData,
     updateFrequencyInSeconds * 1000,
@@ -312,17 +311,14 @@ export function useDeparturesData(
     !isFocused || mode === 'Favourite',
   );
   useInterval(
-    () => dispatch({type: 'TICK_TICK'}),
+    () => {
+      if (isFocused) dispatch({type: 'TICK_TICK'});
+    },
     tickRateInSeconds * 1000,
-    [],
+    [isFocused],
     !isFocused || mode === 'Favourite',
-  );
-  useRefreshOnFocus(
-    isFocused,
-    state.tick,
-    HARD_REFRESH_LIMIT_IN_MINUTES * 60,
-    loadDepartures,
-    loadRealTimeData,
+    // Trigger immediately on focus only if the view is already initialized
+    !!state.tick,
   );
 
   return {


### PR DESCRIPTION
Seems like this bug was caused by a self triggering useEffect that had a dependency on lastRefreshTime and also updated lastRefreshTime. Since this state handling has been quite brittle in the past as well, I refactored it a bit.

closes https://github.com/AtB-AS/kundevendt/issues/4024