### PR TITLE
feat: don't show onboarding if beacon consent is granted even once

### DIFF
--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -178,7 +178,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     }
 
     return permissionsGranted;
-  }, [isBeaconsSupported, rationaleMessages, initializeKettleSDK]);
+  }, [isBeaconsSupported, isConsentAlreadyGrantedOnce, rationaleMessages, initializeKettleSDK]);
 
   const revokeBeacons = useCallback(async () => {
     if (!isBeaconsSupported) return;

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -151,7 +151,15 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     if (!isBeaconsSupported) return false;
     await storage.set(storeKey.beaconsConsent, 'true');
     setIsConsentGranted(true);
-    await storage.set(storeKey.beaconsConsentAlreadyGrantedOnce, 'true');
+    
+    /**
+     * if the consent is granted and 'beaconsConsentAlreadyGrantedOnce' is
+     * not set, then set it, otherwise just skip it. 
+     */
+    if (!isConsentAlreadyGrantedOnce) {
+      await storage.set(storeKey.beaconsConsentAlreadyGrantedOnce, 'true');
+    }
+
     let permissionsGranted = false;
     if (Platform.OS === 'ios') {
       // NOTE: This module can be found in /ios/Shared/BeaconsPermissions.swift

--- a/src/beacons/use-should-show-share-travel-habits-screen.tsx
+++ b/src/beacons/use-should-show-share-travel-habits-screen.tsx
@@ -21,7 +21,7 @@ export const useShouldShowShareTravelHabitsScreen = (
   const sessionCountRef = useRef(0);
   const [sessionCount, setSessionCount] = useState(0);
   const isInitializedRef = useRef(false);
-  const {isBeaconsSupported, isConsentGranted} = useBeaconsState();
+  const {isBeaconsSupported, isConsentGranted, isConsentAlreadyGrantedOnce} = useBeaconsState();
 
   const appStatus = useAppStateStatus();
 
@@ -30,7 +30,7 @@ export const useShouldShowShareTravelHabitsScreen = (
     onboarded && isBeaconsSupported && !shareTravelHabitsOnboarded;
 
   const shouldShowShareTravelHabitsScreen =
-    enabled && !isConsentGranted && sessionCount > runAfterSessionsCount;
+    enabled && !isConsentGranted && !isConsentAlreadyGrantedOnce && sessionCount > runAfterSessionsCount;
 
   const updateCount = useCallback(
     async (currentCount: number) => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -172,6 +172,7 @@ export const Profile_DebugInfoScreen = () => {
   const {setPreference, preferences} = usePreferences();
   const {showTestIds, debugShowSeconds} = preferences;
 
+
   return (
     <View style={style.container}>
       <FullScreenHeader
@@ -266,7 +267,10 @@ export const Profile_DebugInfoScreen = () => {
           />
           <LinkSectionItem
             text="Restart ShareTravelHabits onboarding"
-            onPress={restartShareTravelHabitsOnboarding}
+            onPress={() => {
+              restartShareTravelHabitsOnboarding
+              storage.remove('@ATB_beacons_consent_granted_once')
+            }}
           />
           <LinkSectionItem
             text="Reset one time popovers"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16288

This PR will save the state of the beacons consent granted, if it has ever been toggled once, then we should not show the beacons onboarding. This is to handle if the user toggles the consent directly on the privacy policy screen before they saw the beacons onboarding. 

Also resets the key on the restart beacons onboarding item on the debug screen.