### PR TITLE
feat: update RNMapBox dependency and update usage of UserLocation

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -928,12 +928,12 @@ PODS:
   - Kronos (4.2.2)
   - leveldb-library (1.22.2)
   - libevent (2.1.12)
-  - MapboxCommon (23.8.3)
-  - MapboxCoreMaps (10.16.1):
+  - MapboxCommon (23.8.5)
+  - MapboxCoreMaps (10.16.3):
     - MapboxCommon (~> 23.8)
-  - MapboxMaps (10.16.1):
-    - MapboxCommon (= 23.8.3)
-    - MapboxCoreMaps (= 10.16.1)
+  - MapboxMaps (10.16.3):
+    - MapboxCommon (= 23.8.5)
+    - MapboxCoreMaps (= 10.16.3)
     - MapboxMobileEvents (= 1.0.10)
     - Turf (~> 2.0)
   - MapboxMobileEvents (1.0.10)
@@ -1431,14 +1431,14 @@ PODS:
     - React-Core
   - RNLocalize (2.2.4):
     - React-Core
-  - rnmapbox-maps (10.0.15):
-    - MapboxMaps (~> 10.16.0)
+  - rnmapbox-maps (10.1.3):
+    - MapboxMaps (~> 10.16.2)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.0.15)
+    - rnmapbox-maps/DynamicLibrary (= 10.1.3)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.0.15):
-    - MapboxMaps (~> 10.16.0)
+  - rnmapbox-maps/DynamicLibrary (10.1.3):
+    - MapboxMaps (~> 10.16.2)
     - React
     - React-Core
     - Turf
@@ -1833,9 +1833,9 @@ SPEC CHECKSUMS:
   Kronos: dfa27819541f9f1bf6834d5bfefa792f499001bb
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MapboxCommon: b2c348867dfed7d7a23545e6c2024d712bfda10f
-  MapboxCoreMaps: c66f482b5ea983cf873122853c4ee94c159bec43
-  MapboxMaps: fdbe05e3899abd24f31a7f91789586e44e57f7fc
+  MapboxCommon: 677dd4449e9f7d863a4712cf271c198ed1753494
+  MapboxCoreMaps: 304d4ff1de0b5873e4ce359a7ed107fe65f89bd6
+  MapboxMaps: 89322569ce8b0e98ed2a84c3289e6bc402df6073
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   NextLevelSessionExporter: 4d8aa5e617f1c709724f2453efe5d4628480f65a
@@ -1901,7 +1901,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNLocalize: 0df7970cfc60389f00eb62fd7c097dc75af3fb4f
-  rnmapbox-maps: b6219b7432508ae2cea169365116a811f822612e
+  rnmapbox-maps: c5a6bcd941aef23d9a14af7bbae5042e097687b6
   RNPermissions: 2a9336f58607a4ba0000dd6b8ad7b3dd19004966
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@react-navigation/material-top-tabs": "^6.6.3",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/stack": "^6.3.17",
-    "@rnmapbox/maps": "^10.0.15",
+    "@rnmapbox/maps": "^10.1.3",
     "@seznam/compose-react-refs": "^1.0.6",
     "@tanstack/react-query": "^4.32.0",
     "@turf/bbox-polygon": "^6.5.0",

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -2,8 +2,7 @@ import {useGeolocationState} from '@atb/GeolocationContext';
 import {FOCUS_ORIGIN} from '@atb/api/geocoder';
 import {StyleSheet} from '@atb/theme';
 import {MapRoute} from '@atb/travel-details-map-screen/components/MapRoute';
-import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
-import {MapState} from '@rnmapbox/maps/lib/typescript/components/MapView';
+import MapboxGL, {LocationPuck, MapState} from '@rnmapbox/maps';
 import {Feature} from 'geojson';
 import React, {useMemo, useRef} from 'react';
 import {View} from 'react-native';
