### PR TITLE
fix: Stations and vehicles fetched too often

### DIFF
--- a/src/mobility/use-stations.tsx
+++ b/src/mobility/use-stations.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {AreaState, getOperators, isShowAll, updateAreaState} from './utils';
 import {useIsCityBikesEnabled} from './use-city-bikes-enabled';
 import {
@@ -87,9 +87,9 @@ export const useStations: (
     setStations(emptyStations);
   }, [area, isCityBikesEnabled, isCarSharingEnabled, filter, isFocused]);
 
-  const updateRegion = async (region: MapRegion) => {
+  const updateRegion = useCallback((region: MapRegion) => {
     setArea(updateAreaState(region, BUFFER_DISTANCE_IN_METERS, MIN_ZOOM_LEVEL));
-  };
+  }, []);
 
   const onFilterChange = (filter: MobilityMapFilterType) => {
     setFilter(filter);

--- a/src/mobility/use-vehicles.tsx
+++ b/src/mobility/use-vehicles.tsx
@@ -105,9 +105,9 @@ export const useVehicles: (
     pollingTimeInSeconds: Math.round(pollInterval / 1000),
   });
 
-  const updateRegion = async (region: MapRegion) => {
+  const updateRegion = useCallback((region: MapRegion) => {
     setArea(updateAreaState(region, BUFFER_DISTANCE_IN_METERS, MIN_ZOOM_LEVEL));
-  };
+  }, []);
 
   const onFilterChange = (filter: MobilityMapFilterType) => {
     setFilter(filter);

--- a/src/mobility/utils.ts
+++ b/src/mobility/utils.ts
@@ -1,4 +1,4 @@
-import {Feature, Point, Polygon, Position} from 'geojson';
+import {Feature, Point, Position} from 'geojson';
 import {VehicleBasicFragment} from '@atb/api/types/generated/fragments/vehicles';
 import {
   PricingPlanFragment,
@@ -11,7 +11,6 @@ import {
   toFeaturePoint,
 } from '@atb/components/map';
 import buffer from '@turf/buffer';
-import bbox from '@turf/bbox-polygon';
 import difference from '@turf/difference';
 import {Platform} from 'react-native';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
@@ -75,24 +74,30 @@ export const hasMultiplePricingPlans = (plan: PricingPlanFragment) =>
   (plan.perKmPricing && plan.perKmPricing.length > 1) ||
   (plan.perMinPricing && plan.perMinPricing.length > 1);
 
-export const toBbox = (position: Position[]) => {
-  const [[lonMax, latMax], [lonMin, latMin]] = position;
-  return bbox([lonMin, latMin, lonMax, latMax]);
-};
-
 /**
- * Determines if vehicles need to be reloaded
- * @param visibleBounds Area currently visible in the map
- * @param loadedArea Area in which vehicles are already loaded.
+ * Determines if vehicles need to be reloaded, by checking if the
+ * previously loaded area covers the new area.
+ *
+ * @param newArea Area currently visible in the map
+ * @param prevArea Area in which vehicles are already loaded
+ * @return false if the previous area covers the new area and no reload is
+ * needed, otherwise true
  */
 export const needsReload = (
-  visibleBounds: Position[],
-  loadedArea: Feature<Polygon> | undefined,
-) => {
-  if (!loadedArea) return true;
-  // If the loaded area totally covers the current loaded bounds,
-  // no reload is needed. In this case 'difference' will return null.
-  const diff = difference(toBbox(visibleBounds), loadedArea);
+  prevArea: AreaState,
+  newArea: AreaState,
+): boolean => {
+  const prevAreaFeature = extend(
+    toFeaturePoint({lat: prevArea.lat, lon: prevArea.lon}),
+    prevArea.range,
+  );
+  const newAreaFeature = extend(
+    toFeaturePoint({lat: newArea.lat, lon: newArea.lon}),
+    newArea.range,
+  );
+
+  // If the previous area covers the new area the 'difference' will return null
+  const diff = difference(newAreaFeature, prevAreaFeature);
   return Boolean(diff);
 };
 
@@ -115,10 +120,7 @@ export const extend = (midpoint: Feature<Point>, range: number) =>
 export type AreaState = {
   lat: number;
   lon: number;
-  zoom: number;
   range: number;
-  visibleBounds: Position[];
-  loadedArea: Feature<Polygon> | undefined;
 };
 
 export const updateAreaState = (
@@ -126,27 +128,22 @@ export const updateAreaState = (
   bufferDistance: number,
   minZoomLevel: number,
 ) => {
-  return (previousState: AreaState | undefined) => {
-    if (region.zoomLevel < minZoomLevel) {
-      return undefined;
-    }
+  return (prevArea: AreaState | undefined): AreaState | undefined => {
+    if (region.zoomLevel < minZoomLevel) return undefined;
 
-    const visibleBounds = region.visibleBounds;
-    if (!needsReload(visibleBounds, previousState?.loadedArea)) {
-      return previousState;
-    }
-
-    const [lon, lat] = region.center;
-    const range = getRadius(visibleBounds, bufferDistance);
-    return {
-      lat,
-      lon,
-      zoom: region.zoomLevel,
-      range,
-      visibleBounds,
-      loadedArea: extend(toFeaturePoint({lat, lon}), range),
-    };
+    const newArea = mapRegionToArea(region, bufferDistance);
+    if (!prevArea) return newArea;
+    return needsReload(prevArea, newArea) ? newArea : prevArea;
   };
+};
+
+const mapRegionToArea = (
+  region: MapRegion,
+  bufferDistance: number,
+): AreaState => {
+  const [lon, lat] = region.center;
+  const range = getRadius(region.visibleBounds, bufferDistance);
+  return {lat, lon, range};
 };
 
 export const formatRange = (rangeInMeters: number, language: Language) => {

--- a/src/mobility/utils.ts
+++ b/src/mobility/utils.ts
@@ -76,24 +76,26 @@ export const hasMultiplePricingPlans = (plan: PricingPlanFragment) =>
 
 /**
  * Determines if vehicles need to be reloaded, by checking if the
- * previously loaded area covers the new area.
+ * previously loaded area covers the shown area.
  *
  * @param prevArea Area in which vehicles are already loaded
- * @param newArea Area currently visible in the map
- * @return false if the previous area covers the new area and no reload is
+ * @param shownArea Area currently visible in the map
+ * @return false if the previous area covers the shown area and no reload is
  * needed, otherwise true
  */
 export const needsReload = (
-  prevArea: AreaState,
-  newArea: AreaState,
+  prevArea: AreaState | undefined,
+  shownArea: AreaState,
 ): boolean => {
+  if (!prevArea) return true;
+
   const prevAreaFeature = extend(
     toFeaturePoint({lat: prevArea.lat, lon: prevArea.lon}),
     prevArea.range,
   );
   const newAreaFeature = extend(
-    toFeaturePoint({lat: newArea.lat, lon: newArea.lon}),
-    newArea.range,
+    toFeaturePoint({lat: shownArea.lat, lon: shownArea.lon}),
+    shownArea.range,
   );
 
   // If the previous area covers the new area the 'difference' will return null
@@ -131,9 +133,10 @@ export const updateAreaState = (
   return (prevArea: AreaState | undefined): AreaState | undefined => {
     if (region.zoomLevel < minZoomLevel) return undefined;
 
-    const newArea = mapRegionToArea(region, bufferDistance);
-    if (!prevArea) return newArea;
-    return needsReload(prevArea, newArea) ? newArea : prevArea;
+    const shownArea = mapRegionToArea(region, 0);
+    return needsReload(prevArea, shownArea)
+      ? mapRegionToArea(region, bufferDistance)
+      : prevArea;
   };
 };
 

--- a/src/mobility/utils.ts
+++ b/src/mobility/utils.ts
@@ -78,8 +78,8 @@ export const hasMultiplePricingPlans = (plan: PricingPlanFragment) =>
  * Determines if vehicles need to be reloaded, by checking if the
  * previously loaded area covers the new area.
  *
- * @param newArea Area currently visible in the map
  * @param prevArea Area in which vehicles are already loaded
+ * @param newArea Area currently visible in the map
  * @return false if the previous area covers the new area and no reload is
  * needed, otherwise true
  */


### PR DESCRIPTION
There was two error that together caused this:
- The onMapIdle listener fires way too often, which make it seems
like the viewport has changed when it really hasn't.
- Bug in the code comparing the previously loaded area with the new
area, which caused refetching data when it was not necessary.

Since onMapIdle fired too many times (with the same map region
visible) and there was a bug when comparing two map regions, we
ended up fetching data more than we should.

This is now fixed by:
- The onMapIdle listener updates a state storing the map region, but
only if it has really changed. So now, even though the onMapIdle
listener fires more than it should, it shouldn't update the state.
- Fixed the logic comparing two areas, where we now transform
both previous area and new area to features of the same format
before comparing them.

After this there should be no multiple-spinners after each other
on viewport change, and also no spinner if just clicking the map.