### PR TITLE
fix: setFocusOnLoad in FullScreenView

### DIFF
--- a/src/components/screen-view/FullScreenView.tsx
+++ b/src/components/screen-view/FullScreenView.tsx
@@ -52,7 +52,9 @@ export function FullScreenView(props: Props) {
         <ScreenHeader
           {...props.headerProps}
           textOpacity={opacity}
-          setFocusOnLoad={!props.parallaxContent}
+          setFocusOnLoad={
+            props.parallaxContent ? false : props.headerProps.setFocusOnLoad
+          }
         />
       </View>
 


### PR DESCRIPTION
Fixes a bug where setFocusOnLoad was true regardless of the headerProps input.
This caused several focus calls resulting in race conditions.

Closes https://github.com/AtB-AS/kundevendt/issues/8619#issuecomment-1898076894

Replaces https://github.com/AtB-AS/mittatb-app/pull/4250 for now