### PR TITLE
fix: remove global messages from app purchase overview

### DIFF
--- a/src/global-messages/GlobalMessagesContext.tsx
+++ b/src/global-messages/GlobalMessagesContext.tsx
@@ -17,7 +17,7 @@ import {
   GlobalMessageRaw,
   GlobalMessageType,
 } from '@atb/global-messages/types';
-import {checkRules, RuleVariables} from '../rule-engine/rules';
+import {checkRules, RuleVariables} from '@atb/rule-engine';
 
 type GlobalMessageContextState = {
   findGlobalMessages: (

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -9,7 +9,6 @@ export enum GlobalMessageContextEnum {
   appAssistant = 'app-assistant',
   appDepartures = 'app-departures',
   appTicketing = 'app-ticketing',
-  appPurchaseOverview = 'app-purchase-overview',
   appFareContractDetails = 'app-fare-contract-details',
   appDepartureDetails = 'app-departure-details',
   appTripDetails = 'app-trip-details',
@@ -31,7 +30,7 @@ export type GlobalMessageRaw = {
   startDate?: FirebaseFirestoreTypes.Timestamp;
   endDate?: FirebaseFirestoreTypes.Timestamp;
   rules?: Rule[];
-}
+};
 
 export type GlobalMessageType = Omit<
   GlobalMessageRaw,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -20,7 +20,7 @@ import {FlexTicketDiscountInfo} from './components/FlexTicketDiscountInfo';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {useAnalytics} from '@atb/analytics';
 import {FromToSelection} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection';
-import {GlobalMessage, GlobalMessageContextEnum} from '@atb/global-messages';
+import {GlobalMessageContextEnum} from '@atb/global-messages';
 import {useFocusRefs} from '@atb/utils/use-focus-refs';
 import {isAfter} from '@atb/utils/date';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -269,17 +269,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           ) : (
             <View style={styles.messages}>
               <PurchaseMessages requiresTokenOnMobile={requiresTokenOnMobile} />
-              <GlobalMessage
-                globalMessageContext={
-                  GlobalMessageContextEnum.appPurchaseOverview
-                }
-                textColor="background_0"
-                ruleVariables={{
-                  preassignedFareProductType: preassignedFareProduct.type,
-                  fromTariffZone: fromPlace.id,
-                  toTariffZone: toPlace.id,
-                }}
-              />
             </View>
           )}
 


### PR DESCRIPTION
Removing the `app-purchase-overview` context from the global messages, and removing the global message component in the `PurhaseOverviewScreen`. 

~~After merging the messages should be removed from firebase.~~

The purchaseMessage looks similar to the global message, but gives more urgent information and is therefore kept. In addition to informing when the active token is another device, It also says whether or not the ticket must be used on a phone, which Is something a user should be reminded of before buying.  An example of this is with the express boat tickets.

<details>

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/5cc32a7b-2312-4994-95a1-e61934c50beb">

</details>
