### PR TITLE
revert: remove redundant close function for bottom sheet in map

### DIFF
--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -168,6 +168,8 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
             />
           );
         }, false);
+      } else {
+        closeBottomSheet();
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
The fix in https://github.com/AtB-AS/mittatb-app/pull/4221 was happening because of some cached version locally. Did not work so reverting