### PR TITLE
fix: Set disabled state for screenreader

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -84,6 +84,7 @@ export const HarborSelection = forwardRef<
           </GenericClickableSectionItem>
           <GenericClickableSectionItem
             accessible={true}
+            accessibilityState={{disabled: !fromHarbor}}
             accessibilityRole="button"
             accessibilityLabel={t(
               PurchaseOverviewTexts.stopPlaces.harborSelection.to.a11yLabel(


### PR DESCRIPTION
Set to-harbor to disabled for screenreader when no from-harbor is selected

https://github.com/AtB-AS/kundevendt/issues/4137