### PR TITLE
feat: update ticket assistant tile design

### DIFF
--- a/src/components/beta-tag/BetaTag.tsx
+++ b/src/components/beta-tag/BetaTag.tsx
@@ -1,7 +1,7 @@
-import {StyleProp, View, ViewStyle} from 'react-native';
-import {ThemeText} from '@atb/components/text';
+import {StyleProp, ViewStyle} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import React from 'react';
+import {InfoChip} from '../info-chip';
 
 type Props = {
   style?: StyleProp<ViewStyle>;
@@ -9,11 +9,11 @@ type Props = {
 export const BetaTag = ({style}: Props) => {
   const styles = useStyles();
   return (
-    <View style={[styles.betaLabel, style]}>
-      <ThemeText type={'body__tertiary'} color="background_accent_2">
-        Beta
-      </ThemeText>
-    </View>
+    <InfoChip
+      text="Beta"
+      interactiveColor="interactive_0"
+      style={[styles.betaLabel, style]}
+    />
   );
 };
 
@@ -21,7 +21,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   betaLabel: {
     backgroundColor: theme.static.status.info.background,
     paddingHorizontal: theme.spacings.small,
-    paddingVertical: theme.spacings.xSmall,
     borderRadius: theme.border.radius.circle,
   },
 }));

--- a/src/components/beta-tag/BetaTag.tsx
+++ b/src/components/beta-tag/BetaTag.tsx
@@ -10,7 +10,7 @@ export const BetaTag = ({style}: Props) => {
   const styles = useStyles();
   return (
     <View style={[styles.betaLabel, style]}>
-      <ThemeText type={'body__tertiary'} color="background_accent_3">
+      <ThemeText type={'body__tertiary'} color="background_accent_2">
         Beta
       </ThemeText>
     </View>
@@ -19,9 +19,9 @@ export const BetaTag = ({style}: Props) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   betaLabel: {
-    backgroundColor: theme.static.background.background_accent_3.background,
+    backgroundColor: theme.static.status.info.background,
     paddingHorizontal: theme.spacings.small,
     paddingVertical: theme.spacings.xSmall,
-    borderRadius: theme.border.radius.regular,
+    borderRadius: theme.border.radius.circle,
   },
 }));

--- a/src/components/beta-tag/index.ts
+++ b/src/components/beta-tag/index.ts
@@ -1,1 +1,0 @@
-export {BetaTag} from './BetaTag';

--- a/src/components/info-tag/InfoTag.tsx
+++ b/src/components/info-tag/InfoTag.tsx
@@ -4,21 +4,22 @@ import React from 'react';
 import {InfoChip} from '../info-chip';
 
 type Props = {
+  text: string;
   style?: StyleProp<ViewStyle>;
 };
