### PR TITLE
fix: Remove scroll visual and remove "cutoff" from nonTransitResults

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
@@ -28,7 +28,12 @@ export const NonTransitResults = ({tripPatterns, onDetailsPressed}: Props) => {
   const style = useStyle();
 
   return (
-    <ScrollView horizontal={true} style={style.container}>
+    <ScrollView
+      horizontal={true}
+      style={style.scrollView}
+      contentContainerStyle={style.container}
+      showsHorizontalScrollIndicator={false}
+    >
       {tripPatterns.map((tripPattern) => {
         const {mode, modeText} = getMode(tripPattern, t);
         const durationShort = secondsToDurationShort(
@@ -75,9 +80,11 @@ const getMode = (
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
-  container: {
+  scrollView: {
     marginTop: theme.spacings.medium,
-    marginHorizontal: theme.spacings.medium,
+  },
+  container: {
+    paddingHorizontal: theme.spacings.medium,
   },
   tripMode: {
     marginRight: theme.spacings.small,


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/5eb7b9cc-7fc2-4d03-9ec1-38fded830338"/> | <img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/2a4f0d12-5e72-44e0-8265-ce3a68e3bed3"/> |


<details>
  <summary>📹 Video</summary>
  <p>

https://github.com/AtB-AS/mittatb-app/assets/70323886/a11a1908-41a9-4f87-98f3-e163cec716c9

</p>
</details>
