### PR TITLE
feat: adds bottom sheet with isolated barcode on barcode press

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -241,7 +241,11 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
       accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
       testID="staticBarcode"
     >
-      <PressableOpacity onPress={onOpenBarcodePress}>
+      <PressableOpacity
+        onPress={onOpenBarcodePress}
+        accessibilityRole="button"
+        accessibilityHint={t(FareContractTexts.details.barcodeButtonA11yLabel)}
+      >
         <SvgXml xml={aztecXml} width="100%" height="100%" />
       </PressableOpacity>
     </View>
@@ -269,7 +273,11 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
       accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
       testID="staticQRCode"
     >
-      <PressableOpacity onPress={onOpenBarcodePress}>
+      <PressableOpacity
+        onPress={onOpenBarcodePress}
+        accessibilityRole="button"
+        accessibilityHint={t(FareContractTexts.details.barcodeButtonA11yLabel)}
+      >
         <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
       </PressableOpacity>
     </View>

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -1,27 +1,37 @@
+import DeviceBrightness from '@adrianso/react-native-device-brightness';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {
+  BottomSheetContainer,
+  useBottomSheet,
+} from '@atb/components/bottom-sheet';
+import {MessageBox} from '@atb/components/message-box';
+import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
 import {ValidityStatus} from '@atb/fare-contracts/utils';
-import {ActivityIndicator, View} from 'react-native';
-import {FareContractTexts, useTranslation} from '@atb/translations';
-import {SvgXml} from 'react-native-svg';
-import React, {useEffect, useState} from 'react';
-import {StyleSheet, useTheme} from '@atb/theme';
 import {
   useHasEnabledMobileToken,
   useMobileTokenContextState,
 } from '@atb/mobile-token/MobileTokenContext';
-import {useInterval} from '@atb/utils/use-interval';
-import {MessageBox} from '@atb/components/message-box';
 import {
   findInspectable,
   getDeviceName,
   isTravelCardToken,
 } from '@atb/mobile-token/utils';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {FareContract} from '@atb/ticketing';
-import {useRemoteConfig} from '@atb/RemoteConfigContext';
-import QRCode from 'qrcode';
-import {renderAztec} from '@entur-private/abt-mobile-barcode-javascript-lib';
-import DeviceBrightness from '@adrianso/react-native-device-brightness';
-import Bugsnag from '@bugsnag/react-native';
+import {
+  FareContractTexts,
+  ScreenHeaderTexts,
+  useTranslation,
+} from '@atb/translations';
+import {useInterval} from '@atb/utils/use-interval';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import Bugsnag from '@bugsnag/react-native';
+import {renderAztec} from '@entur-private/abt-mobile-barcode-javascript-lib';
+import QRCode from 'qrcode';
+import React, {useEffect, useState} from 'react';
+import {ActivityIndicator, View} from 'react-native';
+import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {SvgXml} from 'react-native-svg';
 
 type Props = {
   validityStatus: ValidityStatus;
@@ -214,6 +224,7 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
   const styles = useStyles();
   const {t} = useTranslation();
   const [aztecXml, setAztecXml] = useState<string>();
+  const onOpenBarcodePress = useStaticBarcodeBottomSheet(aztecXml);
 
   useEffect(() => {
     if (fc.qrCode) {
@@ -230,7 +241,9 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
       accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
       testID="staticBarcode"
     >
-      <SvgXml xml={aztecXml} width="100%" height="100%" />
+      <PressableOpacity onPress={onOpenBarcodePress}>
+        <SvgXml xml={aztecXml} width="100%" height="100%" />
+      </PressableOpacity>
     </View>
   );
 };
@@ -239,6 +252,7 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
   const styles = useStyles();
   const {t} = useTranslation();
   const [qrCodeSvg, setQrCodeSvg] = useState<string>();
+  const onOpenBarcodePress = useStaticBarcodeBottomSheet(qrCodeSvg);
 
   useEffect(() => {
     if (fc.qrCode) {
@@ -250,12 +264,14 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
 
   return (
     <View
-      style={[styles.aztecCode, styles.staticQrCode]}
+      style={[styles.aztecCode, styles.staticQrCode, styles.staticQrCodeSmall]}
       accessible={true}
       accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
       testID="staticQRCode"
     >
-      <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
+      <PressableOpacity onPress={onOpenBarcodePress}>
+        <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
+      </PressableOpacity>
     </View>
   );
 };
@@ -267,7 +283,58 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     padding: theme.spacings.large,
     backgroundColor: '#FFFFFF',
   },
+  staticBottomContainer: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
   staticQrCode: {
     padding: 0,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    maxWidth: 300,
+  },
+  staticQrCodeSmall: {
+    maxWidth: 200,
   },
 }));
