### PR TITLE
fix: add optional timeout in giveFocus

### DIFF
--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -68,7 +68,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
-    giveFocus(onCloseFocusRef);
+    giveFocus(onCloseFocusRef, 100); // iOS needs a timeout to ensure it reads out the updated state
   };
 
   const open = (

--- a/src/utils/use-focus-on-load.ts
+++ b/src/utils/use-focus-on-load.ts
@@ -36,12 +36,20 @@ export function useFocusOnLoad(setFocusOnLoad: boolean = true) {
   return focusRef;
 }
 
-export const giveFocus = (focusRef: React.MutableRefObject<any>) => {
+export const giveFocus = (
+  focusRef: React.MutableRefObject<any>,
+  timeoutMilliseconds?: number,
+) => {
   if (focusRef.current) {
     InteractionManager.runAfterInteractions(() => {
-      const reactTag = findNodeHandle(focusRef.current);
-      if (reactTag) {
-        AccessibilityInfo.setAccessibilityFocus(reactTag);
+      const setFocus = () => {
+        const reactTag = findNodeHandle(focusRef.current);
+        reactTag && AccessibilityInfo.setAccessibilityFocus(reactTag);
+      };
+      if (timeoutMilliseconds) {
+        setTimeout(setFocus, timeoutMilliseconds);
+      } else {
+        setFocus();
       }
     });
   }


### PR DESCRIPTION
resolves https://github.com/AtB-AS/kundevendt/issues/4714

Timeouts were replaced in https://github.com/AtB-AS/mittatb-app/pull/3702 with InteractionManager.runAfterInteractions, however causing https://github.com/AtB-AS/kundevendt/issues/4714#issuecomment-1619874411.

Fixed by adding a small timeout in giveFocus for the screen reader when the bottomSheet closes.



