### PR TITLE
chore: update @atb-as/generate-assets with illustration size fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@atb-as/generate-assets": "^7.5.2",
+    "@atb-as/generate-assets": "^7.5.3",
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-env": "^7.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,10 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^7.5.2":
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.5.2.tgz#b356ce03f46c023e1fe905f80e4a8e58e41d24e8"
-  integrity sha512-0tikuya37X8yle4luKODh0nznEnOGZeG89Tg4oq4cgro8gzEJS9HkdzkElfpyZQEC5sRRby5iAdgJM/LhA+htQ==
+"@atb-as/generate-assets@^7.5.3":
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-7.5.3.tgz#5736fe297504e24b171255a7eeb95b4f9d4ed84c"
+  integrity sha512-fp6l1Cbz+YUT/PrFeQJnejhowIJaB2IZKbnU14elPhW2d2NTcvDUw0GSomSzGeQ1ashxF+OUDrENNrHxnLueTA==
   dependencies:
     "@atb-as/theme" "^7.1.0"
     commander "^9.4.0"


### PR DESCRIPTION
Updated @atb-as/generate-assets with TravelPlanning.svg size adjustments so that the next button in mobiletoken onboarding doesn't cut off on small screens. 

Closes https://github.com/AtB-AS/kundevendt/issues/5274