### PR TITLE
fix: Error while beacons is activated

### DIFF
--- a/ios/BridgeModules/KettleSDKExtension.m
+++ b/ios/BridgeModules/KettleSDKExtension.m
@@ -5,19 +5,22 @@
 #import <KettleKit/KettleKit.h>
 #import <KettleKit/KettleKit-Swift.h>
 static void InitializeKettle(NSDictionary *launchOptions) {
+  NSString *apiKey = [NSString stringWithFormat:@"%@", KETTLE_API_KEY];
+  if ([apiKey length] > 0) {
     KTLConfig* config = [KTLConfig KTLDefaultConfig];
-    NSString *apiKey = [NSString stringWithFormat:@"%@", KETTLE_API_KEY];
-    #if DEBUG
-        config.developmentApiKey = apiKey;
-    #else
-        config.productionApiKey = apiKey;
-    #endif
-
+    
+#if DEBUG
+    config.developmentApiKey = apiKey;
+#else
+    config.productionApiKey = apiKey;
+#endif
+    
     config.developmentLogLevel = KTLLogLevelDebug;
     config.productionLogLevel = KTLLogLevelNone;
-
+    
     // Initialize Kettle
     [KTLKettle prepare:config launchOptions:launchOptions];
+  }
 }
 #endif
 
