### PR TITLE
feat: adds device brightness adjustment on ticket details sreen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1188,6 +1188,8 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
+  - react-native-device-brightness (1.2.7):
+    - React
   - react-native-flipper (0.191.0):
     - React-Core
   - react-native-flipper-performance-plugin (0.4.0):
@@ -1324,7 +1326,7 @@ PODS:
     - React-perflogger (= 0.72.4)
   - RNBootSplash (4.4.1):
     - React-Core
-  - RNCAsyncStorage (1.17.11):
+  - RNCAsyncStorage (1.19.3):
     - React-Core
   - RNCClipboard (1.11.1):
     - React-Core
@@ -1447,6 +1449,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-device-brightness (from `../node_modules/@adrianso/react-native-device-brightness`)"
   - react-native-flipper (from `../node_modules/react-native-flipper`)
   - react-native-flipper-performance-plugin (from `../node_modules/react-native-flipper-performance-plugin`)
   - react-native-geolocation-service (from `../node_modules/react-native-geolocation-service`)
@@ -1592,6 +1595,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-device-brightness:
+    :path: "../node_modules/@adrianso/react-native-device-brightness"
   react-native-flipper:
     :path: "../node_modules/react-native-flipper"
   react-native-flipper-performance-plugin:
@@ -1762,6 +1767,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
+  react-native-device-brightness: 886cfbfb49a32b6de4ccfc1f720776dc5f381d24
   react-native-flipper: 5d8dcbcb905a7e8076c9a61a3709944c23cf48ee
   react-native-flipper-performance-plugin: 42ec5017abd26e7c5a1f527f2db92c14a90cabdb
   react-native-geolocation-service: 608e1da71a1ac31b4de64d9ef2815f697978c55b
@@ -1788,7 +1794,7 @@ SPEC CHECKSUMS:
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNBootSplash: 4f968c1e098c7ec97939ace039f735e3d335bd4b
-  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
+  RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
   RNDateTimePicker: aade709a5a728c04b9736c7dbe84f172e9d6aec4
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
@@ -1806,7 +1812,7 @@ SPEC CHECKSUMS:
   RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SwiftProtobuf: 7773c4e96a99d7b8ab7cda0fc30a883732ff93b1
