### PR TITLE
fix: inspection symbol for zone names with length greater than 3 characters

### DIFF
--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -78,6 +78,17 @@ const InspectableContent = ({
   const InspectionSvg =
     fareProductTypeConfig?.illustration === 'night' ? Moon : Bus;
 
+  const fromTariffZoneName =
+    fromTariffZone && getReferenceDataName(fromTariffZone, language);
+  const toTariffZoneName =
+    toTariffZone && getReferenceDataName(toTariffZone, language);
+
+  const shouldShowZoneNames =
+    fromTariffZoneName &&
+    toTariffZoneName &&
+    fromTariffZoneName.length < 3 &&
+    toTariffZoneName.length < 3;
+
   return (
     <View
       style={[
@@ -87,15 +98,14 @@ const InspectableContent = ({
         },
       ]}
     >
-      {fromTariffZone && toTariffZone && (
+      {shouldShowZoneNames && (
         <ThemeText
           type="body__primary--bold"
           allowFontScaling={false}
           color={shouldFill ? themeColor : undefined}
         >
-          {getReferenceDataName(fromTariffZone, language)}
-          {fromTariffZone.id !== toTariffZone.id &&
-            '-' + getReferenceDataName(toTariffZone, language)}
+          {fromTariffZoneName}
+          {fromTariffZone.id !== toTariffZone.id && '-' + toTariffZoneName}
         </ThemeText>
       )}
       <ThemeIcon

--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -3,26 +3,21 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import {ActivityIndicator, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
-import {getReferenceDataName} from '@atb/reference-data/utils';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Bus} from '@atb/assets/svg/mono-icons/transportation';
-import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
+import {PreassignedFareProduct} from '@atb/reference-data/types';
 import {ContrastColor} from '@atb-as/theme';
 import {Moon} from '@atb/assets/svg/mono-icons/ticketing';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 export type InspectionSymbolProps = {
   preassignedFareProduct?: PreassignedFareProduct;
-  fromTariffZone?: TariffZone;
-  toTariffZone?: TariffZone;
   isInspectable: boolean;
   isLoading?: boolean;
 };
 
 export const InspectionSymbol = ({
   preassignedFareProduct,
-  fromTariffZone,
-  toTariffZone,
   isInspectable,
   isLoading,
 }: InspectionSymbolProps) => {
@@ -43,8 +38,6 @@ export const InspectionSymbol = ({
       {isInspectable ? (
         <InspectableContent
           preassignedFareProduct={preassignedFareProduct}
-          fromTariffZone={fromTariffZone}
-          toTariffZone={toTariffZone}
           themeColor={themeColor}
         />
       ) : (
@@ -55,17 +48,12 @@ export const InspectionSymbol = ({
 };
 
 const InspectableContent = ({
-  fromTariffZone,
-  toTariffZone,
   preassignedFareProduct,
   themeColor,
 }: {
   preassignedFareProduct?: PreassignedFareProduct;
-  fromTariffZone?: TariffZone;
-  toTariffZone?: TariffZone;
   themeColor: ContrastColor;
 }) => {
-  const {language} = useTranslation();
   const styles = useStyles();
 
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
@@ -87,17 +75,6 @@ const InspectableContent = ({
         },
       ]}
     >
-      {fromTariffZone && toTariffZone && (
-        <ThemeText
-          type="body__primary--bold"
-          allowFontScaling={false}
-          color={shouldFill ? themeColor : undefined}
-        >
-          {getReferenceDataName(fromTariffZone, language)}
-          {fromTariffZone.id !== toTariffZone.id &&
-            '-' + getReferenceDataName(toTariffZone, language)}
-        </ThemeText>
-      )}
       <ThemeIcon
         svg={InspectionSvg}
         fill={shouldFill ? themeColor.text : undefined}

--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -3,21 +3,26 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import {ActivityIndicator, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
+import {getReferenceDataName} from '@atb/reference-data/utils';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Bus} from '@atb/assets/svg/mono-icons/transportation';
-import {PreassignedFareProduct} from '@atb/reference-data/types';
+import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
 import {ContrastColor} from '@atb-as/theme';
 import {Moon} from '@atb/assets/svg/mono-icons/ticketing';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 
 export type InspectionSymbolProps = {
   preassignedFareProduct?: PreassignedFareProduct;
+  fromTariffZone?: TariffZone;
+  toTariffZone?: TariffZone;
   isInspectable: boolean;
   isLoading?: boolean;
 };
 
 export const InspectionSymbol = ({
   preassignedFareProduct,
+  fromTariffZone,
+  toTariffZone,
   isInspectable,
   isLoading,
 }: InspectionSymbolProps) => {
@@ -38,6 +43,8 @@ export const InspectionSymbol = ({
       {isInspectable ? (
         <InspectableContent
           preassignedFareProduct={preassignedFareProduct}
+          fromTariffZone={fromTariffZone}
+          toTariffZone={toTariffZone}
           themeColor={themeColor}
         />
       ) : (
@@ -48,12 +55,17 @@ export const InspectionSymbol = ({
 };
 
 const InspectableContent = ({
+  fromTariffZone,
+  toTariffZone,
   preassignedFareProduct,
   themeColor,
 }: {
   preassignedFareProduct?: PreassignedFareProduct;
+  fromTariffZone?: TariffZone;
+  toTariffZone?: TariffZone;
   themeColor: ContrastColor;
 }) => {
+  const {language} = useTranslation();
   const styles = useStyles();
 
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
@@ -75,6 +87,17 @@ const InspectableContent = ({
         },
       ]}
     >
+      {fromTariffZone && toTariffZone && (
+        <ThemeText
+          type="body__primary--bold"
+          allowFontScaling={false}
+          color={shouldFill ? themeColor : undefined}
+        >
+          {getReferenceDataName(fromTariffZone, language)}
+          {fromTariffZone.id !== toTariffZone.id &&
+            '-' + getReferenceDataName(toTariffZone, language)}
+        </ThemeText>
+      )}
       <ThemeIcon
         svg={InspectionSvg}
         fill={shouldFill ? themeColor.text : undefined}


### PR DESCRIPTION
_Edited_
I've removed the zone names from the inspection symbol if the zone names have more than 3 characters. This is to ensure that we don't experience what is seen in the image below, and still keep it the as today for AtB. The designers will look into how we can make it consistent for all organizations. 

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/0ee341ec-9f4c-4d94-b4f5-af3c1188c5d5)
<details>
<summary>Original description</summary>
I've removed the zone names from the inspection symbol according to the new Figma sketch (See the issue for reasoning (https://github.com/AtB-AS/kundevendt/issues/4160)): 

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/2463229e-01fc-4fda-8761-ad1a66d98ab7) 

</details>
Fixes https://github.com/AtB-AS/kundevendt/issues/4160