+
+function useStaticBarcodeBottomSheet(qrCodeSvg: string | undefined) {
+  const styles = useStyles();
+  const {t} = useTranslation();
+
+  const {
+    open: openBottomSheet,
+    close: closeBottomSheet,
+    onOpenFocusRef,
+  } = useBottomSheet();
+
+  const onOpenBarcodePress = () => {
+    openBottomSheet(() => (
+      <BottomSheetContainer testID="barcodeBottomSheet" fullHeight>
+        <ScreenHeaderWithoutNavigation
+          title={t(FareContractTexts.details.bottomSheetTitle)}
+          color="background_1"
+          leftButton={{
+            text: t(ScreenHeaderTexts.headerButton.close.text),
+            type: 'close',
+            onPress: closeBottomSheet,
+          }}
+        />
+
+        <View style={styles.staticBottomContainer}>
+          <View
+            ref={onOpenFocusRef}
+            style={[styles.aztecCode, styles.staticQrCode]}
+            accessible={true}
+            accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+            testID="staticQRCode"
+          >
+            <SvgXml xml={qrCodeSvg ?? ''} width="100%" height="100%" />
+          </View>
+        </View>
+      </BottomSheetContainer>
+    ));
+  };
+
+  return onOpenBarcodePress;
+}

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -87,6 +87,11 @@ const FareContractTexts = {
       'Barcode. Show this code in case of inspection. ',
       'Barkode. Vis denne koden ved billettkontroll.',
     ),
+    barcodeButtonA11yLabel: _(
+      'Vis stor barkode for enklere avlesing.',
+      'Show larger barcode for better validation',
+      'Vis stor strekkode for enklare avlesing.',
+    ),
     bottomSheetTitle: _('Barkode', 'Barcode', 'Barkode'),
     barcodeErrors: {
       notInspectableDevice: {

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -87,6 +87,7 @@ const FareContractTexts = {
       'Barcode. Show this code in case of inspection. ',
       'Barkode. Vis denne koden ved billettkontroll.',
     ),
+    bottomSheetTitle: _('Barkode', 'Barcode', 'Barkode'),
     barcodeErrors: {
       notInspectableDevice: {
         title: _('Barkode', 'Barcode', 'Barkode'),


### PR DESCRIPTION
After more insights into troubles with reading barcodes using the FLV+, I think the problem isn't the size itself, but also that the device isn't able to separate the QR code from the rest on the page. We have reports even that in some cases the barcode is too big.

Also there is problem with the FLV+ on dark mode. So for the bottom sheet here, in addition to increasing screen brightness I set the entire background to white no matter what theme you use.

Users of the existing app for FRAM are used to being able to press the QR code to see it bigger, even though this is kind of a hidden feature here. But there is existing work on improving visual inspection and restructuring this page where the QR code is smaller, so I think this is OK until that feature gets worked on.

I only added the bottom sheet for static codes, as the bottom sheet doesn't respond well to changes and for FRAM using barcode validation we won't be using mobile token before the entire screen is redesigned.

Fixes https://github.com/AtB-AS/kundevendt/issues/12080 (again)

See demo video:


https://github.com/AtB-AS/mittatb-app/assets/606374/88718c0f-64c2-4512-8db9-2021ccb3d72a

