### PR TITLE
fix: screen reader and error on email in profile screen

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -78,8 +78,12 @@ export const Profile_DeleteProfileScreen = ({
         title: t(DeleteProfileTexts.header.title),
         leftButton: {type: 'back', withIcon: true},
       }}
-      parallaxContent={() => (
-        <View style={{marginHorizontal: theme.spacings.medium}}>
+      parallaxContent={(focusRef) => (
+        <View
+          style={{marginHorizontal: theme.spacings.medium}}
+          accessible={true}
+          ref={focusRef}
+        >
           <ThemeText
             type="heading--medium"
             color="background_accent_0"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -92,8 +92,8 @@ export const Profile_EditProfileScreen = ({
         title: t(EditProfileTexts.header.title),
         leftButton: {type: 'back', withIcon: true},
       }}
-      parallaxContent={() => (
-        <View style={styles.parallaxContent}>
+      parallaxContent={(focusRef) => (
+        <View style={styles.parallaxContent} ref={focusRef} accessible={true}>
           <ThemeText
             type="heading--medium"
             color="background_accent_0"
@@ -163,7 +163,10 @@ export const Profile_EditProfileScreen = ({
                 <TextInputSectionItem
                   editable={!isLoadingOrSubmittingProfile}
                   value={email}
-                  onChangeText={setEmail}
+                  onChangeText={(value) => {
+                    setEmail(value);
+                    setInvalidEmail(false);
+                  }}
                   label={t(EditProfileTexts.personalDetails.email.label)}
                   placeholder={t(
                     EditProfileTexts.personalDetails.email.placeholder,

--- a/src/translations/screens/subscreens/EditProfileScreen.ts
+++ b/src/translations/screens/subscreens/EditProfileScreen.ts
@@ -23,7 +23,7 @@ export const EditProfileTexts = {
       header: _('Telefon', 'Phone', 'Telefon'),
       loggedIn: (phoneNumber: string | undefined) =>
         _(
-          `${phoneNumber} kan ikke endres fordi telefonnummeret er brukt til innlogging`,
+          `${phoneNumber} kan ikke endres fordi telefonnummeret er brukt til innlogging.`,
           `${phoneNumber} cannot be changed because the phone number is used for logging in.`,
           `${phoneNumber} kan ikkje endrast, fordi telefonnummeret ditt er brukt til innlogging.`,
         ),


### PR DESCRIPTION
* using refs in header to set screen reader focus in Edit profile screen and delete profile screen
* added punctuation
* reset error state for email when changing email
Ref. comments in: https://github.com/AtB-AS/kundevendt/issues/4275