### PR TITLE
fix: Not use quay public code as leg public code

### DIFF
--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -216,9 +216,7 @@ export function isLegFlexibleTransport(leg: Leg): boolean {
   return !!leg.line?.flexibleLineType;
 }
 
-export function getPublicCodeFromLeg(leg: Leg): string {
-  return leg.fromPlace?.quay?.publicCode || leg.line?.publicCode || '';
-}
+export const getPublicCodeFromLeg = (leg: Leg) => leg.line?.publicCode || '';
 
 export function getLatestBookingDateFromLeg(leg: Leg): Date {
   const latestBookingTime = leg.bookingArrangements?.latestBookingTime; // e.g. '15:16:00'


### PR DESCRIPTION
### Background
https://mittatb.slack.com/archives/C0116FMPX4Y/p1698127130815159

The quay public code (like P2) should not be used as leg public
code, as it represents the quay number in a stop place with
numbered quays.

### Solution
When finding public code for the leg only use the line public code, and not the quay public code.

### Acceptance criteria
- [ ] All interchange texts should reference the line public code, and not quay public codes.


