### PR TITLE
fix: Update texts on onboarding screens

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -74,7 +74,7 @@ export function ProductSelectionByProducts({
             setProduct(fp);
             setSelectedProduct(fp);
           }}
-          color="interactive_1"
+          color="interactive_2"
           accessibilityHint={t(
             PurchaseOverviewTexts.productSelection.a11yTitle,
           )}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -74,7 +74,7 @@ export function ProductSelectionByProducts({
             setProduct(fp);
             setSelectedProduct(fp);
           }}
-          color="interactive_2"
+          color="interactive_1"
           accessibilityHint={t(
             PurchaseOverviewTexts.productSelection.a11yTitle,
           )}

--- a/src/translations/screens/Onboarding.ts
+++ b/src/translations/screens/Onboarding.ts
@@ -24,15 +24,15 @@ const OnboardingTexts = {
   goodToKnow: {
     title: _('Greit å vite', 'Good to know'),
     description: _(
-      'Når du gjør et reisesøk får du opp forslag til hvordan du kan reise, og en korrespondanse som er garantert er merket med korrespondanse.',
-      'When you perform a travel search, you will receive suggestions on how to travel, and a guaranteed connection is marked with correspondance.',
+      'Når du gjør et reisesøk får du opp forslag til hvordan du kan reise. En korrespondanse som er garantert er merket med korrespondanse.',
+      'When you perform a travel search, you will receive suggestions on how to travel. A guaranteed connection is marked with correspondance.',
     ),
     mainButton: _('Neste', 'Next'),
   },
   alsoGoodToKnow: {
     title: _('Også greit å vite', 'Also good to know'),
     description: _(
-      'Billetten du kjøper blir gyldig med en gang eller til avgangen du velger. Du kan altså kjøpe billett til mer enn 48 timer frem i tid. Husk at kjøpet av billetten ikke er en reservasjon på avgangen.',
+      'Billetten du kjøper blir gyldig med en gang eller til avgangen du velger. Du kan kjøpe billett til mer enn 48 timer frem i tid. Husk at kjøpet av billetten ikke er en reservasjon på avgangen.',
       'The ticket you purchase becomes valid immediately or for the departure time you choose. Therefore, you can buy a ticket for more than 48 hours in advance. Please note that purchasing the ticket does not reserve your spot on the departure.',
     ),
     mainButton: _('Neste', 'Next'),
@@ -65,8 +65,8 @@ export default orgSpecificTranslations(OnboardingTexts, {
       titleA11yLabel: _('Velkommen til FRAM appen', 'Welcome to the FRAM app'),
       description: {
         part1: _(
-          'I appen kan du planlegge reisen, sjekke avganger og betale for billetten i en og samme app. Flere funksjoner og billetter blir lagt til jevnlig!',
-          'In the app, you can plan your journey, check departures and pay for the ticket, all in the same app. More features and ticket types are regularly added!',
+          'I appen kan du planlegge reisen, sjekke avganger og betale for billetten i en og samme app. Flere funksjoner blir lagt til jevnlig!',
+          'In the app, you can plan your journey, check departures and pay for the ticket, all in the same app. More features are regularly added!',
         ),
       },
     },

--- a/src/translations/screens/subscreens/MobileTokenOnboarding.ts
+++ b/src/translations/screens/subscreens/MobileTokenOnboarding.ts
@@ -183,8 +183,8 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
     },
     ticketSafetyInfo: {
       description: _(
-        'Billetten din er trygt lagret på **Min bruker**. Dermed vil du aldri miste den — selv om du mister reisekortet eller bytter mobil.',
-        "Your ticket is safely stored on **My user**. That way you won't lose your ticket even if you lose your travel card or switch phones.",
+        'Billetten din er trygt lagret på din konto i skyen. Dermed vil du aldri miste den — selv om du mister reisekortet eller bytter mobil.',
+        "Your ticket is safely stored on your account in the cloud. That way you won't lose your ticket even if you lose your travel card or switch phones.",
       ),
     },
     tCard: {
@@ -228,8 +228,8 @@ export default orgSpecificTranslations(MobileTokenOnboardingTexts, {
       },
       ticketSafetyInfo: {
         description: _(
-          'Billetten din er trygt lagret på **Min bruker**. Dermed vil du aldri miste den — selv om du mister eller bytter mobil.',
-          "Your ticket is safely stored on **My user**. That way you won't lose your ticket even if you lose or switch phones.",
+          'Billetten din er trygt lagret på din konto i skyen. Dermed vil du aldri miste den — selv om du mister eller bytter mobil.',
+          "Your ticket is safely stored on your account in the cloud. That way you won't lose your ticket even if you lose or switch phones.",
         ),
       },
       phone: {


### PR DESCRIPTION
*App onboarding:*

- Slide 1: «Flere funksjoner og billetter blir lagt til jevnlig!»
Fjernet «og billetter» 

- Slide 2: «…reise, og en korrespondanse …»
Endret til «…reise. En korrespondanse …»

- Slide 3: «…Du kan altså kjøpe…»
Fjernet «altså» 

*Mobile token onboarding*

Slide 3: «Billetten din er trygt lagret på Min bruker.».
Endret til «Billetten din er trygt lagret på din konto i skyen.»

Closes https://github.com/AtB-AS/kundevendt/issues/4273