### PR TITLE
fix: show reservations under fare contracts in design system

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -10,6 +10,7 @@ import {addDays} from 'date-fns';
 import React from 'react';
 import {View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
+import {useAuthState} from '@atb/auth';
 
 export const Profile_FareContractsScreen = () => {
   const styles = useStyles();
@@ -22,10 +23,11 @@ export const Profile_FareContractsScreen = () => {
   const toTimeStamp = (date: Date) =>
     new FirestoreTimestampMock(Math.floor(date.valueOf() / 1000), 0);
   const NOW = new Date();
+  const {abtCustomerId} = useAuthState();
 
   const RESERVATION: Reservation = {
     created: toTimeStamp(NOW),
-    customerAccountId: 'ATB:CustomerAccount:xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
+    customerAccountId: abtCustomerId,
     // discount: 0,
     orderId: 'DW2N19A6',
     paymentId: 870266,


### PR DESCRIPTION
Since fare contracts that are for different abtCustomerIds are filtered out (because we don't want to show reservations for subaccounts) the customerAccountId needs to be correct for it to show up in the design system.

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/1db0daa7-f617-4873-975f-27d9b9068353">
