### PR TITLE
fix: Travel map useEffect loop

### DIFF
--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -41,6 +41,8 @@ import {
   RegionPayload,
 } from '@rnmapbox/maps/lib/typescript/src/components/MapView';
 
+const EMPTY_FILTER = {};
+
 export type TravelDetailsMapScreenParams = {
   legs: MapLeg[];
   vehicleWithPosition?: VehicleWithPosition;
@@ -87,7 +89,7 @@ export const TravelDetailsMapScreenComponent = ({
   const controlStyles = useControlPositionsStyle();
   const styles = useStyles();
 
-  const stations = useStations(mapFilter?.mobility ?? {});
+  const stations = useStations(mapFilter?.mobility ?? EMPTY_FILTER);
 
   const [liveVehicle, isLiveConnected] = useLiveVehicleSubscription({
     serviceJourneyId: vehicleWithPosition?.serviceJourney?.id,


### PR DESCRIPTION
An empty object was used to represent that there was no filters,
but the object was recreated every render, which made several
useEffect's run way to often.

https://mittatb.slack.com/archives/C0116FMPX4Y/p1707984786631569
