### PR TITLE
chore: bottom sheet focus improvements

### DIFF
--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -16,11 +16,11 @@ export const useChatIcon = (
 ): IconButtonProps | undefined => {
   const unreadCount = useChatUnreadCount();
   const styles = useStyles();
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   const {t} = useTranslation();
 
   const openContactSheet = () => {
-    openBottomSheet((close, onOpenFocusRef) => (
+    openBottomSheet((close) => (
       <ContactSheet close={close} ref={onOpenFocusRef} />
     ));
   };

--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -20,8 +20,8 @@ export const useChatIcon = (
   const {t} = useTranslation();
 
   const openContactSheet = () => {
-    openBottomSheet((close, focusRef) => (
-      <ContactSheet close={close} ref={focusRef} />
+    openBottomSheet((close, onOpenFocusRef) => (
+      <ContactSheet close={close} ref={onOpenFocusRef} />
     ));
   };
 

--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -16,12 +16,16 @@ export const useChatIcon = (
 ): IconButtonProps | undefined => {
   const unreadCount = useChatUnreadCount();
   const styles = useStyles();
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
   const {t} = useTranslation();
 
   const openContactSheet = () => {
-    openBottomSheet((close) => (
-      <ContactSheet close={close} ref={onOpenFocusRef} />
+    openBottomSheet(() => (
+      <ContactSheet close={closeBottomSheet} ref={onOpenFocusRef} />
     ));
   };
 

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -22,8 +22,8 @@ import {AnimatedBottomSheet} from './AnimatedBottomSheet';
 
 type BottomSheetContentFunction = (
   close: () => void,
-  /** Use focusRef to give a component accessibility focus when BottomSheet open. The component must be accessible! */
-  focusRef: RefObject<any>,
+  /** Use onOpenFocusRef to give a component accessibility focus when BottomSheet open. The component must be accessible! */
+  onOpenFocusRef: RefObject<any>,
 ) => ReactNode;
 
 type BottomSheetState = {
@@ -48,11 +48,11 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isBackdropEnabled, setBackdropEnabled] = useState(true);
   const [contentFunction, setContentFunction] = useState<
-    (close: () => void, focusRef: RefObject<any>) => ReactNode
+    (close: () => void, onOpenFocusRef: RefObject<any>) => ReactNode
   >(() => () => null);
 
   const animatedOffset = useMemo(() => new Animated.Value(0), []);
-  const focusRef = useFocusOnLoad();
+  const onOpenFocusRef = useFocusOnLoad();
   const [closeRef, setCloseRef] = useState<RefObject<any> | undefined>();
 
   useEffect(
@@ -75,7 +75,10 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   };
 
   const open = (
-    contentFunction: (close: () => void, focusRef: RefObject<any>) => ReactNode,
+    contentFunction: (
+      close: () => void,
+      onOpenFocusRef: RefObject<any>,
+    ) => ReactNode,
     closeRef?: RefObject<any>,
     useBackdrop: boolean = true,
   ) => {
@@ -121,11 +124,11 @@ export const BottomSheetProvider: React.FC = ({children}) => {
           animatedOffset={animatedOffset}
           onLayout={onLayout}
         >
-          {contentFunction(close, focusRef)}
+          {contentFunction(close, onOpenFocusRef)}
         </AnimatedBottomSheet>
       </>
     ),
-    [isOpen, close, focusRef, animatedOffset, safeAreaBottom],
+    [isOpen, close, onOpenFocusRef, animatedOffset, safeAreaBottom],
   );
 
   const state = {

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -21,7 +21,7 @@ import {Backdrop} from './Backdrop';
 import {ClickableBackground} from './ClickableBackground';
 import {AnimatedBottomSheet} from './AnimatedBottomSheet';
 
-type BottomSheetContentFunction = (close: () => void) => ReactNode;
+type BottomSheetContentFunction = () => ReactNode;
 
 type BottomSheetState = {
   open: (
@@ -46,9 +46,9 @@ export const BottomSheetProvider: React.FC = ({children}) => {
 
   const [isOpen, setIsOpen] = useState(false);
   const [isBackdropEnabled, setBackdropEnabled] = useState(true);
-  const [contentFunction, setContentFunction] = useState<
-    (close: () => void) => ReactNode
-  >(() => () => null);
+  const [contentFunction, setContentFunction] = useState<() => ReactNode>(
+    () => () => null,
+  );
 
   const animatedOffset = useMemo(() => new Animated.Value(0), []);
   const onOpenFocusRef = useFocusOnLoad();
@@ -68,13 +68,11 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
-    if (onCloseFocusRef) {
-      giveFocus(onCloseFocusRef);
-    }
+    onCloseFocusRef && giveFocus(onCloseFocusRef);
   };
 
   const open = (
-    contentFunction: (close: () => void) => ReactNode,
+    contentFunction: () => ReactNode,
     useBackdrop: boolean = true,
   ) => {
     setContentFunction(() => contentFunction);
@@ -118,7 +116,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
           animatedOffset={animatedOffset}
           onLayout={onLayout}
         >
-          {contentFunction(close)}
+          {contentFunction()}
         </AnimatedBottomSheet>
       </>
     ),

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -30,7 +30,7 @@ type BottomSheetState = {
   open: (
     contentFunction: BottomSheetContentFunction,
     /** Optional ref to component which should be focused on sheet close */
-    closeRef?: RefObject<any>,
+    onCloseFocusRef?: RefObject<any>,
     useBackdrop?: boolean,
   ) => void;
   isOpen: () => boolean;
@@ -53,7 +53,9 @@ export const BottomSheetProvider: React.FC = ({children}) => {
 
   const animatedOffset = useMemo(() => new Animated.Value(0), []);
   const onOpenFocusRef = useFocusOnLoad();
-  const [closeRef, setCloseRef] = useState<RefObject<any> | undefined>();
+  const [onCloseFocusRef, setOnCloseFocusRef] = useState<
+    RefObject<any> | undefined
+  >();
 
   useEffect(
     () => () =>
@@ -69,8 +71,8 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
-    if (closeRef) {
-      setTimeout(() => giveFocus(closeRef), 200);
+    if (onCloseFocusRef) {
+      setTimeout(() => giveFocus(onCloseFocusRef), 200);
     }
   };
 
@@ -79,11 +81,11 @@ export const BottomSheetProvider: React.FC = ({children}) => {
       close: () => void,
       onOpenFocusRef: RefObject<any>,
     ) => ReactNode,
-    closeRef?: RefObject<any>,
+    onCloseFocusRef?: RefObject<any>,
     useBackdrop: boolean = true,
   ) => {
     setContentFunction(() => contentFunction);
-    setCloseRef(closeRef);
+    setOnCloseFocusRef(onCloseFocusRef);
     setBackdropEnabled(useBackdrop);
     setIsOpen(true);
   };

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -32,9 +32,9 @@ type BottomSheetState = {
   close: () => void;
   height: number;
   /** Use onOpenFocusRef to give a component accessibility focus when BottomSheet open. The component must be accessible! */
-  onOpenFocusRef?: RefObject<any>;
+  onOpenFocusRef: RefObject<any>;
   /** Optional ref to component which should be focused on sheet close */
-  onCloseFocusRef?: RefObject<any>;
+  onCloseFocusRef: RefObject<any>;
 };
 
 const BottomSheetContext = createContext<BottomSheetState | undefined>(
@@ -68,7 +68,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
-    onCloseFocusRef && giveFocus(onCloseFocusRef);
+    giveFocus(onCloseFocusRef);
   };
 
   const open = (

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -76,7 +76,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               }}
             />
           ),
-          undefined,
+          //undefined,
           false,
         );
       } else if (isBikeStation(selectedFeature)) {
@@ -88,7 +88,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               close={closeWithCallback}
             />
           ),
-          undefined,
+          //undefined,
           false,
         );
       } else if (isCarStation(selectedFeature)) {
@@ -100,7 +100,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               close={closeWithCallback}
             />
           ),
-          undefined,
+          //undefined,
           false,
         );
       } else if (isVehicle(selectedFeature)) {
@@ -113,7 +113,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               />
             );
           },
-          undefined,
+          //undefined,
           false,
         );
       } else {

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -76,7 +76,6 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               }}
             />
           ),
-          //undefined,
           false,
         );
       } else if (isBikeStation(selectedFeature)) {
@@ -88,7 +87,6 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               close={closeWithCallback}
             />
           ),
