### PR TITLE
fix: enforce latestActivationDate also on Android

### DIFF
--- a/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
+++ b/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
@@ -39,7 +39,7 @@ export function DateInputSectionItem(props: DateInputSectionItemProps) {
         display="compact"
         testID="dateInput"
         minimumDate={new Date()}
-        maximumDate={maximumDate}
+        maximumDate={undefined}
         onChange={(_, date) => {
           if (date) onChange(date.toISOString());
         }}

--- a/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
+++ b/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
@@ -9,7 +9,7 @@ import {DateInputSectionItemProps} from './utils';
 import {useLocaleContext} from '@atb/LocaleProvider';
 
 export function DateInputSectionItem(props: DateInputSectionItemProps) {
-  const {value, onChange, maximumDate, ...innerprops} = props;
+  const {value, onChange, ...innerprops} = props;
   const {t} = useTranslation();
   const locale = useLocaleContext();
   const {theme} = useTheme();

--- a/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
+++ b/src/components/sections/items/date-input/DateInputSectionItem.ios.tsx
@@ -9,7 +9,7 @@ import {DateInputSectionItemProps} from './utils';
 import {useLocaleContext} from '@atb/LocaleProvider';
 
 export function DateInputSectionItem(props: DateInputSectionItemProps) {
-  const {value, onChange, ...innerprops} = props;
+  const {value, onChange, maximumDate, ...innerprops} = props;
   const {t} = useTranslation();
   const locale = useLocaleContext();
   const {theme} = useTheme();
@@ -39,7 +39,7 @@ export function DateInputSectionItem(props: DateInputSectionItemProps) {
         display="compact"
         testID="dateInput"
         minimumDate={new Date()}
-        maximumDate={undefined}
+        maximumDate={maximumDate}
         onChange={(_, date) => {
           if (date) onChange(date.toISOString());
         }}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -60,6 +60,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
         )
       )
         setTravelDate(undefined);
+      setShowActivationDateWarning(false);
     }
   };
   const [travellerSelection, setTravellerSelection] =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -60,7 +60,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
         )
       )
         setTravelDate(undefined);
-      setShowActivationDateWarning(false);
+      if (showActivationDateWarning) setShowActivationDateWarning(false);
     }
   };
   const [travellerSelection, setTravellerSelection] =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -67,6 +67,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const [travelDate, setTravelDate] = useState<string | undefined>(
     params.travelDate,
   );
+  const [showActivationDateWarning, setShowActivationDateWarning] =
+    useState<boolean>(false);
   const analytics = useAnalytics();
 
   const {
@@ -204,6 +206,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             validFromTime={travelDate}
             maximumDate={maximumDateObjectIfExisting}
             style={styles.selectionComponent}
+            showActivationDateWarning={showActivationDateWarning}
+            setShowActivationDateWarning={setShowActivationDateWarning}
           />
 
           <FlexTicketDiscountInfo

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -105,19 +105,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? new Date(preassignedFareProduct.limitations.latestActivationDate * 1000)
     : undefined;
 
-  const onSetTravelDate = (dateToSet?: string) => {
-    if (!maximumDateObjectIfExisting || !dateToSet) {
-      setTravelDate(dateToSet);
-    } else {
-      if (isAfter(dateToSet, maximumDateObjectIfExisting)) {
-        setShowActivationDateWarning(true);
-      } else {
-        if (showActivationDateWarning) setShowActivationDateWarning(false);
-        setTravelDate(dateToSet);
-      }
-    }
-  };
-
   const hasSelection =
     travellerSelection.some((u) => u.count) &&
     userProfilesWithCountAndOffer.some((u) => u.count);
@@ -215,7 +202,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             selectionMode={timeSelectionMode}
             color="interactive_2"
             travelDate={travelDate}
-            setTravelDate={onSetTravelDate}
+            setTravelDate={setTravelDate}
             validFromTime={travelDate}
             maximumDate={maximumDateObjectIfExisting}
             style={styles.selectionComponent}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -60,7 +60,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
         )
       )
         setTravelDate(undefined);
-      if (showActivationDateWarning) setShowActivationDateWarning(false);
+      else if (showActivationDateWarning) {
+        setShowActivationDateWarning(false);
+      }
+    } else if (showActivationDateWarning) {
+      setShowActivationDateWarning(false);
     }
   };
   const [travellerSelection, setTravellerSelection] =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -105,6 +105,19 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? new Date(preassignedFareProduct.limitations.latestActivationDate * 1000)
     : undefined;
 
