### PR TITLE
feat: handle click actions on push notifications

### DIFF
--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -4,3 +4,4 @@ export {
 } from './use-push-notifications-enabled';
 export {usePushNotifications} from './use-push-notifications';
 export {isConfigEnabled} from './utils';
+export {useOnPushNotificationOpened} from './use-on-push-notification-opened';

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -17,3 +17,12 @@ export type NotificationConfig = {
   modes: NotificationConfigMode[];
   groups: NotificationConfigGroup[];
 };
+
+export type NotificationPayload = {
+  type: NotificationPayloadType.fareContractExpiry;
+  fareContractId: string;
+};
+
+export enum NotificationPayloadType {
+  fareContractExpiry = 'FARE_CONTRACT_EXPIRY',
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod';
+
 export type NotificationConfigType = 'mode' | 'group';
 
 export interface NotificationConfigValue {
@@ -18,11 +20,13 @@ export type NotificationConfig = {
   groups: NotificationConfigGroup[];
 };
 
-export type NotificationPayload = {
-  type: NotificationPayloadType.fareContractExpiry;
-  fareContractId: string;
-};
-
-export enum NotificationPayloadType {
+export enum PushNotificationPayloadType {
   fareContractExpiry = 'FARE_CONTRACT_EXPIRY',
 }
+
+// Can be updated to z.union when we add more types:
+// `z.union([z.object({type: a}), z.object({type: b})])`
+export const PushNotificationData = z.object({
+  type: z.literal(PushNotificationPayloadType.fareContractExpiry),
+  fareContractId: z.string(),
+});

--- a/src/notifications/use-on-push-notification-opened.ts
+++ b/src/notifications/use-on-push-notification-opened.ts
@@ -1,0 +1,55 @@
+import {RootNavigationProps} from '@atb/stacks-hierarchy';
+import {
+  firebase,
+  FirebaseMessagingTypes,
+} from '@react-native-firebase/messaging';
+import {useNavigation} from '@react-navigation/native';
+import {useCallback, useEffect} from 'react';
+import {NotificationPayload, NotificationPayloadType} from './types';
+import Bugsnag from '@bugsnag/react-native';
+
+export function useOnPushNotificationOpened() {
+  const {navigate} = useNavigation<RootNavigationProps>();
+
+  const onMessage = useCallback(
+    (message: FirebaseMessagingTypes.RemoteMessage) => {
+      const isKnownType = Object.values(NotificationPayloadType).includes(
+        message.data?.type as NotificationPayloadType,
+      );
+      if (!isKnownType) return;
+
+      const messageData = message.data as NotificationPayload;
+      switch (messageData.type) {
+        case NotificationPayloadType.fareContractExpiry:
+          navigate('Root_TabNavigatorStack', {
+            screen: 'TabNav_TicketingStack',
+            params: {
+              screen: 'Ticketing_RootScreen',
+              params: {
+                screen: 'TicketTabNav_ActiveFareProductsTabScreen',
+              },
+            },
+          });
+          return;
+        default:
+          Bugsnag.leaveBreadcrumb(
+            `App was opened with unhandled notification type: ${messageData.type}`,
+          );
+          return;
+      }
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    // Handle notifications that are clicked while the app is closed (cold start)
+    firebase
+      .messaging()
+      .getInitialNotification()
+      .then((m) => (m ? onMessage(m) : null));
+
+    // Handle notifications that are clicked while the app is in the bacground
+    const unsubscribe = firebase.messaging().onNotificationOpenedApp(onMessage);
+    return unsubscribe;
+  }, [onMessage]);
+}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -32,6 +32,7 @@ import {useMaybeShowShareTravelHabitsScreen} from '@atb/beacons/use-maybe-show-s
 import {
   usePushNotifications,
   usePushNotificationsEnabled,
+  useOnPushNotificationOpened,
 } from '@atb/notifications';
 import {
   filterValidRightNowFareContract,
@@ -68,6 +69,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
     serverNow,
   );
   const {status: notificationStatus} = usePushNotifications();
+  useOnPushNotificationOpened();
 
   useEffect(() => {
     const shouldShowLocationOnboarding =


### PR DESCRIPTION
Added a new hook "useOnPushNotificationOpened" that is called when the TabNavigator is rendered. This adds two listeners that reacts to app open events, one from background state and one from closed state. 

If `data.type` is "FARE_CONTRACT_EXPIRY", navigate to ActiveFareProductsTabScreen.

closes https://github.com/AtB-AS/kundevendt/issues/7229