### PR TITLE
refactor: change LinkSectionItem a11y role to button

### DIFF
--- a/src/chat/ContactSheet.tsx
+++ b/src/chat/ContactSheet.tsx
@@ -48,6 +48,7 @@ export const ContactSheet = ({onReportParkingViolation}: Props) => {
               accessibilityHint={t(
                 ContactSheetTexts.customer_feedback_website.a11yHint,
               )}
+              accessibilityRole="link"
               rightIcon={{svg: ExternalLink}}
               onPress={() => {
                 Linking.openURL(customer_feedback_url);
@@ -87,6 +88,7 @@ export const ContactSheet = ({onReportParkingViolation}: Props) => {
             accessibilityHint={t(ContactSheetTexts.customer_service.a11yHint)}
             mode="secondary"
             rightIcon={{svg: ExternalLink}}
+            accessibilityRole="link"
             onPress={() => {
               Linking.openURL(customer_service_url);
               analytics.logEvent('Contact', 'Contact customer service clicked');

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -75,6 +75,7 @@ export const SubmittedComponent = ({
             onPress={handleButtonClick}
             text={t(FeedbackTexts.additionalFeedback.contactsheetButton)}
             rightIcon={{svg: ExternalLink}}
+            accessibilityRole="link"
             interactiveColor="interactive_0"
           />
         )}

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -63,7 +63,7 @@ export function LinkSectionItem({
   return (
     <PressableOpacity
       accessible
-      accessibilityRole="link"
+      accessibilityRole="button"
       onPress={disabled ? undefined : onPress}
       disabled={disabled}
       accessibilityLabel={

--- a/src/components/sections/items/MessageSectionItem.tsx
+++ b/src/components/sections/items/MessageSectionItem.tsx
@@ -42,12 +42,14 @@ export function MessageSectionItem({
     ('action' in onPressConfig
       ? onPressConfig.action
       : () => Linking.openURL(onPressConfig.url));
+  const accessibilityRole =
+    onPressConfig && 'action' in onPressConfig ? 'button' : 'link';
 
   return (
     <PressableOpacityOrView
       onClick={onPress}
       accessible={true}
-      accessibilityRole={onPress && 'button'}
+      accessibilityRole={accessibilityRole}
       accessibilityLabel={a11yLabel}
       style={[
         topContainer,

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -56,9 +56,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
             {status === 'reserving' ? (
               <ActivityIndicator color={theme.text.colors.primary} />
             ) : (
-              <FareContractStatusSymbol
-                status={status}
-               />
+              <FareContractStatusSymbol status={status} />
             )}
             <ThemeText type="body__secondary" style={styles.reservationStatus}>
               {t(TicketingTexts.reservation[status])}
@@ -93,6 +91,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
             status === 'reserving' && (
               <Button
                 onPress={() => openVippsUrl(reservation.url)}
+                accessibilityRole="link"
                 text={t(TicketingTexts.reservation.goToVipps)}
                 mode="tertiary"
               />

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -234,7 +234,6 @@ export const DetailsContent: React.FC<Props> = ({
         <LinkSectionItem
           text={t(FareContractTexts.details.askForReceipt)}
           onPress={onReceiptNavigate}
-          accessibility={{accessibilityRole: 'button'}}
           testID="receiptButton"
         />
         {isCanBeConsumedNowFareContract(fc, now) && (

--- a/src/information-screen/InformationScreenComponent.tsx
+++ b/src/information-screen/InformationScreenComponent.tsx
@@ -92,7 +92,7 @@ const Link = ({link}: {link: InformationLink}) => {
     <PressableOpacity
       style={styles.link}
       onPress={() => Linking.openURL(link.link ?? '')}
-      accessibilityRole="button"
+      accessibilityRole="link"
     >
       <ThemeText type="body__primary--underline">{link.text}</ThemeText>
     </PressableOpacity>

--- a/src/loading-screen/LoadingErrorScreen.tsx
+++ b/src/loading-screen/LoadingErrorScreen.tsx
@@ -80,6 +80,7 @@ export const LoadingErrorScreen = React.memo(({retry}: {retry: () => void}) => {
             accessibilityLabel={t(
               LoadingScreenTexts.error.contactButton.a11yLabel,
             )}
+            accessibilityRole="link"
             rightIcon={{svg: ExternalLink}}
             backgroundColor={themeColor}
           />

--- a/src/mobility/components/OperatorActionButton.tsx
+++ b/src/mobility/components/OperatorActionButton.tsx
@@ -74,6 +74,7 @@ export const OperatorActionButton = ({
       mode="primary"
       interactiveColor="interactive_0"
       rightIcon={{svg: ExternalLink}}
+      accessibilityRole="link"
     />
   );
 };

--- a/src/service-disruptions/ServiceDisruptionSheet.tsx
+++ b/src/service-disruptions/ServiceDisruptionSheet.tsx
@@ -39,6 +39,7 @@ export const ServiceDisruptionSheet = () => {
               mode="secondary"
               text={t(ServiceDisruptionsTexts.button.text)}
               accessibilityHint={t(ServiceDisruptionsTexts.button.a11yHint)}
+              accessibilityRole="link"
               rightIcon={{svg: ExternalLink}}
               onPress={() => {
                 Linking.openURL(service_disruption_url);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -114,6 +114,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
             onPress={() => Linking.openURL(flex_ticket_url)}
             accessibility={{
               accessibilityHint: t(PurchaseOverviewTexts.flexDiscount.a11yHint),
+              accessibilityRole: 'link',
             }}
           />
         )}

--- a/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/Root_PurchasePaymentWithVippsScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentWithVippsScreen/Root_PurchasePaymentWithVippsScreen.tsx
@@ -63,6 +63,7 @@ export const Root_PurchasePaymentWithVippsScreen = ({
               interactiveColor="interactive_0"
               text={t(PaymentVippsTexts.buttons.goToVipps)}
               onPress={() => openVipps()}
+              accessibilityRole="link"
               style={styles.button}
             />
           ))}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -112,13 +112,15 @@ export const Announcement = ({announcement, style}: Props) => {
                 announcement.actionButton.actionType
               ],
             ),
+            accessibilityRole:
+              announcement.actionButton.actionType === 'bottom_sheet'
+                ? 'button'
+                : 'link',
           }}
           onPress={async () => {
             if (announcement.actionButton.actionType === 'bottom_sheet') {
               openBottomSheet(() => (
-                <AnnouncementSheet
-                  announcement={announcement}
-                />
+                <AnnouncementSheet announcement={announcement} />
               ));
             } else {
               const actionButtonURL = announcement.actionButton.url;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -58,7 +58,7 @@ import {useFontScale} from '@atb/utils/use-font-scale';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useNow} from '@atb/utils/use-now';
-import {TripPatternBookingStatus} from "@atb/travel-details-screens/types";
+import {TripPatternBookingStatus} from '@atb/travel-details-screens/types';
 
 type ResultItemProps = {
   tripPattern: TripPattern;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -130,6 +130,7 @@ export const Profile_PrivacyScreen = () => {
               accessibilityHint: t(
                 ProfileTexts.sections.privacy.linkSectionItems.privacy.a11yHint,
               ),
+              accessibilityRole: 'link',
             }}
             testID="privacyButton"
             onPress={async () => {
@@ -150,6 +151,7 @@ export const Profile_PrivacyScreen = () => {
                 accessibilityHint: t(
                   PrivacySettingsTexts.sections.items.controlPanel.a11yHint,
                 ),
+                accessibilityRole: 'link',
               }}
               testID="privacyButton"
               onPress={async () => {
@@ -170,8 +172,9 @@ export const Profile_PrivacyScreen = () => {
               accessibility={{
                 accessibilityHint: t(
                   PrivacySettingsTexts.sections.items.dataSharingButton
-                     .a11yHint,
+                    .a11yHint,
                 ),
+                accessibilityRole: 'link',
               }}
               icon="external-link"
               testID="dataSharingInfoButton"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -386,6 +386,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                       ProfileTexts.sections.information.linkSectionItems
                         .ticketing.a11yLabel,
                     ),
+                    accessibilityRole: 'link',
                   }}
                 />
               )}
@@ -403,6 +404,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                       ProfileTexts.sections.information.linkSectionItems.terms
                         .a11yLabel,
                     ),
+                    accessibilityRole: 'link',
                   }}
                 />
               )}
@@ -421,6 +423,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                       ProfileTexts.sections.information.linkSectionItems
                         .inspection.a11yLabel,
                     ),
+                    accessibilityRole: 'link',
                   }}
                 />
               )}
@@ -439,6 +442,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                       ProfileTexts.sections.information.linkSectionItems.refund
                         .a11yLabel,
                     ),
+                    accessibilityRole: 'link',
                   }}
                 />
               )}

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -97,6 +97,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
             type="body__secondary"
             style={[styles.expandedContent, {textDecorationLine: 'underline'}]}
             onPress={handleLinkPress}
+            accessibilityRole="link"
           >
             {t(TicketAssistantTexts.categoryPicker.childLinkText)}
           </ThemeText>


### PR DESCRIPTION
Changes the default accessibilityRole of LinkSectionItem to "button" instead of "link"

follow up to https://github.com/AtB-AS/mittatb-app/pull/4345 and https://mittatb.slack.com/archives/CSCD9JWGP/p1708607084680919

### Acceptance criteria

- [ ] Section items have role "button", not link
- [ ] Any action that links to external web pages have role "link"
