### PR TITLE
feat: add a11y label to destinations container

### DIFF
--- a/src/fare-contracts/components/FareContractDestinations.tsx
+++ b/src/fare-contracts/components/FareContractDestinations.tsx
@@ -2,6 +2,7 @@ import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {StyleSheet, useTheme} from '@atb/theme';
+import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 
 import {ArrowUpDown} from '@atb/assets/svg/mono-icons/navigation';
 
@@ -18,6 +19,7 @@ export function FareContractDestinations({
 }) {
   const {theme} = useTheme();
   const styles = useStyles();
+  const {t} = useTranslation();
 
   const color =
     decorationColor || theme.transport.transport_boat.primary.background;
@@ -27,7 +29,16 @@ export function FareContractDestinations({
     theme.tripLegDetail.decorationLineEndWidth - decorationLineWidth;
 
   return (
-    <View style={styles.container}>
+    <View
+      style={styles.container}
+      accessibilityLabel={t(
+        PurchaseOverviewTexts.summary.destinations(
+          startPlaceName,
+          endPlaceName,
+        ),
+      )}
+      accessible={true}
+    >
       <View
         style={{
           ...styles.destinationEndLine,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -115,6 +115,11 @@ const PurchaseOverviewTexts = {
     ),
   },
   summary: {
+    destinations: (from?: string, to?: string) =>
+      _(
+        `Fra ${from || 'ukjent'}, til ${to || 'ukjent'}`,
+        `From ${from || 'unknown'}, to ${to || 'unknown'}`,
+      ),
     price: (priceString: string) =>
       _(`Totalt ${priceString} kr`, `Total ${priceString} kr`),
     messageInZone: _(


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/4138#issuecomment-1630723842

Reads out "From 'A', to 'B'" with the screen reader when selecting the destinations.

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/134292729/3f3ef301-32d1-429b-aaa5-cf1206b3f862" />
