### PR TITLE
fix: notification onboarding logic

### DIFF
--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -1,9 +1,38 @@
-import {NotificationConfigValue} from './types';
+import {NotificationConfig, NotificationConfigValue} from './types';
 import {isDefined} from '@atb/utils/presence';
+import {
+  findReferenceDataById,
+  PreassignedFareProduct,
+} from '@atb/configuration';
+import {FareContract} from '@atb/ticketing';
 
 export function isConfigEnabled<T extends NotificationConfigValue>(
   config: T[] | undefined,
   key: T['id'],
 ): boolean {
   return config?.filter(isDefined).find((v) => v.id === key)?.enabled ?? false;
+}
+
+export function hasValidFareContractWithActivatedNotification(
+  validFareContracts: FareContract[],
+  preassignedFareProducts: PreassignedFareProduct[],
+  config?: NotificationConfig,
+): boolean {
+  if (!config) return false;
+  return validFareContracts.some((fareContract) => {
+    const fareProductRef = fareContract.travelRights[0]?.fareProductRef;
+
+    if (!fareProductRef) {
+      return false;
+    }
+
+    const preassignedFareProduct = findReferenceDataById(
+      preassignedFareProducts,
+      fareProductRef,
+    );
+
+    return config?.groups.some(
+      (group) => group.id === preassignedFareProduct?.type && group.enabled,
+    );
+  });
 }

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -14,12 +14,12 @@ export function isConfigEnabled<T extends NotificationConfigValue>(
 }
 
 export function hasFareContractWithActivatedNotification(
-  validFareContracts: FareContract[],
+  fareContracts: FareContract[],
   preassignedFareProducts: PreassignedFareProduct[],
   config?: NotificationConfig,
 ): boolean {
   if (!config) return false;
-  return validFareContracts.some((fareContract) => {
+  return fareContracts.some((fareContract) => {
     const fareProductRef = fareContract.travelRights[0]?.fareProductRef;
 
     if (!fareProductRef) {

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -13,7 +13,7 @@ export function isConfigEnabled<T extends NotificationConfigValue>(
   return config?.filter(isDefined).find((v) => v.id === key)?.enabled ?? false;
 }
 
-export function hasValidFareContractWithActivatedNotification(
+export function hasFareContractWithActivatedNotification(
   validFareContracts: FareContract[],
   preassignedFareProducts: PreassignedFareProduct[],
   config?: NotificationConfig,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -27,7 +27,7 @@ import {TabNav_ProfileStack} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/
 import {dictionary, useTranslation} from '@atb/translations';
 import {useAppState} from '@atb/AppContext';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
-import {InteractionManager} from 'react-native';
+import {InteractionManager, Platform} from 'react-native';
 import {useMaybeShowShareTravelHabitsScreen} from '@atb/beacons/use-maybe-show-share-travel-habits-screen';
 import {
   usePushNotificationsEnabled,
@@ -105,10 +105,15 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
       }
     }
 
+    const notificationsNotGranted =
+      Platform.OS === 'ios'
+        ? pushNotificationPermissionStatus === 'undetermined'
+        : pushNotificationPermissionStatus === 'denied';
+
     if (
       !notificationPermissionOnboarded &&
       pushNotificationsEnabled &&
-      pushNotificationPermissionStatus == 'denied' &&
+      notificationsNotGranted &&
       !shouldShowLocationOnboarding &&
       hasFareContractWithActivatedNotification(
         validFareContracts,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -41,7 +41,7 @@ import {
 import {useTimeContextState} from '@atb/time';
 import {useGeolocationState} from '@atb/GeolocationContext';
 import {useFirestoreConfiguration} from '@atb/configuration';
-import {hasValidFareContractWithActivatedNotification} from '@atb/notifications/utils';
+import {hasFareContractWithActivatedNotification} from '@atb/notifications/utils';
 
 const Tab = createBottomTabNavigator<TabNavigatorStackParams>();
 
@@ -74,7 +74,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
   const {
     permissionStatus: pushNotificationPermissionStatus,
     checkPermissions: checkPushNotificationPermissions,
-    config,
+    config: notificationConfig,
   } = useNotifications();
   useOnPushNotificationOpened();
 
@@ -105,19 +105,15 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
       }
     }
 
-    const notificationsNotGranted =
-      pushNotificationPermissionStatus == 'undetermined' ||
-      pushNotificationPermissionStatus == 'denied';
-
     if (
       !notificationPermissionOnboarded &&
       pushNotificationsEnabled &&
-      notificationsNotGranted &&
+      pushNotificationPermissionStatus == 'denied' &&
       !shouldShowLocationOnboarding &&
-      hasValidFareContractWithActivatedNotification(
+      hasFareContractWithActivatedNotification(
         validFareContracts,
         preassignedFareProducts,
-        config,
+        notificationConfig,
       )
     ) {
       InteractionManager.runAfterInteractions(() =>
@@ -133,7 +129,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
     locationWhenInUsePermissionStatus,
     pushNotificationPermissionStatus,
     preassignedFareProducts,
-    config,
+    notificationConfig,
     validFareContracts,
   ]);
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -89,6 +89,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
   }, [checkPushNotificationPermissions]);
 
   const {preassignedFareProducts} = useFirestoreConfiguration();
+
   useEffect(() => {
     const shouldShowLocationOnboarding =
       !locationWhenInUsePermissionOnboarded &&
@@ -146,7 +147,6 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
     pushNotificationsEnabled,
     locationWhenInUsePermissionOnboarded,
     locationWhenInUsePermissionStatus,
-    validFareContracts.length,
     pushNotificationPermissionStatus,
     validFareContracts,
     preassignedFareProducts,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -105,7 +105,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
       }
     }
 
-    const notificationsNotGranted =
+    const pushNotificationPermissionsNotGranted =
       Platform.OS === 'ios'
         ? pushNotificationPermissionStatus === 'undetermined'
         : pushNotificationPermissionStatus === 'denied';
@@ -113,7 +113,7 @@ export const Root_TabNavigatorStack = ({navigation}: Props) => {
     if (
       !notificationPermissionOnboarded &&
       pushNotificationsEnabled &&
-      notificationsNotGranted &&
+      pushNotificationPermissionsNotGranted &&
       !shouldShowLocationOnboarding &&
       hasFareContractWithActivatedNotification(
         validFareContracts,

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -34,6 +34,7 @@ export type TravelRight = {
     | 'PeriodBoatTicket'
     | 'UnknownTicket';
   direction: TravelRightDirection;
+  fareProductRef: string;
 };
 
 export type Timestamp = FirebaseFirestoreTypes.Timestamp;


### PR DESCRIPTION
### Notification onboarding logic fix
This PR updates the logic for displaying the notification onboarding. With these changes:
- The onboarding will only be shown to users who have a ticket with notifications set to default enabled.
- If the user has already enabled notifications through their settings, the onboarding will not be displayed.

