### PR TITLE
fix: fix qa issues on permissions flow

### DIFF
--- a/src/stacks-hierarchy/Root_ShareTravelHabitsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShareTravelHabitsScreen.tsx
@@ -33,7 +33,7 @@ export const Root_ShareTravelHabitsScreen = () => {
   );
 
   const choosePermissions = async () => {
-    await onboardForBeacons();
+    await onboardForBeacons(false);
 
     const permissions = await checkPermissionStatuses(); // get given permissions status
     analytics.logEvent('Onboarding', 'beaconsPermissionAnswers', {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -635,12 +635,12 @@ export const Profile_DebugInfoScreen = () => {
                   <Button
                     interactiveColor="interactive_0"
                     onPress={async () => {
-                      const granted = await onboardForBeacons();
+                      const granted = await onboardForBeacons(true);
                       Alert.alert('Onboarding', `Access granted: ${granted}`);
                     }}
                     disabled={isConsentGranted}
                     style={style.button}
-                    text="Onboard"
+                    text="Onboard and give consent"
                   />
                   <Button
                     interactiveColor="interactive_0"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -76,7 +76,7 @@ export const Profile_PrivacyScreen = () => {
                 )}
                 value={isConsentGranted}
                 onValueChange={(checked) => {
-                  checked ? onboardForBeacons() : revokeBeacons();
+                  checked ? onboardForBeacons(true) : revokeBeacons();
                 }}
                 testID="toggleCollectData"
               />


### PR DESCRIPTION
ref. https://github.com/AtB-AS/kundevendt/issues/16425#issuecomment-1893576632

Fixes a few issues from QA:

- Dismissing the permissions prompt during onboarding no longer sets consent to true.
- The prompt to open phone settings on the privacy page is now based on if we have _any_ beacons permission, not just bluetooth
- The prompt to open phone settings on the privacy page is now removed when permissions are allowed