@@ -110,10 +109,7 @@ export const Map = (props: MapProps) => {
             {...MapCameraConfig}
           />
           {mapLines && <MapRoute lines={mapLines} />}
-          <MapboxGL.UserLocation
-              showsUserHeadingIndicator
-              renderMode={UserLocationRenderMode.Native}
-          />
+          <LocationPuck puckBearing="heading" />
           {props.selectionMode === 'ExploreLocation' && selectedCoordinates && (
             <SelectionPin coordinates={selectedCoordinates} id="selectionPin" />
           )}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -109,7 +109,7 @@ export const Map = (props: MapProps) => {
             {...MapCameraConfig}
           />
           {mapLines && <MapRoute lines={mapLines} />}
-          <LocationPuck puckBearing="heading" />
+          <LocationPuck puckBearing="heading" puckBearingEnabled={true} />
           {props.selectionMode === 'ExploreLocation' && selectedCoordinates && (
             <SelectionPin coordinates={selectedCoordinates} id="selectionPin" />
           )}

--- a/src/components/map/MapConfig.ts
+++ b/src/components/map/MapConfig.ts
@@ -1,6 +1,6 @@
 import {Platform} from 'react-native';
 import {MAPBOX_STOP_PLACES_STYLE_URL} from '@env';
-import {CameraStop} from '@rnmapbox/maps/lib/typescript/components/Camera';
+import {CameraStop} from '@rnmapbox/maps';
 
 export const MapViewConfig = {
   compassEnabled: true,

--- a/src/components/map/components/mobility/Bicycles.tsx
+++ b/src/components/map/components/mobility/Bicycles.tsx
@@ -4,7 +4,7 @@ import {VehicleBasicFragment} from '@atb/api/types/generated/fragments/vehicles'
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 
 type Props = {
   bicycles: FeatureCollection<GeoJSON.Point, VehicleBasicFragment>;

--- a/src/components/map/components/mobility/BikeStations.tsx
+++ b/src/components/map/components/mobility/BikeStations.tsx
@@ -1,7 +1,7 @@
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import React, {RefObject, useRef} from 'react';
 import {StationsWithCount} from './Stations';
 

--- a/src/components/map/components/mobility/CarStations.tsx
+++ b/src/components/map/components/mobility/CarStations.tsx
@@ -1,7 +1,7 @@
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import React, {RefObject, useRef} from 'react';
 import {StationsWithCount} from './Stations';
 

--- a/src/components/map/components/mobility/Scooters.tsx
+++ b/src/components/map/components/mobility/Scooters.tsx
@@ -4,7 +4,7 @@ import {VehicleBasicFragment} from '@atb/api/types/generated/fragments/vehicles'
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 
 type Props = {
   scooters: FeatureCollection<GeoJSON.Point, VehicleBasicFragment>;

--- a/src/components/map/components/mobility/Stations.tsx
+++ b/src/components/map/components/mobility/Stations.tsx
@@ -7,7 +7,7 @@ import {
 } from '@atb/components/map';
 import {getAvailableVehicles} from '@atb/mobility/utils';
 import {Camera, ShapeSource} from '@rnmapbox/maps';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {Feature, FeatureCollection, Point} from 'geojson';
 import React, {RefObject} from 'react';
 import {Cluster} from '../../types';

--- a/src/components/map/components/mobility/Vehicles.tsx
+++ b/src/components/map/components/mobility/Vehicles.tsx
@@ -6,7 +6,7 @@ import {Scooters} from './Scooters';
 import {Bicycles} from './Bicycles';
 import {flyToLocation, isClusterFeature} from '@atb/components/map';
 import {mapPositionToCoordinates} from '../../utils';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 
 type Props = {
   mapCameraRef: RefObject<MapboxGL.Camera>;

--- a/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
+++ b/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
@@ -23,7 +23,7 @@ import {
 import {FeatureCollection, Polygon} from 'geojson';
 import turfCentroid from '@turf/centroid';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
+import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {useInitialCoordinates} from '@atb/utils/use-initial-coordinates';
 
 type Props = {

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -33,13 +33,13 @@ import {DirectionArrow} from './components/DirectionArrow';
 import {MapLabel} from './components/MapLabel';
 import {MapRoute} from './components/MapRoute';
 import {createMapLines, getMapBounds, pointOf} from './utils';
-import {
-  MapState,
-  RegionPayload,
-} from '@rnmapbox/maps/lib/typescript/components/MapView';
 import {useStations} from '@atb/mobility';
 import {Stations} from '@atb/components/map';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import {
+  MapState,
+  RegionPayload,
+} from '@rnmapbox/maps/lib/typescript/src/components/MapView';
 
 export type TravelDetailsMapScreenParams = {
   legs: MapLeg[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4891,10 +4891,10 @@
     color "^4.2.3"
     warn-once "^0.1.0"
 
-"@rnmapbox/maps@^10.0.15":
-  version "10.0.15"
-  resolved "https://registry.yarnpkg.com/@rnmapbox/maps/-/maps-10.0.15.tgz#cf63c8eb6beffb22451718f148c2bea655a3cdb6"
-  integrity sha512-2diBwMF+e7gR6keZ1AEI3xw8U7Cu9+xhv8ce75Bw7flg9aTk+d0KgWv4VDQn4wSphD23EroUgFprVymHvVzZGQ==
+"@rnmapbox/maps@^10.1.3":
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/@rnmapbox/maps/-/maps-10.1.3.tgz#828af7a74da3449e030c34be607b29f48cac47c4"
+  integrity sha512-YuGGNKghQUkqI1zLDy6IoOnYm4xXlm9Zw9cx9YlP/szMupfZ/4jftW6ooPZ22xFvdJpWKVCVXmfKabMNeD2DwA==
   dependencies:
     "@turf/along" "6.5.0"
     "@turf/distance" "6.5.0"


### PR DESCRIPTION
Replaces PR : https://github.com/AtB-AS/mittatb-app/pull/4141
Closes : https://github.com/AtB-AS/kundevendt/issues/16093

This PR updates the RNMapBox dependency to fix the issue with using `UserLocation` with `onMapIdle` on Android.

Also replaces the deprecated `UserLocation` with the new `LocationPuck` as suggested by RNMapBox (`NativeUserLocation` is also deprecated).

~~iOS users might have to run `pod update MapboxMaps` before `pod install` for it to be able to run. Please let me know if I need to update something regarding this issue.~~ just pod install should work now, I have updated the podfile.lock.

Screenshots: 

Android: 
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/4096a6d7-5a18-4e35-aac3-f92a76f62faa)

iOS: 
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/7bd74eab-462f-4f58-986d-bb9f4832c5b8)
