### PR TITLE
fix: updating beacons text and adding translations

### DIFF
--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -78,17 +78,17 @@
 		</dict>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.</string>
+	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.</string>
+	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.</string>
+	<string>I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.</string>
+	<string>I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Vi bruker posisjon til å vise din posisjon i kart og reisesøk, og til å finne holdeplasser og steder i nærheten.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>Du gir tillatelse til å bruke bevegelsesdata til analyse og større forståelse av reisemønster, f.eks. for å skille mellom sykling, gåing og bilkjøring.</string>
+	<string>Du gir oss lov til å bruke disse dataene for å lære mer om dine reisevaner. Vi kan for eksempel se om kunder velger å sykle, gå eller kjøre bil fremfor å busse. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Send bilder for å hjelpe til med å løse problemer i appen</string>
 	<key>NSCameraUsageDescription</key>

--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -1,5 +1,11 @@
-"NSLocationAlwaysAndWhenInUseUsageDescription" = "In addition to displaying your location on maps and planning trips, we gain valuable insights into where you and other customers travel. This helps us improve our travel offerings.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "In addition to being able to show your position on maps and to plan journeys, we will gain valuable learning about where you and other customers travel. The data is used to improve our services to make them better for you.";
 
-"NSLocationAlwaysUsageDescription" = "In addition to displaying your location on maps and planning trips, we gain valuable insights into where you and other customers travel. This helps us improve our travel offerings.";
+"NSLocationAlwaysUsageDescription" = "In addition to being able to show your position on maps and to plan journeys, we will gain valuable learning about where you and other customers travel. The data is used to improve our services to make them better for you.";
 
 "NSLocationWhenInUseUsageDescription" = "We use your location to display it on maps and in travel searches, and to find stops and places nearby.";
+
+"NSBluetoothAlwaysUsageDescription" = "You give us permission to recognize buses and bus stops nearby. This enables us to analyze where you and other customers travel, and to send you relevant surveys. The data is used to improve our services to make them better for you.";
+
+"NSBluetoothPeripheralUsageDescription" = "You give us permission to recognize buses and bus stops nearby. This enables us to analyze where you and other customers travel, and to send you relevant surveys. The data is used to improve our services to make them better for you.";
+
+"NSMotionUsageDescription" = "You give us permission to use this data to learn more about your travel habits. For example, we can see whether customers choose to cycle, walk or drive a car rather than take the bus. The data is used to improve our services to make them better for you.";

--- a/ios/nb.lproj/InfoPlist.strings
+++ b/ios/nb.lproj/InfoPlist.strings
@@ -1,7 +1,11 @@
-"NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";
 
-
-"NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.";
-
+"NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";
 
 "NSLocationWhenInUseUsageDescription" = "Vi bruker posisjon til å vise din posisjon i kart og reisesøk, og til å finne holdeplasser og steder i nærheten.";
+
+"NSBluetoothAlwaysUsageDescription" = "Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";
+
+"NSBluetoothPeripheralUsageDescription" = "Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";
+
+"NSMotionUsageDescription" = "Du gir oss lov til å bruke disse dataene for å lære mer om dine reisevaner. Vi kan for eksempel se om kunder velger å sykle, gå eller kjøre bil fremfor å busse. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -4,7 +4,7 @@
 
 "NSLocationWhenInUseUsageDescription" = "Vi brukar posisjon til å vise di posisjon i kart og reisesøk, og til å finne haldeplassar og stader i nærleiken.";
 
-"NSBluetoothAlwaysUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.";
+"NSBluetoothAlwaysUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet ditt.";
 
 "NSBluetoothPeripheralUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.";
 

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet ditt.";
 
-"NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";
+"NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet ditt.";
 
 "NSLocationWhenInUseUsageDescription" = "Vi brukar posisjon til å vise di posisjon i kart og reisesøk, og til å finne haldeplassar og stader i nærleiken.";
 

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -6,6 +6,6 @@
 
 "NSBluetoothAlwaysUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet ditt.";
 
-"NSBluetoothPeripheralUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.";
+"NSBluetoothPeripheralUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet ditt.";
 
 "NSMotionUsageDescription" = "Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -8,4 +8,4 @@
 
 "NSBluetoothPeripheralUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet ditt.";
 
-"NSMotionUsageDescription" = "Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";
+"NSMotionUsageDescription" = "Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre reisetilbodet ditt.";

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -1,5 +1,11 @@
-"NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";
 
-"NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet.";
+"NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";
 
 "NSLocationWhenInUseUsageDescription" = "Vi brukar posisjon til å vise di posisjon i kart og reisesøk, og til å finne haldeplassar og stader i nærleiken.";
+
+"NSBluetoothAlwaysUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.";
+
+"NSBluetoothPeripheralUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.";
+
+"NSMotionUsageDescription" = "Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-"NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet ditt.";
 
 "NSLocationAlwaysUsageDescription" = "I tillegg til å kunne vise di posisjon i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.";
 

--- a/src/translations/screens/ShareTravelHabits.ts
+++ b/src/translations/screens/ShareTravelHabits.ts
@@ -1,4 +1,4 @@
-import { translation as _ } from '../commons';
+import {translation as _} from '../commons';
 
 const ShareTravelHabitsTexts = {
   title: _(
@@ -8,19 +8,19 @@ const ShareTravelHabitsTexts = {
   ),
   description: {
     improvement: _(
-      'Med din hjelp kan vi gjøre reisetilbudet i Trøndelag enda bedre.',
-      'With your help, we can make the travel offer in Trøndelag even better.',
-      'Med di hjelp kan vi gjere reisetilbodet i Trøndelag enda betre.',
+      'Med din hjelp kan vi gjøre reisetilbudet vårt enda bedre for deg.',
+      'With your help, we can improve our services to make them better for you.',
+      'Med di hjelp kan vi gjere reisetilbodet vårt enda betre for deg.',
     ),
     safety: _(
-      'Å dele data med oss er helt trygt, og du kan når som helst ombestemme deg.',
-      'Sharing data with us is completely safe and you can change your mind at any time.',
-      'Å dele data med oss er heilt trygt, og du kan når som helst ombestemme deg.',
+      'Å dele data med oss er trygt, og du kan når som helst ombestemme deg.',
+      'Sharing data with us is safe and you can change your mind at any time.',
+      'Å dele data med oss er trygt, og du kan når som helst ombestemme deg.',
     ),
   },
   readMoreAboutDataSharing: _(
     'Les hvordan vi bruker dine personopplysninger',
-    'Read how we use your personal data',
+    'Read about how we use your personal data',
     'Les korleis vi brukar personopplysningane dine',
   ),
   readMoreAboutDataSharingA11yHint: _(
@@ -38,35 +38,35 @@ const ShareTravelHabitsTexts = {
     bluethooth: {
       title: _('Bluetooth', 'Bluetooth', 'Bluetooth'),
       message: _(
-        "Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.",
-        "You give us permission to recognize buses and bus stops nearby. This enables us to analyze where you and other customers travel, and to send you relevant surveys. It will help us to be able to improve the travel offer.",
-        "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet."
-      )
+        'Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
+        'You give us permission to recognize buses and bus stops nearby. This enables us to analyze where you and other customers travel, and to send you relevant surveys. The data is used to improve our services to make them better for you.',
+        'Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.',
+      ),
     },
     locationAlways: {
       title: _('Posisjon', 'Location', 'Posisjon'),
       message: _(
-        "I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre reisetilbudet.",
-        "In addition to displaying your location on maps and planning trips, we gain valuable insights into where you and other customers travel. This helps us improve our travel offerings.",
-        "I tillegg til å kunne vise posisjonen din i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet."
-      )
+        'I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
+        'In addition to being able to show your position on maps and to plan journeys, we will gain valuable learning about where you and other customers travel. The data is used to improve our services to make them better for you.',
+        'I tillegg til å kunne vise posisjonen din i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet.',
+      ),
     },
     locationWhenInUse: {
       title: _('Posisjon', 'Location', 'Posisjon'),
       message: _(
         'Vi bruker posisjon til å vise din posisjon i kart og reisesøk, og til å finne holdeplasser og steder i nærheten.',
         'We use your location to display it on maps and in travel searches, and to find stops and places nearby.',
-        'Vi brukar posisjon til å vise posisjonen din i kart og reisesøk, og til å finne haldeplassar og stader i nærleiken.'
+        'Vi brukar posisjon til å vise posisjonen din i kart og reisesøk, og til å finne haldeplassar og stader i nærleiken.',
       ),
     },
     motion: {
       title: _('Fysisk aktivitet', 'Physical activity', 'Fysisk aktivitet'),
       message: _(
-        "Du gir tillatelse til å bruke bevegelsesdata til analyse og større forståelse av reisemønster, f.eks. for å skille mellom sykling, gåing og bilkjøring.",
-        "You give permission to use movement data for analysis and greater understanding of travel patterns, e.g. to distinguish between cycling, walking and driving.",
-        "Du gir løyve til å bruke rørsledata til analyse og større forståing av reisemønster, til dømes for å skilje mellom sykling, gåing og bilkøyring."
-      )
+        'Du gir oss lov til å bruke disse dataene for å lære mer om dine reisevaner. Vi kan for eksempel se om kunder velger å sykle, gå eller kjøre bil fremfor å busse. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
+        'You give us permission to use this data to learn more about your travel habits. For example, we can see whether customers choose to cycle, walk or drive a car rather than take the bus. The data is used to improve our services to make them better for you.',
+        'Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.',
+      ),
     },
-  }
+  },
 };
 export default ShareTravelHabitsTexts;

