### PR TITLE
build: fix .aab path instead of filename

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -354,7 +354,7 @@ platform :android do
         "android.injected.signing.key.alias" => ENV["KEY_ALIAS"],
         "android.injected.signing.key.password" => ENV["KEY_PASS"],
       })
-      sh("cp", "../android/app/build/outputs/bundle/#{app_flavor}/#{build_type}/#{app_flavor}-#{build_type}.aab", "../#{ENV["AAB_FILE_NAME"]}")
+      sh("cp", "../android/app/build/outputs/bundle/#{app_flavor}#{build_type.capitalize}/app-#{app_flavor}-#{build_type}.aab", "../#{ENV["AAB_FILE_NAME"]}")
       sh("mkdir", "-p", "../bundle")
       sh("cp", "../android/app/build/generated/assets/createBundle#{app_flavor.capitalize}#{build_type.capitalize}JsAndAssets/index.android.bundle", "../bundle")
       sh("cp", "../android/app/build/intermediates/sourcemaps/react/#{app_flavor}#{build_type.capitalize}/index.android.bundle.packager.map", "../bundle/index.android.bundle.map")


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/15533

This time changing the path instead of filename.