### PR TITLE
build: fix build-store bug

### DIFF
--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -15,10 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if release tag is org specific and exit for other orgs
-        if: >
-          ${{ (contains(github.ref, 'atb') && matrix.org != 'atb') 
-          || (contains(github.ref, 'nfk') && matrix.org != 'nfk') 
-          || (contains(github.ref, 'fram') && matrix.org != 'fram') }}
+        if: ${{ (contains(github.ref, 'atb') && matrix.org != 'atb') ||
+          (contains(github.ref, 'nfk') && matrix.org != 'nfk') ||
+          (contains(github.ref, 'fram') && matrix.org != 'fram') }}
         run: exit 1
       - name: Checkout project
         uses: actions/checkout@v1

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -15,10 +15,9 @@ jobs:
     runs-on: macOS-12
     steps:
       - name: Check if release tag is org specific and exit for other orgs
-        if: >
-          ${{ (contains(github.ref, 'atb') && matrix.org != 'atb') 
-          || (contains(github.ref, 'nfk') && matrix.org != 'nfk') 
-          || (contains(github.ref, 'fram') && matrix.org != 'fram') }}
+        if: ${{ (contains(github.ref, 'atb') && matrix.org != 'atb') ||
+          (contains(github.ref, 'nfk') && matrix.org != 'nfk') ||
+          (contains(github.ref, 'fram') && matrix.org != 'fram') }}
         run: exit 1
       - name: Checkout project
         uses: actions/checkout@v3


### PR DESCRIPTION
When taking out a release candidate for 1.37 the GitHub action exited when it should not have (https://github.com/AtB-AS/mittatb-app/actions/runs/5144679993/jobs/9261277315). Johannes reverted the change I made (https://github.com/AtB-AS/mittatb-app/pull/3618/files) so that AtB and NFK could do a release. 

We believe the problem was caused due to a formatting error as the check in itself looks good. It seems that it's not necessary to use the operator `>`, so I think we should test without it. 

Ref: https://github.com/orgs/community/discussions/25641#discussioncomment-3248574

Fixes https://github.com/AtB-AS/kundevendt/issues/4176