### PR TITLE
refactor: update naming, docs and formatting in BeaconsContext

### DIFF
--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -20,9 +20,33 @@ import {storage} from '@atb/storage';
 import {parseBoolean} from '@atb/utils/parse-boolean';
 
 type KettleInfo = {
+  /**
+   * If the SDK is currently running.
+   * https://developer.kogenta.com/docs/kettle/react-native/usage#retrieve-sdk-status
+   */
   isKettleStarted: boolean;
+
+  /**
+   * The internal Kettle ID for the user.
+   * https://developer.kogenta.com/docs/kettle/react-native/usage#kettle-identifier
+   */
   kettleIdentifier: string | null;
+
+  /**
+   * Identifiers for the users granted consents. See `KettleConsents` for
+   * definitions.
+   * https://developer.kogenta.com/docs/kettle/react-native/usage#consents
+   */
   kettleConsents: Record<string, boolean> | null;
+
+  /**
+   * Whether or not the user have granted the app permissions to one of the
+   * permission prompts. (At least bluetooth permissions)
+   *
+   * This is "our" state to know if the user have enabled beacons, not based on
+   * data from Kettle. This is because we don't want to start he SDK if the user
+   * have not accepted any prompts about data collection.
+   */
   isConsentGranted: boolean;
 };
 

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -12,7 +12,7 @@ import {Kettle} from 'react-native-kettle-module';
 import {NativeModules, Platform} from 'react-native';
 import {
   BEACONS_CONSENTS,
-  allowedPermissionForBeacons,
+  allowedPermissionsForBeacons,
   requestAndroidBeaconPermissions,
 } from './permissions';
 import {useBeaconsMessages} from './use-beacons-messages';
