### PR TITLE
fix: typo in geolocation prompt

### DIFF
--- a/src/translations/GeoLocation.ts
+++ b/src/translations/GeoLocation.ts
@@ -13,9 +13,9 @@ const GeoLocationTexts = {
       'Vi brukar posisjon for å vise posisjonen din i kart og reisesøk, og for å finne holdeplassar og stader i nærleiken.',
     ),
     goToSettings: _(
-      'Gå til instillinger',
+      'Gå til innstillinger',
       'Go to settings',
-      'Gå til instillingar',
+      'Gå til innstillingar',
     ),
     cancel: _('Avbryt', 'Cancel', 'Avbryt'),
   },


### PR DESCRIPTION
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/530d0ccf-c903-4fe4-9707-e3c7f7f74ccd">
