### PR TITLE
fix: Update new/beta label design

### DIFF
--- a/src/components/label-info/LabelInfo.tsx
+++ b/src/components/label-info/LabelInfo.tsx
@@ -21,7 +21,7 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
   return (
     <View style={linkSectionItemStyle.flag}>
-      <ThemeText color="background_accent_3" type="body__tertiary">
+      <ThemeText color="info" type="body__tertiary">
         {flagTranslated}
       </ThemeText>
     </View>
@@ -30,10 +30,10 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   flag: {
-    backgroundColor: theme.static.background.background_accent_3.background,
+    backgroundColor: theme.static.status.info.background,
     marginRight: theme.spacings.medium,
     paddingHorizontal: theme.spacings.small,
     paddingVertical: theme.spacings.xSmall,
-    borderRadius: theme.border.radius.regular,
+    borderRadius: theme.border.radius.circle,
   },
 }));


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/7415

Note that the images in the linked issue to not agree 100% with the [Figma sketches](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=16551-85510&mode=design&t=pCpX2mgFwu33Q2u4-0). The labels in the issue are aligned to the left with the text, while in Figma they are aligned to the right, next to the arrow. This PR keeps them right aligned in accordance with Figma.