### PR TITLE
fix: remove redundant close function for bottom sheet in map

### DIFF
--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -168,8 +168,6 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
             />
           );
         }, false);
-      } else {
-        closeBottomSheet();
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
When closing any bottom sheet, except for the filter one, on the map on android the app crashed. The reason for the crash was that when pressing the close button the close function was triggered twice leading to an issue with a sending accessibiltyEvent.

I found that the removed close call was not needed for closing the bottom sheet when clicking the map or when clicking the close button. 