### PR TITLE
fix: OMS translations for the on-behalf-of feature

### DIFF
--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
@@ -12,8 +12,8 @@ import {
   PhoneInputTexts,
   PurchaseOverviewTexts,
   useTranslation,
+  OnBehalfOfTexts,
 } from '@atb/translations';
-import {OnBehalfOfTexts} from '@atb/translations/screens/subscreens/OnBehalfOf';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import phone from 'phone';
 import {useState} from 'react';

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -63,3 +63,4 @@ export {default as LoadingScreenTexts} from './screens/LoadingScreen';
 export {default as DeparturesTexts} from './screens/Departures';
 export {default as GeoLocationTexts} from './GeoLocation';
 export {default as PhoneInputTexts} from './components/PhoneInput';
+export {default as OnBehalfOfTexts} from './screens/subscreens/OnBehalfOf';

--- a/src/translations/screens/subscreens/OnBehalfOf.ts
+++ b/src/translations/screens/subscreens/OnBehalfOf.ts
@@ -1,6 +1,7 @@
+import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
 import {translation as _} from '../../commons';
 
-export const OnBehalfOfTexts = {
+const OnBehalfOfTexts = {
   chooseReceiver: {
     header: _('Kjøp til andre', 'Buy for others', 'Kjøp til andre'),
     title: _(
@@ -20,3 +21,24 @@ export const OnBehalfOfTexts = {
     ),
   },
 };
+
+export default orgSpecificTranslations(OnBehalfOfTexts, {
+  nfk: {
+    chooseReceiver: {
+      subtitle: _(
+        'Den du kjøper billett til, må være innlogget i Reis-appen for å få billetten.',
+        'The person receiving the ticket must be logged in to the Reis app to get the ticket.',
+        'Den du kjøper billett til, må vere logga inn i Reis-appen for å få billetten.',
+      ),
+    },
+  },
+  fram: {
+    chooseReceiver: {
+      subtitle: _(
+        'Den du kjøper billett til, må være innlogget i FRAM-appen for å få billetten.',
+        'The person receiving the ticket must be logged in to the FRAM app to get the ticket.',
+        'Den du kjøper billett til, må vere logga inn i FRAM-appen for å få billetten.',
+      ),
+    },
+  },
+});

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -288,6 +288,13 @@ export default orgSpecificTranslations(PurchaseOverviewTexts, {
       'When traveling, you need to bring the travel card registered on your profile.',
       'Når du er på reise, må du ha med deg reisekortet som er registrert på profilen din.',
     ),
+    onBehalfOf: {
+      sectionSubText: _(
+        'Den du kjøper billett til, må være innlogget i Reis-appen for å få billetten.',
+        'The person you buy a ticket for, must be logged in to the Reis app to get the ticket.',
+        'Den du kjøper billett til, må vere logga inn i Reis-appen for å få billetten.',
+      ),
+    },
   },
   fram: {
     warning: _(
@@ -295,5 +302,12 @@ export default orgSpecificTranslations(PurchaseOverviewTexts, {
       'When traveling, you need to bring the travel card registered on your user.',
       'Når du er på reise, må du ha med deg reisekortet som er registrert på brukeren din.',
     ),
+    onBehalfOf: {
+      sectionSubText: _(
+        'Den du kjøper billett til, må være innlogget i FRAM-appen for å få billetten.',
+        'The person you buy a ticket for, must be logged in to the FRAM app to get the ticket.',
+        'Den du kjøper billett til, må vere logga inn i FRAM-appen for å få billetten.',
+      ),
+    },
   },
 });


### PR DESCRIPTION
There are two references to the AtB-app in the app for the OMS partners. Adding `orgSpecificTranslations` fixes this. 

Closes https://github.com/AtB-AS/kundevendt/issues/17056