### PR TITLE
feat: Add toggle button for product description

### DIFF
--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -33,6 +33,7 @@ export type UserPreferences = {
   showTestIds?: boolean;
   tripSearchPreferences?: TripSearchPreferences;
   hideTravellerDescriptions?: boolean;
+  hideProductDescriptions?: boolean;
   debugShowSeconds?: boolean;
 };
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle.tsx
@@ -1,0 +1,64 @@
+import {Toggle} from '@atb/components/toggle';
+import {ThemeText} from '@atb/components/text';
+import {usePreferences} from '@atb/preferences';
+import React from 'react';
+import {View} from 'react-native';
+import {StyleSheet} from '@atb/theme';
+import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+
+export function ProductDescriptionToggle({title}: {title: string}) {
+  const styles = useStyles();
+  const {t} = useTranslation();
+  const {
+    setPreference,
+    preferences: {hideProductDescriptions: hideDescriptions},
+  } = usePreferences();
+
+  return (
+    <View style={styles.container}>
+      <View style={{flexShrink: 1}}>
+        <ThemeText type="body__secondary" color="secondary">
+          {title}
+        </ThemeText>
+      </View>
+
+      <View style={styles.switchAndLabel}>
+        <ThemeText
+          type="body__secondary"
+          accessible={false}
+          importantForAccessibility="no"
+          style={styles.label}
+        >
+          {t(PurchaseOverviewTexts.productSelection.descriptionToggle.label)}
+        </ThemeText>
+        <Toggle
+          value={!hideDescriptions}
+          onValueChange={(checked) => {
+            setPreference({hideProductDescriptions: !checked});
+          }}
+          accessibilityLabel={t(
+            PurchaseOverviewTexts.productSelection.descriptionToggle.a11yLabel,
+          )}
+          testID="descriptionToggle"
+        />
+      </View>
+    </View>
+  );
+}
+
+const useStyles = StyleSheet.createThemeHook((theme) => {
+  return {
+    container: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: theme.spacings.medium,
+      alignItems: 'center',
+    },
+    switchAndLabel: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+    },
+    label: {marginRight: theme.spacings.xSmall},
+  };
+});

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -11,12 +11,12 @@ import {
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {PreassignedFareProduct} from '@atb/reference-data/types';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
-import {ThemeText} from '@atb/components/text';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
-import {StyleSheet} from '@atb/theme';
 import {RadioGroupSection, Section} from '@atb/components/sections';
 import {useTicketingState} from '@atb/ticketing';
+import {ProductDescriptionToggle} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle';
+import {usePreferenceItems} from '@atb/preferences';
 
 type ProductSelectionByProductsProps = {
   selectedProduct: PreassignedFareProduct;
@@ -33,8 +33,8 @@ export function ProductSelectionByProducts({
 }: ProductSelectionByProductsProps) {
   const {t, language} = useTranslation();
   const {preassignedFareProducts} = useFirestoreConfiguration();
-  const styles = useStyles();
   const {customerProfile} = useTicketingState();
+  const {hideProductDescriptions} = usePreferenceItems();
 
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
@@ -47,15 +47,15 @@ export function ProductSelectionByProducts({
 
   return (
     <View style={style}>
-      <ThemeText type="body__secondary" color="secondary" style={styles.title}>
-        {title || t(PurchaseOverviewTexts.productSelection.title)}
-      </ThemeText>
+      <ProductDescriptionToggle
+        title={title || t(PurchaseOverviewTexts.productSelection.title)}
+      />
       <Section>
         <RadioGroupSection<PreassignedFareProduct>
           items={selectableProducts}
           keyExtractor={(u) => u.id}
           itemToText={(fp) => getReferenceDataName(fp, language)}
-          hideSubtext={false}
+          hideSubtext={hideProductDescriptions}
           itemToSubtext={(fp) => {
             const descriptionMessage = getTextForLanguage(
               fp.description ?? [],
@@ -85,9 +85,3 @@ export function ProductSelectionByProducts({
     </View>
   );
 }
-
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  title: {
-    marginBottom: theme.spacings.medium,
-  },
-}));

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -160,6 +160,14 @@ const PurchaseOverviewTexts = {
   },
   productSelection: {
     title: _('Velg billett', 'Select a ticket', 'Vel billett'),
+    descriptionToggle: {
+      label: _('Vis info', 'Show info', 'Vis info'),
+      a11yLabel: _(
+        'Vis informasjon om produkter',
+        'Show information about products',
+        'Vis informasjon om produkt',
+      ),
+    },
     a11yTitle: _(
       'Aktiver for å velge billett',
       'Activate to select ticket',


### PR DESCRIPTION
Added a toggle button, same (similar) as the one used for traveller selection previously (removed in https://github.com/AtB-AS/mittatb-app/pull/3657). The button is added only for products with `productSelectionMode: product`, which is only a few of the products. This is mainly affecting FRAM which has a couple of products of this kind, AtB/NFK mostly has the night ticket.

<img width="276" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/14045515/9c54b555-ceda-428e-983f-99d4f477751f">

<img width="275" alt="2023-08-23 at 22 55 41@2x" src="https://github.com/AtB-AS/mittatb-app/assets/14045515/26941fa7-0a63-4dd2-969d-683cb25ee4f0">


Fixes https://github.com/AtB-AS/kundevendt/issues/4223