### PR TITLE
fix: Readd stuck spinner on iOS fix

### DIFF
--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -17,6 +17,7 @@ import {Platform, RefreshControl, View} from 'react-native';
 import {StopPlacesMode} from './types';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeaderProps} from '@atb/components/screen-header';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 export type NearbyStopPlacesScreenParams = {
   location: Location | undefined;
@@ -149,13 +150,18 @@ export const NearbyStopPlacesScreenComponent = ({
     );
   }
 
+  const isFocused = useIsFocusedAndActive();
+
   return (
     <FullScreenView
       refreshControl={
-        <RefreshControl
-          refreshing={Platform.OS === 'ios' ? false : isLoading}
-          onRefresh={refresh}
-        />
+        // Quick fix for iOS to fix stuck spinner by removing the RefreshControl when not focused
+        isFocused || Platform.OS === 'android' ? (
+          <RefreshControl
+            refreshing={Platform.OS === 'ios' ? false : isLoading}
+            onRefresh={refresh}
+          />
+        ) : undefined
       }
       headerProps={headerProps}
       parallaxContent={() => (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -53,6 +53,7 @@ import {useAnalytics} from '@atb/analytics';
 import {useNonTransitTripsQuery} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query';
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 type RootProps = DashboardScreenProps<'Dashboard_TripSearchScreen'>;
 
@@ -71,6 +72,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const {language, t} = useTranslation();
   const [updatingLocation] = useState<boolean>(false);
   const analytics = useAnalytics();
+  const isFocused = useIsFocusedAndActive();
 
   const shouldShowTravelSearchFilterOnboarding =
     useShouldShowTravelSearchFilterOnboarding();
@@ -257,14 +259,17 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
           },
         }}
         refreshControl={
-          <RefreshControl
-            refreshing={
-              Platform.OS === 'ios'
-                ? false
-                : searchState === 'searching' && !tripPatterns.length
-            }
-            onRefresh={refresh}
-          />
+          // Quick fix for iOS to fix stuck spinner by removing the RefreshControl when not focused
+          isFocused || Platform.OS === 'android' ? (
+            <RefreshControl
+              refreshing={
+                Platform.OS === 'ios'
+                  ? false
+                  : searchState === 'searching' && !tripPatterns.length
+              }
+              onRefresh={refresh}
+            />
+          ) : undefined
         }
         parallaxContent={() => (
           <View style={style.searchHeader}>


### PR DESCRIPTION
[Removing it](https://github.com/AtB-AS/mittatb-app/pull/3855) did actually reintroduce the stuck spinner on iOS bug.
Now just reenabling the previously removed hack, but now just for
iOS.
