### PR TITLE
feat: use interactive color on token toggle screen

### DIFF
--- a/src/components/radio/RadioBox.tsx
+++ b/src/components/radio/RadioBox.tsx
@@ -1,6 +1,5 @@
 import {View, ViewStyle} from 'react-native';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
-import {StaticColorByType} from '@atb/theme/colors';
 import {ThemeText} from '@atb/components/text';
 import {RadioIcon} from './RadioIcon';
 import React from 'react';
@@ -38,16 +37,19 @@ export function RadioBox({
   const {theme} = useTheme();
   const spacing = useSpacing(type);
 
-  const themeColor: StaticColorByType<'background'> = selected
-    ? 'background_accent_3'
-    : 'background_0';
+  const themeColor = selected
+    ? theme.interactive.interactive_2.active.text
+    : theme.interactive.interactive_2.default.text;
+  console.log('theme' + themeColor);
 
   return (
     <PressableOpacity
       style={[
         styles.container,
         {
-          backgroundColor: theme.static.background[themeColor].background,
+          backgroundColor: selected
+            ? theme.interactive.interactive_2.active.background
+            : theme.interactive.interactive_2.default.background,
           padding: spacing,
         },
         style,
@@ -65,7 +67,7 @@ export function RadioBox({
     >
       <ThemeText
         type="heading__title"
-        color={themeColor}
+        color={themeColor} //TODO: fix tsc
         style={{...styles.title, marginBottom: spacing}}
       >
         {title}

--- a/src/components/radio/RadioBox.tsx
+++ b/src/components/radio/RadioBox.tsx
@@ -1,4 +1,4 @@
-import {TextStyle, View, ViewStyle} from 'react-native';
+import {View, ViewStyle} from 'react-native';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {RadioIcon} from './RadioIcon';
@@ -40,9 +40,9 @@ export function RadioBox({
   const {theme} = useTheme();
   const spacing = useSpacing(type);
 
-  const {background: backgroundColor, text: textColor} =
+  const themeColor =
     theme.interactive[interactiveColor][selected ? 'active' : 'default'];
-  const styleText: TextStyle = {color: textColor};
+  const {background: backgroundColor, text: textColor} = themeColor;
 
   return (
     <PressableOpacity
@@ -67,14 +67,16 @@ export function RadioBox({
     >
       <ThemeText
         type="heading__title"
-        style={[{...styles.title, marginBottom: spacing}, styleText]}
+        color={themeColor}
+        style={{...styles.title, marginBottom: spacing}}
       >
         {title}
       </ThemeText>
       <View style={{...styles.icon, marginBottom: spacing}}>{icon}</View>
       <ThemeText
         type="body__secondary"
-        style={[{...styles.description, marginBottom: spacing}, styleText]}
+        color={themeColor}
+        style={{...styles.description, marginBottom: spacing}}
         accessible={false}
       >
         {description}

--- a/src/components/radio/RadioBox.tsx
+++ b/src/components/radio/RadioBox.tsx
@@ -1,9 +1,10 @@
-import {View, ViewStyle} from 'react-native';
+import {TextStyle, View, ViewStyle} from 'react-native';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {RadioIcon} from './RadioIcon';
 import React from 'react';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {InteractiveColor} from '@atb/theme/colors';
 
 type ContainerSizingType = 'compact' | 'standard' | 'spacious';
 
@@ -19,6 +20,7 @@ type Props = {
   onPress: () => void;
   style?: ViewStyle;
   testID?: string;
+  interactiveColor?: InteractiveColor;
 };
 export function RadioBox({
   title,
@@ -32,24 +34,22 @@ export function RadioBox({
   onPress,
   style,
   testID,
+  interactiveColor = 'interactive_2',
 }: Props) {
   const styles = useStyles();
   const {theme} = useTheme();
   const spacing = useSpacing(type);
 
-  const themeColor = selected
-    ? theme.interactive.interactive_2.active.text
-    : theme.interactive.interactive_2.default.text;
-  console.log('theme' + themeColor);
+  const {background: backgroundColor, text: textColor} =
+    theme.interactive[interactiveColor][selected ? 'active' : 'default'];
+  const styleText: TextStyle = {color: textColor};
 
   return (
     <PressableOpacity
       style={[
         styles.container,
         {
-          backgroundColor: selected
-            ? theme.interactive.interactive_2.active.background
-            : theme.interactive.interactive_2.default.background,
+          backgroundColor: backgroundColor,
           padding: spacing,
         },
         style,
@@ -67,16 +67,14 @@ export function RadioBox({
     >
       <ThemeText
         type="heading__title"
-        color={themeColor} //TODO: fix tsc
-        style={{...styles.title, marginBottom: spacing}}
+        style={[{...styles.title, marginBottom: spacing}, styleText]}
       >
         {title}
       </ThemeText>
       <View style={{...styles.icon, marginBottom: spacing}}>{icon}</View>
       <ThemeText
         type="body__secondary"
-        color={themeColor}
-        style={{...styles.description, marginBottom: spacing}}
+        style={[{...styles.description, marginBottom: spacing}, styleText]}
         accessible={false}
       >
         {description}
@@ -85,7 +83,7 @@ export function RadioBox({
         style={styles.radioIcon}
         testID={testID + (selected ? 'RadioChecked' : 'RadioNotChecked')}
       >
-        <RadioIcon checked={selected} color={themeColor} />
+        <RadioIcon checked={selected} color={textColor} />
       </View>
     </PressableOpacity>
   );

--- a/src/components/radio/RadioIcon.tsx
+++ b/src/components/radio/RadioIcon.tsx
@@ -11,7 +11,7 @@ export function RadioIcon({checked, color = 'primary'}: CheckedProps) {
   const styles = useStyles();
   const {theme} = useTheme();
 
-  const colorValue = color ? color : theme.text.colors.primary;
+  const colorValue = color ?? theme.text.colors.primary;
 
   return (
     <View style={[styles.radio, {borderColor: colorValue}]}>

--- a/src/components/radio/RadioIcon.tsx
+++ b/src/components/radio/RadioIcon.tsx
@@ -1,30 +1,17 @@
 import React from 'react';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {View} from 'react-native';
-import {
-  isInteractiveColor,
-  isStaticColor,
-  TextColor,
-  StaticColor,
-  InteractiveColor,
-  getInteractiveColor,
-  getStaticColor,
-} from '@atb/theme/colors';
 
 type CheckedProps = {
   checked: boolean;
-  color?: TextColor | StaticColor | InteractiveColor;
+  color?: string;
 };
 
 export function RadioIcon({checked, color = 'primary'}: CheckedProps) {
   const styles = useStyles();
-  const {theme, themeName} = useTheme();
+  const {theme} = useTheme();
 
-  const colorValue = isStaticColor(color)
-    ? getStaticColor(themeName, color).text
-    : isInteractiveColor(color)
-    ? getInteractiveColor(themeName, color).background
-    : theme.text.colors[color];
+  const colorValue = color ? color : theme.text.colors.primary;
 
   return (
     <View style={[styles.radio, {borderColor: colorValue}]}>

--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -158,6 +158,7 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
               }}
               style={styles.leftRadioBox}
               testID="selectTravelcard"
+              interactiveColor="interactive_2"
             />
           )}
           <RadioBox

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/SelectGroup.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/SelectGroup.tsx
@@ -122,7 +122,10 @@ const SelectItem = <T,>({
           <Checkbox style={itemStyles.indicator} checked={selected} />
         ) : (
           <View style={itemStyles.indicator}>
-            <RadioIcon checked={selected} color="interactive_0" />
+            <RadioIcon
+              checked={selected}
+              color={theme.interactive.interactive_0.default.background}
+            />
           </View>
         )}
         {renderItem(item, selected)}

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -95,13 +95,6 @@ export const isInteractiveColor = (
   return !!color && color in themes.light.interactive;
 };
 
-export const getInteractiveColor = (
-  mode: Mode,
-  color: InteractiveColor,
-  type?: 'active' | 'default',
-) => {
-  return themes[mode].interactive[color][type ?? 'default'];
-};
 /**
  * Static colors object structure:
  * {background: {...}, transport: {...}, status: {...}}


### PR DESCRIPTION
Changed from using static colors to interactive colors for default and active in RadioBoxes, providing a prop to set the interactiveColor. 

Looks like this after current changes:
<img width="300" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/126664682/6794366e-6ba5-4411-939b-a13d9b141b15">



Closes: https://github.com/AtB-AS/kundevendt/issues/8652