### PR TITLE
chore: Distribute APK directly to Google Play

### DIFF
--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -83,15 +83,8 @@ jobs:
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           KEY_PASS: ${{ secrets.KEYSTORE_KEY_PASS }}
           KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
-      - name: Distribute to Google Alpha
-        if: matrix.org == 'atb'
-        run: bundle exec fastlane android appcenter_alpha
-        env:
-          APPCENTER_API_KEY: ${{ secrets.APPCENTER_ANDROID_API_KEY }}
-          RELEASE_NOTES: ${{ steps.get_release.outputs.body }}
-          RELEASE_URL: ${{ steps.get_release.outputs.html_url }}
       - name: Distrubute APK to Google Play Internal Testing
-        if: matrix.org == 'nfk'
+        if: (matrix.org == 'atb') || (matrix.org == 'nfk')
         run: |
           echo ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT}} | base64 --decode > google-play-service-account.json
           bundle exec fastlane android playstore_internal


### PR DESCRIPTION
We are having trouble with the AppCenter integration:
https://mittatb.slack.com/archives/C02EEG7D8EL/p1695204736271979?thread_ts=1695200240.568439&cid=C02EEG7D8EL

But for the store build AppCenter is an unnecessary middle step, so we'll
try sending it directly to Google Play like NFK and Fram does instead.