### PR TITLE
feat: fix session counter for share travel habits screen

### DIFF
--- a/src/beacons/use-should-show-share-travel-habits-screen.tsx
+++ b/src/beacons/use-should-show-share-travel-habits-screen.tsx
@@ -1,12 +1,12 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import {storage} from '@atb/storage';
 
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
-import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 
 import {useAppState} from '@atb/AppContext';
 
 import {useBeaconsState} from './BeaconsContext';
+import {useFocusEffect} from '@react-navigation/native';
 
 export const shareTravelHabitsSessionCountKey =
   '@ATB_share_travel_habits_session_count_v2';
@@ -22,8 +22,6 @@ export const useShouldShowShareTravelHabitsScreen = (
   const [sessionCount, setSessionCount] = useState(0);
   const isInitializedRef = useRef(false);
   const {isBeaconsSupported, beaconsInfo} = useBeaconsState();
-
-  const appStatus = useAppStateStatus();
 
   const {onboarded, shareTravelHabitsOnboarded} = useAppState();
   const enabled =
@@ -48,22 +46,22 @@ export const useShouldShowShareTravelHabitsScreen = (
     [utilizeThisHookInstanceForSessionCounting],
   );
 
-  useEffect(() => {
-    if (!enabled) return;
-    if (appStatus !== 'active') return;
-
-    if (!isInitializedRef.current) {
-      storage
-        .get(shareTravelHabitsSessionCountKey)
-        .then((countStr) => parseInt(countStr ?? '0'))
-        .then((count) => {
-          isInitializedRef.current = true;
-          updateCount(count);
-        });
-    } else {
-      updateCount(sessionCountRef.current);
-    }
-  }, [enabled, appStatus, updateCount]);
+  useFocusEffect(    
+    useCallback(() => {
+      if (!enabled) return;
+      if (!isInitializedRef.current) {
+        storage
+          .get(shareTravelHabitsSessionCountKey)
+          .then((countStr) => parseInt(countStr ?? '0'))
+          .then((count) => {
+            isInitializedRef.current = true;
+            updateCount(count);
+          });
+      } else {
+        updateCount(sessionCountRef.current);
+      }
+    }, [enabled, updateCount]),
+  );
 
   return shouldShowShareTravelHabitsScreen;
 };


### PR DESCRIPTION
When using `appStatus !== 'active'` the counter will increase when something appears on top of our app. For example, a permission dialog, or maybe a phone call, which blocks our app and causes the `appStatus` to change to 'background', triggering the `useEffect` because it is a dependency. 
  
In this particular case, we only want the counter to be increased between app sessions, and not by something incidental such as permission request. Therefore using `useFocusEffect` and `useCallback` seems to be the better choice, since it only updates the counter when the actual screen is shown and focused, instead of calling it everytime the app went to `background` state.

This should fix the issue that the `travelHabitSessionCount` increasing more than intended, a minor issue found by @tormoseng while investigating https://github.com/AtB-AS/kundevendt/issues/16288.