### PR TITLE
refactor: Move function creation out of React render

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -96,7 +96,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_show_valid_time_info: true,
   enable_loading_screen: true,
   enable_loading_error_screen: false,
-  token_timeout_in_seconds: 0,
+  token_timeout_in_seconds: 10,
   enable_beacons: false,
   delay_share_travel_habits_screen_by_sessions_count: 0,
   enable_parking_violations_reporting: false,


### PR DESCRIPTION
Some functions were not necessary to create on render and wrap with
useCallback. Instead move them out of the render body, which
makes them non-reactive functions and as such don't need to be in
the dependency list of the hooks where they are used.

Also change the token timeout default value to 10 as it is really
beneficial to log error to bugsnag after 10 seconds, and it should
instead be opt-out.
