### PR TITLE
refactor: Improve loading state code and add tests

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -3,4 +3,5 @@ export type {
   ConfirmationErrorCode,
   PhoneSignInErrorCode,
   VippsSignInErrorCode,
+  AuthStatus,
 } from './types';

--- a/src/loading-screen/LoadingErrorScreen.tsx
+++ b/src/loading-screen/LoadingErrorScreen.tsx
@@ -57,7 +57,13 @@ export const LoadingErrorScreen = React.memo(({retry}: {retry: () => void}) => {
         <View>
           <Button
             text={t(dictionary.retry)}
-            onPress={retry}
+            onPress={() => {
+              analytics.logEvent(
+                'Loading boundary',
+                'Retry app loading clicked',
+              );
+              retry();
+            }}
             testID="retryAuthButton"
           />
           <Button

--- a/src/loading-screen/LoadingScreenBoundary.tsx
+++ b/src/loading-screen/LoadingScreenBoundary.tsx
@@ -5,7 +5,7 @@ import {useLoadingScreenEnabled} from '@atb/loading-screen/use-loading-screen-en
 import {useDelayGate} from '@atb/utils/use-delay-gate';
 import {useLoadingErrorScreenEnabled} from '@atb/loading-screen/use-loading-error-screen-enabled';
 import {useLoadingState} from '@atb/loading-screen/use-loading-state';
-import {useLogEventOnTimeout} from '@atb/loading-screen/use-log-event-on-timeout';
+import {useLogEventOnTimeoutStatus} from '@atb/loading-screen/use-log-event-on-timeout-status';
 
 const LOADING_TIMEOUT_MS = 10000;
 
@@ -17,7 +17,7 @@ export const LoadingScreenBoundary = ({
   const loadingScreenEnabled = useLoadingScreenEnabled();
   const errScreenEnabled = useLoadingErrorScreenEnabled();
   const {status, retry, paramsRef} = useLoadingState(LOADING_TIMEOUT_MS);
-  useLogEventOnTimeout(status, paramsRef);
+  useLogEventOnTimeoutStatus(status, paramsRef);
 
   // Wait one second after load success to let the app "settle".
   const waitFinished = useDelayGate(1000, status === 'success');

--- a/src/loading-screen/__tests__/use-loading-state.test.ts
+++ b/src/loading-screen/__tests__/use-loading-state.test.ts
@@ -104,6 +104,19 @@ describe('useLoadingState', () => {
     expect(hook.result.current.status).toBe('timeout');
   });
 
+  it('Should not go to timeout after timeout ms if state is success', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'loading'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(80));
+    expect(hook.result.current.status).toBe('loading');
+    mockState = {isLoadingAppState: false, authStatus: 'authenticated'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('success');
+    act(() => jest.advanceTimersByTime(50));
+    hook.rerender();
+    expect(hook.result.current.status).toBe('success');
+  });
+
   it('Should go to loading after retry', async () => {
     mockState = {isLoadingAppState: false, authStatus: 'loading'};
     const hook = renderHook(() => useLoadingState(100));

--- a/src/loading-screen/__tests__/use-loading-state.test.ts
+++ b/src/loading-screen/__tests__/use-loading-state.test.ts
@@ -1,8 +1,6 @@
 import {act, renderHook} from '@testing-library/react-hooks';
-import {
-  LoadingParams,
-  useLoadingState,
-} from '@atb/loading-screen/use-loading-state';
+import {useLoadingState} from '@atb/loading-screen/use-loading-state';
+import {LoadingParams} from "@atb/loading-screen/types";
 
 const DEFAULT_MOCK_STATE: LoadingParams = {
   isLoadingAppState: true,

--- a/src/loading-screen/__tests__/use-loading-state.test.ts
+++ b/src/loading-screen/__tests__/use-loading-state.test.ts
@@ -1,0 +1,152 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import {
+  LoadingParams,
+  useLoadingState,
+} from '@atb/loading-screen/use-loading-state';
+
+const DEFAULT_MOCK_STATE: LoadingParams = {
+  isLoadingAppState: true,
+  authStatus: 'loading',
+};
+
+let mockState = DEFAULT_MOCK_STATE;
+
+let mockRetryAuthInvoked = false;
+
+jest.mock('@atb/auth', () => ({
+  useAuthState: () => ({
+    authStatus: mockState.authStatus,
+    retryAuth: () => {
+      mockRetryAuthInvoked = true;
+    },
+  }),
+}));
+jest.mock('@atb/AppContext', () => ({
+  useAppState: () => ({isLoading: mockState.isLoadingAppState}),
+}));
+
+describe('useLoadingState', () => {
+  beforeAll(() => jest.useFakeTimers());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+
+    mockState = DEFAULT_MOCK_STATE;
+    mockRetryAuthInvoked = false;
+  });
+  afterAll(() => jest.useRealTimers());
+
+  it('Should give loading', async () => {
+    const hook = renderHook(() => useLoadingState(100));
+    expect(hook.result.current.status).toBe('loading');
+
+    mockState = {isLoadingAppState: false, authStatus: 'loading'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('loading');
+
+    mockState = {isLoadingAppState: true, authStatus: 'authenticated'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('loading');
+  });
+
+  it('Should give timeout after given ms', async () => {
+    const hook_100ms = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(90));
+    expect(hook_100ms.result.current.status).toBe('loading');
+    act(() => jest.advanceTimersByTime(20));
+    expect(hook_100ms.result.current.status).toBe('timeout');
+
+    const hook_300ms = renderHook(() => useLoadingState(300));
+    act(() => jest.advanceTimersByTime(290));
+    expect(hook_300ms.result.current.status).toBe('loading');
+    act(() => jest.advanceTimersByTime(20));
+    expect(hook_300ms.result.current.status).toBe('timeout');
+  });
+
+  it('Should give success', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'authenticated'};
+    const hook = renderHook(() => useLoadingState(100));
+    expect(hook.result.current.status).toBe('success');
+  });
+
+  it('Should go from loading to success', async () => {
+    const hook = renderHook(() => useLoadingState(100));
+    expect(hook.result.current.status).toBe('loading');
+    act(() => jest.advanceTimersByTime(50));
+    mockState = {isLoadingAppState: false, authStatus: 'authenticated'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('success');
+  });
+
+  it('Should go from timeout to success', async () => {
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    expect(hook.result.current.status).toBe('timeout');
+    mockState = {isLoadingAppState: false, authStatus: 'authenticated'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('success');
+  });
+
+  it('Should go from success to loading', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'authenticated'};
+    const hook = renderHook(() => useLoadingState(100));
+    expect(hook.result.current.status).toBe('success');
+    mockState = {isLoadingAppState: true, authStatus: 'authenticated'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('loading');
+  });
+
+  it('Should not go from timeout to loading', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'loading'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    expect(hook.result.current.status).toBe('timeout');
+    mockState = {isLoadingAppState: true, authStatus: 'loading'};
+    hook.rerender();
+    expect(hook.result.current.status).toBe('timeout');
+  });
+
+  it('Should go to loading after retry', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'loading'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    expect(hook.result.current.status).toBe('timeout');
+    act(() => hook.result.current.retry());
+    expect(hook.result.current.status).toBe('loading');
+  });
+
+  it('Should go to success after retry', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'loading'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    expect(hook.result.current.status).toBe('timeout');
+    mockState = {isLoadingAppState: false, authStatus: 'authenticated'};
+    act(() => hook.result.current.retry());
+    expect(hook.result.current.status).toBe('success');
+  });
+
+  it('Should not retry auth if auth status is loading', async () => {
+    mockState = {isLoadingAppState: true, authStatus: 'creating-account'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => hook.result.current.retry());
+    expect(mockRetryAuthInvoked).toBe(false);
+  });
+
+  it('Should retry auth if auth status is not authenticated', async () => {
+    mockState = {isLoadingAppState: false, authStatus: 'creating-account'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    expect(hook.result.current.status).toBe('timeout');
+    act(() => hook.result.current.retry());
+    expect(mockRetryAuthInvoked).toBe(true);
+  });
+
+  it('Should not retry auth if auth status is authenticated', async () => {
+    mockState = {isLoadingAppState: true, authStatus: 'authenticated'};
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    expect(hook.result.current.status).toBe('timeout');
+    act(() => hook.result.current.retry());
+    expect(mockRetryAuthInvoked).toBe(false);
+  });
+});

--- a/src/loading-screen/__tests__/use-log-event-on-timeout.test.ts
+++ b/src/loading-screen/__tests__/use-log-event-on-timeout.test.ts
@@ -1,6 +1,6 @@
 import {renderHook} from '@testing-library/react-hooks';
 import {LoadingParams, LoadingStatus} from '@atb/loading-screen/types';
-import {useLogEventOnTimeout} from '@atb/loading-screen/use-log-event-on-timeout';
+import {useLogEventOnTimeoutStatus} from '@atb/loading-screen/use-log-event-on-timeout-status';
 import React, {MutableRefObject} from 'react';
 import {AnalyticsEventContext, useAnalytics} from '@atb/analytics';
 import jestExpect from 'expect';
@@ -23,7 +23,7 @@ jest.mock('@atb/analytics', () => ({
   useAnalytics: () => logEventMock,
 }));
 
-describe('useLogEventOnTimeout', () => {
+describe('useLogEventOnTimeoutStatus', () => {
   beforeAll(() => jest.useFakeTimers());
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,7 +34,7 @@ describe('useLogEventOnTimeout', () => {
 
   it('Should log event if status timeout', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    renderHook(() => useLogEventOnTimeout('timeout', ref));
+    renderHook(() => useLogEventOnTimeoutStatus('timeout', ref));
     expect(mockLoggedEvent).toEqual([
       jestExpect.anything(),
       jestExpect.anything(),
@@ -47,21 +47,24 @@ describe('useLogEventOnTimeout', () => {
 
   it('Should not log event if status loading', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    renderHook(() => useLogEventOnTimeout('loading', ref));
+    renderHook(() => useLogEventOnTimeoutStatus('loading', ref));
     expect(mockLoggedEvent).toEqual(undefined);
   });
 
   it('Should not log event if status success', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    renderHook(() => useLogEventOnTimeout('success', ref));
+    renderHook(() => useLogEventOnTimeoutStatus('success', ref));
     expect(mockLoggedEvent).toEqual(undefined);
   });
 
   it('Should log event on rerender if status changes to timeout', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    const hook = renderHook(({status}) => useLogEventOnTimeout(status, ref), {
-      initialProps: {status: 'loading' as LoadingStatus},
-    });
+    const hook = renderHook(
+      ({status}) => useLogEventOnTimeoutStatus(status, ref),
+      {
+        initialProps: {status: 'loading' as LoadingStatus},
+      },
+    );
     expect(mockLoggedEvent).toEqual(undefined);
     hook.rerender({status: 'timeout'});
     expect(mockLoggedEvent).toEqual([
@@ -76,7 +79,7 @@ describe('useLogEventOnTimeout', () => {
 
   it('Should not log event on rerender when no params change', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    const hook = renderHook(() => useLogEventOnTimeout('timeout', ref));
+    const hook = renderHook(() => useLogEventOnTimeoutStatus('timeout', ref));
     expect(mockLoggedEvent).toEqual([
       jestExpect.anything(),
       jestExpect.anything(),
@@ -92,9 +95,12 @@ describe('useLogEventOnTimeout', () => {
 
   it('Should log event with updated ref params', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    const hook = renderHook(({status}) => useLogEventOnTimeout(status, ref), {
-      initialProps: {status: 'loading' as LoadingStatus},
-    });
+    const hook = renderHook(
+      ({status}) => useLogEventOnTimeoutStatus(status, ref),
+      {
+        initialProps: {status: 'loading' as LoadingStatus},
+      },
+    );
     expect(mockLoggedEvent).toEqual(undefined);
     ref.current = {isLoadingAppState: true, authStatus: 'creating-account'};
     hook.rerender({status: 'timeout'});
@@ -110,7 +116,7 @@ describe('useLogEventOnTimeout', () => {
 
   it('Should not log event again when ref params change', async () => {
     const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
-    const hook = renderHook(() => useLogEventOnTimeout('timeout', ref));
+    const hook = renderHook(() => useLogEventOnTimeoutStatus('timeout', ref));
     expect(mockLoggedEvent).toEqual([
       jestExpect.anything(),
       jestExpect.anything(),

--- a/src/loading-screen/__tests__/use-log-event-on-timeout.test.ts
+++ b/src/loading-screen/__tests__/use-log-event-on-timeout.test.ts
@@ -1,0 +1,133 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {LoadingParams, LoadingStatus} from '@atb/loading-screen/types';
+import {useLogEventOnTimeout} from '@atb/loading-screen/use-log-event-on-timeout';
+import React, {MutableRefObject} from 'react';
+import {AnalyticsEventContext, useAnalytics} from '@atb/analytics';
+import jestExpect from 'expect';
+
+let mockLoggedEvent:
+  | Parameters<ReturnType<typeof useAnalytics>['logEvent']>
+  | undefined;
+
+const logEventMock = {
+  logEvent: (
+    ctx: AnalyticsEventContext,
+    event: string,
+    props?: {[key: string]: any},
+  ) => {
+    mockLoggedEvent = [ctx, event, props];
+  },
+};
+
+jest.mock('@atb/analytics', () => ({
+  useAnalytics: () => logEventMock,
+}));
+
+describe('useLogEventOnTimeout', () => {
+  beforeAll(() => jest.useFakeTimers());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    mockLoggedEvent = undefined;
+  });
+  afterAll(() => jest.useRealTimers());
+
+  it('Should log event if status timeout', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    renderHook(() => useLogEventOnTimeout('timeout', ref));
+    expect(mockLoggedEvent).toEqual([
+      jestExpect.anything(),
+      jestExpect.anything(),
+      jestExpect.objectContaining({
+        isLoadingAppState: true,
+        authStatus: 'loading',
+      }),
+    ]);
+  });
+
+  it('Should not log event if status loading', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    renderHook(() => useLogEventOnTimeout('loading', ref));
+    expect(mockLoggedEvent).toEqual(undefined);
+  });
+
+  it('Should not log event if status success', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    renderHook(() => useLogEventOnTimeout('success', ref));
+    expect(mockLoggedEvent).toEqual(undefined);
+  });
+
+  it('Should log event on rerender if status changes to timeout', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    const hook = renderHook(({status}) => useLogEventOnTimeout(status, ref), {
+      initialProps: {status: 'loading' as LoadingStatus},
+    });
+    expect(mockLoggedEvent).toEqual(undefined);
+    hook.rerender({status: 'timeout'});
+    expect(mockLoggedEvent).toEqual([
+      jestExpect.anything(),
+      jestExpect.anything(),
+      jestExpect.objectContaining({
+        isLoadingAppState: true,
+        authStatus: 'loading',
+      }),
+    ]);
+  });
+
+  it('Should not log event on rerender when no params change', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    const hook = renderHook(() => useLogEventOnTimeout('timeout', ref));
+    expect(mockLoggedEvent).toEqual([
+      jestExpect.anything(),
+      jestExpect.anything(),
+      jestExpect.objectContaining({
+        isLoadingAppState: true,
+        authStatus: 'loading',
+      }),
+    ]);
+    mockLoggedEvent = undefined;
+    hook.rerender();
+    expect(mockLoggedEvent).toEqual(undefined);
+  });
+
+  it('Should log event with updated ref params', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    const hook = renderHook(({status}) => useLogEventOnTimeout(status, ref), {
+      initialProps: {status: 'loading' as LoadingStatus},
+    });
+    expect(mockLoggedEvent).toEqual(undefined);
+    ref.current = {isLoadingAppState: true, authStatus: 'creating-account'};
+    hook.rerender({status: 'timeout'});
+    expect(mockLoggedEvent).toEqual([
+      jestExpect.anything(),
+      jestExpect.anything(),
+      jestExpect.objectContaining({
+        isLoadingAppState: true,
+        authStatus: 'creating-account',
+      }),
+    ]);
+  });
+
+  it('Should not log event again when ref params change', async () => {
+    const ref = createRef({isLoadingAppState: true, authStatus: 'loading'});
+    const hook = renderHook(() => useLogEventOnTimeout('timeout', ref));
+    expect(mockLoggedEvent).toEqual([
+      jestExpect.anything(),
+      jestExpect.anything(),
+      jestExpect.objectContaining({
+        isLoadingAppState: true,
+        authStatus: 'loading',
+      }),
+    ]);
+    mockLoggedEvent = undefined;
+    ref.current = {isLoadingAppState: true, authStatus: 'creating-account'};
+    hook.rerender();
+    expect(mockLoggedEvent).toEqual(undefined);
+  });
+});
+
+const createRef = (params: LoadingParams): MutableRefObject<LoadingParams> => {
+  const ref: MutableRefObject<LoadingParams | null> = React.createRef();
+  ref.current = params;
+  return ref as MutableRefObject<LoadingParams>;
+};

--- a/src/loading-screen/types.ts
+++ b/src/loading-screen/types.ts
@@ -1,0 +1,17 @@
+import {AuthStatus} from "@atb/auth";
+import {RefObject} from "react";
+
+export type LoadingStatus = 'loading' | 'success' | 'timeout';
+
+export type LoadingParams = {isLoadingAppState: boolean; authStatus: AuthStatus};
+
+export type LoadingState = {
+    status: LoadingStatus;
+    retry: () => void;
+    /**
+     The parameters used to deduce the loading status are returned as a ref object,
+     so they can be used in logging, error reporting etc. without causing
+     rerenders.
+     */
+    paramsRef: RefObject<LoadingParams>;
+};

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -7,9 +7,7 @@ import {LoadingState, LoadingStatus} from '@atb/loading-screen/types';
 export const useLoadingState = (timeoutMs: number): LoadingState => {
   const {isLoading: isLoadingAppState} = useAppState();
   const {authStatus, retryAuth} = useAuthState();
-
   const [status, setStatus] = useState<LoadingStatus>('loading');
-
   const paramsRef = useRef({isLoadingAppState, authStatus});
 
   useEffect(() => {
@@ -35,9 +33,5 @@ export const useLoadingState = (timeoutMs: number): LoadingState => {
     }
   }, [status, authStatus, retryAuth]);
 
-  return {
-    status,
-    retry,
-    paramsRef,
-  };
+  return {status, retry, paramsRef};
 };

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -1,23 +1,8 @@
 // import {useAnalytics} from '@atb/analytics';
 import {useAppState} from '@atb/AppContext';
 import {useAuthState} from '@atb/auth';
-import {RefObject, useCallback, useEffect, useRef, useState} from 'react';
-import {AuthStatus} from '@atb/auth/types';
-
-type LoadingStatus = 'loading' | 'success' | 'timeout';
-
-export type LoadingParams = {isLoadingAppState: boolean; authStatus: AuthStatus};
-
-type LoadingState = {
-  status: LoadingStatus;
-  retry: () => void;
-  /**
-   The parameters used to deduce the loading status are returned as a ref object,
-   so they can be used in logging, error reporting etc. without causing
-   rerenders.
-   */
-  paramsRef: RefObject<LoadingParams>;
-};
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {LoadingState, LoadingStatus} from '@atb/loading-screen/types';
 
 export const useLoadingState = (timeoutMs: number): LoadingState => {
   const {isLoading: isLoadingAppState} = useAppState();

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -1,0 +1,58 @@
+// import {useAnalytics} from '@atb/analytics';
+import {useAppState} from '@atb/AppContext';
+import {useAuthState} from '@atb/auth';
+import {RefObject, useCallback, useEffect, useRef, useState} from 'react';
+import {AuthStatus} from '@atb/auth/types';
+
+type LoadingStatus = 'loading' | 'success' | 'timeout';
+
+export type LoadingParams = {isLoadingAppState: boolean; authStatus: AuthStatus};
+
+type LoadingState = {
+  status: LoadingStatus;
+  retry: () => void;
+  /**
+   The parameters used to deduce the loading status are returned as a ref object,
+   so they can be used in logging, error reporting etc. without causing
+   rerenders.
+   */
+  paramsRef: RefObject<LoadingParams>;
+};
+
+export const useLoadingState = (timeoutMs: number): LoadingState => {
+  const {isLoading: isLoadingAppState} = useAppState();
+  const {authStatus, retryAuth} = useAuthState();
+
+  const [status, setStatus] = useState<LoadingStatus>('loading');
+
+  const paramsRef = useRef({isLoadingAppState, authStatus});
+
+  useEffect(() => {
+    if (!isLoadingAppState && authStatus === 'authenticated') {
+      setStatus('success');
+    } else {
+      setStatus((prev) => (prev === 'timeout' ? 'timeout' : 'loading'));
+    }
+    paramsRef.current = {isLoadingAppState, authStatus};
+  }, [isLoadingAppState, authStatus]);
+
+  useEffect(() => {
+    if (status === 'loading') {
+      const id = setTimeout(() => setStatus('timeout'), timeoutMs);
+      return () => clearTimeout(id);
+    }
+  }, [timeoutMs, status]);
+
+  const retry = useCallback(() => {
+    if (status !== 'loading') {
+      setStatus('loading');
+      if (authStatus !== 'authenticated') retryAuth();
+    }
+  }, [status, authStatus, retryAuth]);
+
+  return {
+    status,
+    retry,
+    paramsRef,
+  };
+};

--- a/src/loading-screen/use-log-event-on-timeout-status.ts
+++ b/src/loading-screen/use-log-event-on-timeout-status.ts
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 import {LoadingState} from '@atb/loading-screen/types';
 import {useAnalytics} from '@atb/analytics';
 
-export const useLogEventOnTimeout = (
+export const useLogEventOnTimeoutStatus = (
   status: LoadingState['status'],
   paramsRef: LoadingState['paramsRef'],
 ) => {

--- a/src/loading-screen/use-log-event-on-timeout.ts
+++ b/src/loading-screen/use-log-event-on-timeout.ts
@@ -1,0 +1,19 @@
+import {useEffect} from 'react';
+import {LoadingState} from '@atb/loading-screen/types';
+import {useAnalytics} from '@atb/analytics';
+
+export const useLogEventOnTimeout = (
+  status: LoadingState['status'],
+  paramsRef: LoadingState['paramsRef'],
+) => {
+  const analytics = useAnalytics();
+  useEffect(() => {
+    if (status === 'timeout') {
+      analytics.logEvent(
+        'Loading boundary',
+        'Loading boundary timeout',
+        paramsRef.current || undefined,
+      );
+    }
+  }, [analytics, status, paramsRef]);
+};


### PR DESCRIPTION
The previous code had a subtle bug, where the `isLoadingAppState` and `authStatus` were not in the dependency list of the `useCallback` setting up the timeout. This caused the event logged to PostHog to include the values as they were when the timeout was set up, and not the actual values when the timeout function was executed.
```ts
const setupLoadingTimeout = useCallback(() => {
    setDidTimeout(false);
    timeoutRef.current = setTimeout(() => {
      analytics.logEvent('Loading boundary', 'Loading boundary timeout', {
        isLoadingAppState,
        authStatus,
      });
      setDidTimeout(true);
    }, 10000);
  }, []); // <- Missing deps
```

It couldn't be resolved by just naively adding the values in the callback function dependency array, since that had other unwanted side effects. To solve this I did a refactoring of the code, and also created some unit tests to be more certain the code works as intended.