### PR TITLE
refactor: update ticketing util function to be more reusable

### DIFF
--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -29,7 +29,7 @@ import {
   isCanBeConsumedNowFareContract,
   isSentOrReceivedFareContract,
 } from '@atb/ticketing';
-import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetButton';
+import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetSectionItem';
 
 type Props = {
   now: number;

--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -2,7 +2,7 @@ import {
   findReferenceDataById,
   useFirestoreConfiguration,
 } from '@atb/configuration';
-import {FareContract, FareContractState} from '../ticketing/types';
+import {FareContract} from '../ticketing/types';
 import {
   getFareContractInfo,
   mapToUserProfilesWithCount,
@@ -25,7 +25,10 @@ import {useMobileTokenContextState} from '@atb/mobile-token';
 import {useOperatorBenefitsForFareProduct} from '@atb/mobility/use-operator-benefits-for-fare-product';
 import {UsedAccessValidityHeader} from '@atb/fare-contracts/carnet/UsedAccessValidityHeader';
 import {CarnetFooter} from '@atb/fare-contracts/carnet/CarnetFooter';
-import {isSentOrReceivedFareContract} from '@atb/ticketing';
+import {
+  isCanBeConsumedNowFareContract,
+  isSentOrReceivedFareContract,
+} from '@atb/ticketing';
 import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetButton';
 
 type Props = {
@@ -168,10 +171,9 @@ export const FareContractView: React.FC<Props> = ({
           testID={testID + 'Details'}
         />
       )}
-      {isCarnetFareContract &&
-        fareContract.state === FareContractState.NotActivated && (
-          <ConsumeCarnetSectionItem fareContractId={fareContract.id} />
-        )}
+      {isCanBeConsumedNowFareContract(fareContract, now) && (
+        <ConsumeCarnetSectionItem fareContractId={fareContract.id} />
+      )}
     </Section>
   );
 };

--- a/src/fare-contracts/components/ConsumeCarnetSectionItem.tsx
+++ b/src/fare-contracts/components/ConsumeCarnetSectionItem.tsx
@@ -7,14 +7,14 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ConsumeCarnetBottomSheet} from './ConsumeCarnetBottomSheet';
 
