### PR TITLE
fix: Use custom backdrop for PopOver

### DIFF
--- a/src/components/popover/PopOver.tsx
+++ b/src/components/popover/PopOver.tsx
@@ -48,6 +48,7 @@ export const PopOver = ({
       verticalOffset={
         Platform.OS === 'android' ? -(StatusBar.currentHeight ?? 0) : 0
       }
+      backgroundStyle={style.backdrop}
     >
       <View style={style.heading}>
         <ThemeText type="body__primary--bold">{heading}</ThemeText>
@@ -75,5 +76,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginBottom: theme.spacings.small,
+  },
+  backdrop: {
+    backgroundColor: theme.static.background.background_accent_1.background,
+    opacity: 0.5,
   },
 }));


### PR DESCRIPTION
Sets a custom backdrop for the popover component as described here: https://github.com/AtB-AS/kundevendt/issues/3854#issuecomment-1832021082

Closes https://github.com/AtB-AS/kundevendt/issues/3854