### PR TITLE
feat: external link to terms of use on the login page

### DIFF
--- a/src/assets/information-data/termsInformation.json
+++ b/src/assets/information-data/termsInformation.json
@@ -1,125 +1,125 @@
 {
-    "nb": [
-        {
-            "text": "Det er passasjerens ansvar",
-            "type": "text"
-        },
-        {
-            "text": "å ha tilstrekkelig nettdekning under kjøpsprosessen slik at kjøpet gjennomføres i sin helhet. Datatrafikk må være påslått i en kontrollsituasjon, slik at billetten og kontrollkode kan fremvises på forespørsel.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "å ha gyldig billett for reisen ved ombordstigning",
-            "type": "bullet-point"
-        },
-        {
-            "text": "at mobiletelefonen fungerer normalt, skjermen er leselig og har nok batterikapasitet så lenge reisen varer slik at gyldig billett kan fremvises. Dersom du ikke kan fremvise billett, vil det anses som å reise uten gyldig billett.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "Det vil komme flere betalingsmåter",
-            "type": "heading"
-        },
-        {
-            "text": "AtBs transportvedtekter og takstregler gjelder til enhver tid under hele reisen",
-            "type": "text"
-        },
-        {
-            "text": "Transportvedtekter",
-            "type": "link",
-            "link": "https://www.atb.no/transportvedtekter/"
-        },
-        {
-            "text": "Takstregler",
-            "type": "link",
-            "link": "https://www.atb.no/takstregler/"
-        },
-        {
-            "text": "Personvernerklæring",
-            "type": "link",
-            "link": "https://beta.atb.no/private-policy"
-        }
-    ],
-    "en": [
-        {
-            "text": "As a passenger you are responsible to",
-            "type": "text"
-        },
-        {
-            "text": "have sufficient internet connection while buying tickets and travel passes to ensure that the transactions can be fully completed. Mobile data must be enabled in case of inspection, so that the ticket and the reference code can be presented upon request.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "have a valid ticket upon boarding.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "ensure the mobile phone works properly, the screen is readable and the battery has enough power to present a valid ticket during the whole trip. If you cannot provide a valid ticket upon inspection, you will be considered as travelling without a ticket.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "More methods of payment will be available",
-            "type": "heading"
-        },
-        {
-            "text": "AtB’s transport regulations and fare and discount guidelines apply at all times during your trip.",
-            "type": "text"
-        },
-        {
-            "text": "Transport regulations",
-            "type": "link",
-            "link": "https://www.atb.no/en/transport-regulations/"
-        },
-        {
-            "text": "Fare and discount guidelines",
-            "type": "link",
-            "link": "https://www.atb.no/en/fare-and-discount-guidelines/"
-        },
-        {
-            "text": "Privacy Statement",
-            "type": "link",
-            "link": "https://beta.atb.no/private-policy"
-        }
-    ],
-    "nn": [
-        {
-            "text": "Det er passasjerens ansvar",
-            "type": "text"
-        },
-        {
-            "text": "å ha tilstrekkeleg nettdekning under kjøpsprosessen slik at kjøpet vert gjennomført i sin heilskap. Datatrafikk må vere påslått i ein kontrollsituasjon, slik at billetten og kontrollkoden kan visast fram ved behov.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "å ha gyldig billett for reisa ved ombordstigning",
-            "type": "bullet-point"
-        },
-        {
-            "text": "at mobiltelefonen fungerer normalt, skjermen er lesbar og har nok batterikapasitet så lenge reisen varer, slik at gyldig billett kan visast fram. Dersom du ikkje kan vise fram billetten, vil det verte rekna som å reise utan gyldig billett.",
-            "type": "bullet-point"
-        },
-        {
-            "text": "Det vil kome fleire betalingsmåtar",
-            "type": "heading"
-        },
-        {
-            "text": "AtBs transportvedtekter og takstreglar gjeld til ei kvar tid under heile reisa",
-            "type": "text"
-        },
-        {
-            "text": "Transportvedtekter",
-            "type": "link",
-            "link": "https://www.atb.no/transportvedtekter/"
-        },
-        {
-            "text": "Takstreglar",
-            "type": "link",
-            "link": "https://www.atb.no/takstregler/"
-        },
-        {
-            "text": "Personvernerklæring",
-            "type": "link",
-            "link": "https://beta.atb.no/private-policy"
-        }
-    ]
+  "nb": [
+      {
+          "text": "Det er passasjerens ansvar",
+          "type": "text"
+      },
+      {
+          "text": "å ha tilstrekkelig nettdekning under kjøpsprosessen slik at kjøpet gjennomføres i sin helhet. Datatrafikk må være påslått i en kontrollsituasjon, slik at billetten og kontrollkode kan fremvises på forespørsel.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "å ha gyldig billett for reisen ved ombordstigning",
+          "type": "bullet-point"
+      },
+      {
+          "text": "at mobiletelefonen fungerer normalt, skjermen er leselig og har nok batterikapasitet så lenge reisen varer slik at gyldig billett kan fremvises. Dersom du ikke kan fremvise billett, vil det anses som å reise uten gyldig billett.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "Det vil komme flere betalingsmåter",
+          "type": "heading"
+      },
+      {
+          "text": "AtBs transportvedtekter og takstregler gjelder til enhver tid under hele reisen",
+          "type": "text"
+      },
+      {
+          "text": "Transportvedtekter",
+          "type": "link",
+          "link": "https://www.atb.no/transportvedtekter/"
+      },
+      {
+          "text": "Takstregler",
+          "type": "link",
+          "link": "https://www.atb.no/takstregler/"
+      },
+      {
+          "text": "Personvernerklæring",
+          "type": "link",
+          "link": "https://beta.atb.no/private-policy"
+      }
+  ],
+  "en": [
+      {
+          "text": "As a passenger you are responsible to",
+          "type": "text"
+      },
+      {
+          "text": "have sufficient internet connection while buying tickets and travel passes to ensure that the transactions can be fully completed. Mobile data must be enabled in case of inspection, so that the ticket and the reference code can be presented upon request.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "have a valid ticket upon boarding.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "ensure the mobile phone works properly, the screen is readable and the battery has enough power to present a valid ticket during the whole trip. If you cannot provide a valid ticket upon inspection, you will be considered as travelling without a ticket.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "More methods of payment will be available",
+          "type": "heading"
+      },
+      {
+          "text": "AtB’s transport regulations and fare and discount guidelines apply at all times during your trip.",
+          "type": "text"
+      },
+      {
+          "text": "Transport regulations",
+          "type": "link",
+          "link": "https://www.atb.no/en/transport-regulations/"
+      },
+      {
+          "text": "Fare and discount guidelines",
+          "type": "link",
+          "link": "https://www.atb.no/en/fare-and-discount-guidelines/"
+      },
+      {
+          "text": "Privacy Statement",
+          "type": "link",
+          "link": "https://beta.atb.no/private-policy"
+      }
+  ],
+  "nn": [
+      {
+          "text": "Det er passasjerens ansvar",
+          "type": "text"
+      },
+      {
+          "text": "å ha tilstrekkeleg nettdekning under kjøpsprosessen slik at kjøpet vert gjennomført i sin heilskap. Datatrafikk må vere påslått i ein kontrollsituasjon, slik at billetten og kontrollkoden kan visast fram ved behov.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "å ha gyldig billett for reisa ved ombordstigning",
+          "type": "bullet-point"
+      },
+      {
+          "text": "at mobiltelefonen fungerer normalt, skjermen er lesbar og har nok batterikapasitet så lenge reisen varer, slik at gyldig billett kan visast fram. Dersom du ikkje kan vise fram billetten, vil det verte rekna som å reise utan gyldig billett.",
+          "type": "bullet-point"
+      },
+      {
+          "text": "Det vil kome fleire betalingsmåtar",
+          "type": "heading"
+      },
+      {
+          "text": "AtBs transportvedtekter og takstreglar gjeld til ei kvar tid under heile reisa",
+          "type": "text"
+      },
+      {
+          "text": "Transportvedtekter",
+          "type": "link",
+          "link": "https://www.atb.no/transportvedtekter/"
+      },
+      {
+          "text": "Takstreglar",
+          "type": "link",
+          "link": "https://www.atb.no/takstregler/"
+      },
+      {
+          "text": "Personvernerklæring",
+          "type": "link",
+          "link": "https://beta.atb.no/private-policy"
+      }
+  ]
 }

