### PR TITLE
fix: upload source maps Android using bugsnag plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -72,6 +72,7 @@ android {
 
     // Store the KETTLE_API_KEY in a constant
     def KETTLE_API_KEY_VALUE = System.getProperty("KETTLE_API_KEY") as String
+    def BUGSNAG_API_KEY_VALUE = System.getProperty("BUGSNAG_API_KEY") as String
 
     namespace "no.mittatb"
     defaultConfig {
@@ -91,7 +92,22 @@ android {
 
         // This is fetched inside Java / Kotlin code
         buildConfigField 'String', 'KETTLE_API_KEY', "\"$KETTLE_API_KEY_VALUE\""
+        manifestPlaceholders = [
+                bugsnagApiKey: BUGSNAG_API_KEY_VALUE
+        ]
     }
+
+    bugsnag {
+        variantFilter { variant ->
+            // disables plugin for all variants of the 'staging' productFlavor
+            def name = variant.name.toLowerCase()
+            if (name.contains("staging") || name.contains("debug")) {
+                enabled = false
+            }
+        }
+        uploadReactNativeMappings = true // enables upload of React Native source maps
+    }
+    
     signingConfigs {
         debug {
             storeFile file('debug.keystore')

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,8 @@
                 <data android:scheme="@string/app_scheme" />
             </intent-filter>
         </activity>
+        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="${bugsnagApiKey}"/>
+
         <!-- Kogenta SDK remove receivers / services -->
         <service
             android:name="com.kogenta.kettle.core.mmi.service.SensorService"


### PR DESCRIPTION
This PR tries to fix issue mentioned in this comment : https://github.com/AtB-AS/kundevendt/issues/3744#issuecomment-1875211143

I updated the bugsnag Android gradle implementation based on the link https://docs.bugsnag.com/build-integrations/gradle/, this should automatically uploads the source files to bugsnag for translation of obfuscated errors.