### PR TITLE
fix: update websocket error handling to use onClose events

### DIFF
--- a/src/api/use-subscription.ts
+++ b/src/api/use-subscription.ts
@@ -12,15 +12,13 @@ export type SubscriptionStatus =
 
 export type SubscriptionEventProps = {
   onMessage?: (event: WebSocketMessageEvent) => void;
-  onError?: (event: WebSocketErrorEvent) => void;
   onOpen?: () => void;
-  onClose?: (event: WebSocketCloseEvent) => void;
+  onClose?: (event: WebSocketCloseEvent & {isError: boolean}) => void;
 };
 
 export function useSubscription({
   url,
   onMessage,
-  onError,
   onClose,
   onOpen,
 }: {url: string | null} & SubscriptionEventProps) {
@@ -40,25 +38,29 @@ export function useSubscription({
         onMessage && onMessage(event);
       };
 
-      webSocket.onerror = (event) => {
-        setStatus(getSubscriptionStatus(webSocket.readyState));
-        Bugsnag.notify(`WebSocket error "${event.message}"`);
-        onError && onError(event);
-      };
-
       webSocket.onclose = (event) => {
         setStatus(getSubscriptionStatus(webSocket.readyState));
-        Bugsnag.leaveBreadcrumb(`WebSocket closed with url: ${url}`);
+        let isError: boolean;
 
-        // Reconnect immediately if close event is end of stream, otherwise use
+        // Reconnect immediately if close event is expected, otherwise use
         // exponetial backoff to retry.
-        if (event.code === 1001) {
+        if (
+          event.code === 1000 ||
+          event.code === 1001 ||
+          event.code === undefined
+        ) {
+          Bugsnag.leaveBreadcrumb(`WebSocket closed with code ${event.code}`);
+          isError = false;
           connect();
         } else {
+          isError = true;
+          Bugsnag.notify(
+            `WebSocket closed with unexpected event ${event.code} "${event.message}" (${event.reason})`,
+          );
           retryTimeout = retryWithCappedBackoff(retryCount, connect);
         }
 
-        onClose && onClose(event);
+        onClose && onClose({...event, isError});
       };
 
       webSocket.onopen = () => {
@@ -78,7 +80,7 @@ export function useSubscription({
       setWebSocket((ws) => {
         if (ws) {
           ws.onclose = null;
-          onClose && onClose({code: 1000, reason: 'Cleanup'});
+          onClose && onClose({code: 1000, reason: 'Cleanup', isError: false});
           ws.close();
         }
         return null;

--- a/src/api/use-subscription.ts
+++ b/src/api/use-subscription.ts
@@ -38,6 +38,13 @@ export function useSubscription({
         onMessage && onMessage(event);
       };
 
+      webSocket.onerror = (event) => {
+        setStatus(getSubscriptionStatus(webSocket.readyState));
+        if (event.message !== null) {
+          Bugsnag.notify(`WebSocket error "${event.message}"`);
+        }
+      };
+
       webSocket.onclose = (event) => {
         setStatus(getSubscriptionStatus(webSocket.readyState));
         let isError: boolean;

--- a/src/api/vehicles.ts
+++ b/src/api/vehicles.ts
@@ -32,7 +32,6 @@ export const getServiceJourneyVehicles = async (
 export const useLiveVehicleSubscription = ({
   serviceJourneyId,
   onClose,
-  onError,
   onMessage,
   onOpen,
 }: {serviceJourneyId?: string} & SubscriptionEventProps) => {
@@ -46,7 +45,6 @@ export const useLiveVehicleSubscription = ({
   return useSubscription({
     url: serviceJourneyId ? url : null,
     onMessage,
-    onError,
     onOpen,
     onClose,
   });

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -85,10 +85,13 @@ export const TravelDetailsMapScreenComponent = ({
   useLiveVehicleSubscription({
     serviceJourneyId: vehicleWithPosition?.serviceJourney?.id,
     onMessage: (event: WebSocketMessageEvent) => {
+      if (isError) setIsError(false);
       const vehicle = JSON.parse(event.data) as VehicleWithPosition;
       setVehicle(vehicle);
     },
-    onError: () => setIsError(true),
+    onClose: (event) => {
+      if (event.isError) setIsError(true);
+    },
   });
 
   const [shouldTrack, setShouldTrack] = useState<boolean>(true);


### PR DESCRIPTION
Updates websocket logic to rely on onClose events instead of onError, since they provide status codes, and doesn't of arbitrarily failing on reconnects on android. `useSubscription`s onclose now returns an `isError` field based on expected status codes from https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4

Resolves comment https://github.com/AtB-AS/kundevendt/issues/4213#issuecomment-1607173946

closes https://github.com/AtB-AS/kundevendt/issues/4236
