### PR TITLE
chore: update android dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,8 +4,7 @@ apply plugin: "com.facebook.react"
 
 apply plugin: "kotlin-android"
 
-apply from: "../../node_modules/@bugsnag/react-native/bugsnag-react-native.gradle"
-
+apply plugin: "com.bugsnag.android.gradle"
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
@@ -151,11 +150,11 @@ android {
 
 dependencies {
 
-    implementation 'com.facebook.soloader:soloader:0.9.0+'
+    implementation 'com.facebook.soloader:soloader:0.10.5'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${KOTLIN_VERSION}"
 
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.0.4"
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
 
@@ -163,7 +162,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
 
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation "androidx.core:core-splashscreen:1.0.0"
+    implementation "androidx.core:core-splashscreen:1.0.1"
 
     implementation 'io.intercom.android:intercom-sdk-base:9.+'
     implementation 'io.intercom.android:intercom-sdk:9.+'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -162,7 +162,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
 
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation "androidx.core:core-splashscreen:1.0.1"
+    implementation "androidx.core:core-splashscreen:1.0.0"
 
     implementation 'io.intercom.android:intercom-sdk-base:9.+'
     implementation 'io.intercom.android:intercom-sdk:9.+'

--- a/android/app/src/main/java/no/mittatb/MainApplication.java
+++ b/android/app/src/main/java/no/mittatb/MainApplication.java
@@ -81,7 +81,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
       if (!TextUtils.isEmpty(bugsnagKey)) {
           Configuration config = new Configuration(bugsnagKey);
           String bugsnagReleaseStage = bundle.getString("com.bugsnag.android.RELEASE_STAGE");
-          if (!TextUtils.isEmpty(bugsnagKey)) {
+          if (!TextUtils.isEmpty(bugsnagReleaseStage)) {
               config.setReleaseStage(bugsnagReleaseStage);
           }
           Bugsnag.start(this, config);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         RNMapboxMapsImpl = "mapbox"
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-        ndkVersion = "23.1.7779620"
+        ndkVersion = "26.1.10909125"
         kotlin_version = "1.8.0"
     }
     repositories {
@@ -25,6 +25,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${project.ext.kotlin_version}"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
+        classpath "com.bugsnag:bugsnag-android-gradle-plugin:7.6.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,8 +22,6 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath 'com.google.gms:google-services:4.3.13'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${project.ext.kotlin_version}"
-
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
         classpath "com.bugsnag:bugsnag-android-gradle-plugin:7.6.0"
 


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/15989

- Updated some libraries that can be updated without any issues (soLoader, NDK, desugar, splashscreen).
- Updated Android bugsnag integration based on https://docs.bugsnag.com/platforms/android/#installation
- Updated Android bugsnag initialization (as shown in the issue)