### PR TITLE
fix: no activation hint for non-activatable barcodes

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -239,7 +239,9 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
       <PressableOpacity
         onPress={onOpenBarcodePress}
         accessibilityRole="button"
-        accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+        accessibilityLabel={t(
+          FareContractTexts.details.barcodeA11yLabelWithActivation,
+        )}
         testID="staticBarcode"
       >
         <SvgXml xml={aztecXml} width="100%" height="100%" />
@@ -269,7 +271,9 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
       <PressableOpacity
         onPress={onOpenBarcodePress}
         accessibilityRole="button"
-        accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+        accessibilityLabel={t(
+          FareContractTexts.details.barcodeA11yLabelWithActivation,
+        )}
         testID="staticQRCode"
       >
         <SvgXml xml={qrCodeSvg} width="100%" height="100%" />

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -83,6 +83,11 @@ const FareContractTexts = {
       'Få kvittering tilsendt',
     ),
     barcodeA11yLabel: _(
+      'Barkode. Vis frem denne koden ved billettkontroll.',
+      'Barcode. Show this code in case of inspection.',
+      'Barkode. Vis denne koden ved billettkontroll.',
+    ),
+    barcodeA11yLabelWithActivation: _(
       'Barkode. Vis frem denne koden ved billettkontroll. Aktivér for å vise større barkode.',
       'Barcode. Show this code in case of inspection. Activate for to show larger barcode.',
       'Barkode. Vis denne koden ved billettkontroll. Aktivér for større barkode.',


### PR DESCRIPTION
Fixing https://github.com/AtB-AS/mittatb-app/pull/3952#issuecomment-1779257983

Fixed by splitting the common label into two different labels, with and without the activation hint. 

Only barcodes with `PressableOpacity` having `onPress={onOpenBarcodePress}` should have the activation hint. This means that `MobileTokenAztec` should have label without activation hint.