### PR TITLE
fix: specify kotlin version, enable force build option

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -26,10 +26,6 @@ jobs:
     timeout-minutes: 180
     runs-on: ubuntu-latest
     steps:
-      - name: Debug Variables
-        run: |
-          echo "Force build: ${{ inputs.force-build }}"
-          echo "Cache hit: ${{ steps.modules-cache.outputs.cache-hit }}"
       - name: Checkout project
         uses: actions/checkout@v1
       - name: Set global env vars

--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -26,6 +26,10 @@ jobs:
     timeout-minutes: 180
     runs-on: ubuntu-latest
     steps:
+      - name: Debug Variables
+        run: |
+          echo "Force build: ${{ inputs.force-build }}"
+          echo "Cache hit: ${{ steps.modules-cache.outputs.cache-hit }}"
       - name: Checkout project
         uses: actions/checkout@v1
       - name: Set global env vars
@@ -50,6 +54,7 @@ jobs:
         with:
           node-version: 18
       - name: Get potential cached node_modules
+        if: inputs.force-build != 'true'
         uses: actions/cache@v2
         id: modules-cache
         with:

--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -1,6 +1,15 @@
 name: Build staging Android project
 on:
   workflow_dispatch:
+    inputs:
+      force-build:
+        description: 'Forces a new build and ignores the cache'
+        required: false
+        type: choice
+        default: false
+        options:
+          - true
+          - false
   push:
     branches:
       - master
@@ -47,7 +56,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}
       - name: Install node_modules
-        if: steps.modules-cache.outputs.cache-hit != 'true'
+        if: inputs.force-build == 'true' || steps.modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
@@ -72,17 +81,17 @@ jobs:
         env:
           KEYSTORE: ${{ secrets.KEYSTORE }}
       - name: Generate native assets
-        if: steps.apk-cache.outputs.cache-hit != 'true'
+        if: inputs.force-build == 'true' || steps.apk-cache.outputs.cache-hit != 'true'
         run: yarn generate-native-assets
       - name: Run fastlane build
-        if: steps.apk-cache.outputs.cache-hit != 'true'
+        if: inputs.force-build == 'true' || steps.apk-cache.outputs.cache-hit != 'true'
         run: bundle exec fastlane android build
         env:
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           KEY_PASS: ${{ secrets.KEYSTORE_KEY_PASS }}
           KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
       - name: Replace apk bundle
-        if: steps.apk-cache.outputs.cache-hit == 'true'
+        if: inputs.force-build == 'true' || steps.apk-cache.outputs.cache-hit == 'true'
         run: bash ./scripts/android/replace-bundle.sh
         env:
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,8 +138,8 @@ android {
 dependencies {
 
     implementation 'com.facebook.soloader:soloader:0.9.0+'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${KOTLIN_VERSION}"
 
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
+        kotlin_version = '1.8.0'
         minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
@@ -21,6 +22,8 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath 'com.google.gms:google-services:4.3.13'
+
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        kotlin_version = '1.8.0'
         minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
@@ -23,7 +22,7 @@ buildscript {
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath 'com.google.gms:google-services:4.3.13'
 
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,6 +3,8 @@ android.enableJetifier=true
 
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
+KOTLIN_VERSION=1.8.0
+
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.191.0
 # Use this property to specify which architecture you want to build.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1805,10 +1805,10 @@ SPEC CHECKSUMS:
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  SwiftProtobuf: 7773c4e96a99d7b8ab7cda0fc30a883732ff93b1
-  TimeReactNativeLib: 5915a7ee0d8fed27361f5109b0fe0f7c981d80cc
-  TokenCore: c66fccf39c10238ff753b28956134c489d7ff0dd
-  TokenStateReactNativeLib: a312be9827d8f30489526ae61d8043c26e291111
+  SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
+  TimeReactNativeLib: 8f7bba2f9973fb75f3f5619e5a3da582747663d6
+  TokenCore: 1579a2a2179a283048d9c0a007b4fd38861f4555
+  TokenStateReactNativeLib: cba98cbdb61af0255d2e636565a0feedb6cda069
   Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1805,10 +1805,10 @@ SPEC CHECKSUMS:
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  SwiftProtobuf: b02b5075dcf60c9f5f403000b3b0c202a11b6ae1
-  TimeReactNativeLib: 8f7bba2f9973fb75f3f5619e5a3da582747663d6
-  TokenCore: 1579a2a2179a283048d9c0a007b4fd38861f4555
-  TokenStateReactNativeLib: cba98cbdb61af0255d2e636565a0feedb6cda069
+  SwiftProtobuf: 7773c4e96a99d7b8ab7cda0fc30a883732ff93b1
+  TimeReactNativeLib: 5915a7ee0d8fed27361f5109b0fe0f7c981d80cc
+  TokenCore: c66fccf39c10238ff753b28956134c489d7ff0dd
+  TokenStateReactNativeLib: a312be9827d8f30489526ae61d8043c26e291111
   Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a


### PR DESCRIPTION
Enable a force build option for Android in staging.

Also, when building the Android app, the warning "Detected multiple Kotlin daemon sessions at build/kotlin/sessions" is fixed by specifying a kotlin version. See https://github.com/facebook/react-native/issues/33488