@@ -28,16 +31,19 @@ RCT_EXPORT_METHOD(initializeKettleSDK:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
 #ifdef KETTLE_API_KEY
-  dispatch_async(dispatch_get_main_queue(), ^{
-    InitializeKettle([AppDelegate sharedInstance].launchOptions);
-    resolve(@YES);
-  });
+  NSString *apiKey = [NSString stringWithFormat:@"%@", KETTLE_API_KEY];
+  if ([apiKey length] > 0) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      InitializeKettle([AppDelegate sharedInstance].launchOptions);
+      resolve(@YES);
+    });
+  }
 #endif
 }
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+  return YES;
 }
 
 @end

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -72,7 +72,6 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     const permissions = await allowedPermissionForKettle();
     if (!isInitializedRef.current) {
       if (permissions.length > 0) {
-        console.log('Initializing Kettle SDK');
         await NativeModules.KettleSDKExtension.initializeKettleSDK();
         isInitializedRef.current = true;
       }

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -68,7 +68,6 @@ const BeaconsContextProvider: React.FC = ({children}) => {
   const updateKettleInfo = () => getKettleInfo().then(setKettleInfo);
 
   const initializeKettleSDK = useCallback(async () => {
-    if (!isBeaconsSupported) return;
     const permissions = await allowedPermissionForKettle();
     if (!isInitializedRef.current) {
       if (permissions.length > 0) {
@@ -77,7 +76,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
       }
     }
     return permissions;
-  }, [isBeaconsSupported]);
+  }, []);
 
   const onboardForBeacons = useCallback(async () => {
     if (!isBeaconsSupported) return false;
@@ -126,7 +125,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     (async function () {
       if (!isBeaconsSupported) return;
 
-      if (isInitializedRef.current && isOnboardedButNotStarted) {
+      if (isOnboardedButNotStarted) {
         const permissions = await initializeKettleSDK();
         Kettle.start(permissions);
       }

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -23,8 +23,6 @@ type KettleInfo = {
   kettleIdentifier: string | null;
   kettleConsents: Record<string, boolean> | null;
   isBeaconsOnboarded: boolean;
-  privacyDashboardUrl?: string;
-  privacyTermsUrl?: string;
 };
 
 type BeaconsContextState = {
@@ -33,11 +31,19 @@ type BeaconsContextState = {
   onboardForBeacons: () => Promise<boolean>;
   revokeBeacons: () => Promise<void>;
   deleteCollectedData: () => Promise<void>;
+  getPrivacyDashboardUrl: () => Promise<string>;
+  getPrivacyTermsUrl: () => Promise<string>;
 };
 
 const defaultState = {
   isBeaconsSupported: false,
   kettleInfo: undefined,
+  getPrivacyDashboardUrl: () => {
+    return new Promise<string>(() => {});
+  },
+  getPrivacyTermsUrl: () => {
+    return new Promise<string>(() => {});
+  },
   onboardForBeacons: () => {
     return new Promise<boolean>(() => {
       return false;
@@ -76,6 +82,18 @@ const BeaconsContextProvider: React.FC = ({children}) => {
       }
     }
     return permissions;
+  }, []);
+
+  const getPrivacyDashboardUrl = useCallback(async () => {
+    if (!isInitializedRef.current) return;
+    const url = await Kettle.getPrivacyDashboardUrl();
+    return url;
+  }, []);
+
+  const getPrivacyTermsUrl = useCallback(async () => {
+    if (!isInitializedRef.current) return;
+    const url = await Kettle.getPrivacyTermsUrl();
+    return url;
   }, []);
 
   const onboardForBeacons = useCallback(async () => {
@@ -144,6 +162,8 @@ const BeaconsContextProvider: React.FC = ({children}) => {
         onboardForBeacons,
         revokeBeacons,
         deleteCollectedData,
+        getPrivacyDashboardUrl,
+        getPrivacyTermsUrl,
       }}
     >
       {children}
@@ -155,16 +175,12 @@ const getKettleInfo = async (): Promise<KettleInfo> => {
   const status = await Kettle.isStarted();
   const identifier = await Kettle.getIdentifier();
   const consents = await Kettle.getGrantedConsents();
-  const privacyDashboardUrl = await Kettle.getPrivacyDashboardUrl();
-  const privacyTermsUrl = await Kettle.getPrivacyTermsUrl();
 
   return {
     isKettleStarted: status,
     kettleIdentifier: identifier,
     kettleConsents: consents,
     isBeaconsOnboarded: Object.keys(consents).length > 0,
-    privacyDashboardUrl,
-    privacyTermsUrl,
   };
 };
 

--- a/src/stacks-hierarchy/Root_ShareTravelHabitsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShareTravelHabitsScreen.tsx
@@ -31,7 +31,7 @@ export const Root_ShareTravelHabitsScreen = ({
   const {onboardForBeacons} = useBeaconsState();
 
   const choosePermissions = async () => {
-    onboardForBeacons();
+    await onboardForBeacons();
     navigation.goBack();
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -49,16 +49,7 @@ export const Announcement = ({announcement, style}: Props) => {
     <Section style={style} key={announcement.id} testID="announcement">
       <GenericSectionItem>
         <View style={styles.container}>
-          <View
-            style={styles.content}
-            accessible={true}
-            accessibilityRole={announcement.actionButton ? 'button' : undefined}
-            accessibilityHint={
-              announcement.actionButton !== undefined
-                ? t(DashboardTexts.announcemens.button.accessibility)
-                : undefined
-            }
-          >
+          <View style={styles.content} accessible={true}>
             {announcement.summaryImage && (
               <View style={styles.imageContainer}>
                 <Image

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -77,6 +77,8 @@ export const Profile_DebugInfoScreen = () => {
     deleteCollectedData,
     kettleInfo,
     isBeaconsSupported,
+    getPrivacyDashboardUrl,
+    getPrivacyTermsUrl,
   } = useBeaconsState();
   const {resetDismissedGlobalMessages} = useGlobalMessagesState();
   const {userId} = useAuthState();
@@ -641,8 +643,10 @@ export const Profile_DebugInfoScreen = () => {
                   <Button
                     interactiveColor="interactive_0"
                     onPress={async () => {
-                      kettleInfo?.privacyDashboardUrl &&
-                        Linking.openURL(kettleInfo.privacyDashboardUrl);
+                      const privacyDashboardUrl =
+                        await getPrivacyDashboardUrl();
+                      privacyDashboardUrl &&
+                        Linking.openURL(privacyDashboardUrl);
                     }}
                     style={style.button}
                     disabled={!kettleInfo?.isBeaconsOnboarded}
@@ -651,8 +655,8 @@ export const Profile_DebugInfoScreen = () => {
                   <Button
                     interactiveColor="interactive_0"
                     onPress={async () => {
-                      kettleInfo?.privacyTermsUrl &&
-                        Linking.openURL(kettleInfo.privacyTermsUrl);
+                      const privacyTermsUrl = await getPrivacyTermsUrl();
+                      privacyTermsUrl && Linking.openURL(privacyTermsUrl);
                     }}
                     style={style.button}
                     disabled={!kettleInfo?.isBeaconsOnboarded}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -26,6 +26,7 @@ export const Profile_PrivacyScreen = () => {
     revokeBeacons,
     deleteCollectedData,
     isBeaconsSupported,
+    getPrivacyDashboardUrl,
   } = useBeaconsState();
   const {privacy_policy_url} = useRemoteConfig();
   const style = useStyle();
@@ -83,7 +84,7 @@ export const Profile_PrivacyScreen = () => {
           />
         </Section>
 
-        {isBeaconsSupported && kettleInfo?.privacyDashboardUrl && (
+        {isBeaconsSupported && kettleInfo?.isBeaconsOnboarded && (
           <Section withPadding>
             <LinkSectionItem
               text={t(PrivacySettingsTexts.sections.items.controlPanel.title)}
@@ -98,7 +99,9 @@ export const Profile_PrivacyScreen = () => {
               }}
               testID="privacyButton"
               onPress={async () => {
-                await Linking.openURL(kettleInfo.privacyDashboardUrl!);
+                const privacyDashboardUrl = await getPrivacyDashboardUrl();
+                privacyDashboardUrl &&
+                  (await Linking.openURL(privacyDashboardUrl));
               }}
             />
           </Section>
@@ -132,7 +135,7 @@ export const Profile_PrivacyScreen = () => {
             }
             testID="deleteLocalSearchData"
           />
-          {isBeaconsSupported && (
+          {isBeaconsSupported && kettleInfo?.isBeaconsOnboarded && (
             <Button
               style={style.spacing}
               leftIcon={{svg: Delete}}


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/8621

This issue fix a non-covered case when requesting kettle info but without having initialized the SDK, so it might close the app is the state is not right.