### PR TITLE
feat: add custom view styling for static qr barcode view

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -257,10 +257,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     padding: 0,
     marginLeft: 'auto',
     marginRight: 'auto',
-    maxWidth: 300,
+    maxWidth: 250,
   },
   staticQrCodeSmall: {
-    maxWidth: 200,
+    maxWidth: 125,
   },
 }));
 

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -23,9 +23,14 @@ import {GenericSectionItem} from '@atb/components/sections';
 type Props = {
   validityStatus: ValidityStatus;
   fc: FareContract;
+  setSpecialBarcodeViewStyle: (val: boolean) => void;
 };
 
-export function Barcode({validityStatus, fc}: Props): JSX.Element | null {
+export function Barcode({
+  validityStatus,
+  fc,
+  setSpecialBarcodeViewStyle,
+}: Props): JSX.Element | null {
   const {barcodeStatus} = useMobileTokenContextState();
   useScreenBrightnessIncrease();
   if (validityStatus !== 'valid') return null;
@@ -36,6 +41,7 @@ export function Barcode({validityStatus, fc}: Props): JSX.Element | null {
     case 'static':
       return <StaticAztec fc={fc} />;
     case 'staticQr':
+      setSpecialBarcodeViewStyle(true);
       return <StaticQrCode fc={fc} />;
     case 'mobiletoken':
       return <MobileTokenAztec fc={fc} />;

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -23,14 +23,9 @@ import {GenericSectionItem} from '@atb/components/sections';
 type Props = {
   validityStatus: ValidityStatus;
   fc: FareContract;
-  setSpecialBarcodeViewStyle: (val: boolean) => void;
 };
 
-export function Barcode({
-  validityStatus,
-  fc,
-  setSpecialBarcodeViewStyle,
-}: Props): JSX.Element | null {
+export function Barcode({validityStatus, fc}: Props): JSX.Element | null {
   const {barcodeStatus} = useMobileTokenContextState();
   useScreenBrightnessIncrease();
   if (validityStatus !== 'valid') return null;
@@ -41,7 +36,6 @@ export function Barcode({
     case 'static':
       return <StaticAztec fc={fc} />;
     case 'staticQr':
-      setSpecialBarcodeViewStyle(true);
       return <StaticQrCode fc={fc} />;
     case 'mobiletoken':
       return <MobileTokenAztec fc={fc} />;

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -57,8 +57,7 @@ export const DetailsContent: React.FC<Props> = ({
 
   const firstTravelRight = fc.travelRights[0];
   const {tariffZones, userProfiles} = useFirestoreConfiguration();
-  const {deviceInspectionStatus} = useMobileTokenContextState();
-  const [specialBarcodeViewStyle, setSpecialBarcodeViewStyle] = useState(false);
+  const {deviceInspectionStatus, barcodeStatus} = useMobileTokenContextState();
 
   if (isPreActivatedTravelRight(firstTravelRight)) {
     const validFrom = firstTravelRight.startDateTime.toMillis();
@@ -119,13 +118,9 @@ export const DetailsContent: React.FC<Props> = ({
         </GenericSectionItem>
         {deviceInspectionStatus === 'inspectable' && (
           <GenericSectionItem
-            style={specialBarcodeViewStyle ? styles.qrSection : undefined}
+            style={barcodeStatus === 'staticQr' ? styles.qrSection : undefined}
           >
-            <Barcode
-              validityStatus={validityStatus}
-              fc={fc}
-              setSpecialBarcodeViewStyle={setSpecialBarcodeViewStyle}
-            />
+            <Barcode validityStatus={validityStatus} fc={fc} />
           </GenericSectionItem>
         )}
         <GenericSectionItem>

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {
   FareContract,
   isPreActivatedTravelRight,

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   FareContract,
   isPreActivatedTravelRight,
@@ -58,6 +58,7 @@ export const DetailsContent: React.FC<Props> = ({
   const firstTravelRight = fc.travelRights[0];
   const {tariffZones, userProfiles} = useFirestoreConfiguration();
   const {deviceInspectionStatus} = useMobileTokenContextState();
+  const [specialBarcodeViewStyle, setSpecialBarcodeViewStyle] = useState(false);
 
   if (isPreActivatedTravelRight(firstTravelRight)) {
     const validFrom = firstTravelRight.startDateTime.toMillis();
@@ -117,8 +118,14 @@ export const DetailsContent: React.FC<Props> = ({
           />
         </GenericSectionItem>
         {deviceInspectionStatus === 'inspectable' && (
-          <GenericSectionItem>
-            <Barcode validityStatus={validityStatus} fc={fc} />
+          <GenericSectionItem
+            style={specialBarcodeViewStyle ? styles.qrSection : undefined}
+          >
+            <Barcode
+              validityStatus={validityStatus}
+              fc={fc}
+              setSpecialBarcodeViewStyle={setSpecialBarcodeViewStyle}
+            />
           </GenericSectionItem>
         )}
         <GenericSectionItem>
@@ -165,5 +172,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   globalMessages: {
     flex: 1,
     rowGap: theme.spacings.medium,
+  },
+  qrSection: {
+    backgroundColor: '#ffffff',
+    paddingVertical: theme.spacings.xLarge * 2,
   },
 }));

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -118,7 +118,11 @@ export const DetailsContent: React.FC<Props> = ({
         </GenericSectionItem>
         {deviceInspectionStatus === 'inspectable' && (
           <GenericSectionItem
-            style={barcodeStatus === 'staticQr' ? styles.qrSection : undefined}
+            style={
+              barcodeStatus === 'staticQr'
+                ? styles.enlargedWhiteBarcodePaddingView
+                : undefined
+            }
           >
             <Barcode validityStatus={validityStatus} fc={fc} />
           </GenericSectionItem>
@@ -168,7 +172,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     rowGap: theme.spacings.medium,
   },
-  qrSection: {
+  enlargedWhiteBarcodePaddingView: {
     backgroundColor: '#ffffff',
     paddingVertical: theme.spacings.xLarge * 2,
   },


### PR DESCRIPTION
Closing https://github.com/AtB-AS/kundevendt/issues/15554

Introducing a full width white padding for static QR codes (which means this should only affect FRAM), even in dark mode. Should improve readability for validation at FLV+ in FRAM buses.

<details>
<summary>Screenshots</summary>

After:
![IMG_3112](https://github.com/AtB-AS/mittatb-app/assets/21310942/a15df004-e9a5-4a89-a244-91ee2212377e)

Before:
![IMG_3111](https://github.com/AtB-AS/mittatb-app/assets/21310942/6588b1cf-4bc4-44ef-9491-9408d15238c5)

</details>