### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# https://github.com/AtB-AS/docs-private/blob/main/kundevendt-development-guidelines.md#systemdomain-captains
+
+# App
+* @gorandalum @marius-at-atb @jorelosorio @rosvik
+
+# Mobile token (App, Webshop, Token-server)
+/src/mobile-token/ @gorandalum @jorelosorio @hanne-at-atb
+
+# Mobility (App, BFF)
+/src/mobility/ @gorandalum @marius-at-atb @reidzeibel
+
+# Builds (GH Actions, App Store, Play Store, App Center)
+/.github/workflows/ @gorandalum @jorelosorio @reidzeibel
+/env/ @gorandalum @jorelosorio @reidzeibel
+/fastnane/ @gorandalum @jorelosorio @reidzeibel
+/scripts/ @gorandalum @jorelosorio @reidzeibel
+/tools/ @gorandalum @jorelosorio @reidzeibel
+
+# Firebase (Firestore, RemoteConfig, Configs, Typings)
+/src/configuration/ @gorandalum @reidzeibel @jorelosorio
+
+# Tests
+/e2e/ @gorandalum @marius-at-atb @jorelosorio @rosvik @tormoseng
+
+# Native code
+/android/ @gorandalum @reidzeibel @jorelosorio
+/ios/ @gorandalum @jorelosorio @reidzeibel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 # Builds (GH Actions, App Store, Play Store, App Center)
 /.github/workflows/ @gorandalum @jorelosorio @reidzeibel
 /env/ @gorandalum @jorelosorio @reidzeibel
-/fastnane/ @gorandalum @jorelosorio @reidzeibel
+/fastlane/ @gorandalum @jorelosorio @reidzeibel
 /scripts/ @gorandalum @jorelosorio @reidzeibel
 /tools/ @gorandalum @jorelosorio @reidzeibel
 


### PR DESCRIPTION
Based on https://github.com/AtB-AS/docs-private/blob/main/kundevendt-development-guidelines.md

But took the liberty to add this part:

```
# Native code
/android/ @gorandalum @reidzeibel @jorelosorio
/ios/ @gorandalum @jorelosorio @reidzeibel
```

If that's ok with our native experts 😊 @reidzeibel @jorelosorio 