### PR TITLE
feat: add analytics to share travel habits screen

### DIFF
--- a/src/analytics/types.ts
+++ b/src/analytics/types.ts
@@ -7,6 +7,7 @@ export type AnalyticsEventContext =
   | 'Loading boundary'
   | 'Map'
   | 'Mobility'
+  | 'Onboarding'
   | 'Parking violations'
   | 'Profile'
   | 'Receipt'

--- a/src/beacons/permissions.ts
+++ b/src/beacons/permissions.ts
@@ -91,7 +91,7 @@ export const requestAndroidBeaconPermissions = async (
   return permissionRequiredForBeaconsGranted;
 };
 
-const checkPermissionStatuses = async () => {
+export const checkPermissionStatuses = async () => {
   const statuses = await checkMultiple(Object.values(BEACONS_PERMISSIONS));
   const permissionStatuses: Record<PermissionKey, boolean> = {
     bluetooth: false,

--- a/src/stacks-hierarchy/Root_ShareTravelHabitsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShareTravelHabitsScreen.tsx
@@ -31,11 +31,10 @@ export const Root_ShareTravelHabitsScreen = () => {
   // call useFocusEffect to send analytics once when the screen is shown
   useFocusEffect(
     useCallback(() => {
-      const didSeeShareTravelHabitsScreen = analytics.logEvent(
+      analytics.logEvent(
         'Onboarding',
         'didSeeShareTravelHabitsScreen',
       );
-      return () => didSeeShareTravelHabitsScreen;
     }, [analytics]),
   );
 
@@ -44,7 +43,7 @@ export const Root_ShareTravelHabitsScreen = () => {
 
     const permissions = await checkPermissionStatuses(); // get given permissions status
     analytics.logEvent('Onboarding', 'beaconsPermissionAnswers', {
-      beacons: permissions.bluetooth,
+      bluetooth: permissions.bluetooth,
       locationAlways: permissions.locationAlways,
       motion: permissions.motion,
     });


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16115

Pretty straightforward PR, sends a posthog event everytime the screen is shown, and send another posthog event when the permissions are given by the user.

- [x] PostHog event should be sent when the `Root_ShareTravelHabitsScreen` shows (onboarding), sends `didSeeShareTravelHabitsScreen`

- [x] PostHog event should be sent when permission answers are received. This one should include permission answer metadata. Sends `beaconsPermissionAnswers, metadata ({bluetooth: boolean, locationAlways: boolean, motion: boolean})`.