### PR TITLE
feat: add description to zones

### DIFF
--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -52,6 +52,7 @@ export type TariffZone = {
   version: string;
   geometry: Omit<Polygon, 'type'> & {type: any};
   isDefault?: boolean;
+  description: LanguageAndTextType[];
 };
 
 export type PointToPointValidity = {

--- a/src/tariff-zones-selector/TariffZoneResults.tsx
+++ b/src/tariff-zones-selector/TariffZoneResults.tsx
@@ -5,7 +5,11 @@ import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {getReferenceDataName, TariffZone} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
-import {TariffZoneSearchTexts, useTranslation} from '@atb/translations';
+import {
+  getTextForLanguage,
+  TariffZoneSearchTexts,
+  useTranslation,
+} from '@atb/translations';
 import {insets} from '@atb/utils/insets';
 import React from 'react';
 import {ScrollView, View} from 'react-native';
@@ -55,6 +59,11 @@ export const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                   <ThemeText type="body__primary--bold">
                     {getReferenceDataName(tariffZone, language)}
                   </ThemeText>
+                  {tariffZone.description && (
+                    <ThemeText type="body__secondary">
+                      {getTextForLanguage(tariffZone.description, language)}
+                    </ThemeText>
+                  )}
                 </View>
                 {tariffZoneFromLocation?.id === tariffZone.id ? (
                   <View style={styles.currentLocationIcon}>
@@ -90,6 +99,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   },
   nameContainer: {
     marginLeft: theme.spacings.large,
+    flex: 1,
   },
   currentLocationIcon: {
     marginLeft: theme.spacings.small,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/9642

This will add description to the zone selector. Descriptions are added to another PR in firestore-configuration repo.  https://github.com/AtB-AS/firestore-configuration/pull/418. 

Please see the screenshot below to see how it looks with/without description.

<details>
  <summary>Screenshot</summary>

<img width="300" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/7b9ecc5e-d610-4a3a-bd29-76a2698adace">

</details>