### PR TITLE
fix: Stop infinite loading of cancelled add payment card view

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
@@ -71,7 +71,7 @@ export const Profile_PaymentOptionsScreen = ({
           if (responseCode === 'OK') {
             await authorizeRecurringPayment(paymentId);
             await refreshCards();
-          } else if (responseCode === 'CANCEL') {
+          } else if (responseCode === 'Cancel') {
             await cancelRecurringPayment(paymentId);
           }
         } catch (error: any) {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/15521

The response returned by netaxept nets when cancelling to add payment was

`atb-dev://profile?response_code=Cancel&recurring_payment_id=12210`

we can see that the `response_code` is `Cancel`, but in the code we are handling it using `CANCEL`, by fixing the capitalization, the code can now proceed and handle it properly.

<details>
 <summary>Video proof</summary>

https://github.com/AtB-AS/mittatb-app/assets/1777333/1e1c6f06-1165-4eb4-a13f-9ca69a8342e0
  
</details>


