### PR TITLE
fix: app crash on walk result in trip search

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -564,7 +564,7 @@ const tripSummary = (
   }
 
   const nonFootLegs = tripPattern.legs.filter((l) => l.mode !== 'foot') ?? [];
-  const firstLeg = nonFootLegs.length ? nonFootLegs[0] : undefined;
+  const firstLeg = nonFootLegs.length > 0 ? nonFootLegs[0] : undefined;
 
   const resultNumberText = t(
     TripSearchTexts.results.resultItem.journeySummary.resultNumber(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -564,7 +564,7 @@ const tripSummary = (
   }
 
   const nonFootLegs = tripPattern.legs.filter((l) => l.mode !== 'foot') ?? [];
-  const firstLeg = nonFootLegs[0];
+  const firstLeg = nonFootLegs.length ? nonFootLegs[0] : undefined;
 
   const resultNumberText = t(
     TripSearchTexts.results.resultItem.journeySummary.resultNumber(
@@ -586,20 +586,22 @@ const tripSummary = (
         : '')
     : '';
 
-  const realTimeText = isSignificantDifference(firstLeg)
-    ? t(
-        TripSearchTexts.results.resultItem.journeySummary.realtime(
-          firstLeg.fromPlace?.name ?? '',
-          formatToClock(firstLeg.expectedStartTime, language, 'floor'),
-          formatToClock(firstLeg.aimedStartTime, language, 'floor'),
-        ),
-      )
-    : t(
-        TripSearchTexts.results.resultItem.journeySummary.noRealTime(
-          firstLeg.fromPlace?.name ?? '',
-          formatToClock(firstLeg.expectedStartTime, language, 'floor'),
-        ),
-      );
+  const realTimeText = firstLeg
+    ? isSignificantDifference(firstLeg)
+      ? t(
+          TripSearchTexts.results.resultItem.journeySummary.realtime(
+            firstLeg.fromPlace?.name ?? '',
+            formatToClock(firstLeg.expectedStartTime, language, 'floor'),
+            formatToClock(firstLeg.aimedStartTime, language, 'floor'),
+          ),
+        )
+      : t(
+          TripSearchTexts.results.resultItem.journeySummary.noRealTime(
+            firstLeg.fromPlace?.name ?? '',
+            formatToClock(firstLeg.expectedStartTime, language, 'floor'),
+          ),
+        )
+    : undefined;
 
   const numberOfFootLegsText = !nonFootLegs.length
     ? t(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -584,7 +584,7 @@ const tripSummary = (
             ),
           )
         : '')
-    : '';
+    : undefined;
 
   const realTimeText = firstLeg
     ? isSignificantDifference(firstLeg)


### PR DESCRIPTION
Fixing bug that was created in [this PR](https://github.com/AtB-AS/mittatb-app/pull/3588):
> The app is crashing on Android when doing a trip search Steinkjer skole (bus stop place) > Steinkjer stasjon (train stop place) with TypeError: Cannot read property 'realtime' of undefined

