### PR TITLE
fix: payment webView not scrollable on android

### DIFF
--- a/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/Root_PurchasePaymentWithCreditCardScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/Root_PurchasePaymentWithCreditCardScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from '@atb/translations';
 import Bugsnag from '@bugsnag/react-native';
 import React, {useState} from 'react';
-import {View} from 'react-native';
+import {KeyboardAvoidingView, Platform, View} from 'react-native';
 import WebView from 'react-native-webview';
 import {
   WebViewErrorEvent,
@@ -81,19 +81,29 @@ export const Root_PurchasePaymentWithCreditCardScreen: React.FC<Props> = ({
     navigateBackFromTerminal,
   );
 
+  // Using the header height to adjust the keyboard offset on android
+  const [headerHeight, setHeaderHeight] = useState<number>(0);
+  const onLayout = (event: any) => {
+    const {height} = event.nativeEvent.layout;
+    setHeaderHeight(height);
+  };
+
   return (
     <View style={styles.container}>
-      <FullScreenHeader
-        title={t(PaymentCreditCardTexts.header.title)}
-        leftButton={{
-          type: 'cancel',
-          onPress: async () => {
-            await cancelPayment();
-            analytics.logEvent('Ticketing', 'Payment cancelled');
-            navigateBackFromTerminal();
-          },
-        }}
-      />
+      <View onLayout={onLayout}>
+        <FullScreenHeader
+          title={t(PaymentCreditCardTexts.header.title)}
+          leftButton={{
+            type: 'cancel',
+            onPress: async () => {
+              await cancelPayment();
+              analytics.logEvent('Ticketing', 'Payment cancelled');
+              navigateBackFromTerminal();
+            },
+          }}
+        />
+      </View>
+
       <View
         style={{
           flex: 1,
@@ -101,15 +111,23 @@ export const Root_PurchasePaymentWithCreditCardScreen: React.FC<Props> = ({
         }}
       >
         {terminalUrl && showWebView && (
-          <WebView
-            source={{
-              uri: terminalUrl,
-            }}
-            onError={onWebViewError}
-            onLoadStart={onWebViewLoadStart}
-            onLoadEnd={onWebViewLoadEnd}
-            onNavigationStateChange={onWebViewNavigationChange}
-          />
+          <KeyboardAvoidingView
+            behavior={'padding'}
+            style={{flex: 1}}
+            keyboardVerticalOffset={
+              Platform.OS === 'android' ? headerHeight : 0
+            }
+          >
+            <WebView
+              source={{
+                uri: terminalUrl,
+              }}
+              onError={onWebViewError}
+              onLoadStart={onWebViewLoadStart}
+              onLoadEnd={onWebViewLoadEnd}
+              onNavigationStateChange={onWebViewNavigationChange}
+            />
+          </KeyboardAvoidingView>
         )}
       </View>
       {isLoading && (

--- a/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/Root_PurchasePaymentWithCreditCardScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/Root_PurchasePaymentWithCreditCardScreen.tsx
@@ -113,7 +113,7 @@ export const Root_PurchasePaymentWithCreditCardScreen: React.FC<Props> = ({
         {terminalUrl && showWebView && (
           <KeyboardAvoidingView
             behavior={Platform.OS === 'android' ? 'padding' : undefined}
-            style={{flex: 1}}
+            style={styles.keyboardAvoidingView}
             keyboardVerticalOffset={
               Platform.OS === 'android' ? headerHeight : 0
             }
@@ -181,6 +181,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     backgroundColor: theme.static.background.background_1.background,
   },
+  keyboardAvoidingView: {flex: 1},
   center: {flex: 1, justifyContent: 'center', padding: theme.spacings.medium},
   messageBox: {marginBottom: theme.spacings.small},
   button: {marginBottom: theme.spacings.small},

--- a/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/Root_PurchasePaymentWithCreditCardScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/Root_PurchasePaymentWithCreditCardScreen.tsx
@@ -112,7 +112,7 @@ export const Root_PurchasePaymentWithCreditCardScreen: React.FC<Props> = ({
       >
         {terminalUrl && showWebView && (
           <KeyboardAvoidingView
-            behavior={'padding'}
+            behavior={Platform.OS === 'android' ? 'padding' : undefined}
             style={{flex: 1}}
             keyboardVerticalOffset={
               Platform.OS === 'android' ? headerHeight : 0


### PR DESCRIPTION
Fixed by adding keyboardAvoidingView that adapts to the header height on android. If the header height is not adjusted for, the view will not always adapt when keyboard is over input field. 



Before:
https://github.com/AtB-AS/mittatb-app/assets/70323886/bac61b89-e749-4a0b-bcac-0a3c246dd401

After:
https://github.com/AtB-AS/mittatb-app/assets/70323886/1303f2e1-f64b-464e-bf10-cdecaf5401ba


Still works as intended on iOS:
https://github.com/AtB-AS/mittatb-app/assets/70323886/de737740-bf5d-4efe-9954-a0656bdcc428