@@ -100,7 +100,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
 
   const initializeKettleSDK = useCallback(async () => {
     if (!isInitializedRef.current) {
-      const permissions = await allowedPermissionForBeacons();
+      const permissions = await allowedPermissionsForBeacons();
       if (permissions.length > 0) {
         await NativeModules.KettleSDKExtension.initializeKettleSDK();
         isInitializedRef.current = true;
@@ -145,7 +145,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
   const revokeBeacons = useCallback(async () => {
     if (!isBeaconsSupported) return;
     if (isInitializedRef.current) {
-      const permissions = await allowedPermissionForBeacons();
+      const permissions = await allowedPermissionsForBeacons();
       Kettle.stop(permissions);
       Kettle.revoke(BEACONS_CONSENTS);
       await storage.set(storeKey.beaconsConsent, 'false');
@@ -171,7 +171,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
         await initializeKettleSDK();
       }
 
-      const permissions = await allowedPermissionForBeacons();
+      const permissions = await allowedPermissionsForBeacons();
       if (consentGranted && permissions && !beaconsInfo?.isStarted) {
         Kettle.start(permissions);
         await updateBeaconsInfo();

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -60,9 +60,9 @@ type BeaconsContextState = {
   getPrivacyTermsUrl: () => Promise<string>;
 };
 
-const defaultState = {
+const defaultState: BeaconsContextState = {
   isBeaconsSupported: false,
-  kettleInfo: undefined,
+  beaconsInfo: undefined,
   getPrivacyDashboardUrl: () => {
     return new Promise<string>(() => {});
   },

--- a/src/beacons/permissions.ts
+++ b/src/beacons/permissions.ts
@@ -107,7 +107,7 @@ const checkPermissionStatuses = async () => {
   return permissionStatuses;
 };
 
-export const allowedPermissionForKettle = async () => {
+export const allowedPermissionForBeacons = async () => {
   const permissionStatuses = await checkPermissionStatuses();
   const kettleModulesArray = [];
   if (permissionStatuses.bluetooth) {

--- a/src/beacons/permissions.ts
+++ b/src/beacons/permissions.ts
@@ -107,7 +107,7 @@ const checkPermissionStatuses = async () => {
   return permissionStatuses;
 };
 
-export const allowedPermissionForBeacons = async () => {
+export const allowedPermissionsForBeacons = async () => {
   const permissionStatuses = await checkPermissionStatuses();
   const kettleModulesArray = [];
   if (permissionStatuses.bluetooth) {

--- a/src/beacons/permissions.ts
+++ b/src/beacons/permissions.ts
@@ -1,99 +1,124 @@
-import { Platform } from 'react-native';
-import { KettleModules } from 'react-native-kettle-module';
-import { KettleConsents } from 'react-native-kettle-module';
-import { PERMISSIONS, Permission, RESULTS, checkMultiple, request } from 'react-native-permissions';
-import { RationaleMessages } from './use-beacons-messages';
+import {Platform} from 'react-native';
+import {KettleModules} from 'react-native-kettle-module';
+import {KettleConsents} from 'react-native-kettle-module';
+import {
+  PERMISSIONS,
+  Permission,
+  RESULTS,
+  checkMultiple,
+  request,
+} from 'react-native-permissions';
+import {RationaleMessages} from './use-beacons-messages';
 
-export type PermissionKey = 'bluetooth' | 'locationWhenInUse' | 'locationAlways' | 'motion';
+export type PermissionKey =
+  | 'bluetooth'
+  | 'locationWhenInUse'
+  | 'locationAlways'
+  | 'motion';
 
-export const BEACONS_CONSENTS = [KettleConsents.SURVEYS, KettleConsents.ANALYTICS];
+export const BEACONS_CONSENTS = [
+  KettleConsents.SURVEYS,
+  KettleConsents.ANALYTICS,
+];
 const BEACONS_PERMISSIONS: Record<PermissionKey, Permission> = {
-    bluetooth: getBluetoothPermission(),
-    locationWhenInUse: Platform.OS === 'ios' ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
-    locationAlways: Platform.OS === 'ios' ? PERMISSIONS.IOS.LOCATION_ALWAYS : PERMISSIONS.ANDROID.ACCESS_BACKGROUND_LOCATION,
-    motion: Platform.OS === 'ios' ? PERMISSIONS.IOS.MOTION : PERMISSIONS.ANDROID.ACTIVITY_RECOGNITION,
+  bluetooth: getBluetoothPermission(),
+  locationWhenInUse:
+    Platform.OS === 'ios'
+      ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE
+      : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+  locationAlways:
+    Platform.OS === 'ios'
+      ? PERMISSIONS.IOS.LOCATION_ALWAYS
+      : PERMISSIONS.ANDROID.ACCESS_BACKGROUND_LOCATION,
+  motion:
+    Platform.OS === 'ios'
+      ? PERMISSIONS.IOS.MOTION
+      : PERMISSIONS.ANDROID.ACTIVITY_RECOGNITION,
 };
 
 function getBluetoothPermission(): Permission {
-    if (Platform.OS === 'android') {
-        // For Android 12 (API Level 31) and above
-        if (Platform.Version >= 31) {
-            // Requires BLUETOOTH_SCAN for scanning Bluetooth devices including beacons
-            return PERMISSIONS.ANDROID.BLUETOOTH_SCAN;
-        } else {
-            // For Android 23 (API Level 23) to Android 30 (API Level 30)
-            // Requires ACCESS_FINE_LOCATION for Bluetooth scanning and discovery
-            return PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
-        }
+  if (Platform.OS === 'android') {
+    // For Android 12 (API Level 31) and above
+    if (Platform.Version >= 31) {
+      // Requires BLUETOOTH_SCAN for scanning Bluetooth devices including beacons
+      return PERMISSIONS.ANDROID.BLUETOOTH_SCAN;
+    } else {
+      // For Android 23 (API Level 23) to Android 30 (API Level 30)
+      // Requires ACCESS_FINE_LOCATION for Bluetooth scanning and discovery
+      return PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
     }
+  }
 
-    return PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL;
+  return PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL;
 }
 
 // This function checks if the required permissions are granted for Android
 // If not, it requests the permissions and returns false
 // If the permissions are granted, it returns true
-export const requestAndroidBeaconPermissions = async (rationaleMessages: RationaleMessages) => {
-    let permissionRequiredForBeaconsGranted = false;
+export const requestAndroidBeaconPermissions = async (
+  rationaleMessages: RationaleMessages,
+) => {
+  let permissionRequiredForBeaconsGranted = false;
 
-    // Request Bluetooth permission
-    const bluetoothStatus = await request(
-        BEACONS_PERMISSIONS.bluetooth,
-        rationaleMessages.bluetooth,
+  // Request Bluetooth permission
+  const bluetoothStatus = await request(
+    BEACONS_PERMISSIONS.bluetooth,
+    rationaleMessages.bluetooth,
+  );
+
+  if (bluetoothStatus === RESULTS.GRANTED) {
+    permissionRequiredForBeaconsGranted = true;
+    // Request location when in use
+    const locationWhenInUseStatus = await request(
+      BEACONS_PERMISSIONS.locationWhenInUse,
+      rationaleMessages.locationWhenInUse,
     );
 
-    if (bluetoothStatus === RESULTS.GRANTED) {
-        permissionRequiredForBeaconsGranted = true;
-        // Request location when in use
-        const locationWhenInUseStatus = await request(
-            BEACONS_PERMISSIONS.locationWhenInUse,
-            rationaleMessages.locationWhenInUse,
-        );
+    if (locationWhenInUseStatus === RESULTS.GRANTED) {
+      // Request location always or background location
+      const locationAlwaysStatus = await request(
+        BEACONS_PERMISSIONS.locationAlways,
+        rationaleMessages.locationAlways,
+      );
 
-        if (locationWhenInUseStatus === RESULTS.GRANTED) {
-            // Request location always or background location
-            const locationAlwaysStatus = await request(
-                BEACONS_PERMISSIONS.locationAlways,
-                rationaleMessages.locationAlways,
-            );
-
-            if (locationAlwaysStatus === RESULTS.GRANTED) {
-                // Request motion permission
-                await request(BEACONS_PERMISSIONS.motion, rationaleMessages.motion);
-            }
-        }
+      if (locationAlwaysStatus === RESULTS.GRANTED) {
+        // Request motion permission
+        await request(BEACONS_PERMISSIONS.motion, rationaleMessages.motion);
+      }
     }
+  }
 
-    return permissionRequiredForBeaconsGranted;
+  return permissionRequiredForBeaconsGranted;
 };
 
 const checkPermissionStatuses = async () => {
-    const statuses = await checkMultiple(Object.values(BEACONS_PERMISSIONS));
-    const permissionStatuses: Record<PermissionKey, boolean> = {
-        bluetooth: false,
-        locationWhenInUse: false,
-        locationAlways: false,
-        motion: false,
-    };
-    Object.keys(permissionStatuses).forEach((key) => {
-        const permissionKey = key as PermissionKey;
-        permissionStatuses[permissionKey] = statuses[BEACONS_PERMISSIONS[permissionKey]] === RESULTS.GRANTED;
-    });
-    return permissionStatuses;
+  const statuses = await checkMultiple(Object.values(BEACONS_PERMISSIONS));
+  const permissionStatuses: Record<PermissionKey, boolean> = {
+    bluetooth: false,
+    locationWhenInUse: false,
+    locationAlways: false,
+    motion: false,
+  };
+  Object.keys(permissionStatuses).forEach((key) => {
+    const permissionKey = key as PermissionKey;
+    permissionStatuses[permissionKey] =
+      statuses[BEACONS_PERMISSIONS[permissionKey]] === RESULTS.GRANTED;
+  });
+  return permissionStatuses;
 };
 
 export const allowedPermissionForKettle = async () => {
-    const permissionStatuses = await checkPermissionStatuses();
-    const kettleModulesArray = [];
-    if (permissionStatuses.bluetooth) {
-        kettleModulesArray.push(KettleModules.BLUETOOTH);
-    }
-    if (permissionStatuses.locationAlways) {
-        kettleModulesArray.push(KettleModules.LOCATION);
-    }
-    if (permissionStatuses.motion) {
-        kettleModulesArray.push(KettleModules.ACTIVITY);
-    }
+  const permissionStatuses = await checkPermissionStatuses();
+  const kettleModulesArray = [];
+  if (permissionStatuses.bluetooth) {
+    kettleModulesArray.push(KettleModules.BLUETOOTH);
+  }
+  if (permissionStatuses.locationAlways) {
+    kettleModulesArray.push(KettleModules.LOCATION);
+  }
+  if (permissionStatuses.motion) {
+    kettleModulesArray.push(KettleModules.ACTIVITY);
+  }
 
-    return kettleModulesArray;
+  return kettleModulesArray;
 };

--- a/src/beacons/use-should-show-share-travel-habits-screen.tsx
+++ b/src/beacons/use-should-show-share-travel-habits-screen.tsx
@@ -31,7 +31,7 @@ export const useShouldShowShareTravelHabitsScreen = (
 
   const shouldShowShareTravelHabitsScreen =
     enabled &&
-    !kettleInfo?.isBeaconsOnboarded &&
+    !kettleInfo?.isConsentGranted &&
     sessionCount > runAfterSessionsCount;
 
   const updateCount = useCallback(

--- a/src/beacons/use-should-show-share-travel-habits-screen.tsx
+++ b/src/beacons/use-should-show-share-travel-habits-screen.tsx
@@ -21,7 +21,7 @@ export const useShouldShowShareTravelHabitsScreen = (
   const sessionCountRef = useRef(0);
   const [sessionCount, setSessionCount] = useState(0);
   const isInitializedRef = useRef(false);
-  const {isBeaconsSupported, kettleInfo} = useBeaconsState();
+  const {isBeaconsSupported, beaconsInfo} = useBeaconsState();
 
   const appStatus = useAppStateStatus();
 
@@ -31,7 +31,7 @@ export const useShouldShowShareTravelHabitsScreen = (
 
   const shouldShowShareTravelHabitsScreen =
     enabled &&
-    !kettleInfo?.isConsentGranted &&
+    !beaconsInfo?.isConsentGranted &&
     sessionCount > runAfterSessionsCount;
 
   const updateCount = useCallback(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -27,7 +27,7 @@ export const Announcements = ({style}: Props) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   const ruleVariables = {
-    isBeaconsOnboarded: beaconsInfo?.isConsentGranted ?? false,
+    isBeaconsConsentGranted: beaconsInfo?.isConsentGranted ?? false,
     shareTravelHabitsOnboarded,
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -27,7 +27,7 @@ export const Announcements = ({style}: Props) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   const ruleVariables = {
-    isBeaconsOnboarded: kettleInfo?.isBeaconsOnboarded ?? false,
+    isBeaconsOnboarded: kettleInfo?.isConsentGranted ?? false,
     shareTravelHabitsOnboarded,
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -19,7 +19,7 @@ export const Announcements = ({style}: Props) => {
   const {findAnnouncements} = useAnnouncementsState();
   const {t} = useTranslation();
   const now = useNow(10000);
-  const {kettleInfo} = useBeaconsState();
+  const {beaconsInfo} = useBeaconsState();
 
   const {shareTravelHabitsOnboarded} = useAppState();
 
@@ -27,7 +27,7 @@ export const Announcements = ({style}: Props) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   const ruleVariables = {
-    isBeaconsOnboarded: kettleInfo?.isConsentGranted ?? false,
+    isBeaconsOnboarded: beaconsInfo?.isConsentGranted ?? false,
     shareTravelHabitsOnboarded,
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -636,7 +636,7 @@ export const Profile_DebugInfoScreen = () => {
                       Alert.alert('Onboarding', `Access granted: ${granted}`);
                     }}
                     disabled={
-                      kettleInfo?.isBeaconsOnboarded &&
+                      kettleInfo?.isConsentGranted &&
                       !!kettleInfo?.kettleConsents
                     }
                     style={style.button}
@@ -648,7 +648,7 @@ export const Profile_DebugInfoScreen = () => {
                       await revokeBeacons();
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isBeaconsOnboarded}
+                    disabled={!kettleInfo?.isConsentGranted}
                     text="Revoke"
                   />
                   <Button
@@ -657,7 +657,7 @@ export const Profile_DebugInfoScreen = () => {
                       await deleteCollectedData();
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isBeaconsOnboarded}
+                    disabled={!kettleInfo?.isConsentGranted}
                     text="Delete Collected Data"
                   />
                   <Button
@@ -669,7 +669,7 @@ export const Profile_DebugInfoScreen = () => {
                         Linking.openURL(privacyDashboardUrl);
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isBeaconsOnboarded}
+                    disabled={!kettleInfo?.isConsentGranted}
                     text="Open Privacy Dashboard"
                   />
                   <Button
@@ -679,7 +679,7 @@ export const Profile_DebugInfoScreen = () => {
                       privacyTermsUrl && Linking.openURL(privacyTermsUrl);
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isBeaconsOnboarded}
+                    disabled={!kettleInfo?.isConsentGranted}
                     text="Open Privacy Terms"
                   />
                 </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -78,7 +78,7 @@ export const Profile_DebugInfoScreen = () => {
     onboardForBeacons,
     revokeBeacons,
     deleteCollectedData,
-    kettleInfo,
+    beaconsInfo,
     isBeaconsSupported,
     getPrivacyDashboardUrl,
     getPrivacyTermsUrl,
@@ -620,13 +620,13 @@ export const Profile_DebugInfoScreen = () => {
               showIconText={true}
               expandContent={
                 <View>
-                  {kettleInfo && (
+                  {beaconsInfo && (
                     <View>
-                      <ThemeText>{`Identifier: ${kettleInfo.kettleIdentifier}`}</ThemeText>
+                      <ThemeText>{`Identifier: ${beaconsInfo.identifier}`}</ThemeText>
                       <ThemeText>{`Status: ${
-                        kettleInfo.isKettleStarted ? 'Running' : 'Stopped'
+                        beaconsInfo.isStarted ? 'Running' : 'Stopped'
                       }`}</ThemeText>
-                      <ThemeText>{`Granted consents: ${kettleInfo.kettleConsents}`}</ThemeText>
+                      <ThemeText>{`Granted consents: ${beaconsInfo.consents}`}</ThemeText>
                     </View>
                   )}
                   <Button
@@ -636,8 +636,7 @@ export const Profile_DebugInfoScreen = () => {
                       Alert.alert('Onboarding', `Access granted: ${granted}`);
                     }}
                     disabled={
-                      kettleInfo?.isConsentGranted &&
-                      !!kettleInfo?.kettleConsents
+                      beaconsInfo?.isConsentGranted && !!beaconsInfo?.consents
                     }
                     style={style.button}
                     text="Onboard"
@@ -648,7 +647,7 @@ export const Profile_DebugInfoScreen = () => {
                       await revokeBeacons();
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isConsentGranted}
+                    disabled={!beaconsInfo?.isConsentGranted}
                     text="Revoke"
                   />
                   <Button
@@ -657,7 +656,7 @@ export const Profile_DebugInfoScreen = () => {
                       await deleteCollectedData();
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isConsentGranted}
+                    disabled={!beaconsInfo?.isConsentGranted}
                     text="Delete Collected Data"
                   />
                   <Button
@@ -669,7 +668,7 @@ export const Profile_DebugInfoScreen = () => {
                         Linking.openURL(privacyDashboardUrl);
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isConsentGranted}
+                    disabled={!beaconsInfo?.isConsentGranted}
                     text="Open Privacy Dashboard"
                   />
                   <Button
@@ -679,7 +678,7 @@ export const Profile_DebugInfoScreen = () => {
                       privacyTermsUrl && Linking.openURL(privacyTermsUrl);
                     }}
                     style={style.button}
-                    disabled={!kettleInfo?.isConsentGranted}
+                    disabled={!beaconsInfo?.isConsentGranted}
                     text="Open Privacy Terms"
                   />
                 </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -20,7 +20,7 @@ import {ContentHeading, ScreenHeading} from '@atb/components/heading';
 export const Profile_PrivacyScreen = () => {
   const {t} = useTranslation();
   const {
-    kettleInfo,
+    beaconsInfo,
     onboardForBeacons,
     revokeBeacons,
     deleteCollectedData,
@@ -61,7 +61,7 @@ export const Profile_PrivacyScreen = () => {
                   PrivacySettingsTexts.sections.consents.items
                     .CollectTravelHabits.subText,
                 )}
-                value={kettleInfo?.isConsentGranted}
+                value={beaconsInfo?.isConsentGranted}
                 onValueChange={async (checked) => {
                   if (checked) {
                     await onboardForBeacons();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -61,7 +61,7 @@ export const Profile_PrivacyScreen = () => {
                   PrivacySettingsTexts.sections.consents.items
                     .CollectTravelHabits.subText,
                 )}
-                value={kettleInfo?.isBeaconsOnboarded}
+                value={kettleInfo?.isConsentGranted}
                 onValueChange={async (checked) => {
                   if (checked) {
                     await onboardForBeacons();

--- a/src/translations/screens/subscreens/PrivacySettingsTexts.ts
+++ b/src/translations/screens/subscreens/PrivacySettingsTexts.ts
@@ -1,59 +1,71 @@
-import { translation as _ } from '../../commons';
+import {translation as _} from '../../commons';
 const PrivacySettingsTexts = {
-    sections: {
-        items: {
-            clarCollectedData: {
-                title: _('Tøm innsamlet data', 'Clear collected data', 'Tøm innsamla data'),
-            },
-            controlPanel: {
-                title: _('Kontrollpanel for datainnsamling', 'Control panel for data collection', 'Kontrollpanel for datainnsamling'),
-                subTitle: _(
-                    'Du kan se og laste ned data som blir samlet om dine reisevaner. Det gjelder også data om busser og holdeplasser du er i nærheten av.',
-                    'You can view and download data that is collected about your travel habits. This also applies to data about buses and stops you are close to.',
-                    'Du kan sjå og laste ned data som blir samla om reisevanane dine. Det gjeld også data om bussar og haldeplassar du er i nærleiken av.'
-                ),
-                a11yHint: _(
-                    'Aktivér for å gå til kontrollpanel for datainnsamling (ekstern side)',
-                    'Activate to go to control panel for data collection (external content)',
-                    'Aktiver for å gå til kontrollpanel for datainnsamling (ekstern side)',
-                ),
-            }
-        },
-        consents: {
-            title: _('Samtykke', 'Consent', 'Samtykke'),
-            items: {
-                CollectTravelHabits: {
-                    title: _('Samle reisevaner', 'Collect travel habits', 'Samle reisevanar'),
-                    subText: _(
-                        'Du gir oss samtykke til å samle og analysere dine reisevaner ved hjelp av Bluetooth, din posisjon, bevegelses- og treningsaktivitet. Vi kan for eksempel samle data om holdeplasser i nærheten, busser du tar, hvor du reiser og om du går, sykler eller reiser med bil. Dataene brukes til å forbedre reisetilbudet ditt i Trøndelag. Samtykket lar oss sende deg undersøkelser som er relevante for deg.',
-                        'You give us consent to collect and analyze your travel habits using Bluetooth, your location, movement and exercise activity. For example, we may collect data about nearby stops, buses you take, where you travel and whether you walk, cycle or travel by car. The data is used to improve your travel offer in Trøndelag. The consent allows us to send you surveys that are relevant to you.',
-                        'Du gir oss samtykke til å samle og analysere reisevanane dine ved hjelp av Bluetooth, din posisjon, bevegings- og treningsaktivitet. Vi kan for eksempel samle data om haldeplassar i nærleiken, bussar du tek, kvar du reiser og om du går, syklar eller reiser med bil. Dataene brukast til å forbetre reisetilbodet ditt i Trøndelag. Samtykket lar oss sende deg undersøkingar som er relevante for deg.',
-                    ),
-                },
-            },
-        },
-    },
-    clearCollectedData: {
-        label: _(
-            'Tøm innsamlet data',
-            'Clear collected data',
-            'Tøm innsamla data',
+  sections: {
+    items: {
+      clarCollectedData: {
+        title: _(
+          'Tøm innsamlet data',
+          'Clear collected data',
+          'Tøm innsamla data',
+        ),
+      },
+      controlPanel: {
+        title: _(
+          'Kontrollpanel for datainnsamling',
+          'Control panel for data collection',
+          'Kontrollpanel for datainnsamling',
+        ),
+        subTitle: _(
+          'Du kan se og laste ned data som blir samlet om dine reisevaner. Det gjelder også data om busser og holdeplasser du er i nærheten av.',
+          'You can view and download data that is collected about your travel habits. This also applies to data about buses and stops you are close to.',
+          'Du kan sjå og laste ned data som blir samla om reisevanane dine. Det gjeld også data om bussar og haldeplassar du er i nærleiken av.',
         ),
         a11yHint: _(
-            'Aktivér for å tømme innsamlet data',
-            'Activate to clear collected data',
-            'Aktivér for å tømme innsamla data',
+          'Aktivér for å gå til kontrollpanel for datainnsamling (ekstern side)',
+          'Activate to go to control panel for data collection (external content)',
+          'Aktiver for å gå til kontrollpanel for datainnsamling (ekstern side)',
         ),
-        confirmTitle: _(
-            'Er du sikker på at du vil slette innsamlet data?',
-            'Are you sure you want to delete collected data?',
-            'Er du sikker på at du vil slette innsamla data?',
-        ),
-        alert: {
-            cancel: _('Avbryt', 'Cancel', 'Avbryt'),
-            confirm: _('Tøm innsamlet data', 'Clear collected data', 'Tøm innsamla data'),
-        },
+      },
     },
+    consents: {
+      title: _('Samtykke', 'Consent', 'Samtykke'),
+      items: {
+        CollectTravelHabits: {
+          title: _(
+            'Samle reisevaner',
+            'Collect travel habits',
+            'Samle reisevanar',
+          ),
+          subText: _(
+            'Du gir oss samtykke til å samle og analysere dine reisevaner ved hjelp av Bluetooth, din posisjon, bevegelses- og treningsaktivitet. Vi kan for eksempel samle data om holdeplasser i nærheten, busser du tar, hvor du reiser og om du går, sykler eller reiser med bil. Dataene brukes til å forbedre reisetilbudet ditt i Trøndelag. Samtykket lar oss sende deg undersøkelser som er relevante for deg.',
+            'You give us consent to collect and analyze your travel habits using Bluetooth, your location, movement and exercise activity. For example, we may collect data about nearby stops, buses you take, where you travel and whether you walk, cycle or travel by car. The data is used to improve your travel offer in Trøndelag. The consent allows us to send you surveys that are relevant to you.',
+            'Du gir oss samtykke til å samle og analysere reisevanane dine ved hjelp av Bluetooth, din posisjon, bevegings- og treningsaktivitet. Vi kan for eksempel samle data om haldeplassar i nærleiken, bussar du tek, kvar du reiser og om du går, syklar eller reiser med bil. Dataene brukast til å forbetre reisetilbodet ditt i Trøndelag. Samtykket lar oss sende deg undersøkingar som er relevante for deg.',
+          ),
+        },
+      },
+    },
+  },
+  clearCollectedData: {
+    label: _('Tøm innsamlet data', 'Clear collected data', 'Tøm innsamla data'),
+    a11yHint: _(
+      'Aktivér for å tømme innsamlet data',
+      'Activate to clear collected data',
+      'Aktivér for å tømme innsamla data',
+    ),
+    confirmTitle: _(
+      'Er du sikker på at du vil slette innsamlet data?',
+      'Are you sure you want to delete collected data?',
+      'Er du sikker på at du vil slette innsamla data?',
+    ),
+    alert: {
+      cancel: _('Avbryt', 'Cancel', 'Avbryt'),
+      confirm: _(
+        'Tøm innsamlet data',
+        'Clear collected data',
+        'Tøm innsamla data',
+      ),
+    },
+  },
 };
 
 export default PrivacySettingsTexts;


### PR DESCRIPTION
Before I start https://github.com/AtB-AS/kundevendt/issues/16285, this PR is a refactor to hopefully make beacons less confusing to get started with :)

- Removes all references to Kettle from outside of the BeaconsContext
- Adds some docstrings for the fields in BeaconsInfo
- Fixes some formatting/whitespace

There should be no functional changes.