### PR TITLE
fix: Spinner stuck on iOS

### DIFF
--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -17,6 +17,7 @@ import {Platform, RefreshControl, View} from 'react-native';
 import {StopPlacesMode} from './types';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeaderProps} from '@atb/components/screen-header';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 export type NearbyStopPlacesScreenParams = {
   location: Location | undefined;
@@ -149,13 +150,17 @@ export const NearbyStopPlacesScreenComponent = ({
     );
   }
 
+  const isFocused = useIsFocusedAndActive();
+
   return (
     <FullScreenView
       refreshControl={
-        <RefreshControl
-          refreshing={Platform.OS === 'ios' ? false : isLoading}
-          onRefresh={refresh}
-        />
+        isFocused ? (
+          <RefreshControl
+            refreshing={Platform.OS === 'ios' ? false : isLoading}
+            onRefresh={refresh}
+          />
+        ) : undefined
       }
       headerProps={headerProps}
       parallaxContent={() => (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -58,6 +58,7 @@ import {TripPattern} from '@atb/api/types/trips';
 import {useAnalytics} from '@atb/analytics';
 import {useNonTransitTripsQuery} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query';
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 type RootProps = DashboardScreenProps<'Dashboard_TripSearchScreen'>;
 
@@ -76,6 +77,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const {language, t} = useTranslation();
   const [updatingLocation] = useState<boolean>(false);
   const analytics = useAnalytics();
+  const isFocused = useIsFocusedAndActive();
 
   const shouldShowTravelSearchFilterOnboarding =
     useShouldShowTravelSearchFilterOnboarding();
@@ -262,14 +264,16 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
           },
         }}
         refreshControl={
-          <RefreshControl
-            refreshing={
-              Platform.OS === 'ios'
-                ? false
-                : searchState === 'searching' && !tripPatterns.length
-            }
-            onRefresh={refresh}
-          />
+          isFocused ? (
+            <RefreshControl
+              refreshing={
+                Platform.OS === 'ios'
+                  ? false
+                  : searchState === 'searching' && !tripPatterns.length
+              }
+              onRefresh={refresh}
+            />
+          ) : undefined
         }
         parallaxContent={() => (
           <View style={style.searchHeader}>


### PR DESCRIPTION
### Background
It seems that there is a native iOS bug when the spinner refreshing
state is always set to false. 

### Solution
The issue was (hopefully) fixed this by "resetting" the refresh control by removing it when screen is out of focus.

### Acceptance criteria

- [ ] Test refresh spinner vigorously on both iOS and Android, on TripSearchScreen and NearbyStopPlacesScreen.
