### PR TITLE
refactor: update `getValidityStatus` to accept `FareContract`, added `sent` validity status

### DIFF
--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -164,20 +164,12 @@ export const getFareContractInfoDetails = (
 ): FareContractInfoDetailsProps => {
   const firstTravelRight = fareContract.travelRights?.[0] as NormalTravelRight;
   const {
-    startDateTime,
     endDateTime,
     fareProductRef: productRef,
     tariffZoneRefs,
   } = firstTravelRight;
-  const fareContractState = fareContract.state;
   let validTo = endDateTime.toMillis();
-  const validFrom = startDateTime.toMillis();
-  const validityStatus = getValidityStatus(
-    now,
-    validFrom,
-    validTo,
-    fareContractState,
-  );
+  const validityStatus = getValidityStatus(now, fareContract);
 
   const firstZone = tariffZoneRefs?.[0];
   const lastZone = tariffZoneRefs?.slice(-1)?.[0];

--- a/src/fare-contracts/PreActivatedFareContractInfo.tsx
+++ b/src/fare-contracts/PreActivatedFareContractInfo.tsx
@@ -1,4 +1,4 @@
-import {FareContractState, PreActivatedTravelRight} from '@atb/ticketing';
+import {FareContract, PreActivatedTravelRight} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {
@@ -25,7 +25,7 @@ import {MobilityBenefitsInfoSectionItem} from '@atb/mobility/components/Mobility
 import {useOperatorBenefitsForFareProduct} from '@atb/mobility/use-operator-benefits-for-fare-product';
 
 type Props = {
-  fareContractState: FareContractState;
+  fareContract: FareContract;
   travelRights: PreActivatedTravelRight[];
   now: number;
   hideDetails?: boolean;
@@ -34,7 +34,7 @@ type Props = {
 };
 
 export const PreActivatedFareContractInfo: React.FC<Props> = ({
-  fareContractState,
+  fareContract,
   travelRights,
   now,
   hideDetails,
@@ -53,12 +53,7 @@ export const PreActivatedFareContractInfo: React.FC<Props> = ({
   const {benefits} = useOperatorBenefitsForFareProduct(fareProductRef);
   const validTo = endDateTime.toMillis();
   const validFrom = startDateTime.toMillis();
-  const validityStatus = getValidityStatus(
-    now,
-    validFrom,
-    validTo,
-    fareContractState,
-  );
+  const validityStatus = getValidityStatus(now, fareContract);
 
   const firstZone = tariffZoneRefs?.[0];
   const lastZone = tariffZoneRefs?.slice(-1)?.[0];

--- a/src/fare-contracts/SimpleFareContract.tsx
+++ b/src/fare-contracts/SimpleFareContract.tsx
@@ -29,7 +29,7 @@ export const SimpleFareContract: React.FC<Props> = ({
   if (isPreActivatedTravelRight(firstTravelRight)) {
     return (
       <PreActivatedFareContractInfo
-        fareContractState={fc.state}
+        fareContract={fc}
         travelRights={fc.travelRights.filter(isPreActivatedTravelRight)}
         now={now}
         hideDetails={hideDetails}

--- a/src/fare-contracts/ValidityLine.tsx
+++ b/src/fare-contracts/ValidityLine.tsx
@@ -5,7 +5,7 @@ import LinearGradient from 'react-native-linear-gradient';
 import {ValidityStatus} from '@atb/fare-contracts/utils';
 import {SectionSeparator} from '@atb/components/sections';
 import {useValidityLineColors} from './use-validity-line-colors';
-import {useMobileTokenContextState} from "@atb/mobile-token";
+import {useMobileTokenContextState} from '@atb/mobile-token';
 
 const SPACE_BETWEEN_VERTICAL_LINES = 72;
 const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
@@ -47,7 +47,8 @@ export const ValidityLine = (props: Props): ReactElement => {
 
       // Carnet fare contracts are not inspectable, but we still want to show
       // the validity line
-      return deviceInspectionStatus === 'inspectable' || fareProductType === 'carnet' ? (
+      return deviceInspectionStatus === 'inspectable' ||
+        fareProductType === 'carnet' ? (
         <LineWithVerticalBars
           backgroundColor={backgroundColor}
           lineColor={lineColor}
@@ -64,6 +65,7 @@ export const ValidityLine = (props: Props): ReactElement => {
     case 'inactive':
     case 'rejected':
     case 'cancelled':
+    case 'sent':
       return (
         <View style={styles.container}>
           <SectionSeparator />

--- a/src/fare-contracts/carnet/CarnetDetails.tsx
+++ b/src/fare-contracts/carnet/CarnetDetails.tsx
@@ -43,12 +43,7 @@ export function CarnetDetails(props: {
     validTo: usedAccessValidTo,
   } = getLastUsedAccess(now, usedAccesses);
   const style = useStyles();
-  const fareContractValidityStatus = getValidityStatus(
-    now,
-    fareContractValidFrom,
-    fareContractValidTo,
-    fareContract.state,
-  );
+  const fareContractValidityStatus = getValidityStatus(now, fareContract);
   const firstTravelRight = travelRights[0];
   const {tariffZoneRefs} = firstTravelRight;
   const firstZone = tariffZoneRefs?.[0];

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -72,7 +72,7 @@ export const DetailsContent: React.FC<Props> = ({
     const validFrom = firstTravelRight.startDateTime.toMillis();
     const validTo = firstTravelRight.endDateTime.toMillis();
 
-    const validityStatus = getValidityStatus(now, validFrom, validTo, fc.state);
+    const validityStatus = getValidityStatus(now, fc);
 
     const {tariffZoneRefs} = firstTravelRight;
     const firstZone = tariffZoneRefs?.[0];

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -1,4 +1,8 @@
-import {FareContract, FareContractState} from '@atb/ticketing';
+import {
+  FareContract,
+  FareContractState,
+  isPreActivatedTravelRight,
+} from '@atb/ticketing';
 import {
   findReferenceDataById,
   getReferenceDataName,
@@ -28,7 +32,8 @@ export type ValidityStatus =
   | 'cancelled'
   | 'inactive'
   | 'rejected'
-  | 'approved';
+  | 'approved'
+  | 'sent';
 
 export function getRelativeValidity(
   now: number,
@@ -44,18 +49,22 @@ export function getRelativeValidity(
 export const userProfileCountAndName = (
   u: UserProfileWithCount,
   language: Language,
-) =>
-  `${u.count} ${getReferenceDataName(u, language)}`;
+) => `${u.count} ${getReferenceDataName(u, language)}`;
 
 export function getValidityStatus(
   now: number,
-  validFrom: number,
-  validTo: number,
-  state: FareContractState,
+  fc: FareContract,
+  isSentFareContract?: boolean,
 ): ValidityStatus {
-  if (state === FareContractState.Refunded) return 'refunded';
-  if (state === FareContractState.Cancelled) return 'cancelled';
-  return getRelativeValidity(now, validFrom, validTo);
+  if (fc.state === FareContractState.Refunded) return 'refunded';
+  if (fc.state === FareContractState.Cancelled) return 'cancelled';
+  if (isSentFareContract) return 'sent';
+  const firstTravelRight = fc.travelRights.filter(isPreActivatedTravelRight)[0];
+  return getRelativeValidity(
+    now,
+    firstTravelRight.startDateTime.toMillis(),
+    firstTravelRight.endDateTime.toMillis(),
+  );
 }
 
 export const mapToUserProfilesWithCount = (


### PR DESCRIPTION
Part of 
https://github.com/AtB-AS/kundevendt/issues/15879
https://github.com/AtB-AS/kundevendt/issues/16304

We need to be able to identify that a `FareContract` is `sent` to other recipient, this PR will:

- add new validity status `sent`.
- refactor `getValidityStatus` to accept `FareContract`. 