### PR TITLE
fix: tsc error in e2e

### DIFF
--- a/e2e/test/pageobjects/travelsearch.overview.page.ts
+++ b/e2e/test/pageobjects/travelsearch.overview.page.ts
@@ -95,7 +95,7 @@ class TravelSearchOverviewPage {
     const searchResultId = `//*[@resource-id="tripSearchSearchResult${resultIndex}"]`;
     const durationId = `//*[@resource-id="resultDuration"]`;
     const duration = await $(searchResultId).$(durationId).getText();
-    return parseInt(duration.split(' ')[0]);
+    return duration.split(' ')[0];
   }
 }
 export default new TravelSearchOverviewPage();

--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -45,7 +45,7 @@ describe('Travel search', () => {
 
       const startTime: string = await TravelsearchOverviewPage.getStartTime(0);
       const endTime: string = await TravelsearchOverviewPage.getEndTime(0);
-      const travelTime: number = await TravelsearchOverviewPage.getTravelTime(
+      const travelTime: string = await TravelsearchOverviewPage.getTravelTime(
         0,
       );
       const noLegs = await TravelsearchOverviewPage.getNumberOfLegs(0);


### PR DESCRIPTION
Fix the error `e2e/test/specs/travelsearch.e2e.ts(86,45): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.` from https://github.com/AtB-AS/mittatb-app/actions/runs/6808388945/job/18512750417