### PR TITLE
refactor: add checking for on-behalf-of section in ticket history selection.

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
@@ -6,12 +6,15 @@ import Ticketing from '@atb/translations/screens/Ticketing';
 import TicketHistoryTexts from '@atb/translations/screens/subscreens/TicketHistory';
 import {ProfileScreenProps} from './navigation-types';
 import {StyleSheet} from '@atb/theme';
+import {useOnBehalfOf} from '@atb/on-behalf-of';
 
 type Props = ProfileScreenProps<'Profile_TicketHistorySelectionScreen'>;
 
 export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
   const styles = useStyles();
+
+  const isOnBehalfOfEnabled = useOnBehalfOf();
 
   return (
     <FullScreenView
@@ -36,16 +39,18 @@ export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
             })
           }
         />
-        <LinkSectionItem
-          text={t(Ticketing.sentToOthers.title)}
-          accessibility={{
-            accessibilityHint: t(Ticketing.sentToOthers.a11yHint),
-          }}
-          testID="sentToOthersButton"
-          onPress={() =>
-            navigation.navigate('Profile_TicketHistoryScreen', {mode: 'sent'})
-          }
-        />
+        {isOnBehalfOfEnabled && (
+          <LinkSectionItem
+            text={t(Ticketing.sentToOthers.title)}
+            accessibility={{
+              accessibilityHint: t(Ticketing.sentToOthers.a11yHint),
+            }}
+            testID="sentToOthersButton"
+            onPress={() =>
+              navigation.navigate('Profile_TicketHistoryScreen', {mode: 'sent'})
+            }
+          />
+        )}
       </Section>
     </FullScreenView>
   );


### PR DESCRIPTION
Simple PR, don't show tickets sent to others if we don't have the settings enabled in remote config.