### PR TITLE
refactor: Make use-pollable-resource exhaustive deps fix

### DIFF
--- a/src/utils/use-pollable-resource.ts
+++ b/src/utils/use-pollable-resource.ts
@@ -47,7 +47,7 @@ export const usePollableResource = <T, E extends Error = Error>(
   const [isLoading, setIsLoading] = useIsLoading(false);
   const [error, setError] = useState<E | undefined>(undefined);
   const [state, setState] = useState<T>(initialValue);
-  const [abortController, setAbortController] = useState<AbortController>();
+  const abortControllerRef = useRef<AbortController>();
   const pollTime = pollingTimeInSeconds * 1000;
 
   const prevState = usePrevious(state);
@@ -75,12 +75,12 @@ export const usePollableResource = <T, E extends Error = Error>(
           }
         });
     },
-    [callback],
+    [callback, prevState, setIsLoading],
   );
 
   useEffect(() => {
     const abortController = new AbortController();
-    setAbortController(abortController);
+    abortControllerRef.current = abortController;
     reload('WITH_LOADING', abortController);
     return () => abortController.abort();
   }, [reload]);
@@ -88,13 +88,13 @@ export const usePollableResource = <T, E extends Error = Error>(
   useEffect(() => {
     if (!pollOnFocus || !firstLoadIsDone.current || !isFocused) return;
     const abortController = new AbortController();
-    setAbortController(abortController);
+    abortControllerRef.current = abortController;
     reload('NO_LOADING', abortController);
     return () => abortController.abort();
-  }, [isFocused]);
+  }, [reload, isFocused, pollOnFocus]);
 
   useInterval(
-    () => reload('NO_LOADING', abortController),
+    () => reload('NO_LOADING', abortControllerRef.current),
     pollTime,
     [reload],
     opts.disabled || (pollOnFocus && !isFocused),

--- a/src/utils/use-pollable-resource.ts
+++ b/src/utils/use-pollable-resource.ts
@@ -80,6 +80,7 @@ export const usePollableResource = <T, E extends Error = Error>(
 
   useEffect(() => {
     const abortController = new AbortController();
+    firstLoadIsDone.current = false;
     abortControllerRef.current = abortController;
     reload('WITH_LOADING', abortController);
     return () => abortController.abort();

--- a/src/utils/use-previous.ts
+++ b/src/utils/use-previous.ts
@@ -1,5 +1,9 @@
 import {useEffect, useRef} from 'react';
 
+/**
+ * Returns a current reference to the previous value. The returned value is safe
+ * to use in dependency arrays as refs won't trigger reruns.
+ */
 export const usePrevious = <T>(value: T): T | undefined => {
   const ref = useRef<T>();
   useEffect(() => {

--- a/src/utils/use-previous.ts
+++ b/src/utils/use-previous.ts
@@ -1,8 +1,11 @@
 import {useEffect, useRef} from 'react';
 
 /**
- * Returns a current reference to the previous value. The returned value is safe
- * to use in dependency arrays as refs won't trigger reruns.
+ * Returns a reference to the previous value. The returned value won't trigger
+ * hook reruns as refs don't have an effect in dependency arrays.
+ *
+ * @param value the new value
+ * @return the previous value
  */
 export const usePrevious = <T>(value: T): T | undefined => {
   const ref = useRef<T>();


### PR DESCRIPTION
- Adding prevState to dependency array of reload funcion is safe as
  it is a reference.
- Adding setisLoading to dependency array of reload function is
  safe as it is referentially stable.
- Adding reload to dependency array of the reload-on-focus
  useEffect is safe because the original
  load-on-reload-function-change useEffect now sets firstLoadIsDone
  to false.
- AbortController changed to ref as we don't want to add it in the
  dependency list for the useInterval hook.

And as a final note we should probably look into using useReactQuery
for this logic, as it supports most of what usePollableResource is
trying to achieve.

### Acceptance criteria
- [ ] Trip pattern updates should work as before: Should update every 20 seconds, not update when not focused, and always update when getting focus.