### PR TITLE
feat: hide tariffzoneSummary for authority tickets

### DIFF
--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -1,5 +1,8 @@
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-import {getReferenceDataName} from '@atb/configuration';
+import {
+  getReferenceDataName,
+  useFirestoreConfiguration,
+} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
@@ -137,15 +140,24 @@ export const useFareContractInfoTexts = (
 
   const {t, language} = useTranslation();
   const {deviceInspectionStatus} = useMobileTokenContextState();
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === preassignedFareProduct?.type,
+  );
 
   const productName = preassignedFareProduct
     ? getReferenceDataName(preassignedFareProduct, language)
     : undefined;
 
-  const tariffZoneSummary =
-    fromTariffZone && toTariffZone
-      ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
-      : undefined;
+  const zoneSelectionModeDisabledForProduct =
+    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
+
+  const tariffZoneSummary = zoneSelectionModeDisabledForProduct
+    ? undefined
+    : fromTariffZone && toTariffZone
+    ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
+    : undefined;
 
   const secondsUntilValid = ((validTo || 0) - (now || 0)) / 1000;
   const conjunction = t(FareContractTexts.validityHeader.durationDelimiter);

--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -137,15 +137,16 @@ export const useFareContractInfoTexts = (
 
   const {t, language} = useTranslation();
   const {deviceInspectionStatus} = useMobileTokenContextState();
+
+  const productName = preassignedFareProduct
+    ? getReferenceDataName(preassignedFareProduct, language)
+    : undefined;
+
   const tariffZoneSummary = useTariffZoneSummary(
     preassignedFareProduct,
     fromTariffZone,
     toTariffZone,
   );
-
-  const productName = preassignedFareProduct
-    ? getReferenceDataName(preassignedFareProduct, language)
-    : undefined;
 
   const secondsUntilValid = ((validTo || 0) - (now || 0)) / 1000;
   const conjunction = t(FareContractTexts.validityHeader.durationDelimiter);

--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -1,17 +1,14 @@
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-import {
-  getReferenceDataName,
-  useFirestoreConfiguration,
-} from '@atb/configuration';
+import {getReferenceDataName} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {
   isValidFareContract,
-  tariffZonesSummary,
   useNonInspectableTokenWarning,
   userProfileCountAndName,
+  useTariffZoneSummary,
 } from '@atb/fare-contracts/utils';
 import {useMobileTokenContextState} from '@atb/mobile-token';
 import {secondsToDuration} from '@atb/utils/date';
@@ -140,23 +137,14 @@ export const useFareContractInfoTexts = (
 
   const {t, language} = useTranslation();
   const {deviceInspectionStatus} = useMobileTokenContextState();
-  const {fareProductTypeConfigs} = useFirestoreConfiguration();
-
-  const fareProductTypeConfig = fareProductTypeConfigs.find(
-    (c) => c.type === preassignedFareProduct?.type,
+  const tariffZoneSummary = useTariffZoneSummary(
+    preassignedFareProduct,
+    fromTariffZone,
+    toTariffZone,
   );
 
   const productName = preassignedFareProduct
     ? getReferenceDataName(preassignedFareProduct, language)
-    : undefined;
-
-  const zoneSelectionModeDisabledForProduct =
-    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
-
-  const tariffZoneSummary = zoneSelectionModeDisabledForProduct
-    ? undefined
-    : fromTariffZone && toTariffZone
-    ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
     : undefined;
 
   const secondsUntilValid = ((validTo || 0) - (now || 0)) / 1000;

--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -5,6 +5,7 @@ import {
   PreassignedFareProduct,
   TariffZone,
   UserProfile,
+  useFirestoreConfiguration,
 } from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {
@@ -122,12 +123,21 @@ export const FareContractInfoDetails = (
     userProfilesWithCount,
     omitUserProfileCount,
     status,
+    fareProductType,
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === fareProductType,
+  );
+
+  console.log('preassprod', fareProductTypeConfig);
   const tariffZoneSummary =
-    fromTariffZone && toTariffZone
+    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none'
+      ? undefined
+      : fromTariffZone && toTariffZone
       ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
       : undefined;
 

--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -5,7 +5,6 @@ import {
   PreassignedFareProduct,
   TariffZone,
   UserProfile,
-  useFirestoreConfiguration,
 } from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {
@@ -27,9 +26,9 @@ import {
   getValidityStatus,
   isValidFareContract,
   mapToUserProfilesWithCount,
-  tariffZonesSummary,
   useNonInspectableTokenWarning,
   userProfileCountAndName,
+  useTariffZoneSummary,
   ValidityStatus,
 } from '../fare-contracts/utils';
 import {FareContractDetail} from '../fare-contracts/components/FareContractDetail';
@@ -127,20 +126,12 @@ export const FareContractInfoDetails = (
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
-  const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
-  const fareProductTypeConfig = fareProductTypeConfigs.find(
-    (c) => c.type === preassignedFareProduct?.type,
+  const tariffZoneSummary = useTariffZoneSummary(
+    preassignedFareProduct,
+    fromTariffZone,
+    toTariffZone,
   );
-
-  const zoneSelectionModeDisabledForProduct =
-    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
-
-  const tariffZoneSummary = zoneSelectionModeDisabledForProduct
-    ? undefined
-    : fromTariffZone && toTariffZone
-    ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
-    : undefined;
 
   return (
     <View style={styles.container} accessible={true}>

--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -123,23 +123,24 @@ export const FareContractInfoDetails = (
     userProfilesWithCount,
     omitUserProfileCount,
     status,
-    fareProductType,
+    preassignedFareProduct,
   } = props;
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
   const fareProductTypeConfig = fareProductTypeConfigs.find(
-    (c) => c.type === fareProductType,
+    (c) => c.type === preassignedFareProduct?.type,
   );
 
-  console.log('preassprod', fareProductTypeConfig);
-  const tariffZoneSummary =
-    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none'
-      ? undefined
-      : fromTariffZone && toTariffZone
-      ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
-      : undefined;
+  const zoneSelectionModeDisabledForProduct =
+    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
+
+  const tariffZoneSummary = zoneSelectionModeDisabledForProduct
+    ? undefined
+    : fromTariffZone && toTariffZone
+    ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
+    : undefined;
 
   return (
     <View style={styles.container} accessible={true}>

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -129,6 +129,7 @@ export const DetailsContent: React.FC<Props> = ({
             userProfilesWithCount={userProfilesWithCount}
             status={validityStatus}
             preassignedFareProduct={preassignedFareProduct}
+            fareProductType={preassignedFareProduct?.type}
           />
         </GenericSectionItem>
         {globalMessageCount > 0 && (

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -129,7 +129,6 @@ export const DetailsContent: React.FC<Props> = ({
             userProfilesWithCount={userProfilesWithCount}
             status={validityStatus}
             preassignedFareProduct={preassignedFareProduct}
-            fareProductType={preassignedFareProduct?.type}
           />
         </GenericSectionItem>
         {globalMessageCount > 0 && (

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -2,7 +2,9 @@ import {FareContractState} from '@atb/ticketing';
 import {
   findReferenceDataById,
   getReferenceDataName,
+  PreassignedFareProduct,
   TariffZone,
+  useFirestoreConfiguration,
   UserProfile,
 } from '@atb/configuration';
 import {UserProfileWithCount} from '@atb/fare-contracts';
@@ -145,6 +147,27 @@ export const useOtherDeviceIsInspectableWarning = () => {
             ),
           );
   }
+};
+
+export const useTariffZoneSummary = (
+  preassignedFareProduct?: PreassignedFareProduct,
+  fromTariffZone?: TariffZone,
+  toTariffZone?: TariffZone,
+) => {
+  const {t, language} = useTranslation();
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
+
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (c) => c.type === preassignedFareProduct?.type,
+  );
+
+  const zoneSelectionModeDisabledForProduct =
+    fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
+
+  if (zoneSelectionModeDisabledForProduct) return undefined;
+  return fromTariffZone && toTariffZone
+    ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
+    : undefined;
 };
 
 export const isValidFareContract = (status: ValidityStatus) =>

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -157,17 +157,16 @@ export const useTariffZoneSummary = (
   const {t, language} = useTranslation();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
+  if (!fromTariffZone || !toTariffZone) return undefined;
+
   const fareProductTypeConfig = fareProductTypeConfigs.find(
     (c) => c.type === preassignedFareProduct?.type,
   );
-
   const zoneSelectionModeDisabledForProduct =
     fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
-
   if (zoneSelectionModeDisabledForProduct) return undefined;
-  return fromTariffZone && toTariffZone
-    ? tariffZonesSummary(fromTariffZone, toTariffZone, language, t)
-    : undefined;
+
+  return tariffZonesSummary(fromTariffZone, toTariffZone, language, t);
 };
 
 export const isValidFareContract = (status: ValidityStatus) =>


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/16242.

TariffZoneSummary is no longer shown for FareContracts where the ticket is sold on the authority endpoint and valid for all zones.

The same logic was being applied both for the normal FareContracts and the compact ones, so extracted it into a custom hook.

This might be cherry-picked into a FRAM 1.45 release branch