### PR TITLE
feat: Live position in map not reliant on vehicle position

### DIFF
--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -48,6 +48,7 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {canSellTicketsForSubMode} from '@atb/operator-config';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {getShouldShowLiveVehicle} from '@atb/travel-details-screens/utils';
 
 export type DepartureDetailsScreenParams = {
   items: ServiceJourneyDeparture[];
@@ -91,8 +92,10 @@ export const DepartureDetailsScreenComponent = ({
   const realtimeMapEnabled = useRealtimeMapEnabled();
   const screenReaderEnabled = useIsScreenReaderEnabled();
 
-  const shouldShowLive =
-    !estimatedCallsWithMetadata.find((a) => !a.realtime) && realtimeMapEnabled;
+  const shouldShowLive = getShouldShowLiveVehicle(
+    estimatedCallsWithMetadata,
+    realtimeMapEnabled,
+  );
 
   const {vehiclePositions} = useGetServiceJourneyVehicles(
     shouldShowLive ? [activeItem.serviceJourneyId] : undefined,

--- a/src/travel-details-screens/__tests__/get_should_show_live_vehicle.test.ts
+++ b/src/travel-details-screens/__tests__/get_should_show_live_vehicle.test.ts
@@ -1,0 +1,105 @@
+import {getShouldShowLiveVehicle} from '@atb/travel-details-screens/utils';
+import {EstimatedCallWithMetadata} from '@atb/travel-details-screens/use-departure-data';
+
+const estimatedCallsWhichDepartInGivenMinutes = (
+  minutesToDeparture: number,
+): EstimatedCallWithMetadata[] => {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + minutesToDeparture);
+  return [{aimedDepartureTime: date.toISOString()} as any];
+};
+
+describe('getShouldShowLiveVehicle', () => {
+  it('returns true if less than 10 minutes since departure time', () => {
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(9),
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(5),
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(1),
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true if departure time is passed', () => {
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(0),
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(-10),
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(-7200),
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false if more than 10 minutes until departure time', () => {
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(11),
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(30),
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(7200),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false if realtime map is not enabled', () => {
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(15),
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(0),
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      getShouldShowLiveVehicle(
+        estimatedCallsWhichDepartInGivenMinutes(-15),
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false if estimated call list is empty', () => {
+    expect(
+      getShouldShowLiveVehicle(
+        [],
+        true,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -1,6 +1,6 @@
 import {
   dateWithReplacedTime,
-  iso8601DurationToSeconds,
+  iso8601DurationToSeconds, minutesBetween,
   secondsBetween,
 } from '@atb/utils/date';
 import {Leg, TripPattern} from '@atb/api/types/trips';
@@ -17,6 +17,7 @@ import {
 } from '@atb/api/types/generated/journey_planner_v3_types';
 import {dictionary, TranslateFunction} from '@atb/translations';
 import {APP_ORG} from '@env';
+import {EstimatedCallWithMetadata} from "@atb/travel-details-screens/use-departure-data";
 
 const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES = 1;
 
@@ -427,3 +428,16 @@ export function getIsTooLateToBookTripPattern(
 ): boolean {
   return tripPattern?.legs?.some((leg) => getIsTooLateToBookLeg(leg, now));
 }
+
+export const getShouldShowLiveVehicle = (
+    estimatedCallsWithMetadata: EstimatedCallWithMetadata[],
+    realtimeMapEnabled: boolean,
+): boolean => {
+  if (!realtimeMapEnabled) return false;
+
+  const aimedStartTime: string | undefined =
+      estimatedCallsWithMetadata[0]?.aimedDepartureTime;
+  return aimedStartTime
+      ? minutesBetween(aimedStartTime, new Date()) > -10
+      : false;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -107,6 +107,19 @@ export function secondsBetween(
   return differenceInSeconds(parsedEnd, parsedStart);
 }
 
+/**
+ * Return minutes between start and end. If end is before start the returned
+ * value will be negative.
+ */
+export function minutesBetween(
+  start: string | Date,
+  end: string | Date,
+): number {
+  const parsedStart = parseIfNeeded(start);
+  const parsedEnd = parseIfNeeded(end);
+  return differenceInMinutes(parsedEnd, parsedStart);
+}
+
 export function formatToClock(
   isoDate: string | Date,
   language: Language,


### PR DESCRIPTION
We checked on whether the estimated call had realtime data to
determine whether to show live bus position or not, but it turns
out a vehicle may have live position even if it doesn't have
realtime data.

Changed the logic to be based on departure time instead. If there
is less than 10 minutes until the service journey starts, or it has
started, then we will start to fetch vehicle live position.
