### PR TITLE
Fix: remove edit button in TravelTokenBox

### DIFF
--- a/src/travel-token-box/TravelTokenBox.tsx
+++ b/src/travel-token-box/TravelTokenBox.tsx
@@ -8,7 +8,7 @@ import {dictionary, useTranslation} from '@atb/translations';
 import TravelTokenBoxTexts from '@atb/translations/components/TravelTokenBox';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {ThemedTokenPhone, ThemedTokenTravelCard} from '@atb/theme/ThemedAssets';
-import {Button} from '@atb/components/button';
+//import {Button} from '@atb/components/button'; // re-add when new onboarding ready
 import {InteractiveColor, getInteractiveColor} from '@atb/theme/colors';
 import {TravelTokenDeviceTitle} from './TravelTokenDeviceTitle';
 
@@ -34,7 +34,7 @@ export function TravelTokenBox({
 
   // placeholder for onboarding PR
   //const navigation = useNavigation<RootNavigationProps>();
-  const onPressChangeButton = () => {}; //navigation.navigate('Root_SelectTravelTokenScreen')
+  //const onPressChangeButton = () => {}; //navigation.navigate('Root_SelectTravelTokenScreen')
 
   if (deviceInspectionStatus === 'loading') {
     return (
@@ -114,13 +114,14 @@ export function TravelTokenBox({
           )}
         </View>
       </View>
-      <Button
+      {/*todo: re-add this Button*/}
+      {/* <Button
         interactiveColor={interactiveColor}
         mode="secondary"
         onPress={onPressChangeButton}
         text={t(TravelTokenBoxTexts.change)}
         testID="continueWithoutChangingTravelTokenButton"
-      />
+      /> */}
     </View>
   );
 }
@@ -141,7 +142,7 @@ const useStyles = (interactiveColor: InteractiveColor) =>
       marginBottom: theme.spacings.medium,
     },
     content: {
-      marginBottom: theme.spacings.large,
+      //marginBottom: theme.spacings.large, // re-add when new onboarding ready
       display: 'flex',
       flexDirection: 'row',
     },


### PR DESCRIPTION
The edit button will only fully work after https://github.com/AtB-AS/mittatb-app/pull/4106 has been merged.

Removing the button for 1.46.

The removed button:
<img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/86edc04a-585f-48c6-9a75-f2ae240efc6e" />


Resolves https://github.com/AtB-AS/kundevendt/issues/8620