--- a/src/translations/screens/ShareTravelHabits.ts
+++ b/src/translations/screens/ShareTravelHabits.ts
@@ -64,7 +64,7 @@ const ShareTravelHabitsTexts = {
       message: _(
         'Du gir oss lov til å bruke disse dataene for å lære mer om dine reisevaner. Vi kan for eksempel se om kunder velger å sykle, gå eller kjøre bil fremfor å busse. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
         'You give us permission to use this data to learn more about your travel habits. For example, we can see whether customers choose to cycle, walk or drive a car rather than take the bus. The data is used to improve our services to make them better for you.',
-        'Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre ditt reisetilbod.',
+        'Du gir oss løyve til å bruke desse dataene for å lære meir om reisevanane dine. Vi kan til dømes sjå om kundar vel å sykle, gå eller køyre bil heller enn å busse. Det vil hjelpe oss til å kunne forbetre reisetilbodet ditt.',
       ),
     },
   },

--- a/src/translations/screens/ShareTravelHabits.ts
+++ b/src/translations/screens/ShareTravelHabits.ts
@@ -40,7 +40,7 @@ const ShareTravelHabitsTexts = {
       message: _(
         'Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
         'You give us permission to recognize buses and bus stops nearby. This enables us to analyze where you and other customers travel, and to send you relevant surveys. The data is used to improve our services to make them better for you.',
-        'Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre ditt reisetilbod.',
+        'Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet ditt .',
       ),
     },
     locationAlways: {


### PR DESCRIPTION
### What have been done
- Updated the texts to be according to [Figma](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=18256-2778&mode=dev) and will resolve the comments in [Figma](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=18256-2778&mode=dev) when this is merged. 
- Added translations for the text for iOS.
- The announcements have been updated in firebase to match [Figma](https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=18256-2778&mode=dev). These were only in staging, and I did not add them to prod.

### Note
The "new-norwegian" texts should probably be double checked by @marius-at-atb or @rosvik. (Nynorsk wasn't my strongest side in high school)