### PR TITLE
fix: update TransportationIconBox padding to match sketches

### DIFF
--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -40,10 +40,6 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
   const {svg} = getTransportModeSvg(mode, subMode);
   const styles = useStyles();
 
-  const iconStyle =
-    size == 'xSmall'
-      ? styles.transportationIconBox_small
-      : styles.transportationIconBox;
   const lineNumberElement = lineNumber ? (
     <ThemeText
       type="body__primary--bold"
@@ -58,7 +54,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
   return (
     <View
       style={[
-        iconStyle,
+        styles.transportationIconBox,
         style,
         {
           backgroundColor,
@@ -81,15 +77,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   transportationIconBox: {
     display: 'flex',
     flexDirection: 'row',
-    paddingVertical: theme.spacings.small,
-    paddingHorizontal: theme.spacings.small,
-    borderRadius: theme.border.radius.small,
-  },
-  transportationIconBox_small: {
-    display: 'flex',
-    flexDirection: 'row',
-    paddingVertical: theme.spacings.xSmall,
-    paddingHorizontal: theme.spacings.xSmall,
+    padding: theme.spacings.xSmall,
     borderRadius: theme.border.radius.small,
   },
   lineNumberText: {


### PR DESCRIPTION
Fixes feedback from https://github.com/AtB-AS/kundevendt/issues/3834#issuecomment-1934011715. Based on the sketches, TransportationIconBox should always have xSmall padding. 

<div>
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/0263b8cd-aafd-4dc7-89fb-aa9a66a030c4">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/c5192a3e-26cb-47d7-8b67-a73192a8adad">
</div>

fixes https://github.com/AtB-AS/kundevendt/issues/3834
