### PR TITLE
docs: add chore as a changelog type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ First line is mandatory, but `scope` is optional. `scope` can be anything to gro
 - `refactor:` A code change that neither fixes a bug nor adds a feature
 - `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - `test:` Adding missing tests or correcting existing tests
+- `chore:` Other changes that don't modify src or test files
 
 **([from Angular preset](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type))**
 


### PR DESCRIPTION
Based on observations of "chore: " being used as a type in changelogs, I suggest including it in our file for contributions. It is even part of the example below in the file 🙈 
This is based on the description of conventional commits: https://github.com/commitizen/conventional-commit-types/blob/master/index.json 