### PR TITLE
fix: remove unwanted gap on expired ticket details

### DIFF
--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -116,17 +116,18 @@ export const DetailsContent: React.FC<Props> = ({
             preassignedFareProduct={preassignedFareProduct}
           />
         </GenericSectionItem>
-        {deviceInspectionStatus === 'inspectable' && (
-          <GenericSectionItem
-            style={
-              barcodeStatus === 'staticQr'
-                ? styles.enlargedWhiteBarcodePaddingView
-                : undefined
-            }
-          >
-            <Barcode validityStatus={validityStatus} fc={fc} />
-          </GenericSectionItem>
-        )}
+        {deviceInspectionStatus === 'inspectable' &&
+          validityStatus === 'valid' && (
+            <GenericSectionItem
+              style={
+                barcodeStatus === 'staticQr'
+                  ? styles.enlargedWhiteBarcodePaddingView
+                  : undefined
+              }
+            >
+              <Barcode validityStatus={validityStatus} fc={fc} />
+            </GenericSectionItem>
+          )}
         <GenericSectionItem>
           <FareContractInfoDetails
             fromTariffZone={fromTariffZone}


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16737

This PR will not show the section if the ticket is expired, removing the gap shown in the picture below, between `Single ticket` and `Traveller`.

<img src="https://github.com/AtB-AS/kundevendt/assets/1777333/0ad64e88-ffdb-45bb-8c49-658442f7ca1d" width=200/>