### PR TITLE
fix: use giveFocus util for setting focus

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -1,12 +1,19 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {StyleSheet} from '@atb/theme';
 import {dictionary, useTranslation} from '@atb/translations';
-import React, {useState} from 'react';
-import {ActivityIndicator, Keyboard, View} from 'react-native';
+import React, {useEffect, useRef, useState} from 'react';
+import {
+  ActivityIndicator,
+  Keyboard,
+  TextInput as InternalTextInput,
+  View,
+} from 'react-native';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {TextInputSectionItem} from '@atb/components/sections';
 import {MessageBox} from '@atb/components/message-box';
 import {ScrollView} from 'react-native-gesture-handler';
+import {useIsFocused} from '@react-navigation/native';
+import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {useDebounce} from '@atb/utils/useDebounce';
 import {HarborResults} from '@atb/stacks-hierarchy/Root_PurchaseHarborSearchScreen/HarborResults';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
@@ -21,6 +28,7 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
     route.params;
 
   const {t} = useTranslation();
+  const inputRef = useRef<InternalTextInput>(null);
   const [text, setText] = useState('');
 
   const onSave = (selectedStopPlace: StopPlaceFragment) => {
@@ -40,6 +48,12 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
   };
 
   const styles = useStyles();
+  // capturing focus on mount and on press
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    isFocused && giveFocus(inputRef);
+  }, [isFocused]);
 
   const harborsQuery = useHarbors(fromHarbor?.id);
 
@@ -60,6 +74,7 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
       <View style={styles.header}>
         <View style={styles.withMargin}>
           <TextInputSectionItem
+            ref={inputRef}
             radius="top-bottom"
             label={
               fromHarbor

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -60,7 +60,6 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
       <View style={styles.header}>
         <View style={styles.withMargin}>
           <TextInputSectionItem
-            //ref={inputRef}
             radius="top-bottom"
             label={
               fromHarbor

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -1,18 +1,12 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {StyleSheet} from '@atb/theme';
 import {dictionary, useTranslation} from '@atb/translations';
-import React, {useEffect, useRef, useState} from 'react';
-import {
-  ActivityIndicator,
-  Keyboard,
-  TextInput as InternalTextInput,
-  View,
-} from 'react-native';
+import React, {useState} from 'react';
+import {ActivityIndicator, Keyboard, View} from 'react-native';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {TextInputSectionItem} from '@atb/components/sections';
 import {MessageBox} from '@atb/components/message-box';
 import {ScrollView} from 'react-native-gesture-handler';
-import {useIsFocused} from '@react-navigation/native';
 import {useDebounce} from '@atb/utils/useDebounce';
 import {HarborResults} from '@atb/stacks-hierarchy/Root_PurchaseHarborSearchScreen/HarborResults';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
@@ -27,7 +21,6 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
     route.params;
 
   const {t} = useTranslation();
-  const inputRef = useRef<InternalTextInput>(null);
   const [text, setText] = useState('');
 
   const onSave = (selectedStopPlace: StopPlaceFragment) => {
@@ -47,12 +40,6 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
   };
 
   const styles = useStyles();
-  // capturing focus on mount and on press
-  const isFocused = useIsFocused();
-
-  useEffect(() => {
-    if (isFocused) setTimeout(() => inputRef.current?.focus(), 0);
-  }, [isFocused]);
 
   const harborsQuery = useHarbors(fromHarbor?.id);
 
@@ -73,7 +60,7 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
       <View style={styles.header}>
         <View style={styles.withMargin}>
           <TextInputSectionItem
-            ref={inputRef}
+            //ref={inputRef}
             radius="top-bottom"
             label={
               fromHarbor


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/7367

When going back from PurchaseHarborSearchScreen, the isFocused + setTimeout focus logic interrupted giveFocus in Root_PurchaseOverviewScreen. See https://github.com/AtB-AS/kundevendt/issues/7367#issuecomment-1700464339

Fixed with giveFocus util instead of setTimeout solution