### PR TITLE
fix: Render crash on TravelTokenBox

### DIFF
--- a/src/travel-token-box/TravelTokenBox.tsx
+++ b/src/travel-token-box/TravelTokenBox.tsx
@@ -20,7 +20,8 @@ export function TravelTokenBox({
 }) {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {deviceInspectionStatus, tokens} = useMobileTokenContextState();
+  const {deviceInspectionStatus, mobileTokenStatus, tokens, retry} =
+    useMobileTokenContextState();
 
   if (deviceInspectionStatus === 'loading') {
     return (
@@ -30,15 +31,39 @@ export function TravelTokenBox({
     );
   }
 
-  const errorMessages = ErrorMessages(alwaysShowErrors);
-  if (errorMessages) return errorMessages;
+  const showTokensNotWorkingError =
+    deviceInspectionStatus !== 'inspectable' ||
+    (alwaysShowErrors && mobileTokenStatus !== 'success');
+  if (showTokensNotWorkingError) {
+    return (
+      <MessageBox
+        type="warning"
+        title={t(TravelTokenBoxTexts.errorMessages.tokensNotLoadedTitle)}
+        message={t(TravelTokenBoxTexts.errorMessages.tokensNotLoaded)}
+        style={styles.errorMessage}
+        onPressConfig={{
+          action: retry,
+          text: t(dictionary.retry),
+        }}
+      />
+    );
+  }
 
   if (deviceInspectionStatus === 'inspectable' && !showIfThisDevice) {
     return null;
   }
 
   const inspectableToken = tokens.find((t) => t.isInspectable);
-  if (!inspectableToken) return null;
+  if (!inspectableToken)
+    return (
+      <MessageBox
+        type="warning"
+        isMarkdown={true}
+        title={t(TravelTokenBoxTexts.errorMessages.noInspectableTokenTitle)}
+        message={t(TravelTokenBoxTexts.errorMessages.noInspectableToken)}
+        style={styles.errorMessage}
+      />
+    );
 
   const a11yLabel =
     (inspectableToken.type === 'travel-card'
@@ -138,45 +163,6 @@ export const TravelDeviceTitle = ({
       </ThemeText>
     );
   }
-};
-
-const ErrorMessages = (alwaysShowErrors?: boolean) => {
-  const {t} = useTranslation();
-  const styles = useStyles();
-  const {mobileTokenStatus, retry, tokens, deviceInspectionStatus} =
-    useMobileTokenContextState();
-
-  if (mobileTokenStatus !== 'success') {
-    return deviceInspectionStatus === 'inspectable' &&
-      !alwaysShowErrors ? null : (
-      <MessageBox
-        type="warning"
-        title={t(TravelTokenBoxTexts.errorMessages.tokensNotLoadedTitle)}
-        message={t(TravelTokenBoxTexts.errorMessages.tokensNotLoaded)}
-        style={styles.errorMessage}
-        onPressConfig={{
-          action: retry,
-          text: t(dictionary.retry),
-        }}
-      />
-    );
-  }
-
-  const inspectableToken = tokens.find((t) => t.isInspectable);
-
-  if (!inspectableToken) {
-    return (
-      <MessageBox
-        type="warning"
-        isMarkdown={true}
-        title={t(TravelTokenBoxTexts.errorMessages.noInspectableTokenTitle)}
-        message={t(TravelTokenBoxTexts.errorMessages.noInspectableToken)}
-        style={styles.errorMessage}
-      />
-    );
-  }
-
-  return null;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({

--- a/src/travel-token-box/TravelTokenBox.tsx
+++ b/src/travel-token-box/TravelTokenBox.tsx
@@ -32,8 +32,8 @@ export function TravelTokenBox({
   }
 
   const showTokensNotWorkingError =
-    deviceInspectionStatus !== 'inspectable' ||
-    (alwaysShowErrors && mobileTokenStatus !== 'success');
+    mobileTokenStatus === 'error' &&
+    (alwaysShowErrors || deviceInspectionStatus === 'not-inspectable');
   if (showTokensNotWorkingError) {
     return (
       <MessageBox


### PR DESCRIPTION
React components shouldn't be created like normal javascript functions,
as that bypasses the rules and optimisations of React. The
ErrorMessages component here did not work as intended, as it made
the app crash with 'Rendered fewer hooks than expected' since the
hooks inside the component was rendered conditionally.

The solution now was inlining the error  message boxes into the
TravelTokenBox component.

Fixes:
https://github.com/AtB-AS/kundevendt/issues/10087#issuecomment-1808164753
https://app.bugsnag.com/atb-as/mittatb/errors/655221f4bdc7f80008277524?filters%5Buser.id%5D=d21ab310-04c3-4ba4-afc5-dcc88679951f&event_id=6552221900cc77ff8eac0000