### PR TITLE
feat: Make announcement scroll horizontally when more than one 

### DIFF
--- a/src/announcements/converters.ts
+++ b/src/announcements/converters.ts
@@ -1,10 +1,10 @@
-import { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
-import { AnnouncementRaw, AnnouncementType, ActionButton } from './types';
-import { mapToLanguageAndTexts } from '@atb/utils/map-to-language-and-texts';
-import { APP_VERSION } from '@env';
-import { AppPlatformType } from '@atb/global-messages/types';
-import { Platform } from 'react-native';
-import { mapToRules } from '@atb/rule-engine';
+import {FirebaseFirestoreTypes} from '@react-native-firebase/firestore';
+import {AnnouncementRaw, AnnouncementType, ActionButton} from './types';
+import {mapToLanguageAndTexts} from '@atb/utils/map-to-language-and-texts';
+import {APP_VERSION} from '@env';
+import {AppPlatformType} from '@atb/global-messages/types';
+import {Platform} from 'react-native';
+import {mapToRules} from '@atb/rule-engine';
 
 export const mapToAnnouncements = (
   result: FirebaseFirestoreTypes.QueryDocumentSnapshot<AnnouncementRaw>[],
@@ -38,7 +38,6 @@ export const mapToAnnouncement = (
   const rules = mapToRules(result.rules);
   const actionButton = mapActionButton(result.actionButton);
 
-  if (!result.active) return;
   if (!summary) return;
   if (!fullTitle) return;
   if (!body) return;
@@ -80,8 +79,7 @@ function isAppPlatformValid(platforms: AppPlatformType[]) {
 }
 
 function mapActionButton(data: any): ActionButton | undefined {
-  if (typeof data !== 'object') return;
-  const { label, url, actionType } = data;
+  const {label = [], url, actionType = 'bottom_sheet'} = data ?? {};
   if (!label || !actionType) return;
   if (!['external', 'deeplink', 'bottom_sheet'].includes(actionType)) return;
   const labelWithLanguage = mapToLanguageAndTexts(label);
@@ -90,5 +88,5 @@ function mapActionButton(data: any): ActionButton | undefined {
     label: labelWithLanguage,
     url,
     actionType,
-  }
+  };
 }

--- a/src/announcements/converters.ts
+++ b/src/announcements/converters.ts
@@ -78,12 +78,9 @@ function isAppPlatformValid(platforms: AppPlatformType[]) {
   );
 }
 
-function mapActionButton(data: any): ActionButton | undefined {
+function mapActionButton(data: any): ActionButton {
   const {label = [], url, actionType = 'bottom_sheet'} = data ?? {};
-  if (!label || !actionType) return;
-  if (!['external', 'deeplink', 'bottom_sheet'].includes(actionType)) return;
   const labelWithLanguage = mapToLanguageAndTexts(label);
-  if (!labelWithLanguage) return;
   return {
     label: labelWithLanguage,
     url,

--- a/src/announcements/types.ts
+++ b/src/announcements/types.ts
@@ -1,15 +1,22 @@
-import { LanguageAndTextType } from '@atb/configuration';
-import { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
-import { AppPlatformType } from '@atb/global-messages/types';
-import { Rule } from '@atb/rule-engine/rules';
+import {LanguageAndTextType} from '@atb/configuration';
+import {FirebaseFirestoreTypes} from '@react-native-firebase/firestore';
+import {AppPlatformType} from '@atb/global-messages/types';
+import {Rule} from '@atb/rule-engine/rules';
 
 export type AnnouncementId = string;
 
-export type ActionButton = {
-  label: LanguageAndTextType[];
-  url?: string;
-  actionType: 'external' | 'deeplink' | 'bottom_sheet';
+export type BottomSheetActionButton = {
+  label?: LanguageAndTextType[];
+  actionType: 'bottom_sheet';
 };
+
+export type UrlActionButton = {
+  label?: LanguageAndTextType[];
+  url: string;
+  actionType: 'external' | 'deeplink';
+};
+
+export type ActionButton = BottomSheetActionButton | UrlActionButton;
 
 export type AnnouncementRaw = {
   id: AnnouncementId;
@@ -36,4 +43,5 @@ export type AnnouncementType = Omit<
 > & {
   startDate?: number;
   endDate?: number;
+  actionButton: ActionButton;
 };

--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -81,7 +81,7 @@ function toRadius(index: number, lastIndex: number, firstIndex: number) {
 
 const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
   separator: {
-    flexGrow: 1,
+    flexGrow: 0,
     backgroundColor: theme.static.background.background_2.background,
     height: 1,
   },

--- a/src/components/sections/items/GenericSectionItem.tsx
+++ b/src/components/sections/items/GenericSectionItem.tsx
@@ -1,5 +1,5 @@
 import React, {Children, PropsWithChildren} from 'react';
-import {AccessibilityProps, View} from 'react-native';
+import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
@@ -7,6 +7,7 @@ import {useSectionStyle} from '../use-section-style';
 type Props = PropsWithChildren<
   SectionItemProps<{
     accessibility?: AccessibilityProps;
+    style?: StyleProp<ViewStyle>;
   }>
 >;
 export function GenericSectionItem({children, accessibility, ...props}: Props) {
@@ -14,7 +15,7 @@ export function GenericSectionItem({children, accessibility, ...props}: Props) {
   const style = useSectionStyle();
 
   return (
-    <View style={topContainer} {...accessibility}>
+    <View style={[topContainer, props.style]} {...accessibility}>
       {Children.map(children, (child) => (
         <View style={style.spaceBetween}>{child}</View>
       ))}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
@@ -250,15 +250,14 @@ export const Dashboard_RootScreen: React.FC<RootProps> = ({
           />
         </View>
 
-        <Announcements style={style.contentSection} />
+        <Announcements
+          style={[style.contentSection, style.contentSection__horizontalScroll]}
+        />
 
         {enable_ticketing && (
           <CompactFareContracts
             style={style.contentSection}
-            onPressDetails={(
-              isCarnet: boolean,
-              orderId: string,
-            ) => {
+            onPressDetails={(isCarnet: boolean, orderId: string) => {
               if (isCarnet) {
                 return navigation.navigate({
                   name: 'Root_CarnetDetailsScreen',
@@ -315,7 +314,7 @@ function useLocations(
 
   const memoedCurrentLocation = useMemo<GeoLocation | undefined>(
     () => currentLocation,
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       currentLocation?.coordinates.latitude,
       currentLocation?.coordinates.longitude,
@@ -378,7 +377,7 @@ function useUpdatedLocation(
         }
       }
     },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentLocation, favorites],
   );
 
@@ -428,6 +427,9 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   contentSection: {
     marginTop: theme.spacings.large,
     marginHorizontal: theme.spacings.medium,
+  },
+  contentSection__horizontalScroll: {
+    marginHorizontal: 0,
   },
   contentSection__first: {
     marginTop: 0,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -45,6 +45,11 @@ export const Announcement = ({announcement, style}: Props) => {
     });
   };
 
+  const summaryTitle = getTextForLanguage(
+    announcement.summaryTitle ?? announcement.fullTitle,
+    language,
+  );
+
   return (
     <Section style={style} key={announcement.id} testID="announcement">
       <GenericSectionItem>
@@ -69,12 +74,7 @@ export const Announcement = ({announcement, style}: Props) => {
               </View>
             )}
             <View style={styles.textContainer}>
-              <ThemeText type="body__primary--bold">
-                {getTextForLanguage(
-                  announcement.summaryTitle ?? announcement.fullTitle,
-                  language,
-                )}
-              </ThemeText>
+              <ThemeText type="body__primary--bold">{summaryTitle}</ThemeText>
               <ThemeText style={styles.summary}>
                 {getTextForLanguage(announcement.summary, language)}
               </ThemeText>
@@ -94,44 +94,48 @@ export const Announcement = ({announcement, style}: Props) => {
           </PressableOpacity>
         </View>
       </GenericSectionItem>
-      {announcement.actionButton?.actionType &&
-        announcement.actionButton?.label && (
-          <LinkSectionItem
-            text={
-              getTextForLanguage(announcement.actionButton.label, language) ??
-              ''
-            }
-            icon={
-              announcement.actionButton?.actionType === 'external'
-                ? 'external-link'
-                : 'arrow-right'
-            }
-            accessibility={{
-              accessibilityHint: t(
-                DashboardTexts.announcemens.buttonAction[
-                  announcement.actionButton.actionType
-                ],
+      {announcement.actionButton?.actionType && (
+        <LinkSectionItem
+          text={
+            getTextForLanguage(announcement.actionButton.label, language) ??
+            t(
+              DashboardTexts.announcemens.buttonAction.defaultLabel(
+                summaryTitle,
               ),
-            }}
-            onPress={async () => {
-              if (announcement.actionButton?.actionType === 'bottom_sheet') {
-                openBottomSheet(() => (
-                  <AnnouncementSheet
-                    announcement={announcement}
-                    close={closeBottomSheet}
-                  />
-                ));
-              } else {
-                const actionButtonURL = announcement.actionButton?.url;
-                try {
-                  actionButtonURL && (await Linking.openURL(actionButtonURL));
-                } catch (err: any) {
-                  Bugsnag.notify(err);
-                }
+            )
+          }
+          textType="body__secondary"
+          icon={
+            announcement.actionButton?.actionType === 'external'
+              ? 'external-link'
+              : 'arrow-right'
+          }
+          accessibility={{
+            accessibilityHint: t(
+              DashboardTexts.announcemens.buttonAction.a11yHint[
+                announcement.actionButton.actionType
+              ],
+            ),
+          }}
+          onPress={async () => {
+            if (announcement.actionButton?.actionType === 'bottom_sheet') {
+              openBottomSheet(() => (
+                <AnnouncementSheet
+                  announcement={announcement}
+                  close={closeBottomSheet}
+                />
+              ));
+            } else {
+              const actionButtonURL = announcement.actionButton?.url;
+              try {
+                actionButtonURL && (await Linking.openURL(actionButtonURL));
+              } catch (err: any) {
+                Bugsnag.notify(err);
               }
-            }}
-          />
-        )}
+            }
+          }}
+        />
+      )}
     </Section>
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -53,45 +53,45 @@ export const Announcement = ({announcement, style}: Props) => {
   return (
     <Section style={style} key={announcement.id} testID="announcement">
       <GenericSectionItem style={styles.sectionItem}>
-        <View style={styles.container}>
-          <View
-            style={styles.content}
-            accessible={true}
-            accessibilityRole={announcement.actionButton ? 'button' : undefined}
-            accessibilityHint={
-              announcement.actionButton !== undefined
-                ? t(DashboardTexts.announcemens.button.accessibility)
-                : undefined
-            }
-          >
-            {announcement.summaryImage && (
-              <View style={styles.imageContainer}>
-                <Image
-                  height={50}
-                  width={50}
-                  source={{uri: announcement.summaryImage}}
-                />
-              </View>
-            )}
-            <View style={styles.textContainer}>
-              <ThemeText type="body__primary--bold">{summaryTitle}</ThemeText>
-              <ThemeText style={styles.summary}>
-                {getTextForLanguage(announcement.summary, language)}
-              </ThemeText>
+        <View
+          style={styles.content}
+          accessible={true}
+          accessibilityRole={announcement.actionButton ? 'button' : undefined}
+          accessibilityHint={
+            announcement.actionButton !== undefined
+              ? t(DashboardTexts.announcemens.button.accessibility)
+              : undefined
+          }
+        >
+          {announcement.summaryImage && (
+            <View style={styles.imageContainer}>
+              <Image
+                height={50}
+                width={50}
+                source={{uri: announcement.summaryImage}}
+              />
             </View>
+          )}
+          <View style={styles.textContainer}>
+            <View style={styles.summaryTitle}>
+              <ThemeText type="body__primary--bold">{summaryTitle}</ThemeText>
+              <PressableOpacity
+                style={styles.close}
+                role="button"
+                hitSlop={insets.all(theme.spacings.medium)}
+                accessibilityHint={t(
+                  DashboardTexts.announcemens.announcement.closeA11yHint,
+                )}
+                onPress={() => handleDismiss()}
+                testID="closeAnnouncement"
+              >
+                <ThemeIcon svg={Close} />
+              </PressableOpacity>
+            </View>
+            <ThemeText style={styles.summary}>
+              {getTextForLanguage(announcement.summary, language)}
+            </ThemeText>
           </View>
-          <PressableOpacity
-            style={styles.close}
-            role="button"
-            hitSlop={insets.all(theme.spacings.medium)}
-            accessibilityHint={t(
-              DashboardTexts.announcemens.announcement.closeA11yHint,
-            )}
-            onPress={() => handleDismiss()}
-            testID="closeAnnouncement"
-          >
-            <ThemeIcon svg={Close} />
-          </PressableOpacity>
         </View>
       </GenericSectionItem>
       {announcement.actionButton?.actionType && (
@@ -144,9 +144,6 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   sectionItem: {
     flexGrow: 1,
   },
-  container: {
-    flexDirection: 'row',
-  },
   content: {
     flex: 1,
     flexDirection: 'row',
@@ -161,8 +158,9 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   textContainer: {
     flex: 1,
   },
-  spacing: {
-    marginTop: theme.spacings.medium,
+  summaryTitle: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
   summary: {
     marginTop: theme.spacings.xSmall,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -65,7 +65,12 @@ export const Announcement = ({announcement, style}: Props) => {
           )}
           <View style={styles.textContainer}>
             <View style={styles.summaryTitle}>
-              <ThemeText type="body__primary--bold">{summaryTitle}</ThemeText>
+              <ThemeText
+                style={styles.summaryTitleText}
+                type="body__primary--bold"
+              >
+                {summaryTitle}
+              </ThemeText>
               <PressableOpacity
                 style={styles.close}
                 role="button"
@@ -152,6 +157,9 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   summaryTitle: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  summaryTitleText: {
+    flexShrink: 1,
   },
   summary: {
     marginTop: theme.spacings.xSmall,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -109,7 +109,7 @@ export const Announcement = ({announcement, style}: Props) => {
             ),
           }}
           onPress={async () => {
-            if (announcement.actionButton?.actionType === 'bottom_sheet') {
+            if (announcement.actionButton.actionType === 'bottom_sheet') {
               openBottomSheet(() => (
                 <AnnouncementSheet
                   announcement={announcement}
@@ -117,7 +117,7 @@ export const Announcement = ({announcement, style}: Props) => {
                 />
               ));
             } else {
-              const actionButtonURL = announcement.actionButton?.url;
+              const actionButtonURL = announcement.actionButton.url;
               try {
                 actionButtonURL && (await Linking.openURL(actionButtonURL));
               } catch (err: any) {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -52,7 +52,7 @@ export const Announcement = ({announcement, style}: Props) => {
 
   return (
     <Section style={style} key={announcement.id} testID="announcement">
-      <GenericSectionItem>
+      <GenericSectionItem style={styles.sectionItem}>
         <View style={styles.container}>
           <View
             style={styles.content}
@@ -141,6 +141,9 @@ export const Announcement = ({announcement, style}: Props) => {
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
+  sectionItem: {
+    flexGrow: 1,
+  },
   container: {
     flexDirection: 'row',
   },

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -36,21 +36,26 @@ export const Announcements = ({style: containerStyle}: Props) => {
 
   return (
     <View style={containerStyle} testID="announcements">
-      <SectionHeading>{t(DashboardTexts.announcemens.header)}</SectionHeading>
-      <ScrollView horizontal={filteredAnnouncements.length > 1}>
-        {filteredAnnouncements.map((a) => (
-          <Announcement
-            key={a.id}
-            announcement={a}
-            style={filteredAnnouncements.length > 1 && style.announcement}
-          />
-        ))}
-      </ScrollView>
+      <View style={style.contentWrapper}>
+        <SectionHeading>{t(DashboardTexts.announcemens.header)}</SectionHeading>
+        <ScrollView horizontal={filteredAnnouncements.length > 1}>
+          {filteredAnnouncements.map((a) => (
+            <Announcement
+              key={a.id}
+              announcement={a}
+              style={filteredAnnouncements.length > 1 && style.announcement}
+            />
+          ))}
+        </ScrollView>
+      </View>
     </View>
   );
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
+  contentWrapper: {
+    marginHorizontal: theme.spacings.medium,
+  },
   announcement: {
     width: Dimensions.get('window').width * 0.9 - 2 * theme.spacings.medium,
     marginRight: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -1,4 +1,4 @@
-import {StyleProp, View, ViewStyle} from 'react-native';
+import {Dimensions, StyleProp, View, ViewStyle} from 'react-native';
 import {useAnnouncementsState} from '@atb/announcements';
 import {ScrollView} from 'react-native-gesture-handler';
 import {Announcement} from './Announcement';
@@ -37,11 +37,12 @@ export const Announcements = ({style: containerStyle}: Props) => {
   return (
     <View style={containerStyle} testID="announcements">
       <SectionHeading>{t(DashboardTexts.announcemens.header)}</SectionHeading>
-      <ScrollView>
-        {filteredAnnouncements.map((a, i) => (
+      <ScrollView horizontal={filteredAnnouncements.length > 1}>
+        {filteredAnnouncements.map((a) => (
           <Announcement
+            key={a.id}
             announcement={a}
-            style={i < filteredAnnouncements.length - 1 && style.announcement}
+            style={filteredAnnouncements.length > 1 && style.announcement}
           />
         ))}
       </ScrollView>
@@ -49,10 +50,9 @@ export const Announcements = ({style: containerStyle}: Props) => {
   );
 };
 
-const useStyle = StyleSheet.createThemeHook((theme) => {
-  return {
-    announcement: {
-      marginBottom: theme.spacings.medium,
-    },
-  };
-});
+const useStyle = StyleSheet.createThemeHook((theme) => ({
+  announcement: {
+    width: Dimensions.get('window').width * 0.9 - 2 * theme.spacings.medium,
+    marginRight: theme.spacings.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -60,10 +60,10 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
     marginHorizontal: theme.spacings.medium,
   },
   scrollView: {
-    marginHorizontal: theme.spacings.medium,
+    paddingHorizontal: theme.spacings.medium,
+    columnGap: theme.spacings.medium,
   },
   announcement: {
     width: Dimensions.get('window').width * 0.9 - 2 * theme.spacings.medium,
-    marginRight: theme.spacings.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -36,24 +36,30 @@ export const Announcements = ({style: containerStyle}: Props) => {
 
   return (
     <View style={containerStyle} testID="announcements">
-      <View style={style.contentWrapper}>
+      <View style={style.headerWrapper}>
         <SectionHeading>{t(DashboardTexts.announcemens.header)}</SectionHeading>
-        <ScrollView horizontal={filteredAnnouncements.length > 1}>
-          {filteredAnnouncements.map((a) => (
-            <Announcement
-              key={a.id}
-              announcement={a}
-              style={filteredAnnouncements.length > 1 && style.announcement}
-            />
-          ))}
-        </ScrollView>
       </View>
+      <ScrollView
+        contentContainerStyle={style.scrollView}
+        horizontal={filteredAnnouncements.length > 1}
+      >
+        {filteredAnnouncements.map((a) => (
+          <Announcement
+            key={a.id}
+            announcement={a}
+            style={filteredAnnouncements.length > 1 && style.announcement}
+          />
+        ))}
+      </ScrollView>
     </View>
   );
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
-  contentWrapper: {
+  headerWrapper: {
+    marginHorizontal: theme.spacings.medium,
+  },
+  scrollView: {
     marginHorizontal: theme.spacings.medium,
   },
   announcement: {

--- a/src/translations/screens/Dashboard.ts
+++ b/src/translations/screens/Dashboard.ts
@@ -1,4 +1,4 @@
-import { translation as _ } from '../commons';
+import {translation as _} from '../commons';
 
 const DashboardTexts = {
   header: {
@@ -21,17 +21,31 @@ const DashboardTexts = {
       closeA11yHint: _('Lukk melding', 'Close announcement', 'Lukk melding'),
     },
     buttonAction: {
-      external: _(
-        `Aktiver for å lese mer på ekstern side`,
-        `Activate to read more (external content)`,
-        `Aktiver for å lese meir på ekstern side`,
-      ),
-      deeplink: _('Aktiver for å åpne lenke', 'Activate to open link', 'Aktiver for å opne lenke'),
-      bottom_sheet: _(
-        `Aktiver for å lese mer`,
-        `Activate to read more`,
-        `Aktiver for å lese meir`,
-      ),
+      a11yHint: {
+        external: _(
+          `Aktiver for å lese mer på ekstern side`,
+          `Activate to read more (external content)`,
+          `Aktiver for å lese meir på ekstern side`,
+        ),
+        deeplink: _(
+          'Aktiver for å åpne lenke',
+          'Activate to open link',
+          'Aktiver for å opne lenke',
+        ),
+        bottom_sheet: _(
+          `Aktiver for å lese mer`,
+          `Activate to read more`,
+          `Aktiver for å lese meir`,
+        ),
+      },
+      defaultLabel: (announcementTitle?: string) =>
+        announcementTitle
+          ? _(
+              `Les mer om ${announcementTitle}`,
+              `Read more about ${announcementTitle}`,
+              `Les meir om ${announcementTitle}`,
+            )
+          : _('Les mer', 'Read mre', 'Les meir'),
     },
   },
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/15746

Announcements are stretched vertically to be come as tall as the tallest visible announcement.

In addition to the horizontal scroll, this pr also ensures that legacy announcement  are opened in bottom sheet.

The announcement close icon is moved inside the header. This leaves more room for the content, which is more important now, since the announcements will be narrower.

<details>
<summary>Screen shots</summary>

![Simulator Screenshot - iPhone 15 - 2023-12-20 at 12 55 26](https://github.com/AtB-AS/mittatb-app/assets/4981580/7e3932f6-ebef-404a-94e7-125f175213f9)

![Simulator Screenshot - iPhone 15 - 2023-12-20 at 12 55 38](https://github.com/AtB-AS/mittatb-app/assets/4981580/1cf06756-c2b5-40cf-b6f3-f9d31e19b1ac)

</details>
