### PR TITLE
fix: Support scooter standing

### DIFF
--- a/src/mobility/utils.ts
+++ b/src/mobility/utils.ts
@@ -29,7 +29,8 @@ import {
 export const isScooter = (
   feature: Feature<Point> | undefined,
 ): feature is Feature<Point, VehicleBasicFragment> =>
-  feature?.properties?.vehicleType?.formFactor === FormFactor.Scooter;
+  feature?.properties?.vehicleType?.formFactor === FormFactor.Scooter ||
+  feature?.properties?.vehicleType?.formFactor === FormFactor.ScooterStanding;
 
 export const isBicycle = (
   feature: Feature<Point> | undefined,


### PR DESCRIPTION
Ryde has changed form factor from SCOOTER to SCOOTER_STANDING. We need to treat both these form factors as scooters.

Closes https://github.com/AtB-AS/kundevendt/issues/8649