### PR TITLE
feat: ticket info button on ticket detail screen

### DIFF
--- a/src/components/screen-header/HeaderButton.tsx
+++ b/src/components/screen-header/HeaderButton.tsx
@@ -13,6 +13,7 @@ import {Close} from '@atb/assets/svg/mono-icons/actions';
 import {useServiceDisruptionIcon} from '@atb/service-disruptions/use-service-disruption-icon';
 import {AnalyticsEventContext, useAnalytics} from '@atb/analytics';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {Info} from '@atb/assets/svg/mono-icons/status';
 
 export type ButtonModes =
   | 'back'
@@ -21,6 +22,7 @@ export type ButtonModes =
   | 'chat'
   | 'skip'
   | 'status-disruption'
+  | 'info'
   | 'custom';
 export type HeaderButtonProps = {
   type: ButtonModes;
@@ -108,6 +110,13 @@ const useHeaderButton = (
     }
     case 'chat':
       return chatIcon;
+    case 'info':
+      const {onPress, color, ...accessibilityProps} = buttonProps;
+      return {
+        children: <ThemeIcon svg={Info} colorType={color}/>,
+        onPress: onPress,
+        ...accessibilityProps
+      };
     case 'custom': {
       const {text, color, onPress, ...accessibilityProps} = buttonProps;
       return {

--- a/src/components/screen-header/HeaderButton.tsx
+++ b/src/components/screen-header/HeaderButton.tsx
@@ -114,7 +114,7 @@ const useHeaderButton = (
       const {onPress, type, color, ...accessibilityProps} = buttonProps;
       return {
         children: <ThemeIcon svg={Info} colorType={color}/>,
-        accessibilityHint: t(ScreenHeaderTexts.headerButton[type].a11yHint),
+        accessibilityLabel: t(ScreenHeaderTexts.headerButton[type].text),
         onPress: onPress,
         ...accessibilityProps
       };

--- a/src/components/screen-header/HeaderButton.tsx
+++ b/src/components/screen-header/HeaderButton.tsx
@@ -111,9 +111,10 @@ const useHeaderButton = (
     case 'chat':
       return chatIcon;
     case 'info':
-      const {onPress, color, ...accessibilityProps} = buttonProps;
+      const {onPress, type, color, ...accessibilityProps} = buttonProps;
       return {
         children: <ThemeIcon svg={Info} colorType={color}/>,
+        accessibilityHint: t(ScreenHeaderTexts.headerButton[type].a11yHint),
         onPress: onPress,
         ...accessibilityProps
       };

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -24,7 +24,11 @@ export type LeftButtonProps = HeaderButtonProps & {
 
 export type RightButtonProps =
   | (HeaderButtonProps & {
-      type: 'chat' | 'skip' | 'close' | 'info';
+      type: 'chat' | 'skip' | 'close';
+    })
+  | (HeaderButtonProps & {
+      type: 'info',
+      onPress: () => void; 
     })
   | (HeaderButtonProps & {
       type: 'custom';

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -24,7 +24,7 @@ export type LeftButtonProps = HeaderButtonProps & {
 
 export type RightButtonProps =
   | (HeaderButtonProps & {
-      type: 'chat' | 'skip' | 'close';
+      type: 'chat' | 'skip' | 'close' | 'info';
     })
   | (HeaderButtonProps & {
       type: 'custom';

--- a/src/components/screen-header/index.ts
+++ b/src/components/screen-header/index.ts
@@ -1,6 +1,7 @@
 export {ScreenHeader} from './ScreenHeader';
 export {FullScreenHeader} from './FullScreenHeader';
 export {AnimatedScreenHeader} from './AnimatedScreenHeader';
+export {useTicketInfo} from './use-ticket-info';
 export type {IconButtonProps} from './HeaderButton';
 export type {
   LeftButtonProps,

--- a/src/components/screen-header/use-ticket-info.tsx
+++ b/src/components/screen-header/use-ticket-info.tsx
@@ -1,0 +1,53 @@
+import {useAnalytics} from '@atb/analytics';
+import {
+    PreassignedFareProduct,
+  findReferenceDataById,
+  isOfFareProductRef,
+  useFirestoreConfiguration,
+} from '@atb/configuration';
+import {RootNavigationProps} from '@atb/stacks-hierarchy';
+import {FareContract, useTicketingState} from '@atb/ticketing';
+import {useNavigation} from '@react-navigation/native';
+
+type TicketInfo = {
+  navigateToTicketInfoScreen: () => void;
+  fareContract: FareContract | undefined;
+  preassignedFareProduct: PreassignedFareProduct | undefined;
+};
+
+export const useTicketInfo = (orderId: string): TicketInfo => {
+  const {findFareContractByOrderId} = useTicketingState();
+  const fareContract = findFareContractByOrderId(orderId);
+  const firstTravelRight = fareContract?.travelRights[0];
+
+  const {preassignedFareProducts} = useFirestoreConfiguration();
+  const preassignedFareProduct = findReferenceDataById(
+    preassignedFareProducts,
+    isOfFareProductRef(firstTravelRight) ? firstTravelRight.fareProductRef : '',
+  );
+
+  const analytics = useAnalytics();
+  const navigation = useNavigation<RootNavigationProps>();
+
+  const ticketInfoParams = preassignedFareProduct && {
+    fareProductTypeConfigType: preassignedFareProduct?.type,
+    preassignedFareProductId: preassignedFareProduct?.id,
+  };
+
+  const navigateToTicketInfoScreen = () => {
+    ticketInfoParams &&
+      analytics.logEvent(
+        'Ticketing',
+        'Ticket information button clicked',
+        ticketInfoParams,
+      );
+    ticketInfoParams &&
+      navigation.navigate('Root_TicketInformationScreen', ticketInfoParams);
+  };
+
+  return {
+    navigateToTicketInfoScreen,
+    fareContract,
+    preassignedFareProduct
+  };
+};

--- a/src/stacks-hierarchy/Root_CarnetDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_CarnetDetailsScreen.tsx
@@ -2,7 +2,6 @@ import {FullScreenHeader, useTicketInfo} from '@atb/components/screen-header';
 import {StyleSheet} from '@atb/theme';
 import {
   FareContractTexts,
-  ScreenHeaderTexts,
   useTranslation,
 } from '@atb/translations';
 import React from 'react';
@@ -42,7 +41,7 @@ export function Root_CarnetDetailsScreen({navigation, route}: Props) {
                 onPress: navigateToTicketInfoScreen,
                 color: 'background_accent_0',
                 accessibilityHint: t(
-                  ScreenHeaderTexts.headerButton.info.a11yHint,
+                  FareContractTexts.details.infoButtonA11yHint,
                 ),
               }
             : undefined

--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -4,7 +4,6 @@ import {useApplePassPresentationSuppression} from '@atb/suppress-pass-presentati
 import {StyleSheet} from '@atb/theme';
 import {
   FareContractTexts,
-  ScreenHeaderTexts,
   useTranslation,
 } from '@atb/translations';
 import React from 'react';
@@ -43,7 +42,7 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
                 onPress: navigateToTicketInfoScreen,
                 color: 'background_accent_0',
                 accessibilityHint: t(
-                  ScreenHeaderTexts.headerButton.info.a11yHint,
+                  FareContractTexts.details.infoButtonA11yHint,
                 ),
               }
             : undefined

--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -13,6 +13,8 @@ import React from 'react';
 import {ScrollView, View} from 'react-native';
 import {RootStackScreenProps} from '../stacks-hierarchy/navigation-types';
 import {useTimeContextState} from '@atb/time';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useAnalytics} from '@atb/analytics';
 
 type Props = RootStackScreenProps<'Root_FareContractDetailsScreen'>;
 
@@ -23,6 +25,8 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
   const fc = findFareContractByOrderId(route?.params?.orderId);
   const firstTravelRight = fc?.travelRights[0];
   const {t} = useTranslation();
+  const {enable_ticket_information} = useRemoteConfig();
+  const analytics = useAnalytics();
 
   useApplePassPresentationSuppression();
 
@@ -39,10 +43,31 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
       orderVersion: fc.version,
     });
 
+  const ticketInfoParams = preassignedFareProduct && {
+    fareProductTypeConfigType: preassignedFareProduct?.type,
+    preassignedFareProductId: preassignedFareProduct?.id,
+  };
+
+  const onPressInfo = () => {
+    ticketInfoParams &&
+      navigation.navigate('Root_TicketInformationScreen', ticketInfoParams);
+    ticketInfoParams &&
+      analytics.logEvent(
+        'Ticketing',
+        'Ticket information button clicked',
+        ticketInfoParams,
+      );
+  };
+
   return (
     <View style={styles.container}>
       <FullScreenHeader
         leftButton={{type: 'close'}}
+        rightButton={
+          enable_ticket_information
+            ? {type: 'info', onPress: onPressInfo, color:'background_accent_0'}
+            : undefined
+        }
         title={t(FareContractTexts.details.header.title)}
       />
       <ScrollView contentContainerStyle={styles.content}>

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -45,6 +45,9 @@ const ScreenHeaderTexts = {
     chat: {
       a11yHint: _('Kontakt AtB', 'Contact AtB', 'Kontakt AtB'),
     },
+    info: {
+      a11yHint: _('Aktivér for å gå til billettinformasjon', 'Activate to go to ticket information', 'Aktivér for å gå til billetinformasjon'),
+    }
   },
 };
 

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -47,7 +47,6 @@ const ScreenHeaderTexts = {
     },
     info: {
       text: _('Info', 'Info', 'Info'),
-      a11yHint: _('Aktivér for å gå til billettinformasjon', 'Activate to go to ticket information', 'Aktivér for å gå til billetinformasjon'),
     }
   },
 };

--- a/src/translations/components/ScreenHeader.ts
+++ b/src/translations/components/ScreenHeader.ts
@@ -46,6 +46,7 @@ const ScreenHeaderTexts = {
       a11yHint: _('Kontakt AtB', 'Contact AtB', 'Kontakt AtB'),
     },
     info: {
+      text: _('Info', 'Info', 'Info'),
       a11yHint: _('Aktivér for å gå til billettinformasjon', 'Activate to go to ticket information', 'Aktivér for å gå til billetinformasjon'),
     }
   },

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -146,6 +146,8 @@ const FareContractTexts = {
         'Kunne ikkje laste kaier.',
       ),
     },
+    infoButtonA11yHint: _('Aktivér for å gå til billettinformasjon', 'Activate to go to ticket information', 'Aktivér for å gå til billetinformasjon'),
+
   },
   carnet: {
     numberOfUsedAccessesRemaining: (count: number) =>


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16298

This PR will add new ticket info header button on ticket detail screen (both regular tickets and carnet tickets), and the navigation to the ticket information screen. Also added accessibility information, tested on 200% font size, both iOS and Android. Language is not ready until this issue is done https://github.com/AtB-AS/kundevendt/issues/15863

Sjekk ut skjermbilde for detaljer 
(Check out screenshots for details, hopefully this is correct, trying to not use google translate)

<details>

<summary>Vis skjermbilde</summary>

<img width="300" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/9b9c5395-7ffe-4594-855d-84904f498947">
<img width="300" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/204301a0-689e-4206-bcd8-a44694e39dff">
<img width="250" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/dbadc7e3-40dd-47ca-b4e3-dba0446adc69">
<img width="250" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/b8603c08-d49b-40aa-b10e-4d2413c3ab40">

https://github.com/AtB-AS/mittatb-app/assets/1777333/801ba88e-7188-454b-baa2-80c0c78faadd

https://github.com/AtB-AS/mittatb-app/assets/1777333/ef114f3f-6afe-4161-95bf-fceddf3c7fe2

</details>

- [x] The button should show correctly
- [x] Navigates to the Root_TicketInformationScreen
- [x] 200% Zoom
- [x] Screenreader
- [x] Light and Dark mode
- [ ] Language 

