### PR TITLE
fix: static QR-code readability for FRAM buses

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -222,7 +222,7 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
   return (
     <GenericSectionItem>
       <View
-        style={styles.aztecCode}
+        style={[styles.aztecCode, styles.staticQrCode]}
         accessible={true}
         accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
         testID="staticQRCode"
@@ -239,5 +239,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     aspectRatio: 1,
     padding: theme.spacings.large,
     backgroundColor: '#FFFFFF',
+  },
+  staticQrCode: {
+    aspectRatio: 1.25,
   },
 }));


### PR DESCRIPTION
I've made the static QR-code a bit smaller to make it easier to scan on FRAM buses.

Fixes https://github.com/AtB-AS/kundevendt/issues/4006

<details>
<summary>Screenshots</summary>

# Today

![IMG_2006](https://github.com/AtB-AS/mittatb-app/assets/43166974/0f266735-8bc9-4228-8fa5-641a5bb5e3af)

# Smaller version

![IMG_2005](https://github.com/AtB-AS/mittatb-app/assets/43166974/cb2fe630-9bdd-4683-9417-ba58f1dc1362)

</details>
