### PR TITLE
build: Fixed build id when registering Android app version

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -110,3 +110,4 @@ jobs:
           ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_STAGING }}
           ENTUR_CLIENT_SECRET: ${{ secrets.ABT_ENTUR_CLIENT_SECRET_STAGING }}
           DISABLE_LISTED_ON_PLAY_STORE: true
+          BUILD_ID: 1


### PR DESCRIPTION
When registering Android app versions the newest build overwrites
the old one. Meaning only one build, the newest, will be able to
create and renew mobile tokens.

In staging this is a problem since we have such frequent builds,
and it will be a chore to always ensure to be on the newest build
when testing something related to mobiletoken or ticketing in
general.

We asked Entur, and they said in staging it was ok to do the same
as is done in dev, that every Android build has the same value for
the build id. This means that all staging builds on the same app
version should keep working after new builds.
