### PR TITLE
Fix Vipps Login crash on 1.46 rc7

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -57,3 +57,9 @@
 -dontwarn com.facebook.react.**
 -keep,includedescriptorclasses class com.facebook.react.bridge.** { *; }
 -keep,includedescriptorclasses class com.facebook.react.turbomodule.core.** { *; }
+
+-keepattributes *Annotation*
+-keepclassmembers class ** {
+  @org.greenrobot.eventbus.Subscribe <methods>;
+}
+-keep enum org.greenrobot.eventbus.ThreadMode { *; }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,8 +6,6 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
-        // Setting androidXBrowser to avoid react-native-reborn picking newest alpha requiring SDK 33
-        androidXBrowser = "1.4.0"
         RNMapboxMapsImpl = "mapbox"
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,8 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
+        // Setting androidXBrowser to avoid react-native-reborn picking newest alpha requiring SDK 33
+        androidXBrowser = "1.5.0"
         RNMapboxMapsImpl = "mapbox"
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.


### PR DESCRIPTION
slack discussion : https://mittatb.slack.com/archives/C0116FMPX4Y/p1706874281773619

This PR will: 
- add proguard rules to fix the crash that occurs on Vipps login. 
- update AndroidX Browser version to 1.5.0 (latest version allowed on apps targeting Android SDK 33)