### PR TITLE
fix: Simulator crashes during onboarding for beacons 

### DIFF
--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -159,8 +159,10 @@ const BeaconsContextProvider: React.FC = ({children}) => {
       if (permissionsGranted) {
         // Initialize beacons SDK after consent is granted
         await initializeKettleSDK(false);
-        Kettle.grant(BEACONS_CONSENTS);
-        await updateBeaconsInfo();
+        if (isInitializedRef.current) {
+          Kettle.grant(BEACONS_CONSENTS);
+          await updateBeaconsInfo();
+        }
 
         // If consent wasn't set above, set it to true now
         if (!alreadyConsented) {
@@ -178,10 +180,8 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     if (!isBeaconsSupported) return;
     await initializeKettleSDK(true);
     stopBeacons();
-    if (isInitializedRef.current) {
-      Kettle.revoke(BEACONS_CONSENTS);
-      await updateBeaconsInfo();
-    }
+    Kettle.revoke(BEACONS_CONSENTS);
+    await updateBeaconsInfo();
     await storage.set(storeKey.beaconsConsent, 'false');
     setIsConsentGranted(false);
   }, [isBeaconsSupported, stopBeacons, initializeKettleSDK]);
@@ -189,11 +189,9 @@ const BeaconsContextProvider: React.FC = ({children}) => {
   const deleteCollectedData = useCallback(async () => {
     if (!isBeaconsSupported) return;
     await initializeKettleSDK(true);
-    if (isInitializedRef.current) {
-      await Kettle.deleteCollectedData().catch((error) => {
-        Bugsnag.notify(error);
-      });
-    }
+    await Kettle.deleteCollectedData().catch((error) => {
+      Bugsnag.notify(error);
+    });
   }, [isBeaconsSupported, initializeKettleSDK]);
 
   useEffect(() => {

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -189,7 +189,7 @@ const BeaconsContextProvider: React.FC = ({children}) => {
   const deleteCollectedData = useCallback(async () => {
     if (!isBeaconsSupported) return;
     await initializeKettleSDK(true);
-    await Kettle.deleteCollectedData().catch((error) => {
+    Kettle.deleteCollectedData().catch((error) => {
       Bugsnag.notify(error);
     });
   }, [isBeaconsSupported, initializeKettleSDK]);

--- a/src/beacons/BeaconsContext.tsx
+++ b/src/beacons/BeaconsContext.tsx
@@ -181,9 +181,9 @@ const BeaconsContextProvider: React.FC = ({children}) => {
     await initializeKettleSDK(true);
     stopBeacons();
     Kettle.revoke(BEACONS_CONSENTS);
-    await updateBeaconsInfo();
     await storage.set(storeKey.beaconsConsent, 'false');
     setIsConsentGranted(false);
+    await updateBeaconsInfo();
   }, [isBeaconsSupported, stopBeacons, initializeKettleSDK]);
 
   const deleteCollectedData = useCallback(async () => {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17005

NOTE: This solution makes sure for some cases where the initialization of the SDK is called but not started because lack of permissions on the simulator, so then make sure that only run Kettle of SDK was initialized.