### PR TITLE
feat: added support for errorText

### DIFF
--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useRef, useState} from 'react';
+import React, {forwardRef, useEffect, useRef, useState} from 'react';
 import {
   AccessibilityInfo,
   NativeSyntheticEvent,
@@ -15,11 +15,11 @@ import {ThemeText, MAX_FONT_SCALE} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
-import {SectionTexts, useTranslation} from '@atb/translations';
+import {dictionary, SectionTexts, useTranslation} from '@atb/translations';
 import composeRefs from '@seznam/compose-react-refs';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {Error} from '@atb/assets/svg/color/icons/status';
-import dictionary from '@atb/translations/dictionary';
+import {giveFocus} from '@atb/utils/use-focus-on-load';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 
@@ -55,7 +55,11 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
     const {t} = useTranslation();
     const myRef = useRef<InternalTextInput>(null);
     const combinedRef = composeRefs<InternalTextInput>(forwardedRef, myRef);
+    const errorFocusRef = useRef(null);
 
+    useEffect(() => {
+      giveFocus(errorFocusRef, 100);
+    }, [errorText]);
     function accessibilityEscapeKeyboard() {
       setTimeout(
         () =>
@@ -122,15 +126,10 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         <ThemeText type="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
-        <View style={styles.inputContainer}>
+        <View style={inlineLabel ? contentContainer : undefined}>
           <InternalTextInput
             ref={combinedRef}
-            style={[
-              styles.input,
-              inlineLabel ? contentContainer : undefined,
-              padding,
-              style,
-            ]}
+            style={[styles.input, padding, style]}
             placeholderTextColor={theme.text.colors.secondary}
             onFocus={onFocusEvent}
             onBlur={onBlurEvent}
@@ -153,8 +152,10 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         </View>
         {errorText !== undefined && (
           <View
+            ref={errorFocusRef}
+            accessible={true}
             style={styles.error}
-            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
             accessibilityLabel={`${t(
               dictionary.messageTypes.error,
             )}, ${errorText}`}
@@ -183,6 +184,7 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     borderColor: theme.static.background.background_0.background,
   },
   containerInline: {
+    backgroundColor: 'red',
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -154,13 +154,13 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         {errorText !== undefined && (
           <View
             style={styles.error}
-            accessibilityLiveRegion={'polite'}
+            accessibilityLiveRegion="polite"
             accessibilityLabel={`${t(
               dictionary.messageTypes.error,
             )}, ${errorText}`}
           >
             <ThemeIcon svg={Error} />
-            <ThemeText type={'body__secondary'} style={styles.errorMessage}>
+            <ThemeText type="body__secondary" style={styles.errorMessage}>
               {errorText}
             </ThemeText>
           </View>

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -18,6 +18,7 @@ import {SectionItemProps} from '../types';
 import {SectionTexts, useTranslation} from '@atb/translations';
 import composeRefs from '@seznam/compose-react-refs';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {Error} from '@atb/assets/svg/color/icons/status';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 
@@ -27,12 +28,14 @@ type TextProps = SectionItemProps<
     inlineLabel?: boolean;
     showClear?: boolean;
     onClear?: () => void;
+    errorText?: string;
   }
 >;
 
 export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
   (
     {
+      errorText = undefined,
       label,
       inlineLabel = true,
       onFocus,
@@ -78,9 +81,18 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
       else if (props.onChangeText) props.onChangeText('');
     };
 
-    const borderColor = !isFocused
-      ? undefined
-      : {borderColor: theme.border.focus};
+    const getBorderColor = () => {
+      if (isFocused) {
+        return {borderColor: theme.border.focus};
+      } else if (errorText) {
+        return {
+          borderColor:
+            theme.interactive.interactive_destructive.destructive.background,
+        };
+      } else {
+        return undefined;
+      }
+    };
 
     const padding = {
       // There are some oddities with handling padding
@@ -102,40 +114,50 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
           inlineLabel ? styles.containerInline : styles.containerMultiline,
           topContainerStyle,
           containerPadding,
-          borderColor,
+          getBorderColor(),
         ]}
         onAccessibilityEscape={accessibilityEscapeKeyboard}
       >
         <ThemeText type="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
-        <InternalTextInput
-          ref={combinedRef}
-          style={[
-            styles.input,
-            inlineLabel ? contentContainer : undefined,
-            padding,
-            style,
-          ]}
-          placeholderTextColor={theme.text.colors.secondary}
-          onFocus={onFocusEvent}
-          onBlur={onBlurEvent}
-          maxFontSizeMultiplier={MAX_FONT_SCALE}
-          {...props}
-        />
-        {showClear ? (
-          <View style={styles.inputClear}>
-            <PressableOpacity
-              accessible={true}
-              accessibilityRole="button"
-              accessibilityLabel={t(SectionTexts.textInput.clear)}
-              hitSlop={insets.all(8)}
-              onPress={onClearEvent}
-            >
-              <ThemeIcon svg={Close} />
-            </PressableOpacity>
+        <View style={styles.inputClear}>
+          <InternalTextInput
+            ref={combinedRef}
+            style={[
+              styles.input,
+              inlineLabel ? contentContainer : undefined,
+              padding,
+              style,
+            ]}
+            placeholderTextColor={theme.text.colors.secondary}
+            onFocus={onFocusEvent}
+            onBlur={onBlurEvent}
+            maxFontSizeMultiplier={MAX_FONT_SCALE}
+            {...props}
+          />
+          {showClear ? (
+            <View style={styles.clearButton}>
+              <PressableOpacity
+                accessible={true}
+                accessibilityRole="button"
+                accessibilityLabel={t(SectionTexts.textInput.clear)}
+                hitSlop={insets.all(8)}
+                onPress={onClearEvent}
+              >
+                <ThemeIcon svg={Close} />
+              </PressableOpacity>
+            </View>
+          ) : null}
+        </View>
+        {errorText !== undefined && (
+          <View style={styles.error}>
+            <ThemeIcon svg={Error} />
+            <ThemeText type={'body__secondary'} style={styles.errorMessage}>
+              {errorText}
+            </ThemeText>
           </View>
-        ) : null}
+        )}
       </View>
     );
   },
@@ -166,9 +188,16 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     paddingRight: theme.spacings.xSmall,
   },
   inputClear: {
-    position: 'absolute',
-    right: theme.spacings.medium,
-    bottom: theme.spacings.medium,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  clearButton: {
     alignSelf: 'center',
+  },
+  error: {flexDirection: 'row'},
+  errorMessage: {
+    paddingLeft: theme.spacings.medium,
+    paddingBottom: theme.spacings.small,
+    flex: 1,
   },
 }));

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -19,6 +19,7 @@ import {SectionTexts, useTranslation} from '@atb/translations';
 import composeRefs from '@seznam/compose-react-refs';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {Error} from '@atb/assets/svg/color/icons/status';
+import dictionary from '@atb/translations/dictionary';
 
 type FocusEvent = NativeSyntheticEvent<TextInputFocusEventData>;
 
@@ -151,7 +152,13 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
           ) : null}
         </View>
         {errorText !== undefined && (
-          <View style={styles.error}>
+          <View
+            style={styles.error}
+            accessibilityLiveRegion={'polite'}
+            accessibilityLabel={`${t(
+              dictionary.messageTypes.error,
+            )}, ${errorText}`}
+          >
             <ThemeIcon svg={Error} />
             <ThemeText type={'body__secondary'} style={styles.errorMessage}>
               {errorText}

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -122,7 +122,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         <ThemeText type="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
-        <View style={styles.inputClear}>
+        <View style={styles.inputContainer}>
           <InternalTextInput
             ref={combinedRef}
             style={[
@@ -138,7 +138,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
             {...props}
           />
           {showClear ? (
-            <View style={styles.clearButton}>
+            <View style={styles.inputClear}>
               <PressableOpacity
                 accessible={true}
                 accessibilityRole="button"
@@ -194,9 +194,13 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     minWidth: 60 - theme.spacings.medium,
     paddingRight: theme.spacings.xSmall,
   },
+  inputContainer: {
+    position: 'relative',
+  },
   inputClear: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    position: 'absolute',
+    right: 0,
+    bottom: theme.spacings.medium,
   },
   clearButton: {
     alignSelf: 'center',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -1286,6 +1286,18 @@ export const Profile_DesignSystemScreen = () => {
         </Section>
 
         <Section withPadding withTopPadding>
+          <TextInputSectionItem
+            label="Label"
+            placeholder="Placeholder"
+            onChangeText={() => {}}
+            textContentType="oneTimeCode"
+            showClear={true}
+            inlineLabel={false}
+            errorText="Something went wrong"
+          />
+        </Section>
+
+        <Section withPadding withTopPadding>
           <HeaderSectionItem text="Texts" />
 
           <GenericSectionItem>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -1283,9 +1283,6 @@ export const Profile_DesignSystemScreen = () => {
             showClear={true}
             inlineLabel={false}
           />
-        </Section>
-
-        <Section withPadding withTopPadding>
           <TextInputSectionItem
             label="Label"
             placeholder="Placeholder"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -1284,6 +1284,15 @@ export const Profile_DesignSystemScreen = () => {
             inlineLabel={false}
           />
           <TextInputSectionItem
+            label={'Inline Label'}
+            placeholder={'Placheolder'}
+            onChangeText={() => {}}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            autoComplete="email"
+            inlineLabel={true}
+          />
+          <TextInputSectionItem
             label="Label"
             placeholder="Placeholder"
             onChangeText={() => {}}


### PR DESCRIPTION
As part of https://github.com/AtB-AS/kundevendt/issues/4275, we need to support error state for TextInputSectionItems.

Implemented to look like this:
![image](https://github.com/AtB-AS/mittatb-app/assets/126664682/b3ccf740-7795-478d-8aea-12a53909898e)
