### PR TITLE
feat: add purchasedBy and customerAccountId to FareContract type

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -41,6 +41,7 @@ export const Profile_FareContractsScreen = () => {
   const BASE = {
     created: toTimeStamp(NOW),
     customerAccountId: 'ATB:CustomerAccount:xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
+    purchasedBy: 'ATB:CustomerAccount:xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
     eventTimestamp: toTimeStamp(daysFromNow(-1)),
     id: 'ATB:FareContract:V3TZT6NE-xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
     minimumSecurityLevel: -200,

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -76,6 +76,8 @@ export type FareContract = {
   created: Timestamp;
   version: string;
   id: string;
+  customerAccountId: string;
+  purchasedBy: string;
   orderId: string;
   state: FareContractState;
   minimumSecurityLevel: number;


### PR DESCRIPTION
Adding `purchasedBy` and `customerAccountId` to `FareContract`, these are already in Firestore, just unused until now. 

On-behalf-or / På-vegne-av feature requires these props. 