### PR TITLE
fix: improve contrast on login activity indicator

### DIFF
--- a/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
@@ -20,8 +20,8 @@ import {loginConfirmCodeInputId} from '@atb/test-ids';
 import {MessageBox} from '@atb/components/message-box';
 import {Button} from '@atb/components/button';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
-import {StyleSheet} from '@atb/theme';
-import {StaticColorByType} from '@atb/theme/colors';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {getStaticColor, StaticColorByType} from '@atb/theme/colors';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
@@ -32,6 +32,7 @@ export const Root_LoginConfirmCodeScreen = ({navigation, route}: Props) => {
   const {phoneNumber, afterLogin} = route.params;
   const {t} = useTranslation();
   const styles = useStyles();
+  const {themeName} = useTheme();
   const {authenticationType, confirmCode, signInWithPhoneNumber} =
     useAuthState();
   const [code, setCode] = useState('');
@@ -121,6 +122,7 @@ export const Root_LoginConfirmCodeScreen = ({navigation, route}: Props) => {
               <ActivityIndicator
                 style={styles.activityIndicator}
                 size="large"
+                color={getStaticColor(themeName, themeColor).text}
               />
             )}
 

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -18,7 +18,7 @@ import {MessageBox} from '@atb/components/message-box';
 import {Button} from '@atb/components/button';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
-import {StaticColorByType} from '@atb/theme/colors';
+import {getStaticColor, StaticColorByType} from '@atb/theme/colors';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -32,7 +32,7 @@ export const Root_LoginPhoneInputScreen = ({
 }: Props) => {
   const {t} = useTranslation();
   const styles = useStyles();
-  const {theme} = useTheme();
+  const {themeName} = useTheme();
   const {signInWithPhoneNumber} = useAuthState();
   const [phoneNumber, setPhoneNumber] = useState('');
   const [prefix, setPrefix] = useState('47');
@@ -134,7 +134,7 @@ export const Root_LoginPhoneInputScreen = ({
               <ActivityIndicator
                 style={styles.activityIndicator}
                 size="large"
-                color={theme.text.colors.primary}
+                color={getStaticColor(themeName, themeColor).text}
               />
             )}
 


### PR DESCRIPTION
Noticed that the loading indicator spinner was black on the dark background color on the login screens. Updated to use the text color based on the pages `themeColor` setting.

Clarified with @oyvindmikkelsenatb 

## Before/after

![Screenshot 2023-06-26 at 11 17 03](https://github.com/AtB-AS/mittatb-app/assets/1774972/14359f26-d9fe-4903-9a2c-11269abd386f)
![Screenshot 2023-06-26 at 11 18 17](https://github.com/AtB-AS/mittatb-app/assets/1774972/8bbd67ab-2143-4e47-9b4b-c83eee46a763)


## Acceptance criteria

- [ ] Loading indicator when submitting phone number is white
- [ ] Loading indicator when submitting confirmation code is white