### PR TITLE
chore: adding button to storybook

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -47,6 +47,7 @@ try {
 
 const getStories = () => {
   return {
+    "./src/storybook/stories/Button.stories.js": require("../src/storybook/stories/Button.stories.js"),
     "./src/storybook/stories/MessageInfoBox.stories.js": require("../src/storybook/stories/MessageInfoBox.stories.js"),
     "./src/storybook/stories/MessageInfoText.stories.js": require("../src/storybook/stories/MessageInfoText.stories.js"),
     "./src/storybook/stories/ThemeText.stories.js": require("../src/storybook/stories/ThemeText.stories.js"),

--- a/src/storybook/stories/Button.stories.js
+++ b/src/storybook/stories/Button.stories.js
@@ -18,10 +18,7 @@ const ButtonMeta = {
     },
     backgroundColor: {
       control: 'select',
-      options: [
-        ...Object.keys(themes['light'].static.background),
-        ...Object.keys(themes['light'].static.status),
-      ],
+      options: [...Object.keys(themes['light'].static.background)],
     },
     active: {control: 'boolean'},
     compact: {control: 'boolean'},

--- a/src/storybook/stories/Button.stories.js
+++ b/src/storybook/stories/Button.stories.js
@@ -35,7 +35,6 @@ const ButtonMeta = {
     (Story, {args}) => (
       <View
         style={{
-          alignItems: 'center',
           justifyContent: 'center',
           padding: 12,
           flex: 1,
@@ -87,6 +86,6 @@ const ButtonMeta = {
 
 export default ButtonMeta;
 
-export const Block = {args: {width: '100%'}};
+export const Block = {};
 export const Pill = {args: {type: 'pill'}};
 export const Inline = {args: {type: 'inline'}};

--- a/src/storybook/stories/Button.stories.js
+++ b/src/storybook/stories/Button.stories.js
@@ -26,6 +26,7 @@ const ButtonMeta = {
     active: {control: 'boolean'},
     compact: {control: 'boolean'},
     disabled: {control: 'boolean'},
+    loading: {control: 'boolean'},
   },
   args: {
     theme: 'light',
@@ -80,13 +81,6 @@ const ButtonMeta = {
             ...args,
             mode: 'tertiary',
             rightIcon: {svg: Add},
-          }}
-        />
-        <Story
-          args={{
-            ...args,
-            mode: 'tertiary',
-            loading: true,
           }}
         />
       </View>

--- a/src/storybook/stories/Button.stories.js
+++ b/src/storybook/stories/Button.stories.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import {View} from 'react-native';
+import {getStaticColor, themes} from '@atb/theme/colors';
+import {Button} from '@atb/components/button';
+import {Add} from '@atb/assets/svg/mono-icons/actions';
+
+const ButtonMeta = {
+  title: 'Button',
+  component: Button,
+  argTypes: {
+    theme: {
+      control: {type: 'radio'},
+      options: ['light', 'dark'],
+    },
+    interactiveColor: {
+      control: 'select',
+      options: [...Object.keys(themes['light'].interactive)],
+    },
+    backgroundColor: {
+      control: 'select',
+      options: [
+        ...Object.keys(themes['light'].static.background),
+        ...Object.keys(themes['light'].static.status),
+      ],
+    },
+    active: {control: 'boolean'},
+    compact: {control: 'boolean'},
+    disabled: {control: 'boolean'},
+  },
+  args: {
+    theme: 'light',
+    text: 'text',
+    interactiveColor: 'interactive_0',
+    backgroundColor: 'background_0',
+  },
+  decorators: [
+    (Story, {args}) => (
+      <View
+        style={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 12,
+          flex: 1,
+          width: '100%',
+          alignSelf: 'center',
+          backgroundColor:
+            getStaticColor(args.theme, args.textColor)?.background ||
+            getStaticColor(args.theme, args.backgroundColor).background,
+          gap: 12,
+        }}
+      >
+        <Story args={{...args}} />
+        <Story args={{...args, leftIcon: {svg: Add}}} />
+        <Story args={{...args, rightIcon: {svg: Add}}} />
+        <Story args={{...args, mode: 'secondary'}} />
+        <Story
+          args={{
+            ...args,
+            mode: 'secondary',
+            leftIcon: {svg: Add},
+          }}
+        />
+        <Story
+          args={{
+            ...args,
+            mode: 'secondary',
+            rightIcon: {svg: Add},
+          }}
+        />
+        <Story args={{...args, mode: 'tertiary'}} />
+        <Story
+          args={{
+            ...args,
+            mode: 'tertiary',
+            leftIcon: {svg: Add},
+          }}
+        />
+        <Story
+          args={{
+            ...args,
+            mode: 'tertiary',
+            rightIcon: {svg: Add},
+          }}
+        />
+        <Story
+          args={{
+            ...args,
+            mode: 'tertiary',
+            loading: true,
+          }}
+        />
+      </View>
+    ),
+  ],
+};
+
+export default ButtonMeta;
+
+export const Block = {args: {width: '100%'}};
+export const Pill = {args: {type: 'pill'}};
+export const Inline = {args: {type: 'inline'}};

--- a/src/storybook/stories/MessageInfoBox.stories.js
+++ b/src/storybook/stories/MessageInfoBox.stories.js
@@ -11,7 +11,7 @@ const MessageInfoBoxMeta = {
   component: MessageInfoBox,
   argTypes: {
     theme: {
-      control: 'select',
+      control: {type: 'radio'},
       options: ['light', 'dark'],
     },
     onDismiss: {

--- a/src/storybook/stories/MessageInfoText.stories.js
+++ b/src/storybook/stories/MessageInfoText.stories.js
@@ -8,7 +8,7 @@ const MessageInfoTextMeta = {
   component: MessageInfoText,
   argTypes: {
     theme: {
-      control: 'select',
+      control: {type: 'radio'},
       options: ['light', 'dark'],
     },
   },

--- a/src/storybook/stories/ThemeText.stories.js
+++ b/src/storybook/stories/ThemeText.stories.js
@@ -9,7 +9,7 @@ const ThemeTextMeta = {
   component: ThemeText,
   argTypes: {
     theme: {
-      control: 'select',
+      control: {type: 'radio'},
       options: ['light', 'dark'],
     },
     color: {


### PR DESCRIPTION
###  📖 Adding the button component to storybook

- Added the button component with block, pill and inline  
- Changed theme selection to radio buttons on existing stories for faster switching 🏎️ 

### ❗ Note: 
Another possibility would also to have the switch between button modes(pill, inline, block) to be a selection in the addons instead of separate pages, however I belive it is more structured this way and also the addons page already had a lot of options.

### Showcase

<details>
<summary> 📷  Images </summary>

<img width="300" src="https://github.com/AtB-AS/mittatb-app/assets/70323886/accee163-8dac-47b1-accf-e0139a344908" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 16 01 57">
<img width="300" src="https://github.com/AtB-AS/mittatb-app/assets/70323886/2c9dda01-89c4-4fb2-a095-72608063daaa" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 16 01 48">
<img width="300" src="https://github.com/AtB-AS/mittatb-app/assets/70323886/b98877f1-5f3b-4012-9dac-8aa114b4fd12" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 16 02 04">
<img width="300" src="https://github.com/AtB-AS/mittatb-app/assets/70323886/43b078e2-16ee-46f7-902c-0dbaa2b68a1d" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 16 02 07">
</details>

<details>
<summary> 📹 Video </summary>


https://github.com/AtB-AS/mittatb-app/assets/70323886/3f8e0961-4d27-4b5f-85a0-074ad6060d78


</details>





