### PR TITLE
feat: new onboarding screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^7.2.0",
+    "@atb-as/generate-assets": "^7.3.0",
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-env": "^7.20.2",

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -51,6 +51,7 @@ export type RemoteConfig = {
   use_flexible_on_egressMode: boolean;
   use_trygg_overgang_qr_code: boolean;
   live_vehicle_stale_threshold: number;
+  enable_extended_onboarding: boolean;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -107,6 +108,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   use_flexible_on_egressMode: true,
   use_trygg_overgang_qr_code: false,
   live_vehicle_stale_threshold: 15,
+  enable_extended_onboarding: false,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -272,6 +274,10 @@ export function getConfig(): RemoteConfig {
     values['live_vehicle_stale_threshold']?.asNumber() ??
     defaultRemoteConfig.live_vehicle_stale_threshold;
 
+  const enable_extended_onboarding =
+    values['enable_extended_onboarding']?.asBoolean() ??
+    defaultRemoteConfig.enable_extended_onboarding;
+
   return {
     enable_network_logging,
     enable_ticketing,
@@ -322,6 +328,7 @@ export function getConfig(): RemoteConfig {
     use_flexible_on_egressMode,
     use_trygg_overgang_qr_code,
     live_vehicle_stale_threshold,
+    enable_extended_onboarding,
   };
 }
 

--- a/src/stacks-hierarchy/Root_OnboardingStack/Onboarding_AlsoGoodToKnowScreen.tsx
+++ b/src/stacks-hierarchy/Root_OnboardingStack/Onboarding_AlsoGoodToKnowScreen.tsx
@@ -1,4 +1,4 @@
-import {Onboarding1} from '@atb/assets/svg/color/images/';
+import {Onboarding5} from '@atb/assets/svg/color/images';
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
@@ -7,18 +7,18 @@ import {OnboardingTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ScrollView, useWindowDimensions, View} from 'react-native';
 import {OnboardingScreenProps} from './navigation-types';
-import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
-export const themeColor: StaticColorByType<'background'> =
-  'background_accent_0';
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
-export type Props = OnboardingScreenProps<'Onboarding_WelcomeScreen'>;
+export type AlsoGoodToKnowScreenProps =
+  OnboardingScreenProps<'Onboarding_AlsoGoodToKnowScreen'>;
 
-export const Onboarding_WelcomeScreen = ({navigation}: Props) => {
+export const Onboarding_AlsoGoodToKnowScreen = ({
+  navigation,
+}: AlsoGoodToKnowScreenProps) => {
   const {t} = useTranslation();
   const styles = useThemeStyles();
   const {width: windowWidth} = useWindowDimensions();
-  const {enable_extended_onboarding} = useRemoteConfig();
 
   return (
     <ScrollView
@@ -28,29 +28,22 @@ export const Onboarding_WelcomeScreen = ({navigation}: Props) => {
       <View style={styles.mainView}>
         <ThemeText
           type={'body__primary--jumbo--bold'}
-          style={styles.header}
           color={themeColor}
-          accessibilityLabel={t(OnboardingTexts.welcome.titleA11yLabel)}
+          style={styles.header}
         >
-          {t(OnboardingTexts.welcome.title)}
+          {t(OnboardingTexts.alsoGoodToKnow.title)}
         </ThemeText>
-        <Onboarding1 width={windowWidth} height={windowWidth * (2 / 3)} />
-        <View accessible={true}>
-          <ThemeText style={styles.description} color={themeColor}>
-            {t(OnboardingTexts.welcome.description.part1)}
-          </ThemeText>
-        </View>
+        <Onboarding5 width={windowWidth} height={windowWidth * (4 / 5)} />
+        <ThemeText style={styles.description} color={themeColor}>
+          {t(OnboardingTexts.alsoGoodToKnow.description)}
+        </ThemeText>
       </View>
       <View style={styles.bottomView}>
         <Button
           interactiveColor="interactive_0"
-          onPress={() =>
-            enable_extended_onboarding
-              ? navigation.navigate('Onboarding_GoodToKnowScreen')
-              : navigation.navigate('Onboarding_IntercomInfoScreen')
-          }
-          text={t(OnboardingTexts.welcome.mainButton)}
-          testID="nextButtonOnboardingWelcome"
+          onPress={() => navigation.navigate('Onboarding_IntercomInfoScreen')}
+          text={t(OnboardingTexts.alsoGoodToKnow.mainButton)}
+          testID="nextButtonAlsoGoodToKnowOnboarding"
         />
       </View>
     </ScrollView>
@@ -67,8 +60,8 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     paddingTop: theme.spacings.xLarge,
   },
   mainView: {
-    justifyContent: 'space-between',
     flex: 1,
+    justifyContent: 'space-between',
   },
   header: {
     textAlign: 'center',

--- a/src/stacks-hierarchy/Root_OnboardingStack/Onboarding_GoodToKnowScreen.tsx
+++ b/src/stacks-hierarchy/Root_OnboardingStack/Onboarding_GoodToKnowScreen.tsx
@@ -1,4 +1,4 @@
-import {Onboarding1} from '@atb/assets/svg/color/images/';
+import {Onboarding4} from '@atb/assets/svg/color/images';
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
@@ -7,18 +7,18 @@ import {OnboardingTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ScrollView, useWindowDimensions, View} from 'react-native';
 import {OnboardingScreenProps} from './navigation-types';
-import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
-export const themeColor: StaticColorByType<'background'> =
-  'background_accent_0';
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
-export type Props = OnboardingScreenProps<'Onboarding_WelcomeScreen'>;
+export type GoodToKnowScreenProps =
+  OnboardingScreenProps<'Onboarding_GoodToKnowScreen'>;
 
-export const Onboarding_WelcomeScreen = ({navigation}: Props) => {
+export const Onboarding_GoodToKnowScreen = ({
+  navigation,
+}: GoodToKnowScreenProps) => {
   const {t} = useTranslation();
   const styles = useThemeStyles();
   const {width: windowWidth} = useWindowDimensions();
-  const {enable_extended_onboarding} = useRemoteConfig();
 
   return (
     <ScrollView
@@ -28,29 +28,22 @@ export const Onboarding_WelcomeScreen = ({navigation}: Props) => {
       <View style={styles.mainView}>
         <ThemeText
           type={'body__primary--jumbo--bold'}
-          style={styles.header}
           color={themeColor}
-          accessibilityLabel={t(OnboardingTexts.welcome.titleA11yLabel)}
+          style={styles.header}
         >
-          {t(OnboardingTexts.welcome.title)}
+          {t(OnboardingTexts.goodToKnow.title)}
         </ThemeText>
-        <Onboarding1 width={windowWidth} height={windowWidth * (2 / 3)} />
-        <View accessible={true}>
-          <ThemeText style={styles.description} color={themeColor}>
-            {t(OnboardingTexts.welcome.description.part1)}
-          </ThemeText>
-        </View>
+        <Onboarding4 width={windowWidth} height={windowWidth * (4 / 5)} />
+        <ThemeText style={styles.description} color={themeColor}>
+          {t(OnboardingTexts.goodToKnow.description)}
+        </ThemeText>
       </View>
       <View style={styles.bottomView}>
         <Button
           interactiveColor="interactive_0"
-          onPress={() =>
-            enable_extended_onboarding
-              ? navigation.navigate('Onboarding_GoodToKnowScreen')
-              : navigation.navigate('Onboarding_IntercomInfoScreen')
-          }
-          text={t(OnboardingTexts.welcome.mainButton)}
-          testID="nextButtonOnboardingWelcome"
+          onPress={() => navigation.navigate('Onboarding_AlsoGoodToKnowScreen')}
+          text={t(OnboardingTexts.goodToKnow.mainButton)}
+          testID="nextButtonGoodToKnowOnboarding"
         />
       </View>
     </ScrollView>
@@ -67,8 +60,8 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     paddingTop: theme.spacings.xLarge,
   },
   mainView: {
-    justifyContent: 'space-between',
     flex: 1,
+    justifyContent: 'space-between',
   },
   header: {
     textAlign: 'center',

--- a/src/stacks-hierarchy/Root_OnboardingStack/Root_OnboardingStack.tsx
+++ b/src/stacks-hierarchy/Root_OnboardingStack/Root_OnboardingStack.tsx
@@ -13,6 +13,8 @@ import {OnboardingStackParams} from './navigation-types';
 import {Onboarding_WelcomeScreen} from './Onboarding_WelcomeScreen';
 import {Onboarding_AnonymousPurchaseConsequencesScreen} from './Onboarding_AnonymousPurchaseConsequencesScreen';
 import {Onboarding_IntercomInfoScreen} from './Onboarding_IntercomInfoScreen';
+import {Onboarding_GoodToKnowScreen} from './Onboarding_GoodToKnowScreen';
+import {Onboarding_AlsoGoodToKnowScreen} from './Onboarding_AlsoGoodToKnowScreen';
 
 const Tab = createMaterialTopTabNavigator<OnboardingStackParams>();
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
@@ -20,7 +22,7 @@ const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 export const Root_OnboardingStack = () => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {enable_ticketing} = useRemoteConfig();
+  const {enable_ticketing, enable_extended_onboarding} = useRemoteConfig();
   return (
     <>
       <StatusBar
@@ -38,6 +40,18 @@ export const Root_OnboardingStack = () => {
             name="Onboarding_WelcomeScreen"
             component={Onboarding_WelcomeScreen}
           />
+          {enable_extended_onboarding && (
+            <>
+              <Tab.Screen
+                name="Onboarding_GoodToKnowScreen"
+                component={Onboarding_GoodToKnowScreen}
+              />
+              <Tab.Screen
+                name="Onboarding_AlsoGoodToKnowScreen"
+                component={Onboarding_AlsoGoodToKnowScreen}
+              />
+            </>
+          )}
           <Tab.Screen
             name="Onboarding_IntercomInfoScreen"
             component={Onboarding_IntercomInfoScreen}

--- a/src/stacks-hierarchy/Root_OnboardingStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_OnboardingStack/navigation-types.ts
@@ -7,7 +7,7 @@ export type OnboardingStackParams = {
   Onboarding_IntercomInfoScreen: undefined;
   Onboarding_AnonymousPurchaseConsequencesScreen: undefined;
   Onboarding_GoodToKnowScreen: undefined;
-  Onboarding_AlsoGoodtToKnowScreen: undefined;
+  Onboarding_AlsoGoodToKnowScreen: undefined;
 };
 
 export type OnboardingStackRootProps =

--- a/src/stacks-hierarchy/Root_OnboardingStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_OnboardingStack/navigation-types.ts
@@ -6,6 +6,8 @@ export type OnboardingStackParams = {
   Onboarding_WelcomeScreen: undefined;
   Onboarding_IntercomInfoScreen: undefined;
   Onboarding_AnonymousPurchaseConsequencesScreen: undefined;
+  Onboarding_GoodToKnowScreen: undefined;
+  Onboarding_AlsoGoodtToKnowScreen: undefined;
 };
 
 export type OnboardingStackRootProps =

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -21,6 +21,22 @@ const OnboardingTexts = {
     ),
     mainButton: _('Neste', 'Next'),
   },
+  goodToKnow: {
+    title: _('Greit å vite', 'Good to know'),
+    description: _(
+      'Når du gjør et reisesøk får du opp forslag til hvordan du kan reise, og en korrespondanse som er garantert er merket med korrespondanse.',
+      'When you perform a travel search, you will receive suggestions on how to travel, and a guaranteed connection is marked with correspondance.',
+    ),
+    mainButton: _('Neste', 'Next'),
+  },
+  alsoGoodToKnow: {
+    title: _('Også greit å vite', 'Also good to know'),
+    description: _(
+      'Billetten du kjøper blir gyldig med en gang eller til avgangen du velger. Du kan altså kjøpe billett til mer enn 48 timer frem i tid. Husk at kjøpet av billetten ikke er en reservasjon på avgangen.',
+      'The ticket you purchase becomes valid immediately or for the departure time you choose. Therefore, you can buy a ticket for more than 48 hours in advance. Please note that purchasing the ticket does not reserve your spot on the departure.',
+    ),
+    mainButton: _('Neste', 'Next'),
+  },
 };
 export default orgSpecificTranslations(OnboardingTexts, {
   nfk: {
@@ -49,10 +65,16 @@ export default orgSpecificTranslations(OnboardingTexts, {
       titleA11yLabel: _('Velkommen til FRAM appen', 'Welcome to the FRAM app'),
       description: {
         part1: _(
-          'Her kan du planlegge, betale og gjennomføre reisen din i en og samme app. Appen oppdateres jevnlig med flere billettyper og innovative funksjoner!',
-          'Plan trips and buy tickets throughout Møre og Romsdal. The app will be continuously updated with more products and new functionality.',
+          'I appen kan du planlegge reisen, sjekke avganger og betale for billetten i en og samme app. Flere funksjoner og billetter blir lagt til jevnlig!',
+          'In the app, you can plan your journey, check departures and pay for the ticket, all in the same app. More features and ticket types are regularly added!',
         ),
       },
+    },
+    intercom: {
+      description: _(
+        'Vi ønsker tilbakemeldingen din for å gjøre appen bedre. Oppe til høyre i appen finner du snakkeboblen for å ta kontakt.',
+        'We appreciate your feedback to make the app better. Press the speech bubble in the upper right corner to give feedback.',
+      ),
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,25 +22,17 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.2.0.tgz#c9683a6f450798d711c9b5dc21c781e961fd5079"
-  integrity sha512-ilQWyxzBxII9K+rchfFBm3DMsnBYalyLXjLbf+Kt+rmtROsLJRAclpoI6WteTfhss6LrXuu9H1YpzB4VNjasIA==
+"@atb-as/generate-assets@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.3.0.tgz#72b110a9ffcba98e8e1b57d4205f43d494fff639"
+  integrity sha512-LeCZ6hbsIagTuAW3SW2FUUPIiBIX65DH+zz6BVBoywBcRyqD42P56GlljkcYVsft2R8xq33d97E2MoOC6b0qyg==
   dependencies:
-    "@atb-as/theme" "^6.6.0"
+    "@atb-as/theme" "^7.0.1"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
-
-"@atb-as/theme@^6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-6.6.0.tgz#f97a6e3543c910114b504f4ea0c32ea89eebbce5"
-  integrity sha512-NssmilsVvvh7TzF0ggXIqnziUZe+X32buN9nfaSSmOqfk3vFNz5pGhZwaNzO+L1ihoS5zj8U8G5Pt27vUMOs5g==
-  dependencies:
-    hex-to-rgba "^2.0.1"
-    ts-deepmerge "^4.0.0"
 
 "@atb-as/theme@^7.0.1":
   version "7.0.1"


### PR DESCRIPTION
FRAM would like to have some additional information in the app's onboarding to communicate the differences between the current app and the new one. I decided to use remote config to enable this. 

Before merging we need to release a new version of @atb-as/generate-assets and upgrade the dependency because of new illustrations (https://github.com/AtB-AS/design-system/pull/135). This will fix the tsc error.
<details>
<summary>Screenshots</summary>

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/3b80b2d1-ca4f-4a30-a2b2-5b8d95f2da5c)

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/96a85b8a-740f-4fd5-b17a-5782eaf3519a)

</details>


Closes https://github.com/AtB-AS/kundevendt/issues/4066