### PR TITLE
fix: Outdated non-transit-search

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query.tsx
@@ -48,6 +48,7 @@ export const useNonTransitTripsQuery = (
       !toLocation ||
       !isValidTripLocations(fromLocation, toLocation)
     ) {
+      setNonTransitTrips([]);
       setSearchState('search-empty-result');
       return;
     }


### PR DESCRIPTION
The non-transit results wasn't reset when invalid search
parameters, like equal from and to place. This ment the non-transit
search results from the last successful search was still visisble.
