### PR TITLE
fix: Use user profile id in ticket assistant

### DIFF
--- a/src/api/getRecommendedTicket.ts
+++ b/src/api/getRecommendedTicket.ts
@@ -26,10 +26,7 @@ export async function getRecommendedTicket(
         ...ticket,
         productId: ticket.product_id,
         fareProduct: ticket.fare_product,
-        traveller: {
-          id: ticket.traveller.id,
-          userType: ticket.traveller.user_type,
-        },
+        userProfileId: ticket.user_profile_id,
       })),
       zones: apiResponse.zones,
       singleTicketPrice: apiResponse.single_ticket_price,
@@ -47,7 +44,7 @@ type RecommendedTicketResponseRaw = {
       duration: number;
       quantity: number;
       price: number;
-      traveller: {id: string; user_type: string};
+      user_profile_id: string;
     },
   ];
   zones: string[];

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/handle-recommended-ticket-response.ts
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/handle-recommended-ticket-response.ts
@@ -27,7 +27,7 @@ export function handleRecommendedTicketResponse(
   );
 
   const travellerWithCount: UserProfileWithCount | undefined = {
-    ...(getUserProfile(userProfiles, response.tickets?.[0]?.traveller?.id) ??
+    ...(getUserProfile(userProfiles, response.tickets?.[0]?.userProfileId) ??
       {}),
     count: 1,
   };
@@ -61,9 +61,7 @@ function getUserProfile(
   profiles: UserProfile[],
   profileId: string,
 ): UserProfile {
-  const profile = profiles.find(
-    (profile) => profile.userTypeString === profileId,
-  );
+  const profile = profiles.find((profile) => profile.id === profileId);
   if (profile) {
     return profile;
   }

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/types.ts
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/types.ts
@@ -20,7 +20,7 @@ export type TicketResponseData = {
   duration: number;
   quantity: number;
   price: number;
-  traveller: {id: string; userType: string};
+  userProfileId: string;
 };
 
 export type RecommendedTicketResponse = {


### PR DESCRIPTION
To show the correct category of the offered ticket, now using user profile id to be able to match correctly. Changes also done to endpoint in Atb-ticket.

Example:
The assistant used to show military 180 day ticket, but this should be adult as 180 military does not exist. 

#### Note: This PR is dependent on https://github.com/AtB-AS/atb-ticket/pull/179