### PR TITLE
fix: show the correct number of consumed carnets in CarnetFooter

### DIFF
--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -20,19 +20,34 @@ export const CarnetFooter: React.FC<Props> = ({
   const styles = useStyles();
   const {t} = useTranslation();
 
+  const activeAccess = active ? 1 : 0;
+
   const accessesRemaining = maximumNumberOfAccesses - numberOfUsedAccesses;
 
+  // The number of accesses remaining, including the active one
+  const shownAccessesRemaining = accessesRemaining + activeAccess;
+
   // If any active, the remaining count is the active index
-  const activeIndex = active ? accessesRemaining : undefined;
+  const activeIndex = active
+    ? (shownAccessesRemaining - 1) % CARNET_DIVIDER
+    : undefined;
 
   // Figure out how many unused travel rights there are left
   // does not need to match actual number of travel rights
-  const carnetsLeftCount = Math.ceil(accessesRemaining / CARNET_DIVIDER);
+  const carnetsLeftCount = Math.ceil(
+    (shownAccessesRemaining + activeAccess) / CARNET_DIVIDER,
+  );
 
   // For the ones not displayed as "multi carnets"
   // how many accesses are used in the travel right
   const restUsed =
-    carnetsLeftCount > 0 ? numberOfUsedAccesses % (10 * carnetsLeftCount) : 10;
+    carnetsLeftCount > 0
+      ? (numberOfUsedAccesses - activeAccess) % CARNET_DIVIDER
+      : CARNET_DIVIDER;
+
+  const numberOfMultiCarnets = Math.floor(
+    Math.max(0, shownAccessesRemaining - 1) / CARNET_DIVIDER,
+  );
 
   return (
     <View
@@ -54,10 +69,11 @@ export const CarnetFooter: React.FC<Props> = ({
         </ThemeText>
       </View>
       <View style={styles.container}>
-        {carnetsLeftCount - 1 > 0 &&
-          Array(carnetsLeftCount - 1)
-            .fill(CARNET_DIVIDER)
-            .map((count, idx) => <MultiCarnet key={idx} count={count} />)}
+        {Array(numberOfMultiCarnets)
+          .fill(CARNET_DIVIDER)
+          .map((count, idx) => (
+            <MultiCarnet key={idx} count={count} />
+          ))}
         {Array(CARNET_DIVIDER)
           .fill(true)
           .map((_, idx) => idx < restUsed)
@@ -72,9 +88,7 @@ export const CarnetFooter: React.FC<Props> = ({
                   : undefined,
               ]}
             >
-              {idx === activeIndex && (
-                <View style={styles.dotFill__active} />
-              )}
+              {idx === activeIndex && <View style={styles.dotFill__active} />}
             </View>
           ))}
       </View>
@@ -89,7 +103,7 @@ function MultiCarnet({count}: {count: number}) {
       <View style={[styles.dot, {marginRight: 8}]} />
       <View
         style={[styles.dot, {opacity: 0.8, position: 'absolute', left: 8}]}
-       />
+      />
       <View style={styles.box}>
         <View style={styles.triangle} />
       </View>

--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -11,7 +11,9 @@ type Props = {
 };
 
 /**
- * Total
+ * The number of accesses that should be displayed in a single row. To display
+ * the correct amount of consumed carnets, maximumNumberOfAccesses should be
+ * divisible by this number.
  */
 const CARNET_DIVIDER = 10;
 
@@ -66,15 +68,13 @@ export const CarnetFooter: React.FC<Props> = ({
 };
 
 /**
- * Function to get the arrays required to display the carnet footer dots.
+ * Get the arrays required to display the carnet footer dots.
+ * `multi-carnet dots --- unused dots --- active dots --- used dots`
  *
  * @param active the ticket status (active | inactive).
  * @param maximumNumberOfAccesses total amount of available access that the carnet has.
  * @param numberOfUsedAccesses total amount of used access that the carnet has.
  * @returns values to display the carnet footer, it will be displayed in this order :
- *
- * `multi-carnet dots --- unused dots --- active dots --- used dots`
- *
  */
 
 function calculateCarnetData(
@@ -82,60 +82,43 @@ function calculateCarnetData(
   maximumNumberOfAccesses: number,
   numberOfUsedAccesses: number,
 ) {
-  /**
-   * If the ticket status is active, it should be considered into calculation.
-   */
+  // If the ticket status is active, it should be considered into calculation.
   const activeAccess = active ? 1 : 0;
 
-  /**
-   * The number of the remaining access, calculated by the following formula :
-   *
-   * `maximumNumberOfAccesses - numberOfUsedAccesses`
-   */
+  // Total number of remaining accesses, including multicarnets
   const accessesRemaining = maximumNumberOfAccesses - numberOfUsedAccesses;
 
-  /**
-   * Calculates the amount of padding needed,
-   * if `maximumNumberOfAccesses` are not divisible by `CARNET_DIVIDER`.
-   */
+  // If `maximumNumberOfAccesses` are not divisible by `CARNET_DIVIDER`, we need
+  // to add some extra dots, in order to not break the active dot position.
   const padding =
     Math.abs(CARNET_DIVIDER - maximumNumberOfAccesses) % CARNET_DIVIDER;
 
-  /**
-   * Number of additional dots that should be added when the padding is there.
-   */
+  // Number of additional dots that should be added when the padding is there.
   const numberOfAdditionalDots =
     maximumNumberOfAccesses > CARNET_DIVIDER
       ? CARNET_DIVIDER - padding
       : padding;
 
-  /**
-   * Determines whether we should add extra multi-carnet dots or not.
-   *
-   * Should only add extra carnet when:
-   * - accessesRemaining is divisible by CARNET_DIVIDER
-   * - status is currently active
-   */
+  // Determines whether we should add an extra multicarnet, due to the active
+  // carnet being the last one in the current set.
+  //
+  // Should only add extra carnet when:
+  // - accessesRemaining is divisible by CARNET_DIVIDER
+  // - status is currently active
   const shouldAddExtraMultiCarnet =
     accessesRemaining % CARNET_DIVIDER === 0 && active ? 1 : 0;
 
-  /**
-   * Calculates the amount of dots showing for the multi-carnet part
-   */
+  // Calculates the amount of dots showing for the multi-carnet part
   const numberOfMultiCarnets =
     Math.ceil(accessesRemaining / CARNET_DIVIDER - 1) +
     shouldAddExtraMultiCarnet;
 
-  /**
-   * Calculates the amount of dots showing for the used part
-   */
+  // Calculates the amount of dots showing for the used part
   const numberOfUsedDots =
     (numberOfUsedAccesses + numberOfAdditionalDots - activeAccess) %
     CARNET_DIVIDER;
 
-  /**
-   * Calculates the amount of dots showing for the unused part
-   */
+  // Calculates the amount of dots showing for the unused part
   const numberOfUnusedDots = CARNET_DIVIDER - numberOfUsedDots - activeAccess;
 
   const multiCarnetArray = Array(numberOfMultiCarnets).fill(CARNET_DIVIDER);

--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -3,19 +3,13 @@ import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
+import {calculateCarnetData} from './calculate-carnet-data';
 
 type Props = {
   active: boolean;
   maximumNumberOfAccesses: number;
   numberOfUsedAccesses: number;
 };
-
-/**
- * The number of accesses that should be displayed in a single row. To display
- * the correct amount of consumed carnets, maximumNumberOfAccesses should be
- * divisible by this number.
- */
-const CARNET_DIVIDER = 10;
 
 export const CarnetFooter: React.FC<Props> = ({
   active,
@@ -66,72 +60,6 @@ export const CarnetFooter: React.FC<Props> = ({
     </View>
   );
 };
-
-/**
- * Get the arrays required to display the carnet footer dots.
- * `multi-carnet dots --- unused dots --- active dots --- used dots`
- *
- * @param active the ticket status (active | inactive).
- * @param maximumNumberOfAccesses total amount of available access that the carnet has.
- * @param numberOfUsedAccesses total amount of used access that the carnet has.
- * @returns values to display the carnet footer, it will be displayed in this order :
- */
-
-function calculateCarnetData(
-  active: boolean,
-  maximumNumberOfAccesses: number,
-  numberOfUsedAccesses: number,
-) {
-  // If the ticket status is active, it should be considered into calculation.
-  const activeAccess = active ? 1 : 0;
-
-  // Total number of remaining accesses, including multicarnets
-  const accessesRemaining = maximumNumberOfAccesses - numberOfUsedAccesses;
-
-  // If `maximumNumberOfAccesses` are not divisible by `CARNET_DIVIDER`, we need
-  // to add some extra dots, in order to not break the active dot position.
-  const padding =
-    Math.abs(CARNET_DIVIDER - maximumNumberOfAccesses) % CARNET_DIVIDER;
-
-  // Number of additional dots that should be added when the padding is there.
-  const numberOfAdditionalDots =
-    maximumNumberOfAccesses > CARNET_DIVIDER
-      ? CARNET_DIVIDER - padding
-      : padding;
-
-  // Determines whether we should add an extra multicarnet, due to the active
-  // carnet being the last one in the current set.
-  //
-  // Should only add extra carnet when:
-  // - accessesRemaining is divisible by CARNET_DIVIDER
-  // - status is currently active
-  const shouldAddExtraMultiCarnet =
-    accessesRemaining % CARNET_DIVIDER === 0 && active ? 1 : 0;
-
-  // Calculates the amount of dots showing for the multi-carnet part
-  const numberOfMultiCarnets =
-    Math.ceil(accessesRemaining / CARNET_DIVIDER - 1) +
-    shouldAddExtraMultiCarnet;
-
-  // Calculates the amount of dots showing for the used part
-  const numberOfUsedDots =
-    (numberOfUsedAccesses + numberOfAdditionalDots - activeAccess) %
-    CARNET_DIVIDER;
-
-  // Calculates the amount of dots showing for the unused part
-  const numberOfUnusedDots = CARNET_DIVIDER - numberOfUsedDots - activeAccess;
-
-  const multiCarnetArray = Array(numberOfMultiCarnets).fill(CARNET_DIVIDER);
-  const unusedArray = Array(numberOfUnusedDots).fill(true);
-  const usedArray = Array(numberOfUsedDots).fill(false);
-
-  return {
-    accessesRemaining,
-    multiCarnetArray,
-    unusedArray,
-    usedArray,
-  };
-}
 
 function MultiCarnet({count}: {count: number}) {
   const styles = useStyles();

--- a/src/fare-contracts/carnet/__tests__/calculate-carnet-data.test.ts
+++ b/src/fare-contracts/carnet/__tests__/calculate-carnet-data.test.ts
@@ -74,6 +74,32 @@ describe('Carnet footer: 30 tickets, active', () => {
   });
 });
 
+describe('Carnet footer: Padded when not divisible by 10', () => {
+  it(`13 tickets, 1 used, not active.`, async () => {
+    const carnetData = calculateCarnetData(false, 13, 1);
+    expect(carnetData.accessesRemaining).toEqual(12);
+    expect(carnetData.multiCarnetArray.length).toEqual(1);
+    expect(carnetData.unusedArray.length).toEqual(2);
+    expect(carnetData.usedArray.length).toEqual(8);
+  });
+
+  it(`13 tickets, 3 used, not active.`, async () => {
+    const carnetData = calculateCarnetData(false, 13, 3);
+    expect(carnetData.accessesRemaining).toEqual(10);
+    expect(carnetData.multiCarnetArray.length).toEqual(0);
+    expect(carnetData.unusedArray.length).toEqual(10);
+    expect(carnetData.usedArray.length).toEqual(0);
+  });
+
+  it(`13 tickets, 3 used, active.`, async () => {
+    const carnetData = calculateCarnetData(true, 13, 3);
+    expect(carnetData.accessesRemaining).toEqual(10);
+    expect(carnetData.multiCarnetArray.length).toEqual(1);
+    expect(carnetData.unusedArray.length).toEqual(0);
+    expect(carnetData.usedArray.length).toEqual(9);
+  });
+});
+
 // These states are invalid, but we shouldn't crash if it happends. Make sure we
 // handle it gracefully.
 describe('Carnet footer: Invalid state', () => {

--- a/src/fare-contracts/carnet/__tests__/calculate-carnet-data.test.ts
+++ b/src/fare-contracts/carnet/__tests__/calculate-carnet-data.test.ts
@@ -1,0 +1,87 @@
+import {calculateCarnetData} from '../calculate-carnet-data';
+
+describe('Carnet footer: 10 tickets', () => {
+  for (let i = 0; i <= 10; i++) {
+    it(`10 tickets, ${i} used, not active.`, async () => {
+      const carnetData = calculateCarnetData(false, 10, i);
+      expect(carnetData.accessesRemaining).toEqual(10 - i);
+      expect(carnetData.multiCarnetArray.length).toEqual(0);
+      expect(carnetData.unusedArray.length).toEqual(10 - i);
+      expect(carnetData.usedArray.length).toEqual(i);
+    });
+  }
+
+  for (let i = 1; i <= 10; i++) {
+    it(`10 tickets, ${i} used, active.`, async () => {
+      const carnetData = calculateCarnetData(true, 10, i);
+      expect(carnetData.accessesRemaining).toEqual(10 - i);
+      expect(carnetData.multiCarnetArray.length).toEqual(0);
+      expect(carnetData.unusedArray.length).toEqual(10 - i);
+      expect(carnetData.usedArray.length).toEqual(i - 1);
+    });
+  }
+});
+
+describe('Carnet footer: 30 tickets, not active', () => {
+  for (let i = 0; i < 10; i++) {
+    it(`30 tickets, ${i} used, not active.`, async () => {
+      const carnetData = calculateCarnetData(false, 30, i);
+      expect(carnetData.accessesRemaining).toEqual(30 - i);
+      expect(carnetData.multiCarnetArray.length).toEqual(2);
+      expect(carnetData.unusedArray.length).toEqual(10 - i);
+      expect(carnetData.usedArray.length).toEqual(i);
+    });
+  }
+  it(`30 tickets, 10 used, not active.`, async () => {
+    const carnetData = calculateCarnetData(false, 30, 10);
+    expect(carnetData.accessesRemaining).toEqual(20);
+    expect(carnetData.multiCarnetArray.length).toEqual(1);
+    expect(carnetData.unusedArray.length).toEqual(10);
+    expect(carnetData.usedArray.length).toEqual(0);
+  });
+  it(`30 tickets, 11 used, not active.`, async () => {
+    const carnetData = calculateCarnetData(false, 30, 11);
+    expect(carnetData.accessesRemaining).toEqual(19);
+    expect(carnetData.multiCarnetArray.length).toEqual(1);
+    expect(carnetData.unusedArray.length).toEqual(9);
+    expect(carnetData.usedArray.length).toEqual(1);
+  });
+});
+
+describe('Carnet footer: 30 tickets, active', () => {
+  for (let i = 1; i < 10; i++) {
+    it(`30 tickets, ${i} used, active.`, async () => {
+      const carnetData = calculateCarnetData(true, 30, i);
+      expect(carnetData.accessesRemaining).toEqual(30 - i);
+      expect(carnetData.multiCarnetArray.length).toEqual(2);
+      expect(carnetData.unusedArray.length).toEqual(10 - i);
+      expect(carnetData.usedArray.length).toEqual(i - 1);
+    });
+  }
+  it(`30 tickets, 10 used, active.`, async () => {
+    const carnetData = calculateCarnetData(true, 30, 10);
+    expect(carnetData.accessesRemaining).toEqual(20);
+    expect(carnetData.multiCarnetArray.length).toEqual(2);
+    expect(carnetData.unusedArray.length).toEqual(0);
+    expect(carnetData.usedArray.length).toEqual(9);
+  });
+  it(`30 tickets, 11 used, active.`, async () => {
+    const carnetData = calculateCarnetData(true, 30, 11);
+    expect(carnetData.accessesRemaining).toEqual(19);
+    expect(carnetData.multiCarnetArray.length).toEqual(1);
+    expect(carnetData.unusedArray.length).toEqual(9);
+    expect(carnetData.usedArray.length).toEqual(0);
+  });
+});
+
+// These states are invalid, but we shouldn't crash if it happends. Make sure we
+// handle it gracefully.
+describe('Carnet footer: Invalid state', () => {
+  it(`10 tickets, 0 used, active.`, async () => {
+    const carnetData = calculateCarnetData(true, 10, 1);
+    expect(typeof carnetData.accessesRemaining).toEqual('number');
+    expect(typeof carnetData.multiCarnetArray.length).toEqual('number');
+    expect(typeof carnetData.unusedArray.length).toEqual('number');
+    expect(typeof carnetData.usedArray.length).toEqual('number');
+  });
+});

--- a/src/fare-contracts/carnet/calculate-carnet-data.ts
+++ b/src/fare-contracts/carnet/calculate-carnet-data.ts
@@ -53,10 +53,14 @@ export function calculateCarnetData(
     0,
   );
 
-  // Calculates the amount of dots showing for the used part
+  // Calculates the amount of dots showing for the used part. We show all as
+  // used only if every access has been used, otherwise we "expand the next"
+  // multicarnet.
   const numberOfUsedDots =
-    (numberOfUsedAccesses + numberOfAdditionalDots - activeAccess) %
-    CARNET_DIVIDER;
+    accessesRemaining === 0
+      ? CARNET_DIVIDER - activeAccess
+      : (numberOfUsedAccesses + numberOfAdditionalDots - activeAccess) %
+        CARNET_DIVIDER;
 
   // Calculates the amount of dots showing for the unused part
   const numberOfUnusedDots = CARNET_DIVIDER - numberOfUsedDots - activeAccess;

--- a/src/fare-contracts/carnet/calculate-carnet-data.ts
+++ b/src/fare-contracts/carnet/calculate-carnet-data.ts
@@ -1,0 +1,71 @@
+/**
+ * The number of accesses that should be displayed in a single row. To display
+ * the correct amount of consumed carnets, maximumNumberOfAccesses should be
+ * divisible by this number.
+ */
+export const CARNET_DIVIDER = 10;
+
+/**
+ * Get the arrays required to display the carnet footer dots.
+ * `multi-carnet dots --- unused dots --- active dots --- used dots`
+ *
+ * @param active the ticket status (active | inactive).
+ * @param maximumNumberOfAccesses total amount of available access that the carnet has.
+ * @param numberOfUsedAccesses total amount of used access that the carnet has.
+ * @returns values to display the carnet footer, it will be displayed in this order :
+ */
+export function calculateCarnetData(
+  active: boolean,
+  maximumNumberOfAccesses: number,
+  numberOfUsedAccesses: number,
+) {
+  // If the ticket status is active, it should be considered into calculation.
+  const activeAccess = active ? 1 : 0;
+
+  // Total number of remaining accesses, including multicarnets
+  const accessesRemaining = maximumNumberOfAccesses - numberOfUsedAccesses;
+
+  // If `maximumNumberOfAccesses` are not divisible by `CARNET_DIVIDER`, we need
+  // to add some extra dots, in order to not break the active dot position.
+  const padding =
+    Math.abs(CARNET_DIVIDER - maximumNumberOfAccesses) % CARNET_DIVIDER;
+
+  // Number of additional dots that should be added when the padding is there.
+  const numberOfAdditionalDots =
+    maximumNumberOfAccesses > CARNET_DIVIDER
+      ? CARNET_DIVIDER - padding
+      : padding;
+
+  // Determines whether we should add an extra multicarnet, due to the active
+  // carnet being the last one in the current set.
+  //
+  // Should only add extra carnet when:
+  // - accessesRemaining is divisible by CARNET_DIVIDER
+  // - status is currently active
+  const shouldAddExtraMultiCarnet =
+    accessesRemaining % CARNET_DIVIDER === 0 && active ? 1 : 0;
+
+  // Calculates the amount of dots showing for the multi-carnet part
+  const numberOfMultiCarnets =
+    Math.ceil(accessesRemaining / CARNET_DIVIDER - 1) +
+    shouldAddExtraMultiCarnet;
+
+  // Calculates the amount of dots showing for the used part
+  const numberOfUsedDots =
+    (numberOfUsedAccesses + numberOfAdditionalDots - activeAccess) %
+    CARNET_DIVIDER;
+
+  // Calculates the amount of dots showing for the unused part
+  const numberOfUnusedDots = CARNET_DIVIDER - numberOfUsedDots - activeAccess;
+
+  const multiCarnetArray = Array(numberOfMultiCarnets).fill(CARNET_DIVIDER);
+  const unusedArray = Array(numberOfUnusedDots).fill(true);
+  const usedArray = Array(numberOfUsedDots).fill(false);
+
+  return {
+    accessesRemaining,
+    multiCarnetArray,
+    unusedArray,
+    usedArray,
+  };
+}

--- a/src/fare-contracts/carnet/calculate-carnet-data.ts
+++ b/src/fare-contracts/carnet/calculate-carnet-data.ts
@@ -45,10 +45,13 @@ export function calculateCarnetData(
   const shouldAddExtraMultiCarnet =
     accessesRemaining % CARNET_DIVIDER === 0 && active ? 1 : 0;
 
-  // Calculates the amount of dots showing for the multi-carnet part
-  const numberOfMultiCarnets =
+  // Calculates the amount of dots showing for the multi-carnet part. Prevent
+  // negative when there are no accesses remaining.
+  const numberOfMultiCarnets = Math.max(
     Math.ceil(accessesRemaining / CARNET_DIVIDER - 1) +
-    shouldAddExtraMultiCarnet;
+      shouldAddExtraMultiCarnet,
+    0,
+  );
 
   // Calculates the amount of dots showing for the used part
   const numberOfUsedDots =

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -169,9 +169,9 @@ const FareContractTexts = {
   carnet: {
     numberOfUsedAccessesRemaining: (count: number) =>
       _(
-        `${count} klipp gjenstår`,
-        `${count} tickets left`,
-        `${count} klipp att`,
+        `${count} enkeltbilletter gjenstår`,
+        `${count} single ticket(s) left`,
+        `${count} enkeltbillettar att`,
       ),
   },
   receipt: {


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/16655

- Refactors how the display data for CarnetFooter is calculated
- Fixes several issues with CarnetFooter state for >10 accesses (see code comments for details)
- Adds unit tests to be sure it stays like that!

### Unit test output from `yarn test -t carnet --verbose`

```
  Carnet footer: 10 tickets
    ✓ 10 tickets, 0 used, not active. (2 ms)
    ✓ 10 tickets, 1 used, not active.
    ✓ 10 tickets, 2 used, not active.
    ✓ 10 tickets, 3 used, not active. (1 ms)
    ✓ 10 tickets, 4 used, not active.
    ✓ 10 tickets, 5 used, not active.
    ✓ 10 tickets, 6 used, not active.
    ✓ 10 tickets, 7 used, not active. (1 ms)
    ✓ 10 tickets, 8 used, not active.
    ✓ 10 tickets, 9 used, not active.
    ✓ 10 tickets, 10 used, not active.
    ✓ 10 tickets, 1 used, active. (1 ms)
    ✓ 10 tickets, 2 used, active.
    ✓ 10 tickets, 3 used, active.
    ✓ 10 tickets, 4 used, active.
    ✓ 10 tickets, 5 used, active. (1 ms)
    ✓ 10 tickets, 6 used, active.
    ✓ 10 tickets, 7 used, active.
    ✓ 10 tickets, 8 used, active.
    ✓ 10 tickets, 9 used, active. (1 ms)
    ✓ 10 tickets, 10 used, active. (1 ms)
  Carnet footer: 30 tickets, not active
    ✓ 30 tickets, 0 used, not active.
    ✓ 30 tickets, 1 used, not active.
    ✓ 30 tickets, 2 used, not active.
    ✓ 30 tickets, 3 used, not active.
    ✓ 30 tickets, 4 used, not active.
    ✓ 30 tickets, 5 used, not active. (1 ms)
    ✓ 30 tickets, 6 used, not active.
    ✓ 30 tickets, 7 used, not active.
    ✓ 30 tickets, 8 used, not active.
    ✓ 30 tickets, 9 used, not active.
    ✓ 30 tickets, 10 used, not active.
    ✓ 30 tickets, 11 used, not active.
  Carnet footer: 30 tickets, active
    ✓ 30 tickets, 1 used, active. (1 ms)
    ✓ 30 tickets, 2 used, active.
    ✓ 30 tickets, 3 used, active.
    ✓ 30 tickets, 4 used, active.
    ✓ 30 tickets, 5 used, active.
    ✓ 30 tickets, 6 used, active.
    ✓ 30 tickets, 7 used, active.
    ✓ 30 tickets, 8 used, active.
    ✓ 30 tickets, 9 used, active.
    ✓ 30 tickets, 10 used, active.
    ✓ 30 tickets, 11 used, active.
  Carnet footer: Padded when not divisible by 10
    ✓ 13 tickets, 1 used, not active.
    ✓ 13 tickets, 3 used, not active.
    ✓ 13 tickets, 3 used, active.
  Carnet footer: Invalid state
    ✓ 10 tickets, 0 used, active.
```