### PR TITLE
fix: departure time in favorite departures

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -269,7 +269,7 @@ function DepartureTimeItem({
   }
   return (
     <Button
-      key={departure.serviceJourneyId}
+      key={departure.aimedTime + departure.serviceJourneyId}
       type="inline"
       compact={true}
       interactiveColor="interactive_2"


### PR DESCRIPTION
The issue where the next day's departure shows as "now" in favorite departures is most likely because the service journey ID is the same for these two and therefore the key for the component is the same. To solve this, I've added the aimed time to the key, as is done for the other components. 

An example of this issue can be seen in the following screenshot, where two of the departures marked as "now" is planned to leave the following two days. 
![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/7524cb6f-771a-4e72-97cf-f37ab7668808)


Fixes https://github.com/AtB-AS/kundevendt/issues/4277