### PR TITLE
fix: Use <ContentHeader> on Dashboard and MapFilters

### DIFF
--- a/src/components/content-heading/ContentHeading.tsx
+++ b/src/components/content-heading/ContentHeading.tsx
@@ -1,6 +1,6 @@
 import {StyleSheet} from '@atb/theme';
 import React from 'react';
-import {View} from 'react-native';
+import {StyleProp, View, ViewStyle} from 'react-native';
 import {ThemeText} from '../text';
 import {ContrastColor, StaticColor, TextColor} from '@atb/theme/colors';
 
@@ -8,17 +8,19 @@ type ContentHeadingProps = {
   text: string;
   color?: TextColor | StaticColor | ContrastColor;
   accessibilityLabel?: string;
+  style?: StyleProp<ViewStyle>;
 };
 
 export function ContentHeading({
   text,
   color = 'secondary',
   accessibilityLabel,
+  style,
 }: ContentHeadingProps): JSX.Element {
   const styles = useStyles();
 
   return (
-    <View style={styles.container}>
+    <View style={[style, styles.container]}>
       <ThemeText
         type="body__secondary"
         color={color}

--- a/src/mobility/components/filter/FormFactorFilter.tsx
+++ b/src/mobility/components/filter/FormFactorFilter.tsx
@@ -5,11 +5,11 @@ import {useTranslation} from '@atb/translations';
 import {useOperatorToggle} from './use-operator-toggle';
 import {useOperators} from '../../use-operators';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
-import {ThemeText} from '@atb/components/text';
-import {useFilterStyle} from '@atb/mobility/components/filter/use-filter-style';
 import {View, ViewStyle} from 'react-native';
 import {SvgProps} from 'react-native-svg';
 import {FormFactorFilterType} from '@atb/components/map';
+import {ContentHeading} from '@atb/components/content-heading';
+import {StyleSheet} from '@atb/theme';
 
 type Props = {
   formFactor: FormFactor;
@@ -27,7 +27,7 @@ export const FormFactorFilter = ({
   style,
 }: Props) => {
   const {t} = useTranslation();
-  const filterStyle = useFilterStyle();
+  const styles = useStyle();
   const operators = useOperators().byFormFactor(formFactor);
   const {showAll, isChecked, onAllToggle, onOperatorToggle} = useOperatorToggle(
     operators,
@@ -36,10 +36,8 @@ export const FormFactorFilter = ({
   );
 
   return (
-    <View style={style}>
-      <ThemeText style={filterStyle.sectionHeader} type="body__secondary">
-        {t(MobilityTexts.formFactor(formFactor))}
-      </ThemeText>
+    <View style={[style, styles.container]}>
+      <ContentHeading text={t(MobilityTexts.formFactor(formFactor))} />
       <Section>
         {operators.length !== 1 && (
           <ToggleSectionItem
@@ -61,3 +59,9 @@ export const FormFactorFilter = ({
     </View>
   );
 };
+
+export const useStyle = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    rowGap: theme.spacings.small,
+  },
+}));

--- a/src/mobility/components/filter/MobilityFilters.tsx
+++ b/src/mobility/components/filter/MobilityFilters.tsx
@@ -3,7 +3,6 @@ import React, {useState} from 'react';
 import {useIsCityBikesEnabled, useIsVehiclesEnabled} from '@atb/mobility';
 import {useIsCarSharingEnabled} from '@atb/mobility/use-car-sharing-enabled';
 import {StyleSheet} from '@atb/theme';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
   Bicycle,
   Car,
@@ -11,6 +10,7 @@ import {
 } from '@atb/assets/svg/mono-icons/transportation-entur';
 import {FormFactorFilterType, MobilityMapFilterType} from '@atb/components/map';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {View} from 'react-native';
 
 type Props = {
   filter: MobilityMapFilterType;
@@ -18,7 +18,7 @@ type Props = {
 };
 
 export const MobilityFilters = ({filter, onFilterChanged}: Props) => {
-  const style = useStyle();
+  const styles = useStyle();
   const isVehiclesEnabled = useIsVehiclesEnabled();
   const isCityBikesEnabled = useIsCityBikesEnabled();
   const isCarSharingEnabled = useIsCarSharingEnabled();
@@ -36,10 +36,9 @@ export const MobilityFilters = ({filter, onFilterChanged}: Props) => {
     };
 
   return (
-    <>
+    <View style={styles.container}>
       {isVehiclesEnabled && (
         <FormFactorFilter
-          style={style.filterGroup}
           formFactor={FormFactor.Scooter}
           icon={Scooter}
           initialFilter={filter[FormFactor.Scooter]}
@@ -48,7 +47,6 @@ export const MobilityFilters = ({filter, onFilterChanged}: Props) => {
       )}
       {isCityBikesEnabled && (
         <FormFactorFilter
-          style={style.filterGroup}
           formFactor={FormFactor.Bicycle}
           icon={Bicycle}
           initialFilter={filter[FormFactor.Bicycle]}
@@ -63,22 +61,12 @@ export const MobilityFilters = ({filter, onFilterChanged}: Props) => {
           onFilterChange={onFormFactorFilterChanged(FormFactor.Car)}
         />
       )}
-    </>
+    </View>
   );
 };
 
-const useStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
-  return {
-    activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacings.medium),
-    },
-    container: {
-      marginHorizontal: theme.spacings.medium,
-      marginBottom: theme.spacings.medium,
-    },
-    filterGroup: {
-      marginBottom: theme.spacings.large,
-    },
-  };
-});
+const useStyle = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    rowGap: theme.spacings.small,
+  },
+}));

