### PR TITLE
fix: give receipt LinkSectionItem a11y role "link" instead of "button"

### DIFF
--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -234,7 +234,6 @@ export const DetailsContent: React.FC<Props> = ({
         <LinkSectionItem
           text={t(FareContractTexts.details.askForReceipt)}
           onPress={onReceiptNavigate}
-          accessibility={{accessibilityRole: 'button'}}
           testID="receiptButton"
         />
         {isCanBeConsumedNowFareContract(fc, now) && (


### PR DESCRIPTION
@HanneLH Noticed an inconsistency between the "Get receipt sent" button and "Activate single ticket" LinkSectionItem in ticket details. One said had accessibilityRole "button" and the other "link". 

> - Links take the user to a new location, such as a new web page or new section of the current page.
> - Buttons trigger some action, such as showing content on the page that was previously hidden, playing a video, or submitting a form.
>
> https://www.washington.edu/accesstech/websites/links-buttons/

I think "link" makes the most sense in both cases, given that opening a bottom sheet is considered a new page and not "showing content on the page that was previously hidden".

There are probably lots of inconsistencies around this in the app, this is just one that showed up while testing https://github.com/AtB-AS/kundevendt/issues/12562