### PR TITLE
chore: Update preassigned fare products for boat tickets

### DIFF
--- a/src/reference-data/defaults/preassigned-fare-products.json
+++ b/src/reference-data/defaults/preassigned-fare-products.json
@@ -429,12 +429,37 @@
     "version": "ATB:Version:FP-bdf0941b-1f46-4e9a-8d33-8d0413aa6883"
   },
   {
-    "alternativeNames": [
-      {"lang": "nno", "value": "7-dagersbillett hurtigbåt"},
-      {"lang": "eng", "value": "Weekly pass boat"}
-    ],
-    "distributionChannel": ["app"],
     "id": "ATB:PreassignedFareProduct:5f61ee14",
+    "version": "ATB:Version:b158a267-314f-4176-8462-aee1e16067f3",
+    "type": "boat-period",
+    "distributionChannel": [
+      "app"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "7-dagersbillett hurtigbåt"
+    },
+    "durationDays": 7,
+    "productAlias": [
+      {
+        "lang": "nob",
+        "value": "7 dager"
+      },
+      {
+        "lang": "eng",
+        "value": "7 days"
+      }
+    ],
+    "alternativeNames": [
+      {
+        "lang": "nno",
+        "value": "7-dagersbillett hurtigbåt"
+      },
+      {
+        "lang": "eng",
+        "value": "Weekly pass boat"
+      }
+    ],
     "limitations": {
       "userProfileRefs": [
         "ATB:UserProfile:1ae560ba",
@@ -443,18 +468,40 @@
         "ATB:UserProfile:2832569f"
       ],
       "appVersionMin": "1.39"
-    },
-    "name": {"lang": "nob", "value": "7-dagersbillett hurtigbåt"},
-    "type": "boat-period",
-    "version": "ATB:Version:b158a267-314f-4176-8462-aee1e16067f3"
+    }
   },
   {
-    "alternativeNames": [
-      {"lang": "nno", "value": "30-dagersbillett hurtigbåt"},
-      {"lang": "eng", "value": "Monthly pass boat"}
-    ],
-    "distributionChannel": ["app"],
     "id": "ATB:PreassignedFareProduct:7fb92850",
+    "version": "ATB:Version:4c60d382-fd7f-4c83-b606-94c90a799c9a",
+    "type": "boat-period",
+    "distributionChannel": [
+      "app"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "30-dagersbillett hurtigbåt"
+    },
+    "alternativeNames": [
+      {
+        "lang": "nno",
+        "value": "30-dagersbillett hurtigbåt"
+      },
+      {
+        "lang": "eng",
+        "value": "Monthly pass boat"
+      }
+    ],
+    "durationDays": 30,
+    "productAlias": [
+      {
+        "lang": "nob",
+        "value": "30 dager"
+      },
+      {
+        "lang": "eng",
+        "value": "30 days"
+      }
+    ],
     "limitations": {
       "userProfileRefs": [
         "ATB:UserProfile:1ae560ba",
@@ -463,18 +510,40 @@
         "ATB:UserProfile:2832569f"
       ],
       "appVersionMin": "1.39"
-    },
-    "name": {"lang": "nob", "value": "30-dagersbillett hurtigbåt"},
-    "type": "boat-period",
-    "version": "ATB:Version:4c60d382-fd7f-4c83-b606-94c90a799c9a"
+    }
   },
   {
-    "alternativeNames": [
-      {"lang": "nno", "value": "60-dagersbillett båt"},
-      {"lang": "eng", "value": "60 days pass boat"}
-    ],
-    "distributionChannel": ["app"],
     "id": "ATB:PreassignedFareProduct:450812f3",
+    "version": "ATB:Version:7bd72f16-e107-49f3-be43-61f024241e9c",
+    "type": "boat-period",
+    "distributionChannel": [
+      "app"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "60-dagersbillett båt"
+    },
+    "durationDays": 60,
+    "productAlias": [
+      {
+        "lang": "nob",
+        "value": "60 dager"
+      },
+      {
+        "lang": "eng",
+        "value": "60 days"
+      }
+    ],
+    "alternativeNames": [
+      {
+        "lang": "nno",
+        "value": "60-dagersbillett båt"
+      },
+      {
+        "lang": "eng",
+        "value": "60 days pass boat"
+      }
+    ],
     "limitations": {
       "userProfileRefs": [
         "ATB:UserProfile:1ae560ba",
@@ -483,18 +552,40 @@
         "ATB:UserProfile:2832569f"
       ],
       "appVersionMin": "1.39"
-    },
-    "name": {"lang": "nob", "value": "60-dagersbillett båt"},
-    "type": "boat-period",
-    "version": "ATB:Version:7bd72f16-e107-49f3-be43-61f024241e9c"
+    }
   },
   {
-    "alternativeNames": [
-      {"lang": "nno", "value": "90-dagersbillett båt"},
-      {"lang": "eng", "value": "90 days pass boat"}
-    ],
-    "distributionChannel": ["app"],
     "id": "ATB:PreassignedFareProduct:5d5f9574",
+    "version": "ATB:Version:36144e69-e2ee-40c4-b715-706221701938",
+    "type": "boat-period",
+    "distributionChannel": [
+      "app"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "90-dagersbillett båt"
+    },
+    "durationDays": 90,
+    "productAlias": [
+      {
+        "lang": "nob",
+        "value": "90 dager"
+      },
+      {
+        "lang": "eng",
+        "value": "90 days"
+      }
+    ],
+    "alternativeNames": [
+      {
+        "lang": "nno",
+        "value": "90-dagersbillett båt"
+      },
+      {
+        "lang": "eng",
+        "value": "90 days pass boat"
+      }
+    ],
     "limitations": {
       "userProfileRefs": [
         "ATB:UserProfile:1ae560ba",
@@ -503,18 +594,40 @@
         "ATB:UserProfile:2832569f"
       ],
       "appVersionMin": "1.39"
-    },
-    "name": {"lang": "nob", "value": "90-dagersbillett båt"},
-    "type": "boat-period",
-    "version": "ATB:Version:36144e69-e2ee-40c4-b715-706221701938"
+    }
   },
   {
-    "alternativeNames": [
-      {"lang": "nno", "value": "180-dagers billett båt"},
-      {"lang": "eng", "value": "180 days pass boat"}
-    ],
-    "distributionChannel": ["app"],
     "id": "ATB:PreassignedFareProduct:ccb344d3",
+    "version": "ATB:Version:500a2e78-db4d-42b2-aa42-d869e586d18a",
+    "type": "boat-period",
+    "distributionChannel": [
+      "app"
+    ],
+    "name": {
+      "lang": "nob",
+      "value": "180-dagers billett båt"
+    },
+    "durationDays": 180,
+    "productAlias": [
+      {
+        "lang": "nob",
+        "value": "180 dager"
+      },
+      {
+        "lang": "eng",
+        "value": "180 days"
+      }
+    ],
+    "alternativeNames": [
+      {
+        "lang": "nno",
+        "value": "180-dagers billett båt"
+      },
+      {
+        "lang": "eng",
+        "value": "180 days pass boat"
+      }
+    ],
     "limitations": {
       "userProfileRefs": [
         "ATB:UserProfile:1ae560ba",
@@ -523,9 +636,6 @@
         "ATB:UserProfile:2832569f"
       ],
       "appVersionMin": "1.39"
-    },
-    "name": {"lang": "nob", "value": "180-dagers billett båt"},
-    "type": "boat-period",
-    "version": "ATB:Version:500a2e78-db4d-42b2-aa42-d869e586d18a"
+    }
   }
 ]


### PR DESCRIPTION
Update reference data to match firestore data that fixes bug where you cannot pick duration on period boat tickets

https://github.com/AtB-AS/firestore-configuration/pull/224

https://github.com/AtB-AS/kundevendt/issues/4044