### PR TITLE
fix: Onboarding triggered at startup

### DIFF
--- a/src/stacks-hierarchy/Root_MobileTokenOnboarding/utils.ts
+++ b/src/stacks-hierarchy/Root_MobileTokenOnboarding/utils.ts
@@ -6,6 +6,7 @@ import {useIsFocused, useNavigation} from '@react-navigation/native';
 import {useEffect} from 'react';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {InteractionManager} from 'react-native';
 
 export const useGoToMobileTokenOnboardingWhenNecessary = () => {
   const hasEnabledMobileToken = useHasEnabledMobileToken();
@@ -26,7 +27,9 @@ export const useGoToMobileTokenOnboardingWhenNecessary = () => {
   const isFocused = useIsFocused();
   useEffect(() => {
     if (shouldOnboard && isFocused) {
-      navigation.navigate('Root_MobileTokenOnboardingStack');
+      InteractionManager.runAfterInteractions(() =>
+        navigation.navigate('Root_MobileTokenOnboardingStack'),
+      );
     }
   }, [shouldOnboard, isFocused]);
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -31,6 +31,7 @@ import {TabNav_ProfileStack} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/
 import {dictionary, useTranslation} from '@atb/translations';
 import {useAppState} from '@atb/AppContext';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
+import {InteractionManager} from 'react-native';
 
 const Tab = createBottomTabNavigator<TabNavigatorStackParams>();
 
@@ -47,7 +48,11 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
   useGoToMobileTokenOnboardingWhenNecessary();
 
   useEffect(() => {
-    if (!onboarded) navigation.navigate('Root_OnboardingStack');
+    if (!onboarded) {
+      InteractionManager.runAfterInteractions(() =>
+        navigation.navigate('Root_OnboardingStack'),
+      );
+    }
   }, [onboarded]);
 
   return (


### PR DESCRIPTION
For some reason triggering the onboarding didn't work after adding
the loading screen. It seems to be a race condition of some sort,
and wrapping it in the IntercationManager.runAfterInteractions
seems to work.
