### PR TITLE
fix: add install_id to api calls from iOS widget

### DIFF
--- a/ios/departureWidget/APIService.swift
+++ b/ios/departureWidget/APIService.swift
@@ -63,7 +63,11 @@ class APIService {
             return
         }
 
+        guard let installId = Manifest.data?.installId else {
+         return
+        }
         request.setValue("application/JSON", forHTTPHeaderField: "Content-Type")
+        request.setValue(installId, forHTTPHeaderField: "atb-install-id")
         request.httpBody = data
 
         let decoder = JSONDecoder()

--- a/ios/departureWidget/APIService.swift
+++ b/ios/departureWidget/APIService.swift
@@ -45,9 +45,14 @@ enum AppEndPoint: String {
         guard let url = url else {
             return nil
         }
+        guard let installId = Manifest.data?.installId else {
+          return nil
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = method
+        request.setValue(installId, forHTTPHeaderField: "atb-install-id")
+
 
         return request
     }
@@ -63,11 +68,8 @@ class APIService {
             return
         }
 
-        guard let installId = Manifest.data?.installId else {
-         return
-        }
+       
         request.setValue("application/JSON", forHTTPHeaderField: "Content-Type")
-        request.setValue(installId, forHTTPHeaderField: "atb-install-id")
         request.httpBody = data
 
         let decoder = JSONDecoder()

--- a/ios/departureWidget/APIService.swift
+++ b/ios/departureWidget/APIService.swift
@@ -45,14 +45,9 @@ enum AppEndPoint: String {
         guard let url = url else {
             return nil
         }
-        guard let installId = Manifest.data?.installId else {
-          return nil
-        }
 
         var request = URLRequest(url: url)
         request.httpMethod = method
-        request.setValue(installId, forHTTPHeaderField: "atb-install-id")
-
 
         return request
     }
@@ -68,8 +63,11 @@ class APIService {
             return
         }
 
-       
+        guard let installId = Manifest.data?.installId else {
+         return
+        }
         request.setValue("application/JSON", forHTTPHeaderField: "Content-Type")
+        request.setValue(installId, forHTTPHeaderField: "atb-install-id")
         request.httpBody = data
 
         let decoder = JSONDecoder()

--- a/ios/departureWidget/Storage.swift
+++ b/ios/departureWidget/Storage.swift
@@ -7,15 +7,17 @@ private enum K {
 }
 
 enum ManifestError: Error {
-    case invalidType, keyValueNotFound, decodingData
+    case invalidType, keyValueNotFound, decodingData, missingInstallId
 }
 
 struct Manifest: Codable {
     enum CodingKeys: String, CodingKey {
         case favouriteDepartures = "@ATB_user_departures"
+        case installId = "install_id"
     }
 
     let favouriteDepartures: [FavouriteDeparture]?
+    let installId: String
 
     static var data: Manifest? {
         buildManifest()
@@ -55,6 +57,9 @@ struct Manifest: Codable {
             debugPrint("Error decoding data with error: \(error)")
             throw ManifestError.decodingData
         }
+      
+      let installIdData = try container.decode(String.self, forKey: .installId)
+      installId = installIdData
     }
 
     private static func buildManifest() -> Manifest? {


### PR DESCRIPTION
By adding install_id to the sent requests, we can see how many individual users have the widget active. Was solved this way to avoid adding potshot to the native widget code, and to reduce the amount of logging in posthog.

To find the amount users, check how many individual install_id's have used the `bff/v2/departure-favorites` with a limitPerLine of 50.