### PR TITLE
fix: add correct accessibility text for label in traveller selection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -18,6 +18,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {ContentHeading} from '@atb/components/content-heading';
 import {LabelInfo} from '@atb/components/label-info';
 import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {LabelInfoTexts} from '@atb/translations/components/LabelInfo';
 
 type TravellerSelectionProps = {
   selectableUserProfiles: UserProfileWithCount[];
@@ -105,6 +106,9 @@ export function TravellerSelection({
       ) +
       ' ' +
       travellersDetailsText +
+      (isOnBehalfOfEnabled
+        ? screenReaderPause + t(LabelInfoTexts.labels['new'])
+        : '') +
       screenReaderPause,
     accessibilityHint: t(PurchaseOverviewTexts.travellerSelection.a11yHint),
   };


### PR DESCRIPTION
Fix for this comment : https://github.com/AtB-AS/kundevendt/issues/15546#issuecomment-1860559898

Add a label text for the screen reader.

Pretty straightforward fix.