### PR TITLE
fix: fix consistent use of favourite

### DIFF
--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -126,7 +126,7 @@ const DeparturesTexts = {
     ),
     noFavouritesWidget: _(
       'Du har ingen favorittavganger. \nTrykk “Legg til favorittavgang” for å lagre en avgang du bruker ofte.',
-      'You have no favorite departures. \nPress “Add favorite departure” to save a frequently used departure.',
+      'You have no favourite departures. \nPress “Add favourite departure” to save a frequently used departure.',
       'Du har ingen favorittavgangar. \nTrykk "Legg til favorittavgang" for å lagre ein avgang du brukar ofte.',
     ),
     emptyResult: _(

--- a/src/translations/screens/subscreens/FavoriteDepartures.ts
+++ b/src/translations/screens/subscreens/FavoriteDepartures.ts
@@ -13,7 +13,7 @@ const FavoriteDeparturesTexts = {
   favoriteItemAdd: {
     label: _(
       'Legg til favorittavgang',
-      'Add favorite departure',
+      'Add favourite departure',
       'Legg til favorittavgang',
     ),
     a11yHint: _(

--- a/src/translations/screens/subscreens/SelectFavouriteDeparturesTexts.ts
+++ b/src/translations/screens/subscreens/SelectFavouriteDeparturesTexts.ts
@@ -48,7 +48,7 @@ const SelectFavouriteDeparturesText = {
   edit_button: {
     text: _(
       'Rediger favorittavganger',
-      'Edit favorite departures',
+      'Edit favourite departures',
       'Rediger favorittavgangar',
     ),
     a11yhint: _(


### PR DESCRIPTION
This will not change domain language/code language to be consistent with UK English in regards to favorite vs favourite. And we should discuss if translation language convention is the same as code language. It isn't automatically the same.

This just fixes 3 specific places in translations where it still said favorite.

Fixes https://github.com/AtB-AS/kundevendt/issues/9424