### PR TITLE
fix: make expanded part of expandable section item accessible

### DIFF
--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -45,7 +45,7 @@ export function ExpandableSectionItem({
   testID,
   ...props
 }: Props) {
-  const {contentContainer, topContainer} = useSectionItem(props);
+  const {contentContainer, topContainer, spacing} = useSectionItem(props);
   const sectionStyle = useSectionStyle();
   const styles = useStyles();
   const {t} = useTranslation();
@@ -71,37 +71,39 @@ export function ExpandableSectionItem({
   };
 
   return (
-    <View
-      style={topContainer}
-      accessible={true}
-      accessibilityLabel={text}
-      accessibilityHint={
-        expanded
-          ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
-          : t(SectionTexts.expandableSectionItem.a11yHint.expand)
-      }
-      accessibilityRole="button"
-      accessibilityState={{
-        expanded: expanded,
-      }}
-    >
-      <PressableOpacity
-        onPress={onPress}
-        style={sectionStyle.spaceBetween}
-        testID={testID}
-        {...accessibility}
+    <>
+      <View
+        style={topContainer}
+        accessible={true}
+        accessibilityLabel={text}
+        accessibilityHint={
+          expanded
+            ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
+            : t(SectionTexts.expandableSectionItem.a11yHint.expand)
+        }
+        accessibilityRole="button"
+        accessibilityState={{
+          expanded: expanded,
+        }}
       >
-        <ThemeText style={contentContainer} type={textType}>
-          {text}
-        </ThemeText>
-        <ExpandIcon expanded={expanded} showText={showIconText} />
-      </PressableOpacity>
+        <PressableOpacity
+          onPress={onPress}
+          style={sectionStyle.spaceBetween}
+          testID={testID}
+          {...accessibility}
+        >
+          <ThemeText style={contentContainer} type={textType}>
+            {text}
+          </ThemeText>
+          <ExpandIcon expanded={expanded} showText={showIconText} />
+        </PressableOpacity>
+      </View>
       {expanded && 'expandContent' in props && (
-        <View style={styles.expandContent} accessible={true}>
+        <View style={[{padding: spacing}, styles.expandContent]}>
           {props.expandContent}
         </View>
       )}
-    </View>
+    </>
   );
 }
 
@@ -143,6 +145,7 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     marginRight: theme.spacings.xSmall,
   },
   expandContent: {
-    marginTop: theme.spacings.medium,
+    // marginTop: theme.spacings.medium,
+    backgroundColor: theme.static.background.background_0.background,
   },
 }));

--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -45,7 +45,7 @@ export function ExpandableSectionItem({
   testID,
   ...props
 }: Props) {
-  const {contentContainer, topContainer, spacing} = useSectionItem(props);
+  const {contentContainer, topContainer} = useSectionItem(props);
   const sectionStyle = useSectionStyle();
   const styles = useStyles();
   const {t} = useTranslation();
@@ -71,39 +71,34 @@ export function ExpandableSectionItem({
   };
 
   return (
-    <>
-      <View
-        style={topContainer}
-        accessible={true}
-        accessibilityLabel={text}
-        accessibilityHint={
-          expanded
-            ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
-            : t(SectionTexts.expandableSectionItem.a11yHint.expand)
-        }
-        accessibilityRole="button"
-        accessibilityState={{
-          expanded: expanded,
-        }}
+    <View
+      style={topContainer}
+      accessible={true}
+      accessibilityHint={
+        expanded
+          ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
+          : t(SectionTexts.expandableSectionItem.a11yHint.expand)
+      }
+      accessibilityRole="button"
+      accessibilityState={{
+        expanded: expanded,
+      }}
+    >
+      <PressableOpacity
+        onPress={onPress}
+        style={sectionStyle.spaceBetween}
+        testID={testID}
+        {...accessibility}
       >
-        <PressableOpacity
-          onPress={onPress}
-          style={sectionStyle.spaceBetween}
-          testID={testID}
-          {...accessibility}
-        >
-          <ThemeText style={contentContainer} type={textType}>
-            {text}
-          </ThemeText>
-          <ExpandIcon expanded={expanded} showText={showIconText} />
-        </PressableOpacity>
-      </View>
+        <ThemeText style={contentContainer} type={textType}>
+          {text}
+        </ThemeText>
+        <ExpandIcon expanded={expanded} showText={showIconText} />
+      </PressableOpacity>
       {expanded && 'expandContent' in props && (
-        <View style={[{padding: spacing}, styles.expandContent]}>
-          {props.expandContent}
-        </View>
+        <View style={styles.expandContent}>{props.expandContent}</View>
       )}
-    </>
+    </View>
   );
 }
 
@@ -145,7 +140,6 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     marginRight: theme.spacings.xSmall,
   },
   expandContent: {
-    // marginTop: theme.spacings.medium,
-    backgroundColor: theme.static.background.background_0.background,
+    marginTop: theme.spacings.medium,
   },
 }));

--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -97,7 +97,9 @@ export function ExpandableSectionItem({
         <ExpandIcon expanded={expanded} showText={showIconText} />
       </PressableOpacity>
       {expanded && 'expandContent' in props && (
-        <View style={styles.expandContent}>{props.expandContent}</View>
+        <View style={styles.expandContent} accessible={true}>
+          {props.expandContent}
+        </View>
       )}
     </View>
   );

--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -71,20 +71,17 @@ export function ExpandableSectionItem({
   };
 
   return (
-    <View
-      style={topContainer}
-      accessible={true}
-      accessibilityHint={
-        expanded
-          ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
-          : t(SectionTexts.expandableSectionItem.a11yHint.expand)
-      }
-      accessibilityRole="button"
-      accessibilityState={{
-        expanded: expanded,
-      }}
-    >
+    <View style={topContainer}>
       <PressableOpacity
+        accessibilityHint={
+          expanded
+            ? t(SectionTexts.expandableSectionItem.a11yHint.contract)
+            : t(SectionTexts.expandableSectionItem.a11yHint.expand)
+        }
+        accessibilityRole="button"
+        accessibilityState={{
+          expanded: expanded,
+        }}
         onPress={onPress}
         style={sectionStyle.spaceBetween}
         testID={testID}


### PR DESCRIPTION
The screen reader can now access and read out the content of the expanded section in ExpandableSectionItem, both on android and iOS 👾 

Fixed as part of: https://github.com/AtB-AS/kundevendt/issues/16299
Also closing the reported bug: https://github.com/AtB-AS/kundevendt/issues/10098