-  TimeReactNativeLib: 5915a7ee0d8fed27361f5109b0fe0f7c981d80cc
+  TimeReactNativeLib: f14a3b19d32248220f0f978e7b420a97d9122c70
   TokenCore: c66fccf39c10238ff753b28956134c489d7ff0dd
   TokenStateReactNativeLib: a312be9827d8f30489526ae61d8043c26e291111
   Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "unimported": "npx unimported"
   },
   "dependencies": {
+    "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.6.0",
     "@atb-as/generate-assets": "^9.1.0",
     "@atb-as/theme": "^7.1.1",

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -86,11 +86,11 @@ function useScreenBrightnessIncrease() {
 
   useEffect(
     function () {
-      let originalBrightness = 0.5;
+      let originalBrightness: number | undefined;
       async function setLevel() {
         try {
-          originalBrightness = await DeviceBrightness.getBrightnessLevel();
           if (isActive) {
+            originalBrightness = await DeviceBrightness.getBrightnessLevel();
             DeviceBrightness.setBrightnessLevel(1);
           }
         } catch (e) {
@@ -102,7 +102,9 @@ function useScreenBrightnessIncrease() {
 
       return () => {
         try {
-          DeviceBrightness.setBrightnessLevel(originalBrightness);
+          if (originalBrightness) {
+            DeviceBrightness.setBrightnessLevel(originalBrightness);
+          }
         } catch (e) {
           Bugsnag.leaveBreadcrumb(`Failed to reset brightness.`);
         }

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -20,6 +20,9 @@ import {GenericSectionItem} from '@atb/components/sections';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import QRCode from 'qrcode';
 import {renderAztec} from '@entur-private/abt-mobile-barcode-javascript-lib';
+import DeviceBrightness from '@adrianso/react-native-device-brightness';
+import Bugsnag from '@bugsnag/react-native';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 
 type Props = {
   validityStatus: ValidityStatus;
@@ -33,6 +36,7 @@ export function Barcode({
   fc,
 }: Props): JSX.Element | null {
   const status = useBarcodeCodeStatus(validityStatus, isInspectable);
+  useScreenBrightnessIncrease();
 
   switch (status) {
     case 'none':
@@ -76,6 +80,37 @@ const useBarcodeCodeStatus = (
 
   return 'static';
 };
+
+function useScreenBrightnessIncrease() {
+  const isActive = useIsFocusedAndActive();
+
+  useEffect(
+    function () {
+      let originalBrightness = 0.5;
+      async function setLevel() {
+        try {
+          originalBrightness = await DeviceBrightness.getBrightnessLevel();
+          if (isActive) {
+            DeviceBrightness.setBrightnessLevel(1);
+          }
+        } catch (e) {
+          Bugsnag.leaveBreadcrumb(`Failed to set brightness.`);
+        }
+      }
+
+      setLevel();
+
+      return () => {
+        try {
+          DeviceBrightness.setBrightnessLevel(originalBrightness);
+        } catch (e) {
+          Bugsnag.leaveBreadcrumb(`Failed to reset brightness.`);
+        }
+      };
+    },
+    [isActive],
+  );
+}
 
 const UPDATE_INTERVAL = 10000;
 /**

--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -1,20 +1,18 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
+import {DetailsContent} from '@atb/fare-contracts';
 import {
   findReferenceDataById,
   isOfFareProductRef,
 } from '@atb/reference-data/utils';
+import {useApplePassPresentationSuppression} from '@atb/suppress-pass-presentation';
 import {StyleSheet} from '@atb/theme';
 import {useTicketingState} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {useInterval} from '@atb/utils/use-interval';
-import {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {ScrollView, View} from 'react-native';
-import {DetailsContent} from '@atb/fare-contracts';
 import {RootStackScreenProps} from '../stacks-hierarchy/navigation-types';
-import {useApplePassPresentationSuppression} from '@atb/suppress-pass-presentation';
-import DeviceBrightness from '@adrianso/react-native-device-brightness';
-import Bugsnag from '@bugsnag/react-native';
 
 type Props = RootStackScreenProps<'Root_FareContractDetailsScreen'>;
 
@@ -28,7 +26,6 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
   const {t} = useTranslation();
 
   useApplePassPresentationSuppression();
-  useScreenBrightnessIncrease();
 
   const {preassignedFareProducts} = useFirestoreConfiguration();
   const preassignedFareProduct = findReferenceDataById(
@@ -64,30 +61,6 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
       </ScrollView>
     </View>
   );
-}
-
-function useScreenBrightnessIncrease() {
-  useEffect(function () {
-    let originalBrightness = 0.5;
-    async function setLevel() {
-      try {
-        originalBrightness = await DeviceBrightness.getBrightnessLevel();
-        DeviceBrightness.setBrightnessLevel(1);
-      } catch (e) {
-        Bugsnag.leaveBreadcrumb(`Failed to set brightness.`);
-      }
-    }
-
-    setLevel();
-
-    return () => {
-      try {
-        DeviceBrightness.setBrightnessLevel(originalBrightness);
-      } catch (e) {
-        Bugsnag.leaveBreadcrumb(`Failed to reset brightness.`);
-      }
-    };
-  }, []);
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@adrianso/react-native-device-brightness@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@adrianso/react-native-device-brightness/-/react-native-device-brightness-1.2.7.tgz#46905d0358c4f6dce5c88eb51882f528cc716f60"
+  integrity sha512-q3OTFGohAh04R8cBka7/eNXaeSD8bAZocMsifLIR3oDF5N9cNH2UVEjzJaFXW8DHFEsODpljpT+eyGWIhKlkow==
+
 "@ampproject/remapping@^2.1.0":
   version "2.1.1"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz"


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/9404

This _SHOULD_ adjust brightness when opening the screen for control to read the QR code better. In many cases the screen is too dark to read properly, and instead of having users adjust it manually we temporary try to adjust brightness when opening screen for inspection.

## Important

- This is impossible to test on simulator and emulator. We need to find a way to test this on the device and see if it works and if it is feasible. 
- The dependency used here seems old and not very well maintained. However, there is no other alternative and for now the implementation seems so simple and straightforward that our own implementation would be the same. So reducing administrative overhead and resisting the urge of "not invented here"-isms. I decided to propose this package.
- We MIGHT need permissions on Android. It hard to say without testing as some documentations differ.