### PR TITLE
build: remove duplicate app- from aab copy path in fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -354,7 +354,7 @@ platform :android do
         "android.injected.signing.key.alias" => ENV["KEY_ALIAS"],
         "android.injected.signing.key.password" => ENV["KEY_PASS"],
       })
-      sh("cp", "../android/app/build/outputs/bundle/#{app_flavor}/#{build_type}/app-#{app_flavor}-#{build_type}.aab", "../#{ENV["AAB_FILE_NAME"]}")
+      sh("cp", "../android/app/build/outputs/bundle/#{app_flavor}/#{build_type}/#{app_flavor}-#{build_type}.aab", "../#{ENV["AAB_FILE_NAME"]}")
       sh("mkdir", "-p", "../bundle")
       sh("cp", "../android/app/build/generated/assets/createBundle#{app_flavor.capitalize}#{build_type.capitalize}JsAndAssets/index.android.bundle", "../bundle")
       sh("cp", "../android/app/build/intermediates/sourcemaps/react/#{app_flavor}#{build_type.capitalize}/index.android.bundle.packager.map", "../bundle/index.android.bundle.map")


### PR DESCRIPTION
Closing: https://github.com/AtB-AS/kundevendt/issues/15533

Second attempt at possible fix for https://github.com/AtB-AS/mittatb-app/pull/3972/files#r1394271463