### PR TITLE
feat: Add booking info to departures

### DIFF
--- a/src/api/departures/types.ts
+++ b/src/api/departures/types.ts
@@ -7,6 +7,7 @@ import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import {DeparturesQuery} from '../types/generated/DeparturesQuery';
 import {CursoredData, CursoredQuery} from "@atb/sdk";
+import {BookingArrangementFragment} from "@atb/api/types/generated/fragments/booking-arrangements";
 
 type Notice = {text?: string};
 
@@ -42,6 +43,7 @@ export type DepartureTime = {
   serviceDate: string;
   notices?: NoticeFragment[];
   cancellation?: boolean;
+  bookingArrangements?: BookingArrangementFragment;
 };
 
 export type DepartureGroup = {

--- a/src/api/types/departures.ts
+++ b/src/api/types/departures.ts
@@ -7,6 +7,7 @@ import {
   TransportSubmode,
   DestinationDisplay,
 } from './generated/journey_planner_v3_types';
+import {DepartureTime} from "@atb/api/departures/types";
 
 type QuayWithEstimatedCalls = Required<Types.DeparturesQuery>['quays'][0];
 
@@ -40,16 +41,6 @@ export type DepartureLineInfo = {
   notices: Notice[];
   lineId: string;
   lineVariationIdentifier?: string;
-};
-
-export type DepartureTime = {
-  time: string;
-  aimedTime: string;
-  realtime?: boolean;
-  predictionInaccurate?: boolean;
-  situations?: PtSituationElement[];
-  serviceJourneyId?: string;
-  serviceDate: string;
 };
 
 export type StopPlaceInfo = {

--- a/src/api/types/generated/DeparturesQuery.ts
+++ b/src/api/types/generated/DeparturesQuery.ts
@@ -40,6 +40,20 @@ export type DeparturesQuery = {
         validityPeriod?: {startTime?: any; endTime?: any};
       }>;
       notices: Array<{id: string; text?: string}>;
+      bookingArrangements?: {
+        bookingMethods?: Array<Types.BookingMethod>;
+        latestBookingTime?: any;
+        bookingNote?: string;
+        bookWhen?: Types.PurchaseWhen;
+        minimumBookingPeriod?: string;
+        bookingContact?: {
+          contactPerson?: string;
+          email?: string;
+          url?: string;
+          phone?: string;
+          furtherDetails?: string;
+        };
+      };
     }>;
     situations: Array<{
       id: string;

--- a/src/api/types/generated/fragments/estimated-calls.ts
+++ b/src/api/types/generated/fragments/estimated-calls.ts
@@ -36,4 +36,18 @@ export type EstimatedCallWithQuayFragment = {
     infoLinks?: Array<{uri: string; label?: string}>;
     validityPeriod?: {startTime?: any; endTime?: any};
   }>;
+  bookingArrangements?: {
+    bookingMethods?: Array<Types.BookingMethod>;
+    latestBookingTime?: any;
+    bookingNote?: string;
+    bookWhen?: Types.PurchaseWhen;
+    minimumBookingPeriod?: string;
+    bookingContact?: {
+      contactPerson?: string;
+      email?: string;
+      url?: string;
+      phone?: string;
+      furtherDetails?: string;
+    };
+  };
 };

--- a/src/api/types/generated/fragments/service-journeys.ts
+++ b/src/api/types/generated/fragments/service-journeys.ts
@@ -44,5 +44,19 @@ export type ServiceJourneyWithEstCallsFragment = {
       infoLinks?: Array<{uri: string; label?: string}>;
       validityPeriod?: {startTime?: any; endTime?: any};
     }>;
+    bookingArrangements?: {
+      bookingMethods?: Array<Types.BookingMethod>;
+      latestBookingTime?: any;
+      bookingNote?: string;
+      bookWhen?: Types.PurchaseWhen;
+      minimumBookingPeriod?: string;
+      bookingContact?: {
+        contactPerson?: string;
+        email?: string;
+        url?: string;
+        phone?: string;
+        furtherDetails?: string;
+      };
+    };
   }>;
 };

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -44,6 +44,7 @@ import {
   toMostCriticalStatus,
 } from '@atb/situations/utils';
 import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
+import {Statuses} from '@atb-as/theme';
 
 export type LineItemProps = SectionItemProps<{
   group: DepartureGroup;
@@ -346,8 +347,8 @@ export const getSvgForDeparture = (departure: DepartureTime) => {
   );
   const msgTypeForBooking = bookingStatusToMsgType(bookingStatus);
 
-  const msgType = [msgTypeForSituationOrNotice, msgTypeForBooking].reduce(
-    toMostCriticalStatus,
-  );
+  const msgType = [msgTypeForSituationOrNotice, msgTypeForBooking].reduce<
+    Statuses | undefined
+  >(toMostCriticalStatus, undefined);
   return msgType && messageTypeToIcon(msgType, true);
 };

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -8,12 +8,12 @@ import {
   FavouriteDepartureToggle,
   StoredFavoriteDeparture,
 } from '@atb/favorites';
