### PR TITLE
fix: updating the wrong departure in favorite departures with realtime data

### DIFF
--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -7,13 +7,9 @@ import {
 } from '@atb/api/departures/types';
 import {EstimatedCall} from '@atb/api/types/departures';
 import {DepartureRealtimeData, DeparturesRealtimeData} from '@atb/sdk';
-import {
-  differenceInMinutesStrings,
-  isNumberOfMinutesInThePast,
-} from '@atb/utils/date';
+import {isNumberOfMinutesInThePast} from '@atb/utils/date';
 
 export const HIDE_AFTER_NUM_MINUTES = 1;
-const MAX_REALTIME_DELAY_MINUTES = 600;
 /***
  * Used to update all stops with new time from realtime mapping object returned
  * from the BFF. It also removes outdated departures which most likely have passed.
@@ -86,21 +82,10 @@ function updateDeparturesWithRealtime(
 
       const departureRealtime = realtime.departures[serviceJourneyId];
 
-      if (!departureRealtime) {
-        return departure;
-      }
-
-      // Check if the real-time expected departure time exceeds the maximum allowed delay
-      // (i.e. not scheduled for more than MAX_REALTIME_DELAY_MINUTES in the future),
-      // and return the original planned departure if this is the case.
-      // This is done to ensure that we don't update the next day's departure that has the
-      // same serviceJourneyId.
-      const realmtimeDifferenceInMinutes = differenceInMinutesStrings(
-        departureRealtime.timeData.expectedDepartureTime,
-        departure.aimedTime,
-      );
-
-      if (realmtimeDifferenceInMinutes > MAX_REALTIME_DELAY_MINUTES) {
+      if (
+        !departureRealtime ||
+        departure.aimedTime !== departureRealtime.timeData.aimedDepartureTime
+      ) {
         return departure;
       }
 

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -7,10 +7,13 @@ import {
 } from '@atb/api/departures/types';
 import {EstimatedCall} from '@atb/api/types/departures';
 import {DepartureRealtimeData, DeparturesRealtimeData} from '@atb/sdk';
-import {isNumberOfMinutesInThePast} from '@atb/utils/date';
+import {
+  differenceInMinutesStrings,
+  isNumberOfMinutesInThePast,
+} from '@atb/utils/date';
 
 export const HIDE_AFTER_NUM_MINUTES = 1;
-
+const MAX_REALTIME_DELAY_MINUTES = 600;
 /***
  * Used to update all stops with new time from realtime mapping object returned
  * from the BFF. It also removes outdated departures which most likely have passed.
@@ -84,6 +87,20 @@ function updateDeparturesWithRealtime(
       const departureRealtime = realtime.departures[serviceJourneyId];
 
       if (!departureRealtime) {
+        return departure;
+      }
+
+      // Check if the real-time expected departure time exceeds the maximum allowed delay
+      // (i.e. not scheduled for more than MAX_REALTIME_DELAY_MINUTES in the future),
+      // and return the original planned departure if this is the case.
+      // This is done to ensure that we don't update the next day's departure that has the
+      // same serviceJourneyId.
+      const realmtimeDifferenceInMinutes = differenceInMinutesStrings(
+        departureRealtime.timeData.expectedDepartureTime,
+        departure.aimedTime,
+      );
+
+      if (realmtimeDifferenceInMinutes > MAX_REALTIME_DELAY_MINUTES) {
         return departure;
       }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -178,6 +178,7 @@ export type RealtimeData = {
   timeData: {
     realtime: boolean;
     expectedDepartureTime: string;
+    aimedDepartureTime: string;
   };
 };
 


### PR DESCRIPTION
To prevent us from updating the wrong departure in favorite departures with real-time data for another departure, I've added a check on `aimedDepartureTime`. This change was necessary because departures have the same `serviceJourneyId`, which caused the app to update the wrong departure in the user's favorite departures list. 

See https://github.com/AtB-AS/atb-bff/pull/279 for necessary changes to the bff. 

Closes https://github.com/AtB-AS/kundevendt/issues/4277
