### PR TITLE
feat: add getServerNow to TimeContext

### DIFF
--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -1,12 +1,6 @@
 import {useInterval} from '@atb/utils/use-interval';
 import {clock, start} from '@entur-private/abt-time-react-native-lib';
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import React, {createContext, useContext, useEffect, useState} from 'react';
 
 type TimeContextState = {
   /**
@@ -15,25 +9,18 @@ type TimeContextState = {
    * validity of fare contracts.
    */
   serverNow: number;
-  /**
-   * Returns server time in milliseconds, based on the difference between
-   * the previous serverNow and device time.
-   */
-  getServerNow: () => number;
 };
 
 const TimeContext = createContext<TimeContextState | undefined>(undefined);
 
+/**
+ * The number of milliseconds the device time is ahead of server time.
+ */
+export let serverDiff = 0;
+
 export const TimeContextProvider: React.FC = ({children}) => {
   const [clockIsRunning, setClockIsRunning] = useState(false);
   const [serverNow, setServerNow] = useState(Date.now());
-
-  // The number of milliseconds the local clock is ahead of the server clock.
-  const [clientServerDiff, setClientServerDiff] = useState<number>();
-
-  const getServerNow = useCallback(() => {
-    return Date.now() - (clientServerDiff || 0);
-  }, [clientServerDiff]);
 
   useEffect(() => {
     start({
@@ -46,7 +33,7 @@ export const TimeContextProvider: React.FC = ({children}) => {
   useInterval(
     () =>
       clock.currentTimeMillis().then((ms) => {
-        setClientServerDiff(Date.now() - ms);
+        serverDiff = Date.now() - ms;
         setServerNow(ms);
       }),
     2500,
@@ -59,7 +46,6 @@ export const TimeContextProvider: React.FC = ({children}) => {
     <TimeContext.Provider
       value={{
         serverNow,
-        getServerNow,
       }}
     >
       {children}

--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -13,10 +13,13 @@ type TimeContextState = {
 
 const TimeContext = createContext<TimeContextState | undefined>(undefined);
 
+// The number of milliseconds the device time is ahead of server time.
+let serverDiff = 0;
+
 /**
- * The number of milliseconds the device time is ahead of server time.
+ * Returns the current time in milliseconds.
  */
-export let serverDiff = 0;
+export const getServerNow = () => Date.now() - serverDiff;
 
 export const TimeContextProvider: React.FC = ({children}) => {
   const [clockIsRunning, setClockIsRunning] = useState(false);

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -1,1 +1,5 @@
-export {TimeContextProvider, useTimeContextState} from './TimeContext';
+export {
+  TimeContextProvider,
+  useTimeContextState,
+  serverDiff,
+} from './TimeContext';

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -1,5 +1,5 @@
 export {
   TimeContextProvider,
   useTimeContextState,
-  serverDiff,
+  getServerNow,
 } from './TimeContext';


### PR DESCRIPTION
ref. https://github.com/AtB-AS/mittatb-app/pull/4029#issuecomment-1810328096

Adds getServerNow() to TimeContext, providing our best estimate for the current server time based on the diff from device time, last time it was updated.

### Example usage

When logging serverNow every time it is updated in TimeContext, and logging the state in an useInterval:

```js
useInterval(
  () => {
    console.log('Date.now()', Date.now(), 'getServerNow()', getServerNow(), 'serverNow', serverNow);
  },
  500,
  [getServerNow],
);
```

Gives this in the console
  
```
 LOG  Date.now() 1700211225129 getServerNow() 1700211225144 serverNow 1700211224576
 LOG  Date.now() 1700211225646 getServerNow() 1700211225661 serverNow 1700211224576
 LOG  Date.now() 1700211226181 getServerNow() 1700211226196 serverNow 1700211224576
 LOG  Date.now() 1700211226696 getServerNow() 1700211226711 serverNow 1700211224576
 LOG  TimeContext: Updating serverNow. Was 1700211224576 with diff -15
 LOG  Date.now() 1700211227679 getServerNow() 1700211227695 serverNow 1700211227130
 LOG  Date.now() 1700211228196 getServerNow() 1700211228212 serverNow 1700211227130
 LOG  Date.now() 1700211228730 getServerNow() 1700211228746 serverNow 1700211227130
 LOG  Date.now() 1700211229246 getServerNow() 1700211229262 serverNow 1700211227130
 LOG  TimeContext: Updating serverNow. Was 1700211227130 with diff -16
 LOG  Date.now() 1700211229763 getServerNow() 1700211229779 serverNow 1700211229702
 LOG  Date.now() 1700211230263 getServerNow() 1700211230279 serverNow 1700211229702
 LOG  Date.now() 1700211230780 getServerNow() 1700211230796 serverNow 1700211229702
 LOG  Date.now() 1700211231282 getServerNow() 1700211231298 serverNow 1700211229702
 LOG  Date.now() 1700211231796 getServerNow() 1700211231812 serverNow 1700211229702
 LOG  TimeContext: Updating serverNow. Was 1700211229702 with diff -16
```
 