### PR TITLE
fix: Pull to refresh on trip search

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -216,7 +216,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
               option: 'now',
               date: new Date().toISOString(),
             }
-          : searchTime,
+          : {...searchTime},
     });
   };
 


### PR DESCRIPTION
When dragging down to refresh on the trip search screen, the search
was not refreshed if a departure or arrival time was chosen. This is
fixed by recreating the search time object on refresh so the search
useEffect triggers.
