### PR TITLE
fix: Show announcements vertically on screen reader

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -9,6 +9,7 @@ import {useNow} from '@atb/utils/use-now';
 import {StyleSheet} from '@atb/theme';
 import {useHasSeenShareTravelHabitsScreen} from '@atb/beacons/use-has-seen-share-travel-habits-screen';
 import {useBeaconsState} from '@atb/beacons/BeaconsContext';
+import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
 
 type Props = {
   style?: StyleProp<ViewStyle>;
@@ -22,6 +23,7 @@ export const Announcements = ({style: containerStyle}: Props) => {
   const [hasSeenShareTravelHabitsScreen, _] =
     useHasSeenShareTravelHabitsScreen();
   const style = useStyle();
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   const ruleVariables = {
     isBeaconsOnboarded: kettleInfo?.isBeaconsOnboarded ?? false,
@@ -34,6 +36,9 @@ export const Announcements = ({style: containerStyle}: Props) => {
 
   if (filteredAnnouncements.length === 0) return null;
 
+  const showHorizontally =
+    !isScreenReaderEnabled && filteredAnnouncements.length > 1;
+
   return (
     <View style={containerStyle} testID="announcements">
       <View style={style.headerWrapper}>
@@ -41,13 +46,13 @@ export const Announcements = ({style: containerStyle}: Props) => {
       </View>
       <ScrollView
         contentContainerStyle={style.scrollView}
-        horizontal={filteredAnnouncements.length > 1}
+        horizontal={showHorizontally}
       >
         {filteredAnnouncements.map((a) => (
           <Announcement
             key={a.id}
             announcement={a}
-            style={filteredAnnouncements.length > 1 && style.announcement}
+            style={showHorizontally && style.announcement}
           />
         ))}
       </ScrollView>
@@ -62,6 +67,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   scrollView: {
     paddingHorizontal: theme.spacings.medium,
     columnGap: theme.spacings.medium,
+    rowGap: theme.spacings.medium,
   },
   announcement: {
     width: Dimensions.get('window').width * 0.9 - 2 * theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -66,8 +66,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   },
   scrollView: {
     paddingHorizontal: theme.spacings.medium,
-    columnGap: theme.spacings.medium,
-    rowGap: theme.spacings.medium,
+    gap: theme.spacings.medium,
   },
   announcement: {
     width: Dimensions.get('window').width * 0.9 - 2 * theme.spacings.medium,


### PR DESCRIPTION
Found during testing of https://github.com/AtB-AS/kundevendt/issues/15746

Screen reader on iOS reads horisontal content horizontally, which means all the titles will be read as one "row", then all the descriptions as the next row, etc.

The easies solution to fix this is to align announcements vertically for screen readers since they have to scroll through them anyways.