### PR TITLE
fix: increase qr code size

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -258,7 +258,7 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
   if (!qrCodeSvg) return null;
 
   return (
-    <GenericSectionItem>
+    <GenericSectionItem type="compact">
       <View
         style={[styles.aztecCode, styles.staticQrCode]}
         accessible={true}
@@ -279,8 +279,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: '#FFFFFF',
   },
   staticQrCode: {
-    width: '80%',
-    marginLeft: 'auto',
-    marginRight: 'auto',
+    padding: 0,
   },
 }));

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -16,7 +16,6 @@ import {
   isTravelCardToken,
 } from '@atb/mobile-token/utils';
 import {FareContract} from '@atb/ticketing';
-import {GenericSectionItem} from '@atb/components/sections';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import QRCode from 'qrcode';
 import {renderAztec} from '@entur-private/abt-mobile-barcode-javascript-lib';
@@ -145,18 +144,16 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
   }
 
   return (
-    <GenericSectionItem>
-      <View style={{alignItems: 'center'}}>
-        <View
-          style={styles.aztecCode}
-          accessible={true}
-          accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
-          testID="mobileTokenBarcode"
-        >
-          <SvgXml xml={aztecXml} width="100%" height="100%" />
-        </View>
+    <View style={{alignItems: 'center'}}>
+      <View
+        style={styles.aztecCode}
+        accessible={true}
+        accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+        testID="mobileTokenBarcode"
+      >
+        <SvgXml xml={aztecXml} width="100%" height="100%" />
       </View>
-    </GenericSectionItem>
+    </View>
   );
 };
 
@@ -193,27 +190,23 @@ const DeviceNotInspectable = () => {
         ),
       );
   return (
-    <GenericSectionItem>
-      <MessageBox
-        type={'warning'}
-        title={t(
-          FareContractTexts.details.barcodeErrors.notInspectableDevice.title,
-        )}
-        message={message}
-        isMarkdown={true}
-      />
-    </GenericSectionItem>
+    <MessageBox
+      type={'warning'}
+      title={t(
+        FareContractTexts.details.barcodeErrors.notInspectableDevice.title,
+      )}
+      message={message}
+      isMarkdown={true}
+    />
   );
 };
 
 const LoadingBarcode = () => {
   const {theme} = useTheme();
   return (
-    <GenericSectionItem>
-      <View style={{flex: 1}}>
-        <ActivityIndicator animating={true} color={theme.text.colors.primary} />
-      </View>
-    </GenericSectionItem>
+    <View style={{flex: 1}}>
+      <ActivityIndicator animating={true} color={theme.text.colors.primary} />
+    </View>
   );
 };
 
@@ -231,16 +224,14 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
   if (!aztecXml) return null;
 
   return (
-    <GenericSectionItem>
-      <View
-        style={styles.aztecCode}
-        accessible={true}
-        accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
-        testID="staticBarcode"
-      >
-        <SvgXml xml={aztecXml} width="100%" height="100%" />
-      </View>
-    </GenericSectionItem>
+    <View
+      style={styles.aztecCode}
+      accessible={true}
+      accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+      testID="staticBarcode"
+    >
+      <SvgXml xml={aztecXml} width="100%" height="100%" />
+    </View>
   );
 };
 
@@ -258,16 +249,14 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
   if (!qrCodeSvg) return null;
 
   return (
-    <GenericSectionItem type="compact">
-      <View
-        style={[styles.aztecCode, styles.staticQrCode]}
-        accessible={true}
-        accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
-        testID="staticQRCode"
-      >
-        <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
-      </View>
-    </GenericSectionItem>
+    <View
+      style={[styles.aztecCode, styles.staticQrCode]}
+      accessible={true}
+      accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+      testID="staticQRCode"
+    >
+      <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
+    </View>
   );
 };
 


### PR DESCRIPTION
See the description and problem at https://github.com/AtB-AS/kundevendt/issues/12080

This only changes the size of Static QR (which FRAM also uses for all QRs as of now)

Don't know if there is a specific reason as to why it is small (other than taking a lot of visual space ofc).

## Changes from
![Screenshot 2023-10-13 at 15 39 26](https://github.com/AtB-AS/mittatb-app/assets/606374/bd00b691-05b1-4b02-9504-cf2cc07cdc31)


## To
![Screenshot 2023-10-13 at 15 39 18](https://github.com/AtB-AS/mittatb-app/assets/606374/23548faa-1c93-4da8-851b-facf1b58eb34)





Fixes https://github.com/AtB-AS/kundevendt/issues/12080
