### PR TITLE
fix: travel token consider change screen onboarding flag

### DIFF
--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
@@ -57,8 +57,8 @@ export const Root_ConsiderTravelTokenChangeScreen = () => {
 
   if (mobileTokenStatus !== 'success') return NoTokenView;
 
-  const inspectableToken = tokens.find((token) => token.isInspectable);
-  if (!inspectableToken) return NoTokenView;
+  const hasInspectableToken = tokens.some((token) => token.isInspectable);
+  if (!hasInspectableToken) return NoTokenView;
 
   return (
     <OnboardingFullScreenView

--- a/src/utils/use-onboarding-navigation-flow.ts
+++ b/src/utils/use-onboarding-navigation-flow.ts
@@ -4,6 +4,7 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 import {useAuthState} from '@atb/auth';
 import {useShouldShowShareTravelHabitsScreen} from '@atb/beacons/use-should-show-share-travel-habits-screen';
+import {useMobileTokenContextState} from '@atb/mobile-token';
 import {
   useNotifications,
   usePushNotificationsEnabled,
@@ -155,8 +156,11 @@ const useShouldShowTravelTokenOnboarding = () => {
   const {mobileTokenOnboarded, mobileTokenWithoutTravelcardOnboarded} =
     useAppState();
   const {disable_travelcard} = useRemoteConfig();
-
+  const {tokens, mobileTokenStatus} = useMobileTokenContextState();
+  const inspectableToken = tokens.find((token) => token.isInspectable);
   return (
+    inspectableToken &&
+    mobileTokenStatus === 'success' &&
     authenticationType === 'phone' &&
     ((!mobileTokenOnboarded && !disable_travelcard) ||
       (!mobileTokenWithoutTravelcardOnboarded && disable_travelcard))

--- a/src/utils/use-onboarding-navigation-flow.ts
+++ b/src/utils/use-onboarding-navigation-flow.ts
@@ -157,9 +157,9 @@ const useShouldShowTravelTokenOnboarding = () => {
     useAppState();
   const {disable_travelcard} = useRemoteConfig();
   const {tokens, mobileTokenStatus} = useMobileTokenContextState();
-  const inspectableToken = tokens.find((token) => token.isInspectable);
+  const hasInspectableToken = tokens.some((token) => token.isInspectable);
   return (
-    inspectableToken &&
+    hasInspectableToken &&
     mobileTokenStatus === 'success' &&
     authenticationType === 'phone' &&
     ((!mobileTokenOnboarded && !disable_travelcard) ||


### PR DESCRIPTION
The travel token needs some time before it is ready after a login.
The new onboarding flow showed the `Root_ConsiderTravelTokenChangeScreen` screen immediately, but this caused an error state to be visible. Now the flag for whether that screen should show or not is false until the travel token is ready.
One change this causes, is that it will no longer show as the first screen after login (but atm it has highest priority, so as soon as it is ready, it will be shown.) In most cases it will now be shown right after the location onboarding screen.

Closes https://github.com/AtB-AS/kundevendt/issues/8620#issuecomment-1891961937
