### PR TITLE
fix: allow undefined via to match with empty via

### DIFF
--- a/src/utils/destination-displays-are-equal.ts
+++ b/src/utils/destination-displays-are-equal.ts
@@ -7,8 +7,10 @@ export function destinationDisplaysAreEqual(
 ) {
   const frontTextIsEqual =
     destinationDisplay1?.frontText === destinationDisplay2?.frontText;
-  const viaLengthIsEqual =
-    destinationDisplay1?.via?.length === destinationDisplay2?.via?.length;
+  // fallback to empty array to allow undefined via to match with empty via
+  const via1 = destinationDisplay1?.via || [];
+  const via2 = destinationDisplay1?.via || [];
+  const viaLengthIsEqual = via1.length === via2.length;
   if (!frontTextIsEqual || !viaLengthIsEqual) {
     return false;
   }

--- a/src/utils/destination-displays-are-equal.ts
+++ b/src/utils/destination-displays-are-equal.ts
@@ -9,7 +9,7 @@ export function destinationDisplaysAreEqual(
     destinationDisplay1?.frontText === destinationDisplay2?.frontText;
   // fallback to empty array to allow undefined via to match with empty via
   const via1 = destinationDisplay1?.via || [];
-  const via2 = destinationDisplay1?.via || [];
+  const via2 = destinationDisplay2?.via || [];
   const viaLengthIsEqual = via1.length === via2.length;
   if (!frontTextIsEqual || !viaLengthIsEqual) {
     return false;


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/2732

Allows undefined via to match with empty via.
This caused a bug where getExistingFavorite would not match a favorite, and a star would not be filled in correctly.

Also see https://github.com/AtB-AS/atb-bff/pull/309 keeping destinationDisplaysAreEqual in sync