### PR TITLE
feat: Update delete user text

### DIFF
--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -8,7 +8,7 @@ const DeleteProfileTexts = {
   deleteInfo: _(
     'Når du sletter Min Profil vil alle dine lagrede data slettes. Du mister også tilgang på billett- og kjøpshistorikk, kvitteringer og dine innstillinger.',
     'When you delete My Profile, all your stored data will be deleted. You will also lose access to recent tickets, receipts and settings',
-    'Dersom du sletter Min profil vil alle dine lagra data bli sletta. Du mistar òg tilgang til billett- og kjøpshistorikk, kvitteringar og innstillingane dine.',
+    'Dersom du slettar Min Profil vil alle dine lagra data bli sletta. Du mistar òg tilgang til billett- og kjøpshistorikk, kvitteringar og innstillingane dine.',
   ),
   buttonA11ytext: (customerNumber: string | undefined) =>
     _(

--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -6,9 +6,9 @@ const DeleteProfileTexts = {
     title: _('Slett Min profil', 'Delete My profile', 'Slett Min profil'),
   },
   deleteInfo: _(
-    'Når du sletter Min profil mister du tilgang på billett- og kjøpshistorikk, kvitteringer og dine innstillinger.',
-    'When deleting My profile you will lose access to recent tickets, receipts and settings',
-    'Dersom du sletter Min profil vil du miste tilgang til billett- og kjøpshistorikk, kvitteringar og innstillingane dine.',
+    'Når du sletter Min Profil vil alle dine lagrede data slettes. Du mister også tilgang på billett- og kjøpshistorikk, kvitteringer og dine innstillinger.',
+    'When you delete My Profile, all your stored data will be deleted. You will also lose access to recent tickets, receipts and settings',
+    'Dersom du sletter Min profil vil alle dine lagra data bli sletta. Du mistar òg tilgang til billett- og kjøpshistorikk, kvitteringar og innstillingane dine.',
   ),
   buttonA11ytext: (customerNumber: string | undefined) =>
     _(


### PR DESCRIPTION
AtB wants to add a description that says all your data is deleted.

The text is from @Sebstorvik: `Når du sletter Min Profil vil alle dine lagrede data slettes. Du mister også tilgang på billett- og kjøpshistorikk, kvitteringer og dine innstillinger.`