### PR TITLE
refactor: rename some notification-related file and functions

### DIFF
--- a/src/notifications/api/index.ts
+++ b/src/notifications/api/index.ts
@@ -29,7 +29,7 @@ export const registerForPushNotifications = ({
       return response.status === 200;
     });
 
-export const getConfig = (): Promise<NotificationConfig> =>
+export const getNotificationConfig = (): Promise<NotificationConfig> =>
   client
     .get<NotificationConfig>('/notification/v1/config', {authWithIdToken: true})
     .then((response) => response.data);
@@ -38,7 +38,7 @@ export interface NotificationConfigUpdate extends NotificationConfigValue {
   config_type: NotificationConfigType;
 }
 
-export const updateConfig = (
+export const updateNotificationConfig = (
   update: NotificationConfigUpdate,
 ): Promise<void> => {
   return client.patch('/notification/v1/config', update, {

--- a/src/notifications/use-notification-config.tsx
+++ b/src/notifications/use-notification-config.tsx
@@ -1,16 +1,21 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import {getConfig, NotificationConfigUpdate, updateConfig} from './api';
+import {
+  getNotificationConfig,
+  NotificationConfigUpdate,
+  updateNotificationConfig,
+} from './api';
 
-export const useConfig = () => {
+export const useNotificationConfig = () => {
   const queryClient = useQueryClient();
 
   const queryKey = ['notification/config'];
   const query = useQuery({
     queryKey,
-    queryFn: getConfig,
+    queryFn: getNotificationConfig,
   });
   const mutation = useMutation({
-    mutationFn: (update: NotificationConfigUpdate) => updateConfig(update),
+    mutationFn: (update: NotificationConfigUpdate) =>
+      updateNotificationConfig(update),
     onSuccess: () => queryClient.invalidateQueries(queryKey),
   });
 

--- a/src/notifications/use-push-notifications.tsx
+++ b/src/notifications/use-push-notifications.tsx
@@ -13,7 +13,7 @@ import {
 import {PermissionsAndroid, Platform} from 'react-native';
 import {NotificationConfigUpdate} from './api';
 import {NotificationConfig} from './types';
-import {useConfig} from './use-config';
+import {useNotificationConfig} from './use-notification-config';
 import {useRegister} from './use-register';
 import {getLanguageAndTextEnum} from '@atb/translations/utils';
 import {usePushNotificationsEnabled} from '@atb/notifications/use-push-notifications-enabled';
@@ -47,7 +47,8 @@ export const NotificationContextProvider: React.FC = ({children}) => {
   const [fcmToken, setFcmToken] = useState<string>();
   const {mutation: registerMutation} = useRegister();
   const mutateRegister = registerMutation.mutate;
-  const {query: configQuery, mutation: configMutation} = useConfig();
+  const {query: configQuery, mutation: configMutation} =
+    useNotificationConfig();
   const pushNotificationsEnabled = usePushNotificationsEnabled();
   const {authStatus} = useAuthState();
 


### PR DESCRIPTION
Just a small refactor to make it more intuitive: 

useConfig ➡️ useNotificationConfig
use-config.tsx ➡️ use-notification-config.tsx
getConfig ➡️ getNotificationConfig
updateConfig ➡️ updateNotificationConfig