### PR TITLE
feat: Dismissible announcements

### DIFF
--- a/src/announcements/AnnouncementsContext.tsx
+++ b/src/announcements/AnnouncementsContext.tsx
@@ -1,4 +1,10 @@
-import {createContext, useContext, useEffect, useState} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import firestore from '@react-native-firebase/firestore';
 import {AnnouncementRaw, AnnouncementType} from './types';
 import {mapToAnnouncements} from './converters';
@@ -42,16 +48,19 @@ const AnnouncementsContextProvider: React.FC = ({children}) => {
     return () => unsubscribe();
   }, []);
 
-  const dismissAnnouncement = (dismissedAnnouncement: AnnouncementType) => {
-    addDismissedAnnouncementInStore(dismissedAnnouncement.id);
-    setAnnouncements((announcements) =>
-      announcements.filter((a) => a.id !== dismissedAnnouncement.id),
-    );
-  };
+  const dismissAnnouncement = useCallback(
+    (dismissedAnnouncement: AnnouncementType) => {
+      addDismissedAnnouncementInStore(dismissedAnnouncement.id);
+      setAnnouncements((announcements) =>
+        announcements.filter((a) => a.id !== dismissedAnnouncement.id),
+      );
+    },
+    [addDismissedAnnouncementInStore],
+  );
 
