### PR TITLE
fix: Add duration to bicycle leg

### DIFF
--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -121,6 +121,14 @@ const TripDetailsTexts = {
         label: (duration: string) =>
           _(`Gå i ${duration}`, `Walk for ${duration}`, `Gå i ${duration}`),
       },
+      bicycle: {
+        label: (duration: string) =>
+          _(
+            `Sykle i ${duration}`,
+            `Ride for ${duration}`,
+            `Sykle i ${duration}`,
+          ),
+      },
       shortWalk: _(
         `Gå i mindre enn ett minutt`,
         `Walk for less than a minute`,

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -84,7 +84,8 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const style = useSectionStyles();
   const {themeName} = useTheme();
 
-  const isWalkSection = leg.mode === 'foot';
+  const isWalkSection = leg.mode === Mode.Foot;
+  const isBikeSection = leg.mode === Mode.Bicycle;
   const isFlexible = isLegFlexibleTransport(leg);
   const legColor = useTransportationColor(
     isFlexible ? 'flex' : leg.mode,
@@ -147,7 +148,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
         )}
         {isWalkSection ? (
           <WalkSection {...leg} />
-        ) : leg.mode === Mode.Bicycle ? (
+        ) : isBikeSection ? (
           <BikeSection {...leg} />
         ) : (
           <TripRow

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -39,7 +39,7 @@ import {
 import {Time} from './Time';
 import {TripLegDecoration} from './TripLegDecoration';
 import {TripRow} from './TripRow';
-import {WaitSection, WaitDetails} from './WaitSection';
+import {WaitDetails, WaitSection} from './WaitSection';
 import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
 import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 import {TripProps} from '@atb/travel-details-screens/components/Trip';
@@ -48,6 +48,7 @@ import {Map} from '@atb/assets/svg/mono-icons/map';
 import {ServiceJourneyMapInfoData_v3} from '@atb/api/types/serviceJourney';
 import {useMapData} from '@atb/travel-details-screens/use-map-data';
 import {useRealtimeText} from '@atb/travel-details-screens/use-realtime-text';
+import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 
 type TripSectionProps = {
   isLast?: boolean;
@@ -146,6 +147,8 @@ export const TripSection: React.FC<TripSectionProps> = ({
         )}
         {isWalkSection ? (
           <WalkSection {...leg} />
+        ) : leg.mode === Mode.Bicycle ? (
+          <BikeSection {...leg} />
         ) : (
           <TripRow
             testID="transportationLeg"
@@ -358,6 +361,29 @@ const WalkSection = (leg: Leg) => {
               ),
             )
           : t(TripDetailsTexts.trip.leg.shortWalk)}
+      </ThemeText>
+    </TripRow>
+  );
+};
+const BikeSection = (leg: Leg) => {
+  const {t, language} = useTranslation();
+
+  return (
+    <TripRow
+      rowLabel={
+        <TransportationIconBox
+          mode={leg.mode}
+          subMode={leg.line?.transportSubmode}
+        />
+      }
+      testID="bikeLeg"
+    >
+      <ThemeText type="body__secondary" color="secondary">
+        {t(
+          TripDetailsTexts.trip.leg.bicycle.label(
+            secondsToDuration(leg.duration ?? 0, language),
+          ),
+        )}
       </ThemeText>
     </TripRow>
   );


### PR DESCRIPTION
Adds duration, e.g. "Sykle i 3 minutter" to a bicycle leg, similar to what's done for walking legs.

From findings during testing of https://github.com/AtB-AS/kundevendt/issues/7198