### PR TITLE
fix: Set customerAccountId on reserveOffer

### DIFF
--- a/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/use-terminal-state.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/use-terminal-state.ts
@@ -56,6 +56,7 @@ export function useTerminalState(
                 retry: true,
               },
               scaExemption: true,
+              customerAccountId: user?.uid!,
             })
           : await reserveOffers({
               offers,
@@ -65,6 +66,7 @@ export function useTerminalState(
                 retry: true,
               },
               scaExemption: true,
+              customerAccountId: user?.uid!,
             });
         setReservation(response);
       } catch (err) {

--- a/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/use-vipps-state.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/use-vipps-state.ts
@@ -95,6 +95,7 @@ export function useVippsState(offers: ReserveOffer[], dismiss: () => void) {
             retry: true,
           },
           scaExemption: false,
+          customerAccountId: user?.uid!,
         });
         dispatch({type: 'OFFER_RESERVED', reservation: response});
         if (user) {

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -47,6 +47,7 @@ type ReserveOfferParams = {
   paymentType: PaymentType;
   opts?: AxiosRequestConfig;
   scaExemption: boolean;
+  customerAccountId: string;
 };
 
 export type ReserveOfferWithSavePaymentParams = ReserveOfferParams & {
@@ -95,12 +96,13 @@ export async function reserveOffers({
   paymentType,
   opts,
   scaExemption,
+  customerAccountId,
   ...rest
 }:
   | ReserveOfferWithSavePaymentParams
   | ReserveOfferWithRecurringParams): Promise<OfferReservation> {
   const url = 'ticket/v3/reserve';
-  let body: ReserveOfferRequestBody = {
+  const body: ReserveOfferRequestBody = {
     payment_redirect_url: `${APP_SCHEME}://ticketing?transaction_id={transaction_id}&payment_id={payment_id}`,
     offers,
     payment_type: paymentType,
@@ -109,6 +111,7 @@ export async function reserveOffers({
     recurring_payment_id:
       'recurringPaymentId' in rest ? rest.recurringPaymentId : undefined,
     sca_exemption: scaExemption,
+    customer_account_id: customerAccountId,
   };
   const response = await client.post<OfferReservation>(url, body, {
     ...opts,

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -170,6 +170,7 @@ export type ReserveOfferRequestBody = {
   store_payment: boolean | undefined;
   recurring_payment_id: number | undefined;
   sca_exemption: boolean;
+  customer_account_id: string;
 };
 
 export type OfferReservation = {


### PR DESCRIPTION
### Background
In march, when implementing sub accounts, it was added a field
´customer_account_id´ in the reserve offer endpoint, which also
was added to the reservations in Firestore.

It was added code in the app to check that a reservation has the
correct customer account id, however it was not added code to
set the customer account id when reserving a offer. As such no
reservations created from the app showed up in the app.

### Solution
Sending in customer account id when reserving offer.

### Acceptance criteria
- [ ] Reservation created and showing in app until fare contract is received, for both card and Vipps.
