### PR TITLE
fix: populate user count state with only option

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -45,6 +45,12 @@ export function TravellerSelection({
     userCountState.updateSelectable(selectableUserProfiles);
   }, [selectableUserProfiles]);
 
+  useEffect(() => {
+    if (!userCountState.userProfilesWithCount.length && selectionMode === "none") {
+      userCountState.addCount(selectableUserProfiles[0].userTypeString)
+    }
+  }, [selectionMode, selectableUserProfiles])
+
   if (selectionMode === 'none') {
     return <></>;
   }


### PR DESCRIPTION
Potentially closing https://github.com/AtB-AS/kundevendt/issues/4078

Fills user_state_count with the only possible option if `selectionMode` is none.