### PR TITLE
refactor: Deps fix in useDoOnceWhen

### DIFF
--- a/src/utils/__tests__/use-do-once-when.test.ts
+++ b/src/utils/__tests__/use-do-once-when.test.ts
@@ -1,0 +1,52 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
+
+let functionRunCount = 0;
+describe('useDelayGate', () => {
+  beforeEach(() => (functionRunCount = 0));
+
+  it('Should run on initial render when condition true', async () => {
+    renderHook(() => useDoOnceWhen(() => functionRunCount++, true));
+
+    expect(functionRunCount).toBe(1);
+  });
+
+  it('Should run when condition changes from false to true', async () => {
+    const hook = renderHook(
+      ({condition}) => useDoOnceWhen(() => functionRunCount++, condition),
+      {initialProps: {condition: false}},
+    );
+    expect(functionRunCount).toBe(0);
+    hook.rerender({condition: true});
+    expect(functionRunCount).toBe(1);
+  });
+
+  it('Should rerun if condition switches back to false and to true again', async () => {
+    const hook = renderHook(
+      ({condition}) => useDoOnceWhen(() => functionRunCount++, condition),
+      {initialProps: {condition: false}},
+    );
+    hook.rerender({condition: true});
+    hook.rerender({condition: false});
+    hook.rerender({condition: true});
+    expect(functionRunCount).toBe(2);
+  });
+
+  it('Should not rerun if given function changes', async () => {
+    const hook = renderHook(({func}) => useDoOnceWhen(func, true), {
+      initialProps: {func: () => functionRunCount++},
+    });
+    expect(functionRunCount).toBe(1);
+    hook.rerender({func: () => functionRunCount++});
+    expect(functionRunCount).toBe(1);
+  });
+
+  it('Should run with the most recent function', async () => {
+    const hook = renderHook(({func, cond}) => useDoOnceWhen(func, cond), {
+      initialProps: {func: () => functionRunCount++, cond: false},
+    });
+    expect(functionRunCount).toBe(0);
+    hook.rerender({func: () => (functionRunCount += 2), cond: true});
+    expect(functionRunCount).toBe(2);
+  });
+});

--- a/src/utils/use-do-once-when.ts
+++ b/src/utils/use-do-once-when.ts
@@ -2,10 +2,15 @@ import {useEffect, useRef} from 'react';
 
 export function useDoOnceWhen(fn: () => void, condition: boolean) {
   const firstTimeRef = useRef(true);
+  const fnRef = useRef(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
   useEffect(() => {
     if (firstTimeRef.current && condition) {
       firstTimeRef.current = false;
-      fn();
+      fnRef.current();
     }
     return () => {
       firstTimeRef.current = true;


### PR DESCRIPTION
The input function (fn) was not in the dependency list of the
useEffect running the function. JUst naively adding it could not
be done, as that would make the effect rerun on every render as
input functions are not stable references.

The solution would be either:
- Add the function to the dependency list, and users of the hook
  would need to ensure that they only send in stable references,
  for example by wrapping function with useCallback.
- Use the input function as a ref, which would not rerun the effect
  even though the function changes.

The latter option was selected as that is easier on the client, and
is the same as it is working before.
