### PR TITLE
refactor: Small auth changes

### DIFF
--- a/src/auth/auth-utils.ts
+++ b/src/auth/auth-utils.ts
@@ -56,34 +56,6 @@ export const authSignInWithCustomToken = async (token: string) => {
   }
 };
 
-/*
- * Check whether the user creation is finished up to 10 times with an interval
- * of 1 second.
- */
-export const startAccountCreationFinishedCheck = (
-  user: FirebaseAuthTypes.User | null,
-  dispatch: Dispatch<AuthReducerAction>,
-) => {
-  let retryCount = 0;
-  const intervalId = setInterval(async () => {
-    const idToken = await user?.getIdTokenResult(true);
-    const customerNumber = idToken?.claims['customer_number'];
-    if (customerNumber) {
-      dispatch({
-        type: 'SET_ACCOUNT_CREATION_FINISHED',
-        customerNumber,
-      });
-      clearInterval(intervalId);
-    } else if (retryCount >= 10) {
-      dispatch({type: 'SET_AUTH_ERROR'});
-      clearInterval(intervalId);
-    } else {
-      retryCount += 1;
-    }
-  }, 1000);
-  return intervalId;
-};
-
 export const isAuthError = (
   error: any,
 ): error is FirebaseAuthTypes.NativeFirebaseAuthError => 'code' in error;

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -25,11 +25,9 @@ export type AuthReducerAction =
       authStatus: AuthStatus;
     }
   | {
-      type: 'SET_ACCOUNT_CREATION_FINISHED';
-      customerNumber: number;
-    }
-  | {
-      type: 'SET_AUTH_ERROR';
+      type: 'SET_AUTH_STATUS';
+      authStatus: AuthStatus;
+      customerNumber?: number;
     };
 
 export type ConfirmationErrorCode =

--- a/src/auth/use-check-if-account-creation-finished.ts
+++ b/src/auth/use-check-if-account-creation-finished.ts
@@ -1,8 +1,11 @@
 import {Dispatch, useEffect} from 'react';
-import {startAccountCreationFinishedCheck} from './auth-utils';
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {AuthReducerAction, AuthStatus} from './types';
 
+/*
+ * Check whether the user creation is finished up to 10 times with an interval
+ * of 1 second.
+ */
 export const useCheckIfAccountCreationFinished = (
   user: FirebaseAuthTypes.User | null,
   authStatus: AuthStatus,
@@ -10,8 +13,25 @@ export const useCheckIfAccountCreationFinished = (
 ) => {
   useEffect(() => {
     if (user && authStatus === 'creating-account') {
-      const id = startAccountCreationFinishedCheck(user, dispatch);
-      return () => clearInterval(id);
+      let retryCount = 0;
+      const intervalId = setInterval(async () => {
+        const idToken = await user?.getIdTokenResult(true);
+        const customerNumber = idToken?.claims['customer_number'];
+        if (customerNumber) {
+          dispatch({
+            type: 'SET_AUTH_STATUS',
+            authStatus: 'authenticated',
+            customerNumber,
+          });
+          clearInterval(intervalId);
+        } else if (retryCount >= 10) {
+          dispatch({type: 'SET_AUTH_STATUS', authStatus: 'error'});
+          clearInterval(intervalId);
+        } else {
+          retryCount += 1;
+        }
+      }, 1000);
+      return () => clearInterval(intervalId);
     }
   }, [user?.uid, authStatus]);
 };


### PR DESCRIPTION
I found it was better to change the auth status to retry the
account creation check. By doing it this way the clients doesn't
need to handle clearing timeouts and such.
