### PR TITLE
fix: add margin to vipps payment screen

### DIFF
--- a/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/Root_PurchasePaymentWithVippsScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/Root_PurchasePaymentWithVippsScreen.tsx
@@ -125,6 +125,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   content: {
     flex: 1,
     justifyContent: 'center',
+    margin: theme.spacings.medium,
   },
   messageBox: {marginBottom: theme.spacings.small},
   button: {marginBottom: theme.spacings.small},


### PR DESCRIPTION
The current vipps payment redirection screen has no margin on the sides, this PR will add the necessary margins.

See screenshots below

**Without margin**
<img width=400 src="https://github.com/AtB-AS/mittatb-app/assets/1777333/8866f188-0c57-40c4-8a78-3f72e76f0416" />


**With margin**
<img width=400 src="https://github.com/AtB-AS/mittatb-app/assets/1777333/89dde719-c291-4fd5-9a1a-026132ce7b24" />
