### PR TITLE
feat: add ticket selector to profile - ticket history screen

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -160,7 +160,9 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               ProfileTexts.sections.account.linkSectionItems.ticketHistory
                 .label,
             )}
-            onPress={() => navigation.navigate('Profile_TicketHistoryScreen')}
+            onPress={() =>
+              navigation.navigate('Profile_TicketHistorySelectionScreen')
+            }
             testID="ticketHistoryButton"
           />
           {authenticationType !== 'phone' && (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistoryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistoryScreen.tsx
@@ -1,57 +1,9 @@
 import React from 'react';
-import {useTranslation, TicketingTexts} from '@atb/translations';
-import {filterExpiredFareContracts, useTicketingState} from '@atb/ticketing';
-import {FareContractAndReservationsList} from '@atb/fare-contracts';
-import TicketHistoryTexts from '@atb/translations/screens/subscreens/TicketHistory';
-import {useTimeContextState} from '@atb/time';
-import {FullScreenView} from '@atb/components/screen-view';
-import {ScreenHeading} from '@atb/components/heading';
-import {RefreshControl} from 'react-native-gesture-handler';
+import {ProfileScreenProps} from './navigation-types';
+import {TicketHistoryScreenComponent} from '@atb/ticket-history';
 
-export const Profile_TicketHistoryScreen: React.FC = () => {
-  const {
-    fareContracts,
-    isRefreshingFareContracts,
-    rejectedReservations,
-    resubscribeFirestoreListeners,
-  } = useTicketingState();
+type Props = ProfileScreenProps<'Profile_TicketHistoryScreen'>;
 
-  const {serverNow} = useTimeContextState();
-  const expiredFareContracts = filterExpiredFareContracts(
-    fareContracts,
-    serverNow,
-  );
-
-  const {t} = useTranslation();
-  return (
-    <FullScreenView
-      headerProps={{
-        title: t(TicketHistoryTexts.header),
-        leftButton: {type: 'back', withIcon: true},
-      }}
-      parallaxContent={(focusRef) => (
-        <ScreenHeading ref={focusRef} text={t(TicketHistoryTexts.header)} />
-      )}
-      refreshControl={
-        <RefreshControl
-          refreshing={isRefreshingFareContracts}
-          onRefresh={resubscribeFirestoreListeners}
-        />
-      }
-    >
-      <FareContractAndReservationsList
-        fareContracts={expiredFareContracts}
-        reservations={rejectedReservations}
-        now={serverNow}
-        emptyStateTitleText={t(
-          TicketingTexts.activeFareProductsAndReservationsTab
-            .emptyTicketHistoryTitle,
-        )}
-        emptyStateDetailsText={t(
-          TicketingTexts.activeFareProductsAndReservationsTab
-            .emptyTicketHistoryDetails,
-        )}
-      />
-    </FullScreenView>
-  );
+export const Profile_TicketHistoryScreen = ({route}: Props) => {
+  return <TicketHistoryScreenComponent mode={route.params.mode} />;
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
@@ -1,0 +1,56 @@
+import {ScreenHeading} from '@atb/components/heading';
+import {FullScreenView} from '@atb/components/screen-view';
+import {LinkSectionItem, Section} from '@atb/components/sections';
+import {useTranslation} from '@atb/translations';
+import Ticketing from '@atb/translations/screens/Ticketing';
+import TicketHistoryTexts from '@atb/translations/screens/subscreens/TicketHistory';
+import {ProfileScreenProps} from './navigation-types';
+import {StyleSheet} from '@atb/theme';
+
+type Props = ProfileScreenProps<'Profile_TicketHistorySelectionScreen'>;
+
+export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+
+  return (
+    <FullScreenView
+      headerProps={{
+        title: t(TicketHistoryTexts.header),
+        leftButton: {type: 'back', withIcon: true},
+      }}
+      parallaxContent={(focusRef) => (
+        <ScreenHeading ref={focusRef} text={t(TicketHistoryTexts.header)} />
+      )}
+    >
+      <Section style={styles.content}>
+        <LinkSectionItem
+          text={t(Ticketing.expiredTickets.title)}
+          accessibility={{
+            accessibilityHint: t(Ticketing.expiredTickets.a11yHint),
+          }}
+          testID="expiredTicketsButton"
+          onPress={() =>
+            navigation.navigate('Profile_TicketHistoryScreen', {
+              mode: 'expired',
+            })
+          }
+        />
+        <LinkSectionItem
+          text={t(Ticketing.sentToOthers.title)}
+          accessibility={{
+            accessibilityHint: t(Ticketing.sentToOthers.a11yHint),
+          }}
+          testID="sentToOthersButton"
+          onPress={() =>
+            navigation.navigate('Profile_TicketHistoryScreen', {mode: 'sent'})
+          }
+        />
+      </Section>
+    </FullScreenView>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  content: {flex: 1, padding: theme.spacings.medium},
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -27,6 +27,7 @@ import {Profile_EditProfileScreen} from '@atb/stacks-hierarchy/Root_TabNavigator
 import {Profile_FareContractsScreen} from './Profile_FareContractsScreen';
 import {Profile_NotificationsScreen} from './Profile_NotificationsScreen';
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
+import {Profile_TicketHistorySelectionScreen} from './Profile_TicketHistorySelectionScreen';
 
 const Stack = createStackNavigator<ProfileStackParams>();
 
@@ -42,6 +43,10 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_TicketHistoryScreen"
         component={Profile_TicketHistoryScreen}
+      />
+      <Stack.Screen
+        name="Profile_TicketHistorySelectionScreen"
+        component={Profile_TicketHistorySelectionScreen}
       />
       <Stack.Screen
         name="Profile_PaymentOptionsScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -10,7 +10,8 @@ import {StackParams} from '@atb/stacks-hierarchy/navigation-types';
 export type ProfileStackParams = StackParams<{
   Profile_RootScreen: undefined;
   Profile_PaymentOptionsScreen: undefined;
-  Profile_TicketHistoryScreen: undefined;
+  Profile_TicketHistoryScreen: ProfileTicketHistoryScreenParams;
+  Profile_TicketHistorySelectionScreen: undefined;
   Profile_DeleteProfileScreen: undefined;
   Profile_EditProfileScreen: undefined;
   Profile_FavoriteListScreen: undefined;
@@ -34,6 +35,10 @@ export type ProfileStackParams = StackParams<{
   Profile_NearbyStopPlacesScreen: NearbyStopPlacesScreenParams;
   Profile_PlaceScreen: PlaceScreenParams;
 }>;
+
+export type ProfileTicketHistoryScreenParams = {
+  mode: 'expired' | 'sent';
+};
 
 export type ProfileStackRootProps =
   TabNavigatorScreenProps<'TabNav_ProfileStack'>;


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16303
also closes https://github.com/AtB-AS/kundevendt/issues/16305

- Adds a new screen `Profile_TicketHistorySelectionScreen` with it's corresponding navigation requirements.
- Replaces the content in `Profile_TicketHistoryScreen` with the new `TicketHistoryScreenComponent`.
