### PR TITLE
feat: add latest activation date option to datepicker

### DIFF
--- a/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
+++ b/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
@@ -9,7 +9,7 @@ import {DateInputSectionItemProps} from './utils';
 import {useLocaleContext} from '@atb/LocaleProvider';
 
 export function DateInputSectionItem(props: DateInputSectionItemProps) {
-  const {value, onChange, ...innerprops} = props;
+  const {value, onChange, maximumDate, ...innerprops} = props;
   const {t} = useTranslation();
   const locale = useLocaleContext();
   const {theme} = useTheme();
@@ -39,6 +39,7 @@ export function DateInputSectionItem(props: DateInputSectionItemProps) {
         display="compact"
         testID="dateInput"
         minimumDate={new Date()}
+        maximumDate={maximumDate}
         onChange={(_, date) => {
           if (date) onChange(date.toISOString());
         }}

--- a/src/components/sections/items/date-input/utils.ts
+++ b/src/components/sections/items/date-input/utils.ts
@@ -3,4 +3,5 @@ import {SectionItemProps} from '../../types';
 export type DateInputSectionItemProps = SectionItemProps<{
   value: string;
   onChange(time: string): void;
+  maximumDate?: Date;
 }>;

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -19,6 +19,7 @@ export type PreassignedFareProduct = {
     userProfileRefs: string[];
     appVersionMin: string | undefined;
     appVersionMax: string | undefined;
+    latestActivationDate?: string;
   };
 };
 

--- a/src/reference-data/types.ts
+++ b/src/reference-data/types.ts
@@ -19,7 +19,7 @@ export type PreassignedFareProduct = {
     userProfileRefs: string[];
     appVersionMin: string | undefined;
     appVersionMax: string | undefined;
-    latestActivationDate?: string;
+    latestActivationDate?: number;
   };
 };
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -86,9 +86,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const maximumDateObjectIfExisting = preassignedFareProduct.limitations
     ?.latestActivationDate
-    ? new Date(
-        Number(preassignedFareProduct.limitations.latestActivationDate) * 1000,
-      )
+    ? new Date(preassignedFareProduct.limitations.latestActivationDate * 1000)
     : undefined;
 
   const hasSelection =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -83,6 +83,14 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     travellerSelection,
     travelDate,
   );
+
+  const maximumDateObjectIfExisting = preassignedFareProduct.limitations
+    ?.latestActivationDate
+    ? new Date(
+        Number(preassignedFareProduct.limitations.latestActivationDate) * 1000,
+      )
+    : undefined;
+
   const hasSelection =
     travellerSelection.some((u) => u.count) &&
     userProfilesWithCountAndOffer.some((u) => u.count);
@@ -182,6 +190,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             travelDate={travelDate}
             setTravelDate={setTravelDate}
             validFromTime={travelDate}
+            maximumDate={maximumDateObjectIfExisting}
             style={styles.selectionComponent}
           />
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -25,6 +25,8 @@ import {useAnalytics} from '@atb/analytics';
 import {FromToSelection} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection';
 import {GlobalMessageContextEnum} from '@atb/global-messages';
 import {useFocusRefs} from '@atb/utils/use-focus-refs';
+import {isAfter} from '@atb/utils/date';
+import {formatISO} from 'date-fns';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -51,6 +53,10 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     navigation.setParams({
       preassignedFareProduct: fp,
     });
+    if (fp.limitations.latestActivationDate && travelDate) {
+      if (isAfter(travelDate, formatISO(fp.limitations.latestActivationDate)))
+        setTravelDate(undefined);
+    }
   };
   const [travellerSelection, setTravellerSelection] =
     useState(selectableTravellers);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -19,6 +19,7 @@ type StartTimeSelectionProps = {
   validFromTime?: string;
   travelDate?: string;
   selectionMode: TimeSelectionMode;
+  maximumDate?: Date;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -28,6 +29,7 @@ export function StartTimeSelection({
   validFromTime,
   travelDate,
   selectionMode,
+  maximumDate,
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
@@ -44,6 +46,7 @@ export function StartTimeSelection({
         close={closeBottomSheet}
         save={setTravelDate}
         travelDate={travelDate}
+        maximumDate={maximumDate}
         ref={onOpenFocusRef}
       />
     ));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -68,14 +68,17 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
           centerContent={true}
         >
           {maximumDate && (
-            <MessageBox
-              type="info"
-              message={t(
-                TravelDateTexts.latestActivationDate.warning(
-                  formatToVerboseFullDate(maximumDate, language),
-                ),
-              )}
-            />
+            <Section withBottomPadding>
+              <MessageBox
+                type="info"
+                subtle
+                message={t(
+                  TravelDateTexts.latestActivationDate.warning(
+                    formatToVerboseFullDate(maximumDate, language),
+                  ),
+                )}
+              />
+            </Section>
           )}
 
           <Section>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -12,7 +12,12 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {Button} from '@atb/components/button';
-import {dateWithReplacedTime, formatLocaleTime} from '@atb/utils/date';
+import {MessageBox} from '@atb/components/message-box';
+import {
+  dateWithReplacedTime,
+  formatLocaleTime,
+  formatToVerboseFullDate,
+} from '@atb/utils/date';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
 import {FullScreenFooter} from '@atb/components/screen-footer';
@@ -23,10 +28,11 @@ type Props = {
   travelDate?: string;
   close: () => void;
   save: (dateString?: string) => void;
+  maximumDate?: Date;
 };
 
 export const TravelDateSheet = forwardRef<ScrollView, Props>(
-  ({travelDate, close, save}, focusRef) => {
+  ({travelDate, close, save, maximumDate}, focusRef) => {
     const {t, language} = useTranslation();
     const styles = useStyles();
 
@@ -61,8 +67,23 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
           ref={focusRef}
           centerContent={true}
         >
+          {maximumDate && (
+            <MessageBox
+              type="info"
+              message={t(
+                TravelDateTexts.latestActivationDate.warning(
+                  formatToVerboseFullDate(maximumDate, language),
+                ),
+              )}
+            />
+          )}
+
           <Section>
-            <DateInputSectionItem value={dateString} onChange={setDate} />
+            <DateInputSectionItem
+              value={dateString}
+              onChange={setDate}
+              maximumDate={maximumDate}
+            />
             <TimeInputSectionItem value={timeString} onChange={setTime} />
           </Section>
         </ScrollView>

--- a/src/translations/screens/subscreens/TravelDate.ts
+++ b/src/translations/screens/subscreens/TravelDate.ts
@@ -13,5 +13,13 @@ const TravelDateTexts = {
     ),
   },
   primaryButton: _('Bekreft valg', 'Confirm selection', 'Bekreft val'),
+  latestActivationDate: {
+    warning: (latestActivationDate: string) =>
+      _(
+        `Billetten må aktiveres senest ${latestActivationDate}.`,
+        `This ticket must be activated by ${latestActivationDate}.`,
+        `Billetten må aktiverast seinast ${latestActivationDate}.`,
+      ),
+  },
 };
 export default TravelDateTexts;


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/8388

Adding option to provide limitation to a product in the referenceData, where `latestActivationDate` is provided as a string given by epoch time. Tested with FRAM Buss Vaksen, having latest day of activation 31st of October 23:59:59. 

Will be part of FRAM 1.41 on a separate release branch and AtB 1.42. (No plans to use for AtB AFAIK)