### PR TITLE
feat: Not navigate after login

### DIFF
--- a/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
@@ -1,7 +1,10 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {LoginTexts, useTranslation} from '@atb/translations';
-import {useAuthState} from '@atb/auth';
-import {ConfirmationErrorCode, PhoneSignInErrorCode} from '@atb/auth';
+import {
+  ConfirmationErrorCode,
+  PhoneSignInErrorCode,
+  useAuthState,
+} from '@atb/auth';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {
   ActivityIndicator,
@@ -20,35 +23,34 @@ import {StyleSheet, useTheme} from '@atb/theme';
 import {getStaticColor, StaticColorByType} from '@atb/theme/colors';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
-import {useCompleteOnboardingAndEnterApp} from '@atb/utils/use-complete-onboarding-and-enter-app';
+import {useAppState} from '@atb/AppContext';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
 type Props = RootStackScreenProps<'Root_LoginConfirmCodeScreen'>;
 
 export const Root_LoginConfirmCodeScreen = ({route}: Props) => {
-  const {phoneNumber, afterLogin} = route.params;
+  const {phoneNumber} = route.params;
   const {t} = useTranslation();
   const styles = useStyles();
   const {themeName} = useTheme();
-  const {authenticationType, confirmCode, signInWithPhoneNumber} =
-    useAuthState();
+  const {confirmCode, signInWithPhoneNumber} = useAuthState();
   const [code, setCode] = useState('');
   const [error, setError] = useState<
     ConfirmationErrorCode | PhoneSignInErrorCode
   >();
   const [isLoading, setIsLoading] = useState(false);
   const focusRef = useFocusOnLoad();
-  const completeOnboardingAndEnterApp = useCompleteOnboardingAndEnterApp();
+  const {completeOnboarding} = useAppState();
 
   const onLogin = async () => {
     setIsLoading(true);
+    completeOnboarding();
     const errorCode = await confirmCode(code);
     if (errorCode) {
       setError(errorCode);
       setIsLoading(false);
     }
-    completeOnboardingAndEnterApp();
   };
 
   const onResendCode = async () => {
@@ -61,15 +63,6 @@ export const Root_LoginConfirmCodeScreen = ({route}: Props) => {
       setError(errorCode);
     }
   };
-
-  // User might be automatically logged in with Firebase auth, but only on Android
-  // Check authentication from state and see if it is updated while we wait
-  useEffect(() => {
-    if (authenticationType === 'phone') {
-      completeOnboardingAndEnterApp(afterLogin);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authenticationType]);
 
   return (
     <View style={styles.container}>

--- a/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
@@ -3,8 +3,7 @@ import {
   getOrCreateVippsUserCustomToken,
   VIPPS_CALLBACK_URL,
 } from '@atb/api/vipps-login/api';
-import {useAuthState} from '@atb/auth';
-import {VippsSignInErrorCode} from '@atb/auth';
+import {useAuthState, VippsSignInErrorCode} from '@atb/auth';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
@@ -25,7 +24,7 @@ import {Button} from '@atb/components/button';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {TransitionPresets} from '@react-navigation/stack';
-import {useCompleteOnboardingAndEnterApp} from '@atb/utils/use-complete-onboarding-and-enter-app';
+import {useAppState} from '@atb/AppContext';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -48,7 +47,7 @@ export const Root_LoginOptionsScreen = ({
   const [authorizationCode, setAuthorizationCode] = useState<
     string | undefined
   >(undefined);
-  const completeOnboardingAndEnterApp = useCompleteOnboardingAndEnterApp();
+  const {completeOnboarding} = useAppState();
 
   const authenticateUserByVipps = async () => {
     setIsLoading(true);
@@ -69,10 +68,9 @@ export const Root_LoginOptionsScreen = ({
   );
 
   const signInUsingCustomToken = async (token: string) => {
+    completeOnboarding();
     const errorCode = await signInWithCustomToken(token);
-    if (!errorCode) {
-      completeOnboardingAndEnterApp(afterLogin);
-    } else {
+    if (errorCode) {
       setError(errorCode);
       setIsLoading(false);
     }


### PR DESCRIPTION
Two main changes in this PR:
- We complete onboarding before the last step of the authentication
process, like sending in the confirmation code. This is so we don't
end up in a race condition between Firebase Auth switching user and
setting the onboarded flag to true.
- We do not navigate anywhere after login, as changing user is
basically a reload of the app, and we end up back at the starting
screen no matter what.
