### PR TITLE
fix: map zooming all the way out on bicycle station in map

### DIFF
--- a/src/components/map/hooks/use-trigger-camera-move-effect.tsx
+++ b/src/components/map/hooks/use-trigger-camera-move-effect.tsx
@@ -7,7 +7,7 @@ import {useBottomNavigationStyles} from '@atb/utils/navigation';
 import {Coordinates} from '@atb/utils/coordinates';
 import {fitBounds, flyToLocation, mapPositionToCoordinates} from '../utils';
 import {CameraFocusModeType, MapPadding} from '../types';
-import {Dimensions, PixelRatio, Platform, StatusBar} from 'react-native';
+import {Dimensions, Platform, StatusBar} from 'react-native';
 
 type BoundingBox = {
   xMin: number;
@@ -152,25 +152,18 @@ const useCalculatePaddings = (): MapPadding => {
   const {height: bottomSheetHeight} = useBottomSheet();
   const {minHeight: tabBarMinHeight} = useBottomNavigationStyles();
   const {height: screenHeight} = Dimensions.get('screen');
-  const padding = screenHeight * 0.1;
+  const basePadding = screenHeight * 0.1;
 
-  if (Platform.OS === 'android') {
-    const headerHeight = StatusBar.currentHeight ?? 0;
-
-    // This is the base level for the padding, where the values are divided by the device font scale to match the map unit.
-    const scaledBottomSheetPadding = bottomSheetHeight - tabBarMinHeight;
-    return [
-      padding + headerHeight, // Subtract the header height on Android since it is not see through
-      padding,
-      padding + scaledBottomSheetPadding,
-      padding,
-    ].map((p) => p / PixelRatio.getFontScale()) as MapPadding;
-  }
+  const bottomPaddingAdjustment = bottomSheetHeight - tabBarMinHeight;
+  const topPadding =
+    Platform.OS === 'android'
+      ? basePadding + (StatusBar.currentHeight ?? 0)
+      : basePadding;
 
   return [
-    padding,
-    padding,
-    padding + (bottomSheetHeight - tabBarMinHeight),
-    padding,
+    topPadding,
+    basePadding,
+    basePadding + bottomPaddingAdjustment,
+    basePadding,
   ];
 };


### PR DESCRIPTION
The problem was similar to the one in @gorandalum's PR https://github.com/AtB-AS/mittatb-app/pull/4040. I found the issue to be that we were taking font scale into the calculation of the padding. On the note 10, where the issue was, the scale was 0.8 making the padding bigger which means less space for the walking path. This led to it zooming all the way out since the path never fit inside the remaining space.

The scaling is also kind of counter intuitive, as when the font is smaller and things take less space, the padding was getting bigger. And vice versa with larger font. This made the path not centered when the font was scaled.

So this fixes both the very specific bug, and the map for larger fonts.


Below is before and after with larger font:

<details>


<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/d21ed471-2e45-4b6b-8bf5-cb62f7525edb">

<img width=300 src="https://github.com/AtB-AS/mittatb-app/assets/70323886/202bb7e9-a9cb-4724-a110-54ab7be25667">



</details>
