### PR TITLE
feat: Add feature flag for server time

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,11 +79,11 @@ export const App = () => {
       <StorybookContextProvider>
         <ErrorBoundary type="full-screen">
           <AppContextProvider>
-            <TimeContextProvider>
-              <PreferencesContextProvider>
-                <LocaleContextProvider>
-                  <AuthContextProvider>
-                    <RemoteConfigContextProvider>
+            <PreferencesContextProvider>
+              <LocaleContextProvider>
+                <AuthContextProvider>
+                  <RemoteConfigContextProvider>
+                    <TimeContextProvider>
                       <AnalyticsContextProvider>
                         <AccessibilityContextProvider>
                           <ThemeContextProvider>
@@ -123,11 +123,11 @@ export const App = () => {
                           </ThemeContextProvider>
                         </AccessibilityContextProvider>
                       </AnalyticsContextProvider>
-                    </RemoteConfigContextProvider>
-                  </AuthContextProvider>
-                </LocaleContextProvider>
-              </PreferencesContextProvider>
-            </TimeContextProvider>
+                    </TimeContextProvider>
+                  </RemoteConfigContextProvider>
+                </AuthContextProvider>
+              </LocaleContextProvider>
+            </PreferencesContextProvider>
           </AppContextProvider>
         </ErrorBoundary>
       </StorybookContextProvider>

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -52,6 +52,7 @@ export type RemoteConfig = {
   enable_on_behalf_of: boolean;
   enable_ticket_information: boolean;
   enable_posthog: boolean;
+  enable_server_time: boolean;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -109,6 +110,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_on_behalf_of: false,
   enable_ticket_information: false,
   enable_posthog: false,
+  enable_server_time: true,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -294,6 +296,10 @@ export function getConfig(): RemoteConfig {
   const enable_posthog =
     values['enable_posthog']?.asBoolean() ?? defaultRemoteConfig.enable_posthog;
 
+  const enable_server_time =
+    values['enable_server_time']?.asBoolean() ??
+    defaultRemoteConfig.enable_server_time;
+
   return {
     enable_ticketing,
     enable_intercom,
@@ -345,6 +351,7 @@ export function getConfig(): RemoteConfig {
     enable_ticket_information,
     enable_on_behalf_of,
     enable_posthog,
+    enable_server_time,
   };
 }
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -60,7 +60,7 @@ import {useOnBehalfOfEnabledDebugOverride} from '@atb/on-behalf-of';
 import {useTicketInformationEnabledDebugOverride} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-is-ticket-information-enabled';
 import {usePosthogEnabledDebugOverride} from '@atb/analytics/use-is-posthog-enabled';
 import {useOnboardingSections} from '@atb/utils/use-onboarding-sections';
-import {useServerTimeEnabledDebugOverride} from '@atb/time/use-server-time-enabled';
+import {useServerTimeEnabledDebugOverride} from '@atb/time';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -60,6 +60,7 @@ import {useOnBehalfOfEnabledDebugOverride} from '@atb/on-behalf-of';
 import {useTicketInformationEnabledDebugOverride} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-is-ticket-information-enabled';
 import {usePosthogEnabledDebugOverride} from '@atb/analytics/use-is-posthog-enabled';
 import {useOnboardingSections} from '@atb/utils/use-onboarding-sections';
+import {useServerTimeEnabledDebugOverride} from '@atb/time/use-server-time-enabled';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -124,6 +125,7 @@ export const Profile_DebugInfoScreen = () => {
   const ticketInformationEnabledDebugOverride =
     useTicketInformationEnabledDebugOverride();
   const posthogEnabledDebugOverride = usePosthogEnabledDebugOverride();
+  const serverTimeEnabledDebugOverride = useServerTimeEnabledDebugOverride();
 
   useEffect(() => {
     (async function () {
@@ -398,6 +400,12 @@ export const Profile_DebugInfoScreen = () => {
             <DebugOverride
               description="Enable PostHog"
               override={posthogEnabledDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable server time"
+              override={serverTimeEnabledDebugOverride}
             />
           </GenericSectionItem>
         </Section>

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -25,6 +25,7 @@ export enum StorageModelKeysEnum {
   OneTimePopOver = '@ATB_one_time_popovers_seen',
   EnableTicketInformationDebugOverride = '@ATB_enable_ticket_information_debug_override',
   EnablePosthogDebugOverride = '@ATB_enable_posthog_debug_override',
+  EnableServerTimeDebugOverride = '@ATB_server_time_debug_override',
 }
 
 type StorageModelKeysTypes = keyof typeof StorageModelKeysEnum;

--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -1,7 +1,7 @@
 import {useInterval} from '@atb/utils/use-interval';
 import {clock, start} from '@entur-private/abt-time-react-native-lib';
 import React, {createContext, useContext, useEffect, useState} from 'react';
-import {useServerTimeEnabled} from '@atb/time/use-server-time-enabled';
+import {useServerTimeEnabled} from '@atb/time';
 
 type TimeContextState = {
   /**

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -3,3 +3,7 @@ export {
   useTimeContextState,
   getServerNow,
 } from './TimeContext';
+export {
+  useServerTimeEnabled,
+  useServerTimeEnabledDebugOverride,
+} from './use-server-time-enabled';

--- a/src/time/use-server-time-enabled.ts
+++ b/src/time/use-server-time-enabled.ts
@@ -1,0 +1,20 @@
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {StorageModelKeysEnum} from '@atb/storage';
+import {useDebugOverride} from '@atb/debug';
+
+export const useServerTimeEnabled = () => {
+  const [debugOverride, _, debugOverrideReady] =
+      useServerTimeEnabledDebugOverride();
+  const {enable_server_time: enabledInRemoteConfig} = useRemoteConfig();
+
+  return [
+    debugOverride === undefined ? enabledInRemoteConfig : debugOverride,
+    debugOverrideReady,
+  ];
+};
+
+export const useServerTimeEnabledDebugOverride = () => {
+  return useDebugOverride(
+    StorageModelKeysEnum.EnableServerTimeDebugOverride,
+  );
+};


### PR DESCRIPTION
- Add a feature flag to be able to turn of server time if
necessary. The feature flag has the default value true, and can be
set to false in RemoteConfig.
- Also fixed a bug where if the server clock didn't start as it
should, then the interval wasn't fired. This ment that if
something went wrong with the time-lib, we would never get an
updated time. Now the interval always runs every 2500 ms, but
fallbacks to Date.now() if server time not enabled or the time-lib
isn't started.

### Acceptance criteria
- [ ] If the feature toggle is false, then ticket views should use local device time
- [ ] If the feature toggle is true, then ticket views should use server time
- [ ] The app should handle that it is started in flight mode. Hopefully server time, but falling back to client time is ok, just that it doesn't end up having a stale time like was possible before.