### PR TITLE
feat: add bike station clusters

### DIFF
--- a/src/components/map/components/mobility/BikeStations.tsx
+++ b/src/components/map/components/mobility/BikeStations.tsx
@@ -1,49 +1,93 @@
-import MapboxGL from '@rnmapbox/maps';
-import React from 'react';
-import {StationsWithCount} from './Stations';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import React, {RefObject, useRef} from 'react';
+import {StationsWithCount} from './Stations';
 
 type Props = {
   stations: StationsWithCount;
+  onClusterClick: (
+    e: OnPressEvent,
+    clustersSource: RefObject<ShapeSource>,
+  ) => void;
 };
 
-export const BikeStations = ({stations}: Props) => {
+export const BikeStations = ({stations, onClusterClick}: Props) => {
   const stationBackgroundColor = useTransportationColor(Mode.Bicycle);
   const stationTextColor = useTransportationColor(
     Mode.Bicycle,
     undefined,
     'text',
   );
+  const clustersSource = useRef<MapboxGL.ShapeSource>(null);
+
   return (
-    <MapboxGL.ShapeSource id="bikeStations" shape={stations} tolerance={0}>
-      <MapboxGL.SymbolLayer
-        id="bikeStationPin"
-        minZoomLevel={13}
-        style={{
-          textField: ['get', 'count'],
-          textAnchor: 'center',
-          textOffset: [0.75, 0],
-          textColor: stationBackgroundColor,
-          textSize: 12,
-          iconImage: 'BikeChip',
-          iconAllowOverlap: true,
-          iconSize: 0.85,
+    <>
+      <MapboxGL.ShapeSource
+        id="bikeStations"
+        shape={stations}
+        tolerance={0}
+        cluster
+      >
+        <MapboxGL.SymbolLayer
+          id="bikeStationPin"
+          filter={['!', ['has', 'point_count']]}
+          minZoomLevel={13}
+          style={{
+            textField: ['get', 'count'],
+            textAnchor: 'center',
+            textOffset: [0.75, 0],
+            textColor: stationBackgroundColor,
+            textSize: 12,
+            iconImage: 'BikeChip',
+            iconAllowOverlap: true,
+            iconSize: 0.85,
+          }}
+        />
+      </MapboxGL.ShapeSource>
+      <MapboxGL.ShapeSource
+        id="bikeStationCluster"
+        shape={stations}
+        ref={clustersSource}
+        tolerance={0}
+        cluster
+        clusterProperties={{
+          sum: ['+', ['get', 'count']],
         }}
-      />
-      <MapboxGL.CircleLayer
-        id="bikeStationMini"
-        maxZoomLevel={13}
-        minZoomLevel={12}
-        style={{
-          circleColor: stationBackgroundColor,
-          circleStrokeColor: stationTextColor,
-          circleOpacity: 0.7,
-          circleStrokeOpacity: 0.7,
-          circleRadius: 4,
-          circleStrokeWidth: 1,
-        }}
-      />
-    </MapboxGL.ShapeSource>
+        onPress={(e) => onClusterClick(e, clustersSource)}
+      >
+        <MapboxGL.SymbolLayer
+          id="bikeStationClusterPin"
+          filter={['has', 'point_count']}
+          minZoomLevel={13}
+          style={{
+            textField: ['get', 'sum'],
+            textAnchor: 'center',
+            textOffset: [0.75, 0],
+            textColor: stationBackgroundColor,
+            textSize: 12,
+            iconImage: 'BikeChip',
+            iconAllowOverlap: true,
+            iconSize: 0.85,
+          }}
+        />
+      </MapboxGL.ShapeSource>
+      <MapboxGL.ShapeSource id="bikeStationMini" shape={stations} tolerance={0}>
+        <MapboxGL.CircleLayer
+          id="bikeStationMiniPin"
+          maxZoomLevel={13}
+          minZoomLevel={12}
+          style={{
+            circleColor: stationBackgroundColor,
+            circleStrokeColor: stationTextColor,
+            circleOpacity: 0.7,
+            circleStrokeOpacity: 0.7,
+            circleRadius: 4,
+            circleStrokeWidth: 1,
+          }}
+        />
+      </MapboxGL.ShapeSource>
+    </>
   );
 };

--- a/src/components/map/components/mobility/BikeStations.tsx
+++ b/src/components/map/components/mobility/BikeStations.tsx
@@ -21,6 +21,15 @@ export const BikeStations = ({stations, onClusterClick}: Props) => {
     'text',
   );
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
+  const symbolStyling = {
+    textAnchor: 'center',
+    textOffset: [0.75, 0],
+    textColor: stationBackgroundColor,
+    textSize: 12,
+    iconImage: 'BikeChip',
+    iconAllowOverlap: true,
+    iconSize: 0.85,
+  };
 
   return (
     <>
@@ -35,14 +44,8 @@ export const BikeStations = ({stations, onClusterClick}: Props) => {
           filter={['!', ['has', 'point_count']]}
           minZoomLevel={13}
           style={{
+            ...symbolStyling,
             textField: ['get', 'count'],
-            textAnchor: 'center',
-            textOffset: [0.75, 0],
-            textColor: stationBackgroundColor,
-            textSize: 12,
-            iconImage: 'BikeChip',
-            iconAllowOverlap: true,
-            iconSize: 0.85,
           }}
         />
       </MapboxGL.ShapeSource>
@@ -62,14 +65,8 @@ export const BikeStations = ({stations, onClusterClick}: Props) => {
           filter={['has', 'point_count']}
           minZoomLevel={13}
           style={{
+            ...symbolStyling,
             textField: ['get', 'sum'],
-            textAnchor: 'center',
-            textOffset: [0.75, 0],
-            textColor: stationBackgroundColor,
-            textSize: 12,
-            iconImage: 'BikeChip',
-            iconAllowOverlap: true,
-            iconSize: 0.85,
           }}
         />
       </MapboxGL.ShapeSource>

--- a/src/components/map/components/mobility/CarStations.tsx
+++ b/src/components/map/components/mobility/CarStations.tsx
@@ -18,6 +18,17 @@ export const CarStations = ({stations, onClusterClick}: Props) => {
   const stationTextColor = useTransportationColor(Mode.Car, undefined, 'text');
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
 
+  const symbolStyling = {
+    textAnchor: 'center',
+    textOffset: [0.75, 0],
+    textColor: stationBackgroundColor,
+    textSize: 12,
+    textAllowOverlap: true,
+    iconImage: 'CarChip',
+    iconAllowOverlap: true,
+    iconSize: 0.85,
+  };
+
   return (
     <>
       <MapboxGL.ShapeSource
@@ -31,15 +42,8 @@ export const CarStations = ({stations, onClusterClick}: Props) => {
           filter={['!', ['has', 'point_count']]}
           minZoomLevel={12}
           style={{
+            ...symbolStyling,
             textField: ['get', 'count'],
-            textAnchor: 'center',
-            textOffset: [0.75, 0],
-            textColor: stationBackgroundColor,
-            textSize: 12,
-            textAllowOverlap: true,
-            iconImage: 'CarChip',
-            iconAllowOverlap: true,
-            iconSize: 0.85,
           }}
         />
       </MapboxGL.ShapeSource>
@@ -59,15 +63,8 @@ export const CarStations = ({stations, onClusterClick}: Props) => {
           minZoomLevel={12}
           filter={['has', 'point_count']}
           style={{
+            ...symbolStyling,
             textField: ['get', 'sum'],
-            textAnchor: 'center',
-            textOffset: [0.75, 0],
-            textColor: stationBackgroundColor,
-            textSize: 12,
-            textAllowOverlap: true,
-            iconImage: 'CarChip',
-            iconAllowOverlap: true,
-            iconSize: 0.85,
           }}
         />
       </MapboxGL.ShapeSource>

--- a/src/components/map/components/mobility/Stations.tsx
+++ b/src/components/map/components/mobility/Stations.tsx
@@ -50,7 +50,10 @@ export const Stations = ({stations, onClusterClick, mapCameraRef}: Props) => {
 
   return (
     <>
-      <BikeStations stations={bikeStations} />
+      <BikeStations
+        stations={bikeStations}
+        onClusterClick={handleClusterClick}
+      />
       <CarStations stations={carStations} onClusterClick={handleClusterClick} />
     </>
   );


### PR DESCRIPTION
Same as https://github.com/AtB-AS/mittatb-app/pull/3980, but for bike stations. Adds clustering to bike stations, where the count is the sum of all leaf nodes.