### PR TITLE
fix: Atb bestill button text placement with larger text

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -145,7 +145,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
       flex: isInline ? undefined : 1,
       alignItems: 'center',
       marginHorizontal: textMarginHorizontal,
-      flexShrink: 1,
+      flexShrink: isInline ? 1 : undefined,
     };
     const leftStyling: ViewStyle = {
       position: isInline ? 'relative' : 'absolute',

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -140,12 +140,12 @@ export const Button = React.forwardRef<any, ButtonProps>(
       rightIcon,
     );
 
-    const styleText: TextStyle = {color: textColor};
+    const styleText: TextStyle = {color: textColor, width: '100%'};
     const textContainer: TextStyle = {
       flex: isInline ? undefined : 1,
       alignItems: 'center',
       marginHorizontal: textMarginHorizontal,
-      flexShrink: isInline ? 1 : undefined,
+      flexShrink: 1,
     };
     const leftStyling: ViewStyle = {
       position: isInline ? 'relative' : 'absolute',

--- a/src/travel-details-screens/components/FlexibleTransportBookingOptions.tsx
+++ b/src/travel-details-screens/components/FlexibleTransportBookingOptions.tsx
@@ -61,7 +61,7 @@ export const FlexibleTransportBookingOptions: React.FC<
             )}
             onPress={() => Linking.openURL(`tel:${bookingPhone}`)}
             style={style.bookByPhoneButton}
-            textContainerStyle={{alignItems: 'flex-start'}}
+            textContainerStyle={style.bookByPhoneButtonTextContainer}
             type="pill"
             interactiveColor="interactive_3"
             leftIcon={{svg: Phone}}
@@ -75,6 +75,9 @@ export const FlexibleTransportBookingOptions: React.FC<
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   flexBookingOption: {
     paddingVertical: theme.spacings.medium / 2,
+  },
+  bookByPhoneButtonTextContainer: {
+    alignItems: 'flex-start',
   },
   bookByPhoneButton: {
     backgroundColor: theme.interactive.interactive_3.default.background,

--- a/src/travel-details-screens/components/FlexibleTransportBookingOptions.tsx
+++ b/src/travel-details-screens/components/FlexibleTransportBookingOptions.tsx
@@ -61,7 +61,6 @@ export const FlexibleTransportBookingOptions: React.FC<
             )}
             onPress={() => Linking.openURL(`tel:${bookingPhone}`)}
             style={style.bookByPhoneButton}
-            textContainerStyle={style.bookByPhoneButtonTextContainer}
             type="pill"
             interactiveColor="interactive_3"
             leftIcon={{svg: Phone}}
@@ -75,9 +74,6 @@ export const FlexibleTransportBookingOptions: React.FC<
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   flexBookingOption: {
     paddingVertical: theme.spacings.medium / 2,
-  },
-  bookByPhoneButtonTextContainer: {
-    alignItems: 'flex-start',
   },
   bookByPhoneButton: {
     backgroundColor: theme.interactive.interactive_3.default.background,

--- a/src/travel-details-screens/components/FlexibleTransportBookingOptions.tsx
+++ b/src/travel-details-screens/components/FlexibleTransportBookingOptions.tsx
@@ -61,6 +61,7 @@ export const FlexibleTransportBookingOptions: React.FC<
             )}
             onPress={() => Linking.openURL(`tel:${bookingPhone}`)}
             style={style.bookByPhoneButton}
+            textContainerStyle={{alignItems: 'flex-start'}}
             type="pill"
             interactiveColor="interactive_3"
             leftIcon={{svg: Phone}}


### PR DESCRIPTION
### Text placement on AtB bestill button

> "... has reported a UI error on the button in the travel search when AtB Bestill comes up. We should fix this so that the text is closer to the symbol and make the buttons more similar. The point is the space between the icon and the text on the phone."





| Android Before                                      | Android After                                       |
|-----------------------------------------------------|-----------------------------------------------------|
| <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/c3031871-f826-4ebc-a6c7-2b77c6ba0f1e" width="300"> | <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/25dc6968-91aa-4a53-a2dc-d9f99f20e1dd" width="300"> |
| iOS Before                                          | iOS After                                           |
| <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/b4f43450-d4c8-4ffc-8b99-98d23c604da7" width="300"> | <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/6a45d47e-a381-46a2-a3e2-ed3cbd31d1e2" width="300"> |

### And regular text size looks the same:
<img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/757e3d54-9f81-445a-a977-ffbfebe59acb" width="300">
