### PR TITLE
fix: Correct value for token refresh percentage

### DIFF
--- a/src/mobile-token/mobileTokenClient.ts
+++ b/src/mobile-token/mobileTokenClient.ts
@@ -39,8 +39,8 @@ export const mobileTokenClient = {
   Check if token should be renewed. Will return true if either:
    - Token is expired
    - It is less than 12 hours until token expires
-   - More than 90 % of the token validity time has expired
+   - Less than 10 % of the token validity time is left
    */
   shouldRenew: (token: ActivatedToken) =>
-    abtClient.shouldPreemptiveRenew(token, TWELVE_HOURS_MS, 90),
+    abtClient.shouldPreemptiveRenew(token, TWELVE_HOURS_MS, 10),
 };


### PR DESCRIPTION
The refresh percentage should be 10 instead of 90. With the value
we had the 30 day token was renewed after 3 days, and not after 27
days as intended.

### Acceptance criteria
- [ ] A token should be renewed if the app is opened while less than 10 percent of the total validity period for the token is remaining

Note that changing the validity periods in BackOffice won't help, as it is the validity period on the local token that is evaluated. If we want to test this in a quicker manner than waiting many days we could modify the token-server in staging to create tokens with shorter validity days than 30.