### PR TITLE
feat: popover for tickets sent to others button on my ticket screen.

### DIFF
--- a/src/components/popover/PopOver.tsx
+++ b/src/components/popover/PopOver.tsx
@@ -1,5 +1,5 @@
 import RNPopover from 'react-native-popover-view';
-import React from 'react';
+import React, {Component} from 'react';
 import {
   Dimensions,
   Platform,
@@ -14,7 +14,7 @@ import {StyleSheet} from '@atb/theme';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 export type PopOverProps = {
-  from: React.RefObject<JSX.Element | null>;
+  from: React.RefObject<Component | null>;
   heading?: string;
   text: string;
   isOpen?: boolean;

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {forwardRef} from 'react';
 import {AccessibilityProps, GestureResponderEvent, View} from 'react-native';
 import {ThemeText, screenReaderPause} from '@atb/components/text';
 import {
@@ -29,73 +29,80 @@ type Props = SectionItemProps<{
   textType?: TextNames;
   interactiveColor?: InteractiveColor;
 }>;
-export function LinkSectionItem({
-  text,
-  onPress,
-  subtitle,
-  label,
-  icon,
-  accessibility,
-  disabled,
-  textType,
-  testID,
-  interactiveColor = 'interactive_2',
-  ...props
-}: Props) {
-  const {t} = useTranslation();
-  const {contentContainer, topContainer} = useSectionItem(props);
-  const style = useSectionStyle();
-  const linkSectionItemStyle = useStyles();
-  const {theme} = useTheme();
-  const themeColor = theme.interactive[interactiveColor].default;
-  const iconEl =
-    isNavigationIcon(icon) || !icon ? (
-      <NavigationIcon mode={icon} fill={themeColor.text} />
-    ) : (
-      icon
-    );
-  const disabledStyle = disabled ? linkSectionItemStyle.disabled : undefined;
-  const accessibilityWithOverrides = disabled
-    ? {...accessibility, accessibilityHint: undefined}
-    : accessibility;
-  const accessibilityLabel =
-    text + screenReaderPause + (subtitle ? subtitle + screenReaderPause : '');
-  return (
-    <PressableOpacity
-      accessible
-      accessibilityRole="link"
-      onPress={disabled ? undefined : onPress}
-      disabled={disabled}
-      accessibilityLabel={
-        label
-          ? `${accessibilityLabel} ${t(LabelInfoTexts.labels[label])}`
-          : accessibilityLabel
-      }
-      accessibilityState={{disabled}}
-      style={[topContainer, {backgroundColor: themeColor.background}]}
-      testID={testID}
-      {...accessibilityWithOverrides}
-    >
-      <View style={[style.spaceBetween, disabledStyle]}>
-        <ThemeText
-          style={[contentContainer, {color: themeColor.text}]}
-          type={textType}
-        >
-          {text}
-        </ThemeText>
-        {label && <LabelInfo label={label} />}
-        {iconEl}
-      </View>
-      {subtitle && (
-        <View style={disabledStyle}>
-          <ThemeText color="secondary" type="body__secondary">
-            {subtitle}
+
+export const LinkSectionItem = forwardRef<View, Props>(
+  (
+    {
+      text,
+      onPress,
+      subtitle,
+      label,
+      icon,
+      accessibility,
+      disabled,
+      textType,
+      testID,
+      interactiveColor = 'interactive_2',
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const {t} = useTranslation();
+    const {contentContainer, topContainer} = useSectionItem(props);
+    const style = useSectionStyle();
+    const linkSectionItemStyle = useStyles();
+    const {theme} = useTheme();
+    const themeColor = theme.interactive[interactiveColor].default;
+    const iconEl =
+      isNavigationIcon(icon) || !icon ? (
+        <NavigationIcon mode={icon} fill={themeColor.text} />
+      ) : (
+        icon
+      );
+    const disabledStyle = disabled ? linkSectionItemStyle.disabled : undefined;
+    const accessibilityWithOverrides = disabled
+      ? {...accessibility, accessibilityHint: undefined}
+      : accessibility;
+    const accessibilityLabel =
+      text + screenReaderPause + (subtitle ? subtitle + screenReaderPause : '');
+    return (
+      <PressableOpacity
+        accessible
+        accessibilityRole="link"
+        onPress={disabled ? undefined : onPress}
+        disabled={disabled}
+        accessibilityLabel={
+          label
+            ? `${accessibilityLabel} ${t(LabelInfoTexts.labels[label])}`
+            : accessibilityLabel
+        }
+        accessibilityState={{disabled}}
+        style={[topContainer, {backgroundColor: themeColor.background}]}
+        testID={testID}
+        ref={forwardedRef}
+        {...accessibilityWithOverrides}
+      >
+        <View style={[style.spaceBetween, disabledStyle]}>
+          <ThemeText
+            style={[contentContainer, {color: themeColor.text}]}
+            type={textType}
+          >
+            {text}
           </ThemeText>
+          {label && <LabelInfo label={label} />}
+          {iconEl}
         </View>
-      )}
-    </PressableOpacity>
-  );
-}
+        {subtitle && (
+          <View style={disabledStyle}>
+            <ThemeText color="secondary" type="body__secondary">
+              {subtitle}
+            </ThemeText>
+          </View>
+        )}
+      </PressableOpacity>
+    );
+  },
+);
 
 const useStyles = StyleSheet.createThemeHook(() => ({
   disabled: {opacity: 0.2},

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -79,10 +79,13 @@ export const LinkSectionItem = forwardRef<View, Props>(
         accessibilityState={{disabled}}
         style={[topContainer, {backgroundColor: themeColor.background}]}
         testID={testID}
-        ref={forwardedRef}
         {...accessibilityWithOverrides}
       >
-        <View style={[style.spaceBetween, disabledStyle]}>
+        <View
+          ref={forwardedRef}
+          collapsable={false}
+          style={[style.spaceBetween, disabledStyle]}
+        >
           <ThemeText
             style={[contentContainer, {color: themeColor.text}]}
             type={textType}

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -79,13 +79,11 @@ export const LinkSectionItem = forwardRef<View, Props>(
         accessibilityState={{disabled}}
         style={[topContainer, {backgroundColor: themeColor.background}]}
         testID={testID}
+        ref={forwardedRef}
+        collapsable={false}
         {...accessibilityWithOverrides}
       >
-        <View
-          ref={forwardedRef}
-          collapsable={false}
-          style={[style.spaceBetween, disabledStyle]}
-        >
+        <View style={[style.spaceBetween, disabledStyle]}>
           <ThemeText
             style={[contentContainer, {color: themeColor.text}]}
             type={textType}

--- a/src/popover/PopOverContext.tsx
+++ b/src/popover/PopOverContext.tsx
@@ -1,4 +1,10 @@
-import React, {createContext, useCallback, useContext, useState} from 'react';
+import React, {
+  Component,
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
 import {PopOverKey} from './types';
 import {PopOver} from '@atb/components/popover';
 import {useOneTimePopover} from './use-one-time-popover';
@@ -10,7 +16,7 @@ import {InteractionManager} from 'react-native';
 export const POPOVER_ANIMATION_DURATION = 200;
 
 type PopOverType = {
-  target: React.RefObject<JSX.Element | null>;
+  target: React.RefObject<Component | null>;
   oneTimeKey: PopOverKey;
 };
 

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -1,4 +1,4 @@
 export type PopOverKey =
   | 'trip-search-flexible-transport-dismissed'
   | 'on-behalf-of-new-feature-introduction'
-  | 'on-behalf-of-first-time-purchase';
+  | 'on-behalf-of-sent-tickets-button';

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -1,3 +1,4 @@
 export type PopOverKey =
   | 'trip-search-flexible-transport-dismissed'
-  | 'on-behalf-of-new-feature-introduction';
+  | 'on-behalf-of-new-feature-introduction'
+  | 'on-behalf-of-first-time-purchase';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -74,52 +74,15 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
   useFocusEffect(
     useCallback(() => {
       if (shouldShowPopOver) {
-        // Check if the button for tickets sent to others is visible on screen or not
-        if (sentFareContractRef.current) {
-          const currentView = sentFareContractRef.current as View;
-          currentView.measure((x, y, width, height, pageX, pageY) => {
-            const rectTop = pageX;
-            const rectBottom = pageY + height;
-            const rectWidth = pageX + width;
-            const window = Dimensions.get('window');
-            const isVisible =
-              rectBottom != 0 &&
-              rectTop >= 0 &&
-              rectBottom <= window.height &&
-              rectWidth > 0 &&
-              rectWidth <= window.width;
-
-            // if layout is visible : show pop over
-            // else : scroll to bottom, and then show pop over (see handleScrollEvent)
-            if (isVisible) {
-              showPopOver();
-            } else {
-              scrollViewRef.current?.scrollToEnd({animated: true});
-            }
-          });
-        }
+        showPopOver();
       }
     }, [shouldShowPopOver, showPopOver]),
   );
-
-  // show popover when it reaches the end of scrollview
-  const handleScrollEvent = (
-    event: NativeSyntheticEvent<NativeScrollEvent>,
-  ) => {
-    if (shouldShowPopOver) {
-      const {layoutMeasurement, contentOffset, contentSize} = event.nativeEvent;
-      if (layoutMeasurement.height + contentOffset.y >= contentSize.height) {
-        showPopOver();
-      }
-    }
-  };
 
   return (
     <View style={styles.container}>
       <ScrollView
         ref={scrollViewRef}
-        onScroll={handleScrollEvent}
-        scrollEventThrottle={0} // this will make the onScroll event sent only once
         contentContainerStyle={styles.content}
         refreshControl={
           <RefreshControl

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -14,7 +14,6 @@ import {LinkSectionItem, Section} from '@atb/components/sections';
 import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 import {TicketTabNavScreenProps} from './navigation-types';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
-import {useFocusEffect} from '@react-navigation/native';
 import {usePopOver} from '@atb/popover';
 import {useOneTimePopover} from '@atb/popover/use-one-time-popover';
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -61,14 +61,14 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
   // if user has sent fare contracts AND the popOver is not seen yet,
   // the popOver should be shown
   const shouldShowPopOver =
-    hasSentFareContracts && !isPopOverSeen('on-behalf-of-first-time-purchase');
+    hasSentFareContracts && !isPopOverSeen('on-behalf-of-sent-tickets-button');
 
   const showPopOver = useCallback(() => {
     addPopOver({
-      oneTimeKey: 'on-behalf-of-first-time-purchase',
+      oneTimeKey: 'on-behalf-of-sent-tickets-button',
       target: sentFareContractRef,
     });
-    setPopOverSeen('on-behalf-of-first-time-purchase');
+    setPopOverSeen('on-behalf-of-sent-tickets-button');
   }, [addPopOver, setPopOverSeen]);
 
   useFocusEffect(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -48,7 +48,7 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
 
   const hasSentFareContracts = sentFareContracts.length > 0;
 
-  const sentFareContractRef = useRef(null);
+  const sentFareContractRef = useRef<View>(null);
 
   const {isPopOverSeen, setPopOverSeen} = useOneTimePopover();
 
@@ -65,33 +65,29 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
     setPopOverSeen('on-behalf-of-sent-tickets-button');
   }, [addPopOver, setPopOverSeen]);
 
-  useFocusEffect(
-    useCallback(() => {
-      if (shouldShowPopOver) {
-        // Check if the button for tickets sent to others is visible on screen or not
-        if (sentFareContractRef.current) {
-          const currentView = sentFareContractRef.current as View;
-          currentView.measure((x, y, width, height, pageX, pageY) => {
-            const rectTop = pageX;
-            const rectBottom = pageY + height;
-            const rectWidth = pageX + width;
-            const window = Dimensions.get('window');
-            const isVisible =
-              rectBottom != 0 &&
-              rectTop >= 0 &&
-              rectBottom <= window.height &&
-              rectWidth > 0 &&
-              rectWidth <= window.width;
+  if (shouldShowPopOver) {
+    // Check if the button for tickets sent to others is visible on screen or not
+    if (sentFareContractRef.current) {
+      const currentView = sentFareContractRef.current;
+      currentView.measure((x, y, width, height, pageX, pageY) => {
+        const rectTop = pageX;
+        const rectBottom = pageY + height;
+        const rectWidth = pageX + width;
+        const window = Dimensions.get('window');
+        const isVisible =
+          rectBottom != 0 &&
+          rectTop >= 0 &&
+          rectBottom <= window.height &&
+          rectWidth > 0 &&
+          rectWidth <= window.width;
 
-            // if layout is visible : show pop over
-            if (isVisible) {
-              showPopOver();
-            }
-          });
+        // if layout is visible : show pop over
+        if (isVisible) {
+          showPopOver();
         }
-      }
-    }, [shouldShowPopOver, showPopOver]),
-  );
+      });
+    }
+  }
 
   return (
     <View style={styles.container}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -16,6 +16,7 @@ import {TicketTabNavScreenProps} from './navigation-types';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
 import {usePopOver} from '@atb/popover';
 import {useOneTimePopover} from '@atb/popover/use-one-time-popover';
+import {isViewVisibleOnScreen} from '@atb/utils/is-view-visible-on-screen';
 
 type Props =
   TicketTabNavScreenProps<'TicketTabNav_ActiveFareProductsTabScreen'>;
@@ -64,27 +65,26 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
     setPopOverSeen('on-behalf-of-sent-tickets-button');
   }, [addPopOver, setPopOverSeen]);
 
+  // show popOver when the layout is visible on screen
   if (shouldShowPopOver) {
-    // Check if the button for tickets sent to others is visible on screen or not
     if (sentFareContractRef.current) {
-      const currentView = sentFareContractRef.current;
-      currentView.measure((x, y, width, height, pageX, pageY) => {
-        const rectTop = pageX;
-        const rectBottom = pageY + height;
-        const rectWidth = pageX + width;
-        const window = Dimensions.get('window');
-        const isVisible =
-          rectBottom != 0 &&
-          rectTop >= 0 &&
-          rectBottom <= window.height &&
-          rectWidth > 0 &&
-          rectWidth <= window.width;
+      sentFareContractRef.current.measure(
+        (x, y, width, height, pageX, pageY) => {
+          const window = Dimensions.get('window');
+          const isViewVisible = isViewVisibleOnScreen(
+            width,
+            height,
+            pageX,
+            pageY,
+            window.width,
+            window.height,
+          );
 
-        // if layout is visible : show pop over
-        if (isVisible) {
-          showPopOver();
-        }
-      });
+          if (isViewVisible) {
+            showPopOver();
+          }
+        },
+      );
     }
   }
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -4,8 +4,13 @@ import {
   filterExpiredFareContracts,
   useTicketingState,
 } from '@atb/ticketing';
-import React from 'react';
-import {View} from 'react-native';
+import React, {useCallback, useRef} from 'react';
+import {
+  Dimensions,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  View,
+} from 'react-native';
 import {FareContractAndReservationsList} from '@atb/fare-contracts';
 import {useTranslation, TicketingTexts} from '@atb/translations';
 import {useAnalytics} from '@atb/analytics';
@@ -14,6 +19,9 @@ import {LinkSectionItem, Section} from '@atb/components/sections';
 import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 import {TicketTabNavScreenProps} from './navigation-types';
 import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
+import {useFocusEffect} from '@react-navigation/native';
+import {usePopOver} from '@atb/popover';
+import {useOneTimePopover} from '@atb/popover/use-one-time-popover';
 
 type Props =
   TicketTabNavScreenProps<'TicketTabNav_ActiveFareProductsTabScreen'>;
@@ -38,15 +46,80 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
 
   const styles = useStyles();
   const {t} = useTranslation();
+  const {addPopOver} = usePopOver();
 
   const hasExpiredFareContracts =
     filterExpiredFareContracts(fareContracts, serverNow).length > 0;
 
   const hasSentFareContracts = sentFareContracts.length > 0;
 
+  const sentFareContractRef = useRef(null);
+  const scrollViewRef = useRef<ScrollView>(null);
+
+  const {isPopOverSeen, setPopOverSeen} = useOneTimePopover();
+
+  // if user has sent fare contracts AND the popOver is not seen yet,
+  // the popOver should be shown
+  const shouldShowPopOver =
+    hasSentFareContracts && !isPopOverSeen('on-behalf-of-first-time-purchase');
+
+  const showPopOver = useCallback(() => {
+    addPopOver({
+      oneTimeKey: 'on-behalf-of-first-time-purchase',
+      target: sentFareContractRef,
+    });
+    setPopOverSeen('on-behalf-of-first-time-purchase');
+  }, [addPopOver, setPopOverSeen]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (shouldShowPopOver) {
+        // Check if the button for tickets sent to others is visible on screen or not
+        if (sentFareContractRef.current) {
+          const currentView = sentFareContractRef.current as View;
+          currentView.measure((x, y, width, height, pageX, pageY) => {
+            const rectTop = pageX;
+            const rectBottom = pageY + height;
+            const rectWidth = pageX + width;
+            const window = Dimensions.get('window');
+            const isVisible =
+              rectBottom != 0 &&
+              rectTop >= 0 &&
+              rectBottom <= window.height &&
+              rectWidth > 0 &&
+              rectWidth <= window.width;
+
+            // if layout is visible : show pop over
+            // else : scroll to bottom, and then show pop over (see handleScrollEvent)
+            if (isVisible) {
+              showPopOver();
+            } else {
+              scrollViewRef.current?.scrollToEnd({animated: true});
+            }
+          });
+        }
+      }
+    }, [shouldShowPopOver, showPopOver]),
+  );
+
+  // show popover when it reaches the end of scrollview
+  const handleScrollEvent = (
+    event: NativeSyntheticEvent<NativeScrollEvent>,
+  ) => {
+    if (shouldShowPopOver) {
+      const {layoutMeasurement, contentOffset, contentSize} = event.nativeEvent;
+      if (layoutMeasurement.height + contentOffset.y >= contentSize.height) {
+        showPopOver();
+      }
+    }
+  };
+
   return (
     <View style={styles.container}>
       <ScrollView
+        ref={scrollViewRef}
+        onScroll={handleScrollEvent}
+        scrollEventThrottle={0} // this will make the onScroll event sent only once
         contentContainerStyle={styles.content}
         refreshControl={
           <RefreshControl
@@ -92,18 +165,20 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
           )}
 
           {hasSentFareContracts && (
-            <LinkSectionItem
-              text={t(TicketHistoryModeTexts.sent.title)}
-              accessibility={{
-                accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
-              }}
-              testID="sentToOthersButton"
-              onPress={() =>
-                navigation.navigate('Ticketing_TicketHistoryScreen', {
-                  mode: 'sent',
-                })
-              }
-            />
+            <View ref={sentFareContractRef} collapsable={false}>
+              <LinkSectionItem
+                text={t(TicketHistoryModeTexts.sent.title)}
+                accessibility={{
+                  accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
+                }}
+                testID="sentToOthersButton"
+                onPress={() =>
+                  navigation.navigate('Ticketing_TicketHistoryScreen', {
+                    mode: 'sent',
+                  })
+                }
+              />
+            </View>
           )}
         </Section>
       </ScrollView>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -54,7 +54,6 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
   const hasSentFareContracts = sentFareContracts.length > 0;
 
   const sentFareContractRef = useRef(null);
-  const scrollViewRef = useRef<ScrollView>(null);
 
   const {isPopOverSeen, setPopOverSeen} = useOneTimePopover();
 
@@ -74,7 +73,27 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
   useFocusEffect(
     useCallback(() => {
       if (shouldShowPopOver) {
-        showPopOver();
+        // Check if the button for tickets sent to others is visible on screen or not
+        if (sentFareContractRef.current) {
+          const currentView = sentFareContractRef.current as View;
+          currentView.measure((x, y, width, height, pageX, pageY) => {
+            const rectTop = pageX;
+            const rectBottom = pageY + height;
+            const rectWidth = pageX + width;
+            const window = Dimensions.get('window');
+            const isVisible =
+              rectBottom != 0 &&
+              rectTop >= 0 &&
+              rectBottom <= window.height &&
+              rectWidth > 0 &&
+              rectWidth <= window.width;
+
+            // if layout is visible : show pop over
+            if (isVisible) {
+              showPopOver();
+            }
+          });
+        }
       }
     }, [shouldShowPopOver, showPopOver]),
   );
@@ -82,7 +101,6 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
   return (
     <View style={styles.container}>
       <ScrollView
-        ref={scrollViewRef}
         contentContainerStyle={styles.content}
         refreshControl={
           <RefreshControl

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -141,20 +141,19 @@ export const TicketTabNav_ActiveFareProductsTabScreen = ({
           )}
 
           {hasSentFareContracts && (
-            <View ref={sentFareContractRef} collapsable={false}>
-              <LinkSectionItem
-                text={t(TicketHistoryModeTexts.sent.title)}
-                accessibility={{
-                  accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
-                }}
-                testID="sentToOthersButton"
-                onPress={() =>
-                  navigation.navigate('Ticketing_TicketHistoryScreen', {
-                    mode: 'sent',
-                  })
-                }
-              />
-            </View>
+            <LinkSectionItem
+              ref={sentFareContractRef}
+              text={t(TicketHistoryModeTexts.sent.title)}
+              accessibility={{
+                accessibilityHint: t(TicketHistoryModeTexts.sent.titleA11y),
+              }}
+              testID="sentToOthersButton"
+              onPress={() =>
+                navigation.navigate('Ticketing_TicketHistoryScreen', {
+                  mode: 'sent',
+                })
+              }
+            />
           )}
         </Section>
       </ScrollView>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_ActiveFareProductsTabScreen.tsx
@@ -5,12 +5,7 @@ import {
   useTicketingState,
 } from '@atb/ticketing';
 import React, {useCallback, useRef} from 'react';
-import {
-  Dimensions,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  View,
-} from 'react-native';
+import {Dimensions, View} from 'react-native';
 import {FareContractAndReservationsList} from '@atb/fare-contracts';
 import {useTranslation, TicketingTexts} from '@atb/translations';
 import {useAnalytics} from '@atb/analytics';

--- a/src/translations/components/OneTimePopOver.ts
+++ b/src/translations/components/OneTimePopOver.ts
@@ -27,7 +27,7 @@ const OneTimePopOverTexts: {[key in PopOverKey]: PopOverText} = {
       'Kjøp til nokon andre.',
     ),
   },
-  'on-behalf-of-first-time-purchase': {
+  'on-behalf-of-sent-tickets-button': {
     heading: _(
       'Leter du etter sendte billetter?',
       'Looking for sent tickets?',

--- a/src/translations/components/OneTimePopOver.ts
+++ b/src/translations/components/OneTimePopOver.ts
@@ -27,6 +27,18 @@ const OneTimePopOverTexts: {[key in PopOverKey]: PopOverText} = {
       'Kjøp til nokon andre.',
     ),
   },
+  'on-behalf-of-first-time-purchase': {
+    heading: _(
+      'Leter du etter sendte billetter?',
+      'Looking for sent tickets?',
+      'Leitar du etter sende billettar?',
+    ),
+    text: _(
+      'Oversikt over sendte billetter finner du her.',
+      'You can see the tickets you have sent here.',
+      'Oversikt over sende billettar finn du her.',
+    ),
+  },
 };
 
 export default OneTimePopOverTexts;

--- a/src/utils/__tests__/is-view-visible-on-screen.test.ts
+++ b/src/utils/__tests__/is-view-visible-on-screen.test.ts
@@ -1,0 +1,79 @@
+import {isViewVisibleOnScreen} from '../is-view-visible-on-screen';
+
+describe('isViewVisibleOnScreen: view size <= window size, view located on top left (0,0)', () => {
+  it(`window size 10 x 10, view size 0 x 0 located top left (0,0)`, async () => {
+    const isVisible = isViewVisibleOnScreen(0, 0, 0, 0, 10, 10);
+    expect(isVisible).toEqual(false);
+  });
+
+  for (let i = 1; i <= 10; i++) {
+    it(`window size 10 x 10, view size ${i} x ${i} located top left (0,0)`, async () => {
+      const isVisible = isViewVisibleOnScreen(i, i, 0, 0, 10, 10);
+      expect(isVisible).toEqual(true);
+    });
+  }
+});
+
+describe('isViewVisibleOnScreen: view size > window size, view located on top left (0,0)', () => {
+  for (let i = 11; i <= 20; i++) {
+    it(`window size 10 x 10, view size ${i} x ${i} located top left (0,0)`, async () => {
+      const isVisible = isViewVisibleOnScreen(i, i, 0, 0, 10, 10);
+      expect(isVisible).toEqual(false);
+    });
+  }
+});
+
+describe('isViewVisibleOnScreen: view size <= window size, view positioned at center of the window (5,5)', () => {
+  it(`window size 10 x 10, view size 0 x 0 located center (5,5)`, async () => {
+    const isVisible = isViewVisibleOnScreen(0, 0, 5, 5, 10, 10);
+    expect(isVisible).toEqual(false);
+  });
+  for (let i = 1; i <= 5; i++) {
+    it(`window size 10 x 10, view size ${i} x ${i} located center (5,5)`, async () => {
+      const isVisible = isViewVisibleOnScreen(i, i, 5, 5, 10, 10);
+      expect(isVisible).toEqual(true);
+    });
+  }
+  for (let i = 6; i <= 10; i++) {
+    it(`window size 10 x 10, view size ${i} x ${i} located center (5,5)`, async () => {
+      const isVisible = isViewVisibleOnScreen(i, i, 5, 5, 10, 10);
+      expect(isVisible).toEqual(false);
+    });
+  }
+});
+
+describe('isViewVisibleOnScreen: view located below the window', () => {
+  for (let i = 11; i <= 20; i++) {
+    it(`window size 10 x 10, view size 5 x 5 located (${i},${i})`, async () => {
+      const isVisible = isViewVisibleOnScreen(5, 5, i, i, 10, 10);
+      expect(isVisible).toEqual(false);
+    });
+  }
+});
+
+describe('isViewVisibleOnScreen: located at negative coordinates', () => {
+  for (let i = -1; i >= -10; i--) {
+    it(`window size 10 x 10, view size 5 x 5, located at (${i}, ${i}) `, async () => {
+      const isVisible = isViewVisibleOnScreen(0, 0, i, i, 10, 10);
+      expect(isVisible).toEqual(false);
+    });
+  }
+});
+
+describe('isViewVisibleOnScreen: negative size ', () => {
+  for (let i = -1; i >= -10; i--) {
+    it(`window size 10 x 10, view size ${i} x ${i} located center (5,5)`, async () => {
+      const isVisible = isViewVisibleOnScreen(i, i, 5, 5, 10, 10);
+      expect(isVisible).toEqual(false);
+    });
+  }
+});
+
+describe('isViewVisibleOnScreen: negative size and position', () => {
+  for (let i = -1; i >= -10; i--) {
+    it(`window size 10 x 10, view size ${i} x ${i} located (${i},${i})`, async () => {
+      const isVisible = isViewVisibleOnScreen(i, i, 5, 5, 10, 10);
+      expect(isVisible).toEqual(false);
+    });
+  }
+});

--- a/src/utils/is-view-visible-on-screen.ts
+++ b/src/utils/is-view-visible-on-screen.ts
@@ -1,0 +1,98 @@
+/**
+ * Function for checking whether a layout is visible on-screen or not, by comparing
+ * it's position and size on screen and the available window size.
+ *
+ * If it's border is within the available window size, then the view is visible
+ * otherwise the view is deemed as not visible. So, only a fully visible view is
+ * considered as "visible".
+ *
+ * example of how to use this function:
+ *
+ * const viewRef = useRef<View>(null);
+ *
+ * function doSomethingWhenLayoutIsVisible() {
+ *   if (viewRef.current) {
+ *     viewRef.current.measure((x, y, width, height, pageX, pageY) => {
+ *       const window = Dimensions.get('window');
+ *       const isViewVisible = isViewVisibleOnScreen(
+ *         width,height,pageX,pageY,window.width, window.height
+ *       );
+ *
+ *       if (isViewVisible){
+ *         // do something when view is visible
+ *       } else {
+ *         // do something when view is not fully visible
+ *       }
+ *     });
+ *   }
+ * }
+ *
+ * ---
+ * Logic behind this function
+ * ---
+ *
+ *  wa==================wb
+ *  ||      window      ||
+ *  ||                  ||
+ *  ||   a----w----b    ||
+ *  ||   |         |    ||
+ *  ||   |         |    ||
+ *  ||   h   view  |    ||
+ *  ||   |         |    ||
+ *  ||   |         |    ||
+ *  ||   c---------d    ||
+ *  ||                  ||
+ *  wc==================wd
+ *
+ * A window has position, width and height, if we put it into numbers:
+ *
+ * wa = (0,0)
+ * wb = (windowWidth, 0)
+ * wc = (0, windowHeight)
+ * wd = (windowWidth, windowHeight)
+ *
+ * the View also has position, width, and height, for the view:
+ *
+ * a = (viewX, viewY)
+ * b = (viewX + w, viewY)
+ * c = (viewX, viewY + h)
+ * d = (viewX + w, viewY + h)
+ *
+ *
+ * So, for the view to be fully visible in the window, all of this
+ * comparison must be true:
+ *
+ *  - viewX >= 0
+ *  - viewY >= 0
+ *  - viewX + w <= windowWidth
+ *  - viewY + h <= windowHeight
+ *  - w > 0
+ *  - h > 0
+ *
+ * @param w view width
+ * @param h view height
+ * @param viewX view x-coordinate relative to page
+ * @param viewY view y-coordinate relative to page
+ * @param windowWidth window width
+ * @param windowHeight window height
+ * @returns boolean value, true if view is visible on screen,
+ * false if view is not fully visible on screen.
+ */
+
+export function isViewVisibleOnScreen(
+  w: number,
+  h: number,
+  viewX: number,
+  viewY: number,
+  windowWidth: number,
+  windowHeight: number,
+): boolean {
+  return (
+    viewX >= 0 &&
+    viewY >= 0 &&
+    w > 0 &&
+    h > 0 &&
+    viewX + w <= windowWidth &&
+    viewY + h <= windowHeight
+  );
+}


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16927

This will show a popover to let the user knows where to find their sent tickets.
Added some comments to explain what the code means.

### Unit test output

####  yarn test -t isViewVisibleOnScreen --verbose   
```
  isViewVisibleOnScreen: view size <= window size, view located on top left (0,0)
    ✓ window size 10 x 10, view size 0 x 0 located top left (0,0) (4 ms)
    ✓ window size 10 x 10, view size 1 x 1 located top left (0,0)
    ✓ window size 10 x 10, view size 2 x 2 located top left (0,0)
    ✓ window size 10 x 10, view size 3 x 3 located top left (0,0)
    ✓ window size 10 x 10, view size 4 x 4 located top left (0,0) (1 ms)
    ✓ window size 10 x 10, view size 5 x 5 located top left (0,0)
    ✓ window size 10 x 10, view size 6 x 6 located top left (0,0)
    ✓ window size 10 x 10, view size 7 x 7 located top left (0,0)
    ✓ window size 10 x 10, view size 8 x 8 located top left (0,0)
    ✓ window size 10 x 10, view size 9 x 9 located top left (0,0)
    ✓ window size 10 x 10, view size 10 x 10 located top left (0,0)
  isViewVisibleOnScreen: view size > window size, view located on top left (0,0)
    ✓ window size 10 x 10, view size 11 x 11 located top left (0,0)
    ✓ window size 10 x 10, view size 12 x 12 located top left (0,0)
    ✓ window size 10 x 10, view size 13 x 13 located top left (0,0)
    ✓ window size 10 x 10, view size 14 x 14 located top left (0,0)
    ✓ window size 10 x 10, view size 15 x 15 located top left (0,0)
    ✓ window size 10 x 10, view size 16 x 16 located top left (0,0)
    ✓ window size 10 x 10, view size 17 x 17 located top left (0,0)
    ✓ window size 10 x 10, view size 18 x 18 located top left (0,0)
    ✓ window size 10 x 10, view size 19 x 19 located top left (0,0)
    ✓ window size 10 x 10, view size 20 x 20 located top left (0,0)
  isViewVisibleOnScreen: view size <= window size, view positioned at center of the window (5,5)
    ✓ window size 10 x 10, view size 0 x 0 located center (5,5)
    ✓ window size 10 x 10, view size 1 x 1 located center (5,5)
    ✓ window size 10 x 10, view size 2 x 2 located center (5,5)
    ✓ window size 10 x 10, view size 3 x 3 located center (5,5)
    ✓ window size 10 x 10, view size 4 x 4 located center (5,5)
    ✓ window size 10 x 10, view size 5 x 5 located center (5,5) (1 ms)
    ✓ window size 10 x 10, view size 6 x 6 located center (5,5)
    ✓ window size 10 x 10, view size 7 x 7 located center (5,5)
    ✓ window size 10 x 10, view size 8 x 8 located center (5,5)
    ✓ window size 10 x 10, view size 9 x 9 located center (5,5)
    ✓ window size 10 x 10, view size 10 x 10 located center (5,5)
  isViewVisibleOnScreen: view located below the window
    ✓ window size 10 x 10, view size 5 x 5 located (11,11)
    ✓ window size 10 x 10, view size 5 x 5 located (12,12)
    ✓ window size 10 x 10, view size 5 x 5 located (13,13)
    ✓ window size 10 x 10, view size 5 x 5 located (14,14)
    ✓ window size 10 x 10, view size 5 x 5 located (15,15)
    ✓ window size 10 x 10, view size 5 x 5 located (16,16)
    ✓ window size 10 x 10, view size 5 x 5 located (17,17) (1 ms)
    ✓ window size 10 x 10, view size 5 x 5 located (18,18)
    ✓ window size 10 x 10, view size 5 x 5 located (19,19)
    ✓ window size 10 x 10, view size 5 x 5 located (20,20)
  isViewVisibleOnScreen: located at negative coordinates
    ✓ window size 10 x 10, view size 5 x 5, located at (-1, -1) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-2, -2) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-3, -3) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-4, -4) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-5, -5) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-6, -6) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-7, -7) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-8, -8) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-9, -9) 
    ✓ window size 10 x 10, view size 5 x 5, located at (-10, -10) 
  isViewVisibleOnScreen: negative size 
    ✓ window size 10 x 10, view size -1 x -1 located center (5,5)
    ✓ window size 10 x 10, view size -2 x -2 located center (5,5)
    ✓ window size 10 x 10, view size -3 x -3 located center (5,5)
    ✓ window size 10 x 10, view size -4 x -4 located center (5,5) (1 ms)
    ✓ window size 10 x 10, view size -5 x -5 located center (5,5)
    ✓ window size 10 x 10, view size -6 x -6 located center (5,5)
    ✓ window size 10 x 10, view size -7 x -7 located center (5,5)
    ✓ window size 10 x 10, view size -8 x -8 located center (5,5)
    ✓ window size 10 x 10, view size -9 x -9 located center (5,5)
    ✓ window size 10 x 10, view size -10 x -10 located center (5,5)
  isViewVisibleOnScreen: negative size and position
    ✓ window size 10 x 10, view size -1 x -1 located (-1,-1)
    ✓ window size 10 x 10, view size -2 x -2 located (-2,-2)
    ✓ window size 10 x 10, view size -3 x -3 located (-3,-3)
    ✓ window size 10 x 10, view size -4 x -4 located (-4,-4)
    ✓ window size 10 x 10, view size -5 x -5 located (-5,-5)
    ✓ window size 10 x 10, view size -6 x -6 located (-6,-6)
    ✓ window size 10 x 10, view size -7 x -7 located (-7,-7)
    ✓ window size 10 x 10, view size -8 x -8 located (-8,-8)
    ✓ window size 10 x 10, view size -9 x -9 located (-9,-9)
    ✓ window size 10 x 10, view size -10 x -10 located (-10,-10)
```


### Some video for how it looks
<details>
<summary>User has sent tickets, button is visible on the my tickets screen, popover shown once</summary>

https://github.com/AtB-AS/mittatb-app/assets/1777333/fa7275ec-6547-417b-827d-a311e1193b4f

</details>

<details>
<summary>User has no active tickets and purchase tickets for others for the first time, popover shown once</summary>

https://github.com/AtB-AS/mittatb-app/assets/1777333/e2264923-4f2d-420b-b962-21b57f84a0a5

</details>