### PR TITLE
feat: add "new" label to notifications in my profile

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -317,6 +317,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 ProfileTexts.sections.settings.linkSectionItems.notifications
                   .label,
               )}
+              label="new"
               onPress={() => navigation.navigate('Profile_NotificationsScreen')}
               testID="notificationsButton"
             />


### PR DESCRIPTION
Adds missing "new" label to the notifications link in my profile: https://www.figma.com/file/zdZwvobgpEWSagKt0tderx/App?type=design&node-id=16551-60217&mode=design&t=ttgHFyL8TcJ9VLpp-0

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/4968804e-2b55-4c51-90de-d66b60f155ed">