### PR TITLE
feat: default period ticket

### DIFF
--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -14,6 +14,7 @@ export type PreassignedFareProductId = string;
 export type PreassignedFareProduct = {
   id: PreassignedFareProductId;
   name: LanguageAndTextType;
+  isDefault: boolean;
   version: string;
   description?: LanguageAndTextType[];
   productDescription?: LanguageAndTextType[];

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -2,6 +2,7 @@ import {FareContractState} from '@atb/ticketing';
 import {
   findReferenceDataById,
   getReferenceDataName,
+  PreassignedFareProduct,
   TariffZone,
   UserProfile,
 } from '@atb/configuration';
@@ -171,3 +172,15 @@ export function tariffZonesSummary(
     );
   }
 }
+
+export const useDefaultPreassignedFareProduct = (
+  preAssignedFareProducts: PreassignedFareProduct[],
+): PreassignedFareProduct => {
+  const defaultFareProduct = preAssignedFareProducts.find((p) => p.isDefault);
+
+  if (defaultFareProduct) {
+    return defaultFareProduct;
+  }
+
+  return preAssignedFareProducts[0];
+};

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -11,6 +11,7 @@ import {useTicketingState} from '@atb/ticketing';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {useDefaultTariffZone} from '@atb/stacks-hierarchy/utils';
 import {useMemo} from 'react';
+import {useDefaultPreassignedFareProduct} from '@atb/fare-contracts/utils';
 
 type UserProfileTypeWithCount = {
   userTypeString: string;
@@ -33,8 +34,10 @@ export function useOfferDefaults(
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
+  const defaultFareProduct =
+    useDefaultPreassignedFareProduct(selectableProducts);
   const defaultPreassignedFareProduct =
-    preassignedFareProduct ?? selectableProducts[0];
+    preassignedFareProduct ?? defaultFareProduct;
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(tariffZones);


### PR DESCRIPTION
### Setting the default periodic ticket to 30 days for AtB. 

Added a boolean `isDefault` to the 30 day ticket in [referenceData in Firestore.](https://github.com/AtB-AS/firestore-configuration/pull/421), and made the logic similar as for the defaultTariffZone.