### PR TITLE
chore: ENTUR_REGISTRY_USER from org vars

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: bash ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - name: install node v18
         uses: actions/setup-node@v1

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: sh ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - name: Setup build dependencies, environment and assets
         uses: ./.github/actions/ios-build-setup

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: bash ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - name: install node v18
         uses: actions/setup-node@v1

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: sh ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - name: Setup build dependencies, environment and assets
         uses: ./.github/actions/ios-build-setup

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: sh ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test-e2e-ios.yml
+++ b/.github/workflows/test-e2e-ios.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: sh ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - name: Pre-boot simulator
         run: sh e2e/boot.sh

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Add Entur private registry credentials
         run: sh ./scripts/add-entur-private-registry.sh
         env:
-          ENTUR_REGISTRY_USER: ${{ secrets.ENTUR_REGISTRY_USER }}
+          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Entur registry token expires after a year. To give less work when they
expire we have moved the ENTUR_REGISTRY_USER and
ENTUR_REGISTRY_TOKEN to the organizational level in GitHub. Also
the ENTUR_REGISTRY_USER is now a variable instead of secret, so it
can be read.