### PR TITLE
feat: disable consumption of carnets with several travel rights

### DIFF
--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -123,6 +123,7 @@ export const DetailsContent: React.FC<Props> = ({
       validityStatus: validityStatus,
       tariffZones: firstTravelRight.tariffZoneRefs ?? [],
       numberOfZones: firstTravelRight.tariffZoneRefs?.length ?? 0,
+      numberOfTravelRights: fc.travelRights.length,
     };
     const globalMessageCount = findGlobalMessages(
       GlobalMessageContextEnum.appFareContractDetails,

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -174,6 +174,12 @@ function isActiveNowOrCanBeUsedFareContract(f: FareContract, now: number) {
 export function isCanBeConsumedNowFareContract(f: FareContract, now: number) {
   if (!isCarnet(f)) return false;
   const travelRights = f.travelRights.filter(isCarnetTravelRight);
+
+  // @TODO: This is a temporary limitation because of issues with consumption of
+  // carnets with more than one travel right. Should be removed once there is a
+  // solution for this in the backend.
+  if (travelRights.length > 1) return false;
+
   return (
     hasUsableCarnetTravelRight(travelRights, now) &&
     !hasActiveCarnetTravelRight(travelRights, now)


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17062

Have also added a global message in staging with id `FareContractDetailsMultipleCarnets`, that shows for carnet tickets when `numberOfTravelRights > 1`.