### PR TITLE
fix: prevent immediate triggers if useInterval is disabled

### DIFF
--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -323,9 +323,7 @@ export function useDeparturesData(
     }
   }, [state.tick]);
   useInterval(
-    () => {
-      if (isFocused) dispatch({type: 'TICK_TICK'});
-    },
+    () => dispatch({type: 'TICK_TICK'}),
     tickRateInSeconds * 1000,
     [isFocused],
     !isFocused || mode === 'Favourite',

--- a/src/utils/use-interval.ts
+++ b/src/utils/use-interval.ts
@@ -16,13 +16,14 @@ export function useInterval(
 
   // Set up the interval.
   useEffect(() => {
+    if (disabled) return;
     function tick() {
       savedCallback.current();
     }
     if (triggerImmediately) {
       tick();
     }
-    if (delay !== null && !disabled) {
+    if (delay !== null) {
       let id = setInterval(tick, delay);
       return () => clearInterval(id);
     }


### PR DESCRIPTION
There was an bug in `useInterval` which would cause it to run when deps changed at the same time as it was disabled. This happened in departure details, which would `triggerImmediately` on loss of focus, while also being disabled by the same focus change.

This changes the hook to always abort if `disabled = true`.