### PR TITLE
fix: remove unnecessary padding on harbor selection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -123,7 +123,7 @@ const HarborSelectionItem = forwardRef<
       onPress={() => !disabled && onPress()}
       testID="selectHarborsButton"
     >
-      <View style={fromOrTo === 'from' ? styles.fromHarbor : styles.toHarbor}>
+      <View style={styles.sectionContent}>
         <ThemeText
           color={disabled ? 'disabled' : 'secondary'}
           type="body__secondary"
@@ -162,12 +162,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   sectionText: {
     marginBottom: theme.spacings.medium,
   },
-  fromHarbor: {
+  sectionContent: {
     flexDirection: 'row',
-  },
-  toHarbor: {
-    flexDirection: 'row',
-    marginTop: theme.spacings.small,
   },
   toFromLabel: {
     minWidth: 40,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -59,8 +59,8 @@ const PurchaseOverviewTexts = {
         a11yLabel: _('Velg kaier', 'Select harbors', 'Vel kaier'),
       },
       noneSelected: {
-        text: _('Ingen kai valgt', 'No harbors selected', 'Inga kai valt'),
-        a11yLabel: _('Ingen kai valgt', 'No harbors selected', 'Inga kai valt'),
+        text: _('Ingen kai valgt', 'No harbor selected', 'Inga kai valt'),
+        a11yLabel: _('Ingen kai valgt', 'No harbor selected', 'Inga kai valt'),
       },
       from: {
         a11yLabel: (harbor?: string) =>


### PR DESCRIPTION
Removes some unnecessary padding from the bottom harbor selection, and updates "harbors" to "harbor" in english.

## Before/after

<img width="400px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/ce978c5f-09f2-4a49-af4c-b2c1013b7ae6">
<img width="400px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/11240778-0113-4fdd-8552-425a6a620d86">


closes https://github.com/AtB-AS/kundevendt/issues/8878