### PR TITLE
chore: Fix flipper in CI

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,7 +30,9 @@ target 'app' do
     #
     # Note that if you have use_frameworks! enabled, Flipper will not work and
     # you should disable the next line.
-    :flipper_configuration => FlipperConfiguration.enabled,
+    :flipper_configuration => ENV['CI'] ?
+        FlipperConfiguration.disabled :
+        FlipperConfiguration.enabled,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1115,6 +1115,8 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
+  - react-native-flipper (0.191.0):
+    - React-Core
   - react-native-flipper-performance-plugin (0.4.0):
     - React-Core
     - react-native-flipper-performance-plugin/FBDefines (= 0.4.0)
@@ -1358,6 +1360,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-flipper (from `../node_modules/react-native-flipper`)
   - react-native-flipper-performance-plugin (from `../node_modules/react-native-flipper-performance-plugin`)
   - react-native-geolocation-service (from `../node_modules/react-native-geolocation-service`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
@@ -1499,6 +1502,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-flipper:
+    :path: "../node_modules/react-native-flipper"
   react-native-flipper-performance-plugin:
     :path: "../node_modules/react-native-flipper-performance-plugin"
   react-native-geolocation-service:
@@ -1662,6 +1667,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
+  react-native-flipper: 5d8dcbcb905a7e8076c9a61a3709944c23cf48ee
   react-native-flipper-performance-plugin: 42ec5017abd26e7c5a1f527f2db92c14a90cabdb
   react-native-geolocation-service: 608e1da71a1ac31b4de64d9ef2815f697978c55b
   react-native-get-random-values: a6ea6a8a65dc93e96e24a11105b1a9c8cfe1d72a
@@ -1709,6 +1715,6 @@ SPEC CHECKSUMS:
   Yoga: 99caf8d5ab45e9d637ee6e0174ec16fbbb01bcfc
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 4615622a609be6d9ed8da4a3cc12bbe2253763d9
+PODFILE CHECKSUM: 566d143065aa79f6fd75f03b0f85f2496f7648a1
 
 COCOAPODS: 1.11.3

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-native": "0.70.6",
     "react-native-bootsplash": "^4.4.1",
     "react-native-device-info": "^10.3.0",
+    "react-native-flipper": "^0.191.0",
     "react-native-geolocation-service": "^5.3.1",
     "react-native-gesture-handler": "^2.9.0",
     "react-native-get-random-values": "^1.8.0",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -4,4 +4,9 @@ module.exports = {
     android: {},
   },
   assets: ['./assets/fonts'],
+  dependencies: {
+    ...(process.env.CI
+      ? {'react-native-flipper': {platforms: {ios: null}}}
+      : {}),
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10448,6 +10448,11 @@ react-native-flipper-performance-plugin@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-native-flipper-performance-plugin/-/react-native-flipper-performance-plugin-0.4.0.tgz#961ff2f9ccc942d2a4cabd4f6d401034c5402007"
   integrity sha512-D9Z5VrktJjUenYB4X9qfKcqg9YSyQWOD7fKoxkzXoKxbyalGoWib79iD3OBHOBZEsk5RbQ006zYL7VQwA3D4Wg==
 
+react-native-flipper@^0.191.0:
+  version "0.191.0"
+  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.191.0.tgz#5447f49f02d955891667f8c3128fd66e4fabd1c0"
+  integrity sha512-JKi9Fm9lfOboRLf01iKtVbjs1bVHE/63ls+mvjzn6hsNAKXkXVtI5VE0Jb/TDkGtwN1l7e+qMrh0EKhc40Iu8A==
+
 react-native-geolocation-service@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/react-native-geolocation-service/-/react-native-geolocation-service-5.3.1.tgz#4ce1017789da6fdfcf7576eb6f59435622af4289"


### PR DESCRIPTION
Solution based on:
https://reactnative.dev/docs/next/speeding-ci-builds#:~:text=Flipper%20is%20a%20debugging%20tool,built%20in%20the%20CI%20environment.

https://dev.to/retyui/disable-flipper-on-ci-builds-for-react-native-complete-guide-bnd

