### PR TITLE
refactor: Better encapsulation and logging in auth

### DIFF
--- a/src/analytics/AnalyticsContext.tsx
+++ b/src/analytics/AnalyticsContext.tsx
@@ -17,7 +17,7 @@ export const AnalyticsContext = createContext<PostHog | undefined>(undefined);
 
 export const AnalyticsContextProvider: React.FC = ({children}) => {
   const [client, setClient] = useState<PostHog>();
-  const {abtCustomerId, authenticationType} = useAuthState();
+  const {userId, authenticationType} = useAuthState();
   const appStatus = useAppStateStatus();
 
   const authTypeRef = useRef(authenticationType);
@@ -34,15 +34,15 @@ export const AnalyticsContextProvider: React.FC = ({children}) => {
   }, []);
 
   useEffect(() => {
-    if (abtCustomerId && client) {
-      client.identify(abtCustomerId, {
+    if (userId && client) {
+      client.identify(userId, {
         authenticationType: authTypeRef.current,
       });
       return () => {
         client?.reset();
       };
     }
-  }, [abtCustomerId, client]);
+  }, [userId, client]);
 
   useEffect(() => {
     client?.capture(`App status: ${appStatus}`);

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -75,13 +75,13 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
         ? 'authenticated'
         : 'creating-account';
       Bugsnag.leaveBreadcrumb('Retrieved auth user data', {
-        abtCustomerIdFull: action.abtCustomerIdFull,
+        abtCustomerId: action.abtCustomerId,
         customerNumber: action.customerNumber,
         authStatus,
       });
       return {
         ...prevState,
-        abtCustomerId: action.abtCustomerIdFull,
+        abtCustomerId: action.abtCustomerId,
         customerNumber: action.customerNumber,
         authStatus,
       };
@@ -105,7 +105,7 @@ const initialReducerState: AuthReducerState = {
   phoneNumber: undefined,
   authenticationType: 'none',
   confirmationHandler: undefined,
-  abtCustomerIdFull: undefined,
+  abtCustomerId: undefined,
   customerNumber: undefined,
   authStatus: 'loading',
 };

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -9,13 +9,12 @@ import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {useSubscribeToAuthUserChange} from './use-subscribe-to-auth-user-change';
 import {
   AuthenticationType,
+  AuthReducerAction,
+  AuthStatus,
   ConfirmationErrorCode,
   PhoneSignInErrorCode,
-  AuthStatus,
   VippsSignInErrorCode,
-  AuthReducerAction,
 } from '@atb/auth/types';
-import {getAuthenticationType} from './utils';
 import {useFetchCustomerDataAfterUserChanged} from './use-fetch-customer-data-after-user-changed';
 import {
   authConfirmCode,
@@ -24,13 +23,15 @@ import {
 } from './auth-utils';
 import {useUpdateAuthLanguageOnChange} from './use-update-auth-language-on-change';
 import {useCheckIfAccountCreationFinished} from './use-check-if-account-creation-finished';
+import Bugsnag from '@bugsnag/react-native';
 
 type AuthReducerState = {
-  user: FirebaseAuthTypes.User | null;
+  userId: string | undefined;
+  authenticationType: AuthenticationType;
+  phoneNumber: string | undefined;
   confirmationHandler: FirebaseAuthTypes.ConfirmationResult | undefined;
+  /** Full abt customer id, which is the user id including prefix like "ABT:CustomerAccount:" */
   abtCustomerId: string | undefined;
-  /** Full abt customer id, including prefix like "ABT:CustomerAccount:" */
-  abtCustomerIdFull: string | undefined;
   customerNumber: number | undefined;
   authStatus: AuthStatus;
 };
@@ -49,39 +50,47 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
       };
     }
     case 'SET_USER': {
-      const sameUser = prevState.user?.uid === action.user?.uid;
+      const sameUser = prevState.userId === action.userId;
       if (sameUser) {
         return {
           ...prevState,
-          user: action.user,
+          phoneNumber: action.phoneNumber,
+          authenticationType: action.authenticationType,
         };
       } else {
+        Bugsnag.leaveBreadcrumb('Auth user change', {userId: action.userId});
         return {
+          userId: action.userId,
+          phoneNumber: action.phoneNumber,
+          authenticationType: action.authenticationType,
           confirmationHandler: undefined,
           abtCustomerId: undefined,
-          abtCustomerIdFull: undefined,
           customerNumber: undefined,
-          user: action.user,
           authStatus: 'loading',
         };
       }
     }
     case 'SET_CUSTOMER_DATA': {
-      return {
-        ...prevState,
-        abtCustomerId: action.abtCustomerId,
+      const authStatus = action.customerNumber
+        ? 'authenticated'
+        : 'creating-account';
+      Bugsnag.leaveBreadcrumb('Retrieved auth user data', {
         abtCustomerIdFull: action.abtCustomerIdFull,
         customerNumber: action.customerNumber,
-        /*
-          If no customerNumber, this means the user was newly created in Firestore,
-          but the asynchronous creation of the Entur account is not finished yet.
-        */
-        authStatus: action.customerNumber
-          ? 'authenticated'
-          : 'creating-account',
+        authStatus,
+      });
+      return {
+        ...prevState,
+        abtCustomerId: action.abtCustomerIdFull,
+        customerNumber: action.customerNumber,
+        authStatus,
       };
     }
     case 'SET_AUTH_STATUS': {
+      Bugsnag.leaveBreadcrumb('Updating auth status', {
+        authStatus: action.authStatus,
+        customerNumber: action.customerNumber,
+      });
       return {
         ...prevState,
         authStatus: action.authStatus,
@@ -92,11 +101,12 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
 };
 
 const initialReducerState: AuthReducerState = {
+  userId: undefined,
+  phoneNumber: undefined,
+  authenticationType: 'none',
   confirmationHandler: undefined,
-  abtCustomerId: undefined,
   abtCustomerIdFull: undefined,
   customerNumber: undefined,
-  user: null,
   authStatus: 'loading',
 };
 
@@ -120,8 +130,8 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   const [state, dispatch] = useReducer(authReducer, initialReducerState);
 
   const {resubscribe} = useSubscribeToAuthUserChange(dispatch);
-  useFetchCustomerDataAfterUserChanged(state.user, dispatch);
-  useCheckIfAccountCreationFinished(state.user, state.authStatus, dispatch);
+  useFetchCustomerDataAfterUserChanged(state.userId, dispatch);
+  useCheckIfAccountCreationFinished(state.userId, state.authStatus, dispatch);
 
   useUpdateAuthLanguageOnChange();
 
@@ -153,7 +163,7 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
         signOut: useCallback(async () => {
           await auth().signInAnonymously();
         }, []),
-        authenticationType: getAuthenticationType(state.user),
+        authenticationType: state.authenticationType,
         signInWithCustomToken: useCallback(authSignInWithCustomToken, []),
         retryAuth,
       }}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -21,7 +21,7 @@ export type AuthReducerAction =
     }
   | {
       type: 'SET_CUSTOMER_DATA';
-      abtCustomerIdFull: string | undefined;
+      abtCustomerId: string | undefined;
       customerNumber: number | undefined;
     }
   | {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -15,14 +15,14 @@ export type AuthReducerAction =
     }
   | {
       type: 'SET_USER';
-      user: FirebaseAuthTypes.User | null;
+      userId?: string;
+      phoneNumber?: string;
+      authenticationType: AuthenticationType;
     }
   | {
       type: 'SET_CUSTOMER_DATA';
-      abtCustomerId: string | undefined;
       abtCustomerIdFull: string | undefined;
       customerNumber: number | undefined;
-      authStatus: AuthStatus;
     }
   | {
       type: 'SET_AUTH_STATUS';

--- a/src/auth/use-fetch-customer-data-after-user-changed.ts
+++ b/src/auth/use-fetch-customer-data-after-user-changed.ts
@@ -12,12 +12,12 @@ export const useFetchCustomerDataAfterUserChanged = (
       auth()
         .currentUser?.getIdTokenResult()
         .then((idToken) => {
-          const abtCustomerIdFull = idToken.claims['abt_id'];
+          const abtCustomerId = idToken.claims['abt_id'];
           const customerNumber = idToken.claims['customer_number'];
 
           dispatch({
             type: 'SET_CUSTOMER_DATA',
-            abtCustomerIdFull,
+            abtCustomerId,
             customerNumber,
           });
         });

--- a/src/auth/use-fetch-customer-data-after-user-changed.ts
+++ b/src/auth/use-fetch-customer-data-after-user-changed.ts
@@ -1,35 +1,26 @@
 import {Dispatch, useEffect} from 'react';
-import {FirebaseAuthTypes} from '@react-native-firebase/auth';
+import auth from '@react-native-firebase/auth';
 import {AuthReducerAction} from './types';
 
 export const useFetchCustomerDataAfterUserChanged = (
-  user: FirebaseAuthTypes.User | null,
+  userId: string | undefined,
   dispatch: Dispatch<AuthReducerAction>,
 ) => {
   // Refresh abt customer id from id token after logged in user changes
   useEffect(() => {
-    (async function () {
-      if (user) {
-        const idToken = await user.getIdTokenResult();
-        const abtCustomerId = idToken.claims['sub'];
-        const abtCustomerIdFull = idToken.claims['abt_id'];
-        const customerNumber = idToken.claims['customer_number'];
-        /*
-         If no customerNumber, this means the user was newly created in Firestore,
-         but the asynchronous creation of the Entur account is not finished yet.
-         */
-        const authStatus = customerNumber
-          ? 'authenticated'
-          : 'creating-account';
+    if (userId) {
+      auth()
+        .currentUser?.getIdTokenResult()
+        .then((idToken) => {
+          const abtCustomerIdFull = idToken.claims['abt_id'];
+          const customerNumber = idToken.claims['customer_number'];
 
-        dispatch({
-          type: 'SET_CUSTOMER_DATA',
-          abtCustomerId,
-          abtCustomerIdFull,
-          customerNumber,
-          authStatus,
+          dispatch({
+            type: 'SET_CUSTOMER_DATA',
+            abtCustomerIdFull,
+            customerNumber,
+          });
         });
-      }
-    })();
-  }, [user?.uid]);
+    }
+  }, [dispatch, userId]);
 };

--- a/src/auth/use-subscribe-to-auth-user-change.ts
+++ b/src/auth/use-subscribe-to-auth-user-change.ts
@@ -2,7 +2,8 @@ import {Dispatch, useCallback, useEffect, useState} from 'react';
 import auth from '@react-native-firebase/auth';
 import {updateMetadata} from '@atb/chat/metadata';
 import {AuthReducerAction} from './types';
-import {getAuthenticationType} from './utils';
+import {mapAuthenticationType} from './utils';
+import Bugsnag from '@bugsnag/react-native';
 
 export const useSubscribeToAuthUserChange = (
   dispatch: Dispatch<AuthReducerAction>,
@@ -11,25 +12,36 @@ export const useSubscribeToAuthUserChange = (
   const [resubscribeToggle, setResubscribeToggle] = useState(true);
 
   useEffect(() => {
+    Bugsnag.leaveBreadcrumb('Subscribing to auth user changes');
     dispatch({type: 'SET_AUTH_STATUS', authStatus: 'loading'});
+    let signInInitiated = false;
     const unsubscribe = auth().onUserChanged((user) => {
       if (user) {
         updateMetadata({
-          'AtB-Firebase-Auth-Id': user.uid,
-          'AtB-Auth-Type': getAuthenticationType(user),
+          'AtB-Firebase-Auth-Id': user?.uid,
+          'AtB-Auth-Type': mapAuthenticationType(user),
         });
-        dispatch({type: 'SET_USER', user});
-      } else {
+        dispatch({
+          type: 'SET_USER',
+          userId: user?.uid,
+          phoneNumber: user?.phoneNumber || undefined,
+          authenticationType: mapAuthenticationType(user),
+        });
+      } else if (!signInInitiated) {
         /*
         Sign in anonymously if the onUserChanged event fired immediately on
         subscription did not include user data. In other words, user was not
         previously signed in.
          */
-        auth().signInAnonymously();
+        auth()
+          .signInAnonymously()
+          .then(() => {
+            signInInitiated = true;
+          });
       }
     });
     return () => unsubscribe();
-  }, [resubscribeToggle]);
+  }, [resubscribeToggle, dispatch]);
 
   return {
     resubscribe: useCallback(() => setResubscribeToggle((prev) => !prev), []),

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,7 +1,7 @@
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {AuthenticationType} from './types';
 
-export const getAuthenticationType = (
+export const mapAuthenticationType = (
   user: FirebaseAuthTypes.User | null,
 ): AuthenticationType => {
   if (user?.phoneNumber) return 'phone';

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -20,7 +20,7 @@ type Props = {
 export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {abtCustomerIdFull} = useAuthState();
+  const {abtCustomerId} = useAuthState();
   const {t, language} = useTranslation();
 
   async function openVippsUrl(vippsUrl: string) {
@@ -43,7 +43,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
   };
 
   // Filter out reservations for subaccounts
-  if (reservation.customerAccountId !== abtCustomerIdFull) return null;
+  if (reservation.customerAccountId !== abtCustomerId) return null;
 
   const status = getStatus();
 

--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -60,7 +60,7 @@ const MobileTokenContext = createContext<MobileTokenContextState | undefined>(
 );
 
 export const MobileTokenContextProvider: React.FC = ({children}) => {
-  const {abtCustomerId, authStatus} = useAuthState();
+  const {userId, authStatus} = useAuthState();
 
   const {token_timeout_in_seconds} = useRemoteConfig();
   const hasEnabledMobileToken = useHasEnabledMobileToken();
@@ -87,7 +87,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
   const [isError, setIsError] = useState(false);
 
   const enabled =
-    hasEnabledMobileToken && abtCustomerId && authStatus === 'authenticated';
+    hasEnabledMobileToken && userId && authStatus === 'authenticated';
 
   const fallbackActive =
     (isError && fallbackOnErrorEnabled) ||
@@ -111,14 +111,14 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
   const loadNativeToken = useCallback(
     async (traceId: string) => {
       Bugsnag.leaveBreadcrumb(
-        `Loading mobile token state for user ${abtCustomerId}`,
+        `Loading mobile token state for user ${userId}`,
       );
 
       /*
        Check if there has been a user change.
        */
       const lastUser = await storage.get('@ATB_last_mobile_token_user');
-      const noUserChange = lastUser === abtCustomerId;
+      const noUserChange = lastUser === userId;
 
       let token: ActivatedToken | undefined;
       if (noUserChange) {
@@ -170,10 +170,10 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
         Bugsnag.leaveBreadcrumb(`Creating new mobile token`);
         token = await mobileTokenClient.create(traceId);
       }
-      await storage.set('@ATB_last_mobile_token_user', abtCustomerId!);
+      await storage.set('@ATB_last_mobile_token_user', userId!);
       return token;
     },
-    [abtCustomerId],
+    [userId],
   );
 
   const loadRemoteTokens = useCallback(async (traceId: string) => {
@@ -202,7 +202,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
           ),
           (event) => {
             event.addMetadata('token', {
-              abtCustomerId,
+              userId,
               traceId,
               description: 'Native and remote tokens took too long to load.',
             });
@@ -253,7 +253,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
         });
         Bugsnag.notify(err, (event) => {
           event.addMetadata('token', {
-            abtCustomerId,
+            userId,
             traceId,
             description: 'Error loading native and remote tokens',
           });
@@ -284,7 +284,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
       } catch (err: any) {
         Bugsnag.notify(err, (event) => {
           event.addMetadata('token', {
-            abtCustomerId,
+            userId,
             tokenId: token.tokenId,
             description: 'Error encoding signed token',
           });

--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -117,8 +117,8 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
       /*
        Check if there has been a user change.
        */
-      const lastUser = await storage.get('@ATB_last_mobile_token_user');
-      const noUserChange = lastUser === userId;
+      const lastUserId = await storage.get('@ATB_last_mobile_token_user');
+      const noUserChange = lastUserId === userId;
 
       let token: ActivatedToken | undefined;
       if (noUserChange) {

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsQr.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsQr.tsx
@@ -33,7 +33,7 @@ export const Root_ParkingViolationsQr = ({
   const [isError, setIsError] = useState(false);
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
   const {providers, position} = useParkingViolations();
-  const {abtCustomerId} = useAuthState();
+  const {userId} = useAuthState();
 
   const providersList = useMemo(
     () => [
@@ -69,7 +69,7 @@ export const Root_ParkingViolationsQr = ({
     const imageType = params.photo.split('.').pop();
 
     sendViolationsReport({
-      appId: abtCustomerId,
+      appId: userId,
       image: base64data,
       imageType,
       latitude: position?.latitude ?? 0,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -1,5 +1,4 @@
 import {MasterCard, Vipps, Visa} from '@atb/assets/svg/color/icons/ticketing';
-import {useAuthState} from '@atb/auth';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {MessageBox} from '@atb/components/message-box';
@@ -92,12 +91,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const {theme} = useTheme();
   const {t, language} = useTranslation();
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
-  const {user} = useAuthState();
   const {paymentTypes, vatPercent} = useFirestoreConfiguration();
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const previousPaymentMethod = usePreviousPaymentMethod(user);
+  const previousPaymentMethod = usePreviousPaymentMethod();
   const {deviceIsInspectable, remoteTokens, fallbackActive} =
     useMobileTokenContextState();
   const tokensEnabled = useHasEnabledMobileToken();

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
@@ -83,7 +83,7 @@ export const SelectPaymentMethod: React.FC<Props> = ({
   const [loadingRecurringOptions, setLoadingRecurringOptions] =
     useState<boolean>(true);
 
-  const {user} = useAuthState();
+  const {authenticationType} = useAuthState();
   const {theme} = useTheme();
   const {paymentTypes} = useFirestoreConfiguration();
 
@@ -105,7 +105,7 @@ export const SelectPaymentMethod: React.FC<Props> = ({
   async function getRecurringPaymentOptions(): Promise<
     Array<SavedPaymentOption>
   > {
-    if (!user || user.isAnonymous) return [];
+    if (authenticationType !== 'phone') return [];
     const recurringOptions: Array<SavedPaymentOption> = (
       await listRecurringPayments()
     ).map((option) => {
@@ -254,7 +254,7 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
   const [save, setSave] = useState<boolean>(false);
   const {t} = useTranslation();
   const styles = useStyles();
-  const {user} = useAuthState();
+  const {authenticationType} = useAuthState();
 
   useEffect(() => {
     if (selected) {
@@ -375,7 +375,7 @@ const PaymentOptionView: React.FC<PaymentOptionsProps> = ({
         </View>
       </PressableOpacity>
       {selected &&
-      user?.phoneNumber &&
+      authenticationType === 'phone' &&
       option.savedType === 'normal' &&
       option.paymentType !== PaymentType.Vipps ? (
         <PressableOpacity

--- a/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/use-terminal-state.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithCreditCardScreen/use-terminal-state.ts
@@ -30,7 +30,7 @@ export function useTerminalState(
   const [reservation, setReservation] = useState<OfferReservation>();
   const [error, setError] = useState<PaymentError>();
 
-  const {user, abtCustomerIdFull} = useAuthState();
+  const {userId, phoneNumber, abtCustomerId} = useAuthState();
 
   const handleAxiosError = useCallback(function (
     err: AxiosError | unknown,
@@ -56,7 +56,7 @@ export function useTerminalState(
                 retry: true,
               },
               scaExemption: true,
-              customerAccountId: abtCustomerIdFull!,
+              customerAccountId: abtCustomerId!,
             })
           : await reserveOffers({
               offers,
@@ -66,7 +66,7 @@ export function useTerminalState(
                 retry: true,
               },
               scaExemption: true,
-              customerAccountId: abtCustomerIdFull!,
+              customerAccountId: abtCustomerId!,
             });
         setReservation(response);
       } catch (err) {
@@ -108,13 +108,13 @@ export function useTerminalState(
     recurringPaymentId?: number,
   ) {
     if (recurringPaymentId) {
-      if (user?.phoneNumber) {
+      if (userId && phoneNumber) {
         const existingMethods = await listRecurringPayments();
         const alreadyAddedRecurringCard = existingMethods.find((item) => {
           return item.id === recurringPaymentId;
         });
         if (alreadyAddedRecurringCard) {
-          savePreviousPaymentMethodByUser(user.uid, {
+          savePreviousPaymentMethodByUser(userId, {
             savedType: 'recurring',
             paymentType: paymentType,
             recurringCard: alreadyAddedRecurringCard,
@@ -131,13 +131,13 @@ export function useTerminalState(
             });
 
             if (card) {
-              savePreviousPaymentMethodByUser(user.uid, {
+              savePreviousPaymentMethodByUser(userId, {
                 savedType: 'recurring',
                 paymentType: paymentType,
                 recurringCard: card,
               });
             } else {
-              savePreviousPaymentMethodByUser(user.uid, {
+              savePreviousPaymentMethodByUser(userId, {
                 savedType: 'recurring-without-card',
                 paymentType: paymentType,
                 recurringPaymentId: recurringPaymentId,
@@ -149,8 +149,8 @@ export function useTerminalState(
         }
       }
     } else {
-      if (user) {
-        savePreviousPaymentMethodByUser(user.uid, {
+      if (userId) {
+        savePreviousPaymentMethodByUser(userId, {
           savedType: 'normal',
           paymentType: paymentType,
         });

--- a/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/use-vipps-state.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/use-vipps-state.ts
@@ -68,7 +68,7 @@ export function useVippsState(offers: ReserveOffer[], dismiss: () => void) {
     vippsReducer,
     initialState,
   );
-  const {user, abtCustomerIdFull} = useAuthState();
+  const {userId, abtCustomerId} = useAuthState();
 
   const handleAxiosError = useCallback(
     function (err: AxiosError | unknown, errorContext: ErrorContext) {
@@ -95,11 +95,11 @@ export function useVippsState(offers: ReserveOffer[], dismiss: () => void) {
             retry: true,
           },
           scaExemption: false,
-          customerAccountId: abtCustomerIdFull!,
+          customerAccountId: abtCustomerId!,
         });
         dispatch({type: 'OFFER_RESERVED', reservation: response});
-        if (user) {
-          savePreviousPaymentMethodByUser(user.uid, {
+        if (userId) {
+          savePreviousPaymentMethodByUser(userId, {
             savedType: 'normal',
             paymentType: PaymentType.Vipps,
           });

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -65,7 +65,8 @@ export const Profile_DebugInfoScreen = () => {
     restartOnboarding,
   } = useAppState();
   const {resetDismissedGlobalMessages} = useGlobalMessagesState();
-  const {user, abtCustomerId} = useAuthState();
+  const {userId} = useAuthState();
+  const user = auth().currentUser;
   const [idToken, setIdToken] = useState<
     FirebaseAuthTypes.IdTokenResult | undefined
   >(undefined);
@@ -102,16 +103,10 @@ export const Profile_DebugInfoScreen = () => {
   const [kettleConsents, setKettleConsents] = useState([]);
 
   useEffect(() => {
-    async function run() {
-      if (!!user) {
-        const idToken = await user.getIdTokenResult();
-        setIdToken(idToken);
-      } else {
-        setIdToken(undefined);
-      }
-    }
-
-    run();
+    (async function () {
+      const idToken = await user?.getIdTokenResult();
+      setIdToken(idToken);
+    })();
   }, [user]);
 
   useEffect(() => {
@@ -156,9 +151,9 @@ export const Profile_DebugInfoScreen = () => {
   }, []);
 
   function copyFirestoreLink() {
-    if (abtCustomerId)
+    if (userId)
       setClipboard(
-        `https://console.firebase.google.com/u/1/project/atb-mobility-platform-staging/firestore/data/~2Fcustomers~2F${abtCustomerId}`,
+        `https://console.firebase.google.com/u/1/project/atb-mobility-platform-staging/firestore/data/~2Fcustomers~2F${userId}`,
       );
   }
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
@@ -39,14 +39,14 @@ export const Profile_PaymentOptionsScreen = ({
 }: PaymentOptionsProps) => {
   const style = useStyle();
   const {t} = useTranslation();
-  const {user} = useAuthState();
+  const {authenticationType} = useAuthState();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [storedCards, setStoredCards] = useState<RecurringPayment[]>([]);
   const [showError, setShowError] = useState<boolean>(false);
 
   async function getRecurringPaymentOptions(): Promise<RecurringPayment[]> {
-    if (!user || user.isAnonymous) return [];
+    if (authenticationType !== 'phone') return [];
     try {
       const recurringOptions = await listRecurringPayments();
       return recurringOptions.reverse();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -61,7 +61,12 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const style = useProfileHomeStyle();
   const {clearHistory} = useSearchHistory();
   const {t, language} = useTranslation();
-  const {authenticationType, signOut, user, customerNumber} = useAuthState();
+  const {
+    authenticationType,
+    signOut,
+    phoneNumber: authPhoneNumber,
+    customerNumber,
+  } = useAuthState();
   const config = useLocalConfig();
 
   const {fareContracts, customerProfile} = useTicketingState();
@@ -83,7 +88,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
 
   const [isLoading, setIsLoading] = useIsLoading(false);
 
-  const phoneNumber = parsePhoneNumber(user?.phoneNumber ?? '');
+  const phoneNumber = parsePhoneNumber(authPhoneNumber ?? '');
   const {enable_vipps_login} = useRemoteConfig();
 
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -29,8 +29,7 @@ type Props = TicketTabNavScreenProps<'TicketTabNav_PurchaseTabScreen'>;
 
 export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const {must_upgrade_ticketing} = useRemoteConfig();
-  const {abtCustomerId, authenticationType} = useAuthState();
-  const isSignedInAsAbtCustomer = !!abtCustomerId;
+  const {authenticationType} = useAuthState();
   const {theme} = useTheme();
   const {recentFareContracts, loading} = useRecentFareContracts();
   const hasRecentFareContracts = !!recentFareContracts.length;
@@ -155,7 +154,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
     });
   };
 
-  return isSignedInAsAbtCustomer ? (
+  return authenticationType !== 'none' ? (
     <ScrollView>
       <RecentFareContracts
         recentFareContracts={recentFareContracts}

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -6,16 +6,16 @@ import {
 } from './types';
 import {storage} from '@atb/storage';
 import Bugsnag from '@bugsnag/react-native';
-import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {listRecurringPayments} from '@atb/ticketing';
+import {useAuthState} from '@atb/auth';
 
 async function getCardFromRecurringPaymentId(
   previousPaymentMethod: RecurringPaymentWithoutCardOption,
-  user: FirebaseAuthTypes.User | null,
+  userId?: string,
 ): Promise<RecurringPaymentOption | undefined> {
   const {paymentType, recurringPaymentId} = previousPaymentMethod;
 
-  if (!user || !recurringPaymentId) return undefined;
+  if (!userId || !recurringPaymentId) return undefined;
 
   const allRecurringPaymentOptions = await listRecurringPayments();
   const card = allRecurringPaymentOptions.find((item) => {
@@ -23,7 +23,7 @@ async function getCardFromRecurringPaymentId(
   });
 
   if (card) {
-    await savePreviousPaymentMethodByUser(user.uid, {
+    await savePreviousPaymentMethodByUser(userId, {
       savedType: 'recurring',
       paymentType,
       recurringCard: card,
@@ -36,13 +36,11 @@ async function getCardFromRecurringPaymentId(
   } else return undefined;
 }
 
-export function usePreviousPaymentMethod(
-  user: FirebaseAuthTypes.User | null,
-): SavedPaymentOption | undefined {
+export function usePreviousPaymentMethod(): SavedPaymentOption | undefined {
   const [paymentMethod, setPaymentMethod] = useState<
     SavedPaymentOption | undefined
   >(undefined);
-  const userId = user?.uid;
+  const {userId} = useAuthState();
 
   useEffect(() => {
     async function run(uid: string) {
@@ -50,7 +48,7 @@ export function usePreviousPaymentMethod(
       if (method?.savedType === 'recurring-without-card') {
         const furtherPaymentDetails = await getCardFromRecurringPaymentId(
           method,
-          user,
+          userId,
         );
         setPaymentMethod(furtherPaymentDetails);
       } else {

--- a/src/ticketing/TicketingContext.tsx
+++ b/src/ticketing/TicketingContext.tsx
@@ -130,12 +130,12 @@ export const TicketingContextProvider: React.FC = ({children}) => {
   // A toggle to trigger resubscribe. The actual boolean value is not important.
   const [resubscribeToggle, setResubscribeToggle] = useState(true);
 
-  const {abtCustomerId} = useAuthState();
+  const {userId} = useAuthState();
   const {enable_ticketing} = useRemoteConfig();
 
   useEffect(() => {
-    if (abtCustomerId && enable_ticketing) {
-      const removeListeners = setupFirestoreListeners(abtCustomerId, {
+    if (userId && enable_ticketing) {
+      const removeListeners = setupFirestoreListeners(userId, {
         fareContracts: {
           onSnapshot: (fareContracts) =>
             dispatch({type: 'UPDATE_FARE_CONTRACTS', fareContracts}),
@@ -175,7 +175,7 @@ export const TicketingContextProvider: React.FC = ({children}) => {
       // Stop listening for updates when no longer required
       return () => removeListeners();
     }
-  }, [resubscribeToggle, abtCustomerId, enable_ticketing]);
+  }, [resubscribeToggle, userId, enable_ticketing]);
 
   return (
     <TicketingContext.Provider


### PR DESCRIPTION
### Background
Some reports coming in lately regarding missing customer id.

### Solution
Some refactoring of the auth process. No large changes, but several
smaller ones:
- More logging of Bugsnag breadcrumbs during the authentication
  process.
- No longer exposing the internal Firebase User type out through
  the AuthContext. Now instead exposing the specific fields that
  may be used.
- Fixed all exhaustive deps errors in the auth module. One of the
  changes to fix this was accessing the current user through
  'auth().currentUser' instead of passing around the user object.
  This was necessary as we could get the same user object multiple
  times from the user change subscription, which caused dependency
  change in hooks when it was not intended.
- The userId and the abtCustomerId were the same value, so the
  abtCustomerId was removed. However the abtCustomerIdFull was
  renamed to just abtCustomerId. The difference between userId and
  abtCustomerId is now that the abtCustomerId has prefix
  "ABT:CustomerAccount:" (for AtB).

### Acceptance criteria
- [ ] Exploratory testing of the authentication process, with anonymous accounts, existing accounts, new accounts.