### PR TITLE
fix: add numberOfZones as fare contract details ruleVariable

### DIFF
--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -75,6 +75,7 @@ export const DetailsContent: React.FC<Props> = ({
       firstTravelRightType: firstTravelRight.type,
       validityStatus: validityStatus,
       tariffZones: firstTravelRight.tariffZoneRefs ?? [],
+      numberOfZones: firstTravelRight.tariffZoneRefs?.length ?? 0,
     };
     const globalMessageCount = findGlobalMessages(
       GlobalMessageContextEnum.appFareContractDetails,


### PR DESCRIPTION
Since the collab ticket only applies to tickets that are just in zone A, and not e.g. from A to B1, we need to check that numberOfZones == 1 when showing the message.

fixes https://github.com/AtB-AS/kundevendt/issues/7512#issuecomment-1729336551