### PR TITLE
fix: Stop tracking bus when selecting user position 

### DIFF
--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -215,11 +215,11 @@ export const TravelDetailsMapScreenComponent = ({
       <View style={controlStyles.controlsContainer}>
         <PositionArrow
           onPress={() => {
+            setShouldTrack(false);
             flyToLocation({
               coordinates: geolocation?.coordinates,
               mapCameraRef,
             });
-            setShouldTrack(false);
           }}
         />
       </View>

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -219,6 +219,7 @@ export const TravelDetailsMapScreenComponent = ({
               coordinates: geolocation?.coordinates,
               mapCameraRef,
             });
+            setShouldTrack(false);
           }}
         />
       </View>


### PR DESCRIPTION
> If the bus is in focus, and you press the 'My Location' button on the map, the focus shifts slightly to your position before returning to the bus again. This is related to the 'Touch event.'
>If you have shifted the focus away from the bus on the map and then choose to click on 'My Location,' this issue does not occur.

Fixed by removing tracking when pressing position arrow