### PR TITLE
fix: should not auto-capitalize email input

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -175,6 +175,7 @@ export const Profile_EditProfileScreen = ({
                   showClear={!isLoadingOrSubmittingProfile}
                   errorText={getEmailErrorText(invalidEmail, errorUpdate)}
                   inlineLabel={false}
+                  autoCapitalize="none"
                 />
               </Section>
 


### PR DESCRIPTION
Turning off auto-capitalization for email input in Edit Profile Screen