### PR TITLE
fix: resetting disconnect icon for live vehicles

### DIFF
--- a/src/api/vehicles.ts
+++ b/src/api/vehicles.ts
@@ -44,9 +44,9 @@ export const useLiveVehicleSubscription = ({
 
   connectionIndicatorDebounceTimeInMs?: number;
 }) => {
-  const [vehicle, setVehicle] = useState<VehicleWithPosition | undefined>(
-    vehicleWithPosition,
-  );
+  const [liveVehicle, setLiveVehicle] = useState<
+    VehicleWithPosition | undefined
+  >(vehicleWithPosition);
   const [isConnected, setIsConnected] = useIsLoading(
     false,
     connectionIndicatorDebounceTimeInMs,
@@ -66,9 +66,9 @@ export const useLiveVehicleSubscription = ({
       // set as false every time, React will not update if the value is the same.
       setIsConnected(false);
       const vehicle = JSON.parse(event.data) as VehicleWithPosition;
-      setVehicle(vehicle);
+      setLiveVehicle(vehicle);
     },
-    [setVehicle, setIsConnected],
+    [setLiveVehicle, setIsConnected],
   );
 
   const onErrorHandler = useCallback(
@@ -83,5 +83,5 @@ export const useLiveVehicleSubscription = ({
     enabled,
   });
 
-  return [vehicle, isConnected] as const;
+  return [liveVehicle, isConnected] as const;
 };

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -89,7 +89,7 @@ export const TravelDetailsMapScreenComponent = ({
 
   const stations = useStations(mapFilter?.mobility ?? {});
 
-  const [realtimeVehicle, isRealtimeError] = useLiveVehicleSubscription({
+  const [liveVehicle, isLiveConnected] = useLiveVehicleSubscription({
     serviceJourneyId: vehicleWithPosition?.serviceJourney?.id,
     vehicleWithPosition,
     enabled: isFocusedAndActive,
@@ -146,7 +146,7 @@ export const TravelDetailsMapScreenComponent = ({
   };
 
   useEffect(() => {
-    const location = realtimeVehicle?.location;
+    const location = liveVehicle?.location;
     if (!location) return;
     if (shouldTrack) {
       flyToLocation({
@@ -156,7 +156,7 @@ export const TravelDetailsMapScreenComponent = ({
         animationMode: 'easeTo',
       });
     }
-  }, [realtimeVehicle, shouldTrack]);
+  }, [liveVehicle, shouldTrack]);
 
   return (
     <View style={styles.mapView}>
@@ -193,15 +193,15 @@ export const TravelDetailsMapScreenComponent = ({
             text={t(MapTexts.startPoint.label)}
           />
         )}
-        {realtimeVehicle && (
-          <LiveVehicle
-            vehicle={realtimeVehicle}
+        {liveVehicle && (
+          <LiveVehicleMarker
+            vehicle={liveVehicle}
             setShouldTrack={setShouldTrack}
             mode={mode}
             subMode={subMode}
             zoomLevel={zoomLevel}
             heading={cameraHeading}
-            isError={isRealtimeError}
+            isError={isLiveConnected}
           />
         )}
         {stations && <Stations stations={stations.stations} />}
@@ -236,7 +236,7 @@ type VehicleIconProps = {
   isError: boolean;
 };
 
-const LiveVehicle = ({
+const LiveVehicleMarker = ({
   vehicle,
   setShouldTrack,
   mode,

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -87,22 +87,11 @@ export const TravelDetailsMapScreenComponent = ({
   const controlStyles = useControlPositionsStyle();
   const styles = useStyles();
 
-  const [vehicle, setVehicle] = useState<VehicleWithPosition | undefined>(
-    vehicleWithPosition,
-  );
-
   const stations = useStations(mapFilter?.mobility ?? {});
 
-  const [isError, setIsError] = useState(false);
-
-  useLiveVehicleSubscription({
+  const [realtimeVehicle, isRealtimeError] = useLiveVehicleSubscription({
     serviceJourneyId: vehicleWithPosition?.serviceJourney?.id,
-    onMessage: (event: WebSocketMessageEvent) => {
-      if (isError) setIsError(false);
-      const vehicle = JSON.parse(event.data) as VehicleWithPosition;
-      setVehicle(vehicle);
-    },
-    onError: () => setIsError(true),
+    vehicleWithPosition,
     enabled: isFocusedAndActive,
   });
 
@@ -157,7 +146,7 @@ export const TravelDetailsMapScreenComponent = ({
   };
 
   useEffect(() => {
-    const location = vehicle?.location;
+    const location = realtimeVehicle?.location;
     if (!location) return;
     if (shouldTrack) {
       flyToLocation({
@@ -167,7 +156,7 @@ export const TravelDetailsMapScreenComponent = ({
         animationMode: 'easeTo',
       });
     }
-  }, [vehicle, shouldTrack]);
+  }, [realtimeVehicle, shouldTrack]);
 
   return (
     <View style={styles.mapView}>
@@ -204,15 +193,15 @@ export const TravelDetailsMapScreenComponent = ({
             text={t(MapTexts.startPoint.label)}
           />
         )}
-        {vehicle && (
+        {realtimeVehicle && (
           <LiveVehicle
-            vehicle={vehicle}
+            vehicle={realtimeVehicle}
             setShouldTrack={setShouldTrack}
             mode={mode}
             subMode={subMode}
             zoomLevel={zoomLevel}
             heading={cameraHeading}
-            isError={isError}
+            isError={isRealtimeError}
           />
         )}
         {stations && <Stations stations={stations.stations} />}


### PR DESCRIPTION
There is some newly introduced issue in later React Native that forces Android Websocket connection to close after 30 sec (1006 error). Currently can't find the cause of this issue, but we are able to immediately reconnect. This issue becomes very apparent to the client by the fact that there are stale functions used in `useSubscription` causing the disconnected indicator in the live map _not_ to be updated.

There are apparently cases from before where the client times out by design. I don't think this is that, but as it is already by the design the negative effect of Java WebSocket bug isn't as critical and the workaround with reconnecting is fine I think. Not ideal, but fine.

This PR:

- Fixes error indicator not updating after reconnect for `useSubscription`
- Introduces a delay on the error indicator so that it is only updated after 3 seconds. I think this is a good practice in any case as if it's not connected in only a few seconds the user are non the wiser and get's more confused by why the icon is flashing red.



Related: https://github.com/AtB-AS/kundevendt/issues/7802 https://github.com/AtB-AS/mittatb-app/pull/3784