### PR TITLE
Accept layers as input to reverse

### DIFF
--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -35,12 +35,14 @@ export async function autocomplete(
 
 export async function reverse(
   coordinates: Coordinates | null,
+  layers?: string[],
   config?: AxiosRequestConfig,
 ) {
   const url = 'bff/v1/geocoder/reverse';
   const query = qs.stringify({
     lat: coordinates?.latitude,
     lon: coordinates?.longitude,
+    layers: layers,
   });
 
   return await client.get<Feature[]>(stringifyUrl(url, query), config);

--- a/src/components/map/components/DeparturesDialogSheet.tsx
+++ b/src/components/map/components/DeparturesDialogSheet.tsx
@@ -53,13 +53,11 @@ export const DeparturesDialogSheet = ({
     isSearching: isGeocoderSearching,
     error: geocoderError,
     forceRefresh: forceRefreshReverseGeocode,
-  } = useReverseGeocoder({longitude, latitude} || null);
+  } = useReverseGeocoder({longitude, latitude} || null, ['venue']);
   const appStateStatus = useAppStateStatus();
 
-  const filteredLocations = locations?.filter(
-    (location) =>
-      location.layer === 'venue' &&
-      stopPlaceFeature.properties?.name.includes(location.name),
+  const filteredLocations = locations?.filter((location) =>
+    stopPlaceFeature.properties?.name.includes(location.name),
   );
 
   const closestLocation = filteredLocations?.[0];

--- a/src/geocoder/use-reverse-geocoder.ts
+++ b/src/geocoder/use-reverse-geocoder.ts
@@ -14,6 +14,7 @@ type ReverseGeocoderState = GeocoderState & {
 
 export function useReverseGeocoder(
   coords: Coordinates | null,
+  layers?: string[],
 ): ReverseGeocoderState {
   const [state, dispatch] = useGeocoderReducer();
   const timeoutRequest = useTimeoutRequest();
@@ -23,7 +24,7 @@ export function useReverseGeocoder(
         try {
           dispatch({type: 'SET_IS_SEARCHING'});
           timeoutRequest.start();
-          const response = await reverse(coords, {
+          const response = await reverse(coords, layers, {
             signal: timeoutRequest.signal,
           });
           timeoutRequest.clear();


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/2954

Accepts layers as optional input to the reverse function, and uses ["venue"] as only accepted layer type in DeparturesDialogSheet.

Depends on https://github.com/AtB-AS/atb-bff/pull/269 in the bff.

Before:
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/9033a2c6-6c1b-40e8-8ba0-e4d73b276c23" />

After:
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/a0c338ee-8af8-4bad-8971-cbd02b1502f3" />

