### PR TITLE
fix: Not move to antarctica when opening filters sheet

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,5 +1,4 @@
 import {useGeolocationState} from '@atb/GeolocationContext';
-import {useAnalytics} from '@atb/analytics';
 import {FOCUS_ORIGIN} from '@atb/api/geocoder';
 import {StyleSheet} from '@atb/theme';
 import {MapRoute} from '@atb/travel-details-map-screen/components/MapRoute';
@@ -16,7 +15,7 @@ import {MapFilter} from './components/filter/MapFilter';
 import {Stations, Vehicles} from './components/mobility';
 import {useControlPositionsStyle} from './hooks/use-control-styles';
 import {useMapSelectionChangeEffect} from './hooks/use-map-selection-change-effect';
-import {MapFilterType, MapProps, MapRegion} from './types';
+import {MapProps, MapRegion} from './types';
 import {isFeaturePoint} from './utils';
 
 export const Map = (props: MapProps) => {
@@ -26,7 +25,6 @@ export const Map = (props: MapProps) => {
   const mapViewRef = useRef<MapboxGL.MapView>(null);
   const styles = useMapStyles();
   const controlStyles = useControlPositionsStyle();
-  const analytics = useAnalytics();
 
   const startingCoordinates = useMemo(
     () =>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -75,12 +75,6 @@ export const Map = (props: MapProps) => {
     });
   };
 
-  const onFilterChange = (filter: MapFilterType) => {
-    analytics.logEvent('Map', 'Filter changed', {filter});
-    props.vehicles?.onFilterChange(filter.mobility);
-    props.stations?.onFilterChange(filter.mobility);
-  };
-
   return (
     <View style={styles.container}>
       {props.selectionMode === 'ExploreLocation' && (
@@ -151,7 +145,7 @@ export const Map = (props: MapProps) => {
         <View style={controlStyles.controlsContainer}>
           {(props.vehicles || props.stations) && (
             <MapFilter
-              onFilterChanged={onFilterChange}
+              onPress={() => onMapClick({source: 'filters-button'})}
               isLoading={
                 (props.vehicles?.isLoading || props.stations?.isLoading) ??
                 false

--- a/src/components/map/components/filter/MapFilter.tsx
+++ b/src/components/map/components/filter/MapFilter.tsx
@@ -1,31 +1,17 @@
 import React from 'react';
 import {Button} from '@atb/components/button';
-import {useBottomSheet} from '@atb/components/bottom-sheet';
-import {MapFilterSheet} from './MapFilterSheet';
-import {MapFilterType} from '../../types';
 import {StyleSheet} from '@atb/theme';
 import {shadows} from '../shadows';
 import {Filter} from '@atb/assets/svg/mono-icons/actions';
 import {useAnalytics} from '@atb/analytics';
 
 type MapFilterProps = {
-  onFilterChanged: (filter: MapFilterType) => void;
+  onPress: () => void;
   isLoading: boolean;
 };
-export const MapFilter = ({onFilterChanged, isLoading}: MapFilterProps) => {
+export const MapFilter = ({onPress, isLoading}: MapFilterProps) => {
   const style = useStyle();
-  const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
   const analytics = useAnalytics();
-
-  const onPress = () => {
-    analytics.logEvent('Map', 'Filter button clicked');
-    openBottomSheet(() => (
-      <MapFilterSheet
-        onFilterChanged={onFilterChanged}
-        close={closeBottomSheet}
-      />
-    ));
-  };
 
   return (
     <Button
@@ -34,7 +20,10 @@ export const MapFilter = ({onFilterChanged, isLoading}: MapFilterProps) => {
       compact={true}
       interactiveColor="interactive_2"
       accessibilityRole="button"
-      onPress={onPress}
+      onPress={() => {
+        analytics.logEvent('Map', 'Filter button clicked');
+        onPress();
+      }}
       leftIcon={{svg: Filter, loading: isLoading}}
     />
   );

--- a/src/components/map/hooks/use-decide-camera-focus-mode.tsx
+++ b/src/components/map/hooks/use-decide-camera-focus-mode.tsx
@@ -54,6 +54,11 @@ export const useDecideCameraFocusMode = (
         return;
       }
 
+      if (mapSelectionAction.source === 'filters-button') {
+        setCameraFocusMode(undefined);
+        return;
+      }
+
       if (mapSelectionAction.source === 'cluster-click') {
         setCameraFocusMode(undefined);
         return;

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -1,4 +1,4 @@
-import {MapProps, MapSelectionActionType} from '../types';
+import {MapFilterType, MapProps, MapSelectionActionType} from '../types';
 import React, {RefObject, useEffect, useState} from 'react';
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
@@ -19,6 +19,7 @@ import {
 import {useMapSelectionAnalytics} from './use-map-selection-analytics';
 import {BicycleSheet} from '@atb/mobility/components/BicycleSheet';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
+import {MapFilterSheet} from '../components/filter/MapFilterSheet';
 
 /**
  * Open or close the bottom sheet based on the selected coordinates. Will also
@@ -54,13 +55,27 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
         analytics.logMapSelection(selectedFeature);
       }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapSelectionAction]);
+  }, [mapSelectionAction, analytics, mapViewRef]);
 
   useEffect(() => {
     (async function () {
       if (!isFocused) return;
       if (mapProps.selectionMode !== 'ExploreEntities') return;
+
+      if (mapSelectionAction?.source === 'filters-button') {
+        openBottomSheet(() => (
+          <MapFilterSheet
+            onFilterChanged={(filter: MapFilterType) => {
+              analytics.logEvent('Map', 'Filter changed', {filter});
+              mapProps.vehicles?.onFilterChange(filter.mobility);
+              mapProps.stations?.onFilterChange(filter.mobility);
+            }}
+            close={closeWithCallback}
+          />
+        ));
+        return;
+      }
+
       if (!selectedFeature) {
         closeBottomSheet();
         return;
@@ -158,5 +173,5 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFeature, isFocused, distance, analytics]);
+  }, [mapSelectionAction, selectedFeature, isFocused, distance, analytics]);
 };

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -119,7 +119,8 @@ export type MapSelectionActionType =
   | {
       source: 'my-position';
       coords: Coordinates;
-    };
+    }
+  | {source: 'filters-button'};
 
 export type CameraFocusModeType =
   | {

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -59,11 +59,14 @@ export const findEntityAtClick = async (
     mapViewRef,
     ['==', ['geometry-type'], 'Point'],
   );
-  return renderedFeatures?.filter(isFeaturePoint)[0];
+  return renderedFeatures?.filter(isFeaturePoint)?.filter(hasProperties)[0];
 };
 
 export const isFeaturePoint = (f: Feature): f is Feature<Point> =>
   f.geometry.type === 'Point';
+
+export const hasProperties = (f: Feature) =>
+  Object.keys(f.properties || {}).length > 0;
 
 export const isClusterFeature = (
   feature: Feature,
@@ -91,10 +94,17 @@ export const mapPositionToCoordinates = (p: Position): Coordinates => ({
 
 export const getCoordinatesFromMapSelectionAction = (
   sc: MapSelectionActionType,
-) =>
-  sc.source === 'my-position'
-    ? sc.coords
-    : mapPositionToCoordinates(sc.feature.geometry.coordinates);
+) => {
+  switch (sc.source) {
+    case 'my-position':
+      return sc.coords;
+    case 'map-click':
+    case 'cluster-click':
+      return mapPositionToCoordinates(sc.feature.geometry.coordinates);
+    case 'filters-button':
+      return undefined;
+  }
+};
 
 export const getFeaturesAtClick = async (
   clickedFeature: Feature<Point>,


### PR DESCRIPTION
The reason for the bug was that the Map tried to show a walking
path, but since the filters sheet uses so much of the screen it
wasn't enough space to show to walk path, even if it zoomed all
the way out (showing Antarctica).

The fix is that when the filter sheet is opened, we needed to
reset the map state that said that the departures sheet and the
walk path should be visible.

One drawback of this solution is that there is no animation when
switching from the departures sheet to the filters sheet, but I
couldn't get that to work without causing havoc.