-          //undefined,
           false,
         );
       } else if (isCarStation(selectedFeature)) {
@@ -100,22 +98,17 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               close={closeWithCallback}
             />
           ),
-          //undefined,
           false,
         );
       } else if (isVehicle(selectedFeature)) {
-        openBottomSheet(
-          () => {
-            return (
-              <ScooterSheet
-                vehicleId={selectedFeature.properties.id}
-                close={closeWithCallback}
-              />
-            );
-          },
-          //undefined,
-          false,
-        );
+        openBottomSheet(() => {
+          return (
+            <ScooterSheet
+              vehicleId={selectedFeature.properties.id}
+              close={closeWithCallback}
+            />
+          );
+        }, false);
       } else {
         closeBottomSheet();
       }

--- a/src/components/sections/items/GenericClickableSectionItem.tsx
+++ b/src/components/sections/items/GenericClickableSectionItem.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren} from 'react';
+import React, {PropsWithChildren, forwardRef} from 'react';
 import {AccessibilityProps, TouchableOpacity, View} from 'react-native';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
@@ -10,12 +10,14 @@ type Props = PropsWithChildren<
     } & AccessibilityProps
   >
 >;
-export function GenericClickableSectionItem({children, ...props}: Props) {
-  const {topContainer} = useSectionItem(props);
+export const GenericClickableSectionItem = forwardRef<TouchableOpacity, Props>(
+  ({children, ...props}, focusRef) => {
+    const {topContainer} = useSectionItem(props);
 
-  return (
-    <TouchableOpacity {...props}>
-      <View style={topContainer}>{children}</View>
-    </TouchableOpacity>
-  );
-}
+    return (
+      <TouchableOpacity {...props} ref={focusRef}>
+        <View style={topContainer}>{children}</View>
+      </TouchableOpacity>
+    );
+  },
+);

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -99,14 +99,14 @@ export function useOnMarkFavouriteDepartures(
       );
     } else if (line.lineName && line.lineNumber) {
       openBottomSheet(
-        (close, focusRef) =>
+        (close, onOpenFocusRef) =>
           line.lineName && line.lineNumber ? (
             <FavoriteDialogSheet
               lineName={line.lineName}
               lineNumber={line.lineNumber}
               addFavorite={addFavorite}
               close={close}
-              ref={focusRef}
+              ref={onOpenFocusRef}
             />
           ) : (
             <></>

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -29,7 +29,11 @@ export function useOnMarkFavouriteDepartures(
   const {addFavoriteDeparture, removeFavoriteDeparture, getFavoriteDeparture} =
     useFavorites();
   const {t} = useTranslation();
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
   if (!line.id || !line.lineName || !line.lineNumber) {
     return {onMarkFavourite: undefined, existingFavorite: undefined};
   }
@@ -97,13 +101,13 @@ export function useOnMarkFavouriteDepartures(
         ],
       );
     } else if (line.lineName && line.lineNumber) {
-      openBottomSheet((close) =>
+      openBottomSheet(() =>
         line.lineName && line.lineNumber ? (
           <FavoriteDialogSheet
             lineName={line.lineName}
             lineNumber={line.lineNumber}
             addFavorite={addFavorite}
-            close={close}
+            close={closeBottomSheet}
             ref={onOpenFocusRef}
           />
         ) : (

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -3,7 +3,7 @@ import {AccessibilityInfo, Alert} from 'react-native';
 import {NearbyTexts, useTranslation} from '@atb/translations';
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
-import React, {useRef} from 'react';
+import React from 'react';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {
   TransportSubmode,
@@ -29,8 +29,7 @@ export function useOnMarkFavouriteDepartures(
   const {addFavoriteDeparture, removeFavoriteDeparture, getFavoriteDeparture} =
     useFavorites();
   const {t} = useTranslation();
-  const {open: openBottomSheet} = useBottomSheet();
-  const onCloseFocusRef = useRef(null);
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   if (!line.id || !line.lineName || !line.lineNumber) {
     return {onMarkFavourite: undefined, existingFavorite: undefined};
   }
@@ -98,20 +97,18 @@ export function useOnMarkFavouriteDepartures(
         ],
       );
     } else if (line.lineName && line.lineNumber) {
-      openBottomSheet(
-        (close, onOpenFocusRef) =>
-          line.lineName && line.lineNumber ? (
-            <FavoriteDialogSheet
-              lineName={line.lineName}
-              lineNumber={line.lineNumber}
-              addFavorite={addFavorite}
-              close={close}
-              ref={onOpenFocusRef}
-            />
-          ) : (
-            <></>
-          ),
-        onCloseFocusRef,
+      openBottomSheet((close) =>
+        line.lineName && line.lineNumber ? (
+          <FavoriteDialogSheet
+            lineName={line.lineName}
+            lineNumber={line.lineNumber}
+            addFavorite={addFavorite}
+            close={close}
+            ref={onOpenFocusRef}
+          />
+        ) : (
+          <></>
+        ),
       );
     }
   };

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -30,7 +30,7 @@ export function useOnMarkFavouriteDepartures(
     useFavorites();
   const {t} = useTranslation();
   const {open: openBottomSheet} = useBottomSheet();
-  const closeRef = useRef(null);
+  const onCloseFocusRef = useRef(null);
   if (!line.id || !line.lineName || !line.lineNumber) {
     return {onMarkFavourite: undefined, existingFavorite: undefined};
   }
@@ -111,7 +111,7 @@ export function useOnMarkFavouriteDepartures(
           ) : (
             <></>
           ),
-        closeRef,
+        onCloseFocusRef,
       );
     }
   };

--- a/src/place-screen/components/DateSelection.tsx
+++ b/src/place-screen/components/DateSelection.tsx
@@ -68,9 +68,9 @@ export const DateSelection = ({
 
   const {open: openBottomSheet} = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet((close, focusRef) => (
+    openBottomSheet((close, onOpenFocusRef) => (
       <DepartureTimeSheet
-        ref={focusRef}
+        ref={onOpenFocusRef}
         close={close}
         initialTime={searchTime}
         setSearchTime={onSetSearchTime}

--- a/src/place-screen/components/DateSelection.tsx
+++ b/src/place-screen/components/DateSelection.tsx
@@ -66,12 +66,16 @@ export const DateSelection = ({
     setSearchTime(time);
   };
 
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet((close) => (
+    openBottomSheet(() => (
       <DepartureTimeSheet
         ref={onOpenFocusRef}
-        close={close}
+        close={closeBottomSheet}
         initialTime={searchTime}
         setSearchTime={onSetSearchTime}
         allowTimeInPast={false}

--- a/src/place-screen/components/DateSelection.tsx
+++ b/src/place-screen/components/DateSelection.tsx
@@ -66,9 +66,9 @@ export const DateSelection = ({
     setSearchTime(time);
   };
 
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet((close, onOpenFocusRef) => (
+    openBottomSheet((close) => (
       <DepartureTimeSheet
         ref={onOpenFocusRef}
         close={close}

--- a/src/service-disruptions/use-service-disruption-icon.tsx
+++ b/src/service-disruptions/use-service-disruption-icon.tsx
@@ -24,8 +24,8 @@ export const useServiceDisruptionIcon = (
   );
 
   const openServiceDisruptionSheet = () => {
-    openBottomSheet((close, focusRef) => (
-      <ServiceDisruptionSheet close={close} ref={focusRef} />
+    openBottomSheet((close, onOpenFocusRef) => (
+      <ServiceDisruptionSheet close={close} ref={onOpenFocusRef} />
     ));
   };
 

--- a/src/service-disruptions/use-service-disruption-icon.tsx
+++ b/src/service-disruptions/use-service-disruption-icon.tsx
@@ -16,7 +16,11 @@ export const useServiceDisruptionIcon = (
 ): IconButtonProps | undefined => {
   const {t} = useTranslation();
   const {findGlobalMessages} = useGlobalMessagesState();
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
   const now = useNow(2500);
 
   const globalMessages = findGlobalMessages('all').filter((gm) =>
@@ -24,8 +28,8 @@ export const useServiceDisruptionIcon = (
   );
 
   const openServiceDisruptionSheet = () => {
-    openBottomSheet((close) => (
-      <ServiceDisruptionSheet close={close} ref={onOpenFocusRef} />
+    openBottomSheet(() => (
+      <ServiceDisruptionSheet close={closeBottomSheet} ref={onOpenFocusRef} />
     ));
   };
 

--- a/src/service-disruptions/use-service-disruption-icon.tsx
+++ b/src/service-disruptions/use-service-disruption-icon.tsx
@@ -16,7 +16,7 @@ export const useServiceDisruptionIcon = (
 ): IconButtonProps | undefined => {
   const {t} = useTranslation();
   const {findGlobalMessages} = useGlobalMessagesState();
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   const now = useNow(2500);
 
   const globalMessages = findGlobalMessages('all').filter((gm) =>
@@ -24,7 +24,7 @@ export const useServiceDisruptionIcon = (
   );
 
   const openServiceDisruptionSheet = () => {
-    openBottomSheet((close, onOpenFocusRef) => (
+    openBottomSheet((close) => (
       <ServiceDisruptionSheet close={close} ref={onOpenFocusRef} />
     ));
   };

--- a/src/situations/use-situation-bottom-sheet.tsx
+++ b/src/situations/use-situation-bottom-sheet.tsx
@@ -7,11 +7,11 @@ export const useSituationBottomSheet = () => {
   const {open: openBottomSheet} = useBottomSheet();
 
   const openSituation = (situation: SituationType) => {
-    openBottomSheet((close, focusRef) => (
+    openBottomSheet((close, onOpenFocusRef) => (
       <SituationBottomSheet
         situation={situation}
         close={close}
-        ref={focusRef}
+        ref={onOpenFocusRef}
       />
     ));
   };

--- a/src/situations/use-situation-bottom-sheet.tsx
+++ b/src/situations/use-situation-bottom-sheet.tsx
@@ -4,13 +4,17 @@ import {SituationBottomSheet} from './SituationBottomSheet';
 import {SituationType} from './types';
 
 export const useSituationBottomSheet = () => {
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
 
   const openSituation = (situation: SituationType) => {
-    openBottomSheet((close) => (
+    openBottomSheet(() => (
       <SituationBottomSheet
         situation={situation}
-        close={close}
+        close={closeBottomSheet}
         ref={onOpenFocusRef}
       />
     ));

--- a/src/situations/use-situation-bottom-sheet.tsx
+++ b/src/situations/use-situation-bottom-sheet.tsx
@@ -4,10 +4,10 @@ import {SituationBottomSheet} from './SituationBottomSheet';
 import {SituationType} from './types';
 
 export const useSituationBottomSheet = () => {
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
 
   const openSituation = (situation: SituationType) => {
-    openBottomSheet((close, onOpenFocusRef) => (
+    openBottomSheet((close) => (
       <SituationBottomSheet
         situation={situation}
         close={close}

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -100,10 +100,10 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
     );
   };
 
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
 
   const openEmojiSheet = () => {
-    openBottomSheet((close) => (
+    openBottomSheet(() => (
       <EmojiSheet
         localizedCategories={[
           t(AddEditFavoriteTexts.emojiSheet.categories.smileys),
@@ -124,7 +124,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
             setEmoji(emoji);
           }
         }}
-        close={close}
+        close={closeBottomSheet}
       />
     ));
   };

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -85,7 +85,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const styles = useStyles();
   const {theme} = useTheme();
   const {t, language} = useTranslation();
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
   const {user} = useAuthState();
   const {paymentTypes, vatPercent} = useFirestoreConfiguration();
   const [previousMethod, setPreviousMethod] = useState<
@@ -235,14 +235,14 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   }
 
   async function selectPaymentMethod() {
-    openBottomSheet((close) => {
+    openBottomSheet(() => {
       return (
         <SelectPaymentMethod
           onSelect={(option: PaymentMethod) => {
             selectPaymentOption(option);
-            close();
+            closeBottomSheet();
           }}
-          close={close}
+          close={closeBottomSheet}
           previousPaymentMethod={previousPaymentMethod}
         />
       );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -31,13 +31,17 @@ export function StartTimeSelection({
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
   const styles = useStyles();
 
   const openTravelDateSheet = () => {
-    openBottomSheet((close) => (
+    openBottomSheet(() => (
       <TravelDateSheet
-        close={close}
+        close={closeBottomSheet}
         save={setTravelDate}
         travelDate={travelDate}
         ref={onOpenFocusRef}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -31,11 +31,11 @@ export function StartTimeSelection({
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   const styles = useStyles();
 
   const openTravelDateSheet = () => {
-    openBottomSheet((close, onOpenFocusRef) => (
+    openBottomSheet((close) => (
       <TravelDateSheet
         close={close}
         save={setTravelDate}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -35,12 +35,12 @@ export function StartTimeSelection({
   const styles = useStyles();
 
   const openTravelDateSheet = () => {
-    openBottomSheet((close, focusRef) => (
+    openBottomSheet((close, onOpenFocusRef) => (
       <TravelDateSheet
         close={close}
         save={setTravelDate}
         travelDate={travelDate}
-        ref={focusRef}
+        ref={onOpenFocusRef}
       />
     ));
   };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -35,7 +35,11 @@ export function TravellerSelection({
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
   const styles = useStyles();
-  const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onCloseFocusRef,
+  } = useBottomSheet();
 
   const [userProfilesState, setUserProfilesState] = useState<
     UserProfileWithCount[]
@@ -123,7 +127,10 @@ export function TravellerSelection({
         </ThemeText>
       </View>
       <Section {...accessibility}>
-        <GenericClickableSectionItem onPress={travellerSelectionOnPress}>
+        <GenericClickableSectionItem
+          onPress={travellerSelectionOnPress}
+          ref={onCloseFocusRef}
+        >
           <View style={styles.sectionContentContainer}>
             <View style={{flex: 1}}>
               <ThemeText type="body__primary--bold">

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -15,7 +15,7 @@ import {FavoriteDeparturesTexts, useTranslation} from '@atb/translations';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import {Coordinates} from '@entur/sdk';
 import haversineDistance from 'haversine-distance';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {useFavoriteDepartureData} from '../use-favorite-departure-data';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -45,8 +45,8 @@ export const DeparturesWidget = ({
 
   useEffect(() => loadInitialDepartures(), [favoriteDepartures]);
 
-  const {open: openBottomSheet} = useBottomSheet();
-  const onCloseFocusRef = useRef(null);
+  const {open: openBottomSheet, onCloseFocusRef} = useBottomSheet();
+
   async function openFrontpageFavouritesBottomSheet() {
     openBottomSheet((close) => {
       return (
@@ -55,7 +55,7 @@ export const DeparturesWidget = ({
           onEditFavouriteDeparture={onEditFavouriteDeparture}
         />
       );
-    }, onCloseFocusRef);
+    });
   }
 
   const sortedStopPlaceGroups = location

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -46,7 +46,7 @@ export const DeparturesWidget = ({
   useEffect(() => loadInitialDepartures(), [favoriteDepartures]);
 
   const {open: openBottomSheet} = useBottomSheet();
-  const closeRef = useRef(null);
+  const onCloseFocusRef = useRef(null);
   async function openFrontpageFavouritesBottomSheet() {
     openBottomSheet((close) => {
       return (
@@ -55,7 +55,7 @@ export const DeparturesWidget = ({
           onEditFavouriteDeparture={onEditFavouriteDeparture}
         />
       );
-    }, closeRef);
+    }, onCloseFocusRef);
   }
 
   const sortedStopPlaceGroups = location
@@ -129,7 +129,7 @@ export const DeparturesWidget = ({
           onPress={openFrontpageFavouritesBottomSheet}
           text={t(DeparturesTexts.button.text)}
           rightIcon={{svg: Edit}}
-          ref={closeRef}
+          ref={onCloseFocusRef}
           testID="selectFavoriteDepartures"
         />
       )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -45,13 +45,17 @@ export const DeparturesWidget = ({
 
   useEffect(() => loadInitialDepartures(), [favoriteDepartures]);
 
-  const {open: openBottomSheet, onCloseFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onCloseFocusRef,
+  } = useBottomSheet();
 
   async function openFrontpageFavouritesBottomSheet() {
-    openBottomSheet((close) => {
+    openBottomSheet(() => {
       return (
         <SelectFavouritesBottomSheet
-          close={close}
+          close={closeBottomSheet}
           onEditFavouriteDeparture={onEditFavouriteDeparture}
         />
       );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -351,7 +351,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                       : undefined,
                   }}
                   viewContainerStyle={style.filterButton}
-                  ref={filtersState.closeRef}
+                  ref={filtersState.onCloseFocusRef}
                 />
               )}
             </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -26,7 +26,7 @@ type TravelSearchFiltersState =
  * selected filters, and a function for opening the bottom sheet.
  */
 export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
-  const {open, onOpenFocusRef, onCloseFocusRef} = useBottomSheet();
+  const {open, close, onOpenFocusRef, onCloseFocusRef} = useBottomSheet();
   const travelSearchFiltersEnabled = useTravelSearchFiltersEnabled();
   const {travelSearchFilters} = useFirestoreConfiguration();
   const {filters, setFilters} = useFilters();
@@ -64,7 +64,7 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
   if (!travelSearchFilters?.transportModes) return {enabled: false};
 
   const openBottomSheet = () => {
-    open((close) => (
+    open(() => (
       <TravelSearchFiltersBottomSheet
         close={close}
         ref={onOpenFocusRef}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -1,5 +1,5 @@
 import {useBottomSheet} from '@atb/components/bottom-sheet';
-import React, {useRef, useState} from 'react';
+import React, {useState} from 'react';
 import {TravelSearchFiltersBottomSheet} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {useTravelSearchFiltersEnabled} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-enabled';
@@ -17,7 +17,7 @@ type TravelSearchFiltersState =
       anyFiltersApplied: boolean;
       resetTransportModes: () => void;
       disableFlexibleTransport: () => void;
-      onCloseFocusRef: React.Ref<any>;
+      onCloseFocusRef: React.RefObject<any> | undefined;
     }
   | {enabled: false; filtersSelection?: undefined};
 
@@ -26,7 +26,7 @@ type TravelSearchFiltersState =
  * selected filters, and a function for opening the bottom sheet.
  */
 export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
-  const {open} = useBottomSheet();
+  const {open, onOpenFocusRef, onCloseFocusRef} = useBottomSheet();
   const travelSearchFiltersEnabled = useTravelSearchFiltersEnabled();
   const {travelSearchFilters} = useFirestoreConfiguration();
   const {filters, setFilters} = useFilters();
@@ -59,23 +59,19 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
       transportModes: initialTransportModeSelection,
       flexibleTransport: initialFlexibleTransportFilterOption,
     });
-  const onCloseFocusRef = useRef();
 
   if (!travelSearchFiltersEnabled) return {enabled: false};
   if (!travelSearchFilters?.transportModes) return {enabled: false};
 
   const openBottomSheet = () => {
-    open(
-      (close, onOpenFocusRef) => (
-        <TravelSearchFiltersBottomSheet
-          close={close}
-          ref={onOpenFocusRef}
-          filtersSelection={filtersSelection}
-          onSave={setFiltersSelection}
-        />
-      ),
-      onCloseFocusRef,
-    );
+    open((close) => (
+      <TravelSearchFiltersBottomSheet
+        close={close}
+        ref={onOpenFocusRef}
+        filtersSelection={filtersSelection}
+        onSave={setFiltersSelection}
+      />
+    ));
   };
 
   return {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -17,12 +17,12 @@ type TravelSearchFiltersState =
       anyFiltersApplied: boolean;
       resetTransportModes: () => void;
       disableFlexibleTransport: () => void;
-      onCloseFocusRef: React.RefObject<any> | undefined;
+      onCloseFocusRef: React.RefObject<any>;
     }
   | {enabled: false; filtersSelection?: undefined};
 
 /**
- * THe travel search filters state, including whether it is enabled or not, the
+ * The travel search filters state, including whether it is enabled or not, the
  * selected filters, and a function for opening the bottom sheet.
  */
 export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -66,10 +66,10 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
 
   const openBottomSheet = () => {
     open(
-      (close, focusRef) => (
+      (close, onOpenFocusRef) => (
         <TravelSearchFiltersBottomSheet
           close={close}
-          ref={focusRef}
+          ref={onOpenFocusRef}
           filtersSelection={filtersSelection}
           onSave={setFiltersSelection}
         />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -17,7 +17,7 @@ type TravelSearchFiltersState =
       anyFiltersApplied: boolean;
       resetTransportModes: () => void;
       disableFlexibleTransport: () => void;
-      closeRef: React.Ref<any>;
+      onCloseFocusRef: React.Ref<any>;
     }
   | {enabled: false; filtersSelection?: undefined};
 
@@ -59,7 +59,7 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
       transportModes: initialTransportModeSelection,
       flexibleTransport: initialFlexibleTransportFilterOption,
     });
-  const closeRef = useRef();
+  const onCloseFocusRef = useRef();
 
   if (!travelSearchFiltersEnabled) return {enabled: false};
   if (!travelSearchFilters?.transportModes) return {enabled: false};
@@ -74,7 +74,7 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
           onSave={setFiltersSelection}
         />
       ),
-      closeRef,
+      onCloseFocusRef,
     );
   };
 
@@ -105,6 +105,6 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
       setFilters(filtersWithFlexibleTransportDisabled);
       setFiltersSelection(filtersWithFlexibleTransportDisabled);
     },
-    closeRef,
+    onCloseFocusRef,
   };
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/Nearby_Root.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/Nearby_Root.tsx
@@ -138,12 +138,16 @@ const NearbyOverview: React.FC<Props> = ({
       initialLocation: fromLocation,
     });
 
-  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet((close) => (
+    openBottomSheet(() => (
       <DepartureTimeSheet
         ref={onOpenFocusRef}
-        close={close}
+        close={closeBottomSheet}
         initialTime={searchTime}
         setSearchTime={setSearchTime}
         allowTimeInPast={false}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/Nearby_Root.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/Nearby_Root.tsx
@@ -140,9 +140,9 @@ const NearbyOverview: React.FC<Props> = ({
 
   const {open: openBottomSheet} = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet((close, focusRef) => (
+    openBottomSheet((close, onOpenFocusRef) => (
       <DepartureTimeSheet
-        ref={focusRef}
+        ref={onOpenFocusRef}
         close={close}
         initialTime={searchTime}
         setSearchTime={setSearchTime}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/Nearby_Root.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_NearbyStack/Nearby_Root.tsx
@@ -138,9 +138,9 @@ const NearbyOverview: React.FC<Props> = ({
       initialLocation: fromLocation,
     });
 
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet((close, onOpenFocusRef) => (
+    openBottomSheet((close) => (
       <DepartureTimeSheet
         ref={onOpenFocusRef}
         close={close}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -125,12 +125,12 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const phoneNumber = parsePhoneNumber(user?.phoneNumber ?? '');
   const {enable_vipps_login} = useRemoteConfig();
 
-  const {open: openBottomSheet} = useBottomSheet();
+  const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
   async function selectFavourites() {
-    openBottomSheet((close) => {
+    openBottomSheet(() => {
       return (
         <SelectFavouritesBottomSheet
-          close={close}
+          close={closeBottomSheet}
           onEditFavouriteDeparture={() =>
             navigation.navigate('Profile_FavoriteDeparturesScreen')
           }


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/4714

Return onOpenFocusRef and onCloseFocusRef in BottomSheetState, remove close from contentFunction.
Bonus: no longer using setTimeout for giveFocus.
Also provides onCloseFocusRef to GenericClickableSectionItem which fixes the specific case of returning from traveller selection.