### PR TITLE
fix: adds staging flipper in addition to release

### DIFF
--- a/android/app/src/staging/java/no/mittatb/ReactNativeFlipper.java
+++ b/android/app/src/staging/java/no/mittatb/ReactNativeFlipper.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
+ */
+package no.mittatb;
+import android.content.Context;
+import com.facebook.react.ReactInstanceManager;
+/**
+ * Class responsible of loading Flipper inside your React Native application. This is the release
+ * flavor of it so it's empty as we don't want to load Flipper.
+ */
+public class ReactNativeFlipper {
+  public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+    // Do nothing as we don't want to initialize Flipper on Release.
+  }
+}


### PR DESCRIPTION
ReactNativeFlipper requires a stub for every environment. We have special case where we have added staging build target, which is compiled to QA. This adds stub to that build target also