### PR TITLE
fix: wrong color on button in TravelTokenBox

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -261,7 +261,7 @@ const useButtonStyle = StyleSheet.createThemeHook((theme: Theme) => ({
 }));
 
 const useColor = (color: StaticColor | InteractiveColor): string => {
-  const {theme, themeName} = useTheme();
+  const {themeName} = useTheme();
 
   return isStaticColor(color)
     ? getStaticColor(themeName, color).text

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,6 +1,7 @@
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {
+  getInteractiveColor,
   getStaticColor,
   InteractiveColor,
   isStaticColor,
@@ -56,7 +57,10 @@ type ButtonIconProps = {
 
 type ButtonModeAwareProps =
   | {mode?: 'primary'; interactiveColor?: InteractiveColor}
-  | {mode: Exclude<ButtonMode, 'primary'>; backgroundColor?: StaticColor};
+  | {
+      mode: Exclude<ButtonMode, 'primary'>;
+      backgroundColor?: StaticColor | InteractiveColor;
+    };
 
 export type ButtonProps = {
   onPress(): void;
@@ -256,12 +260,12 @@ const useButtonStyle = StyleSheet.createThemeHook((theme: Theme) => ({
   },
 }));
 
-const useColor = (color: StaticColor): string => {
+const useColor = (color: StaticColor | InteractiveColor): string => {
   const {theme, themeName} = useTheme();
 
   return isStaticColor(color)
     ? getStaticColor(themeName, color).text
-    : theme.text.colors[color];
+    : getInteractiveColor(themeName, color).default.text;
 };
 
 function getTextType(mode: string, type: string) {

--- a/src/travel-token-box/TravelTokenBox.tsx
+++ b/src/travel-token-box/TravelTokenBox.tsx
@@ -118,6 +118,7 @@ export function TravelTokenBox({
       </View>
       <Button
         mode="secondary"
+        backgroundColor={interactiveColor}
         onPress={onPressChangeButton}
         text={t(TravelTokenBoxTexts.change)}
         testID="continueWithoutChangingTravelTokenButton"


### PR DESCRIPTION
AS mentioned by @tormoseng in [this comment](https://github.com/AtB-AS/kundevendt/issues/15986#issuecomment-1923614202), the color was wrong on the button inside `TravelTokenBox `.

`TravelTokenBox ` has `InteractiveColor` as its color, and the button component therefore needed added support for when an `interactiveColor` is the `backgroundColor`.

After changes:

<img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/d4e21880-200c-4a7b-98a9-e3d799077343" width="300px"> 
<img src="https://github.com/AtB-AS/mittatb-app/assets/70323886/2eb5092b-b951-4aeb-817f-949b6dbbcf0d" width="300px"> 

