### PR TITLE
feat: register notifications on startup and language change

### DIFF
--- a/src/notifications/use-push-notifications.tsx
+++ b/src/notifications/use-push-notifications.tsx
@@ -19,6 +19,7 @@ export const usePushNotifications = () => {
   const {language} = useLocaleContext();
   const [status, setStatus] = useState<NotificationsStatus>('loading');
   const {mutation: registerMutation} = useRegister();
+  const mutateRegister = registerMutation.mutate;
   const {query: configQuery, mutation: configMutation} = useConfig();
 
   const checkPermissions = useCallback(() => {
@@ -55,10 +56,9 @@ export const usePushNotifications = () => {
   const register = useCallback(async () => {
     const token = await messaging().getToken();
     if (!token) return;
-    registerMutation.mutate({token, language: language});
+    mutateRegister({token, language: language});
     return token;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [language, registerMutation.mutate]);
+  }, [language, mutateRegister]);
 
   const requestPermissions = useCallback(async () => {
     setStatus('updating');

--- a/src/notifications/use-push-notifications.tsx
+++ b/src/notifications/use-push-notifications.tsx
@@ -53,23 +53,31 @@ export const usePushNotifications = () => {
   }, []);
 
   const register = useCallback(async () => {
+    const token = await messaging().getToken();
+    if (!token) return;
+    registerMutation.mutate({token, language: language});
+    return token;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [language, registerMutation.mutate]);
+
+  const requestPermissions = useCallback(async () => {
     setStatus('updating');
     const permissionStatus = await requestUserPermission();
-    const token = await messaging().getToken();
+    const token = await register();
     if (!token) {
       setStatus('error');
       return;
     }
-    registerMutation.mutate({token, language});
     setStatus(permissionStatus);
     return token;
-  }, [language, registerMutation]);
+  }, [register]);
 
   return {
     status,
     config: configQuery.data,
     updateConfig: configMutation.mutate,
     checkPermissions,
+    requestPermissions,
     register,
   };
 };

--- a/src/notifications/use-push-notifications.tsx
+++ b/src/notifications/use-push-notifications.tsx
@@ -1,11 +1,12 @@
-import {useCallback, useState} from 'react';
-import {useRegister} from './use-register';
-import {useConfig} from './use-config';
-import {PermissionsAndroid, Platform} from 'react-native';
+import {useLocaleContext} from '@atb/LocaleProvider';
+import Bugsnag from '@bugsnag/react-native';
 import messaging, {
   FirebaseMessagingTypes,
 } from '@react-native-firebase/messaging';
-import {useLocaleContext} from '@atb/LocaleProvider';
+import {useCallback, useState} from 'react';
+import {PermissionsAndroid, Platform} from 'react-native';
+import {useConfig} from './use-config';
+import {useRegister} from './use-register';
 
 type NotificationsStatus =
   | 'granted'
@@ -54,10 +55,14 @@ export const usePushNotifications = () => {
   }, []);
 
   const register = useCallback(async () => {
-    const token = await messaging().getToken();
-    if (!token) return;
-    mutateRegister({token, language: language});
-    return token;
+    try {
+      const token = await messaging().getToken();
+      if (!token) return;
+      mutateRegister({token, language: language});
+      return token;
+    } catch (e) {
+      Bugsnag.notify(`Failed to register for push notifications: ${e}`);
+    }
   }, [language, mutateRegister]);
 
   const requestPermissions = useCallback(async () => {

--- a/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
+++ b/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
@@ -14,12 +14,16 @@ export const Root_NotificationPermissionScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
 
   const {completeNotificationPermissionOnboarding} = useAppState();
-  const {register} = usePushNotifications();
+  const {requestPermissions} = usePushNotifications();
   const buttonOnPress = useCallback(async () => {
-    await register();
+    await requestPermissions();
     navigation.popToTop();
     completeNotificationPermissionOnboarding();
-  }, [register, navigation, completeNotificationPermissionOnboarding]);
+  }, [
+    requestPermissions,
+    navigation,
+    completeNotificationPermissionOnboarding,
+  ]);
 
   return (
     <OnboardingScreen

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -68,8 +68,16 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
     fareContracts,
     serverNow,
   );
-  const {status: notificationStatus} = usePushNotifications();
+
+  const {register, status: notificationStatus} = usePushNotifications();
   useOnPushNotificationOpened();
+
+  // Register notification language when the app starts, in case the user have
+  // changed language since last time the app was opened. This useEffect will
+  // also trigger when language is changed manually in the app.
+  useEffect(() => {
+    register();
+  }, [register]);
 
   useEffect(() => {
     const shouldShowLocationOnboarding =

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -69,15 +69,16 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
     serverNow,
   );
 
-  const {register, status: notificationStatus} = usePushNotifications();
+  const {register: registerForNotifications, status: notificationStatus} =
+    usePushNotifications();
   useOnPushNotificationOpened();
 
   // Register notification language when the app starts, in case the user have
   // changed language since last time the app was opened. This useEffect will
   // also trigger when language is changed manually in the app.
   useEffect(() => {
-    register();
-  }, [register]);
+    registerForNotifications();
+  }, [registerForNotifications]);
 
   useEffect(() => {
     const shouldShowLocationOnboarding =

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -136,7 +136,8 @@ export const Profile_DebugInfoScreen = () => {
   } = useMobileTokenContextState();
   const {serverNow} = useTimeContextState();
 
-  const {register: registerForPushNotifications} = usePushNotifications();
+  const {requestPermissions: registerForPushNotifications} =
+    usePushNotifications();
   const [fcmToken, setFcmToken] = useState<string>();
 
   const remoteConfig = useRemoteConfig();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
@@ -17,7 +17,7 @@ export const Profile_NotificationsScreen = () => {
   const style = useStyles();
   const {t} = useTranslation();
   const isFocusedAndActive = useIsFocusedAndActive();
-  const {status, config, register, checkPermissions, updateConfig} =
+  const {status, config, requestPermissions, checkPermissions, updateConfig} =
     usePushNotifications();
 
   useEffect(() => {
@@ -28,7 +28,7 @@ export const Profile_NotificationsScreen = () => {
 
   const handlePushNotificationToggle = async (enabled: boolean) => {
     if (enabled) {
-      await register();
+      await requestPermissions();
     }
     updateConfig({config_type: 'mode', id: 'push', enabled});
   };


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/7230

Renamed the `register` function to `requestPermissions`, and pulled the register endpoint -part into it's own function. This is useful when we want to register the app language without prompting the user, which now happends on app start and on language change.