### PR TITLE
feat: Show traveller count on details screen

### DIFF
--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -71,7 +71,6 @@ const CompactFareContractInfoTexts = (
 ) => {
   const {
     userProfilesWithCount,
-    omitUserProfileCount,
     productName,
     tariffZoneSummary,
     timeUntilExpire,
@@ -86,7 +85,7 @@ const CompactFareContractInfoTexts = (
       </ThemeText>
       {userProfilesWithCount.map((u) => (
         <ThemeText key={u.id} type="body__secondary" color="secondary">
-          {userProfileCountAndName(u, omitUserProfileCount, language)}
+          {userProfileCountAndName(u, language)}
         </ThemeText>
       ))}
       {productName && (
@@ -127,7 +126,6 @@ export const useFareContractInfoTexts = (
 ): FareContractInfoTextsProps => {
   const {
     userProfilesWithCount,
-    omitUserProfileCount,
     preassignedFareProduct,
     fromTariffZone,
     toTariffZone,
@@ -165,7 +163,7 @@ export const useFareContractInfoTexts = (
   accessibilityLabel += timeUntilExpireOrWarning + screenReaderPause;
   accessibilityLabel += userProfilesWithCount.map(
     (u) =>
-      userProfileCountAndName(u, omitUserProfileCount, language) +
+      userProfileCountAndName(u, language) +
       screenReaderPause,
   );
   accessibilityLabel += productName + screenReaderPause;

--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -52,7 +52,6 @@ export type FareContractInfoDetailsProps = {
   userProfilesWithCount: UserProfileWithCount[];
   status: FareContractInfoProps['status'];
   isCarnetFareContract?: boolean;
-  omitUserProfileCount?: boolean;
   testID?: string;
   now?: number;
   validTo?: number;
@@ -120,7 +119,6 @@ export const FareContractInfoDetails = (
     fromTariffZone,
     toTariffZone,
     userProfilesWithCount,
-    omitUserProfileCount,
     status,
     preassignedFareProduct,
   } = props;
@@ -140,7 +138,7 @@ export const FareContractInfoDetails = (
           <FareContractDetail
             header={t(FareContractTexts.label.travellers)}
             content={userProfilesWithCount.map((u) =>
-              userProfileCountAndName(u, omitUserProfileCount, language),
+              userProfileCountAndName(u, language),
             )}
           />
           {tariffZoneSummary && (

--- a/src/fare-contracts/carnet/CarnetDetails.tsx
+++ b/src/fare-contracts/carnet/CarnetDetails.tsx
@@ -111,7 +111,6 @@ export function CarnetDetails(props: {
         <SectionSeparator />
       </View>
       <FareContractInfoDetails
-        omitUserProfileCount={true}
         fromTariffZone={fromTariffZone}
         toTariffZone={toTariffZone}
         userProfilesWithCount={userProfilesWithCount}

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -129,7 +129,6 @@ export const DetailsContent: React.FC<Props> = ({
         )}
         <GenericSectionItem>
           <FareContractInfoDetails
-            omitUserProfileCount={true}
             fromTariffZone={fromTariffZone}
             toTariffZone={toTariffZone}
             userProfilesWithCount={userProfilesWithCount}

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -43,12 +43,9 @@ export function getRelativeValidity(
 
 export const userProfileCountAndName = (
   u: UserProfileWithCount,
-  omitUserProfileCount: Boolean | undefined,
   language: Language,
 ) =>
-  omitUserProfileCount
-    ? `${getReferenceDataName(u, language)}`
-    : `${u.count} ${getReferenceDataName(u, language)}`;
+  `${u.count} ${getReferenceDataName(u, language)}`;
 
 export function getValidityStatus(
   now: number,


### PR DESCRIPTION
Figma sketches now contain the traveller count on ticket details
screen, where we previously omitted the count if it was 1.

Before/After:
<div>
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/80e47f56-d4af-418f-aa6e-d4a12b3e4f45" />
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/6946cdec-b73a-49c5-9981-6a464c2dcbaa" />
</div>

Image from Figma:
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/eeabeb60-8d57-43c9-b2ce-1034e55deda7" />
