### PR TITLE
fix: crash when opening list of tickets

### DIFF
--- a/src/fare-contracts/PreActivatedFareContractInfo.tsx
+++ b/src/fare-contracts/PreActivatedFareContractInfo.tsx
@@ -79,7 +79,8 @@ export const PreActivatedFareContractInfo: React.FC<Props> = ({
     userProfiles,
   );
 
-  const shouldShowBundlingInfo = benefits?.length && validityStatus === 'valid';
+  const shouldShowBundlingInfo =
+    benefits && benefits.length > 0 && validityStatus === 'valid';
 
   return (
     <Section withBottomPadding testID={testID}>


### PR DESCRIPTION
Fixes crash when opening list of tickets page.

Apparently checking `benefits?.length && validityStatus === 'valid'` results in 0, which then results in `shouldShowBundlingInfo` to be always defined. 

Since `shouldShowBundlingInfo` is always defined, the `MobilityBenefitsInfoSectionItem` will be rendered, but there are no value to be rendered, causing a crash.