### PR TITLE
fix: Remove spinner stuck fix

### DIFF
--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -17,7 +17,6 @@ import {Platform, RefreshControl, View} from 'react-native';
 import {StopPlacesMode} from './types';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeaderProps} from '@atb/components/screen-header';
-import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 export type NearbyStopPlacesScreenParams = {
   location: Location | undefined;
@@ -150,17 +149,13 @@ export const NearbyStopPlacesScreenComponent = ({
     );
   }
 
-  const isFocused = useIsFocusedAndActive();
-
   return (
     <FullScreenView
       refreshControl={
-        isFocused ? (
-          <RefreshControl
-            refreshing={Platform.OS === 'ios' ? false : isLoading}
-            onRefresh={refresh}
-          />
-        ) : undefined
+        <RefreshControl
+          refreshing={Platform.OS === 'ios' ? false : isLoading}
+          onRefresh={refresh}
+        />
       }
       headerProps={headerProps}
       parallaxContent={() => (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -53,7 +53,6 @@ import {useAnalytics} from '@atb/analytics';
 import {useNonTransitTripsQuery} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query';
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
-import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 type RootProps = DashboardScreenProps<'Dashboard_TripSearchScreen'>;
 
@@ -72,7 +71,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const {language, t} = useTranslation();
   const [updatingLocation] = useState<boolean>(false);
   const analytics = useAnalytics();
-  const isFocused = useIsFocusedAndActive();
 
   const shouldShowTravelSearchFilterOnboarding =
     useShouldShowTravelSearchFilterOnboarding();
@@ -259,16 +257,14 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
           },
         }}
         refreshControl={
-          isFocused ? (
-            <RefreshControl
-              refreshing={
-                Platform.OS === 'ios'
-                  ? false
-                  : searchState === 'searching' && !tripPatterns.length
-              }
-              onRefresh={refresh}
-            />
-          ) : undefined
+          <RefreshControl
+            refreshing={
+              Platform.OS === 'ios'
+                ? false
+                : searchState === 'searching' && !tripPatterns.length
+            }
+            onRefresh={refresh}
+          />
         }
         parallaxContent={() => (
           <View style={style.searchHeader}>


### PR DESCRIPTION
Adding/removing RefreshControl based on focus gives odd behaviour
on Android where the scroll offset is lost after navigating.

The adding/removing of RefreshControl was added to fix a stuck
spinner on iOS issue, but this doesn't seem to still happen after
updating react-native versions. So the fix for now is to remove
the stuck spinner fix.

The original fix was implemented here:
https://github.com/AtB-AS/mittatb-app/pull/3762

Based on the behaviour in this comment:
https://mittatb.slack.com/archives/C0116FMPX4Y/p1691563608147469