### PR TITLE
chore: remove old slider in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,11 +3752,6 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/slider@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.4.2.tgz#1fea0eb3ae31841fe87bd6c4fc67569066e9cf4b"
-  integrity sha512-D9bv+3Vd2gairAhnRPAghwccgEmoM7g562pm8i4qB3Esrms5mggF81G3UvCyc0w3jjtFHh8dpQkfEoKiP0NW/Q==
-
 "@react-native-firebase/analytics@^16.5.0":
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/@react-native-firebase/analytics/-/analytics-16.5.0.tgz#4fff5f9aa0366252d4e4d6705a1a9dc989fd5aa4"


### PR DESCRIPTION
In [this merge](https://github.com/AtB-AS/mittatb-app/pull/3842) the yarn lock was missing this change. The old slider was removed in the package.json, but not in the yarn.lock