### PR TITLE
fix: screen reader and slider on ticket assistant

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
@@ -57,7 +57,7 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
           title={title}
           description={description}
           accessibilityLabel={accessibilityLabel}
-          showInfoTag={'new'}
+          infoTag={'new'}
         />
       )}
     </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile.tsx
@@ -27,9 +27,7 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
   const title = t(TicketingTexts.ticketAssistantTile.title);
   const description = t(TicketingTexts.ticketAssistantTile.description);
 
-  const accessibilityLabel = [title, 'Beta', description].join(
-    screenReaderPause,
-  );
+  const accessibilityLabel = [title, description].join(screenReaderPause);
 
   const {fareProductTypeConfigs, preassignedFareProducts} =
     useFirestoreConfiguration();
@@ -59,7 +57,7 @@ export const TicketAssistantTile: React.FC<TicketAssistantProps> = ({
           title={title}
           description={description}
           accessibilityLabel={accessibilityLabel}
-          showBetaTag={true}
+          showInfoTag={'new'}
         />
       )}
     </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -25,7 +25,7 @@ export const TicketingTile = ({
   title,
   description,
   accessibilityLabel,
-  showInfoTag = undefined,
+  infoTag,
 }: {
   accented?: boolean;
   onPress: () => void;
@@ -35,7 +35,7 @@ export const TicketingTile = ({
   title?: string;
   description?: string;
   accessibilityLabel?: string;
-  showInfoTag?: 'new' | 'beta';
+  infoTag?: 'new' | 'beta';
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
@@ -71,9 +71,9 @@ export const TicketingTile = ({
     >
       <View style={styles.spreadContent} testID={testID}>
         <View style={styles.contentContainer}>
-          {showInfoTag && (
+          {infoTag && (
             <View style={styles.betaTagContainer}>
-              <InfoTag mode={showInfoTag} style={styles.betaTag} />
+              <InfoTag mode={infoTag} style={styles.betaTag} />
             </View>
           )}
           <ThemeText

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -25,7 +25,7 @@ export const TicketingTile = ({
   title,
   description,
   accessibilityLabel,
-  showBetaTag = false,
+  showInfoTag = undefined,
 }: {
   accented?: boolean;
   onPress: () => void;
@@ -35,7 +35,7 @@ export const TicketingTile = ({
   title?: string;
   description?: string;
   accessibilityLabel?: string;
-  showBetaTag?: boolean;
+  showInfoTag?: 'new' | 'beta';
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
@@ -71,9 +71,9 @@ export const TicketingTile = ({
     >
       <View style={styles.spreadContent} testID={testID}>
         <View style={styles.contentContainer}>
-          {showBetaTag && (
+          {showInfoTag && (
             <View style={styles.betaTagContainer}>
-              <InfoTag mode="new" style={styles.betaTag} />
+              <InfoTag mode={showInfoTag} style={styles.betaTag} />
             </View>
           )}
           <ThemeText

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_FrequencyScreen.tsx
@@ -119,30 +119,26 @@ export const TicketAssistant_FrequencyScreen = ({
           ) : (
             <View>
               <View style={styles.sliderContainer}>
-                <View style={styles.horizontalLine}>
-                  {numbersAsStrings.map((number) => {
-                    return (
-                      <View key={number} style={styles.numberContainer}>
-                        <ThemeText
-                          key={number}
-                          style={styles.number}
-                          type={'body__primary'}
-                          color={themeColor}
-                          numberOfLines={1}
-                          ellipsizeMode={'clip'}
-                        >
-                          {number}
-                        </ThemeText>
-                      </View>
-                    );
-                  })}
-                </View>
                 <Slider
                   containerStyle={styles.slider}
                   maximumValue={sliderMax}
                   minimumValue={2}
                   step={1}
                   value={sliderValue}
+                  trackMarks={numbers}
+                  trackMarkComponent={(index) => {
+                    return (
+                      <ThemeText
+                        style={{
+                          top: -30,
+                          textAlign: 'center',
+                          minWidth: 20,
+                        }}
+                      >
+                        {numbersAsStrings[index]}
+                      </ThemeText>
+                    );
+                  }}
                   onValueChange={(value) => {
                     setSliderValue(value);
                   }}
@@ -195,8 +191,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   sliderContainer: {
     width: '100%',
     backgroundColor: theme.static.background.background_0.background,
-    paddingVertical: theme.spacings.medium,
-    paddingHorizontal: theme.spacings.medium,
+    paddingBottom: theme.spacings.medium,
+    paddingTop: theme.spacings.large,
+    paddingHorizontal: theme.spacings.large,
     borderRadius: theme.border.radius.regular,
   },
   slider: {
@@ -242,18 +239,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     alignSelf: 'center',
     paddingHorizontal: theme.spacings.medium,
   },
-  numberContainer: {
-    width: 30,
-    alignContent: 'center',
-    flexShrink: 1,
-  },
-  number: {
-    width: '100%',
-    textAlign: 'center',
-    flexWrap: 'nowrap',
-    color: theme.text.colors.primary,
-  },
-
   travelText: {
     width: '100%',
     textAlign: 'center',

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/TicketSummary.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketSummary/TicketSummary.tsx
@@ -1,6 +1,6 @@
 import {View} from 'react-native';
 import {TransportModes} from '@atb/components/transportation-modes';
-import {ThemeText} from '@atb/components/text';
+import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {TicketAssistantTexts, useTranslation} from '@atb/translations';
 import {InfoChip} from '@atb/components/info-chip';
 import {themeColor} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_WelcomeScreen';
@@ -85,6 +85,10 @@ export const TicketSummary = () => {
           })
       : TicketAssistantTexts.summary.singleTicketNotice,
   );
+  const perTripAndSavingsAccessibilityLabel = [
+    perTripPriceString,
+    savingsText,
+  ].join(screenReaderPause);
 
   const a11ySummary = t(
     TicketAssistantTexts.summary.ticketSummaryA11yLabel({
@@ -159,7 +163,7 @@ export const TicketSummary = () => {
         type={'body__secondary'}
         style={styles.savingsText}
         color={themeColor}
-        accessibilityLabel={savingsText}
+        accessibilityLabel={perTripAndSavingsAccessibilityLabel}
       >
         {perTripPriceString}
         {'\n'}


### PR DESCRIPTION
[Comment #1](https://github.com/AtB-AS/kundevendt/issues/4240#issuecomment-1756871312)
[Comment #2](https://github.com/AtB-AS/kundevendt/issues/4240#issuecomment-1756876653)

Changes:
- InfoTag on TicketingTile can now be new or beta
- Removed Beta from accessibilityLabel on TicketAssistantTile
- Added line to accessibilityLabel on recommended ticket summary
- Now using track marks for numbers on slider to ensure correct position

Numbers now overflow, but is visible on larger text. Can't move numbers, as they must align with the slider. Was decided that this is better than cutoff with @HanneLH:
<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/c7198cd2-3cbd-4e30-9c54-dbaacab996a5"/>