+  const onSetTravelDate = (dateToSet?: string) => {
+    if (!maximumDateObjectIfExisting || !dateToSet) {
+      setTravelDate(dateToSet);
+    } else {
+      if (isAfter(dateToSet, maximumDateObjectIfExisting)) {
+        setShowActivationDateWarning(true);
+      } else {
+        if (showActivationDateWarning) setShowActivationDateWarning(false);
+        setTravelDate(dateToSet);
+      }
+    }
+  };
+
   const hasSelection =
     travellerSelection.some((u) => u.count) &&
     userProfilesWithCountAndOffer.some((u) => u.count);
@@ -202,7 +215,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             selectionMode={timeSelectionMode}
             color="interactive_2"
             travelDate={travelDate}
-            setTravelDate={setTravelDate}
+            setTravelDate={onSetTravelDate}
             validFromTime={travelDate}
             maximumDate={maximumDateObjectIfExisting}
             style={styles.selectionComponent}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import {
+  PurchaseOverviewTexts,
+  TravelDateTexts,
+  useTranslation,
+} from '@atb/translations';
 import {ThemeText} from '@atb/components/text';
 import {InteractiveColor} from '@atb/theme/colors';
 import {StyleProp, View, ViewStyle} from 'react-native';
@@ -12,6 +16,7 @@ import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {TravelDateSheet} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet';
 import {RadioSegments} from '@atb/components/radio';
 import {TimeSelectionMode} from '@atb/configuration';
+import {MessageBox} from '@atb/components/message-box';
 
 type StartTimeSelectionProps = {
   color: InteractiveColor;
@@ -95,12 +100,25 @@ export function StartTimeSelection({
           },
         ]}
       />
+      {showActivationDateWarning && (
+        <MessageBox
+          style={styles.warningBox}
+          type={'warning'}
+          message={t(
+            TravelDateTexts.latestActivationDate
+              .selectedDateShouldBeEarlierWarning,
+          )}
+        />
+      )}
     </View>
   );
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   radioSegments: {
+    marginTop: theme.spacings.medium,
+  },
+  warningBox: {
     marginTop: theme.spacings.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -21,7 +21,7 @@ type StartTimeSelectionProps = {
   selectionMode: TimeSelectionMode;
   maximumDate?: Date;
   showActivationDateWarning?: boolean;
-  setShowActivationDateWarning: (x: boolean) => void;
+  setShowActivationDateWarning: (value: boolean) => void;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  PurchaseOverviewTexts,
-  TravelDateTexts,
-  useTranslation,
-} from '@atb/translations';
+import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {ThemeText} from '@atb/components/text';
 import {InteractiveColor} from '@atb/theme/colors';
 import {StyleProp, View, ViewStyle} from 'react-native';
@@ -16,7 +12,6 @@ import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {TravelDateSheet} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet';
 import {RadioSegments} from '@atb/components/radio';
 import {TimeSelectionMode} from '@atb/configuration';
-import {MessageBox} from '@atb/components/message-box';
 
 type StartTimeSelectionProps = {
   color: InteractiveColor;
@@ -100,16 +95,6 @@ export function StartTimeSelection({
           },
         ]}
       />
-      {showActivationDateWarning && (
-        <MessageBox
-          style={styles.warningBox}
-          type={'warning'}
-          message={t(
-            TravelDateTexts.latestActivationDate
-              .selectedDateShouldBeEarlierWarning,
-          )}
-        />
-      )}
     </View>
   );
 }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -103,7 +103,4 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   radioSegments: {
     marginTop: theme.spacings.medium,
   },
