### PR TITLE
fix: remove unnecessary texts for beacons toggle

### DIFF
--- a/src/translations/screens/subscreens/PrivacySettingsTexts.ts
+++ b/src/translations/screens/subscreens/PrivacySettingsTexts.ts
@@ -37,9 +37,9 @@ const PrivacySettingsTexts = {
             'Samle reisevanar',
           ),
           subText: _(
-            'Du gir oss samtykke til å samle og analysere dine reisevaner ved hjelp av Bluetooth, din posisjon, bevegelses- og treningsaktivitet. Vi kan for eksempel samle data om holdeplasser i nærheten, busser du tar, hvor du reiser og om du går, sykler eller reiser med bil. Dataene brukes til å forbedre reisetilbudet ditt i Trøndelag. Samtykket lar oss sende deg undersøkelser som er relevante for deg.',
-            'You give us consent to collect and analyze your travel habits using Bluetooth, your location, movement and exercise activity. For example, we may collect data about nearby stops, buses you take, where you travel and whether you walk, cycle or travel by car. The data is used to improve your travel offer in Trøndelag. The consent allows us to send you surveys that are relevant to you.',
-            'Du gir oss samtykke til å samle og analysere reisevanane dine ved hjelp av Bluetooth, din posisjon, bevegings- og treningsaktivitet. Vi kan for eksempel samle data om haldeplassar i nærleiken, bussar du tek, kvar du reiser og om du går, syklar eller reiser med bil. Dataene brukast til å forbetre reisetilbodet ditt i Trøndelag. Samtykket lar oss sende deg undersøkingar som er relevante for deg.',
+            'Du gir oss samtykke til å samle og analysere dine reisevaner. Vi kan for eksempel samle data om holdeplasser i nærheten, busser du tar, hvor du reiser og om du går, sykler eller reiser med bil. Dataene brukes til å forbedre reisetilbudet ditt i Trøndelag. Samtykket lar oss sende deg undersøkelser som er relevante for deg.',
+            'You give us consent to collect and analyze your travel habits. For example, we may collect data about nearby stops, buses you take, where you travel and whether you walk, cycle or travel by car. The data is used to improve your travel offer in Trøndelag. The consent allows us to send you surveys that are relevant to you.',
+            'Du gir oss samtykke til å samle og analysere reisevanane dine. Vi kan for eksempel samle data om haldeplassar i nærleiken, bussar du tek, kvar du reiser og om du går, syklar eller reiser med bil. Dataene brukast til å forbetre reisetilbodet ditt i Trøndelag. Samtykket lar oss sende deg undersøkingar som er relevante for deg.',
           ),
         },
       },


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16574

Super straightforward PR, just removing some translation text.