### PR TITLE
fix: Popover working on Android

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -353,7 +353,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 viewContainerStyle={style.searchTimeButton}
               />
               {filtersState.enabled && (
-                <View ref={filterButtonWrapperRef}>
+                <View ref={filterButtonWrapperRef} collapsable={false}>
                   <Button
                     text={t(TripSearchTexts.filterButton.text)}
                     accessibilityHint={t(TripSearchTexts.filterButton.a11yHint)}


### PR DESCRIPTION
Views without style are removed from the Android native hierarchy
as an optimisation. Since we have attached a ref to it, we set
collapsable to false so it is still there when rendered natively.
