### PR TITLE
fix: a11y focus for travellers and zones selected

### DIFF
--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -53,7 +53,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
 
   const animatedOffset = useMemo(() => new Animated.Value(0), []);
   const focusRef = useFocusOnLoad();
-  const [closeRef, setCloseRef] = useState<RefObject<any> | undefined>();
+  let closeReference: any = undefined;
 
   useEffect(
     () => () =>
@@ -69,8 +69,8 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
-    if (closeRef) {
-      setTimeout(() => giveFocus(closeRef), 200);
+    if (closeReference) {
+      setTimeout(() => giveFocus(closeReference), 200);
     }
   };
 
@@ -80,7 +80,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
     useBackdrop: boolean = true,
   ) => {
     setContentFunction(() => contentFunction);
-    setCloseRef(closeRef);
+    closeReference = closeRef;
     setBackdropEnabled(useBackdrop);
     setIsOpen(true);
   };

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -114,7 +114,7 @@ const BaseHeader = ({
   const css = useHeaderStyle();
   const {theme, themeName} = useTheme();
   const themeColor = color ?? 'background_accent_0';
-  const focusRef = useFocusOnLoad(setFocusOnLoad);
+  //const focusRef = useFocusOnLoad(setFocusOnLoad);
 
   const {buttonsHeight, buttonsTopOffset, setLayoutFor} = useHeaderLayouts();
 
@@ -135,7 +135,7 @@ const BaseHeader = ({
           },
         ]}
         onLayout={setLayoutFor('container')}
-        ref={focusRef}
+        //ref={focusRef}
       >
         <View
           style={{

--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -10,7 +10,6 @@ export type SectionProps = PropsWithChildren<{
   withTopPadding?: boolean;
   withBottomPadding?: boolean;
   type?: ContainerSizingType;
-  containerViewRef?: React.RefObject<View>;
   style?: ViewStyle;
   testID?: string;
 }> &
@@ -23,7 +22,6 @@ export function Section({
   withTopPadding = false,
   withBottomPadding = false,
   type = 'block',
-  containerViewRef,
   style,
   ...props
 }: SectionProps) {
@@ -42,7 +40,7 @@ export function Section({
   ];
 
   return (
-    <View style={containerStyle} {...props} ref={containerViewRef}>
+    <View style={containerStyle} {...props}>
       {React.Children.map(children, (child, index) => {
         if (!React.isValidElement(child)) return child;
         if (child == null) return child;

--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -10,6 +10,7 @@ export type SectionProps = PropsWithChildren<{
   withTopPadding?: boolean;
   withBottomPadding?: boolean;
   type?: ContainerSizingType;
+  containerViewRef?: React.RefObject<View>;
   style?: ViewStyle;
   testID?: string;
 }> &
@@ -22,6 +23,7 @@ export function Section({
   withTopPadding = false,
   withBottomPadding = false,
   type = 'block',
+  containerViewRef,
   style,
   ...props
 }: SectionProps) {
@@ -40,7 +42,7 @@ export function Section({
   ];
 
   return (
-    <View style={containerStyle} {...props}>
+    <View style={containerStyle} {...props} ref={containerViewRef}>
       {React.Children.map(children, (child, index) => {
         if (!React.isValidElement(child)) return child;
         if (child == null) return child;

--- a/src/components/sections/items/GenericClickableSectionItem.tsx
+++ b/src/components/sections/items/GenericClickableSectionItem.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren} from 'react';
+import React, {PropsWithChildren, forwardRef} from 'react';
 import {AccessibilityProps, TouchableOpacity, View} from 'react-native';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
@@ -10,12 +10,14 @@ type Props = PropsWithChildren<
     } & AccessibilityProps
   >
 >;
-export function GenericClickableSectionItem({children, ...props}: Props) {
-  const {topContainer} = useSectionItem(props);
+export const GenericClickableSectionItem = forwardRef<TouchableOpacity, Props>(
+  ({children, ...props}, focusRef) => {
+    const {topContainer} = useSectionItem(props);
 
-  return (
-    <TouchableOpacity {...props}>
-      <View style={topContainer}>{children}</View>
-    </TouchableOpacity>
-  );
-}
+    return (
+      <TouchableOpacity {...props} ref={focusRef}>
+        <View style={topContainer}>{children}</View>
+      </TouchableOpacity>
+    );
+  },
+);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -151,6 +151,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             toTariffZone={toTariffZone}
             fareProductTypeConfig={params.fareProductTypeConfig}
             preassignedFareProduct={preassignedFareProduct}
+            setA11yFocusToZonesSelection={params.setA11yFocusToZonesSelection}
             onSelect={(t) =>
               navigation.push('Root_PurchaseTariffZonesSearchByMapScreen', t)
             }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,5 +1,12 @@
-import React, {useEffect, useState} from 'react';
-import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
+import React, {useEffect, useRef, useState} from 'react';
+import {
+  AccessibilityInfo,
+  AccessibilityProps,
+  StyleProp,
+  View,
+  ViewStyle,
+  findNodeHandle,
+} from 'react-native';
 
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {TravellerSelectionMode} from '@atb/configuration';
@@ -35,6 +42,7 @@ export function TravellerSelection({
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
   const styles = useStyles();
+  const travellersInputSectionRef = useRef<View>(null);
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
 
   const [userProfilesState, setUserProfilesState] = useState<
@@ -108,6 +116,13 @@ export function TravellerSelection({
             setUserProfilesState(chosenSelectableUserProfilesWithCounts);
           }
           closeBottomSheet();
+
+          if (travellersInputSectionRef.current) {
+            const reactTag = findNodeHandle(travellersInputSectionRef.current);
+            if (reactTag) {
+              AccessibilityInfo.setAccessibilityFocus(reactTag);
+            }
+          }
         }}
       />
     ));
@@ -122,7 +137,7 @@ export function TravellerSelection({
             : t(PurchaseOverviewTexts.travellerSelection.title_single)}
         </ThemeText>
       </View>
-      <Section {...accessibility}>
+      <Section {...accessibility} containerViewRef={travellersInputSectionRef}>
         <GenericClickableSectionItem onPress={travellerSelectionOnPress}>
           <View style={styles.sectionContentContainer}>
             <View style={{flex: 1}}>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,12 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
-import {
-  AccessibilityInfo,
-  AccessibilityProps,
-  StyleProp,
-  View,
-  ViewStyle,
-  findNodeHandle,
-} from 'react-native';
+import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {TravellerSelectionMode} from '@atb/configuration';
@@ -42,7 +35,8 @@ export function TravellerSelection({
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
   const styles = useStyles();
-  const travellersInputSectionRef = useRef<View>(null);
+  const travellersInputSectionItemRef = useRef(null);
+
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
 
   const [userProfilesState, setUserProfilesState] = useState<
@@ -104,28 +98,24 @@ export function TravellerSelection({
   };
 
   const travellerSelectionOnPress = () => {
-    openBottomSheet(() => (
-      <TravellerSelectionSheet
-        selectionMode={selectionMode}
-        fareProductType={fareProductType}
-        selectableUserProfilesWithCountInit={userProfilesState}
-        close={(
-          chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
-        ) => {
-          if (chosenSelectableUserProfilesWithCounts !== undefined) {
-            setUserProfilesState(chosenSelectableUserProfilesWithCounts);
-          }
-          closeBottomSheet();
-
-          if (travellersInputSectionRef.current) {
-            const reactTag = findNodeHandle(travellersInputSectionRef.current);
-            if (reactTag) {
-              AccessibilityInfo.setAccessibilityFocus(reactTag);
+    openBottomSheet(
+      () => (
+        <TravellerSelectionSheet
+          selectionMode={selectionMode}
+          fareProductType={fareProductType}
+          selectableUserProfilesWithCountInit={userProfilesState}
+          close={(
+            chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
+          ) => {
+            if (chosenSelectableUserProfilesWithCounts !== undefined) {
+              setUserProfilesState(chosenSelectableUserProfilesWithCounts);
             }
-          }
-        }}
-      />
-    ));
+            closeBottomSheet();
+          }}
+        />
+      ),
+      travellersInputSectionItemRef,
+    );
   };
 
   return (
@@ -137,8 +127,11 @@ export function TravellerSelection({
             : t(PurchaseOverviewTexts.travellerSelection.title_single)}
         </ThemeText>
       </View>
-      <Section {...accessibility} containerViewRef={travellersInputSectionRef}>
-        <GenericClickableSectionItem onPress={travellerSelectionOnPress}>
+      <Section {...accessibility}>
+        <GenericClickableSectionItem
+          onPress={travellerSelectionOnPress}
+          ref={travellersInputSectionItemRef}
+        >
           <View style={styles.sectionContentContainer}>
             <View style={{flex: 1}}>
               <ThemeText type="body__primary--bold">

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -7,8 +7,15 @@ import {
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
-import React from 'react';
-import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
+import React, {useEffect, useRef} from 'react';
+import {
+  AccessibilityInfo,
+  AccessibilityProps,
+  findNodeHandle,
+  StyleProp,
+  View,
+  ViewStyle,
+} from 'react-native';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
@@ -16,12 +23,14 @@ import {PreassignedFareProduct} from '@atb/reference-data/types';
 
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
+import {giveFocus} from '@atb/utils/use-focus-on-load';
 
 type ZonesSelectionProps = {
   fareProductTypeConfig: FareProductTypeConfig;
   fromTariffZone: TariffZoneWithMetadata;
   toTariffZone: TariffZoneWithMetadata;
   preassignedFareProduct: PreassignedFareProduct;
+  setA11yFocusToZonesSelection?: boolean;
   onSelect: (t: {
     fromTariffZone: TariffZoneWithMetadata;
     toTariffZone: TariffZoneWithMetadata;
@@ -36,11 +45,18 @@ export function ZonesSelection({
   fromTariffZone,
   toTariffZone,
   preassignedFareProduct,
+  setA11yFocusToZonesSelection,
   onSelect,
   style,
 }: ZonesSelectionProps) {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const zonesInputSectionItemRef = useRef(null);
+
+  useEffect(() => {
+    setA11yFocusToZonesSelection &&
+      setTimeout(() => giveFocus(zonesInputSectionItemRef), 300);
+  }, [setA11yFocusToZonesSelection]);
 
   const accessibility: AccessibilityProps = {
     accessible: true,
@@ -86,15 +102,16 @@ export function ZonesSelection({
       </ThemeText>
       <Section {...accessibility}>
         <GenericClickableSectionItem
-          onPress={() =>
+          onPress={() => {
             onSelect({
               fromTariffZone,
               toTariffZone,
               fareProductTypeConfig,
               preassignedFareProduct,
-            })
-          }
+            });
+          }}
           testID="selectZonesButton"
+          ref={zonesInputSectionItemRef}
         >
           <View style={styles.sectionContentContainer}>
             <View>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/navigation-types.ts
@@ -12,4 +12,5 @@ export type Root_PurchaseOverviewScreenParams = {
   toTariffZone?: TariffZoneWithMetadata;
   mode?: 'Ticket' | 'TravelSearch';
   travelDate?: string;
+  setA11yFocusToZonesSelection?: boolean;
 };

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -57,6 +57,7 @@ export const Root_PurchaseTariffZonesSearchByMapScreen = ({
         mode: 'Ticket',
         fareProductTypeConfig,
         fromTariffZone: selectedZones.from,
+        setA11yFocusToZonesSelection: true,
         toTariffZone: isApplicableOnSingleZoneOnly
           ? selectedZones.from
           : selectedZones.to,


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/3943

After selecting travellers or zone for a ticket, the focus should go back to that field when returning.