### PR TITLE
fix: proper support selectionMode none for TravellerSelection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -35,10 +35,22 @@ export function TravellerSelection({
       selectableUserProfiles.some((b) => a.id === b.id),
     );
   useEffect(() => {
-    const filteredSelection = userCountState.userProfilesWithCount.filter((u) =>
-      selectableUserProfiles.find((i) => i.id === u.id),
-    );
-    setTravellerSelection(filteredSelection);
+    if (selectionMode == 'none' && selectableUserProfiles.length > 0) {
+      // If selectionMode is none, we should default to the first item.
+      // selectableUserProfiles should be only have one item, but this
+      // is specified by the fare product and reference data in firestore.
+      setTravellerSelection([
+        {
+          ...selectableUserProfiles[0],
+          count: 1,
+        },
+      ]);
+    } else {
+      const filteredSelection = userCountState.userProfilesWithCount.filter(
+        (u) => selectableUserProfiles.find((i) => i.id === u.id),
+      );
+      setTravellerSelection(filteredSelection);
+    }
   }, [userCountState.userProfilesWithCount, fareProductType, selectionMode]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/4078


Adds support for selecting the first and best traveller when traveller selection mode is set to none. This is the same behaviour as in the webshop. Technically there could be more selectable / supported traveller types specified in Firestore, but I think it is reasonable to select the top most item.

<img width="747" alt="Screenshot 2023-05-31 at 09 20 41" src="https://github.com/AtB-AS/mittatb-app/assets/606374/5773fec0-c8ba-4aa5-9c1f-0f0fe4fdebe6">
