### PR TITLE
chore: rename onboarded

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -11,7 +11,7 @@ import {register as registerChatUser} from './chat/user';
 import {storage} from '@atb/storage';
 
 enum storeKey {
-  onboarding = '@ATB_onboarded',
+  userCreationOnboarded = '@ATB_onboarded', // variable renamed, but keep old storage key
   mobileTokenOnboarding = '@ATB_mobile_token_onboarded',
   mobileTokenWithoutTravelcardOnboarding = '@ATB_mobile_token_without_travelcard_onboarded',
   notificationPermissionOnboarding = '@ATB_notification_permission_onboarded',
@@ -20,7 +20,7 @@ enum storeKey {
 }
 type AppState = {
   isLoading: boolean;
-  onboarded: boolean;
+  userCreationOnboarded: boolean;
   mobileTokenOnboarded: boolean;
   mobileTokenWithoutTravelcardOnboarded: boolean;
   notificationPermissionOnboarded: boolean;
@@ -31,15 +31,15 @@ type AppState = {
 type AppReducerAction =
   | {
       type: 'LOAD_APP_SETTINGS';
-      onboarded: boolean;
+      userCreationOnboarded: boolean;
       mobileTokenOnboarded: boolean;
       mobileTokenWithoutTravelcardOnboarded: boolean;
       notificationPermissionOnboarded: boolean;
       locationWhenInUsePermissionOnboarded: boolean;
       shareTravelHabitsOnboarded: boolean;
     }
-  | {type: 'COMPLETE_ONBOARDING'}
-  | {type: 'RESTART_ONBOARDING'}
+  | {type: 'COMPLETE_USER_CREATION_ONBOARDING'}
+  | {type: 'RESTART_USER_CREATION_ONBOARDING'}
   | {type: 'COMPLETE_MOBILE_TOKEN_ONBOARDING'}
   | {type: 'RESTART_MOBILE_TOKEN_ONBOARDING'}
   | {type: 'COMPLETE_MOBILE_TOKEN_WITHOUT_TRAVELCARD_ONBOARDING'}
@@ -52,8 +52,8 @@ type AppReducerAction =
   | {type: 'RESTART_SHARE_TRAVEL_HABITS_ONBOARDING'};
 
 type AppContextState = AppState & {
-  completeOnboarding: () => void;
-  restartOnboarding: () => void;
+  completeUserCreationOnboarding: () => void;
+  restartUserCreationOnboarding: () => void;
   completeMobileTokenOnboarding: () => void;
   restartMobileTokenOnboarding: () => void;
   completeMobileTokenWithoutTravelcardOnboarding: () => void;
@@ -76,7 +76,7 @@ const appReducer: AppReducer = (prevState, action) => {
   switch (action.type) {
     case 'LOAD_APP_SETTINGS':
       const {
-        onboarded,
+        userCreationOnboarded,
         mobileTokenOnboarded,
         mobileTokenWithoutTravelcardOnboarded,
         notificationPermissionOnboarded,
@@ -85,7 +85,7 @@ const appReducer: AppReducer = (prevState, action) => {
       } = action;
       return {
         ...prevState,
-        onboarded,
+        userCreationOnboarded,
         isLoading: false,
         mobileTokenOnboarded,
         mobileTokenWithoutTravelcardOnboarded,
@@ -93,15 +93,15 @@ const appReducer: AppReducer = (prevState, action) => {
         locationWhenInUsePermissionOnboarded,
         shareTravelHabitsOnboarded,
       };
-    case 'COMPLETE_ONBOARDING':
+    case 'COMPLETE_USER_CREATION_ONBOARDING':
       return {
         ...prevState,
-        onboarded: true,
+        userCreationOnboarded: true,
       };
-    case 'RESTART_ONBOARDING':
+    case 'RESTART_USER_CREATION_ONBOARDING':
       return {
         ...prevState,
-        onboarded: false,
+        userCreationOnboarded: false,
       };
     case 'COMPLETE_MOBILE_TOKEN_ONBOARDING':
       return {
@@ -164,7 +164,7 @@ const appReducer: AppReducer = (prevState, action) => {
 
 const defaultAppState: AppState = {
   isLoading: true,
-  onboarded: false,
+  userCreationOnboarded: false,
   mobileTokenOnboarded: false,
   mobileTokenWithoutTravelcardOnboarded: false,
   notificationPermissionOnboarded: false,
@@ -177,8 +177,12 @@ export const AppContextProvider: React.FC = ({children}) => {
 
   useEffect(() => {
     async function loadAppSettings() {
-      const savedOnboarded = await storage.get(storeKey.onboarding);
-      const onboarded = !savedOnboarded ? false : JSON.parse(savedOnboarded);
+      const savedUserCreationOnboarded = await storage.get(
+        storeKey.userCreationOnboarded,
+      );
+      const userCreationOnboarded = !savedUserCreationOnboarded
+        ? false
+        : JSON.parse(savedUserCreationOnboarded);
 
       const savedMobileTokenOnboarded = await storage.get(
         storeKey.mobileTokenOnboarding,
@@ -219,13 +223,13 @@ export const AppContextProvider: React.FC = ({children}) => {
         ? false
         : JSON.parse(savedShareTravelHabitsOnboarded);
 
-      if (onboarded) {
+      if (userCreationOnboarded) {
         registerChatUser();
       }
 
       dispatch({
         type: 'LOAD_APP_SETTINGS',
-        onboarded,
+        userCreationOnboarded,
         mobileTokenOnboarded,
         mobileTokenWithoutTravelcardOnboarded,
         notificationPermissionOnboarded,
@@ -239,8 +243,8 @@ export const AppContextProvider: React.FC = ({children}) => {
   }, []);
 
   const {
-    completeOnboarding,
-    restartOnboarding,
+    completeUserCreationOnboarding,
+    restartUserCreationOnboarding,
     completeMobileTokenOnboarding,
     restartMobileTokenOnboarding,
     completeMobileTokenWithoutTravelcardOnboarding,
@@ -253,15 +257,18 @@ export const AppContextProvider: React.FC = ({children}) => {
     restartShareTravelHabitsOnboarding,
   } = useMemo(
     () => ({
-      completeOnboarding: async () => {
-        await storage.set(storeKey.onboarding, JSON.stringify(true));
-        dispatch({type: 'COMPLETE_ONBOARDING'});
+      completeUserCreationOnboarding: async () => {
+        await storage.set(storeKey.userCreationOnboarded, JSON.stringify(true));
+        dispatch({type: 'COMPLETE_USER_CREATION_ONBOARDING'});
 
         registerChatUser();
       },
-      restartOnboarding: async () => {
-        await storage.set(storeKey.onboarding, JSON.stringify(false));
-        dispatch({type: 'RESTART_ONBOARDING'});
+      restartUserCreationOnboarding: async () => {
+        await storage.set(
+          storeKey.userCreationOnboarded,
+          JSON.stringify(false),
+        );
+        dispatch({type: 'RESTART_USER_CREATION_ONBOARDING'});
       },
       completeMobileTokenOnboarding: async () => {
         dispatch({type: 'COMPLETE_MOBILE_TOKEN_ONBOARDING'});
@@ -340,8 +347,8 @@ export const AppContextProvider: React.FC = ({children}) => {
     <AppContext.Provider
       value={{
         ...state,
-        completeOnboarding,
-        restartOnboarding,
+        completeUserCreationOnboarding,
+        restartUserCreationOnboarding,
         completeMobileTokenOnboarding,
         restartMobileTokenOnboarding,
         completeMobileTokenWithoutTravelcardOnboarding,

--- a/src/beacons/use-should-show-share-travel-habits-screen.tsx
+++ b/src/beacons/use-should-show-share-travel-habits-screen.tsx
@@ -25,9 +25,9 @@ export const useShouldShowShareTravelHabitsScreen = (
 
   const appStatus = useAppStateStatus();
 
-  const {onboarded, shareTravelHabitsOnboarded} = useAppState();
+  const {userCreationOnboarded, shareTravelHabitsOnboarded} = useAppState();
   const enabled =
-    onboarded && isBeaconsSupported && !shareTravelHabitsOnboarded;
+    userCreationOnboarded && isBeaconsSupported && !shareTravelHabitsOnboarded;
 
   const shouldShowShareTravelHabitsScreen =
     enabled && !isConsentGranted && sessionCount > runAfterSessionsCount;

--- a/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
@@ -41,11 +41,11 @@ export const Root_LoginConfirmCodeScreen = ({route}: Props) => {
   >();
   const [isLoading, setIsLoading] = useState(false);
   const focusRef = useFocusOnLoad();
-  const {completeOnboarding} = useAppState();
+  const {completeUserCreationOnboarding} = useAppState();
 
   const onLogin = async () => {
     setIsLoading(true);
-    completeOnboarding();
+    completeUserCreationOnboarding();
     const errorCode = await confirmCode(code);
     if (errorCode) {
       setError(errorCode);

--- a/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
@@ -24,7 +24,7 @@ import {Button} from '@atb/components/button';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {TransitionPresets} from '@react-navigation/stack';
-import {useAppState} from "@atb/AppContext";
+import {useAppState} from '@atb/AppContext';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -46,7 +46,7 @@ export const Root_LoginOptionsScreen = ({
   const [authorizationCode, setAuthorizationCode] = useState<
     string | undefined
   >(undefined);
-  const {completeOnboarding} = useAppState();
+  const {completeUserCreationOnboarding} = useAppState();
 
   const authenticateUserByVipps = async () => {
     setIsLoading(true);
@@ -67,7 +67,7 @@ export const Root_LoginOptionsScreen = ({
   );
 
   const signInUsingCustomToken = async (token: string) => {
-    completeOnboarding();
+    completeUserCreationOnboarding();
     const errorCode = await signInWithCustomToken(token);
     if (errorCode) {
       setError(errorCode);
@@ -174,9 +174,7 @@ export const Root_LoginOptionsScreen = ({
           interactiveColor="interactive_0"
           mode="primary"
           style={styles.loginOptionButton}
-          onPress={() =>
-            navigation.navigate('Root_LoginPhoneInputScreen')
-          }
+          onPress={() => navigation.navigate('Root_LoginPhoneInputScreen')}
           text={t(LoginTexts.logInOptions.options.phoneAndCode.label)}
           accessibilityHint={t(
             LoginTexts.logInOptions.options.phoneAndCode.a11yLabel,

--- a/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
@@ -8,7 +8,7 @@ import {
 } from '@atb/ticketing';
 import {useTimeContextState} from '@atb/time';
 import {TransitionPresets} from '@react-navigation/stack';
-import {useCompleteOnboardingAndEnterApp} from '@atb/utils/use-complete-onboarding-and-enter-app';
+import {useCompleteUserCreationOnboardingAndEnterApp} from '@atb/utils/use-complete-user-creation-onboarding-and-enter-app';
 
 type Props = RootStackScreenProps<'Root_PurchaseAsAnonymousConsequencesScreen'>;
 
@@ -18,7 +18,8 @@ export const Root_PurchaseAsAnonymousConsequencesScreen = ({
 }: Props) => {
   const {enable_vipps_login} = useRemoteConfig();
 
-  const completeOnboardingAndEnterApp = useCompleteOnboardingAndEnterApp();
+  const completeUserCreationOnboardingAndEnterApp =
+    useCompleteUserCreationOnboardingAndEnterApp();
 
   const {fareContracts} = useTicketingState();
   const {serverNow} = useTimeContextState();
@@ -42,7 +43,7 @@ export const Root_PurchaseAsAnonymousConsequencesScreen = ({
   return (
     <AnonymousPurchaseConsequencesScreenComponent
       onPressLogin={params.showLoginButton ? onPressLogin : undefined}
-      onPressContinueWithoutLogin={completeOnboardingAndEnterApp}
+      onPressContinueWithoutLogin={completeUserCreationOnboardingAndEnterApp}
       leftButton={{
         type:
           params?.transitionPreset === TransitionPresets.ModalSlideFromBottomIOS

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -58,7 +58,7 @@ export const Root_TabNavigatorStack = () => {
 
   const navigation = useNavigation<RootNavigationProps>();
 
-  const {nextOnboardingScreen} = useOnboardingFlow(true, true); // assumeLoginOnboardingCompleted true to ensure outdated onboarded value not used
+  const {nextOnboardingScreen} = useOnboardingFlow(true, true); // assumeUserCreationOnboarded true to ensure outdated userCreationOnboarded value not used
   const {goToScreen} = useOnboardingNavigation();
 
   useEffect(() => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -69,7 +69,7 @@ export const Profile_DebugInfoScreen = () => {
   const {
     restartMobileTokenOnboarding,
     restartMobileTokenWithoutTravelcardOnboarding,
-    restartOnboarding,
+    restartUserCreationOnboarding,
     restartNotificationPermissionOnboarding,
     restartLocationWhenInUsePermissionOnboarding,
     restartShareTravelHabitsOnboarding,
@@ -196,8 +196,8 @@ export const Profile_DebugInfoScreen = () => {
             }}
           />
           <LinkSectionItem
-            text="Restart onboarding"
-            onPress={restartOnboarding}
+            text="Restart user creation onboarding"
+            onPress={restartUserCreationOnboarding}
           />
           <LinkSectionItem
             text="Restart notification onboarding"

--- a/src/utils/use-complete-user-creation-onboarding-and-enter-app.ts
+++ b/src/utils/use-complete-user-creation-onboarding-and-enter-app.ts
@@ -10,12 +10,12 @@ import {RootNavigationProps, RootStackParamList} from '@atb/stacks-hierarchy';
  * @returns {Function} A function that, when called, checks if the onboarding is not completed,
  * completes it if not, and then navigates to the next screen using enterApp.
  */
-export const useCompleteOnboardingAndEnterApp = () => {
-  const {onboarded, completeOnboarding} = useAppState();
+export const useCompleteUserCreationOnboardingAndEnterApp = () => {
+  const {userCreationOnboarded, completeUserCreationOnboarding} = useAppState();
   const enterApp = useEnterApp();
 
   return () => {
-    !onboarded && completeOnboarding();
+    !userCreationOnboarded && completeUserCreationOnboarding();
     enterApp();
   };
 };

--- a/src/utils/use-onboarding-flow.ts
+++ b/src/utils/use-onboarding-flow.ts
@@ -36,9 +36,9 @@ export const useOnboardingFlow = (
 
   const {userCreationOnboarded} = useAppState();
 
-  const shouldShowTravelTokenOnboarding = useShouldShowTravelTokenOnboarding();
-
   const shouldShowLocationOnboarding = useShouldShowLocationOnboarding();
+
+  const shouldShowTravelTokenOnboarding = useShouldShowTravelTokenOnboarding();
 
   const shouldShowShareTravelHabitsScreen =
     useShouldShowShareTravelHabitsScreen(
@@ -55,59 +55,63 @@ export const useOnboardingFlow = (
     ): ScreenProps => {
       let screenName: keyof RootStackParamList | undefined = undefined;
       let params = undefined;
-      if (!(userCreationOnboarded || assumeUserCreationOnboarded)) {
-        if (enable_extended_onboarding) {
-          screenName = 'Root_OnboardingStack';
-        } else {
-          screenName = 'Root_LoginOptionsScreen';
-          params = {};
-        }
-      } else {
-        const orderedOnboardingScreensAfterLogin: {
-          shouldShow: boolean;
-          screenName: keyof RootStackParamList;
-          params?: any;
-        }[] = [
-          {
-            shouldShow: shouldShowLocationOnboarding,
-            screenName: 'Root_LocationWhenInUsePermissionScreen',
-          },
-          {
-            shouldShow: shouldShowShareTravelHabitsScreen,
-            screenName: 'Root_ShareTravelHabitsScreen',
-          },
-          {
-            shouldShow: shouldShowNotificationPermissionScreen,
-            screenName: 'Root_NotificationPermissionScreen',
-          },
-          {
-            shouldShow: shouldShowTravelTokenOnboarding,
-            screenName: 'Root_ConsiderTravelTokenChangeScreen',
-          },
-        ];
-        for (const onboardingScreen of orderedOnboardingScreensAfterLogin) {
-          if (
-            onboardingScreen.shouldShow &&
-            onboardingScreen.screenName !== comingFromScreenName
-          ) {
-            screenName = onboardingScreen.screenName;
-            params = onboardingScreen?.params;
-            break;
-          }
+
+      const shouldShowUserCreationOnboarding = !(
+        userCreationOnboarded || assumeUserCreationOnboarded
+      );
+
+      const orderedOnboardingScreens: {
+        shouldShow: boolean;
+        screenName: keyof RootStackParamList;
+        params?: any;
+      }[] = [
+        {
+          shouldShow: shouldShowUserCreationOnboarding,
+          screenName: enable_extended_onboarding
+            ? 'Root_OnboardingStack'
+            : 'Root_LoginOptionsScreen',
+          params: enable_extended_onboarding ? undefined : {},
+        },
+        {
+          shouldShow: shouldShowLocationOnboarding,
+          screenName: 'Root_LocationWhenInUsePermissionScreen',
+        },
+        {
+          shouldShow: shouldShowShareTravelHabitsScreen,
+          screenName: 'Root_ShareTravelHabitsScreen',
+        },
+        {
+          shouldShow: shouldShowNotificationPermissionScreen,
+          screenName: 'Root_NotificationPermissionScreen',
+        },
+        {
+          shouldShow: shouldShowTravelTokenOnboarding,
+          screenName: 'Root_ConsiderTravelTokenChangeScreen',
+        },
+      ];
+      for (const onboardingScreen of orderedOnboardingScreens) {
+        if (
+          onboardingScreen.shouldShow &&
+          onboardingScreen.screenName !== comingFromScreenName
+        ) {
+          screenName = onboardingScreen.screenName;
+          params = onboardingScreen?.params;
+          break;
         }
       }
+
       return {
         screenName,
         params,
       };
     },
     [
-      userCreationOnboarded,
-      shouldShowTravelTokenOnboarding,
-      shouldShowLocationOnboarding,
-      shouldShowShareTravelHabitsScreen,
-      shouldShowNotificationPermissionScreen,
       enable_extended_onboarding,
+      userCreationOnboarded,
+      shouldShowLocationOnboarding,
+      shouldShowTravelTokenOnboarding,
+      shouldShowNotificationPermissionScreen,
+      shouldShowShareTravelHabitsScreen,
     ],
   );
 

--- a/src/utils/use-onboarding-flow.ts
+++ b/src/utils/use-onboarding-flow.ts
@@ -30,11 +30,11 @@ export type GoToScreenType = (screenName: any, params?: any) => void;
 // note: utilizeThisHookInstanceForSessionCounting should only be true for one instance
 export const useOnboardingFlow = (
   utilizeThisHookInstanceForSessionCounting = false,
-  assumeLoginOnboardingCompleted = false,
+  assumeUserCreationOnboarded = false,
 ) => {
   const {enable_extended_onboarding} = useRemoteConfig();
 
-  const {onboarded: loginOnboardingCompleted} = useAppState();
+  const {userCreationOnboarded} = useAppState();
 
   const shouldShowTravelTokenOnboarding = useShouldShowTravelTokenOnboarding();
 
@@ -51,11 +51,11 @@ export const useOnboardingFlow = (
   const getNextOnboardingScreen = useCallback(
     (
       comingFromScreenName?: keyof RootStackParamList,
-      assumeLoginOnboardingCompleted?: Boolean,
+      assumeUserCreationOnboarded?: Boolean,
     ): ScreenProps => {
       let screenName: keyof RootStackParamList | undefined = undefined;
       let params = undefined;
-      if (!(loginOnboardingCompleted || assumeLoginOnboardingCompleted)) {
+      if (!(userCreationOnboarded || assumeUserCreationOnboarded)) {
         if (enable_extended_onboarding) {
           screenName = 'Root_OnboardingStack';
         } else {
@@ -102,7 +102,7 @@ export const useOnboardingFlow = (
       };
     },
     [
-      loginOnboardingCompleted,
+      userCreationOnboarded,
       shouldShowTravelTokenOnboarding,
       shouldShowLocationOnboarding,
       shouldShowShareTravelHabitsScreen,
@@ -112,19 +112,19 @@ export const useOnboardingFlow = (
   );
 
   const [nextOnboardingScreen, setNextOnboardingScreen] = useState<ScreenProps>(
-    getNextOnboardingScreen(undefined, assumeLoginOnboardingCompleted),
+    getNextOnboardingScreen(undefined, assumeUserCreationOnboarded),
   );
 
   useEffect(() => {
     setNextOnboardingScreen(
-      getNextOnboardingScreen(undefined, assumeLoginOnboardingCompleted),
+      getNextOnboardingScreen(undefined, assumeUserCreationOnboarded),
     );
-  }, [getNextOnboardingScreen, assumeLoginOnboardingCompleted]);
+  }, [getNextOnboardingScreen, assumeUserCreationOnboarded]);
 
   /**
-   * add Root_TabNavigatorStack as root when loginOnboardingCompleted
+   * add Root_TabNavigatorStack as root when userCreationOnboarded
    * this allows goBack from an onboarding screen when used as initial screen
-   * @param {Boolean} shouldGoDirectlyToOnboardingScreen when loginOnboardingCompleted, true if going directly to the next onboarding screen, false if instead going to Root_TabNavigatorStack first
+   * @param {Boolean} shouldGoDirectlyToOnboardingScreen when userCreationOnboarded, true if going directly to the next onboarding screen, false if instead going to Root_TabNavigatorStack first
    * @returns navigation state object
    */
   const getInitialNavigationContainerState = (
@@ -139,7 +139,7 @@ export const useOnboardingFlow = (
     const routes: PartialRoute<
       Route<keyof RootStackParamList, object | undefined>
     >[] = [];
-    if (loginOnboardingCompleted) {
+    if (userCreationOnboarded) {
       routes.push({name: 'Root_TabNavigatorStack'});
 
       if (shouldGoDirectlyToOnboardingScreen) {


### PR DESCRIPTION
This PR is all about renaming `onboarded` to `userCreationOnboarded`. Related names have also been renamed the same way.

After the renaming, its current purpose finally becomes obvious, and this allowed a simplification of `useOnboardingFlow`.

Related discussion: https://github.com/AtB-AS/mittatb-app/pull/4257#issuecomment-1903654902

Resolves https://github.com/AtB-AS/kundevendt/issues/8619