--- a/src/mobility/components/filter/use-filter-style.tsx
+++ b/src/mobility/components/filter/use-filter-style.tsx
@@ -1,7 +1,0 @@
-import {StyleSheet} from '@atb/theme';
-
-export const useFilterStyle = StyleSheet.createThemeHook((theme) => ({
-  sectionHeader: {
-    marginBottom: theme.spacings.small,
-  },
-}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
@@ -425,7 +425,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
     margin: 0,
   },
   contentSection: {
-    marginTop: theme.spacings.large,
+    marginTop: theme.spacings.medium,
     marginHorizontal: theme.spacings.medium,
   },
   contentSection__horizontalScroll: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -2,26 +2,26 @@ import {Dimensions, StyleProp, View, ViewStyle} from 'react-native';
 import {useAnnouncementsState} from '@atb/announcements';
 import {ScrollView} from 'react-native-gesture-handler';
 import {Announcement} from './Announcement';
-import {SectionHeading} from './SectionHeading';
 import {DashboardTexts, useTranslation} from '@atb/translations';
 import {isWithinTimeRange} from '@atb/utils/is-within-time-range';
 import {useNow} from '@atb/utils/use-now';
 import {StyleSheet} from '@atb/theme';
 import {useHasSeenShareTravelHabitsScreen} from '@atb/beacons/use-has-seen-share-travel-habits-screen';
 import {useBeaconsState} from '@atb/beacons/BeaconsContext';
+import {ContentHeading} from '@atb/components/content-heading';
 
 type Props = {
   style?: StyleProp<ViewStyle>;
 };
 
-export const Announcements = ({style: containerStyle}: Props) => {
+export const Announcements = ({style}: Props) => {
   const {findAnnouncements} = useAnnouncementsState();
   const {t} = useTranslation();
   const now = useNow(10000);
   const {kettleInfo} = useBeaconsState();
   const [hasSeenShareTravelHabitsScreen, _] =
     useHasSeenShareTravelHabitsScreen();
-  const style = useStyle();
+  const styles = useStyle();
 
   const ruleVariables = {
     isBeaconsOnboarded: kettleInfo?.isBeaconsOnboarded ?? false,
@@ -35,19 +35,22 @@ export const Announcements = ({style: containerStyle}: Props) => {
   if (filteredAnnouncements.length === 0) return null;
 
   return (
-    <View style={containerStyle} testID="announcements">
-      <View style={style.headerWrapper}>
-        <SectionHeading>{t(DashboardTexts.announcemens.header)}</SectionHeading>
+    <View style={[style, styles.container]} testID="announcements">
+      <View style={styles.headerWrapper}>
+        <ContentHeading
+          color="background_accent_0"
+          text={t(DashboardTexts.announcemens.header)}
+        />
       </View>
       <ScrollView
-        contentContainerStyle={style.scrollView}
+        contentContainerStyle={styles.scrollView}
         horizontal={filteredAnnouncements.length > 1}
       >
         {filteredAnnouncements.map((a) => (
           <Announcement
             key={a.id}
             announcement={a}
-            style={filteredAnnouncements.length > 1 && style.announcement}
+            style={filteredAnnouncements.length > 1 && styles.announcement}
           />
         ))}
       </ScrollView>
@@ -56,6 +59,9 @@ export const Announcements = ({style: containerStyle}: Props) => {
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    rowGap: theme.spacings.small,
+  },
   headerWrapper: {
     marginHorizontal: theme.spacings.medium,
   },

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
@@ -14,8 +14,8 @@ import {
 } from '@atb/translations';
 import React from 'react';
 import {View, ViewStyle} from 'react-native';
-import {SectionHeading} from './SectionHeading';
 import {useTimeContextState} from '@atb/time';
+import {ContentHeading} from '@atb/components/content-heading';
 
 type Props = {
   onPressDetails?: (isCarnet: boolean, orderId: string) => void;
@@ -42,10 +42,11 @@ export const CompactFareContracts: React.FC<Props> = ({
     useFirestoreConfiguration();
 
   return (
-    <View style={style}>
-      <SectionHeading accessibilityLabel={t(TicketingTexts.header.title)}>
-        {t(TicketingTexts.header.title)}
-      </SectionHeading>
+    <View style={[style, itemStyle.container]}>
+      <ContentHeading
+        color="background_accent_0"
+        text={t(TicketingTexts.header.title)}
+      />
       {validFareContracts.length == 0 ? (
         <Button
           text={t(DashboardTexts.buyButton)}
@@ -53,45 +54,41 @@ export const CompactFareContracts: React.FC<Props> = ({
           testID="buyTicketsButton"
         />
       ) : (
-        validFareContracts.map((fareContract, index) => {
-          const fareContractInfoDetailsProps = getFareContractInfoDetails(
-            fareContract,
-            serverNow,
-            tariffZones,
-            userProfiles,
-            preassignedFareProducts,
-          );
-          return (
-            <CompactFareContractInfo
-              style={{
-                ...itemStyle.fareContract,
-                ...(index === validFareContracts.length - 1
-                  ? itemStyle.fareContract__last
-                  : {}),
-              }}
-              key={fareContract.id}
-              {...fareContractInfoDetailsProps}
-              now={serverNow}
-              onPressDetails={() => {
-                onPressDetails?.(
-                  fareContractInfoDetailsProps.isCarnetFareContract ?? false,
-                  fareContract.orderId,
-                );
-              }}
-              testID={'fareContract' + index}
-            />
-          );
-        })
+        <View style={itemStyle.fareContracts}>
+          {validFareContracts.map((fareContract, index) => {
+            const fareContractInfoDetailsProps = getFareContractInfoDetails(
+              fareContract,
+              serverNow,
+              tariffZones,
+              userProfiles,
+              preassignedFareProducts,
+            );
+            return (
+              <CompactFareContractInfo
+                key={fareContract.id}
+                {...fareContractInfoDetailsProps}
+                now={serverNow}
+                onPressDetails={() => {
+                  onPressDetails?.(
+                    fareContractInfoDetailsProps.isCarnetFareContract ?? false,
+                    fareContract.orderId,
+                  );
+                }}
+                testID={'fareContract' + index}
+              />
+            );
+          })}
+        </View>
       )}
     </View>
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  fareContract: {
-    marginBottom: theme.spacings.small,
+  container: {
+    rowGap: theme.spacings.small,
   },
-  fareContract__last: {
-    marginBottom: 0,
+  fareContracts: {
+    rowGap: theme.spacings.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -28,7 +28,7 @@ import {
   LinkSectionItem,
   Section,
 } from '@atb/components/sections';
-import {SectionHeading} from './SectionHeading';
+import {ContentHeading} from '@atb/components/content-heading';
 
 type Props = {
   onEditFavouriteDeparture: () => void;
@@ -76,8 +76,11 @@ export const DeparturesWidget = ({
 
   return (
     <View style={style}>
-      <SectionHeading>{t(DeparturesTexts.widget.heading)}</SectionHeading>
-
+      <ContentHeading
+        style={styles.heading}
+        color="background_accent_0"
+        text={t(DeparturesTexts.widget.heading)}
+      />
       {!favoriteDepartures.length && (
         <Section>
           <GenericSectionItem>
@@ -160,6 +163,9 @@ function compareStopsByDistance(
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
+  heading: {
+    marginBottom: theme.spacings.small,
+  },
   noFavouritesView: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16120

Uses the ContentHeader component on Dashboard and MapFilters to ensure a more unified look through the app

<details>
<summary>Before</summary>

![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 25 17](https://github.com/AtB-AS/mittatb-app/assets/4981580/4a7a44d3-2873-4967-8495-f834e7f0429d)
![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 25 26](https://github.com/AtB-AS/mittatb-app/assets/4981580/5ed386d9-5ced-4aaa-a7fb-212a71a1cc3f)

</details>


<details>
<summary>After</summary>

![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 25 52](https://github.com/AtB-AS/mittatb-app/assets/4981580/4c6b7318-c511-4b2b-aed0-a483d0014745)
![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 26 00](https://github.com/AtB-AS/mittatb-app/assets/4981580/38e413c0-219a-4f32-a9f9-b3788224f68f)


</details>