### PR TITLE
feat: add new permission prompts for notifications and beacons

### DIFF
--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -202,8 +202,8 @@ const BeaconsContextProvider: React.FC = ({children}) => {
         await initializeKettleSDK(false);
 
         // If the user have given consents, but permissions were enabled later,
-        // the consents are not necessarily set in the SDK. So we check the list
-        // of granted consents and grant if they are not set.
+        // the consents are not necessarily set in the SDK. So we check the SDKs
+        // list of granted consents and grant if they are not set.
         const consents: any[] = await Kettle.getGrantedConsents();
         if (consents.length === 0) {
           Kettle.grant(BEACONS_CONSENTS);

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -201,11 +201,10 @@ const BeaconsContextProvider: React.FC = ({children}) => {
       ) {
         await initializeKettleSDK(false);
 
-        // TODO: What is the return type?
-        const consents: any = await Kettle.getGrantedConsents();
-
         // If the user have given consents, but permissions were enabled later,
-        // the consents are not necessarily set in the SDK.
+        // the consents are not necessarily set in the SDK. So we check the list
+        // of granted consents and grant if they are not set.
+        const consents: any[] = await Kettle.getGrantedConsents();
         if (consents.length === 0) {
           Kettle.grant(BEACONS_CONSENTS);
         }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
@@ -23,7 +23,6 @@ import {useFirestoreConfiguration} from '@atb/configuration';
 import {NotificationConfigGroup} from '@atb/notifications/types';
 import {ContentHeading} from '@atb/components/heading';
 import {useProfileQuery} from '@atb/queries';
-import {Button} from '@atb/components/button';
 import {ProfileScreenProps} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
@@ -1,6 +1,10 @@
 import React, {useEffect} from 'react';
 import {FullScreenView} from '@atb/components/screen-view';
-import {Section, ToggleSectionItem} from '@atb/components/sections';
+import {
+  MessageSectionItem,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 import {Linking, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import {StaticColorByType} from '@atb/theme/colors';
@@ -49,9 +53,8 @@ export const Profile_NotificationsScreen = ({
   }, [isFocusedAndActive, checkPermissions]);
 
   const hasNoEmail = profileQuery.isSuccess && profileQuery.data.email === '';
-  const mailEnabled = isConfigEnabled(config?.modes, 'mail') && !hasNoEmail;
-  const pushEnabled =
-    isConfigEnabled(config?.modes, 'push') && permissionStatus === 'granted';
+  const mailEnabled = isConfigEnabled(config?.modes, 'mail');
+  const pushEnabled = isConfigEnabled(config?.modes, 'push');
   const anyModeEnabled = mailEnabled || pushEnabled;
 
   const handleModeToggle = async (id: string, enabled: boolean) => {
@@ -111,22 +114,31 @@ export const Profile_NotificationsScreen = ({
                             .notifications.emailToggle.noEmailPlaceholder,
                     )
               }
-              disabled={hasNoEmail}
               value={mailEnabled}
               onValueChange={(enabled) => handleModeToggle('mail', enabled)}
             />
+            {hasNoEmail && mailEnabled && (
+              <MessageSectionItem
+                messageType="info"
+                title={t(
+                  ProfileTexts.sections.settings.linkSectionItems.notifications
+                    .emailRequired.title,
+                )}
+                message={t(
+                  ProfileTexts.sections.settings.linkSectionItems.notifications
+                    .emailRequired.message,
+                )}
+                onPressConfig={{
+                  text: t(
+                    ProfileTexts.sections.settings.linkSectionItems
+                      .notifications.emailRequired.action,
+                  ),
+                  action: () =>
+                    navigation.navigate('Profile_EditProfileScreen'),
+                }}
+              />
+            )}
           </Section>
-          {hasNoEmail && (
-            <Button
-              onPress={() => navigation.navigate('Profile_EditProfileScreen')}
-              text={t(
-                ProfileTexts.sections.settings.linkSectionItems.notifications
-                  .button,
-              )}
-              interactiveColor="interactive_2"
-              mode="secondary"
-            />
-          )}
           <Section>
             <ToggleSectionItem
               text={t(
@@ -138,33 +150,31 @@ export const Profile_NotificationsScreen = ({
                   .pushToggle.subText,
               )}
               value={pushEnabled}
-              disabled={
-                permissionStatus === 'updating' || permissionStatus === 'denied'
-              }
               onValueChange={(enabled) => handleModeToggle('push', enabled)}
             />
+            {pushEnabled &&
+              permissionStatus !== 'error' &&
+              permissionStatus === 'denied' && (
+                <MessageSectionItem
+                  messageType="info"
+                  title={t(
+                    ProfileTexts.sections.settings.linkSectionItems
+                      .notifications.permissionRequired.title,
+                  )}
+                  message={t(
+                    ProfileTexts.sections.settings.linkSectionItems
+                      .notifications.permissionRequired.message,
+                  )}
+                  onPressConfig={{
+                    text: t(
+                      ProfileTexts.sections.settings.linkSectionItems
+                        .notifications.permissionRequired.action,
+                    ),
+                    action: () => Linking.openSettings(),
+                  }}
+                />
+              )}
           </Section>
-
-          {permissionStatus !== 'error' && permissionStatus === 'denied' && (
-            <MessageInfoBox
-              type="info"
-              title={t(
-                ProfileTexts.sections.settings.linkSectionItems.notifications
-                  .permissionRequired.title,
-              )}
-              message={t(
-                ProfileTexts.sections.settings.linkSectionItems.notifications
-                  .permissionRequired.message,
-              )}
-              onPressConfig={{
-                text: t(
-                  ProfileTexts.sections.settings.linkSectionItems.notifications
-                    .permissionRequired.action,
-                ),
-                action: () => Linking.openSettings(),
-              }}
-            />
-          )}
           {permissionStatus === 'error' && (
             <MessageInfoBox
               type="error"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -87,10 +87,19 @@ export const Profile_PrivacyScreen = () => {
               {isConsentGranted && !hasPermissionsForBeacons && (
                 <MessageSectionItem
                   messageType="info"
-                  title="TODO"
-                  message="TODO"
+                  title={t(
+                    ProfileTexts.sections.privacy.linkSectionItems
+                      .permissionRequired.title,
+                  )}
+                  message={t(
+                    ProfileTexts.sections.privacy.linkSectionItems
+                      .permissionRequired.message,
+                  )}
                   onPressConfig={{
-                    text: 'TODO',
+                    text: t(
+                      ProfileTexts.sections.privacy.linkSectionItems
+                        .permissionRequired.action,
+                    ),
                     action: () => Linking.openSettings(),
                   }}
                 />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -75,12 +75,8 @@ export const Profile_PrivacyScreen = () => {
                     .CollectTravelHabits.subText,
                 )}
                 value={isConsentGranted}
-                onValueChange={async (checked) => {
-                  if (checked) {
-                    await onboardForBeacons();
-                  } else {
-                    await revokeBeacons();
-                  }
+                onValueChange={(checked) => {
+                  checked ? onboardForBeacons() : revokeBeacons();
                 }}
                 testID="toggleCollectData"
               />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -1,12 +1,13 @@
 import {
   LinkSectionItem,
+  MessageSectionItem,
   Section,
   ToggleSectionItem,
 } from '@atb/components/sections';
 import {StyleSheet, Theme} from '@atb/theme';
 import {ProfileTexts, useTranslation} from '@atb/translations';
-import React, {useCallback, useEffect, useState} from 'react';
-import {Alert, Linking, View} from 'react-native';
+import React, {useEffect, useState} from 'react';
+import {Linking, View} from 'react-native';
 import PrivacySettingsTexts from '@atb/translations/screens/subscreens/PrivacySettingsTexts';
 import {Button} from '@atb/components/button';
 import {Delete} from '@atb/assets/svg/mono-icons/actions';
@@ -16,6 +17,7 @@ import {useSearchHistory} from '@atb/search-history';
 import {useBeaconsState} from '@atb/beacons/BeaconsContext';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ContentHeading, ScreenHeading} from '@atb/components/heading';
+import {checkPermissionStatuses} from '@atb/beacons/permissions';
 
 export const Profile_PrivacyScreen = () => {
   const {t} = useTranslation();
@@ -27,54 +29,21 @@ export const Profile_PrivacyScreen = () => {
     isBeaconsSupported,
     getPrivacyDashboardUrl,
   } = useBeaconsState();
+
   const {privacy_policy_url} = useRemoteConfig();
   const style = useStyle();
   const {clearHistory} = useSearchHistory();
-  const [isBeaconsToggleEnabled, setIsBeaconsToggleEnabled] = useState(
-    beaconsInfo?.isConsentGranted ?? false,
-  );
-  const [isBeaconsToggleDisabled, setIsBeaconsToggleDisabled] = useState(false);
   const [isCleaningCollectedData, setIsCleaningCollectedData] =
     React.useState<boolean>(false);
 
-  const beaconsPermissionsAlert = useCallback(
-    () =>
-      Alert.alert(
-        t(PrivacySettingsTexts.permissionsAlert.title),
-        t(PrivacySettingsTexts.permissionsAlert.message),
-        [
-          {
-            text: t(PrivacySettingsTexts.permissionsAlert.action),
-            onPress: () => Linking.openSettings(),
-          },
-        ],
-      ),
-    [t],
-  );
+  const [hasPermissionsForBeacons, setHasPermissionsForBeacons] =
+    useState(false);
 
   useEffect(() => {
-    (async () => {
-      setIsBeaconsToggleDisabled(true);
-      if (isBeaconsToggleEnabled) {
-        const permissionsGranted = await onboardForBeacons();
-
-        // If the toggle was set to true, but we don't have the required
-        // permissions, we ask the user to grant permissions from Settings.
-        if (!permissionsGranted) beaconsPermissionsAlert();
-
-        setIsBeaconsToggleEnabled(permissionsGranted);
-      } else {
-        await revokeBeacons();
-        setIsBeaconsToggleEnabled(false);
-      }
-      setIsBeaconsToggleDisabled(false);
-    })();
-  }, [
-    isBeaconsToggleEnabled,
-    onboardForBeacons,
-    revokeBeacons,
-    beaconsPermissionsAlert,
-  ]);
+    checkPermissionStatuses().then((permissions) => {
+      setHasPermissionsForBeacons(permissions.bluetooth);
+    });
+  }, []);
 
   return (
     <FullScreenView
@@ -105,11 +74,29 @@ export const Profile_PrivacyScreen = () => {
                   PrivacySettingsTexts.sections.consents.items
                     .CollectTravelHabits.subText,
                 )}
-                value={isBeaconsToggleEnabled}
-                onValueChange={(checked) => setIsBeaconsToggleEnabled(checked)}
-                disabled={isBeaconsToggleDisabled}
+                value={beaconsInfo ? beaconsInfo.isConsentGranted : false}
+                onValueChange={(checked) => {
+                  async () => {
+                    if (checked) {
+                      await onboardForBeacons();
+                    } else {
+                      await revokeBeacons();
+                    }
+                  };
+                }}
                 testID="toggleCollectData"
               />
+              {beaconsInfo?.isConsentGranted && !hasPermissionsForBeacons && (
+                <MessageSectionItem
+                  messageType="info"
+                  title="TODO"
+                  message="TODO"
+                  onPressConfig={{
+                    text: 'TODO',
+                    action: () => Linking.openSettings(),
+                  }}
+                />
+              )}
             </Section>
           </>
         )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -75,14 +75,12 @@ export const Profile_PrivacyScreen = () => {
                     .CollectTravelHabits.subText,
                 )}
                 value={isConsentGranted}
-                onValueChange={(checked) => {
-                  async () => {
-                    if (checked) {
-                      await onboardForBeacons();
-                    } else {
-                      await revokeBeacons();
-                    }
-                  };
+                onValueChange={async (checked) => {
+                  if (checked) {
+                    await onboardForBeacons();
+                  } else {
+                    await revokeBeacons();
+                  }
                 }}
                 testID="toggleCollectData"
               />

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -216,6 +216,23 @@ const ProfileTexts = {
             'Aktiver for å lese personvernerklæring på ekstern side',
           ),
         },
+        permissionRequired: {
+          title: _(
+            'Tillatelse kreves',
+            'Permission required',
+            'Løyve krevjast',
+          ),
+          message: _(
+            'Gi tilgang til Bluetooth for å dele dine reisevaner.',
+            'Enable Bluetooth to share your travel habits.',
+            'Gi løyve til Bluetooth for å dele dine reisevanar.',
+          ),
+          action: _(
+            'Åpne telefoninnstillinger',
+            'Open Settings',
+            'Opne telefoninnstillingar',
+          ),
+        },
         clearHistory: {
           label: _(
             'Tøm søkehistorikk',

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -124,6 +124,19 @@ const ProfileTexts = {
             ),
           },
           button: _('Legg til e-post', 'Add e-mail address', 'Legg til e-post'),
+          emailRequired: {
+            title: _('E-post mangler', 'E-mail missing', 'E-post manglar'),
+            message: _(
+              'Legg til e-post i min profil for å benytte e-postvarsel.',
+              'Add e-mail to my profile to use e-mail notifications.',
+              'Legg til e-post i min profil for å bruke e-postvarsel.',
+            ),
+            action: _(
+              'Legg til e-post',
+              'Add e-mail address',
+              'Legg til e-post',
+            ),
+          },
           permissionRequired: {
             title: _(
               'Tillatelse kreves',

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -124,6 +124,14 @@ const ProfileTexts = {
             ),
           },
           button: _('Legg til e-post', 'Add e-mail address', 'Legg til e-post'),
+          loginRequired: {
+            title: _('Krever innlogging', 'Login required', 'Krev innlogging'),
+            message: _(
+              'Logg inn for å for å benytte e-postvarsel.',
+              'Log in to use e-mail notifications.',
+              'Logg inn for å nytte deg av e-postvarslingar.',
+            ),
+          },
           emailRequired: {
             title: _('E-post mangler', 'E-mail missing', 'E-post manglar'),
             message: _(
@@ -153,6 +161,19 @@ const ProfileTexts = {
               'Open Settings',
               'Opne telefoninnstillingar',
             ),
+          },
+          promptRequired: {
+            title: _(
+              'Tillatelse kreves',
+              'Permission required',
+              'Løyve krevjast',
+            ),
+            message: _(
+              'Du må tillate appen å sende deg varslinger for å få beskjed før billettene dine utløper.',
+              'You have to allow the app to send you notifications to be informed before your tickets expire.',
+              'Du må tillate appen å sende deg varsel for å bli informert før billettane dine går ut.',
+            ),
+            action: _('Velg tillatelser', 'Choose permissions', 'Vel løyve'),
           },
           permissionError: {
             title: _('Oops!', 'Whoops!', 'Oops!'),

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -118,9 +118,9 @@ const ProfileTexts = {
                 `Gi AtB løyve til å sende varslingar til ${email}`,
               ),
             noEmailPlaceholder: _(
-              'Legg til e-post i min profil for å benytte e-postvarsel.',
-              'Add e-mail to my profile to use e-mail notifications.',
-              'Legg til e-post i min profil for å bruke e-postvarsel.',
+              'Tillat at AtB sender varslinger til e-posten din.',
+              'Allow AtB to send notifications to your e-mail.',
+              'Gi AtB løyve til å sende varslingar til e-posten din.',
             ),
           },
           button: _('Legg til e-post', 'Add e-mail address', 'Legg til e-post'),


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16425

This PR attempts to separate "consents" and "permissions" more clearly by adding message boxes that warns about missing permissions when consent is given. This applies to push notifications, email and beacons. (ref. https://github.com/AtB-AS/kundevendt/issues/15656#issuecomment-1886818199)

In the BeaconsContext, this is reflected by always setting local storage `beaconsConsent = true`, even if the user doesn't give permissions. 

Also changes some variable names and adds some comments :) 

### Screenshots

<div>
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/4eaafd8d-c480-4995-b532-84d004ca55d3">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/7b3c498c-c15d-4652-942c-9165d2b72438">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/a632b1bb-4790-4b5c-b102-7d71b83d4e22">
</div>