### PR TITLE
fix: reset state when email input field is updated

### DIFF
--- a/src/stacks-hierarchy/Root_ReceiptScreen.tsx
+++ b/src/stacks-hierarchy/Root_ReceiptScreen.tsx
@@ -19,7 +19,6 @@ import {useAnalytics} from '@atb/analytics';
 type Props = RootStackScreenProps<'Root_ReceiptScreen'>;
 
 type MessageState =
-  | 'updating'
   | 'loading'
   | 'success'
   | 'error'
@@ -62,6 +61,7 @@ export function Root_ReceiptScreen({route}: Props) {
 
   // resets the state when there are changes to email input field
   function onTextChanged(text: string) {
+    // do not do anything when the state is loading, otherwise it will cause unwanted issues
     if (state !== 'loading') {
       setState(undefined);
       setEmail(text);

--- a/src/stacks-hierarchy/Root_ReceiptScreen.tsx
+++ b/src/stacks-hierarchy/Root_ReceiptScreen.tsx
@@ -19,6 +19,7 @@ import {useAnalytics} from '@atb/analytics';
 type Props = RootStackScreenProps<'Root_ReceiptScreen'>;
 
 type MessageState =
+  | 'updating'
   | 'loading'
   | 'success'
   | 'error'
@@ -59,6 +60,14 @@ export function Root_ReceiptScreen({route}: Props) {
     }
   }
 
+  // resets the state when there are changes to email input field
+  function onTextChanged(text: string) {
+    if (state !== 'loading') {
+      setState(undefined);
+      setEmail(text);
+    }
+  }
+
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -76,7 +85,7 @@ export function Root_ReceiptScreen({route}: Props) {
           <TextInputSectionItem
             label={t(FareContractTexts.receipt.inputLabel)}
             value={email}
-            onChangeText={setEmail}
+            onChangeText={onTextChanged}
             keyboardType="email-address"
             autoCapitalize="none"
             autoComplete="email"


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/14884

### Problem (Screen recording available in issue) 
After user succeeded in sending receipt to their e-mail, entering a new e-mail address updates the text shown by the success message. 

### Solution
Reset the state whenever the e-mail field is updated, unless the state is `loading`.


### Video after changes
<details>
<Summary>video</Summary>

https://github.com/AtB-AS/mittatb-app/assets/1777333/13d802c0-91b9-4955-b8cd-913b896aa6e8

</details>


