### PR TITLE
fix: notification onboarding flow and register for notifications

### DIFF
--- a/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
+++ b/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
@@ -6,6 +6,7 @@ import {PushNotification} from '@atb/assets/svg/color/images';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {useAppState} from '@atb/AppContext';
 import {OnboardingScreen} from '@atb/onboarding-screen';
+import {usePushNotifications} from '@atb/notifications';
 
 type Props = RootStackScreenProps<'Root_NotificationPermissionScreen'>;
 
@@ -13,12 +14,12 @@ export const Root_NotificationPermissionScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
 
   const {completeNotificationPermissionOnboarding} = useAppState();
-
-  const buttonOnPress = useCallback(() => {
-    // TODO: add permission logic
+  const {register} = usePushNotifications();
+  const buttonOnPress = useCallback(async () => {
+    await register();
     navigation.popToTop();
     completeNotificationPermissionOnboarding();
-  }, [navigation, completeNotificationPermissionOnboarding]);
+  }, [register, navigation, completeNotificationPermissionOnboarding]);
 
   return (
     <OnboardingScreen

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -70,27 +70,27 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
   const {status: notificationStatus} = usePushNotifications();
 
   useEffect(() => {
+    const shouldShowLocationOnboarding =
+      !locationWhenInUsePermissionOnboarded &&
+      locationWhenInUsePermissionStatus === 'denied';
+
     if (!onboarded) {
       InteractionManager.runAfterInteractions(() =>
         navigation.navigate('Root_OnboardingStack'),
       );
     } else {
-      if (
-        !locationWhenInUsePermissionOnboarded &&
-        locationWhenInUsePermissionStatus === 'denied'
-      ) {
+      if (shouldShowLocationOnboarding) {
         InteractionManager.runAfterInteractions(() =>
           navigation.navigate('Root_LocationWhenInUsePermissionScreen'),
         );
       }
     }
-
     if (
       !notificationPermissionOnboarded &&
       pushNotificationsEnabled &&
       validFareContracts.length > 0 &&
       notificationStatus !== 'granted' &&
-      locationWhenInUsePermissionOnboarded
+      !shouldShowLocationOnboarding
     ) {
       InteractionManager.runAfterInteractions(() =>
         navigation.navigate('Root_NotificationPermissionScreen'),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -38,7 +38,6 @@ import {
   useTicketingState,
 } from '@atb/ticketing';
 import {useTimeContextState} from '@atb/time';
-import {usePushNotificationsEnabled} from '@atb/notifications';
 import {useGeolocationState} from '@atb/GeolocationContext';
 
 const Tab = createBottomTabNavigator<TabNavigatorStackParams>();
@@ -90,7 +89,8 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
       !notificationPermissionOnboarded &&
       pushNotificationsEnabled &&
       validFareContracts.length > 0 &&
-      notificationStatus !== 'granted'
+      notificationStatus !== 'granted' &&
+      locationWhenInUsePermissionOnboarded
     ) {
       InteractionManager.runAfterInteractions(() =>
         navigation.navigate('Root_NotificationPermissionScreen'),


### PR DESCRIPTION
The notification onboarding will now show:
- After buying a ticket
- When logging in and having an active ticket
- Opening the app after updating and having an active ticket


Screen now also uses the `register` from `usePushNotifications()`

[Figma](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=18256-2778&mode=dev)