### PR TITLE
refactor: Remove unused header without navigation

### DIFF
--- a/src/components/screen-header/HeaderButton.tsx
+++ b/src/components/screen-header/HeaderButton.tsx
@@ -47,93 +47,26 @@ export const HeaderButton: React.FC<HeaderButtonProps> = (buttonProps) => {
     return null;
   }
 
-  const onPress = () => {
+  const {onPress, children, ...accessibilityProps} = iconButton;
+
+  const onPressWithLogEvent = () => {
     if (buttonProps.analyticsEventContext) {
       analytics.logEvent(
         buttonProps.analyticsEventContext,
         `Header button of type ${buttonProps.type} clicked`,
       );
     }
-    iconButton.onPress?.();
+    onPress?.();
   };
-
-  return <BaseHeaderButton {...iconButton} onPress={onPress} />;
-};
-
-export type HeaderButtonWithoutNavigationProps = {
-  text: string;
-  onPress: () => void;
-  type: ButtonModes;
-  analyticsEventContext?: HeaderButtonProps['analyticsEventContext'];
-  color?: StaticColor | TextColor;
-  testID?: string;
-} & AccessibilityProps;
-
-export const HeaderButtonWithoutNavigation = ({
-  text,
-  onPress,
-  type,
-  analyticsEventContext,
-  color,
-  ...accessibilityProps
-}: HeaderButtonWithoutNavigationProps) => {
-  const analytics = useAnalytics();
-  const onPressToUse = () => {
-    if (analyticsEventContext) {
-      analytics.logEvent(
-        analyticsEventContext,
-        `Header button of type ${type} clicked`,
-      );
-    }
-    onPress();
-  };
-
-  return (
-    <BaseHeaderButton onPress={onPressToUse} {...accessibilityProps}>
-      <ThemeText color={color}>{text}</ThemeText>
-    </BaseHeaderButton>
-  );
-};
-
-const BaseHeaderButton = ({
-  onPress,
-  children,
-  ...accessibilityProps
-}: IconButtonProps) => (
-  <PressableOpacity
-    onPress={onPress}
-    hitSlop={insets.all(12)}
-    accessibilityRole="button"
-    {...accessibilityProps}
-  >
-    {children}
-  </PressableOpacity>
-);
-
-export type LargeHeaderButtonProps = Omit<HeaderButtonProps, 'type' | 'text'>;
-export const LargeHeaderButton = (buttonProps: LargeHeaderButtonProps) => {
-  const navigation = useNavigation();
-  const {t} = useTranslation();
-  const {theme} = useTheme();
-  const {color, onPress, ...props} = buttonProps;
 
   return (
     <PressableOpacity
-      onPress={onPress || navigation.goBack}
-      accessibilityHint={t(ScreenHeaderTexts.headerButton.back.a11yHint)}
+      onPress={onPressWithLogEvent}
       hitSlop={insets.all(12)}
       accessibilityRole="button"
-      style={{flexDirection: 'row'}}
-      {...props}
+      {...accessibilityProps}
     >
-      <ThemeIcon
-        colorType={color}
-        svg={ArrowLeft}
-        style={{marginRight: theme.spacings.xSmall}}
-      />
-      <ThemeText color={color}>
-        {t(ScreenHeaderTexts.headerButton.back.text)}
-      </ThemeText>
+      {children}
     </PressableOpacity>
   );
 };

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -4,14 +4,12 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import React, {ReactNode, useMemo, useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
   ButtonModes,
   HeaderButton,
   HeaderButtonProps,
-  HeaderButtonWithoutNavigation,
-  HeaderButtonWithoutNavigationProps,
 } from './HeaderButton';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {getStaticColor, StaticColor} from '@atb/theme/colors';
@@ -50,76 +48,18 @@ export type ScreenHeaderProps = {
   textOpacity?: number;
 };
 
