### PR TITLE
feat: override passenger category texts for special products

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -4,7 +4,6 @@ import {
   useTranslation,
   TicketTravellerTexts,
   PurchaseOverviewTexts,
-  getTextForLanguage,
 } from '@atb/translations';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {usePreferences} from '@atb/preferences';
@@ -32,7 +31,12 @@ export function SingleTravellerSelection({
   function travellerInfoByFareProductType(fareProductType: string | undefined) {
     return (u: UserProfileWithCount) =>
       [
-        getTextForLanguage(u.alternativeDescriptions, language),
+        TicketTravellerTexts.userProfileDescription(
+          u,
+          fareProductType,
+          language,
+          t,
+        ),
         t(TicketTravellerTexts.information(u.userTypeString, fareProductType)),
       ].join(' ');
   }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -4,6 +4,7 @@ import {
   useTranslation,
   TicketTravellerTexts,
   PurchaseOverviewTexts,
+  getTextForLanguage,
 } from '@atb/translations';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {usePreferences} from '@atb/preferences';
@@ -31,12 +32,8 @@ export function SingleTravellerSelection({
   function travellerInfoByFareProductType(fareProductType: string | undefined) {
     return (u: UserProfileWithCount) =>
       [
-        TicketTravellerTexts.userProfileDescription(
-          u,
-          fareProductType,
-          language,
-          t,
-        ),
+        t(TicketTravellerTexts.userProfileDescription(u, fareProductType)) ||
+          getTextForLanguage(u.alternativeDescriptions, language),
         t(TicketTravellerTexts.information(u.userTypeString, fareProductType)),
       ].join(' ');
   }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -29,13 +29,21 @@ export function SingleTravellerSelection({
     addCount(u.userTypeString);
   };
 
-  function travellerInfoByFareProductType(fareProductType: string | undefined) {
-    return (u: UserProfileWithCount) =>
-      [
-        t(TicketTravellerTexts.userProfileDescription(u, fareProductType)) ||
-          getTextForLanguage(u.alternativeDescriptions, language),
-        t(TicketTravellerTexts.information(u.userTypeString, fareProductType)),
-      ].join(' ');
+  function travellerInfoByFareProductType(
+    fareProductType: string | undefined,
+    u: UserProfileWithCount,
+  ) {
+    const genericUserProfileDescription = getTextForLanguage(
+      u.alternativeDescriptions,
+      language,
+    );
+
+    return [
+      t(
+        TicketTravellerTexts.userProfileDescriptionOverride(u, fareProductType),
+      ) || genericUserProfileDescription,
+      t(TicketTravellerTexts.information(u.userTypeString, fareProductType)),
+    ].join(' ');
   }
 
   return (
@@ -45,7 +53,9 @@ export function SingleTravellerSelection({
         keyExtractor={(u) => u.userTypeString}
         itemToText={(u) => getReferenceDataName(u, language)}
         hideSubtext={hideTravellerDescriptions}
-        itemToSubtext={travellerInfoByFareProductType(fareProductType)}
+        itemToSubtext={(u) =>
+          travellerInfoByFareProductType(fareProductType, u)
+        }
         selected={selectedProfile}
         onSelect={select}
         color="interactive_2"

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -100,7 +100,7 @@ function specificUserProfileDescription(
   travellerType: string,
   ticketType: string | undefined,
 ) {
-  if (ticketType === undefined) return false;
+  if (ticketType === undefined) return _('', '');
   switch (ticketType) {
     case 'travel-pass':
       if (travellerType === TravellerType.adult) {

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -1,9 +1,7 @@
-import {Language, translation as _} from '../../commons';
+import {translation as _} from '../../commons';
 import {APP_ORG} from '@env';
 import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
 import {UserProfileWithCount} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
-import {TFunc} from '@leile/lobo-t';
-import {getTextForLanguage} from '@atb/translations/utils';
 
 enum TravellerType {
   adult = 'ADULT',
@@ -125,15 +123,12 @@ const TicketTravellerTexts = {
   userProfileDescription: (
     userProfile: UserProfileWithCount,
     ticketType: string | undefined,
-    language: Language,
-    t: TFunc<typeof Language>,
   ) => {
     const specificDescription = specificUserProfileDescription(
       userProfile.userTypeString,
       ticketType,
     );
-    if (specificDescription) return t(specificDescription);
-    return getTextForLanguage(userProfile.alternativeDescriptions, language);
+    return specificDescription ? specificDescription : _('', '');
   },
 };
 

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -1,6 +1,9 @@
-import {translation as _} from '../../commons';
+import {Language, translation as _} from '../../commons';
 import {APP_ORG} from '@env';
 import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
+import { UserProfileWithCount } from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
+import { TFunc } from '@leile/lobo-t';
+import { getTextForLanguage } from '@atb/translations/utils';
 
 enum TravellerType {
   adult = 'ADULT',
@@ -95,11 +98,42 @@ function generic(travellerType: string) {
   }
 }
 
+function specificUserProfileDescription(
+  travellerType: string,
+  ticketType: string | undefined,
+) {
+  if (ticketType === undefined) return false;
+  switch (ticketType) {
+    case 'travel-pass':
+      if (travellerType === TravellerType.adult) {
+        return _('Over 18 år', 'Age 18 or older');
+      } else if (travellerType === TravellerType.child) {
+        return _('Til og med 17 år', 'Age 17 or younger');
+      }
+      return false;
+    default:
+      return false;
+  }
+}
+
 const TicketTravellerTexts = {
   information: (travellerType: string, ticketType: string | undefined) => {
     return (
       specificOverrides(travellerType, ticketType) || generic(travellerType)
     );
+  },
+  userProfileDescription: (
+    userProfile: UserProfileWithCount,
+    ticketType: string | undefined,
+    language: Language,
+    t: TFunc<typeof Language>,
+  ) => {
+    const specificDescription = specificUserProfileDescription(
+      userProfile.userTypeString,
+      ticketType,
+    );
+    if (specificDescription) return t(specificDescription);
+    return getTextForLanguage(userProfile.alternativeDescriptions, language);
   },
 };
 

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -96,7 +96,7 @@ function generic(travellerType: string) {
   }
 }
 
-function specificUserProfileDescription(
+function UserProfileDescriptionOverrides(
   travellerType: string,
   ticketType: string | undefined,
 ) {
@@ -120,11 +120,11 @@ const TicketTravellerTexts = {
       specificOverrides(travellerType, ticketType) || generic(travellerType)
     );
   },
-  userProfileDescription: (
+  userProfileDescriptionOverride: (
     userProfile: UserProfileWithCount,
     ticketType: string | undefined,
   ) => {
-    return specificUserProfileDescription(
+    return UserProfileDescriptionOverrides(
       userProfile.userTypeString,
       ticketType,
     );

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -96,7 +96,7 @@ function generic(travellerType: string) {
   }
 }
 
-function UserProfileDescriptionOverrides(
+function userProfileDescriptionOverrides(
   travellerType: string,
   ticketType: string | undefined,
 ) {
@@ -124,7 +124,7 @@ const TicketTravellerTexts = {
     userProfile: UserProfileWithCount,
     ticketType: string | undefined,
   ) => {
-    return UserProfileDescriptionOverrides(
+    return userProfileDescriptionOverrides(
       userProfile.userTypeString,
       ticketType,
     );

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -104,9 +104,9 @@ function specificUserProfileDescription(
   switch (ticketType) {
     case 'travel-pass':
       if (travellerType === TravellerType.adult) {
-        return _('Over 18 år', 'Age 18 or older');
+        return _('Over 16 år', 'Age 16 or older');
       } else if (travellerType === TravellerType.child) {
-        return _('Til og med 17 år', 'Age 17 or younger');
+        return _('Til og med 15 år', 'Age 15 or younger');
       }
       return _('', '');
     default:

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -1,9 +1,9 @@
 import {Language, translation as _} from '../../commons';
 import {APP_ORG} from '@env';
 import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
-import { UserProfileWithCount } from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
-import { TFunc } from '@leile/lobo-t';
-import { getTextForLanguage } from '@atb/translations/utils';
+import {UserProfileWithCount} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state';
+import {TFunc} from '@leile/lobo-t';
+import {getTextForLanguage} from '@atb/translations/utils';
 
 enum TravellerType {
   adult = 'ADULT',

--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -108,9 +108,9 @@ function specificUserProfileDescription(
       } else if (travellerType === TravellerType.child) {
         return _('Til og med 17 år', 'Age 17 or younger');
       }
-      return false;
+      return _('', '');
     default:
-      return false;
+      return _('', '');
   }
 }
 
@@ -124,11 +124,10 @@ const TicketTravellerTexts = {
     userProfile: UserProfileWithCount,
     ticketType: string | undefined,
   ) => {
-    const specificDescription = specificUserProfileDescription(
+    return specificUserProfileDescription(
       userProfile.userTypeString,
       ticketType,
     );
-    return specificDescription ? specificDescription : _('', '');
   },
 };
 


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/4174

Ensuring that Nordland can have separate age limits for Travel Pass Nordland that is going into sale with 1.37.

Code is checking if there's an override available for the given product type (only entered for travel-pass type), and returning descriptions as before if not.