### PR TITLE
feat: on behalf of ticket receiver input screen

### DIFF
--- a/src/components/phone-input/PhoneInput.tsx
+++ b/src/components/phone-input/PhoneInput.tsx
@@ -1,0 +1,140 @@
+import {useState} from 'react';
+import {PhoneInputSectionItem, Section} from '@atb/components/sections';
+import {ActivityIndicator, StyleProp, View, ViewStyle} from 'react-native';
+import {LoginTexts, useTranslation} from '@atb/translations';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {PhoneSignInErrorCode} from '@atb/auth';
+import {StaticColorByType, getStaticColor} from '@atb/theme/colors';
+import {MessageInfoBox} from '@atb/components/message-info-box';
+import {Button} from '@atb/components/button';
+import phone from 'phone';
+import { ArrowRight } from '@atb/assets/svg/mono-icons/navigation';
+import { SvgProps } from 'react-native-svg';
+
+type Props = {
+  style?: StyleProp<ViewStyle>;
+  submitButtonText: string;
+  submitButtonTestId: string;
+  onNextPromise: (
+    number: string,
+    forceResend?: boolean,
+  ) => Promise<PhoneSignInErrorCode | undefined>;
+  onNextAction: (number: string) => void;
+  rightIcon?: (props: SvgProps) => JSX.Element;
+};
+
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export const PhoneInput = ({
+  style, 
+  submitButtonText,
+  submitButtonTestId,
+  onNextPromise,
+  onNextAction,
+  rightIcon
+}: Props) => {
+  const styles = useStyles();
+
+  const {t} = useTranslation();
+  const {themeName} = useTheme();
+
+  const [prefix, setPrefix] = useState('47');
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<PhoneSignInErrorCode>();
+
+  const phoneValidationParams = {
+    strictDetection: true,
+    validateMobilePrefix: false,
+  };
+
+  const phoneValidation = phone(
+    '+' + prefix + phoneNumber,
+    phoneValidationParams,
+  );
+
+  const isValidPhoneNumber = phoneValidation.isValid;
+
+  const onNext = async () => {
+    setIsSubmitting(true);
+    if (!phoneValidation.phoneNumber) {
+      setIsSubmitting(false);
+      setError('invalid_phone');
+      return;
+    }
+
+    const errorCode = await onNextPromise(phoneValidation.phoneNumber);
+    if (!errorCode) {
+      setError(undefined);
+      setIsSubmitting(false);
+      onNextAction(phoneValidation.phoneNumber);
+    } else {
+      setIsSubmitting(false);
+      setError(errorCode);
+    }
+  };
+
+  return (
+    <View style={style}>
+      <Section>
+        <PhoneInputSectionItem
+          label={t(LoginTexts.phoneInput.input.heading)}
+          value={phoneNumber}
+          onChangeText={setPhoneNumber}
+          prefix={prefix}
+          onChangePrefix={setPrefix}
+          showClear={true}
+          keyboardType="number-pad"
+          placeholder={t(LoginTexts.phoneInput.input.placeholder)}
+          autoFocus={true}
+          textContentType="telephoneNumber"
+        />
+      </Section>
+
+      <View style={styles.buttonView}>
+        {isSubmitting && (
+          <ActivityIndicator
+            style={styles.activityIndicator}
+            size="large"
+            color={getStaticColor(themeName, themeColor).text}
+          />
+        )}
+
+        {error && !isSubmitting && (
+          <MessageInfoBox
+            style={styles.errorMessage}
+            type="error"
+            message={t(LoginTexts.phoneInput.errors[error])}
+          />
+        )}
+
+        {!isSubmitting && (
+          <Button
+            style={styles.submitButton}
+            interactiveColor="interactive_0"
+            onPress={onNext}
+            text={submitButtonText}
+            disabled={!isValidPhoneNumber}
+            testID={submitButtonTestId}
+            rightIcon={rightIcon && {svg: rightIcon}}
+          />
+        )}
+      </View>
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  activityIndicator: {
+    marginVertical: theme.spacings.large,
+  },
+  errorMessage: {
+    marginBottom: theme.spacings.medium,
+  },
+  buttonView: {
+    marginTop: theme.spacings.medium,
+  },
+  submitButton: {
+    marginTop: theme.spacings.medium,
+  },
+}));

