### PR TITLE
feat: nynorsk duration humanizer

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -35,32 +35,8 @@ const nynorskHumanizerObj = {
   ms: () => 'millisekund',
 };
 
-const completeLanguageObject = {
-  en: {
-    y: () => 'years',
-    mo: () => 'months',
-    w: () => 'weeks',
-    d: () => 'days',
-    h: () => 'hours',
-    m: () => 'minutes',
-    s: () => 'seconds',
-    ms: () => 'milliseconds',
-  },
-  nn: nynorskHumanizerObj,
-  no: {
-    y: () => 'år',
-    mo: () => 'måneder',
-    w: () => 'uker',
-    d: () => 'dager',
-    h: () => 'timer',
-    m: () => 'minutter',
-    s: () => 'sekunder',
-    ms: () => 'millisekunder',
-  },
-};
-
 const humanizer = humanizeDuration.humanizer({
-  languages: completeLanguageObject,
+  languages: {nn: nynorskHumanizerObj},
 });
 
 function parseIfNeeded(a: string | Date): Date {
@@ -102,13 +78,25 @@ export function secondsToMinutesLong(
   });
 }
 
+type HumanizerLanguage = 'no' | 'nn' | 'en';
+
+const languageToHumanizerLanguage = (language: Language): HumanizerLanguage => {
+  switch (language) {
+    case Language.Norwegian:
+      return 'no';
+    case Language.English:
+      return 'en';
+    case Language.Nynorsk:
+      return 'nn';
+  }
+};
+
 export function secondsToDuration(
   seconds: number,
   language: Language,
   opts?: humanizeDuration.Options,
 ): string {
-  const currentLanguage =
-    language === Language.English ? 'en' : Language.Nynorsk ? 'nn' : 'no';
+  const currentLanguage = languageToHumanizerLanguage(language);
   return humanizer(seconds * 1000, {
     units: ['d', 'h', 'm'],
     round: true,
@@ -449,8 +437,8 @@ function getHumanizer(
   options?: humanizeDuration.Options,
 ) {
   const opts = {
-    language,
-    languages: completeLanguageObject,
+    language: languageToHumanizerLanguage(language),
+    languages: {nn: nynorskHumanizerObj},
     ...options,
   };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -20,10 +20,48 @@ import {
 } from 'date-fns';
 import en from 'date-fns/locale/en-GB';
 import nb from 'date-fns/locale/nb';
+import nn from 'date-fns/locale/nn';
 import humanizeDuration from 'humanize-duration';
 import {DEFAULT_LANGUAGE, Language} from '@atb/translations';
 
-const humanizer = humanizeDuration.humanizer({});
+const nynorskHumanizerObj = {
+  y: () => 'år',
+  mo: (c?: number) => 'månad' + (c === 1 ? '' : 'er'),
+  w: (c?: number) => 'veke' + (c === 1 ? '' : 'r'),
+  d: (c?: number) => 'dag' + (c === 1 ? '' : 'ar'),
+  h: (c?: number) => 'tim' + (c === 1 ? 'e' : 'ar'),
+  m: () => 'minutt',
+  s: () => 'sekund',
+  ms: () => 'millisekund',
+};
+
+const completeLanguageObject = {
+  en: {
+    y: () => 'years',
+    mo: () => 'months',
+    w: () => 'weeks',
+    d: () => 'days',
+    h: () => 'hours',
+    m: () => 'minutes',
+    s: () => 'seconds',
+    ms: () => 'milliseconds',
+  },
+  nn: nynorskHumanizerObj,
+  no: {
+    y: () => 'år',
+    mo: () => 'måneder',
+    w: () => 'uker',
+    d: () => 'dager',
+    h: () => 'timer',
+    m: () => 'minutter',
+    s: () => 'sekunder',
+    ms: () => 'millisekunder',
+  },
+};
+
+const humanizer = humanizeDuration.humanizer({
+  languages: completeLanguageObject,
+});
 
 function parseIfNeeded(a: string | Date): Date {
   return a instanceof Date ? a : parseISO(a);
@@ -69,8 +107,9 @@ export function secondsToDuration(
   language: Language,
   opts?: humanizeDuration.Options,
 ): string {
-  const currentLanguage = language === Language.English ? 'en' : 'no';
-  return humanizeDuration(seconds * 1000, {
+  const currentLanguage =
+    language === Language.English ? 'en' : Language.Nynorsk ? 'nn' : 'no';
+  return humanizer(seconds * 1000, {
     units: ['d', 'h', 'm'],
     round: true,
     language: currentLanguage,
@@ -364,7 +403,7 @@ const languageToLocale = (language: Language): Locale => {
     case Language.English:
       return en;
     case Language.Nynorsk:
-      return nb;
+      return nn;
   }
 };
 
@@ -410,30 +449,8 @@ function getHumanizer(
   options?: humanizeDuration.Options,
 ) {
   const opts = {
-    language: language === Language.English ? 'en' : 'no',
-    languages: {
-      no: {
-        y: () => 'år',
-        mo: () => 'måneder',
-        w: () => 'uker',
-        d: () => 'dager',
-        h: () => 'timer',
-        m: () => 'minutter',
-        s: () => 'sekunder',
-        ms: () => 'millisekunder',
-      },
-      en: {
-        y: () => 'years',
-        mo: () => 'months',
-        w: () => 'weeks',
-        d: () => 'days',
-        h: () => 'hours',
-        m: () => 'minutes',
-        s: () => 'seconds',
-        ms: () => 'milliseconds',
-      },
-    },
-
+    language,
+    languages: completeLanguageObject,
     ...options,
   };
 


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/5989.

Restructuring use of [humanize-duration](https://www.npmjs.com/package/humanize-duration) to support Nynorsk. 

Features:
- Initializing humanizer object with nynorsk languages provided
- Removing duplicate wrongly defined Bokmål and English (if these had been used, single units would have been plural e.g. 1 days / 1 minutter)
- Using initialized humanizer instead of calling "humanizeDuration" directly

Also considering adding a PR to the library so we can remove all the nynorsk specific stuff, but guess that will take some time to have approved.