### PR TITLE
fix: Update Beacons starting useEffect

### DIFF
--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -136,14 +136,13 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     }
   }, [isBeaconsSupported]);
 
-  const isOnboardedButNotStarted =
-    !kettleInfo?.isKettleStarted && kettleInfo?.isBeaconsOnboarded;
-
   useEffect(() => {
     (async function () {
       if (!isBeaconsSupported) return;
+      const consentGranted =
+        (await storage.get(storeKey.beaconsConsent)) ?? 'false';
 
-      if (isOnboardedButNotStarted) {
+      if (consentGranted === 'true') {
         const permissions = await initializeKettleSDK();
         Kettle.start(permissions);
       }
@@ -152,7 +151,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
         await updateKettleInfo();
       }
     })();
-  }, [isBeaconsSupported, isOnboardedButNotStarted, initializeKettleSDK]);
+  }, [isBeaconsSupported, initializeKettleSDK]);
 
   return (
     <BeaconsContext.Provider
@@ -175,12 +174,14 @@ const getKettleInfo = async (): Promise<KettleInfo> => {
   const status = await Kettle.isStarted();
   const identifier = await Kettle.getIdentifier();
   const consents = await Kettle.getGrantedConsents();
+  const consentGranted =
+    (await storage.get(storeKey.beaconsConsent)) ?? 'false';
 
   return {
     isKettleStarted: status,
     kettleIdentifier: identifier,
     kettleConsents: consents,
-    isBeaconsOnboarded: Object.keys(consents).length > 0,
+    isBeaconsOnboarded: consentGranted === 'true',
   };
 };
 

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -17,6 +17,7 @@ import {
 } from './permissions';
 import {useBeaconsMessages} from './use-beacons-messages';
 import {storage} from '@atb/storage';
+import {parseBoolean} from '@atb/utils/parse-boolean';
 
 type KettleInfo = {
   isKettleStarted: boolean;
@@ -140,9 +141,9 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     (async function () {
       if (!isBeaconsSupported) return;
       const consentGranted =
-        (await storage.get(storeKey.beaconsConsent)) ?? 'false';
+        parseBoolean(await storage.get(storeKey.beaconsConsent)) ?? false;
 
-      if (consentGranted === 'true') {
+      if (consentGranted) {
         const permissions = await initializeKettleSDK();
         Kettle.start(permissions);
       }
@@ -175,13 +176,13 @@ const getKettleInfo = async (): Promise<KettleInfo> => {
   const identifier = await Kettle.getIdentifier();
   const consents = await Kettle.getGrantedConsents();
   const consentGranted =
-    (await storage.get(storeKey.beaconsConsent)) ?? 'false';
+    parseBoolean(await storage.get(storeKey.beaconsConsent)) ?? false;
 
   return {
     isKettleStarted: status,
     kettleIdentifier: identifier,
     kettleConsents: consents,
-    isBeaconsOnboarded: consentGranted === 'true',
+    isBeaconsOnboarded: consentGranted,
   };
 };
 


### PR DESCRIPTION
While testing, the beacons were not properly started, so after refactoring this class a small piece was missing to keep it on after close the app.

Closes: https://github.com/AtB-AS/kundevendt/issues/8621