### PR TITLE
fix: update section separator color

### DIFF
--- a/src/components/sections/SectionSeparator.tsx
+++ b/src/components/sections/SectionSeparator.tsx
@@ -11,6 +11,6 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
   separator: {
     height: 1,
     width: '100%',
-    backgroundColor: theme.static.background.background_1.background,
+    backgroundColor: theme.static.background.background_2.background,
   },
 }));


### PR DESCRIPTION
One for the pixel-peepers 🧐:

Since most places where sections are used are on a background_2 color, I'm updating the SectionSeparator to look more correct in the places we use it today, and with slightly more contrast.

### Before/after
![Screenshot 2023-10-04 at 10 06 31](https://github.com/AtB-AS/mittatb-app/assets/1774972/12559a35-18ff-4f40-b16f-785c7d6b85af)
![Screenshot 2023-10-04 at 10 06 25](https://github.com/AtB-AS/mittatb-app/assets/1774972/5ea5203e-5aec-446a-af84-898b35ace896)
