### PR TITLE
feat: enable obfuscation and resource shrinking for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "com.bugsnag.android.gradle"
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.
@@ -107,6 +107,10 @@ android {
         store {
             initWith buildTypes.release
             matchingFallbacks = ['release']
+            minifyEnabled enableProguardInReleaseBuilds
+            shrinkResources enableProguardInReleaseBuilds
+            debuggable false
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
         staging {
             initWith buildTypes.release

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,3 +12,15 @@
 -keep class com.facebook.jni.** { *; }
 -keep class com.swmansion.reanimated.** { *; }
 -keep class com.facebook.react.turbomodule.** { *; }
+
+
+# For react-svg
+-keep public class com.horcrux.svg.** {*;}
+
+# For Kogenta SDK
+-keep class com.kogenta.kettle.core.model.** { *; }
+-keep class com.kogenta.kettle.common.model.** { *; }
+
+# For retracing stack traces https://developer.android.com/build/shrink-code#retracing
+-keepattributes LineNumberTable,SourceFile
+-renamesourcefileattribute SourceFile

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -24,3 +24,36 @@
 # For retracing stack traces https://developer.android.com/build/shrink-code#retracing
 -keepattributes LineNumberTable,SourceFile
 -renamesourcefileattribute SourceFile
+
+# Keep our interfaces so they can be used by other ProGuard rules.
+# See http://sourceforge.net/p/proguard/bugs/466/
+-keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
+-keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
+
+# Do not strip any method/class that is annotated with @DoNotStrip
+-keep @com.facebook.proguard.annotations.DoNotStrip class *
+-keepclassmembers class * {
+    @com.facebook.proguard.annotations.DoNotStrip *;
+}
+
+-keep @com.facebook.proguard.annotations.DoNotStripAny class * {
+    *;
+}
+
+-keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {
+  void set*(***);
+  *** get*();
+}
+
+-keep class * implements com.facebook.react.bridge.JavaScriptModule { *; }
+-keep class * implements com.facebook.react.bridge.NativeModule { *; }
+
+-keep class * implements com.facebook.react.ReactPackage { *; }
+
+-keepclassmembers,includedescriptorclasses class * { native <methods>; }
+-keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactProp <methods>; }
+-keepclassmembers class *  { @com.facebook.react.uimanager.annotations.ReactPropGroup <methods>; }
+
+-dontwarn com.facebook.react.**
+-keep,includedescriptorclasses class com.facebook.react.bridge.** { *; }
+-keep,includedescriptorclasses class com.facebook.react.turbomodule.core.** { *; }


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/3744

This PR will enable obfuscation and resource shrinking in Android builds for store variant. 

In order to test the build, you can go to the GitHub Actions, then click on the "Build staging android project", select "run workflow", select branch `ridwan/obfuscation-android`, set force new build to true, and then run the workflow. 

The build will be for "Store" variant even though its "Build staging android project" (just for testing the build). Will only build for AtB, and will publish the result to AppCenter.

![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/36809def-2962-49af-8cb6-7719f8c181d5)