-type ConsumeCarnetButtonProps = SectionItemProps<{
+type ConsumeCarnetSectionItemProps = SectionItemProps<{
   fareContractId: string;
 }>;
 
 export function ConsumeCarnetSectionItem({
   fareContractId,
   ...sectionProps
-}: ConsumeCarnetButtonProps): JSX.Element {
+}: ConsumeCarnetSectionItemProps): JSX.Element {
   const {t} = useTranslation();
   const {theme} = useTheme();
 

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   FareContract,
-  FareContractState,
+  isCanBeConsumedNowFareContract,
   isPreActivatedTravelRight,
   isSentOrReceivedFareContract,
   NormalTravelRight,
@@ -237,10 +237,9 @@ export const DetailsContent: React.FC<Props> = ({
           accessibility={{accessibilityRole: 'button'}}
           testID="receiptButton"
         />
-        {isCarnetFareContract &&
-          fc.state === FareContractState.NotActivated && (
-            <ConsumeCarnetSectionItem fareContractId={fc.id} />
-          )}
+        {isCanBeConsumedNowFareContract(fc, now) && (
+          <ConsumeCarnetSectionItem fareContractId={fc.id} />
+        )}
       </Section>
     );
   } else {

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -46,7 +46,7 @@ import {MobilityBenefitsActionSectionItem} from '@atb/mobility/components/Mobili
 import {useOperatorBenefitsForFareProduct} from '@atb/mobility/use-operator-benefits-for-fare-product';
 import {ValidityLine} from '../ValidityLine';
 import {ValidityHeader} from '../ValidityHeader';
-import {ConsumeCarnetSectionItem} from '../components/ConsumeCarnetButton';
+import {ConsumeCarnetSectionItem} from '../components/ConsumeCarnetSectionItem';
 
 type Props = {
   fareContract: FareContract;

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -171,6 +171,15 @@ function isActiveNowOrCanBeUsedFareContract(f: FareContract, now: number) {
   return false;
 }
 
+export function isCanBeConsumedNowFareContract(f: FareContract, now: number) {
+  if (!isCarnet(f)) return false;
+  const travelRights = f.travelRights.filter(isCarnetTravelRight);
+  return (
+    hasUsableCarnetTravelRight(travelRights, now) &&
+    !hasActiveCarnetTravelRight(travelRights, now)
+  );
+}
+
 export const filterActiveOrCanBeUsedFareContracts = (
   fareContracts: FareContract[],
   now: number,

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -92,21 +92,35 @@ export function isSentOrReceivedFareContract(fc: FareContract) {
   return fc.customerAccountId !== fc.purchasedBy;
 }
 
-export function hasActiveOrUsableCarnetTravelRight(
+export function hasUsableCarnetTravelRight(
   travelRights: CarnetTravelRight[],
-): boolean {
-  const [firstTravelRight] = travelRights;
-  const {usedAccesses, maximumNumberOfAccesses, numberOfUsedAccesses} =
+  now: number,
+) {
+  // Travel right has not expired
+  if (
+    travelRights.some((travelRight) => now > travelRight.endDateTime.toMillis())
+  )
+    return false;
+
+  // There are remaining accesses
+  const {maximumNumberOfAccesses, numberOfUsedAccesses} =
     flattenCarnetTravelRightAccesses(travelRights);
+  if (maximumNumberOfAccesses <= numberOfUsedAccesses) return false;
 
-  const [lastUsedAccess] = usedAccesses?.slice(-1);
-  const validTo = lastUsedAccess?.endDateTime.toMillis() ?? 0;
-  const now = Date.now();
+  return true;
+}
 
-  return (
-    now < validTo ||
-    (firstTravelRight.endDateTime.toMillis() > now &&
-      maximumNumberOfAccesses > numberOfUsedAccesses)
+export function hasActiveCarnetTravelRight(
+  travelRights: CarnetTravelRight[],
+  now: number,
+) {
+  // Some travel right have some active access
+  return travelRights.some((travelRight) =>
+    travelRight.usedAccesses.some(
+      (access) =>
+        now > access.startDateTime.toMillis() &&
+        now < access.endDateTime.toMillis(),
+    ),
   );
 }
 
@@ -138,10 +152,7 @@ export function flattenCarnetTravelRightAccesses(
   };
 }
 
-function isActiveFareContractNowOrCanBeUsed(
-  f: FareContract,
-  now: number,
-): boolean {
+function isActiveNowOrCanBeUsedFareContract(f: FareContract, now: number) {
   if (!isOrWillBeActivatedFareContract(f)) {
     return false;
   }
@@ -150,8 +161,10 @@ function isActiveFareContractNowOrCanBeUsed(
   if (isPreActivatedTravelRight(firstTravelRight)) {
     return isValidPreActivatedTravelRight(firstTravelRight, now);
   } else if (isCarnetTravelRight(firstTravelRight)) {
-    return hasActiveOrUsableCarnetTravelRight(
-      f.travelRights.filter(isCarnetTravelRight),
+    const travelRights = f.travelRights.filter(isCarnetTravelRight);
+    return (
+      hasActiveCarnetTravelRight(travelRights, now) ||
+      hasUsableCarnetTravelRight(travelRights, now)
     );
   }
 
@@ -163,7 +176,7 @@ export const filterActiveOrCanBeUsedFareContracts = (
   now: number,
 ) => {
   return fareContracts.filter((f) =>
-    isActiveFareContractNowOrCanBeUsed(f, now),
+    isActiveNowOrCanBeUsedFareContract(f, now),
   );
 };
 
@@ -190,7 +203,7 @@ export const filterExpiredFareContracts = (
   const isRefunded = (f: FareContract) =>
     f.state === FareContractState.Refunded;
   const isExpiredOrRefunded = (f: FareContract) =>
-    !isActiveFareContractNowOrCanBeUsed(f, now) || isRefunded(f);
+    !isActiveNowOrCanBeUsedFareContract(f, now) || isRefunded(f);
   return fareContracts.filter(isExpiredOrRefunded);
 };
 


### PR DESCRIPTION
- The main change here is to split `hasActiveOrUsableCarnetTravelRight()` into two smaller util functions that when used together, can achieve more granular functionality.
- Since fare contract state doesn't give the wanted data for showing ConsumeCarnetSectionItemProps, we now check active state based on `usedAccesses` trough `isCanBeConsumedNowFareContract`.
- Fixes some naming issues (https://github.com/AtB-AS/mittatb-app/pull/4339#discussion_r1497688948)

fixes https://github.com/AtB-AS/kundevendt/issues/12562