### PR TITLE
feat: Use native user location pin

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -3,7 +3,7 @@ import {useAnalytics} from '@atb/analytics';
 import {FOCUS_ORIGIN} from '@atb/api/geocoder';
 import {StyleSheet} from '@atb/theme';
 import {MapRoute} from '@atb/travel-details-map-screen/components/MapRoute';
-import MapboxGL from '@rnmapbox/maps';
+import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
 import {MapState} from '@rnmapbox/maps/lib/typescript/components/MapView';
 import {Feature} from 'geojson';
 import React, {useMemo, useRef} from 'react';
@@ -118,7 +118,10 @@ export const Map = (props: MapProps) => {
             {...MapCameraConfig}
           />
           {mapLines && <MapRoute lines={mapLines} />}
-          <MapboxGL.UserLocation showsUserHeadingIndicator />
+          <MapboxGL.UserLocation
+              showsUserHeadingIndicator
+              renderMode={UserLocationRenderMode.Native}
+          />
           {props.selectionMode === 'ExploreLocation' && selectedCoordinates && (
             <SelectionPin coordinates={selectedCoordinates} id="selectionPin" />
           )}

--- a/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
+++ b/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
@@ -3,7 +3,7 @@ import {TariffZoneResults} from './TariffZoneResults';
 import {View} from 'react-native';
 import {Button} from '@atb/components/button';
 import {Language, TariffZonesTexts, useTranslation} from '@atb/translations';
-import MapboxGL from '@rnmapbox/maps';
+import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
 import {
   flyToLocation,
   MapCameraConfig,
@@ -185,7 +185,7 @@ const TariffZonesSelectorMap = ({
               centerCoordinate={startCoordinates}
               {...MapCameraConfig}
             />
-            <MapboxGL.UserLocation />
+            <MapboxGL.UserLocation renderMode={UserLocationRenderMode.Native} />
           </MapboxGL.MapView>
 
           <View style={[styles.bottomControls, {bottom: safeAreaBottom}]}>

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -25,7 +25,7 @@ import {Coordinates} from '@atb/utils/coordinates';
 import {secondsBetween} from '@atb/utils/date';
 import {useInterval} from '@atb/utils/use-interval';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
-import MapboxGL from '@rnmapbox/maps';
+import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
 import {Feature, Point, Position} from 'geojson';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {ActivityIndicator, Platform, View} from 'react-native';
@@ -177,7 +177,10 @@ export const TravelDetailsMapScreenComponent = ({
           centerCoordinate={vehicleWithPosition ? centerPosition : undefined}
           animationDuration={0}
         />
-        <MapboxGL.UserLocation showsUserHeadingIndicator />
+        <MapboxGL.UserLocation
+          showsUserHeadingIndicator
+          renderMode={UserLocationRenderMode.Native}
+        />
         <MapRoute lines={features} />
         {toPlace && (
           <MapLabel


### PR DESCRIPTION
The non-native user location pin has an onPress handler which is
hard to circumvent, and the hitbox is quite wide. This means when
the user location pin was close to an entity that should be
clickable (like bus stop, bike station, etc.) the click was not
registered by the map.

To fix this we change to the native location pin. The native
location pin is not interactable, which is kinda exactly what we
want here, as we don't want to register clicks on the location pin.

Another minor drawback is that it is not as pretty as the
non-native pin, but this was ok by designers.

Relevant issue about UserLocation pin blocking presses on
underlying components:
https://github.com/rnmapbox/maps/issues/241

Gif before/after:
<div>
<image width=350 src='https://github.com/AtB-AS/mittatb-app/assets/675421/e1c58a8f-531e-4c40-818a-9da840b4e3b1'/>
<image width=350 src='https://github.com/AtB-AS/mittatb-app/assets/675421/6b9b55e5-9f06-4c90-9c73-e95b458890dc'/>
</div>
