### PR TITLE
feat: improve scooter cluster zoom level on click

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -124,8 +124,9 @@ export const Map = (props: MapProps) => {
           )}
           {props.vehicles && (
             <Vehicles
-              mapCameraRef={mapCameraRef}
               vehicles={props.vehicles.vehicles}
+              mapCameraRef={mapCameraRef}
+              mapViewRef={mapViewRef}
               onClusterClick={(feature) => {
                 onMapClick({
                   source: 'cluster-click',

--- a/src/components/map/components/mobility/Scooters.tsx
+++ b/src/components/map/components/mobility/Scooters.tsx
@@ -29,6 +29,7 @@ export const Scooters = ({scooters, onClusterClick}: Props) => {
         cluster
         maxZoomLevel={22}
         clusterMaxZoomLevel={21}
+        clusterRadius={40}
         onPress={(e) => onClusterClick(e, clustersSource)}
       >
         <MapboxGL.SymbolLayer
@@ -73,6 +74,7 @@ export const Scooters = ({scooters, onClusterClick}: Props) => {
         tolerance={0}
         cluster
         maxZoomLevel={22}
+        clusterRadius={40}
         clusterMaxZoomLevel={21}
       >
         <MapboxGL.SymbolLayer

--- a/src/components/map/components/mobility/Stations.tsx
+++ b/src/components/map/components/mobility/Stations.tsx
@@ -42,7 +42,7 @@ export const Stations = ({stations, onClusterClick, mapCameraRef}: Props) => {
         coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
         mapCameraRef,
         zoomLevel: clusterExpansionZoom,
-        animationDuration: 400,
+        animationDuration: 200,
       });
       onClusterClick && onClusterClick(feature);
     }

--- a/src/components/map/components/mobility/Vehicles.tsx
+++ b/src/components/map/components/mobility/Vehicles.tsx
@@ -29,16 +29,17 @@ export const Vehicles = ({
     if (isClusterFeature(feature)) {
       const clusterExpansionZoom =
         (await clustersSource.current?.getClusterExpansionZoom(feature)) ?? 0;
-      mapViewRef.current?.getZoom().then((fromZoomLevel) => {
-        // Zoom "2 levels" or to the point where the cluster expands, whichever
-        // is greater.
-        const toZoomLevel = Math.max(fromZoomLevel + 2, clusterExpansionZoom);
-        flyToLocation({
-          coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
-          mapCameraRef,
-          zoomLevel: toZoomLevel,
-          animationDuration: Math.abs(fromZoomLevel - toZoomLevel) * 100,
-        });
+
+      const fromZoomLevel = (await mapViewRef.current?.getZoom()) ?? 0;
+      // Zoom "2 levels" or to the point where the cluster expands, whichever
+      // is greater.
+      const toZoomLevel = Math.max(fromZoomLevel + 2, clusterExpansionZoom);
+
+      flyToLocation({
+        coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
+        mapCameraRef,
+        zoomLevel: toZoomLevel,
+        animationDuration: Math.abs(fromZoomLevel - toZoomLevel) * 100,
       });
       onClusterClick(feature);
     }

--- a/src/components/map/components/mobility/Vehicles.tsx
+++ b/src/components/map/components/mobility/Vehicles.tsx
@@ -10,11 +10,17 @@ import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
 
 type Props = {
   mapCameraRef: RefObject<MapboxGL.Camera>;
+  mapViewRef: RefObject<MapboxGL.MapView>;
   vehicles: VehicleFeatures;
   onClusterClick: (feature: Feature<Point, Cluster>) => void;
 };
 
-export const Vehicles = ({mapCameraRef, vehicles, onClusterClick}: Props) => {
+export const Vehicles = ({
+  mapCameraRef,
+  mapViewRef,
+  vehicles,
+  onClusterClick,
+}: Props) => {
   const handleClusterClick = async (
     e: OnPressEvent,
     clustersSource: RefObject<ShapeSource>,
@@ -23,12 +29,16 @@ export const Vehicles = ({mapCameraRef, vehicles, onClusterClick}: Props) => {
     if (isClusterFeature(feature)) {
       const clusterExpansionZoom =
         (await clustersSource.current?.getClusterExpansionZoom(feature)) ?? 0;
-      const zoomLevel = Math.max(clusterExpansionZoom, 17.5);
-      flyToLocation({
-        coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
-        mapCameraRef,
-        zoomLevel,
-        animationDuration: 400,
+      mapViewRef.current?.getZoom().then((fromZoomLevel) => {
+        // Zoom "2 levels" or to the point where the cluster expands, whichever
+        // is greater.
+        const toZoomLevel = Math.max(fromZoomLevel + 2, clusterExpansionZoom);
+        flyToLocation({
+          coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
+          mapCameraRef,
+          zoomLevel: toZoomLevel,
+          animationDuration: Math.abs(fromZoomLevel - toZoomLevel) * 100,
+        });
       });
       onClusterClick(feature);
     }


### PR DESCRIPTION
- Updates the scooter cluster zoom logic to zoom at least "2 steps", or to the point where the cluster expands, whichever is furthest.
- Changes [clusterRadius](https://github.com/rnmapbox/maps/blob/main/docs/ShapeSource.md#clusterradius) from 50 (the default), to 40. This means there are slightly less clusters than before, and more individual scooters. 
- Changes zoom animation for scooter clusters from 400ms to around 200ms (scaled to how far we zoom)
- Changes zoom animation for station clusters from 400ms to 200ms

https://github.com/AtB-AS/mittatb-app/assets/1774972/052d979a-2bac-4865-8ca6-4526bc738893
