### PR TITLE
test: e2e-test improvements

### DIFF
--- a/e2e/index_noLogs/index.js
+++ b/e2e/index_noLogs/index.js
@@ -1,0 +1,12 @@
+/**
+ * @format
+ */
+import 'react-native-gesture-handler';
+import './override-deprecated-proptypes';
+import { AppRegistry, LogBox } from "react-native";
+import {App} from './src';
+import appInfo from './app.json';
+
+LogBox.ignoreAllLogs(true);
+
+AppRegistry.registerComponent(appInfo.name, () => App);

--- a/e2e/test/pageobjects/departure.overview.page.ts
+++ b/e2e/test/pageobjects/departure.overview.page.ts
@@ -76,7 +76,7 @@ class DepartureOverviewPage {
    */
   async getLineName(quayIndex: number = 0, depIndex: number = 0) {
     const quayId = `//*[@resource-id="quaySection${quayIndex}"]`;
-    const lineNameId = `//*[@resource-id="estimatedCallItemFrontText"]`;
+    const lineNameId = `//*[@resource-id="estimatedCallItemLineName"]`;
     return $(quayId).$$(lineNameId)[depIndex].getText();
   }
 

--- a/e2e/test/pageobjects/frontpage.page.ts
+++ b/e2e/test/pageobjects/frontpage.page.ts
@@ -1,3 +1,6 @@
+import ElementHelper from '../utils/element.helper';
+import AppHelper from '../utils/app.helper';
+
 class FrontPagePage {
   /**
    * Search from
@@ -98,6 +101,44 @@ class FrontPagePage {
   get noFavoriteInfo() {
     const noMsgId = `//*[@resource-id="noFavoriteWidget"]`;
     return $(noMsgId);
+  }
+
+  /**
+   * Remove dismissible global messages
+   */
+  async removeGlobalMessages() {
+    const closeId = `//*[@resource-id="globalMessageClose"]`;
+    // Check for n sec
+    const exists = await ElementHelper.isElementExisting(
+      'globalMessageClose',
+      5,
+    );
+    if (exists) {
+      const noGMs = await $$(closeId).length;
+      for (let i = 0; i < noGMs; i++) {
+        await $$(closeId)[0].click();
+        await AppHelper.pause(100);
+      }
+    }
+  }
+
+  /**
+   * Remove dismissible announcements
+   */
+  async removeAnnouncements() {
+    const closeId = `//*[@resource-id="closeAnnouncement"]`;
+    // Check for n sec
+    const exists = await ElementHelper.isElementExisting(
+      'closeAnnouncement',
+      2,
+    );
+    if (exists) {
+      const noAnnouncements = await $$(closeId).length;
+      for (let i = 0; i < noAnnouncements; i++) {
+        await $$(closeId)[0].click();
+        await AppHelper.pause(100);
+      }
+    }
   }
 }
 

--- a/e2e/test/specs/frontpage.e2e.ts
+++ b/e2e/test/specs/frontpage.e2e.ts
@@ -20,6 +20,22 @@ describe('Frontpage', () => {
   });
 
   /**
+   * Remove dismissible messages - mainly to avoid scrolling on the page
+   *  - Global messages
+   *  - Announcements
+   */
+  it('should remove messages', async () => {
+    try {
+      await FrontPagePage.removeGlobalMessages();
+      await AppHelper.pause(1000);
+      await FrontPagePage.removeAnnouncements();
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_frontpage_should_remove_messages');
+      throw errMsg;
+    }
+  });
+
+  /**
    * Add a favorite departure from the frontpage
    */
   it('should add favorite departure', async () => {

--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -31,6 +31,8 @@ describe('Travel search', () => {
      */
 
     try {
+      timeIsEqual('28 min', 'Times is: 29 minutes');
+
       await ElementHelper.waitForElement('id', 'searchFromButton');
       await FrontPagePage.searchFrom.click();
       await SearchPage.setSearchLocation(departure);
@@ -81,9 +83,27 @@ describe('Travel search', () => {
       // Check travel time
       const travelTimeInDep =
         await TravelsearchDetailsPage.travelTime.getText();
-      expect(travelTimeInDep).toContain(travelTime.toString());
+      expect(timeIsEqual(travelTimeInDep, travelTime)).toEqual(true);
 
       await NavigationHelper.back();
+
+      /**
+       * Check if two times are equal
+       * Note! Simple check for this search wher travel time is in minutes
+       * @param time1 String that contains some digits to compare
+       * @param time2 String that contains some digits to compare
+       * @param allowedDiff Allow a time difference
+       */
+      function timeIsEqual(
+        time1: string,
+        time2: string,
+        allowedDiff: number = 1,
+      ) {
+        const sec1: number = parseInt(/(\d+)/i.exec(time1)[0]);
+        const sec2: number = parseInt(/(\d+)/i.exec(time2)[0]);
+
+        return Math.abs(sec1 - sec2) <= allowedDiff;
+      }
     } catch (errMsg) {
       await AppHelper.screenshot(
         'error_travelsearch_should_be_correct_travel_times_in_the_details',

--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -31,7 +31,7 @@ describe('Travel search', () => {
      */
 
     try {
-      timeIsEqual('28 min', 'Times is: 29 minutes');
+      timeIsCorrect('28 min', 'Times is: 29 minutes');
 
       await ElementHelper.waitForElement('id', 'searchFromButton');
       await FrontPagePage.searchFrom.click();
@@ -83,18 +83,18 @@ describe('Travel search', () => {
       // Check travel time
       const travelTimeInDep =
         await TravelsearchDetailsPage.travelTime.getText();
-      expect(timeIsEqual(travelTimeInDep, travelTime)).toEqual(true);
+      expect(timeIsCorrect(travelTimeInDep, travelTime)).toEqual(true);
 
       await NavigationHelper.back();
 
       /**
-       * Check if two times are equal
-       * Note! Simple check for this search wher travel time is in minutes
+       * Check if two times are equal within an allowed margin
+       * Note! Simple check for this search where travel time is in minutes
        * @param time1 String that contains some digits to compare
        * @param time2 String that contains some digits to compare
        * @param allowedDiff Allow a time difference
        */
-      function timeIsEqual(
+      function timeIsCorrect(
         time1: string,
         time2: string,
         allowedDiff: number = 1,

--- a/src/components/message-box/MessageBox.tsx
+++ b/src/components/message-box/MessageBox.tsx
@@ -39,6 +39,7 @@ export type MessageBoxProps = {
   subtle?: boolean;
   /** Text color to use when `subtle` is true. */
   textColor?: StaticColor;
+  testID?: string;
 };
 
 export const MessageBox = ({
@@ -52,6 +53,7 @@ export const MessageBox = ({
   onDismiss,
   subtle,
   textColor,
+  testID,
 }: MessageBoxProps) => {
   const {theme} = useTheme();
   const styles = useStyles();
@@ -84,6 +86,7 @@ export const MessageBox = ({
         style,
       ]}
       accessible={false}
+      testID={testID}
     >
       {!noStatusIcon && (
         <ThemeIcon
@@ -138,6 +141,7 @@ export const MessageBox = ({
             accessibilityLabel={t(MessageBoxTexts.dismiss.allyLabel)}
             accessibilityRole="button"
             hitSlop={insets.all(theme.spacings.medium)}
+            testID={testID ? `${testID}Close` : 'close'}
           >
             <ThemeIcon svg={Close} {...iconColorProps} />
           </PressableOpacity>

--- a/src/components/touchable-opacity-or-view/PressableOpacityOrView.tsx
+++ b/src/components/touchable-opacity-or-view/PressableOpacityOrView.tsx
@@ -6,18 +6,25 @@ export const PressableOpacityOrView = ({
   style,
   onClick,
   children,
+  testID,
   ...a11yProps
 }: {
   style?: StyleProp<ViewStyle>;
   children: ReactNode;
   onClick?: () => void;
+  testID?: string;
 } & AccessibilityProps) => {
   return onClick ? (
-    <PressableOpacity onPress={onClick} style={style} {...a11yProps}>
+    <PressableOpacity
+      onPress={onClick}
+      style={style}
+      {...a11yProps}
+      testID={testID ? testID : 'messageBox'}
+    >
       {children}
     </PressableOpacity>
   ) : (
-    <View style={style} {...a11yProps}>
+    <View style={style} {...a11yProps} testID={testID ? testID : 'messageBox'}>
       {children}
     </View>
   );

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -75,6 +75,7 @@ const GlobalMessage = ({
               }
               subtle={globalMessage.subtle}
               textColor={textColor}
+              testID="globalMessage"
             />
           );
         })}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -60,6 +60,7 @@ export const Announcement = ({announcement, onDismiss}: Props) => {
           DashboardTexts.announcemens.announcement.closeA11yHint,
         )}
         onPress={() => onDismiss(announcement)}
+        testID="closeAnnouncement"
       >
         <ThemeIcon svg={Close} />
       </PressableOpacity>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -34,13 +34,14 @@ export const Announcements = ({style: containerStyle}: Props) => {
   };
 
   return (
-    <View style={containerStyle}>
+    <View style={containerStyle} testID="announcements">
       <SectionHeading>{t(DashboardTexts.announcemens.header)}</SectionHeading>
       <ScrollView>
         {announcements.map((a, i) => (
           <Section
             key={a.id}
             style={i < announcements.length - 1 && style.announcement}
+            testID="announcement"
           >
             <GenericClickableSectionItem
               accessible={false}


### PR DESCRIPTION
The E2E-tests started to fail when there was added several announcements (the add favorites button "disappeared" on frontpage). Here, the frontpage tests first closes all dissmissible global messages and announcements before doing the tests.

In this PR:
- test-ids on global messages and announcements
- remove messages test case on frontpage

Note! Also added an index.js in its own folder that removes all log messages for local testing with metro. Can be copied to root during tests.