-export const ScreenHeader: React.FC<ScreenHeaderProps> = (props) => {
-  const themeColor = props.color ?? 'background_accent_0';
-
-  const leftIcon = props.leftButton ? (
-    <HeaderButton color={themeColor} {...props.leftButton} testID="lhb" />
-  ) : (
-    <View />
-  );
-  const rightIcon = props.rightButton ? (
-    <HeaderButton color={themeColor} {...props.rightButton} testID="rhb" />
-  ) : (
-    <View />
-  );
-
-  return <BaseHeader leftIcon={leftIcon} rightIcon={rightIcon} {...props} />;
-};
-
-type ScreenHeaderWithoutNavigationProps = Omit<ScreenHeaderProps, 'style'> & {
-  leftButton?: HeaderButtonWithoutNavigationProps;
-  rightButton?: HeaderButtonWithoutNavigationProps;
-};
-
-/**
- * A screen header to use in contexts outside a stack navigation, for example in
- * bottom sheet. This is necessary as the normal screen header accesses the
- * navigation object, which throws an error outside of a stack navigations.
- */
-export const ScreenHeaderWithoutNavigation = (
-  props: ScreenHeaderWithoutNavigationProps,
-) => {
-  const styles = useHeaderStyle();
-  const themeColor = props.color ?? 'background_accent_0';
-  const leftIcon = props.leftButton ? (
-    <HeaderButtonWithoutNavigation color={themeColor} {...props.leftButton} />
-  ) : (
-    <View />
-  );
-  const rightIcon = props.rightButton ? (
-    <HeaderButtonWithoutNavigation color={themeColor} {...props.rightButton} />
-  ) : (
-    <View />
-  );
-
-  return (
-    <BaseHeader
-      style={styles.withoutNavigationContainer}
-      leftIcon={leftIcon}
-      rightIcon={rightIcon}
-      {...props}
-    />
-  );
-};
-
-type BaseHeaderProps = ScreenHeaderProps & {
-  rightIcon: ReactNode;
-  leftIcon: ReactNode;
-};
-
-const BaseHeader = ({
+export const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   color,
   setFocusOnLoad,
   style,
   title,
   titleA11yLabel,
   globalMessageContext,
-  leftIcon,
-  rightIcon,
+  leftButton,
+  rightButton,
   textOpacity = 1,
-}: BaseHeaderProps) => {
-  const css = useHeaderStyle();
+}) => {
+  const styles = useStyles();
   const {theme, themeName} = useTheme();
   const themeColor = color ?? 'background_accent_0';
   const focusRef = useFocusOnLoad(setFocusOnLoad);
@@ -128,15 +68,26 @@ const BaseHeader = ({
 
   const backgroundColor = getStaticColor(themeName, themeColor).background;
 
+  const leftIcon = leftButton ? (
+    <HeaderButton color={themeColor} {...leftButton} testID="lhb" />
+  ) : (
+    <View />
+  );
+  const rightIcon = rightButton ? (
+    <HeaderButton color={themeColor} {...rightButton} testID="rhb" />
+  ) : (
+    <View />
+  );
+
   return (
-    <View style={[css.container, style, {backgroundColor}]}>
+    <View style={[styles.container, style, {backgroundColor}]}>
       <View
         accessibilityLabel={titleA11yLabel}
         accessible={!!title && !!textOpacity}
         importantForAccessibility={!!title ? 'yes' : 'no-hide-descendants'}
         accessibilityRole="header"
         style={[
-          css.headerTitle,
+          styles.headerTitle,
           {
             // Make space for absolute positioned buttons in case they are offset below title
             marginBottom: theme.spacings.medium + buttonsTopOffset,
@@ -145,11 +96,7 @@ const BaseHeader = ({
         onLayout={setLayoutFor('container')}
         ref={focusRef}
       >
-        <View
-          style={{
-            opacity: textOpacity,
-          }}
-        >
+        <View style={{opacity: textOpacity}}>
           <ThemeText
             accessible={false}
             onLayout={setLayoutFor('title')}
@@ -163,18 +110,9 @@ const BaseHeader = ({
 
       <View
         style={[
-          css.buttons,
+          styles.buttons,
           {
-            /**
-             * TODO: This is a hack to make sure the buttons are positioned
-             * correctly when padding is passed as a prop, specifically for the
-             * bottom sheet. Can be removed when the bottom sheet starts using
-             * its own header. (https://github.com/AtB-AS/kundevendt/issues/4211)
-             */
-            top:
-              (typeof style?.paddingTop?.valueOf() === 'number'
-                ? (style.paddingTop.valueOf() as number)
-                : theme.spacings.medium) + buttonsTopOffset,
+            top: theme.spacings.medium + buttonsTopOffset,
             height: buttonsHeight,
           },
         ]}
@@ -184,23 +122,17 @@ const BaseHeader = ({
       </View>
       <GlobalMessage
         globalMessageContext={globalMessageContext}
-        style={css.globalMessageBox}
+        style={styles.globalMessageBox}
         textColor={themeColor}
       />
     </View>
   );
 };
 
-const useHeaderStyle = StyleSheet.createThemeHook((theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     paddingHorizontal: theme.spacings.medium,
     paddingTop: theme.spacings.medium,
-  },
-  withoutNavigationContainer: {
-    paddingTop: theme.spacings.large,
-    paddingBottom: theme.spacings.small,
-    borderTopLeftRadius: theme.border.radius.circle,
-    borderTopRightRadius: theme.border.radius.circle,
   },
   headerTitle: {alignItems: 'center'},
   buttons: {

--- a/src/components/screen-header/index.ts
+++ b/src/components/screen-header/index.ts
@@ -1,4 +1,4 @@
-export {ScreenHeader, ScreenHeaderWithoutNavigation} from './ScreenHeader';
+export {ScreenHeader} from './ScreenHeader';
 export {FullScreenHeader} from './FullScreenHeader';
 export {AnimatedScreenHeader} from './AnimatedScreenHeader';
 export type {IconButtonProps} from './HeaderButton';


### PR DESCRIPTION
They were used in bottom sheets, but are no longer in use when the
bottom sheets have gotten a new header.
