### PR TITLE
test: add notification screen in e2e-tests

### DIFF
--- a/e2e/test/pageobjects/onboarding.page.ts
+++ b/e2e/test/pageobjects/onboarding.page.ts
@@ -19,6 +19,14 @@ class OnboardingPage {
   }
 
   /**
+   * Next button on notifications screen
+   */
+  get nextButtonNotificationOnboarding() {
+    const reqId = `//*[@resource-id="nextButtonNotificationOnboarding"]`;
+    return $(reqId);
+  }
+
+  /**
    * Accept restrictions
    */
   get accRestrButton() {
@@ -54,6 +62,13 @@ class OnboardingPage {
       await ElementHelper.waitForElement('id', 'acceptRestrictionsButton');
       await this.accRestrButton.click();
       await this.denyLocation();
+      //NOTE! Will be temporarily until a new onboarding flow is in place
+      await AppHelper.pause(3000, true);
+      await ElementHelper.waitForElement(
+        'id',
+        'nextButtonNotificationOnboarding',
+      );
+      await this.nextButtonNotificationOnboarding.click();
     } catch (errMsg) {
       await AppHelper.screenshot(`error_${testName}_skipOnboarding`);
       throw errMsg;

--- a/e2e/test/specs/onboarding.e2e.ts
+++ b/e2e/test/specs/onboarding.e2e.ts
@@ -27,6 +27,13 @@ describe('Onboarding', () => {
       // Location
       await OnboardingPage.denyLocation();
 
+      //NOTE! Will be temporarily until a new onboarding flow is in place
+      await ElementHelper.waitForElement(
+        'id',
+        'nextButtonNotificationOnboarding',
+      );
+      await OnboardingPage.nextButtonNotificationOnboarding.click();
+
       await ElementHelper.waitForElement('id', 'dashboardScrollView');
       await ElementHelper.expectText(HeadingTexts.travelsearch);
     } catch (errMsg) {

--- a/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
+++ b/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
@@ -61,7 +61,7 @@ export const Root_NotificationPermissionScreen = ({navigation}: Props) => {
             interactiveColor="interactive_0"
             onPress={handleButtonPress}
             text={t(NotificationPermissionTexts.button)}
-            testID="nextButton"
+            testID="nextButtonNotificationOnboarding"
           />
         </View>
       </ScrollView>


### PR DESCRIPTION
Will be a temporary fix to make the tests run until the new onboarding flow is in place.