-  const resetDismissedAnnouncements = () => {
+  const resetDismissedAnnouncements = useCallback(() => {
     setDismissedAnnouncementInStore([]);
-  };
+  }, [setDismissedAnnouncementInStore]);
 
   return (
     <AnnouncementsContext.Provider

--- a/src/announcements/AnnouncementsContext.tsx
+++ b/src/announcements/AnnouncementsContext.tsx
@@ -2,13 +2,22 @@ import {createContext, useContext, useEffect, useState} from 'react';
 import firestore from '@react-native-firebase/firestore';
 import {AnnouncementRaw, AnnouncementType} from './types';
 import {mapToAnnouncements} from './converters';
+import {
+  addDismissedAnnouncementInStore,
+  getDismissedAnnouncementsFromStore,
+  setDismissedAnnouncementInStore,
+} from '@atb/announcements/storage';
 
 type AnnouncementsContextState = {
   announcements: AnnouncementType[];
+  dismissAnnouncement: (announcement: AnnouncementType) => void;
+  resetDismissedAnnouncements: () => void;
 };
 
 const AnnouncementsContext = createContext<AnnouncementsContextState>({
   announcements: [],
+  dismissAnnouncement: (_: AnnouncementType) => {},
+  resetDismissedAnnouncements: () => {},
 });
 
 const AnnouncementsContextProvider: React.FC = ({children}) => {
@@ -20,7 +29,11 @@ const AnnouncementsContextProvider: React.FC = ({children}) => {
       .where('active', '==', true)
       .onSnapshot(
         async (snapshot) => {
-          setAnnouncements(mapToAnnouncements(snapshot.docs));
+          const dismissedIds = await getDismissedAnnouncementsFromStore();
+          const allAnnouncements = mapToAnnouncements(snapshot.docs);
+          setAnnouncements(
+            allAnnouncements.filter((a) => !dismissedIds.includes(a.id)),
+          );
         },
         (err) => {
           console.warn(err);
@@ -29,10 +42,23 @@ const AnnouncementsContextProvider: React.FC = ({children}) => {
     return () => unsubscribe();
   }, []);
 
+  const dismissAnnouncement = (dismissedAnnouncement: AnnouncementType) => {
+    addDismissedAnnouncementInStore(dismissedAnnouncement.id);
+    setAnnouncements((announcements) =>
+      announcements.filter((a) => a.id !== dismissedAnnouncement.id),
+    );
+  };
+
+  const resetDismissedAnnouncements = () => {
+    setDismissedAnnouncementInStore([]);
+  };
+
   return (
     <AnnouncementsContext.Provider
       value={{
         announcements,
+        dismissAnnouncement,
+        resetDismissedAnnouncements,
       }}
     >
       {children}

--- a/src/announcements/storage.ts
+++ b/src/announcements/storage.ts
@@ -1,0 +1,20 @@
+import {storage} from '@atb/storage';
+import {AnnouncementId} from '@atb/announcements/types';
+
+export const DISMISSED_ANNOUNCEMENTS_KEY = '@ATB_user_dismissed_announcements';
+
+export async function addDismissedAnnouncementInStore(id: AnnouncementId) {
+  const dismissedIds = await getDismissedAnnouncementsFromStore();
+  dismissedIds.push(id);
+  setDismissedAnnouncementInStore(dismissedIds);
+  return dismissedIds;
+}
+
+export async function getDismissedAnnouncementsFromStore() {
+  const dismissedIds = await storage.get(DISMISSED_ANNOUNCEMENTS_KEY);
+  return dismissedIds ? (JSON.parse(dismissedIds) as AnnouncementId[]) : [];
+}
+
+export async function setDismissedAnnouncementInStore(ids: AnnouncementId[]) {
+  await storage.set(DISMISSED_ANNOUNCEMENTS_KEY, JSON.stringify(ids));
+}

--- a/src/announcements/types.ts
+++ b/src/announcements/types.ts
@@ -1,8 +1,10 @@
 import {LanguageAndTextType} from '@atb-as/config-specs';
 import {FirebaseFirestoreTypes} from '@react-native-firebase/firestore';
 
+export type AnnouncementId = string;
+
 export type AnnouncementRaw = {
-  id: string;
+  id: AnnouncementId;
   active: boolean;
   summaryTitle?: LanguageAndTextType[];
   summary: LanguageAndTextType[];

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -6,11 +6,11 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {Image, View} from 'react-native';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Close} from '@atb/assets/svg/mono-icons/actions';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
-import {iconSizes} from '@atb-as/theme/lib/sizes';
+import {insets} from '@atb/utils/insets';
 
 type Props = {
   announcement: AnnouncementType;
@@ -18,69 +18,74 @@ type Props = {
 };
 
 export const Announcement = ({announcement, onDismiss}: Props) => {
-  const closeIconSize = 'normal';
-  const style = useStyle(closeIconSize)();
+  const style = useStyle();
   const {t} = useTranslation();
   const {language} = useTranslation();
+  const {theme} = useTheme();
 
   return (
     <View style={style.container}>
-      {announcement.summaryImage && (
-        <View style={style.imageContainer}>
-          <Image
-            height={50}
-            width={50}
-            source={{uri: announcement.summaryImage}}
-          />
+      <View
+        style={style.content}
+        accessible={true}
+        accessibilityRole="button"
+        accessibilityHint={t(DashboardTexts.announcemens.button.accessibility)}
+      >
+        {announcement.summaryImage && (
+          <View style={style.imageContainer}>
+            <Image
+              height={50}
+              width={50}
+              source={{uri: announcement.summaryImage}}
+            />
+          </View>
+        )}
+        <View style={style.textContainer}>
+          <ThemeText type="body__primary--bold">
+            {getTextForLanguage(
+              announcement.summaryTitle ?? announcement.fullTitle,
+              language,
+            )}
+          </ThemeText>
+          <ThemeText>
+            {getTextForLanguage(announcement.summary, language)}
+          </ThemeText>
         </View>
-      )}
-      <View style={style.textContainer}>
-        <ThemeText style={style.title} type="body__primary--bold">
-          {getTextForLanguage(
-            announcement.summaryTitle ?? announcement.fullTitle,
-            language,
-          )}
-        </ThemeText>
-        <ThemeText>
-          {getTextForLanguage(announcement.summary, language)}
-        </ThemeText>
       </View>
       <PressableOpacity
         style={style.close}
         role="button"
-        hitSlop={12}
+        hitSlop={insets.all(theme.spacings.medium)}
         accessibilityHint={t(
           DashboardTexts.announcemens.announcement.closeA11yHint,
         )}
         onPress={() => onDismiss(announcement)}
       >
-        <ThemeIcon size={closeIconSize} svg={Close} />
+        <ThemeIcon svg={Close} />
       </PressableOpacity>
     </View>
   );
 };
 
-const useStyle = (closeIconSize: keyof typeof iconSizes) =>
-  StyleSheet.createThemeHook((theme) => ({
-    container: {
-      flexDirection: 'row',
-      alignItems: 'center',
-    },
-    imageContainer: {
-      marginRight: theme.spacings.medium,
-      borderRadius: theme.border.radius.regular,
-      padding: -theme.border.radius.regular,
-      overflow: 'hidden',
-    },
-    textContainer: {
-      flex: 1,
-    },
-    title: {
-      marginRight: theme.spacings.medium + theme.icon.size[closeIconSize],
-    },
-    close: {
-      position: 'absolute',
-      top: 0,
-      right: 0,
-    },
-  }));
+const useStyle = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    flexDirection: 'row',
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  imageContainer: {
+    marginRight: theme.spacings.medium,
+    borderRadius: theme.border.radius.regular,
+    padding: -theme.border.radius.regular,
+    overflow: 'hidden',
+  },
+  textContainer: {
+    flex: 1,
+  },
+  close: {
+    flexGrow: 0,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -1,15 +1,26 @@
 import {AnnouncementType} from '@atb/announcements/types';
 import {ThemeText} from '@atb/components/text';
-import {getTextForLanguage, useTranslation} from '@atb/translations';
+import {
+  DashboardTexts,
+  getTextForLanguage,
+  useTranslation,
+} from '@atb/translations';
 import {Image, View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Close} from '@atb/assets/svg/mono-icons/actions';
+import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {iconSizes} from '@atb-as/theme/lib/sizes';
 
 type Props = {
   announcement: AnnouncementType;
+  onDismiss: (announcement: AnnouncementType) => void;
 };
 
-export const Announcement = ({announcement}: Props) => {
-  const style = useStyle();
+export const Announcement = ({announcement, onDismiss}: Props) => {
+  const closeIconSize = 'normal';
+  const style = useStyle(closeIconSize)();
+  const {t} = useTranslation();
   const {language} = useTranslation();
 
   return (
@@ -24,7 +35,7 @@ export const Announcement = ({announcement}: Props) => {
         </View>
       )}
       <View style={style.textContainer}>
-        <ThemeText type="body__primary--bold">
+        <ThemeText style={style.title} type="body__primary--bold">
           {getTextForLanguage(
             announcement.summaryTitle ?? announcement.fullTitle,
             language,
@@ -34,22 +45,42 @@ export const Announcement = ({announcement}: Props) => {
           {getTextForLanguage(announcement.summary, language)}
         </ThemeText>
       </View>
+      <PressableOpacity
+        style={style.close}
+        role="button"
+        hitSlop={12}
+        accessibilityHint={t(
+          DashboardTexts.announcemens.announcement.closeA11yHint,
+        )}
+        onPress={() => onDismiss(announcement)}
+      >
+        <ThemeIcon size={closeIconSize} svg={Close} />
+      </PressableOpacity>
     </View>
   );
 };
 
-const useStyle = StyleSheet.createThemeHook((theme) => ({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  imageContainer: {
-    marginRight: theme.spacings.medium,
-    borderRadius: theme.border.radius.regular,
-    padding: -theme.border.radius.regular,
-    overflow: 'hidden',
-  },
-  textContainer: {
-    flex: 1,
-  },
-}));
+const useStyle = (closeIconSize: keyof typeof iconSizes) =>
+  StyleSheet.createThemeHook((theme) => ({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    imageContainer: {
+      marginRight: theme.spacings.medium,
+      borderRadius: theme.border.radius.regular,
+      padding: -theme.border.radius.regular,
+      overflow: 'hidden',
+    },
+    textContainer: {
+      flex: 1,
+    },
+    title: {
+      marginRight: theme.spacings.medium + theme.icon.size[closeIconSize],
+    },
+    close: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+    },
+  }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -43,10 +43,7 @@ export const Announcements = ({style: containerStyle}: Props) => {
             style={i < announcements.length - 1 && style.announcement}
           >
             <GenericClickableSectionItem
-              accessibilityRole="button"
-              accessibilityHint={t(
-                DashboardTexts.announcemens.button.accessibility,
-              )}
+              accessible={false}
               onPress={() =>
                 openBottomSheet(() => (
                   <AnnouncementSheet

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -8,18 +8,30 @@ import {AnnouncementSheet} from './AnnouncementSheet';
 import {SectionHeading} from './SectionHeading';
 import {StyleSheet} from '@atb/theme';
 import {DashboardTexts, useTranslation} from '@atb/translations';
+import {animateNextChange} from '@atb/utils/animation';
+import {useAnalytics} from '@atb/analytics';
+import {AnnouncementType} from '@atb/announcements/types';
 
 type Props = {
   style?: StyleProp<ViewStyle>;
 };
 
 export const Announcements = ({style: containerStyle}: Props) => {
-  const {announcements} = useAnnouncementsState();
+  const {announcements, dismissAnnouncement} = useAnnouncementsState();
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
   const {t} = useTranslation();
   const style = useStyle();
+  const analytics = useAnalytics();
 
   if (announcements.length === 0) return null;
+
+  const handleDismiss = (announcement: AnnouncementType) => {
+    animateNextChange();
+    dismissAnnouncement(announcement);
+    analytics.logEvent('Dashboard', 'Announcement dismissed', {
+      id: announcement.id,
+    });
+  };
 
   return (
     <View style={containerStyle}>
@@ -44,7 +56,10 @@ export const Announcements = ({style: containerStyle}: Props) => {
                 ))
               }
             >
-              <Announcement announcement={a} />
+              <Announcement
+                announcement={a}
+                onDismiss={() => handleDismiss(a)}
+              />
             </GenericClickableSectionItem>
           </Section>
         ))}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -50,6 +50,7 @@ import {useLoadingErrorScreenEnabledDebugOverride} from '@atb/loading-screen/use
 import {Slider} from '@atb/components/slider';
 import {useBeaconsEnabledDebugOverride} from '@atb/beacons';
 import {useParkingViolationsReportingEnabledDebugOverride} from '@atb/parking-violations-reporting';
+import {useAnnouncementsState} from '@atb/announcements';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -97,6 +98,7 @@ export const Profile_DebugInfoScreen = () => {
   const beaconsEnabledDebugOverride = useBeaconsEnabledDebugOverride();
   const parkingViolationsReportingEnabledDebugOverride =
     useParkingViolationsReportingEnabledDebugOverride();
+  const {resetDismissedAnnouncements} = useAnnouncementsState();
 
   useEffect(() => {
     (async function () {
@@ -187,6 +189,10 @@ export const Profile_DebugInfoScreen = () => {
           <LinkSectionItem
             text="Reset dismissed Global messages"
             onPress={resetDismissedGlobalMessages}
+          />
+          <LinkSectionItem
+            text="Reset dismissed Announcements"
+            onPress={resetDismissedAnnouncements}
           />
           <LinkSectionItem
             text="Copy link to customer in Firestore (staging)"

--- a/src/translations/screens/Dashboard.ts
+++ b/src/translations/screens/Dashboard.ts
@@ -18,11 +18,7 @@ const DashboardTexts = {
       ),
     },
     announcement: {
-      closeA11yHint: _(
-        'Fjern meldingen',
-        'Dismiss announcement',
-        'Fjern meldinga',
-      ),
+      closeA11yHint: _('Lukk melding', 'Close announcement', 'Lukk melding'),
     },
   },
 };

--- a/src/translations/screens/Dashboard.ts
+++ b/src/translations/screens/Dashboard.ts
@@ -17,6 +17,13 @@ const DashboardTexts = {
         'Aktiver for å lese meir',
       ),
     },
+    announcement: {
+      closeA11yHint: _(
+        'Fjern meldingen',
+        'Dismiss announcement',
+        'Fjern meldinga',
+      ),
+    },
   },
 };
 


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/10321

Adds an X to the top right corner of each announcement that dismisses the announcement when pressed. Which announcements the user has dismissed is saved in the store.

![Simulator Screenshot - iPhone 13 - 2023-10-27 at 08 36 27](https://github.com/AtB-AS/mittatb-app/assets/4981580/ac62df0c-a291-4993-92b8-532cbd370e46)
