### PR TITLE
fix(nfk): Remove tram/tog for message in harbor zones

### DIFF
--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -191,4 +191,11 @@ export default orgSpecificTranslations(PurchaseConfirmationTexts, {
       },
     },
   },
+  nfk: {
+    validityTexts: {
+      harbor: {
+        messageInHarborZones: _('', '', ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
Tickets not valid on bus. 

Fixes https://github.com/AtB-AS/kundevendt/issues/8894


Only affects NFK