### PR TITLE
test: handle empty state in e2e

### DIFF
--- a/e2e/test/specs/frontpage.e2e.ts
+++ b/e2e/test/specs/frontpage.e2e.ts
@@ -49,7 +49,7 @@ describe('Frontpage', () => {
 
       // Choose stop place
       await FrontPagePage.addFavoriteDeparture.click();
-      await ElementHelper.waitForElement('id', 'nearbyStopsContainerView');
+      await ElementHelper.waitForElement('id', 'noAccessToLocationEmptyStateView');
       await FrontPagePage.searchFrom.click();
       await SearchPage.setSearchLocation(stopPlace);
 

--- a/src/components/empty-state/EmptyState.tsx
+++ b/src/components/empty-state/EmptyState.tsx
@@ -12,6 +12,7 @@ export type EmptyStateProps = {
     onPress: () => void;
     text: string;
   };
+  testID?: string;
 };
 
 export const EmptyState: React.FC<EmptyStateProps> = ({
@@ -19,11 +20,15 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   details,
   illustrationComponent,
   buttonProps,
+  testID,
 }) => {
   const styles = useStyles();
 
   return (
-    <View style={styles.emptyStateContainer}>
+    <View
+      style={styles.emptyStateContainer}
+      testID={testID ? `${testID}EmptyStateView` : 'emptyStateView'}
+    >
       {illustrationComponent}
       <ThemeText
         type="body__primary--bold"

--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -61,6 +61,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
             title={emptyStateTitleText}
             details={emptyStateDetailsText}
             illustrationComponent={<TicketTilted height={84} />}
+            testID="fareContracts"
           />
         )}
         {fareContractsAndReservationsSorted?.map((fcOrReservation, index) => (

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -207,6 +207,7 @@ export const NearbyStopPlacesScreenComponent = ({
             onPress: requestPermission,
             text: t(NearbyTexts.stateAnnouncements.sharePositionButton.title),
           }}
+          testID="noAccessToLocation"
         />
       )}
     </FullScreenView>

--- a/src/nearby-stop-places/components/StopPlaces.tsx
+++ b/src/nearby-stop-places/components/StopPlaces.tsx
@@ -58,6 +58,7 @@ export const StopPlaces = ({
               style={styles.emptyStopPlacesIllustration}
             />
           }
+          testID="nearbyLocations"
         />
       )}
     </ScrollView>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -99,6 +99,7 @@ export const Results: React.FC<Props> = ({
               style={styles.emptySearchResultsIllustration}
             />
           }
+          testID="searchResults"
         />
       </View>
     );


### PR DESCRIPTION
The e2e tests are not using location, so with the empty state change, a test-id was not found.

Added test-ids to the empty state, and updated the e2e-frontpage test.