--- a/src/components/phone-input/PhoneInput.tsx
+++ b/src/components/phone-input/PhoneInput.tsx
@@ -8,8 +8,7 @@ import {StaticColorByType, getStaticColor} from '@atb/theme/colors';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
 import phone from 'phone';
-import { ArrowRight } from '@atb/assets/svg/mono-icons/navigation';
-import { SvgProps } from 'react-native-svg';
+import {SvgProps} from 'react-native-svg';
 
 type Props = {
   style?: StyleProp<ViewStyle>;
@@ -26,12 +25,12 @@ type Props = {
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
 export const PhoneInput = ({
-  style, 
+  style,
   submitButtonText,
   submitButtonTestId,
   onNextPromise,
   onNextAction,
-  rightIcon
+  rightIcon,
 }: Props) => {
   const styles = useStyles();
 

--- a/src/components/phone-input/PhoneInput.tsx
+++ b/src/components/phone-input/PhoneInput.tsx
@@ -14,11 +14,11 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   submitButtonText: string;
   submitButtonTestId: string;
-  onNextPromise: (
+  onSubmitPromise: (
     number: string,
     forceResend?: boolean,
   ) => Promise<PhoneSignInErrorCode | undefined>;
-  onNextAction: (number: string) => void;
+  onSubmitAction: (number: string) => void;
   rightIcon?: (props: SvgProps) => JSX.Element;
 };
 
@@ -28,8 +28,8 @@ export const PhoneInput = ({
   style,
   submitButtonText,
   submitButtonTestId,
-  onNextPromise,
-  onNextAction,
+  onSubmitPromise,
+  onSubmitAction,
   rightIcon,
 }: Props) => {
   const styles = useStyles();
@@ -62,11 +62,11 @@ export const PhoneInput = ({
       return;
     }
 
-    const errorCode = await onNextPromise(phoneValidation.phoneNumber);
+    const errorCode = await onSubmitPromise(phoneValidation.phoneNumber);
     if (!errorCode) {
       setError(undefined);
       setIsSubmitting(false);
-      onNextAction(phoneValidation.phoneNumber);
+      onSubmitAction(phoneValidation.phoneNumber);
     } else {
       setIsSubmitting(false);
       setError(errorCode);

--- a/src/components/phone-input/index.ts
+++ b/src/components/phone-input/index.ts
@@ -1,0 +1,1 @@
+export {PhoneInput} from './PhoneInput';

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -59,6 +59,7 @@ import {Root_NotificationPermissionScreen} from '@atb/stacks-hierarchy/Root_Noti
 import {Root_LocationWhenInUsePermissionScreen} from '@atb/stacks-hierarchy/Root_LocationWhenInUsePermissionScreen';
 import {useBeaconsState} from '@atb/beacons/BeaconsContext';
 import {Root_TicketInformationScreen} from '@atb/stacks-hierarchy/Root_TicketInformationScreen';
+import {Root_ChooseTicketReceiverScreen} from '@atb/stacks-hierarchy/Root_ChooseTicketReceiverScreen';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -427,6 +428,10 @@ export const RootStack = () => {
                 <Stack.Screen
                   name="Root_LocationWhenInUsePermissionScreen"
                   component={Root_LocationWhenInUsePermissionScreen}
+                />
+                <Stack.Screen
+                  name="Root_ChooseTicketReceiverScreen"
+                  component={Root_ChooseTicketReceiverScreen}
                 />
               </Stack.Group>
             </Stack.Navigator>

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
@@ -1,22 +1,13 @@
-import {PhoneSignInErrorCode} from '@atb/auth';
-import {Button} from '@atb/components/button';
-import {MessageBox} from '@atb/components/message-box';
+import {PhoneInput} from '@atb/components/phone-input';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {PhoneInputSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
-import {StyleSheet, useTheme} from '@atb/theme';
-import {StaticColorByType, getStaticColor} from '@atb/theme/colors';
-import {
-  LoginTexts,
-  PurchaseOverviewTexts,
-  useTranslation,
-} from '@atb/translations';
+import {StyleSheet} from '@atb/theme';
+import {StaticColorByType} from '@atb/theme/colors';
+import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {OnBehalfOfTexts} from '@atb/translations/screens/subscreens/OnBehalfOf';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
-import phone from 'phone';
-import {useState} from 'react';
-import {ActivityIndicator, KeyboardAvoidingView, View} from 'react-native';
+import {KeyboardAvoidingView, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 
 type Props = RootStackScreenProps<'Root_ChooseTicketReceiverScreen'>;
@@ -29,53 +20,8 @@ export const Root_ChooseTicketReceiverScreen: React.FC<Props> = ({
   const styles = useStyles();
 
   const {t} = useTranslation();
-  const {themeName} = useTheme();
 
-  const [prefix, setPrefix] = useState('47');
-  const [phoneNumber, setPhoneNumber] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<PhoneSignInErrorCode>();
   const focusRef = useFocusOnLoad();
-
-  const phoneValidationParams = {
-    strictDetection: true,
-    validateMobilePrefix: false,
-  };
-
-  const isValidPhoneNumber = (number: string) => {
-    const validationResult = phone(
-      '+' + prefix + number,
-      phoneValidationParams,
-    );
-    return validationResult.isValid;
-  };
-
-  const onNext = async () => {
-    setIsSubmitting(true);
-    const phoneValidation = phone(
-      '+' + prefix + phoneNumber,
-      phoneValidationParams,
-    );
-    if (!phoneValidation.phoneNumber) {
-      setIsSubmitting(false);
-      setError('invalid_phone');
-      return;
-    }
-    
-    // TODO: replace promise with proper API call
-    const errorCode = await new Promise(r => setTimeout(r, 1000)); 
-    if (!errorCode) {
-      setError(undefined);
-      setIsSubmitting(false);
-      navigation.navigate('Root_PurchaseConfirmationScreen', {
-        ...params.rootPurchaseConfirmationScreenParams,
-        phoneNumber: `+${prefix}${phoneNumber}`,
-      });
-    } else {
-      setIsSubmitting(false);
-      // setError(errorCode);
-    }
-  };
 
   return (
     <View style={styles.container}>
@@ -109,49 +55,18 @@ export const Root_ChooseTicketReceiverScreen: React.FC<Props> = ({
               {t(OnBehalfOfTexts.chooseReceiver.subtitle)}
             </ThemeText>
           </View>
-          <Section>
-            <PhoneInputSectionItem
-              label={t(LoginTexts.phoneInput.input.heading)}
-              value={phoneNumber}
-              onChangeText={setPhoneNumber}
-              prefix={prefix}
-              onChangePrefix={setPrefix}
-              showClear={true}
-              keyboardType="number-pad"
-              placeholder={t(LoginTexts.phoneInput.input.placeholder)}
-              autoFocus={true}
-              textContentType="telephoneNumber"
-            />
-          </Section>
-
-          <View style={styles.buttonView}>
-            {isSubmitting && (
-              <ActivityIndicator
-                style={styles.activityIndicator}
-                size="large"
-                color={getStaticColor(themeName, themeColor).text}
-              />
-            )}
-
-            {error && !isSubmitting && (
-              <MessageBox
-                style={styles.errorMessage}
-                type="error"
-                message={t(LoginTexts.phoneInput.errors[error])}
-              />
-            )}
-
-            {!isSubmitting && (
-              <Button
-                style={styles.submitButton}
-                interactiveColor="interactive_0"
-                onPress={onNext}
-                text={t(PurchaseOverviewTexts.summary.button)}
-                disabled={!isValidPhoneNumber(phoneNumber)}
-                testID="toPaymentButton"
-              />
-            )}
-          </View>
+          <PhoneInput
+            submitButtonText={t(PurchaseOverviewTexts.summary.button)}
+            submitButtonTestId="toPaymentButton"
+            // TODO: this is just a placeholder, update when API is ready
+            onNextPromise={() => new Promise((r) => setTimeout(r, 1000))}
+            onNextAction={(number) => {
+              navigation.navigate('Root_PurchaseConfirmationScreen', {
+                ...params.rootPurchaseConfirmationScreenParams,
+                phoneNumber: number,
+              });
+            }}
+          />
         </ScrollView>
       </KeyboardAvoidingView>
     </View>

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
@@ -1,0 +1,155 @@
+import {Button} from '@atb/components/button';
+import {FullScreenHeader} from '@atb/components/screen-header';
+import {PhoneInputSectionItem, Section} from '@atb/components/sections';
+import {ThemeText} from '@atb/components/text';
+import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
+import {StyleSheet} from '@atb/theme';
+import {StaticColorByType} from '@atb/theme/colors';
+import {LoginTexts, PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import { OnBehalfOfTexts } from '@atb/translations/screens/subscreens/OnBehalfOf';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import phone from 'phone';
+import {useState} from 'react';
+import {KeyboardAvoidingView, View} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
+
+type Props = RootStackScreenProps<'Root_ChooseTicketReceiverScreen'>;
+const themeColor: StaticColorByType<'background'> = 'background_accent_0';
+
+export const Root_ChooseTicketReceiverScreen: React.FC<Props> = ({
+  navigation,
+  route: {params},
+}) => {
+  const styles = useStyles();
+
+  const {t} = useTranslation();
+
+  const [prefix, setPrefix] = useState('47');
+  const [phoneNumber, setPhoneNumber] = useState('');
+
+  const focusRef = useFocusOnLoad();
+
+  const phoneValidationParams = {
+    strictDetection: true,
+    validateMobilePrefix: false,
+  };
+
+  const isValidPhoneNumber = (number: string) => {
+    const validationResult = phone(
+      '+' + prefix + number,
+      phoneValidationParams,
+    );
+    return validationResult.isValid;
+  };
+
+  const {
+    fromPlace,
+    toPlace,
+    preassignedFareProduct,
+    userProfilesWithCount,
+    travelDate,
+  } = params;
+
+  return (
+    <View style={styles.container}>
+      <FullScreenHeader
+        leftButton={{type: 'back'}}
+        title={t(OnBehalfOfTexts.chooseReceiver.header)}
+        setFocusOnLoad={false}
+      />
+      <KeyboardAvoidingView behavior="padding" style={styles.mainView}>
+        <ScrollView
+          centerContent={true}
+          keyboardShouldPersistTaps="handled"
+          style={styles.scrollView}
+          contentContainerStyle={styles.contentContainerStyle}
+        >
+          <View accessible={true} accessibilityRole="header" ref={focusRef}>
+            <ThemeText
+              type="heading--big"
+              color={themeColor}
+              style={styles.header}
+            >
+              {t(OnBehalfOfTexts.chooseReceiver.title)}
+            </ThemeText>
+          </View>
+          <View accessible={true}>
+            <ThemeText
+              type="body__primary"
+              color={themeColor}
+              style={styles.subheader}
+            >
+              {t(OnBehalfOfTexts.chooseReceiver.subtitle)}
+            </ThemeText>
+          </View>
+          <Section>
+            <PhoneInputSectionItem
+              label={t(LoginTexts.phoneInput.input.heading)}
+              value={phoneNumber}
+              onChangeText={setPhoneNumber}
+              prefix={prefix}
+              onChangePrefix={setPrefix}
+              showClear={true}
+              keyboardType="number-pad"
+              placeholder={t(LoginTexts.phoneInput.input.placeholder)}
+              autoFocus={true}
+              textContentType="telephoneNumber"
+            />
+          </Section>
+          <Button
+            style={styles.submitButton}
+            interactiveColor="interactive_0"
+            onPress={() => {
+              navigation.navigate('Root_PurchaseConfirmationScreen', {
+                fareProductTypeConfig: params.fareProductTypeConfig,
+                fromPlace: fromPlace,
+                toPlace: toPlace,
+                userProfilesWithCount: userProfilesWithCount,
+                preassignedFareProduct,
+                travelDate,
+                headerLeftButton: {type: 'back'},
+                mode: params.mode,
+                phoneNumber: phoneNumber,
+              });
+            }}
+            text={t(PurchaseOverviewTexts.summary.button)}
+            disabled={!isValidPhoneNumber(phoneNumber)}
+            testID="toPaymentButton"
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    backgroundColor: theme.static.background[themeColor].background,
+    flex: 1,
+  },
+  mainView: {
+    flex: 1,
+    justifyContent: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  scrollView: {
+    paddingBottom: theme.spacings.xLarge,
+  },
+  contentContainerStyle: {
+    paddingHorizontal: theme.spacings.large,
+    paddingBottom: theme.spacings.xLarge,
+  },
+  header: {
+    alignContent: 'space-around',
+    textAlign: 'center',
+  },
+  subheader: {
+    textAlign: 'center',
+    marginTop: theme.spacings.medium,
+    marginBottom: theme.spacings.xLarge,
+  },
+  submitButton: {
+    marginTop: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
@@ -50,14 +50,6 @@ export const Root_ChooseTicketReceiverScreen: React.FC<Props> = ({
     return validationResult.isValid;
   };
 
-  const {
-    fromPlace,
-    toPlace,
-    preassignedFareProduct,
-    userProfilesWithCount,
-    travelDate,
-  } = params;
-
   const onNext = async () => {
     setIsSubmitting(true);
     const phoneValidation = phone(
@@ -76,14 +68,7 @@ export const Root_ChooseTicketReceiverScreen: React.FC<Props> = ({
       setError(undefined);
       setIsSubmitting(false);
       navigation.navigate('Root_PurchaseConfirmationScreen', {
-        fareProductTypeConfig: params.fareProductTypeConfig,
-        fromPlace: fromPlace,
-        toPlace: toPlace,
-        userProfilesWithCount: userProfilesWithCount,
-        preassignedFareProduct,
-        travelDate,
-        headerLeftButton: {type: 'back'},
-        mode: params.mode,
+        ...params.rootPurchaseConfirmationScreenParams,
         phoneNumber: `+${prefix}${phoneNumber}`,
       });
     } else {

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
@@ -59,10 +59,10 @@ export const Root_ChooseTicketReceiverScreen: React.FC<Props> = ({
             submitButtonText={t(PurchaseOverviewTexts.summary.button)}
             submitButtonTestId="toPaymentButton"
             // TODO: this is just a placeholder, update when API is ready
-            onNextPromise={() => new Promise((r) => setTimeout(r, 1000))}
-            onNextAction={(number) => {
+            onSubmitPromise={() => new Promise((r) => setTimeout(r, 1000))}
+            onSubmitAction={(number) => {
               navigation.navigate('Root_PurchaseConfirmationScreen', {
-                ...params.rootPurchaseConfirmationScreenParams,
+                ...params,
                 phoneNumber: number,
               });
             }}

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/index.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/index.ts
@@ -1,0 +1,2 @@
+export {Root_ChooseTicketReceiverScreen} from './Root_ChooseTicketReceiverScreen';
+export type {Root_ChooseTicketReceiverScreenParams} from './navigation-types';

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types.ts
@@ -4,7 +4,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {LeftButtonProps} from '@atb/components/screen-header';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 
-export type Root_PurchaseConfirmationScreenParams = {
+export type Root_ChooseTicketReceiverScreenParams = {
   fareProductTypeConfig: FareProductTypeConfig;
   preassignedFareProduct: PreassignedFareProduct;
   fromPlace: TariffZone | StopPlaceFragment;
@@ -13,5 +13,4 @@ export type Root_PurchaseConfirmationScreenParams = {
   travelDate?: string;
   headerLeftButton: LeftButtonProps;
   mode?: 'TravelSearch' | 'Ticket';
-  phoneNumber?: string;
 };

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types.ts
@@ -1,5 +1,3 @@
 import {Root_PurchaseConfirmationScreenParams} from '../Root_PurchaseConfirmationScreen';
 
-export type Root_ChooseTicketReceiverScreenParams = {
-  rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams;
-};
+export type Root_ChooseTicketReceiverScreenParams = Omit<Root_PurchaseConfirmationScreenParams, 'phoneNumber'>;

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types.ts
@@ -1,16 +1,5 @@
-import {FareProductTypeConfig} from '@atb/configuration';
-import {PreassignedFareProduct, TariffZone} from '@atb/configuration';
-import {UserProfileWithCount} from '@atb/fare-contracts';
-import {LeftButtonProps} from '@atb/components/screen-header';
-import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
+import {Root_PurchaseConfirmationScreenParams} from '../Root_PurchaseConfirmationScreen';
 
 export type Root_ChooseTicketReceiverScreenParams = {
-  fareProductTypeConfig: FareProductTypeConfig;
-  preassignedFareProduct: PreassignedFareProduct;
-  fromPlace: TariffZone | StopPlaceFragment;
-  toPlace: TariffZone | StopPlaceFragment;
-  userProfilesWithCount: UserProfileWithCount[];
-  travelDate?: string;
-  headerLeftButton: LeftButtonProps;
-  mode?: 'TravelSearch' | 'Ticket';
+  rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams;
 };

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -59,8 +59,8 @@ export const Root_LoginPhoneInputScreen = ({
           <PhoneInput
             submitButtonText={t(LoginTexts.phoneInput.mainButton)}
             submitButtonTestId="sendCodeButton"
-            onNextPromise={signInWithPhoneNumber}
-            onNextAction={(number) => {
+            onSubmitPromise={signInWithPhoneNumber}
+            onSubmitAction={(number) => {
               navigation.navigate('Root_LoginConfirmCodeScreen', {
                 afterLogin,
                 phoneNumber: number,

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -9,7 +9,7 @@ import {ThemeText} from '@atb/components/text';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {StaticColorByType} from '@atb/theme/colors';
 import {PhoneInput} from '@atb/components/phone-input';
-import { ArrowRight } from '@atb/assets/svg/mono-icons/navigation';
+import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -107,6 +107,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     userProfilesWithCount,
     travelDate,
     headerLeftButton,
+    phoneNumber,
   } = params;
 
   const {travellerSelectionMode, zoneSelectionMode} =
@@ -342,6 +343,12 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                 <ThemeText>
                   {getReferenceDataName(preassignedFareProduct, language)}
                 </ThemeText>
+                {phoneNumber && (
+                  <ThemeText type="body__secondary" color="secondary" style={styles.sendingToText}>
+                    {t(PurchaseConfirmationTexts.sendingTo(phoneNumber))}
+                  </ThemeText>
+                )}
+
                 <SummaryText />
                 {!isSearchingOffer &&
                   validDurationSeconds &&
@@ -628,6 +635,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   paymentSummaryContainer: {
     marginVertical: theme.spacings.medium,
+  },
+  sendingToText: {
+    marginTop: theme.spacings.xSmall
   },
   totalPaymentContainer: {
     flexDirection: 'row',

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -306,7 +306,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
               });
               isOnBehalfOfToggle
                 ? navigation.navigate('Root_ChooseTicketReceiverScreen', 
-                    {rootPurchaseConfirmationScreenParams}
+                    rootPurchaseConfirmationScreenParams
                   )
                 : navigation.navigate('Root_PurchaseConfirmationScreen', 
                     rootPurchaseConfirmationScreenParams

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -292,16 +292,27 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 travelDate,
                 mode: params.mode,
               });
-              navigation.navigate('Root_PurchaseConfirmationScreen', {
-                fareProductTypeConfig: params.fareProductTypeConfig,
-                fromPlace: fromPlace,
-                toPlace: toPlace,
-                userProfilesWithCount: travellerSelection,
-                preassignedFareProduct,
-                travelDate,
-                headerLeftButton: {type: 'back'},
-                mode: params.mode,
-              });
+              isOnBehalfOfToggle ?
+                navigation.navigate('Root_ChooseTicketReceiverScreen', {
+                  fareProductTypeConfig: params.fareProductTypeConfig,
+                  fromPlace: fromPlace,
+                  toPlace: toPlace,
+                  userProfilesWithCount: travellerSelection,
+                  preassignedFareProduct,
+                  travelDate,
+                  headerLeftButton: {type: 'back'},
+                  mode: params.mode,
+                }) :
+                navigation.navigate('Root_PurchaseConfirmationScreen', {
+                  fareProductTypeConfig: params.fareProductTypeConfig,
+                  fromPlace: fromPlace,
+                  toPlace: toPlace,
+                  userProfilesWithCount: travellerSelection,
+                  preassignedFareProduct,
+                  travelDate,
+                  headerLeftButton: {type: 'back'},
+                  mode: params.mode,
+                });
             }}
             style={styles.summary}
           />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -26,6 +26,7 @@ import {isAfter} from '@atb/utils/date';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {FullScreenView} from '@atb/components/screen-view';
 import {FareProductHeader} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader';
+import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -107,6 +108,17 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     travellerSelection,
     travelDate,
   );
+
+  const rootPurchaseConfirmationScreenParams : Root_PurchaseConfirmationScreenParams = {
+    fareProductTypeConfig: params.fareProductTypeConfig,
+    fromPlace: fromPlace,
+    toPlace: toPlace,
+    userProfilesWithCount: travellerSelection,
+    preassignedFareProduct,
+    travelDate,
+    headerLeftButton: {type: 'back'},
+    mode: params.mode,
+  };
 
   const maximumDateObjectIfExisting = preassignedFareProduct.limitations
     ?.latestActivationDate
@@ -292,27 +304,13 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 travelDate,
                 mode: params.mode,
               });
-              isOnBehalfOfToggle ?
-                navigation.navigate('Root_ChooseTicketReceiverScreen', {
-                  fareProductTypeConfig: params.fareProductTypeConfig,
-                  fromPlace: fromPlace,
-                  toPlace: toPlace,
-                  userProfilesWithCount: travellerSelection,
-                  preassignedFareProduct,
-                  travelDate,
-                  headerLeftButton: {type: 'back'},
-                  mode: params.mode,
-                }) :
-                navigation.navigate('Root_PurchaseConfirmationScreen', {
-                  fareProductTypeConfig: params.fareProductTypeConfig,
-                  fromPlace: fromPlace,
-                  toPlace: toPlace,
-                  userProfilesWithCount: travellerSelection,
-                  preassignedFareProduct,
-                  travelDate,
-                  headerLeftButton: {type: 'back'},
-                  mode: params.mode,
-                });
+              isOnBehalfOfToggle
+                ? navigation.navigate('Root_ChooseTicketReceiverScreen', 
+                    {rootPurchaseConfirmationScreenParams}
+                  )
+                : navigation.navigate('Root_PurchaseConfirmationScreen', 
+                    rootPurchaseConfirmationScreenParams
+                  );
             }}
             style={styles.summary}
           />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -170,7 +170,9 @@ export function TravellerSelection({
             </View>
 
             {/* remove new label when requested */}
-            {isOnBehalfOfEnabled && <LabelInfo label="new" />}
+            {isOnBehalfOfEnabled && (
+                <LabelInfo label="new" />
+            )}
 
             <ThemeIcon svg={Edit} size="normal" />
           </View>

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -13,6 +13,7 @@ import {PreassignedFareProduct} from '@atb/configuration';
 import {CardPaymentMethod} from '@atb/stacks-hierarchy/types';
 import {Root_PurchaseHarborSearchScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseHarborSearchScreen/navigation-types';
 import {ParkingViolationType} from '@atb/api/types/mobility';
+import {Root_ChooseTicketReceiverScreenParams} from '@atb/stacks-hierarchy/Root_ChooseTicketReceiverScreen/navigation-types';
 
 export type NextScreenParams<T extends keyof RootStackParamList> = {
   screen: T;
@@ -152,6 +153,8 @@ export type RootStackParamList = {
   Root_ParkingViolationsConfirmation: Root_ParkingViolationsConfirmationParams;
   Root_NotificationPermissionScreen: undefined;
   Root_LocationWhenInUsePermissionScreen: undefined;
+
+  Root_ChooseTicketReceiverScreen: Root_ChooseTicketReceiverScreenParams;
 };
 
 export type RootNavigationProps = NavigationProp<RootStackParamList>;

--- a/src/translations/screens/subscreens/OnBehalfOf.ts
+++ b/src/translations/screens/subscreens/OnBehalfOf.ts
@@ -16,7 +16,7 @@ export const OnBehalfOfTexts = {
     errorText: _(
       'Ingen konto tilknyttet dette telefonnummeret',
       'No account is associated with this phone number',
-      'Ingen konto knytte til dette telefonnummeret',
+      'Ingen konto knytta til dette telefonnummeret',
     ),
   },
 };

--- a/src/translations/screens/subscreens/OnBehalfOf.ts
+++ b/src/translations/screens/subscreens/OnBehalfOf.ts
@@ -1,0 +1,22 @@
+import {translation as _} from '../../commons';
+
+export const OnBehalfOfTexts = {
+  chooseReceiver: {
+    header: _('Kjøp til andre', 'Buy for others', 'Kjøp til andre'),
+    title: _(
+      'Hvem skal motta billetten?',
+      'Who will receive the ticket?',
+      'Kven skal få billetten?',
+    ),
+    subtitle: _(
+      'Den du kjøper billett til, må være innlogget i AtB-appen for å få billetten.',
+      'The person receiving the ticket must be logged in to the AtB app to get the ticket.',
+      'Den du kjøper billett til, må vere logga inn i AtB-appen for å få billetten.',
+    ),
+    errorText: _(
+      'Ingen konto tilknyttet dette telefonnummeret',
+      'No account is associated with this phone number',
+      'Ingen konto knytte til dette telefonnummeret',
+    ),
+  },
+};

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -61,6 +61,12 @@ const PurchaseConfirmationTexts = {
         `Billettvarigheit ${validTime} frå oppstart`,
       ),
   },
+  sendingTo: (phoneNumber: string) => 
+    _(
+      `Sendes til ${phoneNumber}`,
+      `Sending to ${phoneNumber}`,
+      `Sendes til ${phoneNumber}`,
+    ),
   totalCost: {
     title: _('Totalt', 'Total', 'Totalt'),
     label: (vatPercentString: string, vatAmountString: string) =>


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/15548

- Made the layout for ticket receiver screen based on [figma design](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=20920-13014)
- The screen flow will be `Root_PurchaseOverviewScreen {params} => Root_ChooseTicketReceiverScreen {params} => Root_PurchaseConfirmationScreen`. Params sent to `Root_ChooseTicketReceiverScreen` is similar to the one sent to `Root_PurchaseConfirmationScreen` because the confirmation screen needs the info from `Root_PurchaseOverviewScreen`.
- All translations are just placeholder until [this page](https://www.figma.com/file/AJZIYrzbvkySeJcRQYS1gX/P%C3%A5-vegne-av%3A-Tekst-og-oversettelser?type=whiteboard&node-id=0-1&t=tmQIkwwbj5KPSvnv-0) is updated from Marked.
- Added dummy loading when tapping on "Til Betaling" button to simulate when there are API calls, some dummy functions are also added to easily integrate the API when its available.
- Created a new component called `PhoneInput` to consolidate the phone input layout into a single component and to put all the phone number validation logic into the component. 