### PR TITLE
fix: only register if push notifications are enabled

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -79,8 +79,8 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
   // changed language since last time the app was opened. This useEffect will
   // also trigger when language is changed manually in the app.
   useEffect(() => {
-    registerForNotifications();
-  }, [registerForNotifications]);
+    if (pushNotificationsEnabled) registerForNotifications();
+  }, [registerForNotifications, pushNotificationsEnabled]);
 
   useEffect(() => {
     const shouldShowLocationOnboarding =


### PR DESCRIPTION
We don't want to call register if notifications are disabled in remote config. 

closes https://github.com/AtB-AS/kundevendt/issues/7230