### PR TITLE
refactor: use PATCH for notification config updates

### DIFF
--- a/src/notifications/api/index.ts
+++ b/src/notifications/api/index.ts
@@ -38,29 +38,7 @@ export interface NotificationConfigUpdate extends NotificationConfigValue {
 export const updateConfig = (
   update: NotificationConfigUpdate,
 ): Promise<void> => {
-  // TODO: The /config endpoint supports patch as well, but currently this does not work properly.
-  // This function should be rewritten to use PATCH whenever that is ready.
-  // return client.patch('/notification/v1/config', update, {
-  //   authWithIdToken: true,
-  // });
-  // Temporary fix:
-  return getConfig().then((config) => {
-    const newConfig: NotificationConfig = {
-      modes:
-        update.config_type === 'mode'
-          ? config.modes.map((m) =>
-              m.id === update.id ? {...m, enabled: update.enabled} : m,
-            )
-          : config.modes,
-      groups:
-        update.config_type === 'group'
-          ? config.groups.map((m) =>
-              m.id === update.id ? {...m, enabled: update.enabled} : m,
-            )
-          : config.groups,
-    };
-    return client.post('/notification/v1/config', newConfig, {
-      authWithIdToken: true,
-    });
+  return client.patch('/notification/v1/config', update, {
+    authWithIdToken: true,
   });
 };


### PR DESCRIPTION
Since https://github.com/AtB-AS/team-platform/issues/481 is now fixed, we can use the PATCH endpoint for updating notification config.

### Acceptance criteria
 
- [ ] The notification toggle sends a PATCH to /notification/v1/config
- [ ] The toggle persist when reloading the page or app.
- [ ] Should also test that granular settings introduced in https://github.com/AtB-AS/mittatb-app/pull/4099 work as expected
