### PR TITLE
fix: Not use expired recurring payment card

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -20,7 +20,7 @@ import {
 } from '@atb/translations';
 import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {formatDecimalNumber} from '@atb/utils/numbers';
-import {addMinutes} from 'date-fns';
+import {addMinutes, parseISO} from 'date-fns';
 import React, {useEffect, useState} from 'react';
 import {
   ActivityIndicator,
@@ -67,10 +67,15 @@ function getPreviousPaymentMethod(
         };
       }
     case 'recurring':
-      return {
-        paymentType: previousPaymentMethod.paymentType,
-        recurringPaymentId: previousPaymentMethod.recurringCard.id,
-      };
+      const notExpired =
+        parseISO(previousPaymentMethod.recurringCard.expires_at).getTime() >
+        Date.now();
+      return notExpired
+        ? {
+            paymentType: previousPaymentMethod.paymentType,
+            recurringPaymentId: previousPaymentMethod.recurringCard.id,
+          }
+        : undefined;
     case 'recurring-without-card':
       return {
         paymentType: previousPaymentMethod.paymentType,


### PR DESCRIPTION
Expired payment card was used for purchase even after expiration,
which ended up in error for the user, and the error message "The
customer has no active recurring payment with given id" from
Entur/Nets.
