### PR TITLE
fix: various header fixes

### DIFF
--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -67,7 +67,7 @@ export const ScreenHeader: React.FC<ScreenHeaderProps> = (props) => {
   return <BaseHeader leftIcon={leftIcon} rightIcon={rightIcon} {...props} />;
 };
 
-type ScreenHeaderWithoutNavigationProps = ScreenHeaderProps & {
+type ScreenHeaderWithoutNavigationProps = Omit<ScreenHeaderProps, 'style'> & {
   leftButton?: HeaderButtonWithoutNavigationProps;
   rightButton?: HeaderButtonWithoutNavigationProps;
 };
@@ -80,6 +80,7 @@ type ScreenHeaderWithoutNavigationProps = ScreenHeaderProps & {
 export const ScreenHeaderWithoutNavigation = (
   props: ScreenHeaderWithoutNavigationProps,
 ) => {
+  const styles = useHeaderStyle();
   const themeColor = props.color ?? 'background_accent_0';
   const leftIcon = props.leftButton ? (
     <HeaderButtonWithoutNavigation color={themeColor} {...props.leftButton} />
@@ -92,7 +93,14 @@ export const ScreenHeaderWithoutNavigation = (
     <View />
   );
 
-  return <BaseHeader leftIcon={leftIcon} rightIcon={rightIcon} {...props} />;
+  return (
+    <BaseHeader
+      style={styles.bottomSheetHeaderContainer}
+      leftIcon={leftIcon}
+      rightIcon={rightIcon}
+      {...props}
+    />
+  );
 };
 
 type BaseHeaderProps = ScreenHeaderProps & {
@@ -157,7 +165,10 @@ const BaseHeader = ({
         style={[
           css.buttons,
           {
-            top: theme.spacings.large + buttonsTopOffset,
+            top:
+              (typeof style?.paddingTop?.valueOf() === 'number'
+                ? (style.paddingTop.valueOf() as number)
+                : theme.spacings.medium) + buttonsTopOffset,
             height: buttonsHeight,
           },
         ]}
@@ -177,8 +188,12 @@ const BaseHeader = ({
 const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
     paddingHorizontal: theme.spacings.medium,
+    paddingTop: theme.spacings.medium,
+  },
+  // TODO: Rename
+  bottomSheetHeaderContainer: {
     paddingTop: theme.spacings.large,
-    paddingBottom: theme.spacings.medium,
+    paddingBottom: theme.spacings.small,
     borderTopLeftRadius: theme.border.radius.circle,
     borderTopRightRadius: theme.border.radius.circle,
   },

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -165,6 +165,12 @@ const BaseHeader = ({
         style={[
           css.buttons,
           {
+            /**
+             * TODO: This is a hack to make sure the buttons are positioned
+             * correctly when padding is passed as a prop, specifically for the
+             * bottom sheet. Can be removed when the bottom sheet starts using
+             * its own header. (https://github.com/AtB-AS/kundevendt/issues/4211)
+             */
             top:
               (typeof style?.paddingTop?.valueOf() === 'number'
                 ? (style.paddingTop.valueOf() as number)

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -95,7 +95,7 @@ export const ScreenHeaderWithoutNavigation = (
 
   return (
     <BaseHeader
-      style={styles.bottomSheetHeaderContainer}
+      style={styles.withoutNavigationContainer}
       leftIcon={leftIcon}
       rightIcon={rightIcon}
       {...props}
@@ -196,8 +196,7 @@ const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacings.medium,
     paddingTop: theme.spacings.medium,
   },
-  // TODO: Rename
-  bottomSheetHeaderContainer: {
+  withoutNavigationContainer: {
     paddingTop: theme.spacings.large,
     paddingBottom: theme.spacings.small,
     borderTopLeftRadius: theme.border.radius.circle,

--- a/src/place-screen/PlaceScreenComponent.tsx
+++ b/src/place-screen/PlaceScreenComponent.tsx
@@ -123,6 +123,7 @@ export const PlaceScreenComponent = ({
           place={place}
           selectedQuay={selectedQuay}
           onPress={(quayId) => onPressQuay?.(place, quayId, true)}
+          style={styles.stopPlaceAndQuaySelection}
         />
       )}
 
@@ -184,6 +185,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginTop: theme.spacings.medium,
     marginBottom: theme.spacings.medium,
     paddingHorizontal: theme.spacings.medium,
+  },
+  stopPlaceAndQuaySelection: {
+    paddingBottom: theme.spacings.medium,
   },
   quayData: {flex: 1},
   messageBox: {

--- a/src/place-screen/components/StopPlaceAndQuaySelection.tsx
+++ b/src/place-screen/components/StopPlaceAndQuaySelection.tsx
@@ -1,5 +1,5 @@
 import {FlatList} from 'react-native-gesture-handler';
-import {ActivityIndicator} from 'react-native';
+import {ActivityIndicator, ViewStyle} from 'react-native';
 import {Button} from '@atb/components/button';
 import DeparturesTexts from '@atb/translations/screens/Departures';
 import React from 'react';
@@ -15,10 +15,12 @@ const StopPlaceAndQuaySelection = ({
   place,
   selectedQuay,
   onPress,
+  style,
 }: {
   place: StopPlace;
   selectedQuay?: Quay;
   onPress: (selectedQuayId?: string) => void;
+  style?: ViewStyle;
 }) => {
   const styles = useStyles();
   const {theme} = useTheme();
@@ -29,7 +31,7 @@ const StopPlaceAndQuaySelection = ({
   return (
     <FlatList
       data={place.quays}
-      style={styles.quayChipContainer}
+      style={[styles.quayChipContainer, style]}
       horizontal={!isMissingQuays}
       showsHorizontalScrollIndicator={false}
       keyExtractor={(item) => item.id}
@@ -74,7 +76,6 @@ function getQuayName(quay: Quay): string {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   quayChipContainer: {
     backgroundColor: theme.static.background.background_accent_0.background,
-    paddingBottom: theme.spacings.medium,
     flexShrink: 0,
     flexGrow: 0,
   },

--- a/src/place-screen/components/StopPlaceAndQuaySelection.tsx
+++ b/src/place-screen/components/StopPlaceAndQuaySelection.tsx
@@ -74,7 +74,7 @@ function getQuayName(quay: Quay): string {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   quayChipContainer: {
     backgroundColor: theme.static.background.background_accent_0.background,
-    paddingVertical: theme.spacings.medium,
+    paddingBottom: theme.spacings.medium,
     flexShrink: 0,
     flexGrow: 0,
   },

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
@@ -62,7 +62,7 @@ export const Map_RootScreen = ({
 
   return (
     <>
-      <StatusBarOnFocus barStyle="dark-content" />
+      <StatusBarOnFocus barStyle="dark-content" backgroundColor="#00000000" />
       <Map
         selectionMode={'ExploreEntities'}
         vehicles={vehicles}


### PR DESCRIPTION
I've noticed there are several places where the header takes up more space than it should according to the sketches. Tried to clean up that here:

- Reduces header margin to 12px/medium instead of large, as that's what's used in [the sketches](https://www.figma.com/file/2QTjAdekdIPuLFovQhVrY3/Components?node-id=4383%3A8566&mode=dev) 
	- This also adds a bit of bottom sheet specific code to give it more padding, that will probably be replaced by https://github.com/AtB-AS/kundevendt/issues/4211
- Makes the status bar on android transparent, fixing some contrast issues, and utilizing more of the screen.
- Removes a bit of padding above the StopPlace/Quay selector on departures


### Less padding in screen header

<img width="400px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/399b60ca-0ea5-4435-ad96-7f074ff5d1bf">

### Bottom sheet stays the same, with more padding than the global screen header

<img width="400px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/28ab5db2-c0ba-4c6a-a314-b1b4e062faa6">

### Less padding between header and StopPlace/Quay selector on departures

<img width="400px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/04f6da84-2822-4795-9e2f-467671709407">

### Transparent header for the map on android

<img width="400px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/660ebf8e-0054-4e9d-8d9b-498eb94d2e9b">

