### PR TITLE
fix: make used carnet dots pixel perfect

### DIFF
--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -50,7 +50,9 @@ export const CarnetFooter: React.FC<Props> = ({
         ))}
         {active && (
           <View style={styles.dot}>
-            <View style={styles.dotFill__active} />
+            <View style={styles.dotFill__activeViewBox}>
+              <View style={styles.dotFill__activeFill} />
+            </View>
           </View>
         )}
         {usedArray.map((_, idx) => (
@@ -120,12 +122,17 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   dot__unused: {
     backgroundColor: theme.static.background.background_0.background,
   },
-  dotFill__active: {
-    borderTopRightRadius: 20,
-    borderBottomRightRadius: 20,
+  dotFill__activeViewBox: {
     height: '100%',
     width: '50%',
-    marginLeft: '50%',
+    overflow: 'hidden',
+    alignSelf: 'flex-end',
+  },
+  dotFill__activeFill: {
+    borderRadius: 20,
+    height: '100%',
+    width: '200%',
+    alignSelf: 'flex-end',
     backgroundColor: theme.static.background.background_0.background,
   },
 }));


### PR DESCRIPTION
In order to make the app usable for our pixel-peeping customers like myself, this PR fixes the radius of active carnet dots ✨ 

### Before 😢 

![IMG_3065](https://github.com/AtB-AS/mittatb-app/assets/1774972/dd6b657a-8edc-42e1-914f-9cc0936c6c9a)

### After 🤩 

![IMG_3066](https://github.com/AtB-AS/mittatb-app/assets/1774972/3de36069-973d-4b16-92e3-5291a54e8c57)
