### PR TITLE
fix: change default periodic ticket duration

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -34,15 +34,11 @@ export function useOfferDefaults(
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
 
-  // Find the index of the product with the specific ID in selectableProducts
-  const specificProductIndex = selectableProducts.findIndex(
-    (p) => p.id === 'ATB:PreassignedFareProduct:925469fb',
+  const defaultProduct = selectableProducts.find(
+    (p) => p.id === 'ATB:PreassignedFareProduct:925469fb', // 30day ticket
   );
   const defaultPreassignedFareProduct =
-    preassignedFareProduct ??
-    (specificProductIndex >= 0
-      ? selectableProducts[specificProductIndex]
-      : selectableProducts[0]);
+    preassignedFareProduct ?? defaultProduct ?? selectableProducts[0];
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(tariffZones);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -33,8 +33,16 @@ export function useOfferDefaults(
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
+
+  // Find the index of the product with the specific ID in selectableProducts
+  const specificProductIndex = selectableProducts.findIndex(
+    (p) => p.id === 'ATB:PreassignedFareProduct:925469fb',
+  );
   const defaultPreassignedFareProduct =
-    preassignedFareProduct ?? selectableProducts[1]; //Default 30day ticket
+    preassignedFareProduct ??
+    (specificProductIndex >= 0
+      ? selectableProducts[specificProductIndex]
+      : selectableProducts[0]);
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(tariffZones);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -34,7 +34,7 @@ export function useOfferDefaults(
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
   const defaultPreassignedFareProduct =
-    preassignedFareProduct ?? selectableProducts[0];
+    preassignedFareProduct ?? selectableProducts[1];
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(tariffZones);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -34,7 +34,7 @@ export function useOfferDefaults(
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
   const defaultPreassignedFareProduct =
-    preassignedFareProduct ?? selectableProducts[1]; //Default 30 day ticket
+    preassignedFareProduct ?? selectableProducts[1]; //Default 30day ticket
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(tariffZones);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -34,7 +34,7 @@ export function useOfferDefaults(
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
   const defaultPreassignedFareProduct =
-    preassignedFareProduct ?? selectableProducts[1];
+    preassignedFareProduct ?? selectableProducts[1]; //Default 30 day ticket
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(tariffZones);

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -35,10 +35,11 @@ export const TicketAssistant_CategoryPickerScreen = ({
 
   const focusRef = useFocusOnLoad(true, 200);
 
-  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+  const {fareProductTypeConfigs, preassignedFareProducts} =
+    useFirestoreConfiguration();
 
   const offerDefaults = useOfferDefaults(
-    undefined,
+    preassignedFareProducts[0],
     fareProductTypeConfigs[0].type,
   );
   const {updateInputParams} = useTicketAssistantState();

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -35,11 +35,10 @@ export const TicketAssistant_CategoryPickerScreen = ({
 
   const focusRef = useFocusOnLoad(true, 200);
 
-  const {fareProductTypeConfigs, preassignedFareProducts} =
-    useFirestoreConfiguration();
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
   const offerDefaults = useOfferDefaults(
-    preassignedFareProducts[0],
+    undefined,
     fareProductTypeConfigs[0].type,
   );
   const {updateInputParams} = useTicketAssistantState();


### PR DESCRIPTION
Setting default ticket to 30 day ticket for atb.

The issue mentions to talk with NFK and Fram, however their default is already the 30day ticket and as the solution is done in this specific way of identifying the ticket I didn't see it necessary to contact them.