### PR TITLE
bug: Parameter transferSlack is not included in trip search when value is 0

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
@@ -217,13 +217,13 @@ async function doSearch(
     fromLocation: query.from,
     toLocation: query.to,
     arriveBy: query.arriveBy,
-    when: query.when || '',
-    cursor: query.cursor || '',
-    transferSlack: query.transferSlack || '',
-    transferPenalty: query.transferPenalty || '',
-    waitReluctance: query.waitReluctance || '',
-    walkReluctance: query.walkReluctance || '',
-    walkSpeed: query.walkSpeed || '',
+    when: query.when ?? '',
+    cursor: query.cursor ?? '',
+    transferSlack: query.transferSlack ?? '',
+    transferPenalty: query.transferPenalty ?? '',
+    waitReluctance: query.waitReluctance ?? '',
+    walkReluctance: query.walkReluctance ?? '',
+    walkSpeed: query.walkSpeed ?? '',
   });
 
   return tripsSearch(query, {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
@@ -80,7 +80,7 @@ export function createQuery(
         const value = preference.options.find(
           (o) => o.id === preference.selectedOption,
         )?.value;
-        if (value) {
+        if (value !== null && value !== undefined) {
           query[preference.type] = value;
         }
       },


### PR DESCRIPTION
When the value for `transferSlack` in trip search filter is set to 0 (which is a totally valid value) the parameter was not included in the request to BFF.