### PR TITLE
refactor: refactor usePushNotifications hook to a context

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,7 @@ import {TimeContextProvider} from '@atb/time';
 import {AnnouncementsContextProvider} from './announcements';
 import {PopOverContextProvider} from '@atb/popover';
 import {StorybookContextProvider} from '@atb/storybook/StorybookContext';
+import {NotificationContextProvider} from './notifications';
 
 configureAndStartBugsnag();
 
@@ -92,13 +93,15 @@ export const App = () => {
                                             <GlobalMessagesContextProvider>
                                               <AnnouncementsContextProvider>
                                                 <ReactQueryProvider>
-                                                  <PopOverContextProvider>
-                                                    <BottomSheetProvider>
-                                                      <FeedbackQuestionsProvider>
-                                                        <RootStack />
-                                                      </FeedbackQuestionsProvider>
-                                                    </BottomSheetProvider>
-                                                  </PopOverContextProvider>
+                                                  <NotificationContextProvider>
+                                                    <PopOverContextProvider>
+                                                      <BottomSheetProvider>
+                                                        <FeedbackQuestionsProvider>
+                                                          <RootStack />
+                                                        </FeedbackQuestionsProvider>
+                                                      </BottomSheetProvider>
+                                                    </PopOverContextProvider>
+                                                  </NotificationContextProvider>
                                                 </ReactQueryProvider>
                                               </AnnouncementsContextProvider>
                                             </GlobalMessagesContextProvider>

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -2,6 +2,9 @@ export {
   usePushNotificationsEnabledDebugOverride,
   usePushNotificationsEnabled,
 } from './use-push-notifications-enabled';
-export {usePushNotifications} from './use-push-notifications';
+export {
+  NotificationContextProvider,
+  useNotificationContextState,
+} from './use-push-notifications';
 export {isConfigEnabled} from './utils';
 export {useOnPushNotificationOpened} from './use-on-push-notification-opened';

--- a/src/notifications/use-push-notifications.tsx
+++ b/src/notifications/use-push-notifications.tsx
@@ -3,8 +3,10 @@ import Bugsnag from '@bugsnag/react-native';
 import messaging, {
   FirebaseMessagingTypes,
 } from '@react-native-firebase/messaging';
-import {useCallback, useState} from 'react';
+import {createContext, useCallback, useContext, useState} from 'react';
 import {PermissionsAndroid, Platform} from 'react-native';
+import {NotificationConfigUpdate} from './api';
+import {NotificationConfig} from './types';
 import {useConfig} from './use-config';
 import {useRegister} from './use-register';
 
@@ -16,9 +18,24 @@ type NotificationsStatus =
   | 'updating'
   | 'error';
 
-export const usePushNotifications = () => {
+type NotificationContextState = {
+  status: NotificationsStatus;
+  config: NotificationConfig | undefined;
+  updateConfig: (config: NotificationConfigUpdate) => void;
+  checkPermissions: () => void;
+  requestPermissions: () => Promise<string | undefined>;
+  register: () => Promise<string | undefined>;
+  fcmToken: string | undefined;
+};
+
+const NotificationContext = createContext<NotificationContextState | undefined>(
+  undefined,
+);
+
+export const NotificationContextProvider: React.FC = ({children}) => {
   const {language} = useLocaleContext();
   const [status, setStatus] = useState<NotificationsStatus>('loading');
+  const [fcmToken, setFcmToken] = useState<string>();
   const {mutation: registerMutation} = useRegister();
   const mutateRegister = registerMutation.mutate;
   const {query: configQuery, mutation: configMutation} = useConfig();
@@ -58,7 +75,8 @@ export const usePushNotifications = () => {
     try {
       const token = await messaging().getToken();
       if (!token) return;
-      mutateRegister({token, language: language});
+      setFcmToken(token);
+      mutateRegister({token, language});
       return token;
     } catch (e) {
       Bugsnag.notify(`Failed to register for push notifications: ${e}`);
@@ -77,15 +95,32 @@ export const usePushNotifications = () => {
     return token;
   }, [register]);
 
-  return {
-    status,
-    config: configQuery.data,
-    updateConfig: configMutation.mutate,
-    checkPermissions,
-    requestPermissions,
-    register,
-  };
+  return (
+    <NotificationContext.Provider
+      value={{
+        status,
+        config: configQuery.data,
+        updateConfig: configMutation.mutate,
+        checkPermissions,
+        requestPermissions,
+        register,
+        fcmToken,
+      }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
 };
+
+export function useNotificationContextState() {
+  const context = useContext(NotificationContext);
+  if (context === undefined) {
+    throw new Error(
+      'useNotificationContextState must be used within a NotificationContextProvider',
+    );
+  }
+  return context;
+}
 
 async function requestUserPermission(): Promise<NotificationsStatus> {
   if (Platform.OS === 'ios') {

--- a/src/notifications/use-push-notifications.tsx
+++ b/src/notifications/use-push-notifications.tsx
@@ -23,7 +23,7 @@ type NotificationContextState = {
   config: NotificationConfig | undefined;
   updateConfig: (config: NotificationConfigUpdate) => void;
   checkPermissions: () => void;
-  requestPermissions: () => Promise<string | undefined>;
+  requestPermissions: () => Promise<void>;
   register: () => Promise<string | undefined>;
   fcmToken: string | undefined;
 };
@@ -92,7 +92,6 @@ export const NotificationContextProvider: React.FC = ({children}) => {
       return;
     }
     setStatus(permissionStatus);
-    return token;
   }, [register]);
 
   return (

--- a/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
+++ b/src/stacks-hierarchy/Root_NotificationPermissionScreen.tsx
@@ -6,7 +6,7 @@ import {PushNotification} from '@atb/assets/svg/color/images';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {useAppState} from '@atb/AppContext';
 import {OnboardingScreen} from '@atb/onboarding-screen';
-import {usePushNotifications} from '@atb/notifications';
+import {useNotificationContextState} from '@atb/notifications';
 
 type Props = RootStackScreenProps<'Root_NotificationPermissionScreen'>;
 
@@ -14,7 +14,7 @@ export const Root_NotificationPermissionScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
 
   const {completeNotificationPermissionOnboarding} = useAppState();
-  const {requestPermissions} = usePushNotifications();
+  const {requestPermissions} = useNotificationContextState();
   const buttonOnPress = useCallback(async () => {
     await requestPermissions();
     navigation.popToTop();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -30,9 +30,9 @@ import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {InteractionManager} from 'react-native';
 import {useMaybeShowShareTravelHabitsScreen} from '@atb/beacons/use-maybe-show-share-travel-habits-screen';
 import {
-  usePushNotifications,
   usePushNotificationsEnabled,
   useOnPushNotificationOpened,
+  useNotificationContextState,
 } from '@atb/notifications';
 import {
   filterValidRightNowFareContract,
@@ -70,7 +70,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
   );
 
   const {register: registerForNotifications, status: notificationStatus} =
-    usePushNotifications();
+    useNotificationContextState();
   useOnPushNotificationOpened();
 
   // Register notification language when the app starts, in case the user have

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -52,7 +52,7 @@ import {shareTravelHabitsSessionCountKey} from '@atb/beacons/use-maybe-show-shar
 import {hasSeenShareTravelHabitsScreenKey} from '@atb/beacons/use-has-seen-share-travel-habits-screen';
 import {useAnnouncementsState} from '@atb/announcements';
 import {
-  usePushNotifications,
+  useNotificationContextState,
   usePushNotificationsEnabledDebugOverride,
 } from '@atb/notifications';
 import {useTimeContextState} from '@atb/time';
@@ -136,9 +136,13 @@ export const Profile_DebugInfoScreen = () => {
   } = useMobileTokenContextState();
   const {serverNow} = useTimeContextState();
 
-  const {requestPermissions: registerForPushNotifications} =
-    usePushNotifications();
-  const [fcmToken, setFcmToken] = useState<string>();
+  const {
+    fcmToken,
+    status: notificationStatus,
+    register: registerNotifications,
+    requestPermissions: requestNotificationPermissions,
+    checkPermissions: checkNotificationPermissions,
+  } = useNotificationContextState();
 
   const remoteConfig = useRemoteConfig();
 
@@ -190,15 +194,6 @@ export const Profile_DebugInfoScreen = () => {
               setPreference({debugShowSeconds});
             }}
           />
-          <LinkSectionItem
-            text="Register for push notifications"
-            onPress={() => registerForPushNotifications().then(setFcmToken)}
-          />
-          {fcmToken && (
-            <GenericSectionItem>
-              <ThemeText>{`FCM token: ${fcmToken}`}</ThemeText>
-            </GenericSectionItem>
-          )}
           <LinkSectionItem
             text="Restart onboarding"
             onPress={restartOnboarding}
@@ -516,6 +511,34 @@ export const Profile_DebugInfoScreen = () => {
                   ))}
                 </View>
               )
+            }
+          />
+        </Section>
+
+        <Section withPadding withTopPadding>
+          <ExpandableSectionItem
+            text="Notifications"
+            showIconText={true}
+            expandContent={
+              <>
+                <ThemeText>Notification status: {notificationStatus}</ThemeText>
+                <Button
+                  style={style.button}
+                  onPress={requestNotificationPermissions}
+                  text="Request permissions"
+                />
+                <Button
+                  style={style.button}
+                  onPress={checkNotificationPermissions}
+                  text="Check permissions"
+                />
+                <Button
+                  style={style.button}
+                  onPress={registerNotifications}
+                  text="Register"
+                />
+                <ThemeText>FCM Token: {fcmToken}</ThemeText>
+              </>
             }
           />
         </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
@@ -9,7 +9,7 @@ import {dictionary, ProfileTexts, useTranslation} from '@atb/translations';
 import {MessageBox} from '@atb/components/message-box';
 import {Processing} from '@atb/components/loading';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
-import {usePushNotifications, isConfigEnabled} from '@atb/notifications';
+import {useNotificationContextState, isConfigEnabled} from '@atb/notifications';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -18,7 +18,7 @@ export const Profile_NotificationsScreen = () => {
   const {t} = useTranslation();
   const isFocusedAndActive = useIsFocusedAndActive();
   const {status, config, requestPermissions, checkPermissions, updateConfig} =
-    usePushNotifications();
+    useNotificationContextState();
 
   useEffect(() => {
     if (isFocusedAndActive) {


### PR DESCRIPTION
Changes the usePushNotifications hook to a context, in order to have shared state. 

Also adds a "Notifications" section to the debug menu, that reflects this state.

closes https://github.com/AtB-AS/kundevendt/issues/7230