### PR TITLE
fix: Retry auth no longer done on outdated state

### DIFF
--- a/src/loading-screen/LoadingScreenBoundary.tsx
+++ b/src/loading-screen/LoadingScreenBoundary.tsx
@@ -39,7 +39,7 @@ export const LoadingScreenBoundary = ({
     analytics.logEvent('Loading boundary', 'Retrying auth');
     setupLoadingTimeout();
     retryAuth();
-  }, [setupLoadingTimeout]);
+  }, [setupLoadingTimeout, retryAuth]);
 
   // Wait one second after load success to let the app "settle".
   const waitFinished = useDelayGate(1000, loadSuccess);


### PR DESCRIPTION
### Acceptance criteria
- [ ] If missing customer claims, pressing retry in loading error screen should retry the secure token requests