### PR TITLE
refactor: Add exhaustive deps rule to useInterval

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
     // - hooks outside of React components and custom hooks
     // - hooks inside loops, conditions, or nested functions
     'react-hooks/rules-of-hooks': 2,
-    'react-hooks/exhaustive-deps': 2,
+    'react-hooks/exhaustive-deps': [2, {additionalHooks: '(useInterval)'}],
 
     // Error on raw text that is not inside Text or ThemeText
     'react-native/no-raw-text': [2, {skip: ['ThemeText']}],

--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -50,10 +50,11 @@ function isUserInfo(a: any): a is UserInfoErrorFromFirebase {
 
 const useRetryIntervalWithBackoff = (): [number, () => void] => {
   const [retryInterval, setRetryInterval] = useState(RETRY_INTERVAL_MS_START);
-  return [
-    retryInterval,
+  const incrementRetryInterval = useCallback(
     () => setRetryInterval((val) => Math.min(val * 2, RETRY_INTERVAL_MS_MAX)),
-  ];
+    [],
+  );
+  return [retryInterval, incrementRetryInterval];
 };
 
 export const RemoteConfigContextProvider: React.FC = ({children}) => {
@@ -95,8 +96,8 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
       fetchConfig();
       incrementRetryInterval();
     },
+    [fetchConfig, incrementRetryInterval],
     retryInterval,
-    [fetchConfig],
     !fetchError,
   );
 

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -14,7 +14,7 @@ import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import Bugsnag from '@bugsnag/react-native';
 import {renderAztec} from '@entur-private/abt-mobile-barcode-javascript-lib';
 import QRCode from 'qrcode';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {SvgXml} from 'react-native-svg';
@@ -91,7 +91,7 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
   const [aztecCodeError, setAztecCodeError] = useState(false);
   const [aztecXml, setAztecXml] = useState<string>();
 
-  const renderAztecCode = async () => {
+  const renderAztecCode = useCallback(async () => {
     const signedToken = await getSignedToken();
     if (!signedToken) {
       setAztecCodeError(true);
@@ -99,9 +99,9 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
       setAztecCodeError(false);
       setAztecXml(renderAztec(signedToken));
     }
-  };
+  }, [getSignedToken]);
 
-  useInterval(renderAztecCode, UPDATE_INTERVAL, [], false, true);
+  useInterval(renderAztecCode, [renderAztecCode], UPDATE_INTERVAL, false, true);
 
   if (aztecCodeError) {
     return <StaticAztec fc={fc} />;

--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -199,8 +199,8 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
       }
     },
     // 10000,
-    SIX_HOURS_MS,
     [state.nativeToken, userId],
+    SIX_HOURS_MS,
     false,
     true,
   );

--- a/src/place-screen/hooks/use-departures-data.ts
+++ b/src/place-screen/hooks/use-departures-data.ts
@@ -331,8 +331,8 @@ export function useDeparturesData(
   }, [state.tick]);
   useInterval(
     () => dispatch({type: 'TICK_TICK'}),
+    [dispatch],
     tickRateInSeconds * 1000,
-    [isFocused],
     !isFocused || mode === 'Favourite',
     // Trigger immediately on focus only if the view is already initialized
     !!state.tick,

--- a/src/stacks-hierarchy/Root_CarnetDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_CarnetDetailsScreen.tsx
@@ -1,20 +1,19 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {StyleSheet} from '@atb/theme';
 import {useTicketingState} from '@atb/ticketing';
-import {useTranslation, FareContractTexts} from '@atb/translations';
-import {useInterval} from '@atb/utils/use-interval';
-import React, {useState} from 'react';
+import {FareContractTexts, useTranslation} from '@atb/translations';
+import React from 'react';
 import {View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {CarnetDetailedView} from '@atb/fare-contracts';
 import {RootStackScreenProps} from '../stacks-hierarchy/navigation-types';
+import {useNow} from '@atb/utils/use-now';
 
 type Props = RootStackScreenProps<'Root_CarnetDetailsScreen'>;
 
 export function Root_CarnetDetailsScreen({navigation, route}: Props) {
   const styles = useStyles();
-  const [now, setNow] = useState<number>(Date.now());
-  useInterval(() => setNow(Date.now()), 2500);
+  const now = useNow(2500);
   const {findFareContractByOrderId} = useTicketingState();
   const fc = findFareContractByOrderId(route?.params?.orderId);
   const {t} = useTranslation();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
@@ -343,8 +343,8 @@ export function useFavoriteDepartureData(
   }, [state.tick]);
   useInterval(
     () => dispatch({type: 'TICK_TICK'}),
+    [dispatch],
     tickRateInSeconds * 1000,
-    [isFocused],
     !isFocused,
     // Trigger immediately on focus only if the view is already initialized
     !!state.tick,

--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -39,8 +39,8 @@ export const TimeContextProvider: React.FC = ({children}) => {
         serverDiff = Date.now() - ms;
         setServerNow(ms);
       }),
-    2500,
     [],
+    2500,
     !clockIsRunning,
     true,
   );

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -265,8 +265,8 @@ const LiveVehicleMarker = ({
       );
       setIsStale(live_vehicle_stale_threshold < secondsSinceUpdate);
     },
+    [vehicle.lastUpdated, live_vehicle_stale_threshold],
     1000,
-    [vehicle.lastUpdated],
     false,
     true,
   );

