### PR TITLE
feat: Check if token should be renewed

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -40,6 +40,9 @@ import {tokenService} from './tokenService';
 import {tokenReducer} from '@atb/mobile-token/tokenReducer';
 import {useQueryClient} from '@tanstack/react-query';
 import {GET_TOKEN_TOGGLE_DETAILS_QUERY_KEY} from '@atb/mobile-token/use-token-toggle-details';
+import {useInterval} from '@atb/utils/use-interval';
+
+const SIX_HOURS_MS = 1000 * 60 * 60 * 6;
 
 type MobileTokenContextState = {
   tokens: Token[];
@@ -153,18 +156,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
          Errors that needs a certain action should already be handled. Just log
          to Bugsnag here.
          */
-        updateMetadata({
-          'AtB-Mobile-Token-Id': undefined,
-          'AtB-Mobile-Token-Status': 'error',
-          'AtB-Mobile-Token-Error-Correlation-Id': traceId,
-        });
-        Bugsnag.notify(err, (event) => {
-          event.addMetadata('token', {
-            userId,
-            traceId,
-            description: 'Error loading native and remote tokens',
-          });
-        });
+        logError(err, traceId, userId);
       } finally {
         // We've finished with remote tokens. Cancel timeout notification.
         cancelTimeoutHandler();
@@ -175,6 +167,43 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
   useEffect(() => {
     load();
   }, [load]);
+
+  useInterval(
+    async function checkIfRenewNecessaryEverySixHours() {
+      const token = state.nativeToken;
+      if (!token) return;
+      Bugsnag.leaveBreadcrumb(
+        `Checking if token (id: ${token.tokenId}, validityEnd: ${token.validityEnd}) should be renewed`,
+      );
+
+      const traceId = uuid();
+      try {
+        const shouldRenew = await mobileTokenClient.shouldRenew(token);
+        if (shouldRenew) {
+          Bugsnag.leaveBreadcrumb(`Renewing token (id: ${token.tokenId})`);
+          const renewedToken = await mobileTokenClient.renew(token, traceId);
+          const updatedRemoteTokens = await loadRemoteTokens(traceId);
+
+          Bugsnag.leaveBreadcrumb(
+            `Token (new id: ${renewedToken.tokenId}) renewed successfully`,
+          );
+          dispatch({
+            type: 'SUCCESS',
+            nativeToken: renewedToken,
+            remoteTokens: updatedRemoteTokens,
+          });
+        }
+      } catch (err: any) {
+        dispatch({type: 'ERROR'});
+        logError(err, traceId, userId);
+      }
+    },
+    // 10000,
+    SIX_HOURS_MS,
+    [state.nativeToken, userId],
+    false,
+    true,
+  );
 
   /**
    * Retrieve the signed representation of the native token. This signed token
@@ -486,4 +515,19 @@ const getTokenToggleDetails = async () => {
   } catch (err) {
     return undefined;
   }
+};
+
+const logError = (err: Error, traceId: string, userId?: string) => {
+  updateMetadata({
+    'AtB-Mobile-Token-Id': undefined,
+    'AtB-Mobile-Token-Status': 'error',
+    'AtB-Mobile-Token-Error-Correlation-Id': traceId,
+  });
+  Bugsnag.notify(err, (event) => {
+    event.addMetadata('token', {
+      userId,
+      traceId,
+      description: 'Error loading native and remote tokens',
+    });
+  });
 };

--- a/src/mobile-token/mobileTokenClient.ts
+++ b/src/mobile-token/mobileTokenClient.ts
@@ -10,6 +10,8 @@ import {tokenService} from './tokenService';
 
 const CONTEXT_ID = 'main';
 
+const TWELVE_HOURS_MS = 1000 * 60 * 60 * 12;
+
 const abtClient = createClient({
   tokenContextIds: [CONTEXT_ID],
   attestation: {
@@ -33,4 +35,12 @@ export const mobileTokenClient = {
   clear: () => abtClient.clearToken(CONTEXT_ID),
   renew: (token: ActivatedToken, traceId: string) =>
     abtClient.renewToken(token, traceId),
+  /*
+  Check if token should be renewed. Will return true if either:
+   - Token is expired
+   - It is less than 12 hours until token expires
+   - More than 90 % of the token validity time has expired
+   */
+  shouldRenew: (token: ActivatedToken) =>
+    abtClient.shouldPreemptiveRenew(token, TWELVE_HOURS_MS, 90),
 };


### PR DESCRIPTION
Every 6 hours, check if token needs to be renewed.

Checks by using the native token validity end. Won't catch changes
to the validity done online. To catch that a validation (on app
start) is necessary.

The original plan was to validate with a given interval, but as first 
measure we try this instead, which is less intruding and doesn't
need network requests.
