### PR TITLE
fix: Onboarding triggered multiple times

### DIFF
--- a/src/stacks-hierarchy/Root_OnboardingStack/use-finish-onboarding.ts
+++ b/src/stacks-hierarchy/Root_OnboardingStack/use-finish-onboarding.ts
@@ -1,19 +1,13 @@
 import {useAppState} from '@atb/AppContext';
 import {useGeolocationState} from '@atb/GeolocationContext';
-import {useEffect, useState} from 'react';
+import {useCallback} from 'react';
 
 export const useFinishOnboarding = () => {
   const {completeOnboarding} = useAppState();
   const {status, requestPermission} = useGeolocationState();
-  const [requestedOnce, setRequestedOnce] = useState(false);
-  useEffect(() => {
-    if (requestedOnce && status) {
-      completeOnboarding();
-    }
-  }, [status, requestedOnce]);
 
-  return async () => {
+  return useCallback(async () => {
+    completeOnboarding();
     if (status !== 'granted') await requestPermission();
-    setRequestedOnce(true);
-  };
+  }, [completeOnboarding, requestPermission]);
 };


### PR DESCRIPTION
### Background
Tor Kjetil found a bug where the onboarding was triggered at app startup even though the user had finished the onboarding.

The reason was that the storage of the "has_onboarded" flag did not always happen, as
the `useFinishOnboarding` hook had unmounted. This was now changed
to a more simple logic:
- Set onboarded to true
- Then fire the request for geolocation