-export const BetaTag = ({style}: Props) => {
+export const InfoTag = ({text, style}: Props) => {
   const styles = useStyles();
   return (
     <InfoChip
-      text="Beta"
+      text={text}
       interactiveColor="interactive_0"
-      style={[styles.betaLabel, style]}
+      style={[styles.infoLabel, style]}
     />
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  betaLabel: {
+  infoLabel: {
     backgroundColor: theme.static.status.info.background,
     paddingHorizontal: theme.spacings.small,
     borderRadius: theme.border.radius.circle,

--- a/src/components/info-tag/index.ts
+++ b/src/components/info-tag/index.ts
@@ -1,0 +1,1 @@
+export {InfoTag} from './InfoTag';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -51,7 +51,7 @@ import {
   ToggleSectionItem,
 } from '@atb/components/sections';
 import {RootStackParamList} from '@atb/stacks-hierarchy';
-import {BetaTag} from '@atb/components/beta-tag';
+import {InfoTag} from '@atb/components/info-tag';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -343,7 +343,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               <ThemeText type="heading__component">
                 {t(ProfileTexts.sections.newFeatures.heading)}
               </ThemeText>
-              <BetaTag style={style.betaTag} />
+              <InfoTag text="Beta" style={style.betaTag} />
             </View>
           </GenericSectionItem>
           <ToggleSectionItem

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
@@ -1,10 +1,13 @@
 import {StyleSheet, useTheme} from '@atb/theme';
-import {getStaticColor, StaticColor} from '@atb/theme/colors';
+import {
+  getStaticColor,
+  getTransportationColor,
+  StaticColor,
+} from '@atb/theme/colors';
 import {TouchableOpacity, View} from 'react-native';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import React from 'react';
 import {TicketingTexts, useTranslation} from '@atb/translations';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {TicketMultiple} from '@atb/assets/svg/mono-icons/ticketing';
 import {FareProductTypeConfig} from '@atb-as/config-specs';
 import {useFirestoreConfiguration} from '@atb/configuration';
@@ -23,11 +26,22 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
   testID,
 }) => {
   const styles = useStyles();
-  const {themeName} = useTheme();
-  const iconColor: StaticColor = 'background_accent_2';
+  const {theme, themeName} = useTheme();
   const color: StaticColor = accented ? 'background_accent_3' : 'background_0';
   const themeColor = getStaticColor(themeName, color);
   const {t} = useTranslation();
+
+  const transportThemePrimaryColor = getTransportationColor(
+    themeName,
+    'transport_other',
+    'primary',
+  );
+
+  const transportThemeSecondaryColor = getTransportationColor(
+    themeName,
+    'transport_other',
+    'secondary',
+  );
 
   const {fareProductTypeConfigs, preassignedFareProducts} =
     useFirestoreConfiguration();
@@ -55,7 +69,10 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
     <View
       style={[
         styles.tipsAndInformation,
-        {backgroundColor: themeColor.background},
+        {
+          backgroundColor: themeColor.background,
+          borderBottomColor: transportThemePrimaryColor.background,
+        },
       ]}
       testID={testID}
     >
@@ -69,21 +86,7 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
         >
           <View style={styles.contentContainer}>
             <View style={styles.titleContainer}>
-              <View style={styles.iconBox}>
-                <ThemeIcon
-                  size={'small'}
-                  svg={TicketMultiple}
-                  colorType={iconColor}
-                  testID={testID}
-                />
-              </View>
-              <ThemeText
-                type="label__uppercase"
-                accessible={false}
-                color={'secondary'}
-              >
-                {t(TicketingTexts.ticketAssistantTile.label)}
-              </ThemeText>
+              <BetaTag style={styles.betaTag} />
             </View>
             <View style={styles.titleContainer}>
               <ThemeText
@@ -94,13 +97,22 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
               >
                 {title}
               </ThemeText>
-              <BetaTag style={styles.betaTag} />
             </View>
 
-            <ThemeText type="body__tertiary" color={'secondary'}>
+            <ThemeText
+              type="body__tertiary"
+              color={'secondary'}
+              style={styles.description}
+            >
               {t(TicketingTexts.ticketAssistantTile.description)}
             </ThemeText>
           </View>
+          <TicketMultiple
+            style={styles.illustration}
+            fill={transportThemeSecondaryColor.background}
+            width={theme.icon.size.large}
+            height={theme.icon.size.large}
+          />
         </TouchableOpacity>
       )}
     </View>
@@ -112,13 +124,20 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexShrink: 1,
     alignSelf: 'stretch',
     padding: theme.spacings.xLarge,
-    borderRadius: theme.border.radius.regular,
+    paddingBottom: theme.spacings.xLarge - 2 * theme.border.width.medium,
+    borderBottomWidth: 2 * theme.border.width.medium,
+    borderRadius: theme.border.radius.small,
+
     marginHorizontal: theme.spacings.medium,
     marginBottom: theme.spacings.large,
   },
   betaTag: {
-    marginHorizontal: theme.spacings.small,
+    marginBottom: theme.spacings.xSmall,
   },
+  illustration: {
+    marginTop: theme.spacings.small,
+  },
+  description: {marginBottom: theme.spacings.small},
   iconBox: {
     backgroundColor: theme.static.status.info.background,
     display: 'flex',
@@ -129,7 +148,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   titleContainer: {
     flexDirection: 'row',
-    alignItems: 'center',
     marginBottom: theme.spacings.small,
   },
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
@@ -1,19 +1,15 @@
 import {StyleSheet, useTheme} from '@atb/theme';
-import {
-  getStaticColor,
-  getTransportationColor,
-  StaticColor,
-} from '@atb/theme/colors';
-import {TouchableOpacity, View} from 'react-native';
-import {screenReaderPause, ThemeText} from '@atb/components/text';
+
+import {View} from 'react-native';
+import {screenReaderPause} from '@atb/components/text';
 import React from 'react';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import {TicketMultiple} from '@atb/assets/svg/mono-icons/ticketing';
 import {FareProductTypeConfig} from '@atb-as/config-specs';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {isProductSellableInApp} from '@atb/reference-data/utils';
-import {BetaTag} from '@atb/components/beta-tag';
 import {useTicketingState} from '@atb/ticketing';
+import {TicketingTile} from '../TicketingTile';
 
 type TicketAssistantProps = {
   accented?: boolean;
@@ -26,21 +22,14 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
   testID,
 }) => {
   const styles = useStyles();
-  const {theme, themeName} = useTheme();
-  const color: StaticColor = accented ? 'background_accent_3' : 'background_0';
-  const themeColor = getStaticColor(themeName, color);
   const {t} = useTranslation();
+  const {theme} = useTheme();
 
-  const transportThemePrimaryColor = getTransportationColor(
-    themeName,
-    'transport_other',
-    'primary',
-  );
+  const title = t(TicketingTexts.ticketAssistantTile.title);
+  const description = t(TicketingTexts.ticketAssistantTile.description);
 
-  const transportThemeSecondaryColor = getTransportationColor(
-    themeName,
-    'transport_other',
-    'secondary',
+  const accessibilityLabel = [title, 'Beta', description].join(
+    screenReaderPause,
   );
 
   const {fareProductTypeConfigs, preassignedFareProducts} =
@@ -59,103 +48,36 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
     (config) => config.configuration.requiresLogin,
   );
 
-  const title = t(TicketingTexts.ticketAssistantTile.title);
-  const description = t(TicketingTexts.ticketAssistantTile.description);
-  const accessibilityLabel = [title, 'Beta', description].join(
-    screenReaderPause,
-  );
-
-  return (
-    <View
-      style={[
-        styles.tipsAndInformation,
-        {
-          backgroundColor: themeColor.background,
-          borderBottomColor: transportThemePrimaryColor.background,
-        },
-      ]}
-      testID={testID}
-    >
-      {requiresLoginConfig && (
-        <TouchableOpacity
+  if (!requiresLoginConfig) {
+    return <View style={{height: theme.spacings.medium}} />;
+  } else {
+    return (
+      <View style={styles.tipsAndInformation}>
+        <TicketingTile
+          accented={accented}
           onPress={() => onPress(requiresLoginConfig)}
-          accessible={true}
+          testID={testID}
+          transportColor="transport_other"
+          title={title}
+          description={description}
           accessibilityLabel={accessibilityLabel}
-          accessibilityHint={t(TicketingTexts.ticketAssistantTile.a11yHint)}
-          style={styles.spreadContent}
+          showBetaTag={true}
         >
-          <View style={styles.contentContainer}>
-            <View style={styles.titleContainer}>
-              <BetaTag style={styles.betaTag} />
-            </View>
-            <View style={styles.titleContainer}>
-              <ThemeText
-                type="body__secondary--bold"
-                accessibilityLabel={t(TicketingTexts.ticketAssistantTile.title)}
-                color={themeColor}
-                testID={testID + 'Title'}
-              >
-                {title}
-              </ThemeText>
-            </View>
-
-            <ThemeText
-              type="body__tertiary"
-              color={'secondary'}
-              style={styles.description}
-            >
-              {t(TicketingTexts.ticketAssistantTile.description)}
-            </ThemeText>
-          </View>
-          <TicketMultiple
-            style={styles.illustration}
-            fill={transportThemeSecondaryColor.background}
-            width={theme.icon.size.large}
-            height={theme.icon.size.large}
-          />
-        </TouchableOpacity>
-      )}
-    </View>
-  );
+          <TicketMultiple style={styles.illustration} />
+        </TicketingTile>
+      </View>
+    );
+  }
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   tipsAndInformation: {
     flexShrink: 1,
     alignSelf: 'stretch',
-    padding: theme.spacings.xLarge,
-    paddingBottom: theme.spacings.xLarge - 2 * theme.border.width.medium,
-    borderBottomWidth: 2 * theme.border.width.medium,
-    borderRadius: theme.border.radius.small,
-
     marginHorizontal: theme.spacings.medium,
     marginBottom: theme.spacings.large,
   },
-  betaTag: {
-    marginBottom: theme.spacings.xSmall,
-  },
   illustration: {
     marginTop: theme.spacings.small,
-  },
-  description: {marginBottom: theme.spacings.small},
-  iconBox: {
-    backgroundColor: theme.static.status.info.background,
-    display: 'flex',
-    flexDirection: 'row',
-    padding: theme.spacings.xSmall,
-    borderRadius: theme.border.radius.small,
-    marginRight: theme.spacings.xSmall,
-  },
-  titleContainer: {
-    flexDirection: 'row',
-    marginBottom: theme.spacings.small,
-  },
-
-  contentContainer: {
-    flexShrink: 1,
-  },
-  spreadContent: {
-    flex: 1,
-    justifyContent: 'space-between',
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
@@ -1,10 +1,10 @@
-import {StyleSheet, useTheme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 
 import {View} from 'react-native';
 import {screenReaderPause} from '@atb/components/text';
 import React from 'react';
 import {TicketingTexts, useTranslation} from '@atb/translations';
-import {TicketMultiple} from '@atb/assets/svg/mono-icons/ticketing';
+
 import {FareProductTypeConfig} from '@atb-as/config-specs';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {isProductSellableInApp} from '@atb/reference-data/utils';
@@ -23,7 +23,6 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {theme} = useTheme();
 
   const title = t(TicketingTexts.ticketAssistantTile.title);
   const description = t(TicketingTexts.ticketAssistantTile.description);
@@ -48,26 +47,23 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
     (config) => config.configuration.requiresLogin,
   );
 
-  if (!requiresLoginConfig) {
-    return <View style={{height: theme.spacings.medium}} />;
-  } else {
-    return (
-      <View style={styles.tipsAndInformation}>
+  return (
+    <View style={styles.tipsAndInformation}>
+      {requiresLoginConfig && (
         <TicketingTile
           accented={accented}
           onPress={() => onPress(requiresLoginConfig)}
           testID={testID}
           transportColor="transport_other"
+          illustrationName="ticketMultiple"
           title={title}
           description={description}
           accessibilityLabel={accessibilityLabel}
           showBetaTag={true}
-        >
-          <TicketMultiple style={styles.illustration} />
-        </TicketingTile>
-      </View>
-    );
-  }
+        />
+      )}
+    </View>
+  );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
@@ -76,8 +72,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     alignSelf: 'stretch',
     marginHorizontal: theme.spacings.medium,
     marginBottom: theme.spacings.large,
-  },
-  illustration: {
-    marginTop: theme.spacings.small,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -1,6 +1,6 @@
 import {TouchableOpacity, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
-import React, {Children, ReactNode, cloneElement} from 'react';
+import React from 'react';
 import {StyleSheet, useTheme} from '@atb/theme';
 
 import {TicketingTexts, useTranslation} from '@atb/translations';
@@ -13,31 +13,30 @@ import {
 
 import {BetaTag} from '@atb/components/beta-tag';
 
-import {FareProductTypeConfig} from '@atb/configuration';
-import {FareProductIllustration} from './Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration';
+import {TicketingTileIllustration} from './TicketingTileIllustration';
 
 export const TicketingTile = ({
   accented = false,
   onPress,
   testID,
-  config,
+  illustrationName,
+  isPeriodTicket = false,
   transportColor,
   title,
   description,
   accessibilityLabel,
   showBetaTag = false,
-  children,
 }: {
   accented?: boolean;
   onPress: () => void;
   testID: string;
-  config?: FareProductTypeConfig;
+  illustrationName: string;
+  isPeriodTicket?: boolean;
   transportColor: TransportColor;
   title?: string;
   description?: string;
   accessibilityLabel?: string;
   showBetaTag?: boolean;
-  children?: ReactNode;
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
@@ -100,23 +99,14 @@ export const TicketingTile = ({
             {description}
           </ThemeText>
         </View>
-        {children ? (
-          Children.map(children, (child: any) =>
-            cloneElement(child, {
-              fill: themeSecondaryColor.background,
-              width: theme.icon.size.large,
-              height: theme.icon.size.large,
-            }),
-          )
-        ) : (
-          <FareProductIllustration
-            style={styles.illustration}
-            config={config}
-            fill={themeSecondaryColor.background}
-            width={theme.icon.size.large}
-            height={theme.icon.size.large}
-          />
-        )}
+        <TicketingTileIllustration
+          illustrationName={illustrationName}
+          isPeriodTicket={isPeriodTicket}
+          style={styles.illustration}
+          fill={themeSecondaryColor.background}
+          width={theme.icon.size.large}
+          height={theme.icon.size.large}
+        />
       </TouchableOpacity>
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -57,7 +57,11 @@ export const TicketingTile = ({
   );
 
   return (
-    <View
+    <TouchableOpacity
+      onPress={onPress}
+      accessible={true}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={t(TicketingTexts.availableFareProducts.navigateToBuy)}
       style={[
         styles.fareProduct,
         {
@@ -65,17 +69,8 @@ export const TicketingTile = ({
           borderBottomColor: themePrimaryColor.background,
         },
       ]}
-      testID={testID}
     >
-      <TouchableOpacity
-        onPress={onPress}
-        accessible={true}
-        accessibilityLabel={accessibilityLabel}
-        accessibilityHint={t(
-          TicketingTexts.availableFareProducts.navigateToBuy,
-        )}
-        style={styles.spreadContent}
-      >
+      <View style={styles.spreadContent} testID={testID}>
         <View style={styles.contentContainer}>
           {showBetaTag && (
             <View style={styles.betaTagContainer}>
@@ -107,8 +102,8 @@ export const TicketingTile = ({
           width={theme.icon.size.large}
           height={theme.icon.size.large}
         />
-      </TouchableOpacity>
-    </View>
+      </View>
+    </TouchableOpacity>
   );
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -1,0 +1,163 @@
+import {TouchableOpacity, View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import React, {Children, ReactNode, cloneElement} from 'react';
+import {StyleSheet, useTheme} from '@atb/theme';
+
+import {TicketingTexts, useTranslation} from '@atb/translations';
+import {
+  getStaticColor,
+  getTransportationColor,
+  StaticColor,
+  TransportColor,
+} from '@atb/theme/colors';
+
+import {BetaTag} from '@atb/components/beta-tag';
+
+import {FareProductTypeConfig} from '@atb/configuration';
+import {FareProductIllustration} from './Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration';
+
+export const TicketingTile = ({
+  accented = false,
+  onPress,
+  testID,
+  config,
+  transportColor,
+  title,
+  description,
+  accessibilityLabel,
+  showBetaTag = false,
+  children,
+}: {
+  accented?: boolean;
+  onPress: () => void;
+  testID: string;
+  config?: FareProductTypeConfig;
+  transportColor: TransportColor;
+  title?: string;
+  description?: string;
+  accessibilityLabel?: string;
+  showBetaTag?: boolean;
+  children?: ReactNode;
+}) => {
+  const styles = useStyles();
+  const {t} = useTranslation();
+  const {theme, themeName} = useTheme();
+
+  const color: StaticColor = accented ? 'background_accent_3' : 'background_0';
+  const themeColor = getStaticColor(themeName, color);
+
+  const themePrimaryColor = getTransportationColor(
+    themeName,
+    transportColor,
+    'primary',
+  );
+  const themeSecondaryColor = getTransportationColor(
+    themeName,
+    transportColor,
+    'secondary',
+  );
+
+  return (
+    <View
+      style={[
+        styles.fareProduct,
+        {
+          backgroundColor: themeColor.background,
+          borderBottomColor: themePrimaryColor.background,
+        },
+      ]}
+      testID={testID}
+    >
+      <TouchableOpacity
+        onPress={onPress}
+        accessible={true}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={t(
+          TicketingTexts.availableFareProducts.navigateToBuy,
+        )}
+        style={styles.spreadContent}
+      >
+        <View style={styles.contentContainer}>
+          {showBetaTag && (
+            <View style={styles.betaTagContainer}>
+              <BetaTag style={styles.betaTag} />
+            </View>
+          )}
+          <ThemeText
+            type="body__secondary--bold"
+            style={styles.title}
+            accessibilityLabel={title}
+            color={themeColor}
+            testID={testID + 'Title'}
+          >
+            {title}
+          </ThemeText>
+          <ThemeText
+            type="body__tertiary"
+            style={styles.description}
+            color={'secondary'}
+          >
+            {description}
+          </ThemeText>
+        </View>
+        {children ? (
+          Children.map(children, (child: any) =>
+            cloneElement(child, {
+              fill: themeSecondaryColor.background,
+              width: theme.icon.size.large,
+              height: theme.icon.size.large,
+            }),
+          )
+        ) : (
+          <FareProductIllustration
+            style={styles.illustration}
+            config={config}
+            fill={themeSecondaryColor.background}
+            width={theme.icon.size.large}
+            height={theme.icon.size.large}
+          />
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  fareProduct: {
+    width: '100%',
+    flexShrink: 1,
+    alignSelf: 'stretch',
+    marginRight: theme.spacings.medium,
+    padding: theme.spacings.xLarge,
+    paddingBottom: theme.spacings.xLarge - 2 * theme.border.width.medium,
+    borderBottomWidth: 2 * theme.border.width.medium,
+    borderRadius: theme.border.radius.small,
+  },
+  contentContainer: {
+    flexShrink: 1,
+  },
+  iconContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  spreadContent: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  label: {marginLeft: theme.spacings.xSmall},
+  illustration: {
+    marginTop: theme.spacings.small,
+  },
+  title: {
+    marginBottom: theme.spacings.small,
+  },
+  description: {marginBottom: theme.spacings.small},
+  betaTag: {
+    marginBottom: theme.spacings.xSmall,
+  },
+  betaTagContainer: {
+    flexDirection: 'row',
+    marginBottom: theme.spacings.small,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -11,7 +11,7 @@ import {
   TransportColor,
 } from '@atb/theme/colors';
 
-import {BetaTag} from '@atb/components/beta-tag';
+import {InfoTag} from '@atb/components/info-tag';
 
 import {TicketingTileIllustration} from './TicketingTileIllustration';
 
@@ -74,7 +74,7 @@ export const TicketingTile = ({
         <View style={styles.contentContainer}>
           {showBetaTag && (
             <View style={styles.betaTagContainer}>
-              <BetaTag style={styles.betaTag} />
+              <InfoTag text="Beta" style={styles.betaTag} />
             </View>
           )}
           <ThemeText

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 /* eslint-enable no-restricted-syntax, no-param-reassign */
 import {SvgProps} from 'react-native-svg';
-import {FareProductTypeConfig} from '@atb/configuration';
 
 import {Boat} from '@atb/assets/svg/mono-icons/transportation/';
 import {Klippekort} from '@atb/assets/svg/color/icons/ticketing/';
@@ -14,9 +13,10 @@ import {
   Ticket,
   Sun,
   Youth,
+  TicketMultiple,
 } from '@atb/assets/svg/mono-icons/ticketing/';
 
-const fareProductIllustrations = {
+const ticketingTileIllustrations = {
   Ticket,
   PeriodTicket: Date,
   H24,
@@ -25,27 +25,34 @@ const fareProductIllustrations = {
   Youth,
   Carnet: Klippekort,
   Boat,
+  TicketMultiple,
 };
 
-type FareProductIllustrationType = keyof typeof fareProductIllustrations;
+type ticketingTileIllustrationType = keyof typeof ticketingTileIllustrations;
 
-type FareProductIllustrationsProps = {
-  config?: FareProductTypeConfig;
+type ticketingTileIllustrationsProps = {
+  illustrationName: string;
+  isPeriodTicket?: boolean;
 } & SvgProps;
 
-export const FareProductIllustration = ({
-  config,
+export const TicketingTileIllustration = ({
+  illustrationName,
+  isPeriodTicket = false,
   ...props
-}: FareProductIllustrationsProps): JSX.Element => {
-  const illustrationName = getIllustrationFileName(config);
-  const Illustration = fareProductIllustrations[illustrationName];
+}: ticketingTileIllustrationsProps): JSX.Element => {
+  const illustrationFileName = getIllustrationFileName(
+    illustrationName,
+    isPeriodTicket,
+  );
+  const Illustration = ticketingTileIllustrations[illustrationFileName];
   return <Illustration {...props} />;
 };
 
 const getIllustrationFileName = (
-  config?: FareProductTypeConfig,
-): FareProductIllustrationType => {
-  switch (config?.illustration) {
+  illustrationName?: string,
+  isPeriodTicket?: boolean,
+): ticketingTileIllustrationType => {
+  switch (illustrationName) {
     case 'single':
       return 'Ticket';
     case 'period':
@@ -61,11 +68,9 @@ const getIllustrationFileName = (
     case 'youth':
       return 'Youth';
     case 'boat':
-      if (config?.configuration.productSelectionMode === 'duration') {
-        return 'PeriodTicket';
-      } else {
-        return 'Ticket';
-      }
+      return isPeriodTicket ? 'PeriodTicket' : 'Ticket';
+    case 'ticketMultiple':
+      return 'TicketMultiple';
     default:
       return 'Ticket';
   }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration.tsx
@@ -4,14 +4,17 @@ import React from 'react';
 import {SvgProps} from 'react-native-svg';
 import {FareProductTypeConfig} from '@atb/configuration';
 
-import Boat from '@atb/assets/svg/mono-icons/transportation/Boat';
-import Klippekort from '@atb/assets/svg/color/icons/ticketing/Klippekort';
-import H24 from '@atb/assets/svg/mono-icons/ticketing/H24';
-import Moon from '@atb/assets/svg/mono-icons/ticketing/Moon';
-import Date from '@atb/assets/svg/mono-icons/time/Date';
-import Ticket from '@atb/assets/svg/mono-icons/ticketing/Ticket';
-import Sun from '@atb/assets/svg/mono-icons/ticketing/Sun';
-import Youth from '@atb/assets/svg/mono-icons/ticketing/Youth';
+import {Boat} from '@atb/assets/svg/mono-icons/transportation/';
+import {Klippekort} from '@atb/assets/svg/color/icons/ticketing/';
+import {Date} from '@atb/assets/svg/mono-icons/time/';
+
+import {
+  H24,
+  Moon,
+  Ticket,
+  Sun,
+  Youth,
+} from '@atb/assets/svg/mono-icons/ticketing/';
 
 const fareProductIllustrations = {
   Ticket,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductIllustration.tsx
@@ -30,7 +30,7 @@ const fareProductIllustrations = {
 type FareProductIllustrationType = keyof typeof fareProductIllustrations;
 
 type FareProductIllustrationsProps = {
-  config: FareProductTypeConfig;
+  config?: FareProductTypeConfig;
 } & SvgProps;
 
 export const FareProductIllustration = ({
@@ -43,9 +43,9 @@ export const FareProductIllustration = ({
 };
 
 const getIllustrationFileName = (
-  config: FareProductTypeConfig,
+  config?: FareProductTypeConfig,
 ): FareProductIllustrationType => {
-  switch (config.illustration) {
+  switch (config?.illustration) {
     case 'single':
       return 'Ticket';
     case 'period':
@@ -61,7 +61,7 @@ const getIllustrationFileName = (
     case 'youth':
       return 'Youth';
     case 'boat':
-      if (config.configuration.productSelectionMode === 'duration') {
+      if (config?.configuration.productSelectionMode === 'duration') {
         return 'PeriodTicket';
       } else {
         return 'Ticket';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
@@ -50,7 +50,8 @@ export const FareProductTile = ({
       accented={accented}
       onPress={onPress}
       testID={testID}
-      config={config}
+      illustrationName={config.illustration || 'unknown'}
+      isPeriodTicket={config.configuration.productSelectionMode === 'duration'}
       transportColor={transportColor}
       title={title}
       description={description}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
@@ -1,25 +1,17 @@
-import {TouchableOpacity, View} from 'react-native';
-import {ThemeText} from '@atb/components/text';
 import React from 'react';
-import {StyleSheet, useTheme} from '@atb/theme';
-import {FareProductIllustration} from './FareProductIllustration';
+
 import {
   FareContractTexts,
-  TicketingTexts,
   useTranslation,
   TranslateFunction,
 } from '@atb/translations';
-import {
-  getStaticColor,
-  getTransportationColor,
-  StaticColor,
-} from '@atb/theme/colors';
 
 import {FareProductTypeConfig} from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 
 import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
 import {TransportModePair} from '@atb/components/transportation-modes';
+import {TicketingTile} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile';
 
 const modesDisplayLimit = 2;
 
@@ -34,125 +26,38 @@ export const FareProductTile = ({
   testID: string;
   config: FareProductTypeConfig;
 }) => {
-  const styles = useStyles();
   const {t} = useTranslation();
-  const {theme, themeName} = useTheme();
 
   const transportModes = config.transportModes;
-
-  const color: StaticColor = accented ? 'background_accent_3' : 'background_0';
-  const themeColor = getStaticColor(themeName, color);
 
   const transportColor = useThemeColorForTransportMode(
     transportModes[0]?.mode,
     transportModes[0]?.subMode,
   );
 
-  const transportThemePrimaryColor = getTransportationColor(
-    themeName,
-    transportColor,
-    'primary',
-  );
-  const transportThemeSecondaryColor = getTransportationColor(
-    themeName,
-    transportColor,
-    'secondary',
-  );
-
-  const title = useTextForLanguage(config.name);
-  const description = useTextForLanguage(config.description);
-
   const transportModesText = getFareProductTravelModesText(
     transportModes,
     t,
     modesDisplayLimit,
   );
-  const accessibilityLabel = [title, transportModesText, description].join(
-    '. ',
-  );
+
+  const title = useTextForLanguage(config.name) + ', ' + transportModesText;
+  const description = useTextForLanguage(config.description);
+  const accessibilityLabel = [title, description].join('. ');
 
   return (
-    <View
-      style={[
-        styles.fareProduct,
-        {
-          backgroundColor: themeColor.background,
-          borderBottomColor: transportThemePrimaryColor.background,
-        },
-      ]}
+    <TicketingTile
+      accented={accented}
+      onPress={onPress}
       testID={testID}
-    >
-      <TouchableOpacity
-        onPress={onPress}
-        accessible={true}
-        accessibilityLabel={accessibilityLabel}
-        accessibilityHint={t(
-          TicketingTexts.availableFareProducts.navigateToBuy,
-        )}
-        style={styles.spreadContent}
-      >
-        <View style={styles.contentContainer}>
-          <ThemeText
-            type="body__secondary--bold"
-            style={styles.title}
-            accessibilityLabel={title}
-            color={themeColor}
-            testID={testID + 'Title'}
-          >
-            {title + ', ' + transportModesText}
-          </ThemeText>
-          <ThemeText
-            type="body__tertiary"
-            style={styles.description}
-            color={'secondary'}
-          >
-            {description}
-          </ThemeText>
-        </View>
-        <FareProductIllustration
-          style={styles.illustration}
-          config={config}
-          fill={transportThemeSecondaryColor.background}
-          width={theme.icon.size.large}
-          height={theme.icon.size.large}
-        />
-      </TouchableOpacity>
-    </View>
+      config={config}
+      transportColor={transportColor}
+      title={title}
+      description={description}
+      accessibilityLabel={accessibilityLabel}
+    />
   );
 };
-
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  fareProduct: {
-    width: '100%',
-    flexShrink: 1,
-    alignSelf: 'stretch',
-    marginRight: theme.spacings.medium,
-    padding: theme.spacings.xLarge,
-    paddingBottom: theme.spacings.xLarge - 2 * theme.border.width.medium,
-    borderBottomWidth: 2 * theme.border.width.medium,
-    borderRadius: theme.border.radius.small,
-  },
-  contentContainer: {
-    flexShrink: 1,
-  },
-  iconContainer: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  spreadContent: {
-    flex: 1,
-    justifyContent: 'space-between',
-  },
-  label: {marginLeft: theme.spacings.xSmall},
-  illustration: {
-    marginTop: theme.spacings.small,
-  },
-  title: {
-    marginBottom: theme.spacings.small,
-  },
-  description: {marginBottom: theme.spacings.small},
-}));
 
 const getFareProductTravelModesText = (
   modes: TransportModePair[],


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/3363

This updates the design of the TicketAssistantTile.

Also TicketingTile.tsx was created, shared by both FareProductTile and TicketAssistantTile, as [suggested](https://github.com/AtB-AS/mittatb-app/pull/3710#issuecomment-1623166177).
Turned FareProductIllustration into TicketingTileIllustration.

Also updates the BetaTag design.

Before:

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/aa9ebb37-cff6-4c8e-a012-444c4437a57e" />
<br /><br />

After:

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/c1576937-fe8a-4a9b-a97e-888bef633aa8" />

<br />
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/6b63d8c3-c061-4a26-bcc6-2c29f0c9882a" />

