### PR TITLE
refactor: Make translate func a stable reference

### DIFF
--- a/src/beacons/use-beacons.ts
+++ b/src/beacons/use-beacons.ts
@@ -127,7 +127,7 @@ export const useBeacons = () => {
         buttonPositive,
       },
     };
-  }, []);
+  }, [t]);
 
   const onboardForBeacons = useCallback(async () => {
     if (!isBeaconsSupported) return false;

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -145,7 +145,7 @@ export const NearbyStopPlacesScreenComponent = ({
             ),
       );
     }
-  }, [updatingLocation, isLoading]);
+  }, [updatingLocation, isLoading, t]);
 
   function refresh() {
     onUpdateLocation(

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -98,7 +98,7 @@ export function LocationSearchContent({
     if (error) {
       setErrorMessage(translateErrorType(error, t));
     }
-  }, [error]);
+  }, [error, t]);
 
   const hasPreviousResults = !!previousLocations.length;
   const hasResults = !!locationSearchResults.length;

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsQr.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsQr.tsx
@@ -40,7 +40,7 @@ export const Root_ParkingViolationsQr = ({
       ...providers,
       {name: t(ParkingViolationTexts.selectProvider.unknownProvider)},
     ],
-    [providers],
+    [providers, t],
   );
 
   useEffect(() => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -122,7 +122,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
         setSearchStateMessage('');
         break;
     }
-  }, [searchState]);
+  }, [searchState, t]);
 
   const setCurrentLocationAsFrom = useCallback(
     function setCurrentLocationAsFrom() {
@@ -426,9 +426,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
               />
             </View>
           )}
-          {!tripPatterns.length && (
-            <View style={style.emptyResultsSpacer} />
-          )}
+          {!tripPatterns.length && <View style={style.emptyResultsSpacer} />}
           {!error && isValidLocations && (
             <PressableOpacity
               onPress={loadMore}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -64,7 +64,7 @@ export const Results: React.FC<Props> = ({
           break;
       }
     }
-  }, [errorType]);
+  }, [errorType, t]);
 
   if (showEmptyScreen) {
     return null;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -67,7 +67,7 @@ export const Profile_DeleteProfileScreen = ({
       );
     }
     setDeleteError(false);
-  }, [deleteError, setDeleteError]);
+  }, [deleteError, setDeleteError, t]);
 
   return (
     <View style={style.container}>

--- a/src/translations/commons.ts
+++ b/src/translations/commons.ts
@@ -1,6 +1,7 @@
 import {TFunc} from '@leile/lobo-t';
 
 import {initLobot, Translatable} from '@leile/lobo-t';
+import {useCallback} from 'react';
 
 export enum Language {
   Norwegian = 'nb',
@@ -15,7 +16,13 @@ export const DEFAULT_REGION = 'NO';
 export type TranslatedString = Translatable<typeof Language, string>;
 
 export const lobot = initLobot<typeof Language>(DEFAULT_LANGUAGE);
-export const useTranslation = lobot.useTranslation;
+export const useTranslation: typeof lobot.useTranslation = () => {
+  const {language} = lobot.useTranslation();
+  return {
+    t: useCallback((arg) => arg[language], [language]),
+    language: language,
+  };
+};
 
 export type TranslateFunction = TFunc<typeof Language>;
 export function translation(

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -82,7 +82,7 @@ export function useDepartureData(
         notices,
       };
     },
-    [activeItem],
+    [activeItem, t],
   );
 
   const [data, , isLoading] = usePollableResource<DepartureData>(getService, {


### PR DESCRIPTION
The translate function (t) from lobot was not a stable reference,
and recreated on every render. This ment it could not be added to
dependency lists without causing the hooks to be run too often.

In this PR we wrap the translate function with 'useCallback', and
add the 't' function to the dependency lists.

I also created an [issue at the lobo-t repo](https://github.com/leile/lobo-t/issues/7), and offered creating a
PR there, but no response yet.
