### PR TITLE
fix: remove realtime position in details on cancelled departures

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -313,6 +313,7 @@ const useItemStyles = StyleSheet.createThemeHook((theme) => ({
   },
   strikethrough: {
     textDecorationLine: 'line-through',
+    fontWeight: 'normal',
   },
   departure: {
     backgroundColor: theme.static.background.background_1.background,

--- a/src/place-screen/components/EstimatedCallList.tsx
+++ b/src/place-screen/components/EstimatedCallList.tsx
@@ -61,7 +61,7 @@ export const EstimatedCallList = ({
         },
         existingFavorite,
       ),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
@@ -71,8 +71,9 @@ export const EstimatedCallList = ({
       departure.date,
       departure.aimedDepartureTime,
       departure.quay.id,
+      departure.cancellation,
     );
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const listData: EstimatedCallItemProps[] = departures.map(

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -35,6 +35,7 @@ export type QuaySectionProps = {
     serviceDate: string,
     date?: string,
     fromQuayId?: string,
+    isCancelled?: boolean,
   ) => void;
   stopPlace: StopPlace;
   showOnlyFavorites: boolean;

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -162,7 +162,9 @@ export const DepartureDetailsScreenComponent = ({
             </View>
             {shouldShowMapButton || realtimeText ? (
               <View style={styles.headerSubSection}>
-                {realtimeText && <LastPassedStop realtimeText={realtimeText} />}
+                {realtimeText && !activeItem.isTripCancelled && (
+                  <LastPassedStop realtimeText={realtimeText} />
+                )}
                 {shouldShowMapButton ? (
                   <Button
                     type="pill"


### PR DESCRIPTION
Now removes the realtime icon and the text with position if the route is cancelled. Also shows the warning seen below now. 

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/afb78da1-7aff-4a19-9f01-392e886e859b"/>
