### PR TITLE
fix: Use correct illustration on front page ticket

### DIFF
--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -5,7 +5,7 @@ import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {getReferenceDataName} from '@atb/reference-data/utils';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {Bus} from '@atb/assets/svg/mono-icons/transportation';
+import {Boat, Bus} from '@atb/assets/svg/mono-icons/transportation';
 import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
 import {ContrastColor} from '@atb-as/theme';
 import {Moon} from '@atb/assets/svg/mono-icons/ticketing';
@@ -76,7 +76,11 @@ const InspectableContent = ({
     fareProductTypeConfig?.illustration === 'period' ||
     fareProductTypeConfig?.illustration === 'hour24';
   const InspectionSvg =
-    fareProductTypeConfig?.illustration === 'night' ? Moon : Bus;
+    fareProductTypeConfig?.illustration === 'night'
+      ? Moon
+      : fareProductTypeConfig?.illustration === 'boat'
+      ? Boat
+      : Bus;
 
   const fromTariffZoneName =
     fromTariffZone && getReferenceDataName(fromTariffZone, language);

--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -113,8 +113,6 @@ const InspectableContent = ({
         styles.symbolContent,
         {
           backgroundColor: shouldFill ? themeColor.background : undefined,
-          borderColor: shouldFill ? themeColor.background : undefined,
-          borderRadius: shouldFill ? 1 : 0,
         },
       ]}
     >

--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -7,9 +7,11 @@ import {getReferenceDataName} from '@atb/reference-data/utils';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Boat, Bus} from '@atb/assets/svg/mono-icons/transportation';
 import {PreassignedFareProduct, TariffZone} from '@atb/reference-data/types';
-import {ContrastColor} from '@atb-as/theme';
 import {Moon} from '@atb/assets/svg/mono-icons/ticketing';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
+import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
+import {ContrastColor} from '@atb-as/theme';
+import {getTransportationColor} from '@atb/theme/colors';
 
 export type InspectionSymbolProps = {
   preassignedFareProduct?: PreassignedFareProduct;
@@ -27,9 +29,20 @@ export const InspectionSymbol = ({
   isLoading,
 }: InspectionSymbolProps) => {
   const styles = useStyles();
-  const {theme} = useTheme();
+  const {theme, themeName} = useTheme();
+
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === preassignedFareProduct?.type,
+  );
+
+  const transportColor = useThemeColorForTransportMode(
+    fareProductTypeConfig?.transportModes[0].mode,
+    fareProductTypeConfig?.transportModes[0].subMode,
+  );
+
   const themeColor = isInspectable
-    ? theme.static.status['valid']
+    ? getTransportationColor(themeName, transportColor)
     : theme.static.status['warning'];
 
   if (isLoading) {
@@ -72,13 +85,14 @@ const InspectableContent = ({
   const fareProductTypeConfig = fareProductTypeConfigs.find(
     (c) => c.type === preassignedFareProduct?.type,
   );
+
   const shouldFill =
-    fareProductTypeConfig?.illustration === 'period' ||
+    fareProductTypeConfig?.illustration?.includes('period') ||
     fareProductTypeConfig?.illustration === 'hour24';
   const InspectionSvg =
     fareProductTypeConfig?.illustration === 'night'
       ? Moon
-      : fareProductTypeConfig?.illustration === 'boat'
+      : fareProductTypeConfig?.illustration?.includes('boat')
       ? Boat
       : Bus;
 
@@ -99,6 +113,8 @@ const InspectableContent = ({
         styles.symbolContent,
         {
           backgroundColor: shouldFill ? themeColor.background : undefined,
+          borderColor: shouldFill ? themeColor.background : undefined,
+          borderRadius: shouldFill ? 1 : 0,
         },
       ]}
     >

--- a/src/reference-data/defaults/fare-product-type-config.json
+++ b/src/reference-data/defaults/fare-product-type-config.json
@@ -11,6 +11,7 @@
         "value": "Single ticket bus/tram"
       }
     ],
+    "illustration": "single",
     "transportModes": [
       {"mode": "bus", "subMode": "localBus"},
       {"mode": "tram"}
@@ -46,6 +47,7 @@
         "value": "Periodic ticket"
       }
     ],
+    "illustration": "period",
     "transportModes": [
       {"mode": "bus", "subMode": "localBus"},
       {"mode": "tram"}
@@ -81,6 +83,7 @@
         "value": "24 hour pass"
       }
     ],
+    "illustration": "hour24",
     "transportModes": [
       {"mode": "bus", "subMode": "localBus"},
       {"mode": "tram"}
@@ -151,6 +154,7 @@
         "value": "Punch card"
       }
     ],
