### PR TITLE
feat: add popover for on-behalf–of

### DIFF
--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -1,1 +1,3 @@
-export type PopOverKey = 'trip-search-flexible-transport-dismissed';
+export type PopOverKey =
+  | 'trip-search-flexible-transport-dismissed'
+  | 'on-behalf-of-new-feature-introduction';

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -83,11 +83,13 @@ export function TravellerSelection({
 
   useFocusEffect(
     useCallback(() => {
-      addPopOver({
-        oneTimeKey: 'on-behalf-of-new-feature-introduction',
-        target: onBehalfOfIndicatorRef,
-      });
-    }, [addPopOver]),
+      if (isOnBehalfOfEnabled) {
+        addPopOver({
+          oneTimeKey: 'on-behalf-of-new-feature-introduction',
+          target: onBehalfOfIndicatorRef,
+        });
+      }
+    }, [isOnBehalfOfEnabled, addPopOver]),
   );
 
   if (selectionMode === 'none') {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
@@ -19,6 +19,8 @@ import {ContentHeading} from '@atb/components/heading';
 import {LabelInfo} from '@atb/components/label-info';
 import {useOnBehalfOf} from '@atb/on-behalf-of';
 import {LabelInfoTexts} from '@atb/translations/components/LabelInfo';
+import {usePopOver} from '@atb/popover';
+import {useFocusEffect} from '@react-navigation/native';
 
 type TravellerSelectionProps = {
   selectableUserProfiles: UserProfileWithCount[];
@@ -51,6 +53,9 @@ export function TravellerSelection({
 
   const isOnBehalfOfEnabled = useOnBehalfOf();
 
+  const {addPopOver} = usePopOver();
+  const onBehalfOfIndicatorRef = useRef(null);
+
   const [userProfilesState, setUserProfilesState] = useState<
     UserProfileWithCount[]
   >(selectableUserProfiles);
@@ -75,6 +80,15 @@ export function TravellerSelection({
     setTravellerSelection(filteredSelection);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fareProductType, selectionMode, userProfilesState]);
+
+  useFocusEffect(
+    useCallback(() => {
+      addPopOver({
+        oneTimeKey: 'on-behalf-of-new-feature-introduction',
+        target: onBehalfOfIndicatorRef,
+      });
+    }, [addPopOver]),
+  );
 
   if (selectionMode === 'none') {
     return null;
@@ -187,7 +201,15 @@ export function TravellerSelection({
             </View>
 
             {/* remove new label when requested */}
-            {isOnBehalfOfEnabled && <LabelInfo label="new" />}
+            {isOnBehalfOfEnabled && (
+              <View
+                ref={onBehalfOfIndicatorRef}
+                renderToHardwareTextureAndroid={true}
+                collapsable={false}
+              >
+                <LabelInfo label="new" />
+              </View>
+            )}
 
             <ThemeIcon svg={Edit} size="normal" />
           </View>

--- a/src/translations/components/OneTimePopOver.ts
+++ b/src/translations/components/OneTimePopOver.ts
@@ -19,6 +19,14 @@ const OneTimePopOverTexts: {[key in PopOverKey]: PopOverText} = {
       'Tips om bestillingstransport kan skruast på igjen i filter.',
     ),
   },
+  'on-behalf-of-new-feature-introduction': {
+    heading: _('Nyhet!', 'New!', 'Nyhet!'),
+    text: _(
+      'Kjøp til noen andre.',
+      'Buy for someone else.',
+      'Kjøp til nokon andre.',
+    ),
+  },
 };
 
 export default OneTimePopOverTexts;


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16033

Pretty straightforward PR, things added:

- ref to the new label.
- useFocusEffect to trigger popover when view is rendered and screen is shown.
- text for popover.

Preview below

<img width="250" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/8ec91d04-1da3-4a4b-a5c3-dba38d00a637">

<img width="250" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/b5a5d360-8026-4f95-ab96-23f8cf30d8b3">
