### PR TITLE
refactor: Add eslint rule for import from stacks-hiearchy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,13 @@
 const rulesDirPlugin = require('eslint-plugin-rulesdir');
 rulesDirPlugin.RULES_DIR = 'eslint-rules/';
 
+const noRestrictedImportsPatterns = [
+  {
+    group: ['@atb/components/*/'],
+    message: 'Components should be imported through their index file',
+  },
+];
+
 module.exports = {
   env: {
     es6: true,
@@ -28,7 +35,7 @@ module.exports = {
       {restrictDefaultExports: {direct: true}},
     ],
 
-    'no-restricted-imports': ['warn', {patterns: ['@atb/components/*/']}],
+    'no-restricted-imports': ['error', {patterns: noRestrictedImportsPatterns}],
 
     'no-restricted-syntax': [
       'error',
@@ -89,6 +96,21 @@ module.exports = {
       files: ['src/api/types/**'],
       rules: {
         'no-restricted-syntax': 'off',
+      },
+    },
+    {
+      files: ['src/components/**'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              ...noRestrictedImportsPatterns,
+              // Not allowed to import stuff from stacks-hierarchy from the components folder
+              {group: ['@atb/stacks-hierarchy/**']},
+            ],
+          },
+        ],
       },
     },
   ],

--- a/src/components/location-icon/LocationIcon.tsx
+++ b/src/components/location-icon/LocationIcon.tsx
@@ -3,7 +3,7 @@ import {Location as LocationMonoIcon} from '@atb/assets/svg/mono-icons/places';
 import {Location} from '@atb/favorites';
 import React from 'react';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {getVenueIconTypes} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
+import {getVenueIconTypes} from './utils';
 import {
   Bus,
   Ferry,

--- a/src/components/location-icon/index.ts
+++ b/src/components/location-icon/index.ts
@@ -1,1 +1,2 @@
 export {LocationIcon} from './LocationIcon';
+export {getVenueIconTypes} from './utils';

--- a/src/components/location-icon/utils.ts
+++ b/src/components/location-icon/utils.ts
@@ -1,0 +1,30 @@
+import {FeatureCategory} from '@atb/sdk';
+
+export const getVenueIconTypes = (category: FeatureCategory[]) => {
+  return category
+    .map(mapLocationCategoryToVenueType)
+    .filter((v, i, arr) => arr.indexOf(v) === i); // get distinct values
+};
+
+const mapLocationCategoryToVenueType = (category: FeatureCategory) => {
+  switch (category) {
+    case 'onstreetBus':
+    case 'busStation':
+    case 'coachStation':
+      return 'bus';
+    case 'onstreetTram':
+    case 'tramStation':
+      return 'tram';
+    case 'railStation':
+    case 'metroStation':
+      return 'rail';
+    case 'airport':
+      return 'airport';
+    case 'harbourPort':
+    case 'ferryPort':
+    case 'ferryStop':
+      return 'boat';
+    default:
+      return 'unknown';
+  }
+};

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationResults.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationResults.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {TouchableOpacity, View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {LocationIcon} from '@atb/components/location-icon';
+import {getVenueIconTypes, LocationIcon} from '@atb/components/location-icon';
 import {insets} from '@atb/utils/insets';
 import {LocationSearchResultType} from '../types';
 import {FavoriteIcon} from '@atb/favorites';
@@ -12,7 +12,6 @@ import {
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
-import {getVenueIconTypes} from '../utils';
 import {SearchLocation} from '@atb/favorites';
 
 type Props = {

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/index.ts
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/index.ts
@@ -3,4 +3,3 @@ export type {Root_LocationSearchByTextScreenParams} from './navigation-types';
 export {useLocationSearchValue, useOnlySingleLocation} from './hooks';
 export {LocationSearchContent} from './components/LocationSearchContent';
 export type {SelectableLocationType} from './types';
-export {getVenueIconTypes} from './utils';

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/utils.ts
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/utils.ts
@@ -6,7 +6,6 @@ import {
 import {useSearchHistory} from '@atb/search-history';
 import {LocationSearchResultType} from './types';
 import {getLocationLayer} from '@atb/utils/location';
-import {FeatureCategory} from '@atb/sdk';
 
 export function useFilteredJourneySearch(searchText?: string) {
   const {journeyHistory} = useSearchHistory();
@@ -77,33 +76,4 @@ export const filterCurrentLocation = (
   return locations
     .filter((l) => !previousLocations.some((pl) => pl.location.id === l.id))
     .map((location) => ({location}));
-};
-
-export const getVenueIconTypes = (category: FeatureCategory[]) => {
-  return category
-    .map(mapLocationCategoryToVenueType)
-    .filter((v, i, arr) => arr.indexOf(v) === i); // get distinct values
-};
-
-const mapLocationCategoryToVenueType = (category: FeatureCategory) => {
-  switch (category) {
-    case 'onstreetBus':
-    case 'busStation':
-    case 'coachStation':
-      return 'bus';
-    case 'onstreetTram':
-    case 'tramStation':
-      return 'tram';
-    case 'railStation':
-    case 'metroStation':
-      return 'rail';
-    case 'airport':
-      return 'airport';
-    case 'harbourPort':
-    case 'ferryPort':
-    case 'ferryStop':
-      return 'boat';
-    default:
-      return 'unknown';
-  }
 };


### PR DESCRIPTION
In general I don't think any files outside of stacks-hierarchy
should import anything from stacks-hierarchy. For now just turn
this on for the components folder.

### Acceptance criteria
No testing necessary
