### PR TITLE
fix: change token screen back button

### DIFF
--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -150,7 +150,7 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
             ? t(TravelTokenTexts.toggleToken.titleWithoutTravelcard)
             : t(TravelTokenTexts.toggleToken.title)
         }
-        leftButton={{type: 'back'}}
+        leftButton={{type: 'close'}}
       />
       <ScrollView
         contentContainerStyle={styles.scrollView}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SelectTravelTokenScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SelectTravelTokenScreen.tsx
@@ -1,8 +1,0 @@
-import {ProfileScreenProps} from './navigation-types';
-import {SelectTravelTokenScreenComponent} from '@atb/select-travel-token-screen';
-
-type Props = ProfileScreenProps<'Profile_SelectTravelTokenScreen'>;
-
-export const Profile_SelectTravelTokenScreen = ({navigation}: Props) => (
-  <SelectTravelTokenScreenComponent onAfterSave={navigation.goBack} />
-);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -21,7 +21,6 @@ import {Profile_TicketInspectionInformationScreen} from './Profile_TicketInspect
 import {Profile_GenericWebsiteInformationScreen} from './Profile_GenericWebsiteInformationScreen';
 import {Profile_DeleteProfileScreen} from './Profile_DeleteProfileScreen';
 import {Profile_TravelTokenScreen} from './Profile_TravelTokenScreen';
-import {Profile_SelectTravelTokenScreen} from './Profile_SelectTravelTokenScreen';
 import {Profile_FavoriteListScreen} from './Profile_FavoriteListScreen';
 import {Profile_SortFavoritesScreen} from './Profile_SortFavoritesScreen';
 import {Profile_EditProfileScreen} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen';
@@ -75,10 +74,6 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_TravelTokenScreen"
         component={Profile_TravelTokenScreen}
-      />
-      <Stack.Screen
-        name="Profile_SelectTravelTokenScreen"
-        component={Profile_SelectTravelTokenScreen}
       />
       <Stack.Screen
         name="Profile_AppearanceScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -18,7 +18,6 @@ export type ProfileStackParams = StackParams<{
   Profile_FavoriteDeparturesScreen: undefined;
   Profile_SelectStartScreenScreen: undefined;
   Profile_TravelTokenScreen: undefined;
-  Profile_SelectTravelTokenScreen: undefined;
   Profile_AppearanceScreen: undefined;
   Profile_LanguageScreen: undefined;
   Profile_PrivacyScreen: undefined;


### PR DESCRIPTION
Since the screen transitions in popping up, it should have a close button instead of back button.
Also deletes a now unused profile screen.

<img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/cba8c3a3-d990-4b12-8430-962589b0730c" />

Resolves https://github.com/AtB-AS/kundevendt/issues/8619#issuecomment-1903824259