### PR TITLE
feat: Add one second loading after user change

### DIFF
--- a/src/debug/use-debug-override.ts
+++ b/src/debug/use-debug-override.ts
@@ -11,9 +11,7 @@ export type UseDebugOverride = [
 export const useDebugOverride = (
   key: StorageModelKeysEnum,
 ): UseDebugOverride => {
-  const [debugOverride, setDebugOverride] = useState<boolean | undefined>(
-    false,
-  );
+  const [debugOverride, setDebugOverride] = useState<boolean | undefined>();
   const [debugOverrideReady, setDebugOverrideReady] = useState(false);
 
   useEffect(() => {

--- a/src/loading-screen/LoadingScreenBoundary.tsx
+++ b/src/loading-screen/LoadingScreenBoundary.tsx
@@ -4,6 +4,7 @@ import {LoadingScreen} from './LoadingScreen';
 import {LoadingErrorScreen} from './LoadingErrorScreen';
 import {useAppState} from '@atb/AppContext';
 import {useLoadingScreenEnabled} from '@atb/loading-screen/use-loading-screen-enabled';
+import {useDelayGate} from '@atb/utils/use-delay-gate';
 
 export const LoadingScreenBoundary = ({
   children,
@@ -14,8 +15,12 @@ export const LoadingScreenBoundary = ({
   const {isLoading} = useAppState();
   const {authStatus} = useAuthState();
 
+  // Wait one second after user authenticated to let the app "settle".
+  const waitFinished = useDelayGate(1000, authStatus === 'authenticated');
+
   if (!loadingScreenEnabled) return children;
   if (isLoading) return <LoadingScreen />;
+  if (!waitFinished) return <LoadingScreen />;
 
   switch (authStatus) {
     case 'loading':

--- a/src/utils/__tests__/use-delay-gate.test.ts
+++ b/src/utils/__tests__/use-delay-gate.test.ts
@@ -1,0 +1,75 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import {useDelayGate} from '@atb/utils/use-delay-gate';
+
+describe('useDelayGate', () => {
+  beforeAll(() => jest.useFakeTimers());
+  beforeEach(() => jest.clearAllTimers());
+  afterAll(() => jest.useRealTimers());
+
+  it('Should give true after waiting the given delay', async () => {
+    const hook = renderHook(() => useDelayGate(200));
+
+    expect(hook.result.current).toBe(false);
+    act(() => jest.advanceTimersByTime(195));
+    expect(hook.result.current).toBe(false);
+    act(() => jest.advanceTimersByTime(10));
+    expect(hook.result.current).toBe(true);
+  });
+
+  it('Should give true after waiting the given delay, when explicitly enabled', () => {
+    const hook = renderHook(() => useDelayGate(200, true));
+
+    expect(hook.result.current).toBe(false);
+    act(() => jest.advanceTimersByTime(205));
+    expect(hook.result.current).toBe(true);
+  });
+
+  it('Should always give true if not enabled', () => {
+    const hook = renderHook(() => useDelayGate(200, false));
+
+    expect(hook.result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(205));
+    expect(hook.result.current).toBe(true);
+  });
+
+  it('Should immediately change to true when it goes from enabled to disabled', () => {
+    const hook = renderHook(({enabled}) => useDelayGate(200, enabled), {
+      initialProps: {enabled: true},
+    });
+
+    expect(hook.result.current).toBe(false);
+    hook.rerender({enabled: false});
+    expect(hook.result.current).toBe(true);
+  });
+
+  it('Should restart the wait when it goes from disabled to enabled', () => {
+    const hook = renderHook(({enabled}) => useDelayGate(200, enabled), {
+      initialProps: {enabled: false},
+    });
+
+    expect(hook.result.current).toBe(true);
+    hook.rerender({enabled: true});
+    expect(hook.result.current).toBe(false);
+    act(() => jest.advanceTimersByTime(205));
+    expect(hook.result.current).toBe(true);
+  });
+
+  it('Should not have a stale value when it changes from enabled -> disabled -> enabled', () => {
+    const hook = renderHook(({enabled}) => useDelayGate(200, enabled), {
+      initialProps: {enabled: true},
+    });
+
+    expect(hook.result.current).toBe(false);
+    act(() => jest.runOnlyPendingTimers());
+    expect(hook.result.current).toBe(true);
+
+    hook.rerender({enabled: false});
+    expect(hook.result.current).toBe(true);
+
+    const previousStatesCount = hook.result.all.length;
+    hook.rerender({enabled: true});
+    act(() => jest.runAllTimers());
+    const statesAfter = [...hook.result.all].slice(previousStatesCount);
+    expect(statesAfter).toEqual([false, true]);
+  });
+});

--- a/src/utils/use-delay-gate.ts
+++ b/src/utils/use-delay-gate.ts
@@ -1,12 +1,27 @@
 import {useState, useEffect} from 'react';
 
-/** Returns false at first, then true after a set time */
-export function useDelayGate(delayMs: number): boolean {
+/**
+ * Returns false at first, then true after a set time. If the hook is not
+ * enabled it will always return true. If the hook changes from disabled to
+ * enabled, the delay gate timer will restart.
+ */
+export function useDelayGate(
+  delayMs: number,
+  enabled: boolean = true,
+): boolean {
   const [gate, setGate] = useState(false);
+
   useEffect(() => {
-    setTimeout(() => {
-      setGate(true);
-    }, delayMs);
-  });
-  return gate;
+    setGate(false);
+    if (enabled) {
+      const id = setTimeout(() => {
+        setGate(true);
+      }, delayMs);
+      return () => {
+        clearInterval(id);
+      };
+    }
+  }, [enabled]);
+
+  return enabled ? gate : true;
 }


### PR DESCRIPTION
This is to let the app "settle" before rendering, by letting the
different user data be fully loaded before we start rendering the
app.
