### PR TITLE
fix: Renew can create inspection right on two mobile tokens #66

### DIFF
--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -91,7 +91,7 @@ export const tokenService: TokenService = {
       .catch(handleError),
   initiateMobileTokenRenewal: (token, secureContainer, traceId, attestation) =>
     client
-      .post<InitiateTokenRenewalResponse>('/tokens/v4/renew', undefined, {
+      .post<InitiateTokenRenewalResponse>('/tokens/v4/renew', {"tokenId": token.tokenId}, {
         headers: {
           [CorrelationIdHeaderName]: traceId,
           [SignedTokenHeaderName]: secureContainer,


### PR DESCRIPTION
Closes  [#4215](https://github.com/AtB-AS/kundevendt/issues/4215)

Requires: https://github.com/AtB-AS/abt-token-server/pull/66