### PR TITLE
feat: disable retries on 429 responses

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -33,14 +33,17 @@ declare module 'axios' {
 }
 
 function shouldRetry(error: AxiosError): boolean {
+  const isRateLimited = error.response?.status === 429;
+  if (isRateLimited) return false;
+
+  const shouldForceRefresh = error.config?.forceRefreshIdToken;
+  if (shouldForceRefresh) return true;
+
   const shouldRetryOnNetworkErrorOrIdempotentRequest =
     Boolean(error.config?.retry) &&
     (getAxiosErrorType(error) === 'network-error' ||
       isIdempotentRequestError(error));
-  return (
-    error.config?.forceRefreshIdToken ||
-    shouldRetryOnNetworkErrorOrIdempotentRequest
-  );
+  return shouldRetryOnNetworkErrorOrIdempotentRequest;
 }
 
 export function createClient(baseUrl: string | undefined) {


### PR DESCRIPTION
Doesn't look like this will actually change anything in practice, since the `config.retry` field defaults to undefined / falsy, and I don't think it is set to true anywhere at the moment. But disabling retries entirely on 429 (Too Many Requests) is nice to have for the future.

closes https://github.com/AtB-AS/kundevendt/issues/3978