### PR TITLE
fix: shows warning when logging in with active tickets

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
@@ -1,7 +1,11 @@
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import React from 'react';
 import {AnonymousPurchaseConsequencesScreenComponent} from '@atb/anonymous-purchase-consequences-screen';
-import {RootStackScreenProps} from './navigation-types';
+import {RootStackParamList, RootStackScreenProps} from './navigation-types';
+import {
+  filterActiveOrCanBeUsedFareContracts,
+  useTicketingState,
+} from '@atb/ticketing';
 
 type Props = RootStackScreenProps<'Root_PurchaseAsAnonymousConsequencesScreen'>;
 
@@ -10,29 +14,23 @@ export const Root_PurchaseAsAnonymousConsequencesScreen = ({
 }: Props) => {
   const {enable_vipps_login} = useRemoteConfig();
 
+  const {fareContracts} = useTicketingState();
+  const activeFareContracts =
+    filterActiveOrCanBeUsedFareContracts(fareContracts);
+  const hasActiveFareContracts = activeFareContracts.length > 0;
+
   return (
     <AnonymousPurchaseConsequencesScreenComponent
-      onPressLogin={() =>
-        navigation.navigate(
-          enable_vipps_login
-            ? 'Root_LoginOptionsScreen'
-            : 'Root_LoginPhoneInputScreen',
-          {
-            afterLogin: {
-              screen: 'Root_TabNavigatorStack',
-              params: {
-                screen: 'TabNav_TicketingStack',
-                params: {
-                  screen: 'Ticketing_RootScreen',
-                  params: {
-                    screen: 'TicketTabNav_PurchaseTabScreen',
-                  },
-                },
-              },
-            },
-          },
-        )
-      }
+      onPressLogin={() => {
+        let screen: keyof RootStackParamList = 'Root_LoginPhoneInputScreen';
+        if (hasActiveFareContracts) {
+          screen = 'Root_LoginActiveFareContractWarningScreen';
+        } else if (enable_vipps_login) {
+          screen = 'Root_LoginOptionsScreen';
+        }
+
+        return navigation.navigate(screen, {});
+      }}
       onPressContinueWithoutLogin={navigation.goBack}
       showHeader={true}
     />


### PR DESCRIPTION
When logging in with active tickets we don't show a warning if we navigate using the warning box on the ticket view. This is causing some issues for FRAM where people don't know they'll lose their tickets.

This solves it in the same way as it is solved for login button on Profile page. It doesn't solve the same direct navigation as before if vipps is not activated. Don't know if this is needed?

Also, not an ideal solution as such, you create some nested stacks here that might not seem like an optimal flow. Might also add the warning on the step before showing why you should log in, but this is also kind of odd 🤔

This is just a quick proposal for me and we can discuss if this is the best way to solve it or not.

<details>
<summary>Screen recordings</summary>


https://github.com/AtB-AS/mittatb-app/assets/606374/cf552361-87d9-4796-9451-f644d5135b75


https://github.com/AtB-AS/mittatb-app/assets/606374/3f861b3d-9ce4-4648-9a2d-ad65416a2c8c



</details>