--- a/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
@@ -11,7 +11,11 @@ import {VippsLoginButton} from '@atb/components/vipps-login-button';
 import {storage} from '@atb/storage';
 import {StyleSheet} from '@atb/theme';
 import {StaticColorByType} from '@atb/theme/colors';
-import {LoginTexts, useTranslation} from '@atb/translations';
+import {
+  getTextForLanguage,
+  LoginTexts,
+  useTranslation,
+} from '@atb/translations';
 import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 import React, {useEffect, useState} from 'react';
 import {ActivityIndicator, Linking, ScrollView, View} from 'react-native';
@@ -21,10 +25,12 @@ import {parseUrl} from 'query-string/base';
 
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {Button} from '@atb/components/button';
-import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
+import {ArrowRight, ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {TransitionPresets} from '@react-navigation/stack';
 import {useAppState} from '@atb/AppContext';
+import {useFirestoreConfiguration} from '@atb/configuration';
+import {APP_ORG} from '@env';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -37,7 +43,7 @@ export const Root_LoginOptionsScreen = ({
   const showGoBack = params?.showGoBack;
   const transitionPreset = params?.transitionPreset;
 
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const styles = useStyles();
   const {signInWithCustomToken} = useAuthState();
   const [error, setError] = useState<VippsSignInErrorCode>();
@@ -47,6 +53,7 @@ export const Root_LoginOptionsScreen = ({
     string | undefined
   >(undefined);
   const {completeOnboardingSection} = useAppState();
+  const {configurableLinks} = useFirestoreConfiguration();
 
   const authenticateUserByVipps = async () => {
     setIsLoading(true);
@@ -130,6 +137,11 @@ export const Root_LoginOptionsScreen = ({
     return () => eventSubscription.remove();
   }, [appStatus]);
 
+  const termsInfoUrl = getTextForLanguage(
+    configurableLinks?.termsInfo,
+    language,
+  );
+
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -205,17 +217,31 @@ export const Root_LoginOptionsScreen = ({
             testID="useAppAnonymouslyButton"
           />
         </View>
-
-        <View style={styles.termsOfUseContainer}>
-          <PressableOpacity
-            onPress={() => navigation.navigate('Root_TermsInformationScreen')}
-            role="button"
-          >
-            <ThemeText color={themeColor} style={styles.termsOfUseText}>
-              {t(LoginTexts.logInOptions.termsOfUse)}
-            </ThemeText>
-          </PressableOpacity>
-        </View>
+        {APP_ORG === 'atb' ? (
+          <View style={styles.termsOfUseButtonContainer}>
+            <PressableOpacity
+              onPress={() => navigation.navigate('Root_TermsInformationScreen')}
+              role="button"
+            >
+              <ThemeText color={themeColor} style={styles.termsOfUseText}>
+                {t(LoginTexts.logInOptions.termsOfUse)}
+              </ThemeText>
+            </PressableOpacity>
+          </View>
+        ) : (
+          termsInfoUrl && (
+            <View style={styles.termsOfUseLinkContainer}>
+              <Button
+                backgroundColor={themeColor}
+                mode="tertiary"
+                rightIcon={{svg: ExternalLink}}
+                onPress={() => Linking.openURL(termsInfoUrl)}
+                text={t(LoginTexts.logInOptions.termsOfUse)}
+                accessibilityRole="link"
+              />
+            </View>
+          )
+        )}
       </ScrollView>
     </View>
   );
@@ -254,7 +280,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     buttonContainer: {
       gap: theme.spacings.medium,
     },
-    termsOfUseContainer: {
+    termsOfUseLinkContainer: {
+      marginVertical: theme.spacings.xLarge - theme.spacings.medium,
+    },
+    termsOfUseButtonContainer: {
       marginVertical: theme.spacings.xLarge - theme.spacings.medium,
       flexDirection: 'row',
       justifyContent: 'center',


### PR DESCRIPTION
In this pull request, I have addressed the issue of hardcoded terms of use information on the login screen by introducing the use of an external link for FRAM and NFK. This adjustment ensures that the terms of use information remains correct across different environments, including AtB, NFK and FRAM. 

When AtB has moved their terms of use information to their website, we can update this so that we have the same solution for everyone. 

<details>
<summary>Screenshot</summary>

![IMG_3695](https://github.com/AtB-AS/mittatb-app/assets/43166974/0e812182-08c9-4bbf-9a19-d4b886bc8026)

</details>


Closes https://github.com/AtB-AS/kundevendt/issues/17084