### PR TITLE
feat: Add BorderedInfoBox component

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -47,6 +47,7 @@ try {
 
 const getStories = () => {
   return {
+    "./src/storybook/stories/BorderedInfoBox.stories.js": require("../src/storybook/stories/BorderedInfoBox.stories.js"),
     "./src/storybook/stories/Button.stories.js": require("../src/storybook/stories/Button.stories.js"),
     "./src/storybook/stories/MessageInfoBox.stories.js": require("../src/storybook/stories/MessageInfoBox.stories.js"),
     "./src/storybook/stories/MessageInfoText.stories.js": require("../src/storybook/stories/MessageInfoText.stories.js"),

--- a/src/components/bordered-info-box/BorderedInfoBox.tsx
+++ b/src/components/bordered-info-box/BorderedInfoBox.tsx
@@ -1,0 +1,52 @@
+import {getStaticColor, StaticColor} from '@atb/theme/colors';
+import {ThemeText} from '@atb/components/text';
+import {StyleProp, View, ViewStyle} from 'react-native';
+import React, {ReactNode} from 'react';
+import {StyleSheet} from '@atb/theme';
+import {addOpacity} from '@atb/utils/add-opacity';
+
+type Props =
+  | {
+      backgroundColor: StaticColor;
+      type: 'large' | 'small';
+      style?: StyleProp<ViewStyle>;
+    } & ({text: string} | {children: ReactNode});
+
+export const BorderedInfoBox = ({
+  type,
+  backgroundColor,
+  style,
+  ...props
+}: Props) => {
+  const styles = useStyles(type, backgroundColor);
+  return (
+    <View style={[styles.container, style]}>
+      {'text' in props ? (
+        <ThemeText color={backgroundColor}>{props.text}</ThemeText>
+      ) : (
+        props.children
+      )}
+    </View>
+  );
+};
+
+const useStyles = (
+  type: Props['type'],
+  backgroundColor: Props['backgroundColor'],
+) =>
+  StyleSheet.createThemeHook((theme, themeName) => ({
+    container: {
+      borderColor: addOpacity(
+        getStaticColor(themeName, backgroundColor).text,
+        0.1,
+      ),
+      borderWidth: theme.border.width.slim,
+      borderRadius: theme.border.radius.regular,
+      paddingHorizontal:
+        type === 'large' ? theme.spacings.medium : theme.spacings.small,
+      paddingVertical:
+        type === 'large' ? theme.spacings.medium : theme.spacings.xSmall,
+      width: type === 'large' ? '100%' : undefined,
+      alignSelf: 'flex-start',
+    },
+  }))();

--- a/src/components/bordered-info-box/BorderedInfoBox.tsx
+++ b/src/components/bordered-info-box/BorderedInfoBox.tsx
@@ -12,6 +12,12 @@ type Props =
       style?: StyleProp<ViewStyle>;
     } & ({text: string} | {children: ReactNode});
 
+/**
+ * A bordered info box, where the border color is based on the text color of the
+ * background where it is applied. The component can be used either by sending
+ * in text or children, but if using children remember to ensure correct
+ * typography and text color on the child component.
+ */
 export const BorderedInfoBox = ({
   type,
   backgroundColor,
@@ -22,7 +28,9 @@ export const BorderedInfoBox = ({
   return (
     <View style={[styles.container, style]}>
       {'text' in props ? (
-        <ThemeText color={backgroundColor}>{props.text}</ThemeText>
+        <ThemeText type="body__tertiary" color={backgroundColor}>
+          {props.text}
+        </ThemeText>
       ) : (
         props.children
       )}

--- a/src/components/bordered-info-box/index.ts
+++ b/src/components/bordered-info-box/index.ts
@@ -1,0 +1,1 @@
+export {BorderedInfoBox} from './BorderedInfoBox';

--- a/src/storybook/stories/BorderedInfoBox.stories.js
+++ b/src/storybook/stories/BorderedInfoBox.stories.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import {View} from 'react-native';
 import {getStaticColor, themes} from '@atb/theme/colors';
-import {BorderedInfoBox} from "@atb/components/bordered-info-box";
+import {BorderedInfoBox} from '@atb/components/bordered-info-box';
+import {ThemeText} from '@atb/components/text';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Info} from '@atb/assets/svg/mono-icons/status';
 
 const BorderedInfoBoxMeta = {
   title: 'BorderedInfoBox',
@@ -36,8 +39,26 @@ const BorderedInfoBoxMeta = {
           gap: 12,
         }}
       >
-        <Story args={{...args, type: 'large', text: "This is the large box"}} />
-        <Story args={{...args, type: 'small', text: "Small box"}} />
+        <Story args={{...args, type: 'small', text: 'Small box'}} />
+        <Story args={{...args, type: 'large', text: 'This is a large box'}} />
+        <Story
+          args={{
+            ...args,
+            type: 'large',
+            children: (
+              <View style={{flexDirection: 'row'}}>
+                <ThemeIcon
+                  svg={Info}
+                  style={{marginRight: 4}}
+                  colorType={args.backgroundColor}
+                />
+                <ThemeText type="body__tertiary" color={args.backgroundColor} style={{flex: 1}}>
+                  This is a large box with custom child component. Can have icons, line breaks, and such.
+                </ThemeText>
+              </View>
+            ),
+          }}
+        />
       </View>
     ),
   ],

--- a/src/storybook/stories/BorderedInfoBox.stories.js
+++ b/src/storybook/stories/BorderedInfoBox.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {View} from 'react-native';
+import {getStaticColor, themes} from '@atb/theme/colors';
+import {BorderedInfoBox} from "@atb/components/bordered-info-box";
+
+const BorderedInfoBoxMeta = {
+  title: 'BorderedInfoBox',
+  component: BorderedInfoBox,
+  argTypes: {
+    theme: {
+      control: {type: 'radio'},
+      options: ['light', 'dark'],
+    },
+    backgroundColor: {
+      control: 'select',
+      options: [
+        ...Object.keys(themes['light'].static.background),
+        ...Object.keys(themes['light'].static.status),
+      ],
+    },
+  },
+  args: {
+    theme: 'light',
+    backgroundColor: 'background_0',
+  },
+  decorators: [
+    (Story, {args}) => (
+      <View
+        style={{
+          justifyContent: 'center',
+          padding: 12,
+          flex: 1,
+          backgroundColor:
+            getStaticColor(args.theme, args.backgroundColor)?.background ||
+            getStaticColor(args.theme, 'background_0').background,
+          gap: 12,
+        }}
+      >
+        <Story args={{...args, type: 'large', text: "This is the large box"}} />
+        <Story args={{...args, type: 'small', text: "Small box"}} />
+      </View>
+    ),
+  ],
+};
+
+export default BorderedInfoBoxMeta;
+
+export const Basic = {};

--- a/src/utils/add-opacity.ts
+++ b/src/utils/add-opacity.ts
@@ -1,0 +1,15 @@
+/**
+ * Adds opacity to the input hex color. Should be used with colors from the
+ * design system, as that is the hex format this function supports. It doesn't
+ * work with 3 letter hex codes, or hex codes already containing the
+ * opacity/alpha channel.
+ *
+ * Example usage:
+ * addOpacity(theme.static.background.background_0.background, 0.2)
+ */
+export const addOpacity = (hex: string, opacity: number) => {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};

--- a/src/utils/add-opacity.ts
+++ b/src/utils/add-opacity.ts
@@ -4,12 +4,18 @@
  * work with 3 letter hex codes, or hex codes already containing the
  * opacity/alpha channel.
  *
+ * If the input value isn't a supported hex format, the hex will be returned
+ * without adding opacity.
+ *
  * Example usage:
  * addOpacity(theme.static.background.background_0.background, 0.2)
  */
 export const addOpacity = (hex: string, opacity: number) => {
-    const r = parseInt(hex.slice(1, 3), 16);
-    const g = parseInt(hex.slice(3, 5), 16);
-    const b = parseInt(hex.slice(5, 7), 16);
-    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+  const isSupportedHexFormat = hex.startsWith('#') && hex.length === 7;
+  if (!isSupportedHexFormat) return hex;
+
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
 };


### PR DESCRIPTION
Adds a new component to the src and storybook. This is the bordered
info box introduced in the on behalf of product initiative. Pretty
basic component, where the main cavaet is that the border is based
on the text color with 0.1 opacity. This was since we didn't have
an appropriate color to use in the design-system, and we didn't
want to introduced a new one just for this use case.

<details>
<summary>Screenshots from Storybook:</summary>

![Screenshot 2024-01-17 at 12 07 50](https://github.com/AtB-AS/mittatb-app/assets/675421/aecf5e7b-dbdd-42d7-a4a5-a08b0b544d3a)
![Screenshot 2024-01-17 at 12 07 57](https://github.com/AtB-AS/mittatb-app/assets/675421/c752bb1c-4a89-47ad-96d3-dd424c8efc89)
![Screenshot 2024-01-17 at 12 08 06](https://github.com/AtB-AS/mittatb-app/assets/675421/9b2aeca7-8be1-45ee-bf9d-3091d1642d53)
![Screenshot 2024-01-17 at 12 08 16](https://github.com/AtB-AS/mittatb-app/assets/675421/66b0b483-4dd3-4c3f-92c1-bcd328f93ed4)
![Screenshot 2024-01-17 at 12 08 24](https://github.com/AtB-AS/mittatb-app/assets/675421/a5d7fbaf-c196-4d28-9960-84192a22b002)

</details>
