### PR TITLE
fix: Traveller order in recent tickets

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
@@ -144,6 +144,7 @@ export const RecentFareContractComponent = ({
                   <>
                     {userProfilesWithCount.slice(0, 1).map((u) => (
                       <InfoChip
+                        key={u.id}
                         interactiveColor={interactiveColorName}
                         style={styles.infoChip}
                         text={`${u.count} ${getReferenceDataName(u, language)}`}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/use-recent-fare-contracts.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/use-recent-fare-contracts.ts
@@ -130,7 +130,6 @@ const mapBackendRecentFareContracts = (
     fromTariffZone?.id +
     toTariffZone?.id +
     userProfilesWithCount
-      .sort((u1, u2) => (u1.id > u2.id ? 1 : -1))
       .map((u) => u.id + u.count)
       .join();
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/use-recent-fare-contracts.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/use-recent-fare-contracts.ts
@@ -129,9 +129,7 @@ const mapBackendRecentFareContracts = (
     preassignedFareProduct?.id +
     fromTariffZone?.id +
     toTariffZone?.id +
-    userProfilesWithCount
-      .map((u) => u.id + u.count)
-      .join();
+    userProfilesWithCount.map((u) => u.id + u.count).join();
 
   return {
     id,


### PR DESCRIPTION
### Background
The traveller order should be based on user profile order, but it
was overwritten by some redundant sorting code.

### Solution
Before/After:
<div>
<img src='https://github.com/AtB-AS/mittatb-app/assets/675421/b27fc83e-2260-4338-b008-3ec7aec9e599'/>
<img src='https://github.com/AtB-AS/mittatb-app/assets/675421/81614f88-29d1-4d5d-bff5-c39ebe745c49'/>
</div>

### Acceptance criteria
- [ ] The traveller categories on recent fare contracts should be sorted by user profile order in Firestore.

