### PR TITLE
fix: refetch notification config on auth user change

### DIFF
--- a/src/notifications/use-config.tsx
+++ b/src/notifications/use-config.tsx
@@ -1,16 +1,19 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {getConfig, NotificationConfigUpdate, updateConfig} from './api';
+import {useAuthState} from '@atb/auth';
 
 export const useConfig = () => {
   const queryClient = useQueryClient();
+  const {userId} = useAuthState();
 
+  const queryKey = ['notification/config', userId];
   const query = useQuery({
-    queryKey: ['notification/config'],
+    queryKey,
     queryFn: getConfig,
   });
   const mutation = useMutation({
     mutationFn: (update: NotificationConfigUpdate) => updateConfig(update),
-    onSuccess: () => queryClient.invalidateQueries(['notification/config']),
+    onSuccess: () => queryClient.invalidateQueries(queryKey),
   });
 
   return {query, mutation};


### PR DESCRIPTION
This fixes a bug where stale notification config data would stay after the auth user had changed. By providing userId as part of the useQuery key, this is automagically refetched when the userId changes.

### Acceptance criteria

- [ ] Reproduce the bug / verify the fix:
	1. While logged in, go to My profile -> Notifications
	2. Enable notifications from some tickets other that the defaults
	3. Log out
	4. Open the Notifications page again,
		- Before this fix, the settings would show as the same as for the logged in user, even though this is a new anonymous user with default configs. Once you toggle something, the default configs will be loaded.
		- After this fix, the default configs should be shown.