### PR TITLE
feat: support favorite migration also on departures response

### DIFF
--- a/src/api/departures/stops-nearest.ts
+++ b/src/api/departures/stops-nearest.ts
@@ -7,6 +7,7 @@ import {NearestStopPlacesQuery} from '../types/generated/NearestStopPlacesQuery'
 import {StopsDetailsQuery} from '../types/generated/StopsDetailsQuery';
 import {stringifyUrl} from 'query-string/base';
 import {DeparturesQuery} from '../types/generated/DeparturesQuery';
+import {DeparturesWithLineName} from './types';
 
 export type StopsNearestQuery = CursoredQuery<{
   latitude: number;
@@ -55,7 +56,7 @@ export async function getDepartures(
   query: DeparturesVariables,
   favorites?: UserFavoriteDepartures,
   opts?: AxiosRequestConfig,
-): Promise<DeparturesQuery> {
+): Promise<DeparturesWithLineName> {
   const queryString = stringifyWithDate(query);
   const url = `${BASE_URL}/departures?${queryString}`;
   return requestDepartures(url, {favorites}, opts);

--- a/src/api/departures/types.ts
+++ b/src/api/departures/types.ts
@@ -5,6 +5,7 @@ import {
 } from '@atb/api/types/generated/journey_planner_v3_types';
 import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
+import {DeparturesQuery} from '../types/generated/DeparturesQuery';
 
 type Notice = {text?: string};
 
@@ -18,6 +19,16 @@ export type DepartureLineInfo = {
   quayId: string;
   notices: Notice[];
   lineId: string;
+};
+
+export type EstimatedCallWithLineName =
+  DeparturesQuery['quays'][0]['estimatedCalls'][0] & {
+    lineName?: string;
+  };
+export type DeparturesWithLineName = DeparturesQuery & {
+  quays: (DeparturesQuery['quays'][0] & {
+    estimatedCalls: EstimatedCallWithLineName[];
+  })[];
 };
 
 export type DepartureTime = {

--- a/src/favorites/FavoritesContext.tsx
+++ b/src/favorites/FavoritesContext.tsx
@@ -13,10 +13,11 @@ import {
 import {RCTWidgetUpdater} from '../widget-updater';
 import {destinationDisplaysAreEqual} from '@atb/utils/destination-displays-are-equal';
 import {
+  ItemWithDestinationDisplayMigrationPairType,
   getFavoriteDeparturesWithDestinationDisplay,
+  getUniqueDestinationDisplayMigrationPairs,
   getUpToDateFavoriteDepartures,
 } from './utils';
-import {StopPlaceGroup} from '@atb/api/departures/types';
 
 type FavoriteContextState = {
   favorites: UserFavorites;
@@ -24,7 +25,9 @@ type FavoriteContextState = {
   addFavoriteLocation(location: LocationFavorite): Promise<void>;
   removeFavoriteLocation(id: string): Promise<void>;
   setFavoriteDepartures(favorite: UserFavoriteDepartures): Promise<void>;
-  migrateFavoriteDepartures(stopPlaceGroups: StopPlaceGroup[]): Promise<void>;
+  potentiallyMigrateFavoriteDepartures(
+    itemsWithDestinationDisplayMigrationPair?: ItemWithDestinationDisplayMigrationPairType[],
+  ): Promise<void>;
   setDashboardFavorite(id: string, value: boolean): Promise<void>;
   updateFavoriteLocation(favorite: StoredLocationFavorite): Promise<void>;
   setFavoriteLocations(favorites: UserFavorites): Promise<void>;
@@ -112,11 +115,21 @@ export const FavoritesContextProvider: React.FC = ({children}) => {
       await departures.setFavorites(favorites);
       RCTWidgetUpdater.refreshWidgets();
     },
-    async migrateFavoriteDepartures(stopPlaceGroups) {
-      if (!stopPlaceGroups.length) return;
+    async potentiallyMigrateFavoriteDepartures(
+      itemsWithDestinationDisplayMigrationPair,
+    ) {
+      if (!itemsWithDestinationDisplayMigrationPair?.length) return;
+
+      const destinationDisplayMigrationPairs =
+        getUniqueDestinationDisplayMigrationPairs(
+          itemsWithDestinationDisplayMigrationPair,
+        );
 
       const {upToDateFavoriteDepartures, aFavoriteDepartureWasUpdated} =
-        getUpToDateFavoriteDepartures(favoriteDepartures, stopPlaceGroups);
+        getUpToDateFavoriteDepartures(
+          favoriteDepartures,
+          destinationDisplayMigrationPairs,
+        );
 
       if (aFavoriteDepartureWasUpdated) {
         setFavoriteDeparturesState(upToDateFavoriteDepartures);

--- a/src/favorites/utils.ts
+++ b/src/favorites/utils.ts
@@ -3,8 +3,11 @@ import {DestinationDisplay} from '@atb/api/types/generated/journey_planner_v3_ty
 import {UserFavoriteDepartures, UserFavoriteDeparturesLegacy} from './types';
 import {StoredFavoriteDeparture} from '@atb/favorites';
 import {uniqBy} from 'lodash';
-import {EstimatedCall} from '@atb/api/types/departures';
-import {DepartureLineInfo} from '@atb/api/departures/types';
+
+import {
+  DepartureLineInfo,
+  EstimatedCallWithLineName,
+} from '@atb/api/departures/types';
 
 function mapLegacyLineNameToDestinationDisplay(
   legacyLineName: string | undefined,
@@ -49,9 +52,9 @@ export type DestinationDisplayMigrationPair = {
   destinationDisplay?: DestinationDisplay;
 };
 
-type ItemWithDestinationDisplayMigrationPairType =
+export type ItemWithDestinationDisplayMigrationPairType =
   | DepartureLineInfo
-  | EstimatedCall;
+  | EstimatedCallWithLineName;
 
 export function getUniqueDestinationDisplayMigrationPairs(
   itemsWithDestinationDisplayMigrationPair?: ItemWithDestinationDisplayMigrationPairType[],

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -246,7 +246,8 @@ export function useDeparturesData(
   tickRateInSeconds: number = 10,
 ) {
   const [state, dispatch] = useReducerWithSideEffects(reducer, initialState);
-  const {favoriteDepartures} = useFavorites();
+  const {favoriteDepartures, potentiallyMigrateFavoriteDepartures} =
+    useFavorites();
   const [queryStartTime, setQueryStartTime] = useState<string | undefined>();
   const [timeRange, setTimeRange] = useState<number | undefined>();
   const lastHardRefreshTime = useRef<Date>(new Date());
@@ -336,6 +337,11 @@ export function useDeparturesData(
     // Trigger immediately on focus only if the view is already initialized
     !!state.tick,
   );
+
+  useEffect(() => {
+    const estimatedCalls = state.data;
+    estimatedCalls && potentiallyMigrateFavoriteDepartures(estimatedCalls);
+  }, [state.data, potentiallyMigrateFavoriteDepartures]);
 
   return {
     state,


### PR DESCRIPTION
Migrate favorites using data received from the `/bff/v2/departures/departures` call

Depends on https://github.com/AtB-AS/atb-bff/pull/313

Resolves https://github.com/AtB-AS/kundevendt/issues/2732
(mentioned in this [comment](https://github.com/AtB-AS/kundevendt/issues/2732#issuecomment-1792286534))

