### PR TITLE
fix: add autocomplete=email to email input

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -172,6 +172,7 @@ export const Profile_EditProfileScreen = ({
                     EditProfileTexts.personalDetails.email.placeholder,
                   )}
                   keyboardType="email-address"
+                  autoComplete="email"
                   showClear={!isLoadingOrSubmittingProfile}
                   errorText={getEmailErrorText(invalidEmail, errorUpdate)}
                   inlineLabel={false}


### PR DESCRIPTION
~Noticed in the demo today that it looks like email input was with capital letter 🤔 Wonder if it is due to keyboard type being set instead of input mode? Is there a specific reason as to why it was set without input type? I think maybe also input type will improve autocomplete features~

~I see `autoCapitalize` is set so that fixes the letter, but will it work with autocomplete?~

OK, doing some research and seeing that keyboardType should work as expected. Just found it odd that it didn't handle capitalized automatically 🤔 But also, maybe it makes sense to add autocomplete property?


## Acceptance

- [ ] Should get autofill on email