-  warningBox: {
-    marginTop: theme.spacings.medium,
-  },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -20,6 +20,8 @@ type StartTimeSelectionProps = {
   travelDate?: string;
   selectionMode: TimeSelectionMode;
   maximumDate?: Date;
+  showActivationDateWarning?: boolean;
+  setShowActivationDateWarning: (x: boolean) => void;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -30,6 +32,8 @@ export function StartTimeSelection({
   travelDate,
   selectionMode,
   maximumDate,
+  showActivationDateWarning,
+  setShowActivationDateWarning,
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
@@ -48,6 +52,8 @@ export function StartTimeSelection({
         travelDate={travelDate}
         maximumDate={maximumDate}
         ref={onOpenFocusRef}
+        showActivationDateWarning={showActivationDateWarning}
+        setShowActivationDateWarning={setShowActivationDateWarning}
       />
     ));
   };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -51,11 +51,16 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
 
     const defaultDate = travelDate ?? new Date().toISOString();
     const [dateString, setDate] = useState(defaultDate);
+    const [
+      replicatedShowActivationDateWarning,
+      setReplicatedShowActivationDateWarning,
+    ] = useState<boolean>(false);
 
     const onSetDate = (date: string) => {
       console.log('Attempting to set date: ', date);
       setDate(date);
       setShowActivationDateWarning(true);
+      setReplicatedShowActivationDateWarning(true);
       /*if (!maximumDate) setDate(date);
       else {
         console.log('Max date is', maximumDate);
@@ -121,7 +126,7 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
             />
             <TimeInputSectionItem value={timeString} onChange={setTime} />
           </Section>
-          {showActivationDateWarning && (
+          {replicatedShowActivationDateWarning && (
             <MessageBox
               style={styles.dateWarningMessageBox}
               type={'warning'}
@@ -140,7 +145,7 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
             style={[styles.saveButton, {marginBottom: keyboardHeight}]}
             testID="confirmTimeButton"
             rightIcon={{svg: SvgConfirm}}
-            disabled={showActivationDateWarning}
+            disabled={replicatedShowActivationDateWarning}
           />
         </FullScreenFooter>
       </BottomSheetContainer>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -29,15 +29,36 @@ type Props = {
   close: () => void;
   save: (dateString?: string) => void;
   maximumDate?: Date;
+  showActivationDateWarning?: boolean;
+  setShowActivationDateWarning: (x: boolean) => void;
 };
 
 export const TravelDateSheet = forwardRef<ScrollView, Props>(
-  ({travelDate, close, save, maximumDate}, focusRef) => {
+  (
+    {
+      travelDate,
+      close,
+      save,
+      maximumDate,
+      showActivationDateWarning,
+      setShowActivationDateWarning,
+    },
+    focusRef,
+  ) => {
     const {t, language} = useTranslation();
     const styles = useStyles();
 
     const defaultDate = travelDate ?? new Date().toISOString();
     const [dateString, setDate] = useState(defaultDate);
+
+    const onSetDate = (date: string) => {
+      console.log('new date!', date);
+
+      setDate(date);
+      // The one below should be trigged when user selects date later date than allowed
+      setShowActivationDateWarning(true);
+    };
+
     const [timeString, setTime] = useState(() =>
       formatLocaleTime(defaultDate, language),
     );
@@ -83,11 +104,21 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
           <Section>
             <DateInputSectionItem
               value={dateString}
-              onChange={setDate}
+              onChange={onSetDate}
               maximumDate={maximumDate}
             />
             <TimeInputSectionItem value={timeString} onChange={setTime} />
           </Section>
+          {showActivationDateWarning && (
+            <MessageBox
+              style={styles.dateWarningMessageBox}
+              type={'warning'}
+              message={t(
+                TravelDateTexts.latestActivationDate
+                  .selectedDateShouldBeEarlierWarning,
+              )}
+            />
+          )}
         </ScrollView>
         <FullScreenFooter>
           <Button
@@ -97,6 +128,7 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
             style={[styles.saveButton, {marginBottom: keyboardHeight}]}
             testID="confirmTimeButton"
             rightIcon={{svg: SvgConfirm}}
+            disabled={showActivationDateWarning}
           />
         </FullScreenFooter>
       </BottomSheetContainer>
@@ -117,5 +149,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   messageBox: {
     marginBottom: theme.spacings.large,
+  },
+  dateWarningMessageBox: {
+    marginTop: theme.spacings.large,
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -54,19 +54,21 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
 
     const onSetDate = (date: string) => {
       console.log('Attempting to set date: ', date);
-      if (!maximumDate) setDate(date);
+      setDate(date);
+      setShowActivationDateWarning(true);
+      /*if (!maximumDate) setDate(date);
       else {
         console.log('Max date is', maximumDate);
         if (isAfter(date, maximumDate)) {
           console.log('Date is after limit');
           setShowActivationDateWarning(true);
-          setDate('2023-11-28T18:14:00.000Z');
+          setDate(defaultDate);
         } else {
           console.log('Date is before limit');
           if (showActivationDateWarning) setShowActivationDateWarning(false);
           setDate(date);
         }
-      }
+      }*/
     };
 
     const [timeString, setTime] = useState(() =>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -31,7 +31,7 @@ type Props = {
   save: (dateString?: string) => void;
   maximumDate?: Date;
   showActivationDateWarning?: boolean;
-  setShowActivationDateWarning: (x: boolean) => void;
+  setShowActivationDateWarning: (value: boolean) => void;
 };
 
 export const TravelDateSheet = forwardRef<ScrollView, Props>(
@@ -56,9 +56,9 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
       setReplicatedShowActivationDateWarning,
     ] = useState<boolean>(false);
 
-    const setInternalAndExternalWarningState = (val: boolean) => {
-      setShowActivationDateWarning(val);
-      setReplicatedShowActivationDateWarning(val);
+    const setInternalAndExternalWarningState = (value: boolean) => {
+      setShowActivationDateWarning(value);
+      setReplicatedShowActivationDateWarning(value);
     };
 
     const onSetDate = (date: string) => {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -66,16 +66,14 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
       else {
         if (isAfter(date, maximumDate)) {
           setInternalAndExternalWarningState(true);
-          setDate(date);
-        } else {
-          if (
-            replicatedShowActivationDateWarning ||
-            showActivationDateWarning
-          ) {
-            setInternalAndExternalWarningState(false);
-          }
-          setDate(date);
+        } else if (
+          replicatedShowActivationDateWarning ||
+          showActivationDateWarning
+        ) {
+          setInternalAndExternalWarningState(false);
         }
+
+        setDate(date);
       }
     };
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -56,24 +56,27 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
       setReplicatedShowActivationDateWarning,
     ] = useState<boolean>(false);
 
+    const setInternalAndExternalWarningState = (val: boolean) => {
+      setShowActivationDateWarning(val);
+      setReplicatedShowActivationDateWarning(val);
+    };
+
     const onSetDate = (date: string) => {
-      console.log('Attempting to set date: ', date);
-      setDate(date);
-      setShowActivationDateWarning(true);
-      setReplicatedShowActivationDateWarning(true);
-      /*if (!maximumDate) setDate(date);
+      if (!maximumDate) setDate(date);
       else {
-        console.log('Max date is', maximumDate);
         if (isAfter(date, maximumDate)) {
-          console.log('Date is after limit');
-          setShowActivationDateWarning(true);
-          setDate(defaultDate);
+          setInternalAndExternalWarningState(true);
+          setDate(date);
         } else {
-          console.log('Date is before limit');
-          if (showActivationDateWarning) setShowActivationDateWarning(false);
+          if (
+            replicatedShowActivationDateWarning ||
+            showActivationDateWarning
+          ) {
+            setInternalAndExternalWarningState(false);
+          }
           setDate(date);
         }
-      }*/
+      }
     };
 
     const [timeString, setTime] = useState(() =>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -54,7 +54,7 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
     const [
       replicatedShowActivationDateWarning,
       setReplicatedShowActivationDateWarning,
-    ] = useState<boolean>(false);
+    ] = useState<boolean | undefined>(showActivationDateWarning);
 
     const setInternalAndExternalWarningState = (value: boolean) => {
       setShowActivationDateWarning(value);
@@ -66,10 +66,7 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
       else {
         if (isAfter(date, maximumDate)) {
           setInternalAndExternalWarningState(true);
-        } else if (
-          replicatedShowActivationDateWarning ||
-          showActivationDateWarning
-        ) {
+        } else if (replicatedShowActivationDateWarning) {
           setInternalAndExternalWarningState(false);
         }
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -17,6 +17,7 @@ import {
   dateWithReplacedTime,
   formatLocaleTime,
   formatToVerboseFullDate,
+  isAfter,
 } from '@atb/utils/date';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
@@ -52,11 +53,20 @@ export const TravelDateSheet = forwardRef<ScrollView, Props>(
     const [dateString, setDate] = useState(defaultDate);
 
     const onSetDate = (date: string) => {
-      console.log('new date!', date);
-
-      setDate(date);
-      // The one below should be trigged when user selects date later date than allowed
-      setShowActivationDateWarning(true);
+      console.log('Attempting to set date: ', date);
+      if (!maximumDate) setDate(date);
+      else {
+        console.log('Max date is', maximumDate);
+        if (isAfter(date, maximumDate)) {
+          console.log('Date is after limit');
+          setShowActivationDateWarning(true);
+          setDate('2023-11-28T18:14:00.000Z');
+        } else {
+          console.log('Date is before limit');
+          if (showActivationDateWarning) setShowActivationDateWarning(false);
+          setDate(date);
+        }
+      }
     };
 
     const [timeString, setTime] = useState(() =>

--- a/src/translations/screens/subscreens/TravelDate.ts
+++ b/src/translations/screens/subscreens/TravelDate.ts
@@ -20,6 +20,11 @@ const TravelDateTexts = {
         `This ticket must be activated by ${latestActivationDate}.`,
         `Billetten må aktiverast seinast ${latestActivationDate}.`,
       ),
+    selectedDateShouldBeEarlierWarning: _(
+      'Din valgte dato er etter siste mulige aktiveringsdato.',
+      'The selected date is later than the latest possible activation date.',
+      'Din valde dato er etter siste moglege aktiveringdato.',
+    ),
   },
 };
 export default TravelDateTexts;


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/8886

Based on suggestion from https://github.com/AtB-AS/mittatb-app/pull/3886#issuecomment-1731197343

Enforces `latestActivationDate` also on Android where the `maximumDate` prop is not respected in our datepicker.

If a date later than the latest activation date is entered, a yellow warning `MessageBox` will appear and the submit button will be disabled. These measures are reverted when a valid date before the latest activation date is set, or when a different category / product is selected.

https://github.com/AtB-AS/mittatb-app/assets/21310942/ad92f541-c38d-4419-892b-6bc7c3b97ba0

