### PR TITLE
fix: qa feedback for benefit tiles

### DIFF
--- a/src/components/tile/TileWithButton.tsx
+++ b/src/components/tile/TileWithButton.tsx
@@ -43,6 +43,7 @@ export function TileWithButton({
       onPress={onPress}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
+      accessibilityRole="button"
       testID={testID}
     >
       <View

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -113,6 +113,9 @@ export const DetailsContent: React.FC<Props> = ({
       globalMessageRuleVariables,
     ).length;
 
+    const shouldShowBundlingInfo =
+      benefits && benefits.length > 0 && validityStatus === 'valid';
+
     return (
       <Section withBottomPadding>
         <GenericSectionItem>
@@ -185,7 +188,7 @@ export const DetailsContent: React.FC<Props> = ({
             />
           </GenericSectionItem>
         )}
-        {benefits && benefits.length > 0 && (
+        {shouldShowBundlingInfo && (
           <MobilityBenefitsActionSectionItem
             benefits={benefits}
             onNavigateToMap={onNavigateToMap}

--- a/src/mobility/components/BenefitTiles.tsx
+++ b/src/mobility/components/BenefitTiles.tsx
@@ -74,6 +74,7 @@ export const BenefitTile = ({
         interactiveColor={interactiveColor}
         style={styles.contentContainer}
         onPress={onPress}
+        accessibilityHint={t(MobilityTexts.showInMapA11yLabel)}
       >
         <BenefitImageAsset
           formFactor={benefit.formFactors[0] as FormFactor}

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -88,6 +88,11 @@ export const MobilityTexts = {
     'Inkludert i billetten',
   ),
   showInMap: _('Se i kart', 'Show in map', 'Sjå i kart'),
+  showInMapA11yLabel: _(
+    'Aktiver for å se i kart',
+    'Activate to show in map',
+    'Aktiver for å sjå i kart',
+  ),
 };
 
 export const ScooterTexts = {


### PR DESCRIPTION
Fix of QA feedback on bundling actions in ticket details

- Adds a11y role "button" to TileWithButton.
- Adds a11y hint to benefit tiles.
- Only shows benefits when the ticket is active.

fixes https://github.com/AtB-AS/kundevendt/issues/16297