### PR TITLE
style: new icons and added border around notification indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.15.0",
-    "@atb-as/generate-assets": "^9.11.1",
+    "@atb-as/generate-assets": "^10.0.0",
     "@atb-as/theme": "^8.0.0",
     "@bugsnag/react-native": "^7.21.0",
     "@bugsnag/source-maps": "^2.3.1",

--- a/src/chat/ContactSheet.tsx
+++ b/src/chat/ContactSheet.tsx
@@ -76,7 +76,6 @@ export const ContactSheet = ({onReportParkingViolation}: Props) => {
                 notification: unreadCount
                   ? {
                       color: 'valid',
-                      backgroundColor: 'background_accent_3',
                     }
                   : undefined,
               }}

--- a/src/chat/ContactSheet.tsx
+++ b/src/chat/ContactSheet.tsx
@@ -76,6 +76,7 @@ export const ContactSheet = ({onReportParkingViolation}: Props) => {
                 notification: unreadCount
                   ? {
                       color: 'valid',
+                      backgroundColor: 'background_accent_3',
                     }
                   : undefined,
               }}

--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -8,9 +8,9 @@ import {StaticColor, TextColor} from '@atb/theme/colors';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {ContactSheet} from '@atb/chat/ContactSheet';
 import {ScreenHeaderTexts, useTranslation} from '@atb/translations';
-import {Chat} from '@atb/assets/svg/mono-icons/actions';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
+import {Chat} from '@atb/assets/svg/mono-icons/actions';
 
 export const useChatIcon = (
   color?: StaticColor | TextColor,
@@ -42,6 +42,7 @@ export const useChatIcon = (
             unreadCount
               ? {
                   color: 'valid',
+                  backgroundColor: color,
                 }
               : undefined
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^9.11.1":
-  version "9.11.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-9.11.1.tgz#1a076b1ece07d0ca20d42e0f053a25daddb6b704"
-  integrity sha512-5fk1y18bECjnuKRCVnzrfA9ZU2DSmCtZ7DvVxNq5Jqg3fxzyZ6rxkTTXh3NiaZ6bfGzGZGT+0TRZ0Fuk+l6DCA==
+"@atb-as/generate-assets@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-10.0.0.tgz#51cb2a8c9dc00f2223d7e661c979d896c89ce25a"
+  integrity sha512-NFXTYDyDnQcCmcEMudcyXeFXHy6cp76a0wBBhZDFfAyUaEsFMcPwRp+hyU71jyr+AyLiK2m3N8ugQr2lWhAl5A==
   dependencies:
     "@atb-as/theme" "^8.0.0"
     commander "^9.4.0"


### PR DESCRIPTION
* update generate-assets for new icons on Chat and ServiceDisruptions
* added border around notification indicator when used with chat icon

Closes: https://github.com/AtB-AS/kundevendt/issues/15573 