### PR TITLE
feat: add support for showing product alias in product selection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelection.tsx
@@ -28,6 +28,15 @@ export function ProductSelection({
         />
       );
     case 'productAlias':
+      return (
+        <ProductSelectionByProducts
+          selectedProduct={preassignedFareProduct}
+          fareProductTypeConfig={fareProductTypeConfig}
+          setSelectedProduct={setSelectedProduct}
+          style={style}
+          useAlias={true}
+        />
+      );
     case 'duration':
       return (
         <ProductSelectionByAlias

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -28,6 +28,7 @@ type ProductSelectionByProductsProps = {
   fareProductTypeConfig: FareProductTypeConfig;
   setSelectedProduct: (product: PreassignedFareProduct) => void;
   style?: StyleProp<ViewStyle>;
+  useAlias?: boolean;
 };
 
 export function ProductSelectionByProducts({
@@ -35,6 +36,7 @@ export function ProductSelectionByProducts({
   fareProductTypeConfig,
   setSelectedProduct,
   style,
+  useAlias,
 }: ProductSelectionByProductsProps) {
   const {t, language} = useTranslation();
   const {preassignedFareProducts} = useFirestoreConfiguration();
@@ -50,6 +52,14 @@ export function ProductSelectionByProducts({
     useTextForLanguage(
       fareProductTypeConfig.configuration.productSelectionTitle,
     ) || t(PurchaseOverviewTexts.productSelection.title);
+
+  const aliasText = useAlias
+    ? getTextForLanguage(selectedProduct.productAlias, language)
+    : undefined;
+
+  const productName = aliasText
+    ? aliasText
+    : getReferenceDataName(selectedProduct, language);
 
   const subText = (fp: PreassignedFareProduct) => {
     const descriptionMessage = getTextForLanguage(fp.description, language);
@@ -89,7 +99,7 @@ export function ProductSelectionByProducts({
           <ContentHeading text={title} />
           <Section>
             <HeaderSectionItem
-              text={getReferenceDataName(selectedProduct, language)}
+              text={productName}
               subtitle={subText(selectedProduct)}
             />
           </Section>


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/12059

This PR will implement the use of `productAlias` on the `fareProductTypeConfig`. I reused the `ProductSelectionByProducts` component instead of making a new one since we can just use a flag for it to reduce code duplication.

This will display the `productAlias` declared in the `preassignedFareProduct` instead of `name`. 

For example, with the data below in `preassignedFareProduct`:

```
      "name": {
        "lang": "nob",
        "value": "Klippekort"
      },
      "productAlias": [
        {
          "lang": "nob",
          "value": "10 enkeltbilletter"
        },
        {
          "lang": "eng",
          "value": "10 single tickets"
        }
      ],
```

by using `productAlias` as the `productSelectionMode`, it will display `10 enkeltbilletter` instead of `Klippekort`. (se skjermbilde)

### `productAlias` (left) vs `product`(right)                   
<img width="300" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/16d78291-e5eb-4104-8f63-68412c843d2b">
<img width="300" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/1b1bf374-3e3d-4b2c-97a5-8d5f7caf46ac">

