### PR TITLE
fix: Accessibility for set active token to phone

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTheme} from '@atb/theme';
-import {Platform, Text, TextProps, TextStyle, View} from 'react-native';
+import {Platform, Text, TextProps, TextStyle} from 'react-native';
 import {renderMarkdown} from './markdown-renderer';
 import {MAX_FONT_SCALE} from './utils';
 import {
@@ -18,7 +18,6 @@ export type ThemeTextProps = TextProps & {
   type?: TextNames;
   color?: ColorType;
   isMarkdown?: boolean;
-  focusRef?: React.ForwardedRef<View>;
 };
 
 export const ThemeText: React.FC<ThemeTextProps> = ({
@@ -27,7 +26,6 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   isMarkdown = false,
   style,
   children,
-  focusRef,
   ...props
 }) => {
   const {theme, useAndroidSystemFont} = useTheme();
@@ -69,7 +67,6 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
     <Text
       style={[textStyle, style]}
       maxFontSizeMultiplier={MAX_FONT_SCALE}
-      ref={focusRef}
       {...props}
     >
       {content}

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTheme} from '@atb/theme';
-import {Platform, Text, TextProps, TextStyle} from 'react-native';
+import {Platform, Text, TextProps, TextStyle, View} from 'react-native';
 import {renderMarkdown} from './markdown-renderer';
 import {MAX_FONT_SCALE} from './utils';
 import {
@@ -18,6 +18,7 @@ export type ThemeTextProps = TextProps & {
   type?: TextNames;
   color?: ColorType;
   isMarkdown?: boolean;
+  focusRef?: React.ForwardedRef<View>;
 };
 
 export const ThemeText: React.FC<ThemeTextProps> = ({
@@ -26,6 +27,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   isMarkdown = false,
   style,
   children,
+  focusRef,
   ...props
 }) => {
   const {theme, useAndroidSystemFont} = useTheme();
@@ -67,6 +69,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
     <Text
       style={[textStyle, style]}
       maxFontSizeMultiplier={MAX_FONT_SCALE}
+      ref={focusRef}
       {...props}
     >
       {content}

--- a/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
@@ -145,7 +145,6 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
           type={'body__secondary'}
           color={themeColor}
           style={[styles.text, styles.textSpacing]}
-          focusRef={selectedToken ? focusRef : undefined}
         >
           {t(ActiveTokenRequiredTexts.actionMessage)}
         </ThemeText>

--- a/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
@@ -71,7 +71,11 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
         color={themeColor}
       />
       <ScrollView centerContent={true} contentContainerStyle={styles.mainView}>
-        <View accessible={true} accessibilityRole="header" ref={focusRef}>
+        <View
+          accessible={true}
+          accessibilityRole="header"
+          ref={!selectedToken ? focusRef : undefined}
+        >
           <View style={styles.textSpacing}>
             <ThemeText
               type={'body__primary--big'}
@@ -137,6 +141,15 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
           />
         )}
 
+        <ThemeText
+          type={'body__secondary'}
+          color={themeColor}
+          style={[styles.text, styles.textSpacing]}
+          focusRef={selectedToken ? focusRef : undefined}
+        >
+          {t(ActiveTokenRequiredTexts.actionMessage)}
+        </ThemeText>
+
         {saveState.saving ? (
           <ActivityIndicator size="large" />
         ) : (
@@ -148,13 +161,6 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
             testID="confirmSelectionButton"
           />
         )}
-        <ThemeText
-          type={'body__secondary'}
-          color={themeColor}
-          style={[styles.text, styles.textSpacing]}
-        >
-          {t(ActiveTokenRequiredTexts.actionMessage)}
-        </ThemeText>
       </ScrollView>
     </View>
   );


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/4051

This PR fixes:

1. Move the information about all active tickets to mobile before the "Switch to phone" button
2. With screen reader, after choosing a device as bearer, the focus now jumps to the header. The focus should here remain on the chosen bearer - to allow the user to focus down and read the "warning" before making the switch.