### PR TITLE
fix: results with AtB bestill as first leg not showing with larger text

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -176,14 +176,12 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
 
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
-    if (
-      legIconsParentWidth &&
-      legIconsContentWidth &&
-      legIconsContentWidth >= legIconsParentWidth
-    ) {
-      updateNumberOfExpandedLegsOrFadeIn();
-    } else {
-      fadeIn();
+    if (legIconsParentWidth && legIconsContentWidth) {
+      if (legIconsContentWidth >= legIconsParentWidth) {
+        updateNumberOfExpandedLegsOrFadeIn();
+      } else {
+        fadeIn();
+      }
     }
   }, [
     fadeIn,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -32,7 +32,7 @@ import {
   getTranslatedModeName,
 } from '@atb/utils/transportation-names';
 
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {
   AccessibilityProps,
   Animated,
@@ -158,37 +158,32 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   );
   const fadeInValueRef = useRef(new Animated.Value(0));
 
-  const fadeIn = useCallback(() => {
-    Animated.timing(fadeInValueRef.current, {
-      toValue: 1,
-      duration: 250,
-      useNativeDriver: true,
-    }).start();
-  }, []);
-
-  const updateNumberOfExpandedLegsOrFadeIn = useCallback(() => {
-    if (numberOfExpandedLegs > 1) {
-      setNumberOfExpandedLegs((val) => val - 1);
-    } else {
-      fadeIn();
-    }
-  }, [fadeIn, numberOfExpandedLegs]);
+  const [hasMinimumOfExpandedLegs, setHasMinimumOfExpandedLegs] =
+    useState(false);
 
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
     if (legIconsParentWidth && legIconsContentWidth) {
-      if (legIconsContentWidth >= legIconsParentWidth) {
-        updateNumberOfExpandedLegsOrFadeIn();
+      if (
+        legIconsContentWidth >= legIconsParentWidth &&
+        !hasMinimumOfExpandedLegs
+      ) {
+        setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
       } else {
-        fadeIn();
+        Animated.timing(fadeInValueRef.current, {
+          toValue: 1,
+          duration: 250,
+          useNativeDriver: true,
+        }).start();
       }
     }
-  }, [
-    fadeIn,
-    legIconsParentWidth,
-    legIconsContentWidth,
-    updateNumberOfExpandedLegsOrFadeIn,
-  ]);
+  }, [legIconsParentWidth, legIconsContentWidth, hasMinimumOfExpandedLegs]);
+
+  useEffect(() => {
+    if (numberOfExpandedLegs <= 1) {
+      setHasMinimumOfExpandedLegs(true);
+    }
+  }, [numberOfExpandedLegs, setHasMinimumOfExpandedLegs]);
 
   if (filteredLegs.length < 1) return null;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -160,7 +160,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
 
   const updateNumberOfExpandedLegsOrFadeIn = useCallback(() => {
     if (numberOfExpandedLegs > 1) {
-      setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
+      setNumberOfExpandedLegs((val) => val - 1);
     } else {
       Animated.timing(fadeInValueRef.current, {
         toValue: 1,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -158,30 +158,32 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   );
   const fadeInValueRef = useRef(new Animated.Value(0));
 
-  const fadeIn = useCallback(() => {
-    Animated.timing(fadeInValueRef.current, {
-      toValue: 1,
-      duration: 250,
-      useNativeDriver: true,
-    }).start();
-  }, []);
+  const updateNumberOfExpandedLegsOrFadeIn = useCallback(() => {
+    if (numberOfExpandedLegs > 1) {
+      setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
+    } else {
+      Animated.timing(fadeInValueRef.current, {
+        toValue: 1,
+        duration: 250,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [numberOfExpandedLegs]);
 
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
-    if (legIconsParentWidth && legIconsContentWidth) {
-      if (legIconsContentWidth >= legIconsParentWidth) {
-        setNumberOfExpandedLegs((val) => {
-          const newVal = Math.max(val - 1, 1);
-          if (newVal === val) {
-            fadeIn();
-          }
-          return newVal;
-        });
-      } else {
-        fadeIn();
-      }
+    if (
+      legIconsParentWidth &&
+      legIconsContentWidth &&
+      legIconsContentWidth >= legIconsParentWidth
+    ) {
+      updateNumberOfExpandedLegsOrFadeIn();
     }
-  }, [fadeIn, legIconsParentWidth, legIconsContentWidth]);
+  }, [
+    legIconsParentWidth,
+    legIconsContentWidth,
+    updateNumberOfExpandedLegsOrFadeIn,
+  ]);
 
   if (filteredLegs.length < 1) return null;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -32,7 +32,7 @@ import {
   getTranslatedModeName,
 } from '@atb/utils/transportation-names';
 
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {
   AccessibilityProps,
   Animated,
@@ -158,24 +158,33 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   );
   const fadeInValueRef = useRef(new Animated.Value(0));
 
+  const fadeIn = useCallback(() => {
+    Animated.timing(fadeInValueRef.current, {
+      toValue: 1,
+      duration: 250,
+      useNativeDriver: true,
+    }).start();
+  }, []);
+
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
-    if (
-      legIconsParentWidth &&
-      legIconsContentWidth &&
-      legIconsContentWidth >= legIconsParentWidth
-    ) {
-      setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
+    if (legIconsParentWidth && legIconsContentWidth) {
+      if (legIconsContentWidth >= legIconsParentWidth) {
+        setNumberOfExpandedLegs((val) => {
+          const newVal = Math.max(val - 1, 1);
+          if (newVal == val - 1) {
+            fadeIn();
+          }
+          return newVal;
+        });
+      } else {
+        fadeIn();
+      }
     }
-  }, [legIconsParentWidth, legIconsContentWidth]);
+  }, [fadeIn, legIconsParentWidth, legIconsContentWidth]);
 
   useEffect(() => {
-    if (numberOfExpandedLegs === 1) {
-      Animated.timing(fadeInValueRef.current, {
-        toValue: 1,
-        duration: 250,
-        useNativeDriver: true,
-      }).start();
+    if (numberOfExpandedLegs >= 1) {
     }
   }, [numberOfExpandedLegs]);
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -160,21 +160,24 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
 
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
-    if (legIconsParentWidth && legIconsContentWidth) {
-      if (
-        legIconsContentWidth >= legIconsParentWidth &&
-        numberOfExpandedLegs > 1
-      ) {
-        setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
-      } else {
-        Animated.timing(fadeInValueRef.current, {
-          toValue: 1,
-          duration: 250,
-          useNativeDriver: true,
-        }).start();
-      }
+    if (
+      legIconsParentWidth &&
+      legIconsContentWidth &&
+      legIconsContentWidth >= legIconsParentWidth
+    ) {
+      setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
     }
-  }, [legIconsParentWidth, legIconsContentWidth, numberOfExpandedLegs]);
+  }, [legIconsParentWidth, legIconsContentWidth]);
+
+  useEffect(() => {
+    if (numberOfExpandedLegs === 1) {
+      Animated.timing(fadeInValueRef.current, {
+        toValue: 1,
+        duration: 250,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [numberOfExpandedLegs]);
 
   if (filteredLegs.length < 1) return null;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -183,11 +183,6 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
     }
   }, [fadeIn, legIconsParentWidth, legIconsContentWidth]);
 
-  useEffect(() => {
-    if (numberOfExpandedLegs >= 1) {
-    }
-  }, [numberOfExpandedLegs]);
-
   if (filteredLegs.length < 1) return null;
 
   const lastLegIsFlexible = isLegFlexibleTransport(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -158,17 +158,21 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   );
   const fadeInValueRef = useRef(new Animated.Value(0));
 
+  const fadeIn = useCallback(() => {
+    Animated.timing(fadeInValueRef.current, {
+      toValue: 1,
+      duration: 250,
+      useNativeDriver: true,
+    }).start();
+  }, []);
+
   const updateNumberOfExpandedLegsOrFadeIn = useCallback(() => {
     if (numberOfExpandedLegs > 1) {
       setNumberOfExpandedLegs((val) => val - 1);
     } else {
-      Animated.timing(fadeInValueRef.current, {
-        toValue: 1,
-        duration: 250,
-        useNativeDriver: true,
-      }).start();
+      fadeIn();
     }
-  }, [numberOfExpandedLegs]);
+  }, [fadeIn, numberOfExpandedLegs]);
 
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
@@ -178,8 +182,11 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
       legIconsContentWidth >= legIconsParentWidth
     ) {
       updateNumberOfExpandedLegsOrFadeIn();
+    } else {
+      fadeIn();
     }
   }, [
+    fadeIn,
     legIconsParentWidth,
     legIconsContentWidth,
     updateNumberOfExpandedLegsOrFadeIn,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -172,7 +172,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
       if (legIconsContentWidth >= legIconsParentWidth) {
         setNumberOfExpandedLegs((val) => {
           const newVal = Math.max(val - 1, 1);
-          if (newVal == val - 1) {
+          if (newVal === val) {
             fadeIn();
           }
           return newVal;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -161,7 +161,10 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   // Dynamically collapse legs to fit horizontally
   useEffect(() => {
     if (legIconsParentWidth && legIconsContentWidth) {
-      if (legIconsContentWidth >= legIconsParentWidth) {
+      if (
+        legIconsContentWidth >= legIconsParentWidth &&
+        numberOfExpandedLegs > 1
+      ) {
         setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
       } else {
         Animated.timing(fadeInValueRef.current, {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -174,7 +174,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
         }).start();
       }
     }
-  }, [legIconsParentWidth, legIconsContentWidth]);
+  }, [legIconsParentWidth, legIconsContentWidth, numberOfExpandedLegs]);
 
   if (filteredLegs.length < 1) return null;
 


### PR DESCRIPTION
### Problem
On some screens, both android and iOS, the trip results which had _AtB bestill_ as its first leg did not show but were clickable. This was caused by the width of the content being larger than the parent. The following code therefore made it so that the **opacity was always 0**:
```
 const fadeInValueRef = useRef(new Animated.Value(0));

  // Dynamically collapse legs to fit horizontally
  useEffect(() => {
    if (legIconsParentWidth && legIconsContentWidth) {
      if (legIconsContentWidth >= legIconsParentWidth) {
        setNumberOfExpandedLegs((val) => Math.max(val - 1, 1));
      } else {
        Animated.timing(fadeInValueRef.current, {
          toValue: 1,
          duration: 250,
          useNativeDriver: true,
        }).start();
      }
    }
  }, [legIconsParentWidth, legIconsContentWidth]);
```

### Before

<details>
<summary>The results were invisible but clickable</summary>

| Android(Pixel) | iOS(iPhone 13 mini) |
|---------|-----|
| <img width=250 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/224af1c6-d3f8-4933-9410-3b16c97657a5"/> | <img width=250 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/e7955c34-15d6-46d6-90a8-4553cd386679"/> |


</details>

### After

<details>
<summary>The results are visible</summary>


https://github.com/AtB-AS/mittatb-app/assets/70323886/f1d659bc-91cf-4233-b6a6-1e02909c527c



| Android(Pixel) | iOS(iPhone 13 mini) |
|---------|-----|
| <img width=250 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/e6028a57-0615-4093-8a36-3bd1412ce59c"/> | <img width=250 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/3e1a01fb-7e40-46ea-8981-6bc6daad3784"/> |


</details>

