### PR TITLE
fix: Fix after login onboarding race condition

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -214,29 +214,29 @@ export const AppContextProvider: React.FC = ({children}) => {
         dispatch({type: 'RESET_TICKETING'});
       },
       completeMobileTokenOnboarding: async () => {
-        await storage.set(storeKey.mobileTokenOnboarding, JSON.stringify(true));
         dispatch({type: 'COMPLETE_MOBILE_TOKEN_ONBOARDING'});
+        await storage.set(storeKey.mobileTokenOnboarding, JSON.stringify(true));
       },
       restartMobileTokenOnboarding: async () => {
+        dispatch({type: 'RESTART_MOBILE_TOKEN_ONBOARDING'});
         await storage.set(
           storeKey.mobileTokenOnboarding,
           JSON.stringify(false),
         );
-        dispatch({type: 'RESTART_MOBILE_TOKEN_ONBOARDING'});
       },
       completeMobileTokenWithoutTravelcardOnboarding: async () => {
+        dispatch({type: 'COMPLETE_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'});
         await storage.set(
           storeKey.mobileTokenWithoutTravelcardOnboarding,
           JSON.stringify(true),
         );
-        dispatch({type: 'COMPLETE_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'});
       },
       restartMobileTokenWithoutTravelcardOnboarding: async () => {
+        dispatch({type: 'RESTART_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'});
         await storage.set(
           storeKey.mobileTokenWithoutTravelcardOnboarding,
           JSON.stringify(false),
         );
-        dispatch({type: 'RESTART_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'});
       },
     }),
     [],

--- a/src/stacks-hierarchy/Root_MobileTokenOnboarding/utils.ts
+++ b/src/stacks-hierarchy/Root_MobileTokenOnboarding/utils.ts
@@ -2,7 +2,7 @@ import {useHasEnabledMobileToken} from '@atb/mobile-token/MobileTokenContext';
 import {useAuthState} from '@atb/auth';
 import {useAppState} from '@atb/AppContext';
 import {shouldOnboardMobileToken} from '@atb/api/utils';
-import {useNavigation} from '@react-navigation/native';
+import {useIsFocused, useNavigation} from '@react-navigation/native';
 import {useEffect} from 'react';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
@@ -23,9 +23,10 @@ export const useGoToMobileTokenOnboardingWhenNecessary = () => {
     disable_travelcard,
   );
 
+  const isFocused = useIsFocused();
   useEffect(() => {
-    if (shouldOnboard) {
+    if (shouldOnboard && isFocused) {
       navigation.navigate('Root_MobileTokenOnboardingStack');
     }
-  }, [shouldOnboard]);
+  }, [shouldOnboard, isFocused]);
 };


### PR DESCRIPTION
After login in there was a race condition between the navigation
done by the login screen and the navigation to the mobile token
onboarding. This is fixed by only redirecting to the mobile token
onboarding when the TabNavigator is actually focused.
