### PR TITLE
feat: add global message for carnet tickets summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^3.15.0",
+    "@atb-as/config-specs": "^3.16.0",
     "@atb-as/generate-assets": "^10.0.0",
     "@atb-as/theme": "^8.0.0",
     "@bugsnag/react-native": "^7.21.0",

--- a/src/components/message-info-text/MessageInfoText.tsx
+++ b/src/components/message-info-text/MessageInfoText.tsx
@@ -4,7 +4,7 @@ import {Statuses, StyleSheet} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
-import {StaticColor} from '@atb/theme/colors';
+import {StaticColor, TextColor} from '@atb/theme/colors';
 
 export type MessageInfoTextProps = {
   type: Statuses;
@@ -12,7 +12,7 @@ export type MessageInfoTextProps = {
   style?: StyleProp<ViewStyle>;
   testID?: string;
   iconPosition?: 'right' | 'left';
-  textColor?: StaticColor;
+  textColor?: StaticColor | TextColor;
   isMarkdown?: boolean;
 };
 

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -11,7 +11,7 @@ import {getTextForLanguage} from '@atb/translations';
 import {useNow} from '@atb/utils/use-now';
 import {isWithinTimeRange} from '@atb/utils/is-within-time-range';
 import {RuleVariables} from '../rule-engine/rules';
-import {StaticColor} from '@atb/theme/colors';
+import {StaticColor, TextColor} from '@atb/theme/colors';
 import {MessageInfoText} from '@atb/components/message-info-text';
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   includeDismissed?: boolean;
   ruleVariables?: RuleVariables;
-  textColor: StaticColor;
+  textColor: StaticColor | TextColor;
 };
 
 const GlobalMessage = ({
@@ -70,6 +70,7 @@ const GlobalMessage = ({
                   message={message}
                   textColor={textColor}
                   isMarkdown={true}
+                  style={style}
                   testID="globalMessage"
                 />
               ) : (

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -10,6 +10,7 @@ export enum GlobalMessageContextEnum {
   appDepartures = 'app-departures',
   appTicketing = 'app-ticketing',
   appPurchaseOverview = 'app-purchase-overview',
+  appPurchaseConfirmation = 'app-purchase-confirmation',
   appFareContractDetails = 'app-fare-contract-details',
   appDepartureDetails = 'app-departure-details',
   appTripDetails = 'app-trip-details',
@@ -31,7 +32,7 @@ export type GlobalMessageRaw = {
   startDate?: FirebaseFirestoreTypes.Timestamp;
   endDate?: FirebaseFirestoreTypes.Timestamp;
   rules?: Rule[];
-}
+};
 
 export type GlobalMessageType = Omit<
   GlobalMessageRaw,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -41,11 +41,11 @@ import {CardPaymentMethod, PaymentMethod, SavedPaymentOption} from '../types';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {useAnalytics} from '@atb/analytics';
-import {Info} from '@atb/assets/svg/color/icons/status';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {GlobalMessageContextEnum} from '@atb/global-messages';
+import {GlobalMessage, GlobalMessageContextEnum} from '@atb/global-messages';
 import {useShowValidTimeInfoEnabled} from '../Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-show-valid-time-info-enabled';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {MessageInfoText} from '@atb/components/message-info-text';
 
 function getPreviousPaymentMethod(
   previousPaymentMethod: SavedPaymentOption | undefined,
@@ -168,6 +168,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
         ),
       )
     : t(PurchaseConfirmationTexts.travelDate.now);
+
+  const isCarnet = preassignedFareProduct.type === 'carnet';
 
   useEffect(() => {
     const prevMethod = getPreviousPaymentMethod(
@@ -346,7 +348,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           )}
           <Section>
             <GenericSectionItem>
-              <View accessible={true}>
+              <View accessible={true} style={styles.ticketInfoContainer}>
                 <ThemeText>
                   {getReferenceDataName(preassignedFareProduct, language)}
                 </ThemeText>
@@ -364,6 +366,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                 {!isSearchingOffer &&
                   validDurationSeconds &&
                   isShowValidTimeInfoEnabled &&
+                  !isCarnet &&
                   summary(
                     t(
                       PurchaseConfirmationTexts.validityTexts.time(
@@ -378,17 +381,27 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                         .onlyOnPhone,
                     ),
                   )}
-
-                <View style={[styles.smallTopMargin, {flexDirection: 'row'}]}>
-                  <Info
-                    height={theme.icon.size.normal}
-                    width={theme.icon.size.normal}
-                    style={{marginRight: theme.spacings.small}}
+                {isCarnet ? (
+                  <GlobalMessage
+                    style={styles.globalMessage}
+                    globalMessageContext={
+                      GlobalMessageContextEnum.appPurchaseConfirmation
+                    }
+                    textColor="secondary"
+                    ruleVariables={{
+                      preassignedFareProductType: preassignedFareProduct.type,
+                      fromTariffZone: fromPlace.id,
+                      toTariffZone: toPlace.id,
+                    }}
                   />
-                  <ThemeText type="body__secondary" color="secondary">
-                    {travelDateText}
-                  </ThemeText>
-                </View>
+                ) : (
+                  <MessageInfoText
+                    style={styles.smallTopMargin}
+                    type="info"
+                    message={travelDateText}
+                    textColor="secondary"
+                  />
+                )}
               </View>
             </GenericSectionItem>
           </Section>
@@ -650,6 +663,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   sendingToText: {
     marginTop: theme.spacings.xSmall,
   },
+  ticketInfoContainer: {
+    flex: 1,
+  },
   totalPaymentContainer: {
     flexDirection: 'row',
     width: '100%',
@@ -658,6 +674,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   totalContainerHeadings: {
     paddingVertical: theme.spacings.xSmall,
+  },
+  globalMessage: {
+    marginTop: theme.spacings.small,
   },
   smallTopMargin: {
     marginTop: theme.spacings.xSmall,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -388,12 +388,14 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                     preassignedFareProductType: preassignedFareProduct.type,
                   }}
                 />
-                <MessageInfoText
-                  style={styles.smallTopMargin}
-                  type="info"
-                  message={travelDateText}
-                  textColor="secondary"
-                />
+                {!fareProductTypeConfig.isCollectionOfAccesses && (
+                  <MessageInfoText
+                    style={styles.smallTopMargin}
+                    type="info"
+                    message={travelDateText}
+                    textColor="secondary"
+                  />
+                )}
               </View>
             </GenericSectionItem>
           </Section>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -169,8 +169,6 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
       )
     : t(PurchaseConfirmationTexts.travelDate.now);
 
-  const isCarnet = preassignedFareProduct.type === 'carnet';
-
   useEffect(() => {
     const prevMethod = getPreviousPaymentMethod(
       previousPaymentMethod,
@@ -366,7 +364,6 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                 {!isSearchingOffer &&
                   validDurationSeconds &&
                   isShowValidTimeInfoEnabled &&
-                  !isCarnet &&
                   summary(
                     t(
                       PurchaseConfirmationTexts.validityTexts.time(
@@ -381,27 +378,22 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                         .onlyOnPhone,
                     ),
                   )}
-                {isCarnet ? (
-                  <GlobalMessage
-                    style={styles.globalMessage}
-                    globalMessageContext={
-                      GlobalMessageContextEnum.appPurchaseConfirmation
-                    }
-                    textColor="secondary"
-                    ruleVariables={{
-                      preassignedFareProductType: preassignedFareProduct.type,
-                      fromTariffZone: fromPlace.id,
-                      toTariffZone: toPlace.id,
-                    }}
-                  />
-                ) : (
-                  <MessageInfoText
-                    style={styles.smallTopMargin}
-                    type="info"
-                    message={travelDateText}
-                    textColor="secondary"
-                  />
-                )}
+                <GlobalMessage
+                  style={styles.globalMessage}
+                  globalMessageContext={
+                    GlobalMessageContextEnum.appPurchaseConfirmation
+                  }
+                  textColor="secondary"
+                  ruleVariables={{
+                    preassignedFareProductType: preassignedFareProduct.type,
+                  }}
+                />
+                <MessageInfoText
+                  style={styles.smallTopMargin}
+                  type="info"
+                  message={travelDateText}
+                  textColor="secondary"
+                />
               </View>
             </GenericSectionItem>
           </Section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^3.15.0":
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.15.0.tgz#efc056970f3591518e0ff7934a1d68247ce188a2"
-  integrity sha512-MUSQBKKqvxz+deFe1GVlZFHbdcleKr1yW76CIUEsz3XQqrKR0xtSwcfO8iNx2hwhUbhdj1yO2WrhMGiK9L3QpA==
+"@atb-as/config-specs@^3.16.0":
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.16.0.tgz#c0693176ad894283a99eca421c9d158436e9f9bb"
+  integrity sha512-+xmB4zKpAWumMjmbwu2Mpyzm5gkejZC2+f+dc1hFQrQnyCcv+6BOIfKfqUs52ziJqzeK2l4YSUlaqqB8lkrrkQ==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/12547

This PR will : 

- Introduce global message on Purchase Confirmation screen.
- Adds a new global message context: `app-purchase-confirmation`.
- Add `TextColor` to `MessageInfoBox`, there was no way to give `secondary` color to the text component otherwise, none of the colors in `StaticColor` works.
- Add styling to necessary parts of `Root_PurchaseConfirmationScreen.tsx`, the flex part is necessary to make the text rendered correctly, especially line wrap on long text.
- Since we cannot get the carnet validity through the offer (only shows the validity of single ticket), we use global message to display the validity time.
- utilize the new `isCollectionOfAccesses` field for fareProductTypeConfig, to determine whether a ticket is a collection of travel access or not. If the value is true, do not show the start period (Oppstart nå information).

Some previews: 

### Klippekort
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/1c1a4107-f2e3-4767-840e-d8606d104916)

### Enkeltbillett
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/8cd3d000-5d0d-4286-aa63-c3e523c0b3fb)

### Periodebillett (30-dagersbillett, oppstart senere)
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/8c04d624-6eb2-49c7-b00e-ac7e88933b4f)

### Enkeltbillett Hurtigbåt
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/c95389f7-9834-40a9-ae33-925289a210e9)