### PR TITLE
fix: update gemfile comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
+# # install correct ruby version with rbenv, which can be installed with brew install rbenv
 ruby '2.7.6'
 
 gem "fastlane"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# # install correct ruby version with rbenv, which can be installed with brew install rbenv
+# install correct ruby version with rbenv, which can be installed with brew install rbenv
 ruby '2.7.6'
 
 gem "fastlane"


### PR DESCRIPTION
The changed comment was outdated. https://rbenv.org is no longer live, and installing with rvm caused issues.