### PR TITLE
chore: build store ios - remove unused beacons

### DIFF
--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Enable apple pass suppression
         if: ${{ env.ENABLE_APPLE_PASS_SUPPRESSION == 'true' }}
         run: bundle exec fastlane ios enable_pass_presentation_suppression_entitlement
+      - name: Remove use of beacons
+        if: ${{ env.KETTLE_API_KEY == '' }}
+        run: bundle exec fastlane ios remove_use_of_beacons
       - name: Run fastlane build
         run: bundle exec fastlane ios build
         env:


### PR DESCRIPTION
Add the same [build step](https://github.com/AtB-AS/mittatb-app/pull/4273/files) for store-ios as in stage-ios.

Resolves https://github.com/AtB-AS/kundevendt/issues/16030