### PR TITLE
fix: status message button color

### DIFF
--- a/src/service-disruptions/ServiceDisruptionSheet.tsx
+++ b/src/service-disruptions/ServiceDisruptionSheet.tsx
@@ -55,7 +55,7 @@ export const ServiceDisruptionSheet = forwardRef<View, Props>(
                 </View>
               </Section>
               <Button
-                interactiveColor="interactive_3"
+                interactiveColor="interactive_2"
                 mode="secondary"
                 text={t(ServiceDisruptionsTexts.button.text)}
                 accessibilityHint={t(ServiceDisruptionsTexts.button.a11yHint)}


### PR DESCRIPTION
Fixes issue found when testing https://github.com/AtB-AS/kundevendt/issues/4141

I believe we've been using the wrong interactive color for the status message button. I guess this hasn't been noticed as it works for AtB. This is what it currently looks like for FRAM:
![File (1)](https://github.com/AtB-AS/mittatb-app/assets/43166974/78dd33a4-55db-405e-9a9a-61dc488cbaa2)

This can be fixed by changing this to interactive_2 which is used for the contact button. This changes nothing for AtB and solves the issue for NFK/FRAM. See screenshots: 

<details>
<summary>Screenshots</summary>
AtB

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/92973f80-7be6-4856-98b6-4715d28f963e)

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/4a234331-454f-4af3-853f-940188a82eea)

NFK

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/9709e266-c471-48bf-b1ac-fe80693aa352)

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/1de77a80-9248-477f-98ea-df1c6c40e68f)

FRAM

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/df5579e9-7cd3-437b-b6c2-e0308d966b6a)

</details>
