### PR TITLE
feat: show on-behalf-of menu on tickets without traveller selection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -135,10 +135,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const isEmptyOffer = error?.type === 'empty-offers';
 
-  const isTravellerNotSelectable =
-    travellerSelectionMode === 'none' ||
-    (travellerSelectionMode === 'single' && selectableTravellers.length <= 1);
-
   const handleTicketInfoButtonPress = () => {
     const parameters = {
       fareProductTypeConfigType: params.fareProductTypeConfig.type,
@@ -262,7 +258,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             setShowActivationDateWarning={setShowActivationDateWarning}
           />
 
-          {isTravellerNotSelectable && (
+          {travellerSelectionMode === 'none' && (
             <>
               <ContentHeading
                 text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -29,7 +29,6 @@ import {FareProductHeader} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScre
 import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen';
 import {Section, ToggleSectionItem} from '@atb/components/sections';
 import {HoldingHands} from '@atb/assets/svg/color/images';
-import {ThemeText} from '@atb/components/text';
 import {ContentHeading} from '@atb/components/heading';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -263,9 +263,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           />
 
           {isTravellerNotSelectable && (
-            <View>
+            <>
               <ContentHeading
-                style={styles.onBehalfOfTitle}
                 text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
               />
               <Section>
@@ -281,7 +280,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                   }}
                 />
               </Section>
-            </View>
+            </>
           )}
 
           <FlexTicketDiscountInfo
@@ -374,9 +373,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     messages: {
       rowGap: theme.spacings.medium,
       marginTop: theme.spacings.medium,
-    },
-    onBehalfOfTitle: {
-      marginBottom: theme.spacings.medium,
     },
     selectionComponent: {
       rowGap: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -30,6 +30,7 @@ import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_
 import {Section, ToggleSectionItem} from '@atb/components/sections';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {ThemeText} from '@atb/components/text';
+import {ContentHeading} from '@atb/components/heading';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -134,6 +135,10 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     userProfilesWithCountAndOffer.some((u) => u.count);
 
   const isEmptyOffer = error?.type === 'empty-offers';
+
+  const isTravellerNotSelectable =
+    travellerSelectionMode === 'none' ||
+    (travellerSelectionMode === 'single' && selectableTravellers.length <= 1);
 
   const handleTicketInfoButtonPress = () => {
     const parameters = {
@@ -246,15 +251,24 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             ref={focusRefs}
           />
 
-          {travellerSelectionMode === 'none' && (
+          <StartTimeSelection
+            selectionMode={timeSelectionMode}
+            color="interactive_2"
+            travelDate={travelDate}
+            setTravelDate={setTravelDate}
+            validFromTime={travelDate}
+            maximumDate={maximumDateObjectIfExisting}
+            style={styles.selectionComponent}
+            showActivationDateWarning={showActivationDateWarning}
+            setShowActivationDateWarning={setShowActivationDateWarning}
+          />
+
+          {isTravellerNotSelectable && (
             <View>
-              <ThemeText
+              <ContentHeading
                 style={styles.onBehalfOfTitle}
-                type="body__secondary"
-                color="secondary"
-              >
-                {t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
-              </ThemeText>
+                text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
+              />
               <Section>
                 <ToggleSectionItem
                   leftImage={<HoldingHands />}
@@ -270,18 +284,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
               </Section>
             </View>
           )}
-
-          <StartTimeSelection
-            selectionMode={timeSelectionMode}
-            color="interactive_2"
-            travelDate={travelDate}
-            setTravelDate={setTravelDate}
-            validFromTime={travelDate}
-            maximumDate={maximumDateObjectIfExisting}
-            style={styles.selectionComponent}
-            showActivationDateWarning={showActivationDateWarning}
-            setShowActivationDateWarning={setShowActivationDateWarning}
-          />
 
           <FlexTicketDiscountInfo
             userProfiles={userProfilesWithCountAndOffer}
@@ -375,9 +377,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       marginTop: theme.spacings.medium,
     },
     onBehalfOfTitle: {
-      marginHorizontal: theme.spacings.medium,
       marginBottom: theme.spacings.medium,
-      marginTop: theme.spacings.small,
     },
     selectionComponent: {
       rowGap: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -27,6 +27,9 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {FullScreenView} from '@atb/components/screen-view';
 import {FareProductHeader} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader';
 import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen';
+import {Section, ToggleSectionItem} from '@atb/components/sections';
+import {HoldingHands} from '@atb/assets/svg/color/images';
+import {ThemeText} from '@atb/components/text';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -243,6 +246,31 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             ref={focusRefs}
           />
 
+          {travellerSelectionMode === 'none' && (
+            <View>
+              <ThemeText
+                style={styles.onBehalfOfTitle}
+                type="body__secondary"
+                color="secondary"
+              >
+                {t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
+              </ThemeText>
+              <Section>
+                <ToggleSectionItem
+                  leftImage={<HoldingHands />}
+                  text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
+                  subtext={t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
+                  value={isOnBehalfOfToggle}
+                  label="new"
+                  textType="body__primary--bold"
+                  onValueChange={(checked) => {
+                    setIsOnBehalfOfToggle(checked);
+                  }}
+                />
+              </Section>
+            </View>
+          )}
+
           <StartTimeSelection
             selectionMode={timeSelectionMode}
             color="interactive_2"
@@ -345,6 +373,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     messages: {
       rowGap: theme.spacings.medium,
       marginTop: theme.spacings.medium,
+    },
+    onBehalfOfTitle: {
+      marginHorizontal: theme.spacings.medium,
+      marginBottom: theme.spacings.medium,
+      marginTop: theme.spacings.small,
     },
     selectionComponent: {
       rowGap: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -83,13 +83,13 @@ export function TravellerSelection({
 
   useFocusEffect(
     useCallback(() => {
-      if (isOnBehalfOfEnabled) {
+      if (isOnBehalfOfEnabled && selectionMode !== 'none') {
         addPopOver({
           oneTimeKey: 'on-behalf-of-new-feature-introduction',
           target: onBehalfOfIndicatorRef,
         });
       }
-    }, [isOnBehalfOfEnabled, addPopOver]),
+    }, [isOnBehalfOfEnabled, addPopOver, selectionMode]),
   );
 
   if (selectionMode === 'none') {


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17066

This PR will show the on-behalf-of toggle when the `travellerSelection=none`, also fixes an issue where the on-behalf-of popover was triggered even though the layout isn't there.

Tested on Fram youth ticket.
 

https://github.com/AtB-AS/mittatb-app/assets/1777333/81591b62-53ce-48ad-b54c-b10335578fb2

