### PR TITLE
fix: Update the position always on prompt text

### DIFF
--- a/src/translations/screens/ShareTravelHabits.ts
+++ b/src/translations/screens/ShareTravelHabits.ts
@@ -46,7 +46,7 @@ const ShareTravelHabitsTexts = {
     locationAlways: {
       title: _('Posisjon', 'Location', 'Posisjon'),
       message: _(
-        'I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring når appen er lukket om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.'
+        'I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring når appen er lukket om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
         'In addition to being able to show your location on maps and to plan journeys, we will gain valuable learning when the app is closed about where you and other customers travel. The data is used to improve our services to make them better for you.',
         'I tillegg til å kunne vise posisjonen din i kart og til å planleggje reiser, vil vi få verdifull læring når appen er lukka om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet.',
       ),

--- a/src/translations/screens/ShareTravelHabits.ts
+++ b/src/translations/screens/ShareTravelHabits.ts
@@ -46,9 +46,9 @@ const ShareTravelHabitsTexts = {
     locationAlways: {
       title: _('Posisjon', 'Location', 'Posisjon'),
       message: _(
-        'I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.',
-        'In addition to being able to show your position on maps and to plan journeys, we will gain valuable learning about where you and other customers travel. The data is used to improve our services to make them better for you.',
-        'I tillegg til å kunne vise posisjonen din i kart og til å planleggje reiser, vil vi få verdifull læring om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet.',
+        'I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring når appen er lukket om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.'
+        'In addition to being able to show your location on maps and to plan journeys, we will gain valuable learning when the app is closed about where you and other customers travel. The data is used to improve our services to make them better for you.',
+        'I tillegg til å kunne vise posisjonen din i kart og til å planleggje reiser, vil vi få verdifull læring når appen er lukka om kor du og andre kundar reiser. Det vil hjelpe oss til å kunne forbetre reisetilbodet.',
       ),
     },
     locationWhenInUse: {


### PR DESCRIPTION
After the rejected Google submission, they asked us to change the location always on prompt. We have to include either `background`, `when the app is closed`, `always in use` or `when the app is not in use`.

The text has been changed by Marked.

See more in the Slack [thread](https://mittatb.slack.com/archives/C02EEG7D8EL/p1708787438664609).