### PR TITLE
fix: android error because of apple pass suppression

### DIFF
--- a/src/suppress-pass-presentation/index.ts
+++ b/src/suppress-pass-presentation/index.ts
@@ -1,5 +1,5 @@
 import {useEffect} from 'react';
-import {NativeModules} from 'react-native';
+import {NativeModules, Platform} from 'react-native';
 
 // Found in ./ios/Modules/PassPresentationBridge.m
 const {PassPresentationBridge: PassPresentation} = NativeModules;
@@ -8,12 +8,10 @@ interface RCTPassPresentationInterface {
   requestAutomaticPassPresentationSuppression(): void;
   endAutomaticPassPresentationSuppression(): void;
 }
-
-export const RCTPassPresentation =
-  PassPresentation as RCTPassPresentationInterface;
-
+const RCTPassPresentation = PassPresentation as RCTPassPresentationInterface;
 export function useApplePassPresentationSuppression() {
   useEffect(() => {
+    if (Platform.OS === 'android') return;
     RCTPassPresentation.requestAutomaticPassPresentationSuppression();
     return () => {
       RCTPassPresentation.endAutomaticPassPresentationSuppression();


### PR DESCRIPTION
Fixes fare contract details screen from crashing on Android because of calling iOS native functionality.  