### PR TITLE
chore: simplify getInitialNavigationContainerState

### DIFF
--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -174,7 +174,7 @@ export const RootStack = () => {
         <LoadingScreenBoundary>
           <NavigationContainer<RootStackParamList>
             onStateChange={trackNavigation}
-            initialState={getInitialNavigationContainerState(true)}
+            initialState={getInitialNavigationContainerState()}
             ref={navRef}
             theme={ReactNavigationTheme}
             fallback={<LoadingScreen />}

--- a/src/utils/use-onboarding-flow.ts
+++ b/src/utils/use-onboarding-flow.ts
@@ -127,31 +127,26 @@ export const useOnboardingFlow = (
   }, [getNextOnboardingScreen, assumeUserCreationOnboarded]);
 
   /**
-   * add Root_TabNavigatorStack as root when userCreationOnboarded
+   * add defaultInitialRouteName as root when userCreationOnboarded
    * this allows goBack from an onboarding screen when used as initial screen
-   * @param {Boolean} shouldGoDirectlyToOnboardingScreen when userCreationOnboarded, true if going directly to the next onboarding screen, false if instead going to Root_TabNavigatorStack first
    * @returns navigation state object
    */
-  const getInitialNavigationContainerState = (
-    shouldGoDirectlyToOnboardingScreen: boolean,
-  ) => {
+  const getInitialNavigationContainerState = () => {
+    const defaultInitialRouteName = 'Root_TabNavigatorStack';
     const initialOnboardingScreen = getNextOnboardingScreen(); // dont rely on effects as it will be too late for initialState
     const initialOnboardingRoute = {
-      name: initialOnboardingScreen?.screenName ?? 'Root_TabNavigatorStack',
+      name: initialOnboardingScreen?.screenName ?? defaultInitialRouteName,
       params: initialOnboardingScreen?.params,
     };
 
     const routes: PartialRoute<
       Route<keyof RootStackParamList, object | undefined>
-    >[] = [];
-    if (shouldShowUserCreationOnboarding) {
-      routes.push(initialOnboardingRoute);
-    } else {
-      routes.push({name: 'Root_TabNavigatorStack'});
-
-      if (shouldGoDirectlyToOnboardingScreen) {
-        routes.push(initialOnboardingRoute);
-      }
+    >[] = [initialOnboardingRoute];
+    if (
+      !shouldShowUserCreationOnboarding &&
+      initialOnboardingScreen?.screenName
+    ) {
+      routes.unshift({name: defaultInitialRouteName});
     }
     return {routes};
   };


### PR DESCRIPTION
This PR is just to simplify the `getInitialNavigationContainerState` function.
Note: The `shouldGoDirectlyToOnboardingScreen` parameter was unnecessary and is removed.

Resolves https://github.com/AtB-AS/kundevendt/issues/8619