### PR TITLE
fix: Make Hyre ticket bundling work

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^3.11.1",
+    "@atb-as/config-specs": "^3.13.1",
     "@atb-as/generate-assets": "^9.8.0",
     "@atb-as/theme": "^7.1.1",
     "@bugsnag/react-native": "^7.21.0",

--- a/src/mobility/components/OperatorActionButton.tsx
+++ b/src/mobility/components/OperatorActionButton.tsx
@@ -33,10 +33,11 @@ export const OperatorActionButton = ({
     isUserEligibleForBenefit ? operatorId : undefined,
   );
 
-  const buttonText = benefit?.callToAction?.name
-    ? getTextForLanguage(benefit.callToAction.name, language) ??
-      t(MobilityTexts.operatorAppSwitchButton(operatorName))
-    : t(MobilityTexts.operatorAppSwitchButton(operatorName));
+  const buttonText =
+    isUserEligibleForBenefit && benefit?.callToAction?.name
+      ? getTextForLanguage(benefit.callToAction.name, language) ??
+        t(MobilityTexts.operatorAppSwitchButton(operatorName))
+      : t(MobilityTexts.operatorAppSwitchButton(operatorName));
 
   const handleCallToAction = useCallback(async () => {
     analytics.logEvent('Mobility', 'Open operator app', {
@@ -45,7 +46,7 @@ export const OperatorActionButton = ({
       isUserEligibleForBenefit,
     });
     let url = rentalAppUri;
-    if (benefit?.callToAction.url) {
+    if (isUserEligibleForBenefit && benefit?.callToAction.url) {
       // Benefit urls can contain variables to be re replaced runtime, e.g. '{APP_URL}?voucherCode={VOUCHER_CODE}'
       url = replaceTokens(benefit.callToAction.url, {
         APP_URL: rentalAppUri,

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^3.11.1":
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.11.1.tgz#423ccc7f35c2828fbdae16ea17ca9f805656523f"
-  integrity sha512-FqcOFdCFjglW8tN7+yC9J82P5ziX0nS5A6w4ZBGcGAiAGeY1O9Pif5QYlGkkRpAr2a2x7nY+udJw06DCbGBueA==
+"@atb-as/config-specs@^3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.13.1.tgz#8d3b253634b23c54d10c4bc8ed5e1039957e942f"
+  integrity sha512-qPW+gb29b1Ihx7aLIZgDreOIunvyE0yqvh8QOOtz5C30mXYyWpXdpQqOP1ZBHgepa5wWLu02SaNrvslwkaKVoQ==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
Closes https://github.com/AtB-AS/team-platform/issues/473

A new version of config-specs is required to get the correct benefit type when parsing data from Firestore. Correspondig PRs: 

- https://github.com/AtB-AS/fare-product-type-configs/pull/33
- https://github.com/AtB-AS/firestore-configuration/pull/380