### PR TITLE
fix: release flipper namespace

### DIFF
--- a/android/app/src/release/java/no/mittatb/ReactNativeFlipper.java
+++ b/android/app/src/release/java/no/mittatb/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package no.mittatb;
 import android.content.Context;
 import com.facebook.react.ReactInstanceManager;
 /**


### PR DESCRIPTION
Corrects wrong default namespace package for Release ReactNativeFlipper class