### PR TITLE
refactor: rework ticket history typing and text translations

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
@@ -42,9 +42,9 @@ export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
         />
         {isOnBehalfOfEnabled && (
           <LinkSectionItem
-            text={t(Ticketing.sentToOthers.title)}
+            text={t(TicketHistoryModeTexts.sent.title)}
             accessibility={{
-              accessibilityHint: t(Ticketing.sentToOthers.a11yHint),
+              accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
             }}
             testID="sentToOthersButton"
             onPress={() =>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
@@ -2,8 +2,9 @@ import {ScreenHeading} from '@atb/components/heading';
 import {FullScreenView} from '@atb/components/screen-view';
 import {LinkSectionItem, Section} from '@atb/components/sections';
 import {useTranslation} from '@atb/translations';
-import Ticketing from '@atb/translations/screens/Ticketing';
-import TicketHistoryTexts from '@atb/translations/screens/subscreens/TicketHistory';
+import Ticketing, {
+  TicketHistoryModeTexts,
+} from '@atb/translations/screens/Ticketing';
 import {ProfileScreenProps} from './navigation-types';
 import {StyleSheet} from '@atb/theme';
 
@@ -16,18 +17,18 @@ export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
   return (
     <FullScreenView
       headerProps={{
-        title: t(TicketHistoryTexts.header),
+        title: t(Ticketing.ticketHistory.title),
         leftButton: {type: 'back', withIcon: true},
       }}
       parallaxContent={(focusRef) => (
-        <ScreenHeading ref={focusRef} text={t(TicketHistoryTexts.header)} />
+        <ScreenHeading ref={focusRef} text={t(Ticketing.ticketHistory.title)} />
       )}
     >
       <Section style={styles.content}>
         <LinkSectionItem
-          text={t(Ticketing.expiredTickets.title)}
+          text={t(TicketHistoryModeTexts.expired.title)}
           accessibility={{
-            accessibilityHint: t(Ticketing.expiredTickets.a11yHint),
+            accessibilityHint: t(TicketHistoryModeTexts.expired.titleA11y),
           }}
           testID="expiredTicketsButton"
           onPress={() =>
@@ -37,9 +38,9 @@ export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
           }
         />
         <LinkSectionItem
-          text={t(Ticketing.sentToOthers.title)}
+          text={t(TicketHistoryModeTexts.sent.title)}
           accessibility={{
-            accessibilityHint: t(Ticketing.sentToOthers.a11yHint),
+            accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
           }}
           testID="sentToOthersButton"
           onPress={() =>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -6,11 +6,12 @@ import {PlaceScreenParams} from '@atb/place-screen/PlaceScreenComponent';
 import {RootStackParamList} from '@atb/stacks-hierarchy';
 import {NearbyStopPlacesScreenParams} from '@atb/nearby-stop-places/NearbyStopPlacesScreenComponent';
 import {StackParams} from '@atb/stacks-hierarchy/navigation-types';
+import {TicketHistoryScreenParams} from '@atb/ticket-history';
 
 export type ProfileStackParams = StackParams<{
   Profile_RootScreen: undefined;
   Profile_PaymentOptionsScreen: undefined;
-  Profile_TicketHistoryScreen: ProfileTicketHistoryScreenParams;
+  Profile_TicketHistoryScreen: TicketHistoryScreenParams;
   Profile_TicketHistorySelectionScreen: undefined;
   Profile_DeleteProfileScreen: undefined;
   Profile_EditProfileScreen: undefined;
@@ -35,10 +36,6 @@ export type ProfileStackParams = StackParams<{
   Profile_NearbyStopPlacesScreen: NearbyStopPlacesScreenParams;
   Profile_PlaceScreen: PlaceScreenParams;
 }>;
-
-export type ProfileTicketHistoryScreenParams = {
-  mode: 'expired' | 'sent';
-};
 
 export type ProfileStackRootProps =
   TabNavigatorScreenProps<'TabNav_ProfileStack'>;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -11,7 +11,7 @@ import {useTranslation, TicketingTexts} from '@atb/translations';
 import {useAnalytics} from '@atb/analytics';
 import {useTimeContextState} from '@atb/time';
 import {LinkSectionItem, Section} from '@atb/components/sections';
-import Ticketing from '@atb/translations/screens/Ticketing';
+import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 import {TicketTabNavScreenProps} from './navigation-types';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
 
@@ -76,9 +76,9 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
         <Section style={styles.content}>
           {hasExpiredFareContracts && (
             <LinkSectionItem
-              text={t(Ticketing.expiredTickets.title)}
+              text={t(TicketHistoryModeTexts.expired.title)}
               accessibility={{
-                accessibilityHint: t(Ticketing.expiredTickets.a11yHint),
+                accessibilityHint: t(TicketHistoryModeTexts.expired.titleA11y),
               }}
               testID="expiredTicketsButton"
               onPress={() =>
@@ -91,9 +91,9 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
 
           {hasSentFareContracts && (
             <LinkSectionItem
-              text={t(Ticketing.sentToOthers.title)}
+              text={t(TicketHistoryModeTexts.sent.title)}
               accessibility={{
-                accessibilityHint: t(Ticketing.sentToOthers.a11yHint),
+                accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
               }}
               testID="sentToOthersButton"
               onPress={() =>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/navigation-types.ts
@@ -8,10 +8,6 @@ export type TicketTabNavStackParams = StackParams<{
   TicketTabNav_ActiveFareProductsTabScreen: undefined;
 }>;
 
-export type TicketingTicketHistoryScreenParams = {
-  mode: 'expired' | 'sent';
-};
-
 export type TicketTabNavStackRootProps =
   TicketingScreenProps<'Ticketing_RootScreen'>;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/navigation-types.ts
@@ -6,17 +6,15 @@ import {
   CompositeScreenProps,
   NavigatorScreenParams,
 } from '@react-navigation/native';
-import {
-  TicketTabNavStackParams,
-  TicketingTicketHistoryScreenParams,
-} from './Ticketing_TicketTabNavStack/navigation-types';
+import {TicketTabNavStackParams} from './Ticketing_TicketTabNavStack/navigation-types';
 import {TabNavigatorScreenProps} from '../navigation-types';
 import {StackScreenProps} from '@react-navigation/stack';
+import {TicketHistoryScreenParams} from '@atb/ticket-history';
 
 export type TicketingStackParams = StackParams<{
   Ticketing_NotEnabledScreen: undefined;
   Ticketing_RootScreen: NavigatorScreenParams<TicketTabNavStackParams>;
-  Ticketing_TicketHistoryScreen: TicketingTicketHistoryScreenParams;
+  Ticketing_TicketHistoryScreen: TicketHistoryScreenParams;
 }>;
 
 export type TicketingStackRootProps =

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -11,12 +11,15 @@ import {useTimeContextState} from '@atb/time';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import {View} from 'react-native';
 import {RefreshControl} from 'react-native-gesture-handler';
-import {TicketHistoryMode} from '@atb/ticket-history';
+import {
+  TicketHistoryMode,
+  TicketHistoryScreenParams,
+} from '@atb/ticket-history';
 import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 
-type Props = {mode: TicketHistoryMode};
-
-export const TicketHistoryScreenComponent = ({mode}: Props) => {
+export const TicketHistoryScreenComponent = ({
+  mode,
+}: TicketHistoryScreenParams) => {
   const {
     fareContracts,
     isRefreshingFareContracts,

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -8,17 +8,13 @@ import {
   useTicketingState,
 } from '@atb/ticketing';
 import {useTimeContextState} from '@atb/time';
-import {
-  TicketingTexts,
-  TranslateFunction,
-  useTranslation,
-} from '@atb/translations';
+import {TicketingTexts, useTranslation} from '@atb/translations';
 import {View} from 'react-native';
 import {RefreshControl} from 'react-native-gesture-handler';
+import {TicketHistoryMode} from '@atb/ticket-history';
+import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 
-type Mode = 'expired' | 'sent';
-
-type Props = {mode: Mode};
+type Props = {mode: TicketHistoryMode};
 
 export const TicketHistoryScreenComponent = ({mode}: Props) => {
   const {
@@ -35,11 +31,14 @@ export const TicketHistoryScreenComponent = ({mode}: Props) => {
   return (
     <FullScreenView
       headerProps={{
-        title: getTitle(mode, t),
+        title: t(TicketHistoryModeTexts[mode].title),
         leftButton: {type: 'back', withIcon: true},
       }}
       parallaxContent={(focusRef) => (
-        <ScreenHeading ref={focusRef} text={getTitle(mode, t)} />
+        <ScreenHeading
+          ref={focusRef}
+          text={t(TicketHistoryModeTexts[mode].title)}
+        />
       )}
       refreshControl={
         <RefreshControl
@@ -54,31 +53,16 @@ export const TicketHistoryScreenComponent = ({mode}: Props) => {
           reservations={rejectedReservations}
           now={serverNow}
           emptyStateMode={mode}
-          emptyStateTitleText={t(
-            TicketingTexts.activeFareProductsAndReservationsTab
-              .emptyTicketHistoryTitle,
-          )}
-          emptyStateDetailsText={t(
-            TicketingTexts.activeFareProductsAndReservationsTab
-              .emptyTicketHistoryDetails,
-          )}
+          emptyStateTitleText={t(TicketingTexts.ticketHistory.emptyState)}
+          emptyStateDetailsText={t(TicketHistoryModeTexts[mode].emptyDetail)}
         />
       </View>
     </FullScreenView>
   );
 };
 
-const getTitle = (mode: Mode, t: TranslateFunction) => {
-  switch (mode) {
-    case 'expired':
-      return t(TicketingTexts.expiredTickets.title);
-    case 'sent':
-      return t(TicketingTexts.sentToOthers.title);
-  }
-};
-
 const displayFareContracts = (
-  mode: Mode,
+  mode: TicketHistoryMode,
   fareContracts: FareContract[],
   serverNow: number,
 ) => {

--- a/src/ticket-history/index.tsx
+++ b/src/ticket-history/index.tsx
@@ -1,1 +1,3 @@
 export {TicketHistoryScreenComponent} from './TicketHistoryScreenComponent';
+export type {TicketHistoryMode} from './types';
+export type {TicketHistoryScreenParams} from './types';

--- a/src/ticket-history/types.ts
+++ b/src/ticket-history/types.ts
@@ -1,0 +1,5 @@
+export type TicketHistoryMode = 'expired' | 'sent';
+
+export type TicketHistoryScreenParams = {
+  mode: TicketHistoryMode;
+};

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -14,8 +14,12 @@ export const TicketHistoryModeTexts: {
   [key in TicketHistoryMode]: TicketHistoryModeText;
 } = {
   expired: {
-    title: _('', '', ''),
-    titleA11y: _('', '', ''),
+    title: _('Utløpte billetter', 'Expired tickets', 'Utgåtte billettar'),
+    titleA11y: _(
+      'Aktiver for å vise dine utløpte billetter',
+      'Activate to show your expired tickets',
+      'Aktiver for å vise billettane dine som har gått ut',
+    ),
     emptyDetail: _(
       'Dine utløpte billetter vil dukke opp her. Dra ned for å oppdatere om du ikke finner billetten din.',
       "Your expired tickets will show here. Pull down to refresh if you can't find your ticket.",

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -1,7 +1,45 @@
 import {orgSpecificTranslations} from '../orgSpecificTranslations';
-import {translation as _} from '../commons';
+import {TranslatedString, translation as _} from '../commons';
+import {TicketHistoryMode} from '@atb/ticket-history';
 
 const bulletPoint = '\u2022';
+
+type TicketHistoryModeText = {
+  title: TranslatedString;
+  titleA11y: TranslatedString;
+  emptyDetail: TranslatedString;
+};
+
+export const TicketHistoryModeTexts: {
+  [key in TicketHistoryMode]: TicketHistoryModeText;
+} = {
+  expired: {
+    title: _('', '', ''),
+    titleA11y: _('', '', ''),
+    emptyDetail: _(
+      'Dine utløpte billetter vil dukke opp her. Dra ned for å oppdatere om du ikke finner billetten din.',
+      "Your expired tickets will show here. Pull down to refresh if you can't find your ticket.",
+      'Billettane dine som har gått ut vil dukke opp her. Drag ned for å oppdatere om du ikkje finn billetten din.',
+    ),
+  },
+  sent: {
+    title: _(
+      'Billetter sendt til andre',
+      'Tickets sent to others',
+      'Billettar sendt til andre',
+    ),
+    titleA11y: _(
+      'Aktiver for å vise billetter sendt til andre',
+      'Activate to show tickets sent to other',
+      'Aktiver for å vise billettar sendt til andre',
+    ),
+    emptyDetail: _(
+      'Billetter sendt til andre vil dukke opp her. Dra ned for å oppdatere om du ikke finner billetten din.',
+      "Tickets sent to others will show here. Pull down to refresh if you can't find your ticket.",
+      'Billettar sendt til andre vil dukke opp her. Drag ned for å oppdatere om du ikkje finn billetten din.',
+    ),
+  },
+};
 
 const TicketingTexts = {
   header: {
@@ -58,16 +96,6 @@ const TicketingTexts = {
       'When you buy tickets, they will show up here. Pull down to refresh if your ticket is not showing.',
       'Når du kjøper billettar vil dei dukke opp her. Drag ned for å oppdatere dersom billetten din ikkje visast.',
     ),
-    emptyTicketHistoryTitle: _(
-      'Ingen billetter kjøpt',
-      'No tickets bought',
-      'Ingen billettar kjøpt',
-    ),
-    emptyTicketHistoryDetails: _(
-      'Dine utløpte billetter vil dukke opp her. Dra ned for å oppdatere om du ikke finner billetten din.',
-      "Your expired tickets will show here. Pull down to refresh if you can't find your ticket.",
-      'Billettane dine som har gått ut vil dukke opp her. Drag ned for å oppdatere om du ikkje finn billetten din.',
-    ),
   },
   ticketHistoryTab: {
     noItems: _(
@@ -75,6 +103,10 @@ const TicketingTexts = {
       'Nothing to show here until you have purchased a ticket.',
       'Fann ingen billetthistorikk.',
     ),
+  },
+  ticketHistory: {
+    title: _('Billetthistorikk', 'Ticket history', 'Billetthistorikk'),
+    emptyState: _('Ingen billetter', 'No tickets', 'Ingen billettar'),
   },
   ticket: {
     valid: {
@@ -135,26 +167,6 @@ const TicketingTexts = {
     carnet: {
       transportModes: _('Buss/trikk', 'Bus/tram', 'Buss/trikk'),
     },
-  },
-  expiredTickets: {
-    title: _('Utløpte billetter', 'Expired tickets', 'Utgåtte billettar'),
-    a11yHint: _(
-      'Aktiver for å vise dine utløpte billetter',
-      'Activate to show your expired tickets',
-      'Aktiver for å vise billettane dine som har gått ut',
-    ),
-  },
-  sentToOthers: {
-    title: _(
-      'Billetter sendt til andre',
-      'Tickets sent to others',
-      'Billettar sendt til andre',
-    ),
-    a11yHint: _(
-      'Aktiver for å vise billetter sendt til andre',
-      'Activate to show tickets sent to other',
-      'Aktiver for å vise billettar sendt til andre',
-    ),
   },
   reservation: {
     reserving: _(

--- a/src/translations/screens/subscreens/TicketHistory.ts
+++ b/src/translations/screens/subscreens/TicketHistory.ts
@@ -1,6 +1,0 @@
-import {translation as _} from '../../commons';
-const TicketHistoryTexts = {
-  header: _('Billetthistorikk', 'Ticket history', 'Billetthistorikk'),
-};
-
-export default TicketHistoryTexts;


### PR DESCRIPTION
Part of https://github.com/AtB-AS/kundevendt/issues/16305

This PR will : 
- Improve the usage of `TicketHistoryMode = 'expired' | 'sent'` by using it everywhere else on the code (Profile ticket history screen, Ticket tab history screen, and Ticket history component).
- Allow the use of dynamic text translation on screens based on the mode `expired` or `sent` in `TicketHistoryScreenComponent`, moving the logic from the view to translation file.
- Remove unused file.