### PR TITLE
Fix: Add info icon to message about boat tickets in assistant

### DIFF
--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
@@ -8,6 +8,8 @@ import {Button} from '@atb/components/button';
 import {StaticColorByType} from '@atb/theme/colors';
 import {TicketAssistantScreenProps} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import SvgInfo from '@atb/assets/svg/color/icons/status/Info';
 
 export const themeColor: StaticColorByType<'background'> =
   'background_accent_0';
@@ -49,13 +51,20 @@ export const TicketAssistant_WelcomeScreen = ({
         >
           {t(TicketAssistantTexts.welcome.description)}
         </ThemeText>
-        <ThemeText
-          style={styles.boatInfo}
-          type={'body__secondary'}
-          color={themeColor}
-        >
-          {t(TicketAssistantTexts.welcome.boatInfo)}
-        </ThemeText>
+
+        <View style={styles.notice}>
+          <ThemeIcon style={styles.icon} svg={SvgInfo} />
+          <ThemeText
+            style={styles.noticeText}
+            type={'body__tertiary'}
+            color={themeColor}
+            accessibilityLabel={t(
+              TicketAssistantTexts.summary.a11yDurationNoticeLabel,
+            )}
+          >
+            {t(TicketAssistantTexts.welcome.boatInfo)}
+          </ThemeText>
+        </View>
       </View>
       <View style={styles.bottomView}>
         <Button
@@ -91,6 +100,19 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     marginTop: theme.spacings.medium,
     marginHorizontal: theme.spacings.xLarge,
     textAlign: 'center',
+  },
+  notice: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: theme.spacings.large,
+    marginHorizontal: theme.spacings.xLarge,
+  },
+  noticeText: {
+    textAlign: 'left',
+    flexShrink: 1,
+  },
+  icon: {
+    marginRight: theme.spacings.small,
   },
   boatInfo: {
     marginTop: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen.tsx
@@ -52,15 +52,16 @@ export const TicketAssistant_WelcomeScreen = ({
           {t(TicketAssistantTexts.welcome.description)}
         </ThemeText>
 
-        <View style={styles.notice}>
+        <View
+          style={styles.notice}
+          accessible={true}
+          accessibilityLabel={t(TicketAssistantTexts.welcome.boatInfo)}
+        >
           <ThemeIcon style={styles.icon} svg={SvgInfo} />
           <ThemeText
             style={styles.noticeText}
             type={'body__tertiary'}
             color={themeColor}
-            accessibilityLabel={t(
-              TicketAssistantTexts.summary.a11yDurationNoticeLabel,
-            )}
           >
             {t(TicketAssistantTexts.welcome.boatInfo)}
           </ThemeText>


### PR DESCRIPTION
https://github.com/AtB-AS/kundevendt/issues/3917#issuecomment-1568409637

> @adriawh Legg på en info (i) for informasjonen rundt at fungerer ikke på båtbillett.

Before:
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/08b63588-575d-46fe-998a-2f6c5cf9fd54"/>

After:
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/887b8f84-3101-42af-b5e5-40afadc3b49c"/>
