### PR TITLE
feat: add on behalf of option in bottom sheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.13.1",
-    "@atb-as/generate-assets": "^9.9.0",
+    "@atb-as/generate-assets": "^9.10.0",
     "@atb-as/theme": "^7.1.1",
     "@bugsnag/react-native": "^7.21.0",
     "@bugsnag/source-maps": "^2.3.1",

--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -2,15 +2,14 @@ import React, {useEffect, useState} from 'react';
 import {AccessibilityProps, View} from 'react-native';
 import {StyleSheet, Theme} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
 import {Toggle} from '@atb/components/toggle';
 import {InteractiveColor, TextNames} from '@atb/theme/colors';
-import {SvgProps} from 'react-native-svg';
 import {LabelType} from '@atb/configuration';
 import {LabelInfo} from '@atb/components/label-info';
+import {SvgProps} from 'react-native-svg';
 
 type Props = SectionItemProps<{
   text: string;
@@ -18,7 +17,7 @@ type Props = SectionItemProps<{
   label?: LabelType;
   onValueChange: (checked: boolean) => void;
   value?: boolean;
-  leftIcon?: (props: SvgProps) => JSX.Element;
+  leftImage?: (props: SvgProps) => JSX.Element;
   interactiveColor?: InteractiveColor;
   accessibility?: AccessibilityProps;
   textType?: TextNames;
@@ -29,7 +28,7 @@ export function ToggleSectionItem({
   subtext,
   label,
   onValueChange,
-  leftIcon,
+  leftImage: LeftImage,
   value = false,
   accessibility,
   testID,
@@ -67,37 +66,44 @@ export function ToggleSectionItem({
       onAccessibilityAction={() => onChange(!checked)}
       {...accessibility}
     >
-      <View style={sectionStyle.spaceBetween}>
-        {leftIcon && <ThemeIcon svg={leftIcon} style={styles.leftIcon} />}
-        <View style={styles.textContainer}>
-          <ThemeText type={textType}>{text}</ThemeText>
+      <View style={{flexDirection: 'row'}}>
+        <View style={styles.leftImageContainer}>{LeftImage && <LeftImage />}</View>
+        <View style={{flexDirection: 'column', flex: 1}}>
+          <View style={sectionStyle.spaceBetween}>
+            <View style={styles.textContainer}>
+              <ThemeText type={textType}>{text}</ThemeText>
+            </View>
+            {label && <LabelInfo label={label} />}
+            <Toggle
+              importantForAccessibility="no-hide-descendants"
+              accessible={false}
+              value={checked}
+              onValueChange={onChange}
+              testID={testID}
+              interactiveColor={interactiveColor}
+              disabled={disabled}
+            />
+          </View>
+          {subtext && (
+            <ThemeText
+              type="body__secondary"
+              color="secondary"
+              style={styles.subtext}
+            >
+              {subtext}
+            </ThemeText>
+          )}
         </View>
-        {label && <LabelInfo label={label} />}
-        <Toggle
-          importantForAccessibility="no-hide-descendants"
-          accessible={false}
-          value={checked}
-          onValueChange={onChange}
-          testID={testID}
-          interactiveColor={interactiveColor}
-          disabled={disabled}
-        />
       </View>
-      {subtext && (
-        <ThemeText
-          type="body__secondary"
-          color="secondary"
-          style={styles.subtext}
-        >
-          {subtext}
-        </ThemeText>
-      )}
     </View>
   );
 }
 
 const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
-  leftIcon: {marginRight: theme.spacings.small},
+  leftImageContainer: {
+    marginRight: theme.spacings.small,
+    justifyContent: 'center',
+  },
   textContainer: {flex: 1, marginRight: theme.spacings.small},
   subtext: {marginTop: theme.spacings.xSmall},
 }));

--- a/src/mobility/components/filter/FormFactorFilter.tsx
+++ b/src/mobility/components/filter/FormFactorFilter.tsx
@@ -52,7 +52,7 @@ export const FormFactorFilter = ({
           <ToggleSectionItem
             key={operator.id}
             text={operator.name}
-            leftIcon={icon}
+            leftImage={icon}
             value={isChecked(operator.id)}
             onValueChange={onOperatorToggle(operator.id)}
           />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -69,6 +69,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   };
   const [travellerSelection, setTravellerSelection] =
     useState(selectableTravellers);
+
+  const [isOnBehalfOfToggle, setOnBehalfOfToggle] = useState<boolean>(false);
+
   const [travelDate, setTravelDate] = useState<string | undefined>(
     params.travelDate,
   );
@@ -192,6 +195,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             selectionMode={travellerSelectionMode}
             selectableUserProfiles={selectableTravellers}
             style={styles.selectionComponent}
+            setOnBehalfOfToggle={setOnBehalfOfToggle}
+            isOnBehalfOfToggle={isOnBehalfOfToggle}
           />
           <FromToSelection
             fareProductTypeConfig={params.fareProductTypeConfig}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -70,7 +70,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const [travellerSelection, setTravellerSelection] =
     useState(selectableTravellers);
 
-  const [isOnBehalfOfToggle, setOnBehalfOfToggle] = useState<boolean>(false);
+  const [isOnBehalfOfToggle, setIsOnBehalfOfToggle] = useState<boolean>(false);
 
   const [travelDate, setTravelDate] = useState<string | undefined>(
     params.travelDate,
@@ -195,7 +195,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             selectionMode={travellerSelectionMode}
             selectableUserProfiles={selectableTravellers}
             style={styles.selectionComponent}
-            setOnBehalfOfToggle={setOnBehalfOfToggle}
+            setIsOnBehalfOfToggle={setIsOnBehalfOfToggle}
             isOnBehalfOfToggle={isOnBehalfOfToggle}
           />
           <FromToSelection

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -16,6 +16,8 @@ import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {ContentHeading} from '@atb/components/content-heading';
+import {LabelInfo} from '@atb/components/label-info';
+import {useOnBehalfOf} from '@atb/on-behalf-of';
 
 type TravellerSelectionProps = {
   selectableUserProfiles: UserProfileWithCount[];
@@ -25,6 +27,8 @@ type TravellerSelectionProps = {
   style?: StyleProp<ViewStyle>;
   selectionMode: TravellerSelectionMode;
   fareProductType: string;
+  setOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  isOnBehalfOfToggle: boolean;
 };
 
 export function TravellerSelection({
@@ -33,6 +37,8 @@ export function TravellerSelection({
   selectableUserProfiles,
   selectionMode,
   fareProductType,
+  setOnBehalfOfToggle,
+  isOnBehalfOfToggle,
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
   const styles = useStyles();
@@ -41,6 +47,8 @@ export function TravellerSelection({
     close: closeBottomSheet,
     onCloseFocusRef,
   } = useBottomSheet();
+
+  const isOnBehalfOfEnabled = useOnBehalfOf();
 
   const [userProfilesState, setUserProfilesState] = useState<
     UserProfileWithCount[]
@@ -107,6 +115,8 @@ export function TravellerSelection({
         selectionMode={selectionMode}
         fareProductType={fareProductType}
         selectableUserProfilesWithCountInit={userProfilesState}
+        setOnBehalfOfToggle={setOnBehalfOfToggle}
+        isOnBehalfOfToggle={isOnBehalfOfToggle}
         close={(
           chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
         ) => {
@@ -155,6 +165,9 @@ export function TravellerSelection({
                 </ThemeText>
               )}
             </View>
+
+            {/* remove new label when requested */}
+            {isOnBehalfOfEnabled && <LabelInfo label="new" />}
 
             <ThemeIcon svg={Edit} size="normal" />
           </View>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -27,7 +27,7 @@ type TravellerSelectionProps = {
   style?: StyleProp<ViewStyle>;
   selectionMode: TravellerSelectionMode;
   fareProductType: string;
-  setOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  setIsOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
   isOnBehalfOfToggle: boolean;
 };
 
@@ -37,7 +37,7 @@ export function TravellerSelection({
   selectableUserProfiles,
   selectionMode,
   fareProductType,
-  setOnBehalfOfToggle,
+  setIsOnBehalfOfToggle,
   isOnBehalfOfToggle,
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
@@ -124,9 +124,7 @@ export function TravellerSelection({
             setUserProfilesState(chosenSelectableUserProfilesWithCounts);
           }
           if (onBehalfOfToggle !== undefined) {
-            setOnBehalfOfToggle(onBehalfOfToggle);
-          } else {
-            setOnBehalfOfToggle(isOnBehalfOfToggle);
+            setIsOnBehalfOfToggle(onBehalfOfToggle);
           }
           closeBottomSheet();
         }}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -115,13 +115,18 @@ export function TravellerSelection({
         selectionMode={selectionMode}
         fareProductType={fareProductType}
         selectableUserProfilesWithCountInit={userProfilesState}
-        setOnBehalfOfToggle={setOnBehalfOfToggle}
         isOnBehalfOfToggle={isOnBehalfOfToggle}
         close={(
           chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
+          onBehalfOfToggle?: boolean,
         ) => {
           if (chosenSelectableUserProfilesWithCounts !== undefined) {
             setUserProfilesState(chosenSelectableUserProfilesWithCounts);
+          }
+          if (onBehalfOfToggle !== undefined) {
+            setOnBehalfOfToggle(onBehalfOfToggle);
+          } else {
+            setOnBehalfOfToggle(isOnBehalfOfToggle);
           }
           closeBottomSheet();
         }}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -34,7 +34,7 @@ export const TravellerSelectionSheet = ({
   const style = useStyle();
 
   const userCountState = useUserCountState(selectableUserProfilesWithCountInit);
-  const [travelerOnBehalfOfToggle, setTravelerOnBehalfOfToggle] =
+  const [isTravelerOnBehalfOfToggle, setIsTravelerOnBehalfOfToggle] =
     useState<boolean>(isOnBehalfOfToggle);
   const selectableUserProfilesWithCount =
     userCountState.userProfilesWithCount.filter((a) =>
@@ -62,16 +62,16 @@ export const TravellerSelectionSheet = ({
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
-            setTravelerOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
-            isTravelerOnBehalfOfToggle={travelerOnBehalfOfToggle}
+            setIsTravelerOnBehalfOfToggle={setIsTravelerOnBehalfOfToggle}
+            isTravelerOnBehalfOfToggle={isTravelerOnBehalfOfToggle}
           />
         ) : (
           <SingleTravellerSelection
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
-            setTravelerOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
-            isTravelerOnBehalfOfToggle={travelerOnBehalfOfToggle}
+            setIsTravelerOnBehalfOfToggle={setIsTravelerOnBehalfOfToggle}
+            isTravelerOnBehalfOfToggle={isTravelerOnBehalfOfToggle}
           />
         )}
       </ScrollView>
@@ -80,7 +80,7 @@ export const TravellerSelectionSheet = ({
           text={t(PurchaseOverviewTexts.travellerSelectionSheet.confirm)}
           disabled={totalTravellersCount < 1}
           onPress={() =>
-            close(selectableUserProfilesWithCount, travelerOnBehalfOfToggle)
+            close(selectableUserProfilesWithCount, isTravelerOnBehalfOfToggle)
           }
           rightIcon={{svg: Confirm}}
         />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -3,7 +3,7 @@ import {ScreenHeaderWithoutNavigation} from '@atb/components/screen-header';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {TravellerSelectionMode} from '@atb/configuration';
 import {ScrollView} from 'react-native';
-import React from 'react';
+import React, {useState} from 'react';
 import {StyleSheet} from '@atb/theme';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {Button} from '@atb/components/button';
@@ -17,8 +17,10 @@ type TravellerSelectionSheetProps = {
   selectionMode: TravellerSelectionMode;
   fareProductType: string;
   selectableUserProfilesWithCountInit: UserProfileWithCount[];
-  close: (chosenSelectableUserProfiles?: UserProfileWithCount[]) => void;
-  setOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  close: (
+    chosenSelectableUserProfiles?: UserProfileWithCount[],
+    onBehalfOfToggle?: boolean,
+  ) => void;
   isOnBehalfOfToggle: boolean;
 };
 export const TravellerSelectionSheet = ({
@@ -26,13 +28,14 @@ export const TravellerSelectionSheet = ({
   fareProductType,
   selectableUserProfilesWithCountInit,
   close,
-  setOnBehalfOfToggle,
   isOnBehalfOfToggle,
 }: TravellerSelectionSheetProps) => {
   const {t} = useTranslation();
   const style = useStyle();
 
   const userCountState = useUserCountState(selectableUserProfilesWithCountInit);
+  const [travelerOnBehalfOfToggle, setTravelerOnBehalfOfToggle] =
+    useState<boolean>(isOnBehalfOfToggle);
   const selectableUserProfilesWithCount =
     userCountState.userProfilesWithCount.filter((a) =>
       selectableUserProfilesWithCountInit.some((b) => a.id === b.id),
@@ -59,16 +62,16 @@ export const TravellerSelectionSheet = ({
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
-            setOnBehalfOfToggle={setOnBehalfOfToggle}
-            isOnBehalfOfToggle={isOnBehalfOfToggle}
+            setOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
+            isOnBehalfOfToggle={travelerOnBehalfOfToggle}
           />
         ) : (
           <SingleTravellerSelection
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
-            setOnBehalfOfToggle={setOnBehalfOfToggle}
-            isOnBehalfOfToggle={isOnBehalfOfToggle}
+            setOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
+            isOnBehalfOfToggle={travelerOnBehalfOfToggle}
           />
         )}
       </ScrollView>
@@ -76,7 +79,9 @@ export const TravellerSelectionSheet = ({
         <Button
           text={t(PurchaseOverviewTexts.travellerSelectionSheet.confirm)}
           disabled={totalTravellersCount < 1}
-          onPress={() => close(selectableUserProfilesWithCount)}
+          onPress={() =>
+            close(selectableUserProfilesWithCount, travelerOnBehalfOfToggle)
+          }
           rightIcon={{svg: Confirm}}
         />
       </FullScreenFooter>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -18,12 +18,16 @@ type TravellerSelectionSheetProps = {
   fareProductType: string;
   selectableUserProfilesWithCountInit: UserProfileWithCount[];
   close: (chosenSelectableUserProfiles?: UserProfileWithCount[]) => void;
+  setOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  isOnBehalfOfToggle: boolean;
 };
 export const TravellerSelectionSheet = ({
   selectionMode,
   fareProductType,
   selectableUserProfilesWithCountInit,
   close,
+  setOnBehalfOfToggle,
+  isOnBehalfOfToggle,
 }: TravellerSelectionSheetProps) => {
   const {t} = useTranslation();
   const style = useStyle();
@@ -55,12 +59,16 @@ export const TravellerSelectionSheet = ({
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
+            setOnBehalfOfToggle={setOnBehalfOfToggle}
+            isOnBehalfOfToggle={isOnBehalfOfToggle}
           />
         ) : (
           <SingleTravellerSelection
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
+            setOnBehalfOfToggle={setOnBehalfOfToggle}
+            isOnBehalfOfToggle={isOnBehalfOfToggle}
           />
         )}
       </ScrollView>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -62,16 +62,16 @@ export const TravellerSelectionSheet = ({
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
-            setOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
-            isOnBehalfOfToggle={travelerOnBehalfOfToggle}
+            setTravelerOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
+            isTravelerOnBehalfOfToggle={travelerOnBehalfOfToggle}
           />
         ) : (
           <SingleTravellerSelection
             fareProductType={fareProductType}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
-            setOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
-            isOnBehalfOfToggle={travelerOnBehalfOfToggle}
+            setTravelerOnBehalfOfToggle={setTravelerOnBehalfOfToggle}
+            isTravelerOnBehalfOfToggle={travelerOnBehalfOfToggle}
           />
         )}
       </ScrollView>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -10,18 +10,32 @@ import {
 } from '@atb/translations';
 import {getReferenceDataName} from '@atb/configuration';
 import {useScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
-import {CounterSectionItem, Section} from '@atb/components/sections';
+import {
+  CounterSectionItem,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 import {UserProfileWithCount} from '@atb/fare-contracts';
+import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {HoldingHands} from '@atb/assets/svg/color/images';
+import {View} from 'react-native';
+import {StyleSheet} from '@atb/theme';
+import {OnBehalfOfProps} from './types';
 
 export function MultipleTravellersSelection({
   userProfilesWithCount,
   addCount,
   removeCount,
   fareProductType,
-}: UserCountState) {
+  setOnBehalfOfToggle,
+  isOnBehalfOfToggle,
+}: UserCountState & OnBehalfOfProps) {
   const {t, language} = useTranslation();
+  const styles = useStyles();
 
   const travellersModified = useRef(false);
+
+  const isOnBehalfOfEnabled = useOnBehalfOf();
 
   const addTraveller = (userTypeString: string) => {
     travellersModified.current = true;
@@ -39,29 +53,46 @@ export function MultipleTravellersSelection({
   );
 
   return (
-    <Section>
-      {userProfilesWithCount.map((u) => (
-        <CounterSectionItem
-          key={u.userTypeString}
-          text={getReferenceDataName(u, language)}
-          count={u.count}
-          addCount={() => addTraveller(u.userTypeString)}
-          removeCount={() => removeTraveller(u.userTypeString)}
-          type="spacious"
-          testID={'counterInput_' + u.userTypeString.toLowerCase()}
-          color="interactive_2"
-          subtext={[
-            getTextForLanguage(u.alternativeDescriptions, language),
-            t(
-              TicketTravellerTexts.information(
-                u.userTypeString,
-                fareProductType,
+    <View>
+      <Section>
+        {userProfilesWithCount.map((u) => (
+          <CounterSectionItem
+            key={u.userTypeString}
+            text={getReferenceDataName(u, language)}
+            count={u.count}
+            addCount={() => addTraveller(u.userTypeString)}
+            removeCount={() => removeTraveller(u.userTypeString)}
+            type="spacious"
+            testID={'counterInput_' + u.userTypeString.toLowerCase()}
+            color="interactive_2"
+            subtext={[
+              getTextForLanguage(u.alternativeDescriptions, language),
+              t(
+                TicketTravellerTexts.information(
+                  u.userTypeString,
+                  fareProductType,
+                ),
               ),
-            ),
-          ].join(' ')}
-        />
-      ))}
-    </Section>
+            ].join(' ')}
+          />
+        ))}
+      </Section>
+      {isOnBehalfOfEnabled && (
+        <Section style={styles.onBehalfOfContainer}>
+          <ToggleSectionItem
+            leftImage={HoldingHands}
+            text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
+            subtext={t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
+            value={isOnBehalfOfToggle}
+            label="new"
+            textType="body__primary--bold"
+            onValueChange={(checked) => {
+              setOnBehalfOfToggle(checked);
+            }}
+          />
+        </Section>
+      )}
+    </View>
   );
 }
 
@@ -103,3 +134,11 @@ function createTravellersText(
     );
   }
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => {
+  return {
+    onBehalfOfContainer: {
+      marginTop: theme.spacings.medium,
+    },
+  };
+});

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -20,16 +20,16 @@ import {useOnBehalfOf} from '@atb/on-behalf-of';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {OnBehalfOfProps} from './types';
+import {TravelerOnBehalfOfProps} from './types';
 
 export function MultipleTravellersSelection({
   userProfilesWithCount,
   addCount,
   removeCount,
   fareProductType,
-  setOnBehalfOfToggle,
-  isOnBehalfOfToggle,
-}: UserCountState & OnBehalfOfProps) {
+  setTravelerOnBehalfOfToggle,
+  isTravelerOnBehalfOfToggle,
+}: UserCountState & TravelerOnBehalfOfProps) {
   const {t, language} = useTranslation();
   const styles = useStyles();
 
@@ -83,11 +83,11 @@ export function MultipleTravellersSelection({
             leftImage={HoldingHands}
             text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
             subtext={t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
-            value={isOnBehalfOfToggle}
+            value={isTravelerOnBehalfOfToggle}
             label="new"
             textType="body__primary--bold"
             onValueChange={(checked) => {
-              setOnBehalfOfToggle(checked);
+              setTravelerOnBehalfOfToggle(checked);
             }}
           />
         </Section>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -27,7 +27,7 @@ export function MultipleTravellersSelection({
   addCount,
   removeCount,
   fareProductType,
-  setTravelerOnBehalfOfToggle,
+  setIsTravelerOnBehalfOfToggle,
   isTravelerOnBehalfOfToggle,
 }: UserCountState & TravelerOnBehalfOfProps) {
   const {t, language} = useTranslation();
@@ -87,7 +87,7 @@ export function MultipleTravellersSelection({
             label="new"
             textType="body__primary--bold"
             onValueChange={(checked) => {
-              setTravelerOnBehalfOfToggle(checked);
+              setIsTravelerOnBehalfOfToggle(checked);
             }}
           />
         </Section>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -7,17 +7,31 @@ import {
   getTextForLanguage,
 } from '@atb/translations';
 import {getReferenceDataName} from '@atb/configuration';
-import {RadioGroupSection, Section} from '@atb/components/sections';
+import {
+  RadioGroupSection,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 import {UserProfileWithCount} from '@atb/fare-contracts';
+import {View} from 'react-native';
+import {StyleSheet} from '@atb/theme';
+import {HoldingHands} from '@atb/assets/svg/color/images';
+import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {OnBehalfOfProps} from './types';
 
 export function SingleTravellerSelection({
   userProfilesWithCount,
   addCount,
   removeCount,
   fareProductType,
-}: UserCountState) {
+  setOnBehalfOfToggle,
+  isOnBehalfOfToggle,
+}: UserCountState & OnBehalfOfProps) {
   const {t, language} = useTranslation();
+  const styles = useStyles();
   const selectedProfile = userProfilesWithCount.find((u) => u.count);
+
+  const isOnBehalfOfEnabled = useOnBehalfOf();
 
   const select = (u: UserProfileWithCount) => {
     if (selectedProfile) {
@@ -47,19 +61,46 @@ export function SingleTravellerSelection({
   }
 
   return (
-    <Section>
-      <RadioGroupSection<UserProfileWithCount>
-        items={userProfilesWithCount}
-        keyExtractor={(u) => u.userTypeString}
-        itemToText={(u) => getReferenceDataName(u, language)}
-        itemToSubtext={(u) =>
-          travellerInfoByFareProductType(fareProductType, u)
-        }
-        selected={selectedProfile}
-        onSelect={select}
-        color="interactive_2"
-        accessibilityHint={t(PurchaseOverviewTexts.travellerSelection.a11yHint)}
-      />
-    </Section>
+    <View>
+      <Section>
+        <RadioGroupSection<UserProfileWithCount>
+          items={userProfilesWithCount}
+          keyExtractor={(u) => u.userTypeString}
+          itemToText={(u) => getReferenceDataName(u, language)}
+          itemToSubtext={(u) =>
+            travellerInfoByFareProductType(fareProductType, u)
+          }
+          selected={selectedProfile}
+          onSelect={select}
+          color="interactive_2"
+          accessibilityHint={t(
+            PurchaseOverviewTexts.travellerSelection.a11yHint,
+          )}
+        />
+      </Section>
+      {isOnBehalfOfEnabled && (
+        <Section style={styles.onBehalfOfContainer}>
+          <ToggleSectionItem
+            leftImage={HoldingHands}
+            text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
+            subtext={t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
+            value={isOnBehalfOfToggle}
+            label="new"
+            textType="body__primary--bold"
+            onValueChange={(checked) => {
+              setOnBehalfOfToggle(checked);
+            }}
+          />
+        </Section>
+      )}
+    </View>
   );
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => {
+  return {
+    onBehalfOfContainer: {
+      marginTop: theme.spacings.medium,
+    },
+  };
+});

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -17,16 +17,16 @@ import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {useOnBehalfOf} from '@atb/on-behalf-of';
-import {OnBehalfOfProps} from './types';
+import {TravelerOnBehalfOfProps} from './types';
 
 export function SingleTravellerSelection({
   userProfilesWithCount,
   addCount,
   removeCount,
   fareProductType,
-  setOnBehalfOfToggle,
-  isOnBehalfOfToggle,
-}: UserCountState & OnBehalfOfProps) {
+  setTravelerOnBehalfOfToggle,
+  isTravelerOnBehalfOfToggle,
+}: UserCountState & TravelerOnBehalfOfProps) {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const selectedProfile = userProfilesWithCount.find((u) => u.count);
@@ -84,11 +84,11 @@ export function SingleTravellerSelection({
             leftImage={HoldingHands}
             text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
             subtext={t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
-            value={isOnBehalfOfToggle}
+            value={isTravelerOnBehalfOfToggle}
             label="new"
             textType="body__primary--bold"
             onValueChange={(checked) => {
-              setOnBehalfOfToggle(checked);
+              setTravelerOnBehalfOfToggle(checked);
             }}
           />
         </Section>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -24,7 +24,7 @@ export function SingleTravellerSelection({
   addCount,
   removeCount,
   fareProductType,
-  setTravelerOnBehalfOfToggle,
+  setIsTravelerOnBehalfOfToggle,
   isTravelerOnBehalfOfToggle,
 }: UserCountState & TravelerOnBehalfOfProps) {
   const {t, language} = useTranslation();
@@ -88,7 +88,7 @@ export function SingleTravellerSelection({
             label="new"
             textType="body__primary--bold"
             onValueChange={(checked) => {
-              setTravelerOnBehalfOfToggle(checked);
+              setIsTravelerOnBehalfOfToggle(checked);
             }}
           />
         </Section>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
@@ -1,4 +1,4 @@
 export type TravelerOnBehalfOfProps = {
-  setTravelerOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  setIsTravelerOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
   isTravelerOnBehalfOfToggle: boolean;
 };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
@@ -1,0 +1,4 @@
+export type OnBehalfOfProps = {
+  setOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  isOnBehalfOfToggle: boolean;
+};

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
@@ -1,4 +1,4 @@
-export type OnBehalfOfProps = {
-  setOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
-  isOnBehalfOfToggle: boolean;
+export type TravelerOnBehalfOfProps = {
+  setTravelerOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
+  isTravelerOnBehalfOfToggle: boolean;
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
@@ -120,7 +120,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
               <ToggleSectionItem
                 key={option.id}
                 text={text}
-                leftIcon={
+                leftImage={
                   getTransportModeSvg(
                     option.icon?.transportMode,
                     option.icon?.transportSubMode,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -1219,7 +1219,7 @@ export const Profile_DesignSystemScreen = ({
           />
           <ToggleSectionItem
             text="Some short text"
-            leftIcon={Bus}
+            leftImage={Bus}
             onValueChange={() => {}}
           />
           <ActionSectionItem

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -247,6 +247,14 @@ const PurchaseOverviewTexts = {
       'Aktiver for å lese meir om rabatt på fleksibel billett på ekstern side',
     ),
   },
+  onBehalfOf: {
+    sectionTitle: _('Kjøp til andre', 'Buy for others', 'Kjøp til andre'),
+    sectionSubText: _(
+      'Den du kjøper billett til, må være innlogget i AtB-appen for å få billetten.',
+      'The person you buy a ticket for, must be logged in to the AtB app to get the ticket.',
+      'Den du kjøper billett til, må vera innlogga i AtB-appen for å få billetten.',
+    ),
+  }
 };
 
 export default orgSpecificTranslations(PurchaseOverviewTexts, {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -252,7 +252,7 @@ const PurchaseOverviewTexts = {
     sectionSubText: _(
       'Den du kjøper billett til, må være innlogget i AtB-appen for å få billetten.',
       'The person you buy a ticket for, must be logged in to the AtB app to get the ticket.',
-      'Den du kjøper billett til, må vera innlogga i AtB-appen for å få billetten.',
+      'Den du kjøper billett til, må vere logga inn i AtB-appen for å få billetten.',
     ),
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^9.9.0":
-  version "9.9.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-9.9.0.tgz#bcbd378c6107a7eed6870318f3e4ddf937d36e8e"
-  integrity sha512-Ng73CrPu4E4ie1+4KbPX0oYI/pFjZumjZ9KSds+QNRGB4nOCfA6Chnu7yg/o17hoV5XLjjyDBZwaR7rNeDWFPg==
+"@atb-as/generate-assets@^9.10.0":
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-9.10.0.tgz#08dac2773fcc28ad0648aacf6deafe8247249685"
+  integrity sha512-JUPWhncMm3bxJOoHF/q365zhTqw74W0L2LTYcbbXzM9yjQxiuK/6BoLIgn+XqlYs9Vq5z15PxACDUV24UGU+MQ==
   dependencies:
     "@atb-as/theme" "^7.1.1"
     commander "^9.4.0"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/15546

also closes https://github.com/AtB-AS/kundevendt/issues/15547

- Added [image from design system for the bottom sheet](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=20920-13075&mode=design&t=8EbbMsjGLKbyaeJ0-4), updated design system package version.
- Use "on behalf of" feature flag to show/hide components (can test via debug developer menu in profile)
- Refactored the `leftIcon` on `ToggleSectionItem` component to allow better flexibility of use, it is now called `leftImage` and can use SVGs for image. Also updated the styling to closely match existing components (only 1 part is different, see screenshots below)
- toggle value of the `on behalf of` toggle is prepared on `Root_PurchaseOverviewScreen`.

<details>
  <summary>Screenshots</summary>
   Travel Filter difference on `Other` toggle </br>
<img width="250" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/f792c853-08c4-41d4-ba49-49bd6fad2633">

</br>
Feature flag "on behalf of" disabled/false
</br>
<img width="439" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/fffac81d-5415-47f1-94b8-1fc62feb20d1">
</br>
Feature flag "on behalf of" enabled/true
</br>
<img width="439" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/6d657a28-7a4f-40e7-a536-df0e838f4326">

</details>