-import {
-  getSituationOrNoticeA11yLabel,
-  getSvgForMostCriticalSituationOrNotice,
-} from '@atb/situations';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {formatDestinationDisplay} from '@atb/travel-details-screens/utils';
+import {
+  formatDestinationDisplay,
+  bookingStatusToMsgType,
+  getBookingStatus,
+} from '@atb/travel-details-screens/utils';
 import {destinationDisplaysAreEqual} from '@atb/utils/destination-displays-are-equal';
 
 import {
@@ -21,6 +21,7 @@ import {
   DeparturesTexts,
   dictionary,
   Language,
+  SituationsTexts,
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
@@ -38,6 +39,12 @@ import {View} from 'react-native';
 import {GenericClickableSectionItem} from '@atb/components/sections';
 import {isDefined} from '@atb/utils/presence';
 import {StopPlacesMode} from '@atb/nearby-stop-places';
+import {
+  getMsgTypeForMostCriticalSituationOrNotice,
+  toMostCriticalStatus,
+} from '@atb/situations/utils';
+import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
+import {Statuses} from '@atb-as/theme';
 
 export type EstimatedCallItemProps = {
   secondsUntilDeparture: number;
@@ -210,15 +217,11 @@ export function getLineAndTimeA11yLabel(
   t: TranslateFunction,
   language: Language,
 ) {
+  const msgType = getMsgTypeForEstimatedCall(departure);
   return [
     departure.cancellation ? t(CancelledDepartureTexts.message) : undefined,
     getLineA11yLabel(departure, t),
-    getSituationOrNoticeA11yLabel(
-      departure.situations,
-      getNoticesForEstimatedCall(departure),
-      departure.cancellation,
-      t,
-    ),
+    msgType && t(SituationsTexts.a11yLabel[msgType]),
     departure.realtime
       ? t(dictionary.a11yRealTimePrefix)
       : t(dictionary.a11yRouteTimePrefix),
@@ -271,13 +274,8 @@ function LineChip({
     'text',
   );
 
-  const icon =
-    mode !== 'Favourite' &&
-    getSvgForMostCriticalSituationOrNotice(
-      departure.situations,
-      getNoticesForEstimatedCall(departure),
-      departure.cancellation,
-    );
+  const msgType = mode !== 'Favourite' && getMsgTypeForEstimatedCall(departure);
+  const icon = msgType && messageTypeToIcon(msgType, true);
 
   if (!publicCode && !transportMode) return null;
 
@@ -310,6 +308,27 @@ const isMoreThanOneMinuteDelayed = (departure: EstimatedCall) =>
     departure.aimedDepartureTime,
     departure.expectedDepartureTime,
   ) >= 60;
+
+export const getMsgTypeForEstimatedCall = (
+  estimatedCall: EstimatedCall,
+): Exclude<Statuses, 'valid'> | undefined => {
+  const msgTypeForSituationOrNotice =
+    getMsgTypeForMostCriticalSituationOrNotice(
+      estimatedCall.situations,
+      getNoticesForEstimatedCall(estimatedCall),
+      estimatedCall.cancellation,
+    );
+
+  const bookingStatus = getBookingStatus(
+    estimatedCall.bookingArrangements,
+    estimatedCall.aimedDepartureTime,
+  );
+  const msgTypeForBooking = bookingStatusToMsgType(bookingStatus);
+
+  return [msgTypeForSituationOrNotice, msgTypeForBooking].reduce(
+    toMostCriticalStatus,
+  );
+};
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -325,9 +325,9 @@ export const getMsgTypeForEstimatedCall = (
   );
   const msgTypeForBooking = bookingStatusToMsgType(bookingStatus);
 
-  return [msgTypeForSituationOrNotice, msgTypeForBooking].reduce(
-    toMostCriticalStatus,
-  );
+  return [msgTypeForSituationOrNotice, msgTypeForBooking].reduce<
+    Exclude<Statuses, 'valid'> | undefined
+  >(toMostCriticalStatus, undefined);
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/situations/utils.ts
+++ b/src/situations/utils.ts
@@ -73,7 +73,10 @@ export const getMsgTypeForMostCriticalSituationOrNotice = (
   }
   return situations
     .map(getMessageTypeForSituation)
-    .reduce(toMostCriticalStatus);
+    .reduce<Exclude<Statuses, 'valid'> | undefined>(
+      toMostCriticalStatus,
+      undefined,
+    );
 };
 
 /**
@@ -83,10 +86,13 @@ export const getMsgTypeForMostCriticalSituationOrNotice = (
 export const toMostCriticalStatus = <T extends Statuses | undefined>(
   currentlyMostCritical: T,
   msgType: T,
-): T =>
-  statusComparator(currentlyMostCritical, msgType) === -1
+): T => {
+  if (!msgType) return currentlyMostCritical;
+  if (!currentlyMostCritical) return msgType;
+  return statusComparator(currentlyMostCritical, msgType) === 1
     ? currentlyMostCritical
     : msgType;
+};
 
 export const bookingStatusToIcon = (bookingStatus: BookingStatus) => {
   const bookingMsgType = bookingStatusToMsgType(bookingStatus);

--- a/src/situations/utils.ts
+++ b/src/situations/utils.ts
@@ -9,8 +9,11 @@ import {Info, Warning} from '@atb/assets/svg/color/icons/status';
 import {SvgProps} from 'react-native-svg';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import {isAfter, isBefore, isBetween} from '@atb/utils/date';
-import {Statuses} from '@atb-as/theme';
+import {statusComparator} from '@atb/utils/status-comparator';
+import {Statuses} from '@atb/theme';
 import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
+import {bookingStatusToMsgType} from '@atb/travel-details-screens/utils';
+import {BookingStatus} from '@atb/travel-details-screens/types';
 
 export const getUniqueSituations = (situations: SituationType[] = []) => {
   const seenIds: string[] = [];
@@ -42,7 +45,9 @@ export const getSituationSummary = (
   return text || undefined;
 };
 
-export const getMessageTypeForSituation = (situation: SituationType) =>
+export const getMessageTypeForSituation = (
+  situation: SituationType,
+): Extract<Statuses, 'warning' | 'info'> =>
   situation.reportType === 'incident' ? 'warning' : 'info';
 
 export const getSvgForSituation = (
@@ -61,18 +66,31 @@ export const getMsgTypeForMostCriticalSituationOrNotice = (
   situations: SituationType[],
   notices?: NoticeFragment[],
   cancellation: boolean = false,
-): Statuses | undefined => {
+): Exclude<Statuses, 'valid'> | undefined => {
   if (cancellation) return 'error';
   if (!situations.length) {
     return notices?.length ? 'info' : undefined;
   }
   return situations
     .map(getMessageTypeForSituation)
-    .reduce(
-      (mostCritical, msgType) =>
-        msgType === 'warning' ? 'warning' : mostCritical,
-      'info',
-    );
+    .reduce(toMostCriticalStatus);
+};
+
+/**
+ * A function which may be used in a reducer function to decide what the most
+ * critical status level is.
+ */
+export const toMostCriticalStatus = <T extends Statuses | undefined>(
+  currentlyMostCritical: T,
+  msgType: T,
+): T =>
+  statusComparator(currentlyMostCritical, msgType) === -1
+    ? currentlyMostCritical
+    : msgType;
+
+export const bookingStatusToIcon = (bookingStatus: BookingStatus) => {
+  const bookingMsgType = bookingStatusToMsgType(bookingStatus);
+  return bookingMsgType && messageTypeToIcon(bookingMsgType, true);
 };
 
 export const getSvgForMostCriticalSituationOrNotice = (

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -440,7 +440,7 @@ function EstimatedCallRow({
 
   const {group, isStartOfGroup, isEndOfGroup, isStartOfServiceJourney} =
     call.metadata;
-  const isFirstOfTrip = group === 'trip' && isStartOfGroup;
+  const isStartOfTripGroup = group === 'trip' && isStartOfGroup;
 
   const isBetween = !isStartOfGroup && !isEndOfGroup;
   const iconColor = useTransportationColor(
@@ -516,7 +516,7 @@ function EstimatedCallRow({
         </TripRow>
       ))}
 
-      {isFirstOfTrip && bookingStatus !== 'none' && (
+      {isStartOfTripGroup && bookingStatus !== 'none' && (
         <TripRow rowLabel={bookingIcon && <ThemeIcon svg={bookingIcon} />}>
           <BookingInfoBox
             bookingArrangements={call.bookingArrangements}
@@ -527,7 +527,7 @@ function EstimatedCallRow({
         </TripRow>
       )}
 
-      {isFirstOfTrip && !call.cancellation && bookingStatus === 'bookable' && (
+      {isStartOfTripGroup && !call.cancellation && bookingStatus === 'bookable' && (
         <TripRow>
           <BookingOptions bookingArrangements={call.bookingArrangements} />
         </TripRow>

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -20,6 +20,7 @@ import {dictionary, TranslateFunction} from '@atb/translations';
 import {APP_ORG} from '@env';
 import {BookingArrangementFragment} from '@atb/api/types/generated/fragments/booking-arrangements';
 import {BookingStatus, TripPatternBookingStatus} from './types';
+import {Statuses} from '@atb-as/theme';
 
 const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES = 1;
 
@@ -399,6 +400,20 @@ export function getTripPatternBookingStatus(
     }
   }, 'none');
 }
+
+export const bookingStatusToMsgType = (
+  bookingStatus: BookingStatus,
+): Extract<Statuses, 'warning' | 'error'> | undefined => {
+  switch (bookingStatus) {
+    case 'none':
+      return undefined;
+    case 'early':
+    case 'bookable':
+      return 'warning';
+    case 'late':
+      return 'error';
+  }
+};
 
 export function getIsTooLateToBookFlexLine(
   tripPattern: TripPattern,

--- a/src/utils/__tests__/status-comparator.test.ts
+++ b/src/utils/__tests__/status-comparator.test.ts
@@ -1,0 +1,50 @@
+import {statusComparator} from '@atb/utils/status-comparator';
+import {Statuses} from '@atb-as/theme';
+
+describe('statusComparator', () => {
+  it('Should return 0 if equal', async () => {
+    expect(statusComparator('error', 'error')).toEqual(0);
+    expect(statusComparator('warning', 'warning')).toEqual(0);
+    expect(statusComparator('info', 'info')).toEqual(0);
+    expect(statusComparator('valid', 'valid')).toEqual(0);
+    expect(statusComparator(undefined, undefined)).toEqual(0);
+  });
+
+  it('Should return -1 if first item of higher importance', async () => {
+    expect(statusComparator('error', 'warning')).toEqual(-1);
+    expect(statusComparator('error', undefined)).toEqual(-1);
+    expect(statusComparator('warning', 'valid')).toEqual(-1);
+    expect(statusComparator('warning', 'info')).toEqual(-1);
+    expect(statusComparator('info', 'valid')).toEqual(-1);
+    expect(statusComparator('valid', undefined)).toEqual(-1);
+  });
+
+  it('Should return 1 if second item of higher importance', async () => {
+    expect(statusComparator('warning', 'error')).toEqual(1);
+    expect(statusComparator('info', 'warning')).toEqual(1);
+    expect(statusComparator(undefined, 'warning')).toEqual(1);
+    expect(statusComparator(undefined, 'valid')).toEqual(1);
+    expect(statusComparator('valid', 'error')).toEqual(1);
+    expect(statusComparator('valid', 'info')).toEqual(1);
+  });
+
+  it('Should sort list by importance', async () => {
+    const list: (Statuses | undefined)[] = [
+      'valid',
+      undefined,
+      'info',
+      'error',
+      'warning',
+      'info',
+    ];
+    list.sort(statusComparator);
+    expect(list).toEqual([
+      'error',
+      'warning',
+      'info',
+      'info',
+      'valid',
+      undefined,
+    ]);
+  });
+});

--- a/src/utils/__tests__/status-comparator.test.ts
+++ b/src/utils/__tests__/status-comparator.test.ts
@@ -7,44 +7,25 @@ describe('statusComparator', () => {
     expect(statusComparator('warning', 'warning')).toEqual(0);
     expect(statusComparator('info', 'info')).toEqual(0);
     expect(statusComparator('valid', 'valid')).toEqual(0);
-    expect(statusComparator(undefined, undefined)).toEqual(0);
   });
 
   it('Should return -1 if first item of higher importance', async () => {
-    expect(statusComparator('error', 'warning')).toEqual(-1);
-    expect(statusComparator('error', undefined)).toEqual(-1);
-    expect(statusComparator('warning', 'valid')).toEqual(-1);
-    expect(statusComparator('warning', 'info')).toEqual(-1);
-    expect(statusComparator('info', 'valid')).toEqual(-1);
-    expect(statusComparator('valid', undefined)).toEqual(-1);
+    expect(statusComparator('error', 'warning')).toEqual(1);
+    expect(statusComparator('warning', 'valid')).toEqual(1);
+    expect(statusComparator('warning', 'info')).toEqual(1);
+    expect(statusComparator('info', 'valid')).toEqual(1);
   });
 
   it('Should return 1 if second item of higher importance', async () => {
-    expect(statusComparator('warning', 'error')).toEqual(1);
-    expect(statusComparator('info', 'warning')).toEqual(1);
-    expect(statusComparator(undefined, 'warning')).toEqual(1);
-    expect(statusComparator(undefined, 'valid')).toEqual(1);
-    expect(statusComparator('valid', 'error')).toEqual(1);
-    expect(statusComparator('valid', 'info')).toEqual(1);
+    expect(statusComparator('warning', 'error')).toEqual(-1);
+    expect(statusComparator('info', 'warning')).toEqual(-1);
+    expect(statusComparator('valid', 'error')).toEqual(-1);
+    expect(statusComparator('valid', 'info')).toEqual(-1);
   });
 
   it('Should sort list by importance', async () => {
-    const list: (Statuses | undefined)[] = [
-      'valid',
-      undefined,
-      'info',
-      'error',
-      'warning',
-      'info',
-    ];
+    const list: Statuses[] = ['info', 'valid', 'error', 'warning', 'info'];
     list.sort(statusComparator);
-    expect(list).toEqual([
-      'error',
-      'warning',
-      'info',
-      'info',
-      'valid',
-      undefined,
-    ]);
+    expect(list).toEqual(['valid', 'info', 'info', 'warning', 'error']);
   });
 });

--- a/src/utils/status-comparator.ts
+++ b/src/utils/status-comparator.ts
@@ -1,0 +1,21 @@
+import {Statuses} from '@atb/theme';
+
+/**
+ * Comparator for comparing status levels. The order is:
+ * 'error' -> 'warning' -> 'info' -> 'valid' -> undefined
+ */
+export const statusComparator = (s1?: Statuses, s2?: Statuses): number => {
+  if (s1 === s2) return 0;
+  switch (s1) {
+    case 'error':
+      return -1;
+    case 'warning':
+      return s2 === 'error' ? 1 : -1;
+    case 'info':
+      return s2 === 'error' || s2 === 'warning' ? 1 : -1;
+    case 'valid':
+      return !s2 ? -1 : 1;
+    case undefined:
+      return 1;
+  }
+};

--- a/src/utils/status-comparator.ts
+++ b/src/utils/status-comparator.ts
@@ -2,7 +2,7 @@ import {Statuses} from '@atb/theme';
 
 /**
  * Comparator for comparing status levels. The order is:
- * 'error' -> 'warning' -> 'info' -> 'valid' -> undefined
+ * 'error' -> 'warning' -> 'info' -> 'valid'
  */
 export const statusComparator = (s1: Statuses, s2: Statuses): number => {
   if (s1 === s2) return 0;
@@ -12,10 +12,8 @@ export const statusComparator = (s1: Statuses, s2: Statuses): number => {
     case 'warning':
       return s2 === 'error' ? -1 : 1;
     case 'info':
-      return s2 === 'error' || s2 === 'warning' ? -1 : 1;
+      return s2 === 'valid' ? 1 : -1;
     case 'valid':
-      return !s2 ? 1 : -1;
-    case undefined:
       return -1;
   }
 };

--- a/src/utils/status-comparator.ts
+++ b/src/utils/status-comparator.ts
@@ -4,18 +4,18 @@ import {Statuses} from '@atb/theme';
  * Comparator for comparing status levels. The order is:
  * 'error' -> 'warning' -> 'info' -> 'valid' -> undefined
  */
-export const statusComparator = (s1?: Statuses, s2?: Statuses): number => {
+export const statusComparator = (s1: Statuses, s2: Statuses): number => {
   if (s1 === s2) return 0;
   switch (s1) {
     case 'error':
-      return -1;
-    case 'warning':
-      return s2 === 'error' ? 1 : -1;
-    case 'info':
-      return s2 === 'error' || s2 === 'warning' ? 1 : -1;
-    case 'valid':
-      return !s2 ? -1 : 1;
-    case undefined:
       return 1;
+    case 'warning':
+      return s2 === 'error' ? -1 : 1;
+    case 'info':
+      return s2 === 'error' || s2 === 'warning' ? -1 : 1;
+    case 'valid':
+      return !s2 ? 1 : -1;
+    case undefined:
+      return -1;
   }
 };


### PR DESCRIPTION
Show booking info on:
- As info-box on The departure details screen, with booking action
buttons if currently bookable.
- As icon in the upper left corner (same as situations) in the
departures list v2.
- As right icon on the departure chip in departures list v1.
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/e27b1774-ad6f-40ae-b7ac-aa6132a88363" />
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/3d1fb07e-f35b-4599-b089-51992a1c7f16" />
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/32505544-cf28-428e-8afd-ea6dd060c88b" />
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/dd6c351b-2466-4abf-8f20-d49cf7f02f87" />

