### PR TITLE
fix: hide token warning message if buying ticket for someone else

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -436,7 +436,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             </View>
           </GenericSectionItem>
         </Section>
-        {inspectableTokenWarningText && (
+        {inspectableTokenWarningText && !phoneNumber && (
           <MessageInfoBox
             type="warning"
             message={inspectableTokenWarningText}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -268,7 +268,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             />
           ) : (
             <View style={styles.messages}>
-              <PurchaseMessages requiresTokenOnMobile={requiresTokenOnMobile} />
+              {!isOnBehalfOfToggle && (
+                <PurchaseMessages
+                  requiresTokenOnMobile={requiresTokenOnMobile}
+                />
+              )}
               <GlobalMessage
                 globalMessageContext={
                   GlobalMessageContextEnum.appPurchaseOverview


### PR DESCRIPTION
fixes issue from slack : https://mittatb.slack.com/archives/CSFC6PG23/p1707392965566429

When sending to someone else, we should not show any token warning message.
This PR will hide the warning if `on-behalf-of` toggle is activated.

<img src="https://github.com/AtB-AS/mittatb-app/assets/1777333/e6024b01-f328-4ccf-83ca-6cf0fac62f19" width=400/>
