### PR TITLE
fix: use small padding around icons in travel search results

### DIFF
--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -16,7 +16,7 @@ export type TransportationIconBoxProps = {
   subMode?: AnySubMode;
   lineNumber?: string;
   size?: keyof Theme['icon']['size'];
-  spacious?: boolean;
+  type?: 'compact' | 'standard';
   style?: StyleProp<ViewStyle>;
   disabled?: boolean;
   testID?: string;
@@ -27,7 +27,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
   subMode,
   lineNumber,
   size = 'normal',
-  spacious = false,
+  type = 'compact',
   style,
   disabled,
   testID,
@@ -57,7 +57,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
     <View
       style={[
         styles.transportationIconBox,
-        spacious && styles.spaciousTransportationIconBox,
+        type === 'standard' && styles.standardTransportationIconBox,
         style,
         {
           backgroundColor,
@@ -83,7 +83,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     padding: theme.spacings.xSmall,
     borderRadius: theme.border.radius.small,
   },
-  spaciousTransportationIconBox: {
+  standardTransportationIconBox: {
     padding: theme.spacings.small,
   },
   lineNumberText: {

--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -16,6 +16,7 @@ export type TransportationIconBoxProps = {
   subMode?: AnySubMode;
   lineNumber?: string;
   size?: keyof Theme['icon']['size'];
+  spacious?: boolean;
   style?: StyleProp<ViewStyle>;
   disabled?: boolean;
   testID?: string;
@@ -26,6 +27,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
   subMode,
   lineNumber,
   size = 'normal',
+  spacious = false,
   style,
   disabled,
   testID,
@@ -55,6 +57,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
     <View
       style={[
         styles.transportationIconBox,
+        spacious && styles.spaciousTransportationIconBox,
         style,
         {
           backgroundColor,
@@ -79,6 +82,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     padding: theme.spacings.xSmall,
     borderRadius: theme.border.radius.small,
+  },
+  spaciousTransportationIconBox: {
+    padding: theme.spacings.small,
   },
   lineNumberText: {
     marginLeft: theme.spacings.xSmall,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -58,7 +58,7 @@ import {useFontScale} from '@atb/utils/use-font-scale';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useNow} from '@atb/utils/use-now';
-import {TripPatternBookingStatus} from "@atb/travel-details-screens/types";
+import {TripPatternBookingStatus} from '@atb/travel-details-screens/types';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -581,6 +581,7 @@ const TransportationLeg = ({
       mode={isLegFlexibleTransport(leg) ? 'flex' : leg.mode}
       subMode={leg.line?.transportSubmode}
       lineNumber={leg.line?.publicCode}
+      spacious={true}
       testID="trLeg"
     />
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -581,7 +581,7 @@ const TransportationLeg = ({
       mode={isLegFlexibleTransport(leg) ? 'flex' : leg.mode}
       subMode={leg.line?.transportSubmode}
       lineNumber={leg.line?.publicCode}
-      spacious={true}
+      type="standard"
       testID="trLeg"
     />
   );


### PR DESCRIPTION
This adds some more padding around transport icons in travel search ResultItems.

I was unsure about what kind of prop I should use here, so I'm open to feedback 😊 

1. I could use ContainerSizingType (`'compact' | 'standard' | 'spacious'`), but it didn't quite fit since all I needed was two modes, and default would be compact. 
2. A new prop `type='normal' | 'spacious'`. The `mode` name is taken for Transport Mode.
3. I felt like `spacious=boolean` was the simplest solution, but it doesn't really fit what we've done elsewhere

fixes https://github.com/AtB-AS/kundevendt/issues/3834#issuecomment-1943696655