### PR TITLE
refactor: Use reducer in MobileTokenContext

### DIFF
--- a/src/mobile-token/__tests__/tokenReducer.test.ts
+++ b/src/mobile-token/__tests__/tokenReducer.test.ts
@@ -1,0 +1,65 @@
+import {tokenReducer, TokenReducerState} from '@atb/mobile-token/tokenReducer';
+
+describe('tokenReducer', () => {
+  it('should set state to loading', function () {
+    const prevState: TokenReducerState = {status: 'none'};
+    const newState = tokenReducer(prevState, {type: 'LOADING'});
+    expect(newState).toEqual({status: 'loading'});
+  });
+  it('should set state to error', function () {
+    const prevState: TokenReducerState = {status: 'loading'};
+    const newState = tokenReducer(prevState, {type: 'ERROR'});
+    expect(newState).toEqual({status: 'error'});
+  });
+  it('should set state to timeout', function () {
+    const prevState: TokenReducerState = {status: 'loading'};
+    const newState = tokenReducer(prevState, {type: 'TIMEOUT'});
+    expect(newState).toEqual({status: 'timeout'});
+  });
+  it('should set state to success', function () {
+    const prevState: TokenReducerState = {status: 'loading'};
+    const nativeToken = {} as any;
+    const remoteTokens = [] as any;
+    const newState = tokenReducer(prevState, {
+      type: 'SUCCESS',
+      nativeToken,
+      remoteTokens,
+    });
+    expect(newState.status).toEqual('success');
+    expect(newState.nativeToken).toBe(nativeToken);
+    expect(newState.remoteTokens).toBe(remoteTokens);
+  });
+  it('should update remote tokens if success', function () {
+    const prevState: TokenReducerState = {
+      status: 'success',
+      nativeToken: {} as any,
+      remoteTokens: [],
+    };
+    const remoteTokens = [] as any;
+    const newState = tokenReducer(prevState, {
+      type: 'UPDATE_REMOTE_TOKENS',
+      remoteTokens,
+    });
+    expect(newState.status).toEqual(prevState.status);
+    expect(newState.nativeToken).toBe(prevState.nativeToken);
+    expect(newState.remoteTokens).toBe(remoteTokens);
+  });
+  it('should not update remote tokens if not success', function () {
+    const prevState: TokenReducerState = {status: 'loading'};
+    const remoteTokens = [] as any;
+    const newState = tokenReducer(prevState, {
+      type: 'UPDATE_REMOTE_TOKENS',
+      remoteTokens,
+    });
+    expect(newState).toEqual(prevState);
+  });
+  it('should clear tokens', function () {
+    const prevState: TokenReducerState = {
+      status: 'success',
+      nativeToken: {} as any,
+      remoteTokens: [],
+    };
+    const newState = tokenReducer(prevState, {type: 'CLEAR_TOKENS'});
+    expect(newState).toEqual({status: 'none'});
+  });
+});

--- a/src/mobile-token/tokenReducer.ts
+++ b/src/mobile-token/tokenReducer.ts
@@ -1,0 +1,47 @@
+import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
+import {MobileTokenStatus, RemoteToken} from '@atb/mobile-token/types';
+
+export type TokenReducerState = {
+  nativeToken?: ActivatedToken;
+  remoteTokens?: RemoteToken[];
+  status: MobileTokenStatus;
+};
+
+type TokenReducerAction =
+  | {type: 'LOADING'}
+  | {type: 'SUCCESS'; nativeToken: ActivatedToken; remoteTokens: RemoteToken[]}
+  | {type: 'UPDATE_REMOTE_TOKENS'; remoteTokens: RemoteToken[]}
+  | {type: 'CLEAR_TOKENS'}
+  | {type: 'ERROR'}
+  | {type: 'TIMEOUT'};
+
+type TokenReducer = (
+  prevState: TokenReducerState,
+  action: TokenReducerAction,
+) => TokenReducerState;
+
+export const tokenReducer: TokenReducer = (
+  prevState,
+  action,
+): TokenReducerState => {
+  switch (action.type) {
+    case 'LOADING':
+      return {status: 'loading'};
+    case 'SUCCESS':
+      return {
+        status: 'success',
+        nativeToken: action.nativeToken,
+        remoteTokens: action.remoteTokens,
+      };
+    case 'UPDATE_REMOTE_TOKENS':
+      return prevState.status === 'success'
+        ? {...prevState, remoteTokens: action.remoteTokens}
+        : prevState;
+    case 'CLEAR_TOKENS':
+      return {status: 'none'};
+    case 'ERROR':
+      return {status: 'error'};
+    case 'TIMEOUT':
+      return {status: 'timeout'};
+  }
+};

--- a/src/mobile-token/types.ts
+++ b/src/mobile-token/types.ts
@@ -94,7 +94,7 @@ export type Token = RemoteToken & {
 };
 
 export type MobileTokenStatus =
-  | 'disabled'
+  | 'none'
   | 'loading'
   | 'timeout'
   | 'error'

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -132,7 +132,12 @@ export const Profile_DebugInfoScreen = () => {
     deviceInspectionStatus,
     mobileTokenStatus,
     barcodeStatus,
-    debug: {token, createToken, validateToken, removeRemoteToken, renewToken},
+    debug: {
+      nativeToken,
+      validateToken,
+      removeRemoteToken,
+      renewToken,
+    },
   } = useMobileTokenContextState();
   const {serverNow} = useTimeContextState();
 
@@ -599,14 +604,14 @@ export const Profile_DebugInfoScreen = () => {
             showIconText={true}
             expandContent={
               <View>
-                {token && (
+                {nativeToken && (
                   <View>
-                    <ThemeText>{`Token id: ${token.getTokenId()}`}</ThemeText>
+                    <ThemeText>{`Token id: ${nativeToken.getTokenId()}`}</ThemeText>
                     <ThemeText>{`Token start: ${new Date(
-                      token.getValidityStart(),
+                      nativeToken.getValidityStart(),
                     ).toISOString()}`}</ThemeText>
                     <ThemeText>{`Token end: ${new Date(
-                      token.getValidityEnd(),
+                      nativeToken.getValidityEnd(),
                     ).toISOString()}`}</ThemeText>
                   </View>
                 )}
@@ -621,26 +626,21 @@ export const Profile_DebugInfoScreen = () => {
                   text="Reload token(s)"
                   onPress={retry}
                 />
-                <Button
-                  style={style.button}
-                  text="Create token"
-                  onPress={createToken}
-                />
-                {token && (
+                {nativeToken && (
                   <Button
                     style={style.button}
                     text="Wipe token"
                     onPress={wipeToken}
                   />
                 )}
-                {token && (
+                {nativeToken && (
                   <Button
                     style={style.button}
                     text="Validate token"
                     onPress={validateToken}
                   />
                 )}
-                {token && (
+                {nativeToken && (
                   <Button
                     style={style.button}
                     text="Renew token"


### PR DESCRIPTION
To get better control of the internal state a reducer is used
instead of multiple states.