--- a/src/utils/__tests__/use-interval.test.ts
+++ b/src/utils/__tests__/use-interval.test.ts
@@ -20,7 +20,7 @@ describe('useInterval', () => {
 
   it('should invoke with specified delay', async () => {
     const delay = 300;
-    renderHook(() => useInterval(callback, delay));
+    renderHook(() => useInterval(callback, [], delay));
     expect(callback).toHaveBeenCalledTimes(0);
 
     await advanceByTimer(delay);
@@ -31,7 +31,7 @@ describe('useInterval', () => {
 
   it('should invoke with specified delay and immediate if set', async () => {
     const delay = 300;
-    renderHook(() => useInterval(callback, delay, [], false, true));
+    renderHook(() => useInterval(callback, [], delay, false, true));
     expect(callback).toHaveBeenCalledTimes(1);
 
     // This is needed to make timers move passed by promises.
@@ -46,7 +46,7 @@ describe('useInterval', () => {
 
   it('should not have less than 100ms delay', async () => {
     const minimumDelay = 100;
-    renderHook(() => useInterval(callback, 0));
+    renderHook(() => useInterval(callback, [], 0));
 
     expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenLastCalledWith(
@@ -68,7 +68,7 @@ describe('useInterval', () => {
 
   it('should be able to disable useInterval', async () => {
     const hook = renderHook(
-      ({disabled}) => useInterval(callback, 200, [], disabled),
+      ({disabled}) => useInterval(callback, [], 200, disabled),
       {
         initialProps: {
           disabled: false,

--- a/src/utils/use-interval.ts
+++ b/src/utils/use-interval.ts
@@ -10,8 +10,8 @@ type IntervalCallback = () => Promise<void> | void;
  */
 export function useInterval(
   callback: IntervalCallback,
+  deps: React.DependencyList,
   delay: number,
-  deps: React.DependencyList = [],
   disabled: boolean = false,
   triggerImmediately: boolean = false,
 ) {

--- a/src/utils/use-now.ts
+++ b/src/utils/use-now.ts
@@ -3,6 +3,6 @@ import {useInterval} from '@atb/utils/use-interval';
 
 export function useNow(milliseconds: number = 2500): number {
   const [now, setNow] = useState<number>(Date.now());
-  useInterval(() => setNow(Date.now()), milliseconds);
+  useInterval(() => setNow(Date.now()), [], milliseconds);
   return now;
 }

--- a/src/utils/use-pollable-resource.ts
+++ b/src/utils/use-pollable-resource.ts
@@ -91,8 +91,8 @@ export const usePollableResource = <T, E extends Error = Error>(
 
   useInterval(
     () => reload('NO_LOADING', abortControllerRef.current),
-    pollTime,
     [reload],
+    pollTime,
     opts.disabled || (pollOnFocus && !isFocused),
   );
 


### PR DESCRIPTION
You get the power of the exhaustive deps eslint rule on your
custom hooks by adding them in the 'additionalHooks' argument
in the rule options.

To make this work the first argument of the custom hook needs to
be the function, while the second argument needs to be the deps.

Added this to the 'useInterval' hook and fixed the errors that
showed up.
