### PR TITLE
feat: add app-fare-contract-details global message context

### DIFF
--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -21,6 +21,13 @@ import {
   LinkSectionItem,
   Section,
 } from '@atb/components/sections';
+import {
+  GlobalMessage,
+  GlobalMessageContextEnum,
+  useGlobalMessagesState,
+} from '@atb/global-messages';
+import {View} from 'react-native';
+import {StyleSheet} from '@atb/theme';
 
 type Props = {
   fareContract: FareContract;
@@ -38,12 +45,14 @@ export const DetailsContent: React.FC<Props> = ({
   hasActiveTravelCard = false,
 }) => {
   const {t} = useTranslation();
+  const styles = useStyles();
   const hasEnabledMobileToken = useHasEnabledMobileToken();
   const {
     deviceIsInspectable,
     isError: mobileTokenError,
     fallbackEnabled,
   } = useMobileTokenContextState();
+  const {findGlobalMessages} = useGlobalMessagesState();
 
   const firstTravelRight = fc.travelRights[0];
 
@@ -60,6 +69,18 @@ export const DetailsContent: React.FC<Props> = ({
     );
 
     const validityStatus = getValidityStatus(now, validFrom, validTo, fc.state);
+
+    const globalMessageRuleVariables = {
+      fareProductType: preassignedFareProduct?.type ?? 'unknown',
+      firstTravelRightType: firstTravelRight.type,
+      validityStatus: validityStatus,
+      tariffZones: firstTravelRight.tariffZoneRefs ?? [],
+    };
+    const globalMessageCount = findGlobalMessages(
+      GlobalMessageContextEnum.appFareContractDetails,
+      globalMessageRuleVariables,
+    ).length;
+
     return (
       <Section withBottomPadding>
         <GenericSectionItem>
@@ -88,6 +109,20 @@ export const DetailsContent: React.FC<Props> = ({
             fareProductType={preassignedFareProduct?.type}
           />
         </GenericSectionItem>
+        {globalMessageCount > 0 && (
+          <GenericSectionItem>
+            <View style={styles.globalMessages}>
+              <GlobalMessage
+                globalMessageContext={
+                  GlobalMessageContextEnum.appFareContractDetails
+                }
+                textColor="background_0"
+                ruleVariables={globalMessageRuleVariables}
+                style={styles.globalMessages}
+              />
+            </View>
+          </GenericSectionItem>
+        )}
         <GenericSectionItem>
           <OrderDetails fareContract={fc} />
         </GenericSectionItem>
@@ -103,3 +138,10 @@ export const DetailsContent: React.FC<Props> = ({
     return <UnknownFareContractDetails fc={fc} />;
   }
 };
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  globalMessages: {
+    flex: 1,
+    rowGap: theme.spacings.medium,
+  },
+}));

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -10,6 +10,7 @@ export enum GlobalMessageContextEnum {
   appDepartures = 'app-departures',
   appTicketing = 'app-ticketing',
   appPurchaseOverview = 'app-purchase-overview',
+  appFareContractDetails = 'app-fare-contract-details',
   appDepartureDetails = 'app-departure-details',
   appTripDetails = 'app-trip-details',
   appServiceDisruptions = 'app-service-disruptions',

--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -1,4 +1,3 @@
-import {MessageBox} from '@atb/components/message-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {
@@ -6,16 +5,12 @@ import {
   isOfFareProductRef,
 } from '@atb/reference-data/utils';
 import {StyleSheet} from '@atb/theme';
-import {isPreActivatedTravelRight, useTicketingState} from '@atb/ticketing';
-import {
-  FareContractTexts,
-  TranslateFunction,
-  useTranslation,
-} from '@atb/translations';
+import {useTicketingState} from '@atb/ticketing';
+import {FareContractTexts, useTranslation} from '@atb/translations';
 import {useInterval} from '@atb/utils/use-interval';
 import React, {useState} from 'react';
 import {ScrollView, View} from 'react-native';
-import {DetailsContent, getValidityStatus} from '@atb/fare-contracts';
+import {DetailsContent} from '@atb/fare-contracts';
 import {RootStackScreenProps} from '../stacks-hierarchy/navigation-types';
 import {useApplePassPresentationSuppression} from '@atb/suppress-pass-presentation';
 
@@ -47,20 +42,6 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
       orderVersion: fc.version,
     });
 
-  const shouldShowValidOnTrainNotice: boolean =
-    fc !== undefined &&
-    isPreActivatedTravelRight(firstTravelRight) &&
-    getValidityStatus(
-      now,
-      firstTravelRight.startDateTime.toMillis(),
-      firstTravelRight.endDateTime.toMillis(),
-      fc.state,
-    ) === 'valid' &&
-    !!firstTravelRight.tariffZoneRefs?.length &&
-    firstTravelRight.tariffZoneRefs?.every(
-      (val: string) => val === 'ATB:TariffZone:1',
-    ) === true;
-
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -77,27 +58,9 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
             hasActiveTravelCard={hasActiveTravelCard}
           />
         )}
-
-        {shouldShowValidOnTrainNotice && (
-          <MessageBox
-            message={getValidOnTrainNoticeText(t, preassignedFareProduct?.type)}
-            type="info"
-          />
-        )}
       </ScrollView>
     </View>
   );
-}
-
-export function getValidOnTrainNoticeText(
-  t: TranslateFunction,
-  fareProductType?: string,
-) {
-  if (fareProductType === 'single')
-    return t(FareContractTexts.samarbeidsbillettenInfo.single);
-  if (fareProductType === 'hour24')
-    return t(FareContractTexts.samarbeidsbillettenInfo.hour24);
-  return t(FareContractTexts.samarbeidsbillettenInfo.period);
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -297,23 +297,6 @@ const FareContractTexts = {
     }
   },
   otherFareContracts: _('Andre billetter', 'Other tickets', 'Andre billettar'),
-  samarbeidsbillettenInfo: {
-    single: _(
-      'Enkeltbilletter i sone A kan også brukes på tog i sone A, men ikke på nattbuss.',
-      'Single tickets in zone A can also be used on train in zone A, but not on night buses.',
-      'Enkeltbillettar i sone A kan også brukast på tog i sone A, men ikkje på nattbuss.',
-    ),
-    period: _(
-      'Periodebilletter i sone A kan også brukes på tog i sone A.',
-      'Periodic tickets in zone A can also be used on train in zone A.',
-      'Periodebillettar i sone A kan også brukast på tog i sone A.',
-    ),
-    hour24: _(
-      '24-timersbillett i sone A kan også brukes på tog i sone A, men ikke på nattbuss.',
-      '24 hour pass in zone A can also be used on train in zone A, but not on night buses.',
-      '24-timersbillett i sone A kan også brukast på tog i sone A, men ikkje på nattbuss.',
-    ),
-  },
 };
 
 export default orgSpecificTranslations(FareContractTexts, {


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/7512

Adds a `app-fare-contract-details` global message context, replacing the last hard coded collab ticket messages in the app 🎉  (But some "from travel search to ticketing" logic still remains) 

## Before/after

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/8a919558-ae9a-427e-b5b0-c9a62d7cbd9b">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/d59f2223-fd1d-4a87-9f70-4eddc8734553">