### PR TITLE
fix: giveFocus to unmounted node

### DIFF
--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -68,7 +68,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
   const close = () => {
     setContentFunction(() => () => null);
     setIsOpen(false);
-    giveFocus(onCloseFocusRef.current);
+    giveFocus(onCloseFocusRef);
   };
 
   const open = (
@@ -120,7 +120,7 @@ export const BottomSheetProvider: React.FC = ({children}) => {
         </AnimatedBottomSheet>
       </>
     ),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isOpen, close, animatedOffset, safeAreaBottom],
   );
 

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -168,6 +168,8 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
             />
           );
         }, false);
+      } else {
+        closeBottomSheet();
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -168,8 +168,6 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
             />
           );
         }, false);
-      } else {
-        closeBottomSheet();
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -58,7 +58,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
     const errorFocusRef = useRef(null);
 
     useEffect(() => {
-      giveFocus(errorFocusRef.current);
+      giveFocus(errorFocusRef);
     }, [errorText]);
     function accessibilityEscapeKeyboard() {
       setTimeout(

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -52,7 +52,7 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
   const isFocused = useIsFocused();
 
   useEffect(() => {
-    isFocused && giveFocus(inputRef.current);
+    isFocused && giveFocus(inputRef);
   }, [isFocused]);
 
   const harborsQuery = useHarbors(fromHarbor?.id);

--- a/src/utils/use-focus-on-load.ts
+++ b/src/utils/use-focus-on-load.ts
@@ -20,8 +20,8 @@ export function useFocusOnLoad(setFocusOnLoad: boolean = true): Ref<any> {
 
   const focusCallbackRef: RefCallback<any> = useCallback(
     (node) => {
-      if (setFocusOnLoad) giveFocus(node);
       focusRef.current = node;
+      if (setFocusOnLoad) giveFocus(focusRef);
     },
     [setFocusOnLoad],
   );

--- a/src/utils/use-focus-on-load.ts
+++ b/src/utils/use-focus-on-load.ts
@@ -1,5 +1,9 @@
-import {Ref, RefCallback, useCallback, useEffect, useRef} from 'react';
-import {AccessibilityInfo, findNodeHandle, InteractionManager,} from 'react-native';
+import React, {Ref, RefCallback, useCallback, useEffect, useRef} from 'react';
+import {
+  AccessibilityInfo,
+  findNodeHandle,
+  InteractionManager,
+} from 'react-native';
 import {useNavigationSafe} from '@atb/utils/use-navigation-safe';
 
 /**
@@ -23,10 +27,10 @@ export function useFocusOnLoad(setFocusOnLoad: boolean = true): Ref<any> {
   );
 
   useEffect(() => {
-    if (!navigation || !focusRef.current || !setFocusOnLoad) return;
+    if (!navigation || !focusRef || !setFocusOnLoad) return;
 
     const unsubscribe = navigation.addListener('focus', () =>
-      giveFocus(focusRef.current),
+      giveFocus(focusRef),
     );
     return () => unsubscribe();
   }, [navigation, setFocusOnLoad]);
@@ -34,11 +38,13 @@ export function useFocusOnLoad(setFocusOnLoad: boolean = true): Ref<any> {
   return focusCallbackRef;
 }
 
-export const giveFocus = (node: any) => {
-  if (node) {
+export const giveFocus = (
+  focusRef?: React.RefObject<any> | null | undefined,
+) => {
+  if (focusRef && focusRef.current) {
     InteractionManager.runAfterInteractions(() => {
       setTimeout(() => {
-        const reactTag = findNodeHandle(node);
+        const reactTag = findNodeHandle(focusRef?.current);
         reactTag && AccessibilityInfo.setAccessibilityFocus(reactTag);
       }, 100);
     });

--- a/src/utils/use-focus-refs.ts
+++ b/src/utils/use-focus-refs.ts
@@ -10,7 +10,7 @@ export function useFocusRefs(focusOnElementName: string | undefined) {
   const ref = useRef<FocusRefsType>(null);
 
   useEffect(
-    () => giveFocus(ref.current?.[focusOnElementName + 'Ref' || '']?.current),
+    () => giveFocus(ref.current?.[focusOnElementName + 'Ref' || '']),
     [focusOnElementName],
   );
 


### PR DESCRIPTION
Issue link: https://github.com/AtB-AS/kundevendt/issues/16389

The problem was the node trying to call `AccessibilityInfo.setAccessibilityFocus(reactTag)` when the node was unmounted. 

As @marius-at-atb said in [a comment](https://github.com/AtB-AS/mittatb-app/pull/4221#issuecomment-1887463960):

> When giveFocus receives a ref, then its current value will later be modified, and this change will be reflected inside giveFocus.
> 
> When giveFocus receives a ref.current directly, that value will later be reassigned, and the change won't be reflected inside giveFocus.
> 
> Therefore when using async logic inside giveFocus and accepting a ref.current directly, the value can be outdated by the time it is used, causing a crash.

This fix addresses the bottom-sheet crashing when pressing the close button in the map, and @reidzeibel's case of the app crashing after logging in with vipps on a fresh install. 