### PR TITLE
fix: filter flex transport search results on bus filter

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
@@ -266,8 +266,12 @@ async function doSearch(
     const selectedFilters = travelSearchFiltersSelection.transportModes.filter(
       (m) => m.selected,
     );
+
+    const includeFlexibleTransport = selectedFilters.some(
+      (sf) => sf.id == 'bus', // filter flex transport on bus filter
+    );
     query.modes = {
-      ...journeySearchModes,
+      ...(includeFlexibleTransport ? journeySearchModes : {}),
       transportModes: flatMap(selectedFilters, (tm) =>
         transportModeToEnum(tm.modes),
       ),


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/5018

[Hide search results](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=16035-68659&mode=design&t=9lTdYbiKZaBdAoJH-4) with AtB Bestill when bus results are hidden by the filter.
