### PR TITLE
fix: Top margin in PrivacyScreen

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -68,7 +68,7 @@ export const Profile_PrivacyScreen = () => {
             </Section>
           </>
         )}
-        <Section style={isBeaconsSupported ? style.spacingTop : undefined}>
+        <Section style={style.spacingTop}>
           <LinkSectionItem
             text={t(
               ProfileTexts.sections.privacy.linkSectionItems.privacy.label,
@@ -175,6 +175,7 @@ export const Profile_PrivacyScreen = () => {
 const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   content: {
     marginHorizontal: theme.spacings.medium,
+    marginTop: theme.spacings.small,
     rowGap: theme.spacings.small,
   },
   spacingTop: {


### PR DESCRIPTION
Fixes margin at the top of the page both when beacons are enabled and not


<details>
<summary>Before</summary>

![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 59 38](https://github.com/AtB-AS/mittatb-app/assets/4981580/c5a57619-73a7-4ef6-b22d-afaffab9bf3c)
![Simulator Screenshot - iPhone 15 - 2023-12-22 at 15 00 12](https://github.com/AtB-AS/mittatb-app/assets/4981580/2961ab6b-b8cf-4af9-99d9-1e257bf54ee9)

</details>

<details>
<summary>After</summary>

![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 59 11](https://github.com/AtB-AS/mittatb-app/assets/4981580/a63f422c-fe35-4d9a-97c5-2f39e3c9647a)
![Simulator Screenshot - iPhone 15 - 2023-12-22 at 14 58 46](https://github.com/AtB-AS/mittatb-app/assets/4981580/25419808-4c65-4014-9d50-5f2b416111a7)


</details>