### PR TITLE
fix: Only stations and stop places clickable in map

### DIFF
--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -18,7 +18,7 @@ import {
   ParkingType,
 } from './types';
 import distance from '@turf/distance';
-import {isBicycle, isScooter} from '@atb/mobility/utils';
+import {isStation} from '@atb/mobility/utils';
 
 export async function zoomIn(
   mapViewRef: RefObject<MapboxGL.MapView>,
@@ -179,7 +179,7 @@ export const getVisibleRange = (visibleBounds: Position[]) => {
 };
 
 export const shouldShowMapLines = (entityFeature: Feature<Point>) =>
-  !isScooter(entityFeature) && !isBicycle(entityFeature);
+  isStation(entityFeature) || isStopPlace(entityFeature);
 
 export const shouldZoomToFeature = (entityFeature: Feature<Point>) =>
-  !isScooter(entityFeature) && !isBicycle(entityFeature);
+  isStation(entityFeature) || isStopPlace(entityFeature);


### PR DESCRIPTION
The logic was originally the other way around, that el-scooters
and free-floating-bikes were not clickable, but this ment some
other entities (like quays) was unintentionally clickable. Now
instead change the logic around so we whitelist which entities
that should be clickable.

Before/After:
<div>
<image width=300 src='https://github.com/AtB-AS/mittatb-app/assets/675421/a6f418e4-f96c-4038-b2e3-ffca9b23d019'/>
<image width=300 src='https://github.com/AtB-AS/mittatb-app/assets/675421/72559e5b-d5f0-4646-957d-a5e96af8c541'/>
</div>


