### PR TITLE
fix: boat ticket screen reader focus fix

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -2,7 +2,7 @@ import {ThemeText} from '@atb/components/text';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
-import React, {ForwardedRef, forwardRef, useRef} from 'react';
+import React, {forwardRef, useRef} from 'react';
 import {StyleProp, TouchableOpacity, View, ViewStyle} from 'react-native';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 import {PreassignedFareProduct} from '@atb/reference-data/types';
@@ -17,6 +17,9 @@ type StopPlaceSelectionProps = {
   onSelect: (params: Root_PurchaseHarborSearchScreenParams) => void;
   style?: StyleProp<ViewStyle>;
 };
+
+const FROM = 'from';
+const TO = 'to';
 
 export const HarborSelection = forwardRef<
   TouchableOpacity,
@@ -53,12 +56,12 @@ export const HarborSelection = forwardRef<
         </ThemeText>
 
         <Section accessible={false}>
-          {(['from', 'to'] as ('from' | 'to')[]).map((fromOrTo) => {
-            const harbor = fromOrTo === 'from' ? fromHarbor : toHarbor;
+          {([FROM, TO] as (typeof FROM | typeof TO)[]).map((fromOrTo) => {
+            const harbor = fromOrTo === FROM ? fromHarbor : toHarbor;
             const harborStyle =
-              fromOrTo === 'from' ? styles.fromHarbor : styles.toHarbor;
-            const disabled = fromOrTo === 'to' && !fromHarbor;
-            const ref = fromOrTo == 'from' ? fromRef : toRef;
+              fromOrTo === FROM ? styles.fromHarbor : styles.toHarbor;
+            const disabled = fromOrTo === TO && !fromHarbor;
+            const ref = fromOrTo == FROM ? fromRef : toRef;
             return (
               <GenericClickableSectionItem
                 key={fromOrTo}
@@ -82,7 +85,7 @@ export const HarborSelection = forwardRef<
                 }
                 onPress={() => {
                   onSelect({
-                    ...(fromOrTo === 'to' && fromHarbor ? {fromHarbor} : {}),
+                    ...(fromOrTo === TO && fromHarbor ? {fromHarbor} : {}),
                     fareProductTypeConfig,
                     preassignedFareProduct,
                   });

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -48,78 +48,58 @@ export const HarborSelection = forwardRef<
         >
           {t(PurchaseOverviewTexts.stopPlaces.harborSelection.select.text)}
         </ThemeText>
+
         <Section accessible={false}>
-          <GenericClickableSectionItem
-            ref={harborInputSectionItemRef}
-            accessible={true}
-            accessibilityRole="button"
-            accessibilityLabel={t(
-              PurchaseOverviewTexts.stopPlaces.harborSelection.from.a11yLabel(
-                fromHarbor?.name,
-              ),
-            )}
-            accessibilityHint={t(
-              PurchaseOverviewTexts.stopPlaces.harborSelection.from.a11yHint,
-            )}
-            onPress={() =>
-              onSelect({
-                fareProductTypeConfig,
-                preassignedFareProduct,
-              })
-            }
-            testID="selectHarborsButton"
-          >
-            <>
-              <View style={styles.fromHarbor}>
-                <ThemeText
-                  color="secondary"
-                  type="body__secondary"
-                  style={styles.toFromLabel}
-                >
-                  {t(PurchaseOverviewTexts.fromToLabel.from)}
-                </ThemeText>
-                <HarborLabel harbor={fromHarbor} />
-              </View>
-            </>
-          </GenericClickableSectionItem>
-          <GenericClickableSectionItem
-            accessible={true}
-            accessibilityState={{disabled: !fromHarbor}}
-            accessibilityRole="button"
-            accessibilityLabel={t(
-              PurchaseOverviewTexts.stopPlaces.harborSelection.to.a11yLabel(
-                toHarbor?.name,
-              ),
-            )}
-            accessibilityHint={
-              fromHarbor
-                ? t(
-                    PurchaseOverviewTexts.stopPlaces.harborSelection.to
-                      .a11yHint,
-                  )
-                : undefined
-            }
-            onPress={() =>
-              fromHarbor &&
-              onSelect({
-                fromHarbor,
-                fareProductTypeConfig,
-                preassignedFareProduct,
-              })
-            }
-            testID="selectHarborsButton"
-          >
-            <View style={styles.toHarbor}>
-              <ThemeText
-                color={!!fromHarbor ? 'secondary' : 'disabled'}
-                type="body__secondary"
-                style={styles.toFromLabel}
+          {(['from', 'to'] as ('from' | 'to')[]).map((fromOrTo) => {
+            const harbor = fromOrTo === 'from' ? fromHarbor : toHarbor;
+            const harborStyle =
+              fromOrTo === 'from' ? styles.fromHarbor : styles.toHarbor;
+            const disabled = fromOrTo === 'to' && !fromHarbor;
+            return (
+              <GenericClickableSectionItem
+                key={fromOrTo}
+                ref={harborInputSectionItemRef}
+                accessibilityState={{disabled}}
+                accessible={true}
+                accessibilityRole="button"
+                accessibilityLabel={t(
+                  PurchaseOverviewTexts.stopPlaces.harborSelection[
+                    fromOrTo
+                  ].a11yLabel(harbor?.name),
+                )}
+                accessibilityHint={
+                  disabled
+                    ? undefined
+                    : t(
+                        PurchaseOverviewTexts.stopPlaces.harborSelection[
+                          fromOrTo
+                        ].a11yHint,
+                      )
+                }
+                onPress={() =>
+                  onSelect({
+                    ...(fromOrTo !== 'from' && fromHarbor ? {fromHarbor} : {}),
+                    fareProductTypeConfig,
+                    preassignedFareProduct,
+                  })
+                }
+                testID="selectHarborsButton"
               >
-                {t(PurchaseOverviewTexts.fromToLabel.to)}
-              </ThemeText>
-              <HarborLabel harbor={toHarbor} disabled={!fromHarbor} />
-            </View>
-          </GenericClickableSectionItem>
+                <>
+                  <View style={harborStyle}>
+                    <ThemeText
+                      color={disabled ? 'disabled' : 'secondary'}
+                      type="body__secondary"
+                      style={styles.toFromLabel}
+                    >
+                      {t(PurchaseOverviewTexts.fromToLabel[fromOrTo])}
+                    </ThemeText>
+                    <HarborLabel harbor={harbor} disabled={disabled} />
+                  </View>
+                </>
+              </GenericClickableSectionItem>
+            );
+          })}
         </Section>
       </View>
     );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -39,9 +39,6 @@ export const HarborSelection = forwardRef<
     const styles = useStyles();
     const {t} = useTranslation();
 
-    const fromRef = useRef<TouchableOpacity>(null);
-    const toRef = useRef<TouchableOpacity>(null);
-
     return (
       <View style={style} accessible={false}>
         <ThemeText
@@ -56,65 +53,99 @@ export const HarborSelection = forwardRef<
         </ThemeText>
 
         <Section accessible={false}>
-          {([FROM, TO] as (typeof FROM | typeof TO)[]).map((fromOrTo) => {
-            const harbor = fromOrTo === FROM ? fromHarbor : toHarbor;
-            const harborStyle =
-              fromOrTo === FROM ? styles.fromHarbor : styles.toHarbor;
-            const disabled = fromOrTo === TO && !fromHarbor;
-            const ref = fromOrTo == FROM ? fromRef : toRef;
-            return (
-              <GenericClickableSectionItem
-                key={fromOrTo}
-                ref={ref}
-                accessibilityState={{disabled}}
-                accessible={true}
-                accessibilityRole="button"
-                accessibilityLabel={t(
-                  PurchaseOverviewTexts.stopPlaces.harborSelection[
-                    fromOrTo
-                  ].a11yLabel(harbor?.name),
-                )}
-                accessibilityHint={
-                  disabled
-                    ? undefined
-                    : t(
-                        PurchaseOverviewTexts.stopPlaces.harborSelection[
-                          fromOrTo
-                        ].a11yHint,
-                      )
-                }
-                onPress={() => {
-                  onSelect({
-                    ...(fromOrTo === TO && fromHarbor ? {fromHarbor} : {}),
-                    fareProductTypeConfig,
-                    preassignedFareProduct,
-                  });
-                  if (
-                    harborInputSectionItemRef &&
-                    typeof harborInputSectionItemRef !== 'function'
-                  ) {
-                    harborInputSectionItemRef.current = ref.current;
-                  }
-                }}
-                testID="selectHarborsButton"
-              >
-                <>
-                  <View style={harborStyle}>
-                    <ThemeText
-                      color={disabled ? 'disabled' : 'secondary'}
-                      type="body__secondary"
-                      style={styles.toFromLabel}
-                    >
-                      {t(PurchaseOverviewTexts.fromToLabel[fromOrTo])}
-                    </ThemeText>
-                    <HarborLabel harbor={harbor} disabled={disabled} />
-                  </View>
-                </>
-              </GenericClickableSectionItem>
-            );
-          })}
+          <HarborSelectionItem
+            fromOrTo={FROM}
+            harbor={fromHarbor}
+            disabled={false}
+            onPress={() =>
+              onSelect({
+                fareProductTypeConfig,
+                preassignedFareProduct,
+              })
+            }
+            ref={harborInputSectionItemRef}
+          />
+          <HarborSelectionItem
+            fromOrTo={TO}
+            harbor={toHarbor}
+            disabled={!fromHarbor}
+            onPress={() =>
+              onSelect({
+                fromHarbor,
+                fareProductTypeConfig,
+                preassignedFareProduct,
+              })
+            }
+            ref={harborInputSectionItemRef}
+          />
         </Section>
       </View>
+    );
+  },
+);
+
+type HarborSelectionItemProps = {
+  harbor?: StopPlaceFragment;
+  disabled: boolean;
+  onPress: () => void;
+  fromOrTo: typeof FROM | typeof TO;
+};
+
+const HarborSelectionItem = forwardRef<
+  TouchableOpacity,
+  HarborSelectionItemProps
+>(
+  (
+    {harbor, onPress, disabled, fromOrTo}: HarborSelectionItemProps,
+    harborInputSectionItemRef,
+  ) => {
+    const itemRef = useRef<TouchableOpacity>(null);
+    const {t} = useTranslation();
+    const styles = useStyles();
+
+    return (
+      <GenericClickableSectionItem
+        ref={itemRef}
+        accessibilityState={{disabled}}
+        accessible={true}
+        accessibilityRole="button"
+        accessibilityLabel={t(
+          PurchaseOverviewTexts.stopPlaces.harborSelection[fromOrTo].a11yLabel(
+            harbor?.name,
+          ),
+        )}
+        accessibilityHint={
+          disabled
+            ? undefined
+            : t(
+                PurchaseOverviewTexts.stopPlaces.harborSelection[fromOrTo]
+                  .a11yHint,
+              )
+        }
+        onPress={() => {
+          if (!disabled) {
+            onPress();
+            if (
+              harborInputSectionItemRef &&
+              typeof harborInputSectionItemRef !== 'function'
+            ) {
+              harborInputSectionItemRef.current = itemRef.current;
+            }
+          }
+        }}
+        testID="selectHarborsButton"
+      >
+        <View style={fromOrTo === FROM ? styles.fromHarbor : styles.toHarbor}>
+          <ThemeText
+            color={disabled ? 'disabled' : 'secondary'}
+            type="body__secondary"
+            style={styles.toFromLabel}
+          >
+            {t(PurchaseOverviewTexts.fromToLabel[fromOrTo])}
+          </ThemeText>
+          <HarborLabel harbor={harbor} disabled={disabled} />
+        </View>
+      </GenericClickableSectionItem>
     );
   },
 );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -2,7 +2,7 @@ import {ThemeText} from '@atb/components/text';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
-import React, {forwardRef} from 'react';
+import React, {ForwardedRef, forwardRef, useRef} from 'react';
 import {StyleProp, TouchableOpacity, View, ViewStyle} from 'react-native';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 import {PreassignedFareProduct} from '@atb/reference-data/types';
@@ -36,6 +36,9 @@ export const HarborSelection = forwardRef<
     const styles = useStyles();
     const {t} = useTranslation();
 
+    const fromRef = useRef<TouchableOpacity>(null);
+    const toRef = useRef<TouchableOpacity>(null);
+
     return (
       <View style={style} accessible={false}>
         <ThemeText
@@ -55,10 +58,11 @@ export const HarborSelection = forwardRef<
             const harborStyle =
               fromOrTo === 'from' ? styles.fromHarbor : styles.toHarbor;
             const disabled = fromOrTo === 'to' && !fromHarbor;
+            const ref = fromOrTo == 'from' ? fromRef : toRef;
             return (
               <GenericClickableSectionItem
                 key={fromOrTo}
-                ref={harborInputSectionItemRef}
+                ref={ref}
                 accessibilityState={{disabled}}
                 accessible={true}
                 accessibilityRole="button"
@@ -76,13 +80,19 @@ export const HarborSelection = forwardRef<
                         ].a11yHint,
                       )
                 }
-                onPress={() =>
+                onPress={() => {
                   onSelect({
-                    ...(fromOrTo !== 'from' && fromHarbor ? {fromHarbor} : {}),
+                    ...(fromOrTo === 'to' && fromHarbor ? {fromHarbor} : {}),
                     fareProductTypeConfig,
                     preassignedFareProduct,
-                  })
-                }
+                  });
+                  if (
+                    harborInputSectionItemRef &&
+                    typeof harborInputSectionItemRef !== 'function'
+                  ) {
+                    harborInputSectionItemRef.current = ref.current;
+                  }
+                }}
                 testID="selectHarborsButton"
               >
                 <>


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/7367

The ref used to focus the screen reader when returning from a boat harbor selection, is now set according to which selection you just set (from or to).