### PR TITLE
chore: use correct nav flow logic for extended onboarding

### DIFF
--- a/src/stacks-hierarchy/Root_OnboardingStack/Onboarding_AlsoGoodToKnowScreen.tsx
+++ b/src/stacks-hierarchy/Root_OnboardingStack/Onboarding_AlsoGoodToKnowScreen.tsx
@@ -6,19 +6,18 @@ import {StaticColorByType} from '@atb/theme/colors';
 import {OnboardingTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ScrollView, useWindowDimensions, View} from 'react-native';
-import {OnboardingScreenProps} from './navigation-types';
+import {useOnboardingNavigation} from '@atb/utils/use-onboarding-navigation';
+import {useAppState} from '@atb/AppContext';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
-export type AlsoGoodToKnowScreenProps =
-  OnboardingScreenProps<'Onboarding_AlsoGoodToKnowScreen'>;
-
-export const Onboarding_AlsoGoodToKnowScreen = ({
-  navigation,
-}: AlsoGoodToKnowScreenProps) => {
+export const Onboarding_AlsoGoodToKnowScreen = () => {
   const {t} = useTranslation();
   const styles = useThemeStyles();
   const {width: windowWidth} = useWindowDimensions();
+
+  const {continueFromOnboardingScreen} = useOnboardingNavigation();
+  const {completeExtendedOnboarding} = useAppState();
 
   return (
     <ScrollView
@@ -41,7 +40,10 @@ export const Onboarding_AlsoGoodToKnowScreen = ({
       <View style={styles.bottomView}>
         <Button
           interactiveColor="interactive_0"
-          onPress={() => navigation.navigate('Root_LoginOptionsScreen', {})}
+          onPress={() => {
+            completeExtendedOnboarding();
+            continueFromOnboardingScreen('Root_OnboardingStack');
+          }}
           text={t(OnboardingTexts.alsoGoodToKnow.mainButton)}
           testID="nextButtonAlsoGoodToKnowOnboarding"
         />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -69,6 +69,7 @@ export const Profile_DebugInfoScreen = () => {
   const {
     restartMobileTokenOnboarding,
     restartMobileTokenWithoutTravelcardOnboarding,
+    restartExtendedOnboarding,
     restartUserCreationOnboarding,
     restartNotificationPermissionOnboarding,
     restartLocationWhenInUsePermissionOnboarding,
@@ -194,6 +195,10 @@ export const Profile_DebugInfoScreen = () => {
             onValueChange={(debugShowSeconds) => {
               setPreference({debugShowSeconds});
             }}
+          />
+          <LinkSectionItem
+            text="Restart extended onboarding"
+            onPress={restartExtendedOnboarding}
           />
           <LinkSectionItem
             text="Restart user creation onboarding"

--- a/src/utils/use-onboarding-flow.ts
+++ b/src/utils/use-onboarding-flow.ts
@@ -32,9 +32,10 @@ export const useOnboardingFlow = (
   utilizeThisHookInstanceForSessionCounting = false,
   assumeUserCreationOnboarded = false,
 ) => {
-  const {enable_extended_onboarding} = useRemoteConfig();
+  const shouldShowExtendedOnboarding = useShouldShowExtendedOnboarding();
 
-  const {userCreationOnboarded} = useAppState();
+  const shouldShowUserCreationOnboarding =
+    useShouldShowUserCreationOnboarding();
 
   const shouldShowLocationOnboarding = useShouldShowLocationOnboarding();
 
@@ -56,21 +57,21 @@ export const useOnboardingFlow = (
       let screenName: keyof RootStackParamList | undefined = undefined;
       let params = undefined;
 
-      const shouldShowUserCreationOnboarding = !(
-        userCreationOnboarded || assumeUserCreationOnboarded
-      );
-
       const orderedOnboardingScreens: {
         shouldShow: boolean;
         screenName: keyof RootStackParamList;
         params?: any;
       }[] = [
         {
-          shouldShow: shouldShowUserCreationOnboarding,
-          screenName: enable_extended_onboarding
-            ? 'Root_OnboardingStack'
-            : 'Root_LoginOptionsScreen',
-          params: enable_extended_onboarding ? undefined : {},
+          shouldShow:
+            shouldShowExtendedOnboarding && !assumeUserCreationOnboarded,
+          screenName: 'Root_OnboardingStack',
+        },
+        {
+          shouldShow:
+            shouldShowUserCreationOnboarding && !assumeUserCreationOnboarded,
+          screenName: 'Root_LoginOptionsScreen',
+          params: {},
         },
         {
           shouldShow: shouldShowLocationOnboarding,
@@ -106,8 +107,8 @@ export const useOnboardingFlow = (
       };
     },
     [
-      enable_extended_onboarding,
-      userCreationOnboarded,
+      shouldShowExtendedOnboarding,
+      shouldShowUserCreationOnboarding,
       shouldShowLocationOnboarding,
       shouldShowTravelTokenOnboarding,
       shouldShowNotificationPermissionScreen,
@@ -143,14 +144,14 @@ export const useOnboardingFlow = (
     const routes: PartialRoute<
       Route<keyof RootStackParamList, object | undefined>
     >[] = [];
-    if (userCreationOnboarded) {
+    if (shouldShowUserCreationOnboarding) {
+      routes.push(initialOnboardingRoute);
+    } else {
       routes.push({name: 'Root_TabNavigatorStack'});
 
       if (shouldGoDirectlyToOnboardingScreen) {
         routes.push(initialOnboardingRoute);
       }
-    } else {
-      routes.push(initialOnboardingRoute);
     }
     return {routes};
   };
@@ -160,6 +161,18 @@ export const useOnboardingFlow = (
     getNextOnboardingScreen,
     getInitialNavigationContainerState,
   };
+};
+
+const useShouldShowExtendedOnboarding = () => {
+  const {enable_extended_onboarding} = useRemoteConfig();
+  const {extendedOnboardingOnboarded} = useAppState();
+
+  return enable_extended_onboarding && !extendedOnboardingOnboarded;
+};
+
+const useShouldShowUserCreationOnboarding = () => {
+  const {userCreationOnboarded} = useAppState();
+  return !userCreationOnboarded;
 };
 
 const useShouldShowTravelTokenOnboarding = () => {

--- a/src/utils/use-onboarding-flow.ts
+++ b/src/utils/use-onboarding-flow.ts
@@ -167,7 +167,12 @@ const useShouldShowExtendedOnboarding = () => {
   const {enable_extended_onboarding} = useRemoteConfig();
   const {extendedOnboardingOnboarded} = useAppState();
 
-  return enable_extended_onboarding && !extendedOnboardingOnboarded;
+  const {userCreationOnboarded} = useAppState();
+  return (
+    enable_extended_onboarding &&
+    !extendedOnboardingOnboarded &&
+    !userCreationOnboarded // this is for backward compatibility
+  );
 };
 
 const useShouldShowUserCreationOnboarding = () => {


### PR DESCRIPTION
The extended onboarding wasn't properly supported by the new onboarding flow.
One issue with it was that if you restarted the app after completing it, you had to go through it again.
Now the implementation is in line with the new way to deal with the onboarding flow.

- Added `extendedOnboardingOnboarded` flag in AppContext (not a great name, but refactoring `AppContext` will have to wait)
- Using `extendedOnboardingOnboarded` in the new `useShouldShowExtendedOnboarding` in `useOnboardingFlow`

Resolves https://github.com/AtB-AS/kundevendt/issues/8619