### PR TITLE
feat: support Nynorsk `LanguageAndTextType`

### DIFF
--- a/src/translations/types.ts
+++ b/src/translations/types.ts
@@ -1,6 +1,7 @@
 export enum LanguageAndTextLanguagesEnum {
   'nob' = 'nob',
   'nno' = 'nno',
+  'nn' = 'nn',
   'nor' = 'nor',
   'no' = 'no',
   'eng' = 'eng',

--- a/src/translations/utils.ts
+++ b/src/translations/utils.ts
@@ -2,9 +2,9 @@ import {Language, useTranslation} from './commons';
 import {LanguageAndTextLanguagesEnum, LanguageAndTextType} from './types';
 
 /**
- * Get the text in the requested language. If English is requested, it will
- * fall back to Norwegian if no English text is found. If neither English nor
- * Norwegian is found the first text in the provided texts array is returned.
+ * Get the text in the requested language. If the requested translation isn't
+ * found, it will fall back to Bokmål/Norwegian. If no known translation is
+ * found, the first text in the provided texts array is returned.
  */
 export const getTextForLanguage = (
   texts: LanguageAndTextType[] | undefined,
@@ -17,6 +17,14 @@ export const getTextForLanguage = (
         getLanguage(t) === LanguageAndTextLanguagesEnum.en,
     );
     if (englishText?.value) return englishText.value;
+  }
+  if (language === Language.Nynorsk) {
+    const nynorskText = texts?.find(
+      (t) =>
+        getLanguage(t) === LanguageAndTextLanguagesEnum.nno ||
+        getLanguage(t) === LanguageAndTextLanguagesEnum.nn,
+    );
+    if (nynorskText?.value) return nynorskText.value;
   }
   const norwegianText = texts?.find(
     (t) =>

--- a/src/utils/map-to-language-and-texts.ts
+++ b/src/utils/map-to-language-and-texts.ts
@@ -14,7 +14,7 @@ export function mapToLanguageAndTexts(
 
 function mapToLanguageAndText(data: any): LanguageAndTextType | undefined {
   if (!data) return;
-  if (data.lang != 'nob' && data.lang != 'eng') return;
+  if (data.lang != 'nob' && data.lang != 'eng' && data.lang != 'nno') return;
 
   return {
     lang: data.lang,


### PR DESCRIPTION
In order to support nynorsk in features like global messages, this adds checks for "nn" and "nno" in `getTextForLanguage`, and adds "nno" as an allowed language in `mapToLanguageAndText` (global messages).

### Acceptance criteria 

- [ ] Adding global messsages with title or body translation as `nno`, shows the message in the app when it it set to nynorsk.
- [ ] Should fall back to bokmål if no `nno` translation is given.

This also applies to things like disruption messages from journey planner, but I don't know if there are any messages in nynorsk, so I don't think we're able to test it.

fixes https://github.com/AtB-AS/kundevendt/issues/5935