### PR TITLE
feat: add support for custom fareproductgroup heading

### DIFF
--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -115,7 +115,12 @@ export const TransportModes = ({
         type={textType ?? 'label__uppercase'}
         color={textColor ?? 'secondary'}
         accessibilityLabel={t(
-          FareContractTexts.transportModes.a11yLabel(transportModeText),
+          customTransportModeText
+            ? FareContractTexts.transportModes.a11yLabelWithCustomText(
+                transportModeText,
+                customTransportModeText,
+              )
+            : FareContractTexts.transportModes.a11yLabel(transportModeText),
         )}
       >
         {customTransportModeText ? customTransportModeText : transportModeText}

--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -64,6 +64,7 @@ export const TransportModes = ({
   textType,
   textColor,
   style,
+  customTransportModeText,
 }: {
   modes: TransportModePair[];
   iconSize?: keyof Theme['icon']['size'];
@@ -71,6 +72,7 @@ export const TransportModes = ({
   textType?: TextNames;
   textColor?: TextColor;
   style?: ViewStyle;
+  customTransportModeText?: string;
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
@@ -116,7 +118,7 @@ export const TransportModes = ({
           FareContractTexts.transportModes.a11yLabel(transportModeText),
         )}
       >
-        {transportModeText}
+        {customTransportModeText ? customTransportModeText : transportModeText}
       </ThemeText>
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
@@ -8,7 +8,6 @@ import {FareProductTile} from './FareProductTile';
 import React from 'react';
 import {StyleSheet} from '@atb/theme';
 import {TransportModes} from '@atb/components/transportation-modes';
-import {ThemeText} from '@atb/components/text';
 
 type Props = {
   heading?: string | undefined;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
@@ -40,11 +40,14 @@ export const FareProductGroup = ({
   return (
     <View>
       {heading ? (
-        <ThemeText style={styles.heading}>{heading}</ThemeText>
-      ) : transportModes.length === 0 ? (
-        <ThemeText style={styles.heading}>
-          {t(FareContractTexts.otherFareContracts)}
-        </ThemeText>
+        <TransportModes
+          modes={transportModes}
+          iconSize={'small'}
+          style={styles.heading}
+          textType={'body__secondary'}
+          textColor={'primary'}
+          customTransportModeText={heading}
+        />
       ) : (
         <TransportModes
           modes={transportModes}
@@ -52,6 +55,11 @@ export const FareProductGroup = ({
           style={styles.heading}
           textType={'body__secondary'}
           textColor={'primary'}
+          customTransportModeText={
+            transportModes.length === 0
+              ? t(FareContractTexts.otherFareContracts)
+              : undefined
+          }
         />
       )}
       {groupedConfigs.map(([firstConfig, secondConfig], i) => (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
@@ -4,13 +4,21 @@ import {isProductSellableInApp} from '@atb/reference-data/utils';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {useTicketingState} from '@atb/ticketing';
 import {FareProductGroup} from './FareProductGroup';
-import {ProductTypeTransportModes} from '@atb-as/config-specs';
+import {
+  LanguageAndTextType,
+  ProductTypeTransportModes,
+} from '@atb-as/config-specs';
 import {flatMap} from '@atb/utils/array';
-import {TicketingTexts, useTranslation} from '@atb/translations';
+import {
+  TicketingTexts,
+  getTextForLanguage,
+  useTranslation,
+} from '@atb/translations';
 
 type GroupedFareProducts = {
   transportModes: ProductTypeTransportModes[];
   fareProducts: FareProductTypeConfig[];
+  heading?: LanguageAndTextType[];
 };
 
 export const FareProducts = ({
@@ -18,7 +26,7 @@ export const FareProducts = ({
 }: {
   onProductSelect: (config: FareProductTypeConfig) => void;
 }) => {
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const {preassignedFareProducts, fareProductTypeConfigs, fareProductGroups} =
     useFirestoreConfiguration();
   const {customerProfile} = useTicketingState();
@@ -38,6 +46,7 @@ export const FareProducts = ({
         sellableFareProductTypeConfigs.filter((fareProduct) =>
           group.types.includes(fareProduct.type),
         ) ?? [],
+      heading: group.heading,
     }),
   );
 
@@ -60,7 +69,9 @@ export const FareProducts = ({
       {groupedFareProducts.map((group) => (
         <FareProductGroup
           heading={
-            groupedFareProducts.length === 1
+            group.heading
+              ? getTextForLanguage(group.heading, language)
+              : groupedFareProducts.length === 1
               ? t(TicketingTexts.availableFareProducts.allTickets)
               : undefined
           }

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -251,6 +251,12 @@ const FareContractTexts = {
         `Ticket is valid on ${transportModes}`,
         `Billetten gjeld ${transportModes}`,
       ),
+    a11yLabelWithCustomText: (transportModes: string, customText: string) =>
+      _(
+        `Billetten gjelder ${transportModes}, produktgruppen heter ${customText}`,
+        `Ticket is valid on ${transportModes}, product group is called ${customText}`,
+        `Billetten gjeld ${transportModes}, produktgruppa heiter ${customText}`,
+      ),
     a11yLabelMultipleTravelModes: (count: number) =>
       _(
         `Totalt ${count} reisemåter`,


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/8114

Also fixing that "Other tickets" title had different font size than the transportmode texts, due to being regular ThemeText. 

Please let me know if this is intentional, they seem to have been designed with same size according to [Figma sketches](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=17165-67089&mode=design&t=Z25Fo7tOiaaAc7DH-0).

<details>
<summary>Screenshots - current title difference</summary>

Notice larger font size of "Andre billetter" title in first image

![IMG_8099](https://github.com/AtB-AS/mittatb-app/assets/21310942/a76ca98b-b555-48d7-b5fa-c7eaa2ddb725)

![IMG_8100](https://github.com/AtB-AS/mittatb-app/assets/21310942/0fea76e7-88f8-4cdb-b24a-e5c19da2669b)

</details>


<details>
<summary>Screenshots - new behaviour</summary>

![IMG_8098](https://github.com/AtB-AS/mittatb-app/assets/21310942/c3df9d12-537b-4d11-a2bb-535fc2eb9063)

![IMG_8097](https://github.com/AtB-AS/mittatb-app/assets/21310942/f1625b18-09e1-4e9a-bb42-828217eec5b6)

![IMG_8094](https://github.com/AtB-AS/mittatb-app/assets/21310942/eea413cf-0991-4cc5-8684-4c57c6c8102c)

![IMG_8093](https://github.com/AtB-AS/mittatb-app/assets/21310942/cc92c28d-61f3-47aa-99cf-be07aafa3f44)

</details>