### PR TITLE
feat: add message for travels with short wait times and no guaranteed correspondence

### DIFF
--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -1,3 +1,4 @@
+import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
 import {translation as _} from '../../commons';
 
 const TripDetailsTexts = {
@@ -152,9 +153,10 @@ const TripDetailsTexts = {
 
   messages: {
     shortTime: _(
-      'Vær oppmerksom på kort byttetid',
-      'Please note short changeover time',
+      'Vær oppmerksom på kort byttetid.',
+      'Please note short changeover time.',
     ),
+    correspondenceNotGuaranteed: _('', ''),
     errorNetwork: _(
       'Hei, er du på nett? Vi kan ikke hente reiseforslag siden nettforbindelsen din mangler eller er ustabil.',
       `Are you online? We're unable to conduct a search since your device seems to be offline or the connection is unstable`,
@@ -187,4 +189,13 @@ const TripDetailsTexts = {
       ),
   },
 };
-export default TripDetailsTexts;
+export default orgSpecificTranslations(TripDetailsTexts, {
+  fram: {
+    messages: {
+      correspondenceNotGuaranteed: _(
+        'Kan ikke garantere korrespondanse.',
+        'Cannot guarantee correspondence.',
+      ),
+    },
+  },
+});

--- a/src/travel-details-screens/components/DetailsMessages.tsx
+++ b/src/travel-details-screens/components/DetailsMessages.tsx
@@ -22,6 +22,7 @@ import {
 import {
   canSellCollabTicket,
   hasShortWaitTime,
+  hasShortWaitTimeAndNotGuaranteedCorrespondence,
 } from '@atb/travel-details-screens/utils';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {TransportSubmode} from '@entur/sdk/lib/journeyPlanner/types';
@@ -46,6 +47,8 @@ export const TripMessages: React.FC<TripMessagesProps> = ({
   const styles = useStyles();
   const canSellCollab = canSellCollabTicket(tripPattern);
   const shortWaitTime = hasShortWaitTime(tripPattern.legs);
+  const shortWaitTimeAndNotGuaranteedCorrespondence =
+    hasShortWaitTimeAndNotGuaranteedCorrespondence(tripPattern.legs);
 
   const {enable_ticketing} = useRemoteConfig();
   const isTicketingEnabledAndSomeTicketsAreUnavailableInApp =
@@ -67,7 +70,12 @@ export const TripMessages: React.FC<TripMessagesProps> = ({
         <MessageBox
           style={styles.messageBox}
           type="info"
-          message={t(TripDetailsTexts.messages.shortTime)}
+          message={[
+            t(TripDetailsTexts.messages.shortTime),
+            shortWaitTimeAndNotGuaranteedCorrespondence
+              ? t(TripDetailsTexts.messages.correspondenceNotGuaranteed)
+              : '',
+          ].join(' ')}
         />
       )}
       {isTicketingEnabledAndSomeTicketsAreUnavailableInApp && (

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -122,6 +122,21 @@ export function hasShortWaitTime(legs: Leg[]) {
     .some((waitTime) => timeIsShort(waitTime));
 }
 
+export function hasShortWaitTimeAndNotGuaranteedCorrespondence(legs: Leg[]) {
+  return iterateWithNext(legs)
+    .map((pair) => {
+      if (pair.current.interchangeTo?.guaranteed) {
+        return 0;
+      }
+      return differenceInSeconds(
+        parseDateIfString(pair.next.expectedStartTime),
+        parseDateIfString(pair.current.expectedEndTime),
+      );
+    })
+    .filter((waitTime) => waitTime > 0)
+    .some((waitTime) => timeIsShort(waitTime));
+}
+
 function parseDateIfString(date: any): Date {
   if (typeof date === 'string') {
     return parseISO(date);


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/4067

This PR adds a new message to be displayed for travels with short wait times and no guaranteed correspondence. The message will be displayed in addition to the already existing message about the short wait time. This change is specific to FRAM's needs, and I've used org-specific translations for the message.

<details>
<summary>Screenshots</summary>

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/9f667bbc-650b-4079-bd98-3476f77edbd3)

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/6e6215ec-70bd-4196-8ed4-3faecd0a0731)

</details>