### PR TITLE
feat: handle empty state for searches

### DIFF
--- a/src/components/empty-state/EmptyState.tsx
+++ b/src/components/empty-state/EmptyState.tsx
@@ -46,6 +46,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   emptyStateTitle: {
     marginTop: theme.spacings.xSmall,
     marginBottom: theme.spacings.xSmall,
+    textAlign: 'center',
   },
   emptyStateDetails: {
     textAlign: 'center',

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -150,6 +150,7 @@ export const NearbyStopPlacesScreenComponent = ({
   }
 
   const isFocused = useIsFocusedAndActive();
+  console.log('isLoading', isLoading);
 
   return (
     <FullScreenView
@@ -181,6 +182,8 @@ export const NearbyStopPlacesScreenComponent = ({
     >
       <ScreenReaderAnnouncement message={loadAnnouncement} />
       <StopPlaces
+        location={location}
+        isLoading={isLoading}
         header={getListDescription()}
         stopPlaces={orderedStopPlaces}
         navigateToPlace={onSelectStopPlace}

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -150,7 +150,6 @@ export const NearbyStopPlacesScreenComponent = ({
   }
 
   const isFocused = useIsFocusedAndActive();
-  console.log('isLoading', isLoading);
 
   return (
     <FullScreenView
@@ -182,12 +181,12 @@ export const NearbyStopPlacesScreenComponent = ({
     >
       <ScreenReaderAnnouncement message={loadAnnouncement} />
       <StopPlaces
-        location={location}
-        isLoading={isLoading}
         header={getListDescription()}
         stopPlaces={orderedStopPlaces}
         navigateToPlace={onSelectStopPlace}
         testID={'nearbyStopsContainerView'}
+        location={location}
+        isLoading={isLoading}
       />
     </FullScreenView>
   );

--- a/src/nearby-stop-places/components/StopPlaces.tsx
+++ b/src/nearby-stop-places/components/StopPlaces.tsx
@@ -7,23 +7,29 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {EmptyState} from '@atb/components/empty-state';
 import {NearbyTexts, useTranslation} from '@atb/translations';
 import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
+import {Location} from '@atb/favorites';
 
 export const StopPlaces = ({
   header,
   stopPlaces,
   navigateToPlace,
   testID,
+  location,
+  isLoading,
 }: {
   header?: string;
   stopPlaces: NearestStopPlaceNode[];
   navigateToPlace: (place: StopPlace) => void;
   testID?: string;
+  location?: Location;
+  isLoading: boolean;
 }) => {
   const {t} = useTranslation();
   const styles = useStyles();
+  const noStopPlacesFound = stopPlaces.length === 0 && location && !isLoading;
   return (
     <ScrollView style={styles.container} testID={testID}>
-      {header && stopPlaces.length > 0 && (
+      {header && !noStopPlacesFound && (
         <ThemeText
           style={styles.header}
           type="body__secondary"
@@ -40,7 +46,7 @@ export const StopPlaces = ({
           testID={'stopPlaceItem' + stopPlaces.indexOf(node)}
         />
       ))}
-      {stopPlaces.length === 0 && (
+      {noStopPlacesFound && (
         <EmptyState
           title={t(NearbyTexts.stateAnnouncements.emptyNearbyLocationsTitle)}
           details={t(

--- a/src/nearby-stop-places/components/StopPlaces.tsx
+++ b/src/nearby-stop-places/components/StopPlaces.tsx
@@ -4,6 +4,9 @@ import {StopPlaceItem} from './StopPlaceItem';
 import React from 'react';
 import {StyleSheet} from '@atb/theme';
 import {ScrollView} from 'react-native-gesture-handler';
+import {EmptyState} from '@atb/components/empty-state';
+import {NearbyTexts, useTranslation} from '@atb/translations';
+import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
 
 export const StopPlaces = ({
   header,
@@ -16,10 +19,11 @@ export const StopPlaces = ({
   navigateToPlace: (place: StopPlace) => void;
   testID?: string;
 }) => {
+  const {t} = useTranslation();
   const styles = useStyles();
   return (
     <ScrollView style={styles.container} testID={testID}>
-      {header && (
+      {header && stopPlaces.length > 0 && (
         <ThemeText
           style={styles.header}
           type="body__secondary"
@@ -36,6 +40,20 @@ export const StopPlaces = ({
           testID={'stopPlaceItem' + stopPlaces.indexOf(node)}
         />
       ))}
+      {stopPlaces.length === 0 && (
+        <EmptyState
+          title={t(NearbyTexts.stateAnnouncements.emptyNearbyLocationsTitle)}
+          details={t(
+            NearbyTexts.stateAnnouncements.emptyNearbyLocationsDetails,
+          )}
+          illustrationComponent={
+            <ThemedOnBehalfOf
+              height={90}
+              style={styles.emptyStopPlacesIllustration}
+            />
+          }
+        />
+      )}
     </ScrollView>
   );
 };
@@ -50,5 +68,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   noStopMessage: {
     marginHorizontal: theme.spacings.large,
+  },
+  emptyStopPlacesIllustration: {
+    marginBottom: theme.spacings.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -20,6 +20,9 @@ import {TripPatternWithKey} from '@atb/travel-details-screens/types';
 import {getIsTooLateToBookTripPattern} from '@atb/travel-details-screens/utils';
 import {useNow} from '@atb/utils/use-now';
 
+import {EmptyState} from '@atb/components/empty-state';
+import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
+
 type Props = {
   tripPatterns: TripPatternWithKey[];
   showEmptyScreen: boolean;
@@ -82,11 +85,22 @@ export const Results: React.FC<Props> = ({
 
   if (isEmptyResult) {
     return (
-      <MessageBox
-        type="info"
-        style={styles.messageBoxContainer}
-        message={getTextForEmptyResult(resultReasons, anyFiltersApplied, t)}
-      />
+      <View style={styles.emptyStateContainer}>
+        <EmptyState
+          title={t(TripSearchTexts.results.info.emptySearchResultsTitle)}
+          details={getDetailsTextForEmptyResult(
+            resultReasons,
+            anyFiltersApplied,
+            t,
+          )}
+          illustrationComponent={
+            <ThemedOnBehalfOf
+              height={90}
+              style={styles.emptySearchResultsIllustration}
+            />
+          }
+        />
+      </View>
     );
   }
 
@@ -113,16 +127,16 @@ export const Results: React.FC<Props> = ({
   );
 };
 
-const getTextForEmptyResult = (
+const getDetailsTextForEmptyResult = (
   resultReasons: string[],
   anyFiltersApplied: boolean,
   t: TranslateFunction,
 ) => {
-  let text = t(TripSearchTexts.results.info.emptyResult) + '\n\n';
+  let text = '';
   if (!resultReasons?.length) {
     text += anyFiltersApplied
-      ? t(TripSearchTexts.results.info.genericHintWithFilters)
-      : t(TripSearchTexts.results.info.genericHint);
+      ? t(TripSearchTexts.results.info.emptySearchResultsDetailsWithFilters)
+      : t(TripSearchTexts.results.info.emptySearchResultsDetails);
   } else if (resultReasons.length === 1) {
     text += resultReasons[0];
   } else {
@@ -144,5 +158,11 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   messageBoxContainer: {
     marginHorizontal: theme.spacings.medium,
     marginTop: theme.spacings.medium,
+  },
+  emptyStateContainer: {
+    marginTop: theme.spacings.medium,
+  },
+  emptySearchResultsIllustration: {
+    marginBottom: theme.spacings.medium,
   },
 }));

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -7,6 +7,8 @@ import {Map as LightMap} from '@atb/assets/svg/color/images/light';
 import {Map as DarkMap} from '@atb/assets/svg/color/images/dark';
 import {NoFavouriteDeparture as LightNoFavouriteDeparture} from '@atb/assets/svg/color/images/light';
 import {NoFavouriteDeparture as DarkNoFavouriteDeparture} from '@atb/assets/svg/color/images/dark';
+import {OnBehalfOf as LightOnBehalfOf} from '@atb/assets/svg/color/images/light';
+import {OnBehalfOf as DarkOnBehalfOf} from '@atb/assets/svg/color/images/dark';
 import {useTheme} from '@atb/theme/ThemeContext';
 
 export const ThemedTokenTravelCard = () => {
@@ -32,4 +34,10 @@ export const ThemedNoFavouriteDepartureImage = () => {
   const NoFavouriteDeparture =
     themeName === 'dark' ? DarkNoFavouriteDeparture : LightNoFavouriteDeparture;
   return <NoFavouriteDeparture />;
+};
+
+export const ThemedOnBehalfOf = ({...props}) => {
+  const {themeName} = useTheme();
+  const OnBehalfOf = themeName === 'dark' ? DarkOnBehalfOf : LightOnBehalfOf;
+  return <OnBehalfOf {...props} />;
 };

--- a/src/translations/screens/Nearby.ts
+++ b/src/translations/screens/Nearby.ts
@@ -39,6 +39,16 @@ const NearbyTexts = {
         `Loading departures near ${locationName}`,
         `Lastar avgangar nær ${locationName}`,
       ),
+    emptyNearbyLocationsTitle: _(
+      'Finner ingen holdeplasser i nærheten',
+      'No nearby stop places found',
+      'Finn ingen haldeplassar i nærleiken',
+    ),
+    emptyNearbyLocationsDetails: _(
+      'Prøv å søke på et annet navn eller bruk et annet stoppested for å finne avganger i nærheten.',
+      'Try to search for another name or use another stop place to find departures nearby.',
+      'Prøv å søkje på eit anna namn eller bruk ein annan stoppestad for å finne avgangar i nærleiken.',
+    ),
   },
 };
 export default NearbyTexts;

--- a/src/translations/screens/TripSearch.ts
+++ b/src/translations/screens/TripSearch.ts
@@ -161,25 +161,25 @@ const TripSearchTexts = {
     },
 
     info: {
-      emptyResult: _(
-        'Vi fant dessverre ingen kollektivreiser som passer til ditt søk.',
-        'We could not find any public transport routes matching your search criteria.',
-        'Vi fann dessverre ingen kollektivreiser som passa til ditt søk.',
+      emptySearchResultsTitle: _(
+        'Ingen kollektivreiser passer til ditt søk',
+        'No public transportation routes match your search criteria',
+        'Ingen kollektivreiser passar til søket ditt',
+      ),
+      emptySearchResultsDetails: _(
+        'Prøv å justere på sted eller tidspunkt.',
+        'Try adjusting your time or location input.',
+        'Prøv å justere på stad eller tidspunkt.',
+      ),
+      emptySearchResultsDetailsWithFilters: _(
+        'Prøv å justere på sted, filter eller tidspunkt.',
+        'Try adjusting your time, filters or location input.',
+        'Prøv å justere på stad, filter eller tidspunkt.',
       ),
       reasonsTitle: _(
         'Mulige årsaker:',
         'Possible causes:',
         'Moglege årsaker:',
-      ),
-      genericHint: _(
-        'Prøv å justere på sted eller tidspunkt.',
-        'Try adjusting your time or location input.',
-        'Prøv å justere på stad eller tidspunkt.',
-      ),
-      genericHintWithFilters: _(
-        'Prøv å justere sted, filter eller tidspunkt.',
-        'Try adjusting your time, filters or location input.',
-        'Prøv å justere stad, filter eller tidspunkt.',
       ),
       resultList: {
         listPositionExplanation: (


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/7302

When no nearby stop places are found:
<img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/324d7003-42dc-4937-9e93-714c2fa17382" /> <img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/21267956-3558-4deb-b4e9-b7855a4f337b" />


When no trip search results are found:
<img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/8eddbf8d-f292-4e9f-803a-68cf8aa39ea6" /> <img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/fb56b3d2-206e-4eb7-9ad0-1060d417ea07" /> <img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/78669448-1dfe-43ea-8845-0530c3b684a3" />


Note: Following discussion with @ckbilstad, renaming the OnBehalfOf illustration will be addressed together with other renaming issues later. Also even though both OnBehalfOf svgs are identical at the moment, it is expected to have an updated dark mode version.