### PR TITLE
feat: hide certain default traveller profiles

### DIFF
--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -34,6 +34,7 @@ export type UserProfile = {
   alternativeDescriptions: LanguageAndTextType[];
   version: string;
   emoji?: string;
+  hideFromDefaultTravellerSelection?: boolean;
 };
 
 export type TariffZone = {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DefaultUserProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DefaultUserProfileScreen.tsx
@@ -27,7 +27,7 @@ export const Profile_DefaultUserProfileScreen = () => {
       (userProfile) => userProfile.userTypeString === defaultUserTypeString,
     ) ?? userProfiles[0];
 
-  const userProfilesWithoutHiddenCategories = userProfiles.filter(
+  const selectableUserProfiles = userProfiles.filter(
     (profile) => !profile.hideFromDefaultTravellerSelection,
   );
 
@@ -43,7 +43,7 @@ export const Profile_DefaultUserProfileScreen = () => {
         </ThemeText>
 
         <RadioGroupSection<UserProfile>
-          items={userProfilesWithoutHiddenCategories}
+          items={selectableUserProfiles}
           keyExtractor={(u) => u.id}
           itemToText={(u) => getReferenceDataName(u, language)}
           selected={selectedProfile}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DefaultUserProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DefaultUserProfileScreen.tsx
@@ -27,6 +27,10 @@ export const Profile_DefaultUserProfileScreen = () => {
       (userProfile) => userProfile.userTypeString === defaultUserTypeString,
     ) ?? userProfiles[0];
 
+  const userProfilesWithoutHiddenCategories = userProfiles.filter(
+    (profile) => !profile.hideFromDefaultTravellerSelection,
+  );
+
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -39,7 +43,7 @@ export const Profile_DefaultUserProfileScreen = () => {
         </ThemeText>
 
         <RadioGroupSection<UserProfile>
-          items={userProfiles}
+          items={userProfilesWithoutHiddenCategories}
           keyExtractor={(u) => u.id}
           itemToText={(u) => getReferenceDataName(u, language)}
           selected={selectedProfile}


### PR DESCRIPTION
Part of https://github.com/AtB-AS/kundevendt/issues/4225

Hiding userProfiles with flag `hideFromDefaultTravellerSelection` from default traveller category selection. 

Used at FRAM for hiding userProfiles only associated with certain products on the authority endpoint.

<details>
<summary>Screenshots</summary>

Before:
![image](https://github.com/AtB-AS/mittatb-app/assets/21310942/e31f16ba-7346-4eb3-9413-b6723998a647)

Now:
![IMG_121B3FBE2030-1](https://github.com/AtB-AS/mittatb-app/assets/21310942/f4129122-d3b1-408b-9811-8da531e73d30)

</details>