### PR TITLE
fix: rewrites use-interval to use setTimout

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@react-native/metro-config": "^0.72.11",
     "@svgr/cli": "^6.3.1",
     "@tanstack/eslint-plugin-query": "^4.32.5",
+    "@testing-library/react-hooks": "^8.0.1",
     "@tsconfig/react-native": "^3.0.2",
     "@types/child-process-promise": "^2.2.2",
     "@types/geojson": "^7946.0.10",

--- a/src/utils/__tests__/use-interval.test.ts
+++ b/src/utils/__tests__/use-interval.test.ts
@@ -65,6 +65,44 @@ describe('useInterval', () => {
     await runPendingTimers();
     expect(callback).toBeCalledTimes(2);
   });
+
+  it('should be able to disable useInterval', async () => {
+    const hook = renderHook(
+      ({disabled}) => useInterval(callback, 200, [], disabled),
+      {
+        initialProps: {
+          disabled: false,
+        },
+      },
+    );
+
+    // Start with it enabled, should call callback
+    await nextTimerTick();
+    expect(callback).toBeCalledTimes(1);
+
+    hook.rerender({disabled: true});
+
+    // Should not call callback any time as it is disabled
+    // even over multiple timer ticks
+    await nextTimerTick();
+    expect(callback).toBeCalledTimes(1);
+
+    await nextTimerTick();
+    expect(callback).toBeCalledTimes(1);
+
+    await nextTimerTick();
+    expect(callback).toBeCalledTimes(1);
+
+    // Re-enable interval,
+    hook.rerender({disabled: false});
+
+    // Callback called on each timer tick.
+    await nextTimerTick();
+    expect(callback).toBeCalledTimes(2);
+
+    await nextTimerTick();
+    expect(callback).toBeCalledTimes(3);
+  });
 });
 
 async function advanceByTimer(time: number) {

--- a/src/utils/__tests__/use-interval.test.ts
+++ b/src/utils/__tests__/use-interval.test.ts
@@ -19,18 +19,23 @@ describe('useInterval', () => {
   });
 
   it('should invoke with specified delay', () => {
-    const {result} = renderHook(() => useInterval(callback, 300));
+    const delay = 300;
+    const {result} = renderHook(() => useInterval(callback, delay));
+    expect(callback).toHaveBeenCalledTimes(0);
 
+    jest.advanceTimersByTime(delay);
     expect(result.current).toBeUndefined();
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it.only('should invoke with specified delay and immediate if set', () => {
+  it('should invoke with specified delay and immediate if set', () => {
+    const delay = 300;
     const {result} = renderHook(
       // () => useInterval(callback, 300),
-      () => useInterval(callback, 300, [], false, true),
+      () => useInterval(callback, delay, [], false, true),
     );
-    jest.runOnlyPendingTimers();
+
+    jest.advanceTimersByTime(delay);
 
     expect(result.current).toBeUndefined();
     expect(callback).toHaveBeenCalledTimes(2);

--- a/src/utils/__tests__/use-interval.test.ts
+++ b/src/utils/__tests__/use-interval.test.ts
@@ -1,0 +1,47 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {useInterval} from '../use-interval';
+
+describe('useInterval', () => {
+  let callback = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+  });
+
+  afterEach(() => {
+    callback.mockRestore();
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should invoke with specified delay', () => {
+    const {result} = renderHook(() => useInterval(callback, 300));
+
+    expect(result.current).toBeUndefined();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it.only('should invoke with specified delay and immediate if set', () => {
+    const {result} = renderHook(
+      // () => useInterval(callback, 300),
+      () => useInterval(callback, 300, [], false, true),
+    );
+    jest.runOnlyPendingTimers();
+
+    expect(result.current).toBeUndefined();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not have less than 100ms delay', () => {
+    const {result} = renderHook(() => useInterval(callback, 0));
+    jest.advanceTimersByTime(100);
+
+    expect(result.current).toBeUndefined();
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100);
+  });
+});

--- a/src/utils/__tests__/use-interval.test.ts
+++ b/src/utils/__tests__/use-interval.test.ts
@@ -18,35 +18,79 @@ describe('useInterval', () => {
     jest.useRealTimers();
   });
 
-  it('should invoke with specified delay', () => {
+  it('should invoke with specified delay', async () => {
     const delay = 300;
-    const {result} = renderHook(() => useInterval(callback, delay));
+    renderHook(() => useInterval(callback, delay));
     expect(callback).toHaveBeenCalledTimes(0);
 
-    jest.advanceTimersByTime(delay);
-    expect(result.current).toBeUndefined();
+    await advanceByTimer(delay);
+
     expect(callback).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), delay);
   });
 
-  it('should invoke with specified delay and immediate if set', () => {
+  it('should invoke with specified delay and immediate if set', async () => {
     const delay = 300;
-    const {result} = renderHook(
-      // () => useInterval(callback, 300),
-      () => useInterval(callback, delay, [], false, true),
-    );
+    renderHook(() => useInterval(callback, delay, [], false, true));
+    expect(callback).toHaveBeenCalledTimes(1);
 
-    jest.advanceTimersByTime(delay);
+    // This is needed to make timers move passed by promises.
+    await resolvePromiseEnforceStep();
 
-    expect(result.current).toBeUndefined();
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), delay);
+
+    await runPendingTimers();
     expect(callback).toHaveBeenCalledTimes(2);
   });
 
-  it('should not have less than 100ms delay', () => {
-    const {result} = renderHook(() => useInterval(callback, 0));
-    jest.advanceTimersByTime(100);
+  it('should not have less than 100ms delay', async () => {
+    const minimumDelay = 100;
+    renderHook(() => useInterval(callback, 0));
 
-    expect(result.current).toBeUndefined();
     expect(setTimeout).toHaveBeenCalledTimes(1);
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100);
+    expect(setTimeout).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      minimumDelay,
+    );
+    await nextTimerTick();
+
+    expect(callback).toBeCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledTimes(2);
+    expect(setTimeout).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      minimumDelay,
+    );
+
+    await runPendingTimers();
+    expect(callback).toBeCalledTimes(2);
   });
 });
+
+async function advanceByTimer(time: number) {
+  jest.advanceTimersByTime(time);
+  // This is a workaround for fake timers in jest to support async code
+  // as useInterval supports promises.
+  // See https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function
+  await resolvePromiseEnforceStep();
+}
+
+async function nextTimerTick() {
+  jest.advanceTimersToNextTimer();
+  // This is a workaround for fake timers in jest to support async code
+  // as useInterval supports promises.
+  // See https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function
+  await resolvePromiseEnforceStep();
+}
+
+async function runPendingTimers() {
+  jest.runOnlyPendingTimers();
+  // This is a workaround for fake timers in jest to support async code
+  // as useInterval supports promises.
+  // See https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function
+  await resolvePromiseEnforceStep();
+}
+
+async function resolvePromiseEnforceStep() {
+  await Promise.resolve();
+}

--- a/src/utils/use-interval.ts
+++ b/src/utils/use-interval.ts
@@ -27,7 +27,7 @@ export function useInterval(
         await savedCallback.current();
 
         if (!disabled) {
-          tick();
+          id = tick();
         }
       }, actualDelay);
     }

--- a/src/utils/use-interval.ts
+++ b/src/utils/use-interval.ts
@@ -1,6 +1,13 @@
 import {useRef, useEffect} from 'react';
 
 type IntervalCallback = () => Promise<void> | void;
+/***
+ * Periodically execute a callback every N milliseconds.
+ * Does not guarantee precision in interval if execution time of the callback is higher than delay.
+ * Should not be used for animations or timers where precision is needed.
+ *
+ * If callback returns a promise execution for each interval awaits fulfilled promise.
+ */
 export function useInterval(
   callback: IntervalCallback,
   delay: number,
@@ -23,6 +30,10 @@ export function useInterval(
     let id: NodeJS.Timeout | number = 0;
 
     function tick() {
+      // Uses recursive setTimout loop instead of setInterval to prevent filling the message queue with
+      // executions when execution of callback takes longer than the interval specified.
+      // This means that we won't guarantee any specific execution time, but this is in liue with the intention of this function in any case.
+      // See example https://developer.mozilla.org/en-US/docs/Web/API/setInterval#ensure_that_execution_duration_is_shorter_than_interval_frequency
       return setTimeout(async function innerCallback() {
         await savedCallback.current();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.11.tgz#7a9ba3bbe406ad6f9e8dd4da2ece453eb23a77a4"
+  integrity sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.22.10":
   version "7.22.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
@@ -4121,6 +4128,14 @@
   dependencies:
     "@tanstack/query-core" "4.32.0"
     use-sync-external-store "^1.2.0"
+
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
 
 "@trysound/sax@0.2.0":
   version "0.2.0"
@@ -11099,6 +11114,13 @@ react-devtools-core@^4.27.2:
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-freeze@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
This removes useInterval to remove cases
where useInterval is called infinitely. Rewriting
to setTimeout will only call recursively and not
fill the message queue with as many awaiting
invocations in some cases.

Still not a perfect solution, but will be an improvement.

---


I have tested some locally and started writing some tests for this, but having some issues with fake timers and invocations. We should experiment with the implementations. But feeling the lack of good unit tests in cases like this. I haven't checked out if Detox tests are fixed.

This might also just be reference implementation to show a more elaborate example from what we discussed on Slack @gorandalum and @marius-at-atb .


Trying to debug some I added some logging. There are A LOT of time loops running in the app 😅. Many of the cases is either `useNow` or `setNow()` inside `useInterval`. All these should be replaced with a global clock timer I think.