### PR TITLE
refactor: Harbor names from Entur in ticket purchase flow

### DIFF
--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -9,7 +9,6 @@ import firestore, {
   FirebaseFirestoreTypes,
 } from '@react-native-firebase/firestore';
 import {
-  BoatStopPoint,
   CityZone,
   PreassignedFareProduct,
   TariffZone,
@@ -61,7 +60,6 @@ type ConfigurationContextState = {
   paymentTypes: PaymentType[];
   vatPercent: number;
   fareProductTypeConfigs: FareProductTypeConfig[];
-  boatStopPoints: BoatStopPoint[];
   travelSearchFilters: TravelSearchFiltersType | undefined;
   appTexts: AppTexts | undefined;
   configurableLinks: ConfigurableLinks | undefined;
@@ -77,7 +75,6 @@ const defaultConfigurationContextState: ConfigurationContextState = {
   paymentTypes: defaultPaymentTypes,
   vatPercent: defaultVatPercent,
   fareProductTypeConfigs: defaultFareProductTypeConfig,
-  boatStopPoints: [],
   travelSearchFilters: undefined,
   appTexts: undefined,
   configurableLinks: undefined,
@@ -103,7 +100,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   const [fareProductTypeConfigs, setFareProductTypeConfigs] = useState<
     FareProductTypeConfig[]
   >(defaultFareProductTypeConfig);
-  const [boatStopPoints, setBoatStopPoints] = useState<BoatStopPoint[]>([]);
   const [travelSearchFilters, setTravelSearchFilters] =
     useState<TravelSearchFiltersType>();
   const [appTexts, setAppTexts] = useState<AppTexts>();
@@ -161,11 +157,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
             setFareProductTypeConfigs(fareProductTypeConfigs);
           }
 
-          const boatStopPoints = getBoatStopPointsFromSnapshot(snapshot);
-          if (boatStopPoints) {
-            setBoatStopPoints(boatStopPoints);
-          }
-
           const travelSearchFilters =
             getTravelSearchFiltersFromSnapshot(snapshot);
           if (travelSearchFilters) {
@@ -206,7 +197,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       paymentTypes,
       vatPercent,
       fareProductTypeConfigs,
-      boatStopPoints,
       travelSearchFilters,
       appTexts,
       configurableLinks,
@@ -221,7 +211,6 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     paymentTypes,
     vatPercent,
     fareProductTypeConfigs,
-    boatStopPoints,
     travelSearchFilters,
     appTexts,
     configurableLinks,
@@ -370,23 +359,6 @@ function getFareProductTypeConfigsFromSnapshot(
     return mapToFareProductTypeConfigs(fareProductTypeConfigs);
   }
 
-  return undefined;
-}
-
-function getBoatStopPointsFromSnapshot(
-  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
-): BoatStopPoint[] | undefined {
-  const boatStopPointsFromFirestore = snapshot.docs
-    .find((doc) => doc.id == 'referenceData')
-    ?.get<string>('boatStopPoints');
-
-  try {
-    if (boatStopPointsFromFirestore) {
-      return JSON.parse(boatStopPointsFromFirestore) as BoatStopPoint[];
-    }
-  } catch (error: any) {
-    Bugsnag.notify(error);
-  }
   return undefined;
 }
 

--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -43,7 +43,7 @@ import {SectionSeparator} from '@atb/components/sections';
 import {getLastUsedAccess} from './carnet/CarnetDetails';
 import {InspectionSymbol} from '../fare-contracts/components/InspectionSymbol';
 import {UserProfileWithCount} from './types';
-import {FareContractDestinations} from './components/FareContractDestinations';
+import {FareContractHarborStopPlaces} from './components/FareContractHarborStopPlaces';
 
 export type FareContractInfoProps = {
   travelRights: PreActivatedTravelRight[];
@@ -79,15 +79,15 @@ export const FareContractInfo = ({
   fareContract,
   fareProductType,
 }: FareContractInfoProps) => {
-  const {tariffZones, userProfiles, preassignedFareProducts, boatStopPoints} =
+  const {tariffZones, userProfiles, preassignedFareProducts} =
     useFirestoreConfiguration();
 
   const firstTravelRight = travelRights[0];
   const {
     fareProductRef: productRef,
     tariffZoneRefs,
-    startPointRef,
-    endPointRef,
+    startPointRef: fromStopPlaceId,
+    endPointRef: toStopPlaceId,
   } = firstTravelRight;
 
   const firstZone = tariffZoneRefs?.[0];
@@ -109,10 +109,6 @@ export const FareContractInfo = ({
     userProfiles,
   );
 
-  const [startPlaceName, endPlaceName] = [startPointRef, endPointRef].map(
-    (pointRef) => boatStopPoints.find((bsp) => bsp.id == pointRef)?.name || '',
-  );
-
   return (
     <View style={{flex: 1}}>
       <FareContractInfoHeader
@@ -121,8 +117,8 @@ export const FareContractInfo = ({
         testID={testID}
         status={status}
         fareProductType={fareProductType}
-        startPlaceName={startPlaceName}
-        endPlaceName={endPlaceName}
+        fromStopPlaceId={fromStopPlaceId}
+        toStopPlaceId={toStopPlaceId}
       />
       <SectionSeparator />
       {fareContract && (
@@ -155,16 +151,16 @@ const FareContractInfoHeader = ({
   testID,
   status,
   fareProductType,
-  startPlaceName,
-  endPlaceName,
+  fromStopPlaceId,
+  toStopPlaceId,
 }: {
   preassignedFareProduct?: PreassignedFareProduct;
   isInspectable?: boolean;
   testID?: string;
   status: FareContractInfoProps['status'];
   fareProductType?: string;
-  startPlaceName?: string;
-  endPlaceName?: string;
+  fromStopPlaceId?: string;
+  toStopPlaceId?: string;
 }) => {
   const styles = useStyles();
   const {language} = useTranslation();
@@ -210,9 +206,9 @@ const FareContractInfoHeader = ({
         )}
       </View>
       {['boat-single', 'boat-period'].includes(fareProductType || '') && (
-        <FareContractDestinations
-          startPlaceName={startPlaceName}
-          endPlaceName={endPlaceName}
+        <FareContractHarborStopPlaces
+          fromStopPlaceId={fromStopPlaceId}
+          toStopPlaceId={toStopPlaceId}
           showTwoWayIcon={fareProductType === 'boat-period'}
         />
       )}

--- a/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
+++ b/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
@@ -1,29 +1,50 @@
-import {View} from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import {dictionary, FareContractTexts, useTranslation} from '@atb/translations';
 
 import {ArrowUpDown} from '@atb/assets/svg/mono-icons/navigation';
+import {useHarborsQuery} from '@atb/queries';
+import {MessageBox} from '@atb/components/message-box';
 
-export function FareContractDestinations({
-  startPlaceName,
-  endPlaceName,
+export function FareContractHarborStopPlaces({
+  fromStopPlaceId,
+  toStopPlaceId,
   showTwoWayIcon,
-  decorationColor,
 }: {
-  startPlaceName?: string;
-  endPlaceName?: string;
-  showTwoWayIcon?: boolean;
-  decorationColor?: string;
+  fromStopPlaceId?: string;
+  toStopPlaceId?: string;
+  showTwoWayIcon: boolean;
 }) {
   const {theme} = useTheme();
   const styles = useStyles();
   const {t} = useTranslation();
+  const harborsQuery = useHarborsQuery();
 
-  const color =
-    decorationColor || theme.transport.transport_boat.primary.background;
+  if (!fromStopPlaceId || !toStopPlaceId) return null;
+  if (harborsQuery.isLoading)
+    return <ActivityIndicator style={styles.loading} />;
+  if (harborsQuery.isError)
+    return (
+      <MessageBox
+        style={styles.errorMessage}
+        type="warning"
+        message={t(FareContractTexts.details.harbors.error)}
+        onPressConfig={{
+          text: t(dictionary.retry),
+          action: harborsQuery.refetch,
+        }}
+      />
+    );
 
+  const harbors = harborsQuery.data;
+  const fromName = harbors.find(({id}) => id === fromStopPlaceId)?.name;
+  const toName = harbors.find((sp) => sp.id === toStopPlaceId)?.name;
+
+  if (!fromName || !toName) return null;
+
+  const color = theme.transport.transport_boat.primary.background;
   const decorationLineWidth = theme.tripLegDetail.decorationLineWidth;
   const verticalLinePaddingLeft =
     theme.tripLegDetail.decorationLineEndWidth - decorationLineWidth;
@@ -32,10 +53,7 @@ export function FareContractDestinations({
     <View
       style={styles.container}
       accessibilityLabel={t(
-        PurchaseOverviewTexts.summary.destinations(
-          startPlaceName,
-          endPlaceName,
-        ),
+        FareContractTexts.details.harbors.directions(fromName, toName),
       )}
       accessible={true}
     >
@@ -56,7 +74,7 @@ export function FareContractDestinations({
         }}
       >
         <ThemeText type="body__secondary" color={'primary'}>
-          {startPlaceName}
+          {fromName}
         </ThemeText>
 
         <View
@@ -85,7 +103,7 @@ export function FareContractDestinations({
         </View>
 
         <ThemeText type="body__secondary" color={'primary'}>
-          {endPlaceName}
+          {toName}
         </ThemeText>
       </View>
 
@@ -106,6 +124,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginBottom: theme.spacings.medium,
     marginLeft: theme.spacings.xSmall,
   },
+  loading: {alignItems: 'flex-start', marginTop: 12},
+  errorMessage: {marginTop: 12},
   destinationEndLine: {
     width: theme.tripLegDetail.decorationLineEndWidth,
     height: theme.tripLegDetail.decorationLineWidth,

--- a/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
+++ b/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
@@ -39,7 +39,7 @@ export function FareContractHarborStopPlaces({
     );
 
   const harbors = harborsQuery.data;
-  const fromName = harbors.find(({id}) => id === fromStopPlaceId)?.name;
+  const fromName = harbors.find((sp) => sp.id === fromStopPlaceId)?.name;
   const toName = harbors.find((sp) => sp.id === toStopPlaceId)?.name;
 
   if (!fromName || !toName) return null;

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -54,8 +54,3 @@ export type CityZone = {
   phoneNumber?: string;
   geometry: Omit<Polygon, 'type'> & {type: any};
 };
-
-export type BoatStopPoint = {
-  id: string;
-  name: string;
-};

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -130,7 +130,7 @@ const FareContractTexts = {
         ),
       error: _(
         'Kunne ikke laste kaier.',
-        'Could not load harbors',
+        'Could not load harbors.',
         'Kunne ikkje laste kaier.',
       ),
     },

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -121,6 +121,19 @@ const FareContractTexts = {
         retry: _('Prøv på nytt.', 'Try again.', 'Prøv på nytt.'),
       },
     },
+    harbors: {
+      directions: (from: string, to: string) =>
+        _(
+          `Fra ${from}, til ${to}`,
+          `From ${from}, to ${to}`,
+          `Frå ${from}, til ${to}`,
+        ),
+      error: _(
+        'Kunne ikke laste kaier.',
+        'Could not load harbors',
+        'Kunne ikkje laste kaier.',
+      ),
+    },
   },
   carnet: {
     numberOfUsedAccessesRemaining: (count: number) =>


### PR DESCRIPTION
Reuse the harbors query to fetch harbor names from Entur, instead
of using Firestore.
