### PR TITLE
fix: widget set url with env

### DIFF
--- a/ios/departureWidget/APIService.swift
+++ b/ios/departureWidget/APIService.swift
@@ -3,14 +3,18 @@ import Foundation
 enum AppEndPoint: String {
     case departureFavourites, quayCoordinates
 
-    private var host: String {
-        "https://api.staging.mittatb.no"
-    }
+    private var API_BASE_URL: String {
+        guard let hostUrl = Bundle.main.object(forInfoDictionaryKey: "ApiBaseUrl") as? String else {
+             fatalError("Not able to read ApiBaseUrl")
+        }
+        return  hostUrl
+     }
+
 
     private var path: String? {
         switch self {
         case .departureFavourites:
-            var urlComponents = URLComponents(string: "\(host)/bff/v2/departure-favorites")
+            var urlComponents = URLComponents(string: "\(API_BASE_URL)bff/v2/departure-favorites")
             urlComponents?.queryItems = [
                 /* Fetching a large number of departures to be able to give the widgetManager a better
                  estimate of the future rerenders needed */
@@ -21,7 +25,7 @@ enum AppEndPoint: String {
 
             return urlComponents?.string
         case .quayCoordinates:
-            return "\(host)/bff/v2/quays-coordinates"
+            return "\(API_BASE_URL)bff/v2/quays-coordinates"
         }
     }
 

--- a/ios/departureWidget/Info.plist
+++ b/ios/departureWidget/Info.plist
@@ -9,5 +9,7 @@
 	</dict>
 	<key>NSWidgetWantsLocation</key>
 	<true/>
+	<key>ApiBaseUrl</key>
+	<string>$(API_BASE_URL)</string>
 </dict>
 </plist>


### PR DESCRIPTION
Noticed that the widget had been using the staging build of the api. 

Acceptance criteria:
- [ ] Widget is able to get departures

