### PR TITLE
fix: Improve visuals on cancelled departures

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.13.1",
     "@atb-as/generate-assets": "^9.9.0",
-    "@atb-as/theme": "^7.1.1",
+    "@atb-as/theme": "^7.2.0",
     "@bugsnag/react-native": "^7.21.0",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-barcode-javascript-lib": "1.3.4",

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -1,7 +1,4 @@
-import {
-  DepartureGroup,
-  DepartureTime,
-} from '@atb/api/departures/types';
+import {DepartureGroup, DepartureTime} from '@atb/api/departures/types';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {Button} from '@atb/components/button';
 import {
@@ -236,11 +233,12 @@ function DepartureTimeItem({
     notices,
     departure.cancellation,
   );
-  const leftIcon = departure.realtime
-    ? themeName === 'dark'
-      ? RealtimeDark
-      : RealtimeLight
-    : undefined;
+  const leftIcon =
+    !departure.cancellation && departure.realtime
+      ? themeName === 'dark'
+        ? RealtimeDark
+        : RealtimeLight
+      : undefined;
 
   if (!isValidDeparture(departure)) {
     return null;

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -84,6 +84,7 @@ export const EstimatedCallItem = memo(
     const {destinationDisplay} = departure;
     const lineName = formatDestinationDisplay(t, destinationDisplay);
 
+    const showAsCancelled = departure.cancellation && mode !== 'Favourite';
     return (
       <GenericClickableSectionItem
         radius={showBottomBorder ? 'bottom' : undefined}
@@ -96,7 +97,14 @@ export const EstimatedCallItem = memo(
           <View style={styles.estimatedCallItem}>
             <View style={styles.transportInfo}>
               <LineChip departure={departure} mode={mode} testID={testID} />
-              <ThemeText style={styles.lineName} testID={`${testID}LineName`}>
+              <ThemeText
+                type={
+                  showAsCancelled ? 'body__primary--strike' : 'body__primary'
+                }
+                color={showAsCancelled ? 'secondary' : 'primary'}
+                style={styles.lineName}
+                testID={`${testID}LineName`}
+              >
                 {lineName}
               </ThemeText>
             </View>
@@ -156,7 +164,7 @@ const DepartureTime = ({departure}: {departure: EstimatedCall}) => {
   return (
     <View>
       <View style={{flexDirection: 'row', alignItems: 'center'}}>
-        {departure.realtime && (
+        {departure.realtime && !departure.cancellation && (
           <ThemeIcon
             style={styles.realtimeIcon}
             svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
@@ -164,8 +172,12 @@ const DepartureTime = ({departure}: {departure: EstimatedCall}) => {
           />
         )}
         <ThemeText
-          type="body__primary--bold"
-          style={departure.cancellation && styles.strikethrough}
+          type={
+            departure.cancellation
+              ? 'body__primary--strike'
+              : 'body__primary--bold'
+          }
+          color={departure.cancellation ? 'secondary' : 'primary'}
         >
           {formatToClockOrRelativeMinutes(
             departure.expectedDepartureTime,
@@ -334,7 +346,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     color: theme.static.background.background_accent_3.text,
     textAlign: 'center',
   },
-  strikethrough: {textDecorationLine: 'line-through'},
   realtimeAndText: {flexDirection: 'row', alignItems: 'center'},
   realtime: {flexDirection: 'row', alignItems: 'center'},
   aimedTime: {textAlign: 'right'},

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,14 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
+"@atb-as/theme@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-7.2.0.tgz#9d35a63aab097b3cc3762634b2ec92c7722dafa4"
+  integrity sha512-eamBOSrCoWNCh+Bgb3TPQsfvLaTn1TpqwRnKN51MJp7UIchcYvzTqzCia4aCKlvuNd3/VT+15+o+F8pPHtZ8xw==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"


### PR DESCRIPTION
# Improve visuals on cancelled departures
### On cancelled departures:
- Removed realtime icon
- Changed to Primary--strike with secondary color ([also added to design system](https://github.com/AtB-AS/design-system/commit/ded2c4d1f94632f7ed8e2c3326c02e365e40c2d0))
- Added Primary--strike with secondary color on line name


| Before    | After |
| -------- | ------- |
| <img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/62fa713b-e790-45e3-8dd0-ecbcfc208746"/> | <img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/d48a61e2-b681-4b9f-b1b1-91416f712cb4"/>    |
| <img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/93fdb485-1ded-4c83-b1b2-03f442969f76"/> | <img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/a6c854c0-70a5-4b81-a1e1-6aae879d9bfd"/>  |




