### PR TITLE
fix: only show travel token onboarding if not on your device

### DIFF
--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -17,7 +17,7 @@ import {
 } from '@atb/translations';
 import {animateNextChange} from '@atb/utils/animation';
 import {flatMap} from '@atb/utils/array';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {RadioGroupSection, Section} from '@atb/components/sections';
@@ -32,6 +32,7 @@ import {useTimeContextState} from '@atb/time';
 import {getDeviceNameWithUnitInfo} from './utils';
 import {TokenToggleInfo} from '@atb/token-toggle-info';
 import {useTokenToggleDetailsQuery} from '@atb/mobile-token/use-token-toggle-details';
+import {useAppState} from '@atb/AppContext';
 
 type Props = {onAfterSave: () => void};
 
@@ -43,6 +44,11 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
   const {disable_travelcard} = useRemoteConfig();
   const {fareProductTypeConfigs, preassignedFareProducts} =
     useFirestoreConfiguration();
+
+  const {
+    completeMobileTokenOnboarding,
+    completeMobileTokenWithoutTravelcardOnboarding,
+  } = useAppState();
 
   const {tokens, toggleToken} = useMobileTokenContextState();
   const {data} = useTokenToggleDetailsQuery();
@@ -88,6 +94,21 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
       (fareProductTypeConfig) =>
         fareProductTypeConfig?.configuration.requiresTokenOnMobile === true,
     );
+
+  useEffect(() => {
+    // Whenever a user enters this screen, the onboarding is done.
+    // This useEffect is needed for when onboarding was skipped because of
+    // already being on your own device, but then changed to another device
+    if (disable_travelcard) {
+      completeMobileTokenWithoutTravelcardOnboarding();
+    } else {
+      completeMobileTokenOnboarding();
+    }
+  }, [
+    disable_travelcard,
+    completeMobileTokenWithoutTravelcardOnboarding,
+    completeMobileTokenOnboarding,
+  ]);
 
   const [saveState, setSaveState] = useState({
     saving: false,

--- a/src/utils/use-onboarding-flow.ts
+++ b/src/utils/use-onboarding-flow.ts
@@ -164,9 +164,10 @@ const useShouldShowTravelTokenOnboarding = () => {
     useAppState();
   const {disable_travelcard} = useRemoteConfig();
   const {tokens, mobileTokenStatus} = useMobileTokenContextState();
-  const hasInspectableToken = tokens.some((token) => token.isInspectable);
+  const inspectableToken = tokens.find((token) => token.isInspectable);
   return (
-    hasInspectableToken &&
+    !!inspectableToken &&
+    !inspectableToken?.isThisDevice &&
     mobileTokenStatus === 'success' &&
     authenticationType === 'phone' &&
     ((!mobileTokenOnboarded && !disable_travelcard) ||


### PR DESCRIPTION
No longer showing the travel token onboarding screen when the travel token is already on your device.

Note: this opened up a new path where a user doesn't have to see the travel token onboarding screen to finish the onboarding. So when changing the token to another device, it would show the onboarding then instead. To ensure this doesn't happen, an extra useEffect was added in the `SelectTravelTokenScreenComponent`.

Resolves https://github.com/AtB-AS/kundevendt/issues/8619#issuecomment-1903824259