### PR TITLE
fix: bottom sheet close button color

### DIFF
--- a/src/components/bottom-sheet/BottomSheetHeader.tsx
+++ b/src/components/bottom-sheet/BottomSheetHeader.tsx
@@ -32,7 +32,7 @@ export const BottomSheetHeader = ({
 
   const themeColor = 'interactive_3';
   const {background: backgroundColor, text: textColor} =
-    theme.interactive[themeColor]['active'];
+    theme.interactive[themeColor]['default'];
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
@ckbilstad discovered that we used the wrong interactive color on the[ button on the bottom-sheet.](https://www.figma.com/file/2QTjAdekdIPuLFovQhVrY3/Components?type=design&node-id=4573-10756&mode=dev)

| Before | After |
| ------ | ----- |
| <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/35938a7a-91a3-4256-ac69-e49af3e1d5bd" width="300"> | <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/66b1dc5f-3737-4d5f-8d01-53ff6ccda567" width="300"> |