+    "illustration": "carnet",
     "transportModes": [
       {"mode": "bus", "subMode": "localBus"},
       {"mode": "tram"}
@@ -229,7 +233,7 @@
         "value": "Periodic ticket, boat"
       }
     ],
-    "illustration": "boat",
+    "illustration": "boat-period",
     "transportModes": [
       {
         "mode": "water",

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
@@ -13,7 +13,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {Button} from '@atb/components/button';
-import {getFareContractInfoDetails} from '../../../../../fare-contracts/FareContractInfo';
+import {getFareContractInfoDetails} from '@atb/fare-contracts/FareContractInfo';
 import {
   useHasEnabledMobileToken,
   useMobileTokenContextState,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -20,7 +20,6 @@ export const TicketingTile = ({
   onPress,
   testID,
   illustrationName,
-  isPeriodTicket = false,
   transportColor,
   title,
   description,
@@ -31,7 +30,6 @@ export const TicketingTile = ({
   onPress: () => void;
   testID: string;
   illustrationName: string;
-  isPeriodTicket?: boolean;
   transportColor: TransportColor;
   title?: string;
   description?: string;
@@ -96,7 +94,6 @@ export const TicketingTile = ({
         </View>
         <TicketingTileIllustration
           illustrationName={illustrationName}
-          isPeriodTicket={isPeriodTicket}
           style={styles.illustration}
           fill={themeSecondaryColor.background}
           width={theme.icon.size.large}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
@@ -32,25 +32,19 @@ type ticketingTileIllustrationType = keyof typeof ticketingTileIllustrations;
 
 type ticketingTileIllustrationsProps = {
   illustrationName: string;
-  isPeriodTicket?: boolean;
 } & SvgProps;
 
 export const TicketingTileIllustration = ({
   illustrationName,
-  isPeriodTicket = false,
   ...props
 }: ticketingTileIllustrationsProps): JSX.Element => {
-  const illustrationFileName = getIllustrationFileName(
-    illustrationName,
-    isPeriodTicket,
-  );
+  const illustrationFileName = getIllustrationFileName(illustrationName);
   const Illustration = ticketingTileIllustrations[illustrationFileName];
   return <Illustration {...props} />;
 };
 
 const getIllustrationFileName = (
   illustrationName?: string,
-  isPeriodTicket?: boolean,
 ): ticketingTileIllustrationType => {
   switch (illustrationName) {
     case 'single':
@@ -68,7 +62,9 @@ const getIllustrationFileName = (
     case 'youth':
       return 'Youth';
     case 'boat':
-      return isPeriodTicket ? 'PeriodTicket' : 'Ticket';
+      return 'Ticket';
+    case 'boat-period':
+      return 'PeriodTicket';
     case 'ticketMultiple':
       return 'TicketMultiple';
     default:

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
@@ -51,7 +51,6 @@ export const FareProductTile = ({
       onPress={onPress}
       testID={testID}
       illustrationName={config.illustration || 'unknown'}
-      isPeriodTicket={config.configuration.productSelectionMode === 'duration'}
       transportColor={transportColor}
       title={title}
       description={description}


### PR DESCRIPTION
Update front page ticket view to show correct transport icon and color

https://www.figma.com/file/XdptDDbXUrO2Phz4NWfgdi/Boat-tickets?type=design&node-id=607%3A24834&mode=design&t=xpsDPVj4UaiKJdTo-1

Updating illustration to "boat-period" for boat period ticket:
https://github.com/AtB-AS/firestore-configuration/pull/226

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-07-25 at 13 40 02](https://github.com/AtB-AS/mittatb-app/assets/85479566/20d3a0b0-6994-4ae8-8168-d139c2d315d9)
