### PR TITLE
feat: adds timeout notification for token and fallback to static aztec

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -54,7 +54,7 @@ const useBarcodeCodeStatus = (
   validityStatus: ValidityStatus,
   isInspectable: boolean,
 ) => {
-  const {remoteTokens, deviceIsInspectable, isLoading, isError} =
+  const {remoteTokens, deviceIsInspectable, isLoading, isTimedout, isError} =
     useMobileTokenContextState();
   const mobileTokenEnabled = useHasEnabledMobileToken();
   const {use_trygg_overgang_qr_code: useTryggOvergangQrCode} =
@@ -67,6 +67,7 @@ const useBarcodeCodeStatus = (
 
   if (!mobileTokenEnabled) return 'static';
 
+  if (isTimedout) return 'static';
   if (isLoading) return 'loading';
   if (isError) return 'static';
   if (deviceIsInspectable) return 'mobiletoken';

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -43,6 +43,7 @@ export type RemoteConfig = {
   enable_show_valid_time_info: boolean;
   enable_loading_screen: boolean;
   enable_beacons: boolean;
+  token_timeout_in_seconds: number;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -91,6 +92,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_show_valid_time_info: true,
   enable_loading_screen: true,
   enable_beacons: false,
+  token_timeout_in_seconds: 0,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -243,6 +245,10 @@ export function getConfig(): RemoteConfig {
   const enable_beacons =
     values['enable_beacons']?.asBoolean() ?? defaultRemoteConfig.enable_beacons;
 
+  const token_timeout_in_seconds =
+    values['token_timeout_in_seconds']?.asNumber() ??
+    defaultRemoteConfig.token_timeout_in_seconds;
+
   return {
     enable_ticketing,
     enable_intercom,
@@ -285,6 +291,7 @@ export function getConfig(): RemoteConfig {
     enable_show_valid_time_info,
     enable_loading_screen,
     enable_beacons,
+    token_timeout_in_seconds,
   };
 }
 


### PR DESCRIPTION
I've added a new RemoteConfig prop defaulting to 0 so we can opt-in on the timeout behavior: `token_timeout_in_seconds`. If this is 0 timeout will always be false.

This feature adds a timeout flag to the token context. It does not stop the execution of the code, as I think that is hard to stop the execution flow like this and I don't think it is favorable either. So the logic here is to have a timeout mechanism that marks the loading as timed out and if it proceeds afterwards it will unmark it as timed out making it proper again.

I've also added a BugSnag notification when the timeout handler is invoked. This will allow us to see how often this happens and all the breadcrumbs that the token SDK cases will get posted to BugSnag. Hopefully, we'll get more context and information on what is going on.

I have only now checked for timeout in the Barcode component. Better error messages to the user could be added to other places that uses token context also, but trying to minimize development time here.



NB: I haven't verified this myself yet, but adding as PR while I do so to save some time and get more eyes on this.

## Verification of PR

- [ ] Run device and let token take a long time. Should trigger timeout mechanism.