### PR TITLE
fix: button text placement

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -140,7 +140,10 @@ export const Button = React.forwardRef<any, ButtonProps>(
       rightIcon,
     );
 
-    const styleText: TextStyle = {color: textColor, width: '100%'};
+    const styleText: TextStyle = {
+      color: textColor,
+      width: isInline ? '100%' : undefined,
+    };
     const textContainer: TextStyle = {
       flex: isInline ? undefined : 1,
       alignItems: 'center',


### PR DESCRIPTION
@reidzeibel noticed that the text was not centered on block buttons.([Slack thread](https://mittatb.slack.com/archives/C02EEG7D8EL/p1704357853109059))

It was caused by https://github.com/AtB-AS/mittatb-app/pull/4178

Fixed by making the `width: 100%` dependent on whether or not the button is inline. 

### Buttons back to normal after fix:

<img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/710d181f-deb1-45a2-a2e2-27b749bbe91a"/>
<img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/6ec553f6-33d0-4561-8978-e4ea22f7fc9a"/>
<img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/e33bd1fd-3a70-492c-9ea4-76a48f979be8"/>
<img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/81ccd82a-8ecb-4ef2-ab2a-aa1621068a72"/>


### And the initial problem-button still looks as wanted:
<img width=200 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/71718f5f-380d-44dc-8bc6-c7d9a9b28607"/>