### PR TITLE
fix: rename "active" tab title

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/Ticketing_TicketTabNavStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/Ticketing_TicketTabNavStack.tsx
@@ -55,9 +55,6 @@ export const Ticketing_TicketTabNavStack = () => {
           tabBarLabel: t(
             TicketingTexts.activeFareProductsAndReservationsTab.label,
           ),
-          tabBarAccessibilityLabel: t(
-            TicketingTexts.activeFareProductsAndReservationsTab.a11yLabel,
-          ),
           tabBarTestID: 'activeTicketsTab',
         }}
       />

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -48,11 +48,6 @@ const TicketingTexts = {
   },
   activeFareProductsAndReservationsTab: {
     label: _('Mine billetter', 'My tickets', 'Mine billettar'),
-    a11yLabel: _(
-      'Mine aktive billetter',
-      'My active tickets',
-      'Mine aktive billettar',
-    ),
     noActiveTicketsTitle: _(
       'Ingen aktive billetter',
       'No active tickets',

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -47,8 +47,12 @@ const TicketingTexts = {
     },
   },
   activeFareProductsAndReservationsTab: {
-    label: _('Aktive', 'Active', 'Aktive'),
-    a11yLabel: _('Aktive billetter', 'Active tickets', 'Aktive billettar'),
+    label: _('Mine billetter', 'My tickets', 'Mine billettar'),
+    a11yLabel: _(
+      'Mine aktive billetter',
+      'My active tickets',
+      'Mine aktive billettar',
+    ),
     noActiveTicketsTitle: _(
       'Ingen aktive billetter',
       'No active tickets',


### PR DESCRIPTION
| English | Bokmål | Nynorsk |
|---------|--------|---------|
| <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/4ee17af3-0408-4433-bfc1-524ac8942d70" width="250" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-08 at 14 36 52"> | <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/50c48fe2-2bd4-4e70-ac5a-544e15f20f45" width="250" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-08 at 14 36 33"> | <img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/8fb9f959-67de-4d54-892a-ec29de420055" width="250" alt="Simulator Screenshot - iPhone 15 Pro - 2024-01-08 at 14 36 57"> |
