### PR TITLE
refactor: rework TravellerSelection to add non-clickable section

### DIFF
--- a/src/components/sections/items/GenericClickableSectionItem.tsx
+++ b/src/components/sections/items/GenericClickableSectionItem.tsx
@@ -8,7 +8,6 @@ type Props = PropsWithChildren<
   SectionItemProps<
     {
       onPress?(): void;
-      disabled?: boolean;
     } & AccessibilityProps
   >
 >;
@@ -17,7 +16,7 @@ export const GenericClickableSectionItem = forwardRef<any, Props>(
     const {topContainer} = useSectionItem(props);
 
     return (
-      <PressableOpacity {...props} ref={focusRef} disabled={props.disabled}>
+      <PressableOpacity {...props} ref={focusRef}>
         <View style={topContainer}>{children}</View>
       </PressableOpacity>
     );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -54,6 +54,8 @@ export function TravellerSelection({
   isOnBehalfOfToggle,
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
+  const styles = useStyles();
+
   const {
     open: openBottomSheet,
     close: closeBottomSheet,
@@ -191,121 +193,83 @@ export function TravellerSelection({
             : t(PurchaseOverviewTexts.travellerSelection.titleNotSelectable)
         }
       />
-      <SelectionContentWrapper
+      <TravellerSelectionWrapper
         condition={canSelectUserProfile}
         travellerSelectionOnPress={travellerSelectionOnPress}
         ref={onCloseFocusRef}
         {...accessibility}
       >
-        <SelectionContent
-          multipleTravellerCategoriesSelectedFrom={
-            multipleTravellerCategoriesSelectedFrom
-          }
-          totalTravellersCount={totalTravellersCount}
-          travellersDetailsText={travellersDetailsText}
-          isOnBehalfOfToggle={isOnBehalfOfToggle}
-          isOnBehalfOfEnabled={isOnBehalfOfEnabled}
-          canSelectUserProfile={canSelectUserProfile}
-          ref={onBehalfOfIndicatorRef}
-        />
-      </SelectionContentWrapper>
+        <View style={styles.sectionContentContainer}>
+          <View style={{flex: 1}}>
+            <ThemeText type="body__primary--bold">
+              {multipleTravellerCategoriesSelectedFrom
+                ? t(
+                    PurchaseOverviewTexts.travellerSelection.travellers_title(
+                      totalTravellersCount,
+                    ),
+                  )
+                : travellersDetailsText}
+            </ThemeText>
+
+            {isOnBehalfOfToggle && (
+              <ThemeText type="body__secondary" color="secondary">
+                {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
+              </ThemeText>
+            )}
+
+            {multipleTravellerCategoriesSelectedFrom && (
+              <ThemeText
+                type="body__secondary"
+                color="secondary"
+                style={styles.multipleTravellersDetails}
+              >
+                {travellersDetailsText}
+              </ThemeText>
+            )}
+          </View>
+
+          {/* remove new label when requested */}
+          {isOnBehalfOfEnabled && canSelectUserProfile && (
+            <View
+              ref={onBehalfOfIndicatorRef}
+              renderToHardwareTextureAndroid={true}
+              collapsable={false}
+            >
+              <LabelInfo label="new" />
+            </View>
+          )}
+
+          {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
+        </View>
+      </TravellerSelectionWrapper>
     </View>
   );
 }
 
-type SelectionContentWrapperProps = {
+type TravellerSelectionWrapperProps = {
   condition: boolean;
   children: JSX.Element;
   travellerSelectionOnPress: () => void;
 };
 
-const SelectionContentWrapper = forwardRef<any, SelectionContentWrapperProps>(
-  ({condition, children, travellerSelectionOnPress, ...props}, ref) =>
-    condition ? (
-      <Section {...props}>
-        <GenericClickableSectionItem
-          onPress={travellerSelectionOnPress}
-          ref={ref}
-        >
-          {children}
-        </GenericClickableSectionItem>
-      </Section>
-    ) : (
-      <Section {...props}>
-        <GenericSectionItem>{children}</GenericSectionItem>
-      </Section>
-    ),
-);
-
-type SelectionContentProps = {
-  multipleTravellerCategoriesSelectedFrom: boolean;
-  totalTravellersCount: number;
-  travellersDetailsText: string;
-  isOnBehalfOfToggle: boolean;
-  isOnBehalfOfEnabled: boolean;
-  canSelectUserProfile: boolean;
-};
-
-const SelectionContent = forwardRef<any, SelectionContentProps>(
-  (
-    {
-      multipleTravellerCategoriesSelectedFrom,
-      totalTravellersCount,
-      travellersDetailsText,
-      isOnBehalfOfToggle,
-      isOnBehalfOfEnabled,
-      canSelectUserProfile,
-    },
-    onBehalfOfRef,
-  ) => {
-    const {t} = useTranslation();
-    const styles = useStyles();
-
-    return (
-      <View style={styles.sectionContentContainer}>
-        <View style={{flex: 1}}>
-          <ThemeText type="body__primary--bold">
-            {multipleTravellerCategoriesSelectedFrom
-              ? t(
-                  PurchaseOverviewTexts.travellerSelection.travellers_title(
-                    totalTravellersCount,
-                  ),
-                )
-              : travellersDetailsText}
-          </ThemeText>
-
-          {isOnBehalfOfToggle && (
-            <ThemeText type="body__secondary" color="secondary">
-              {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
-            </ThemeText>
-          )}
-
-          {multipleTravellerCategoriesSelectedFrom && (
-            <ThemeText
-              type="body__secondary"
-              color="secondary"
-              style={styles.multipleTravellersDetails}
-            >
-              {travellersDetailsText}
-            </ThemeText>
-          )}
-        </View>
-
-        {/* remove new label when requested */}
-        {isOnBehalfOfEnabled && canSelectUserProfile && (
-          <View
-            ref={onBehalfOfRef}
-            renderToHardwareTextureAndroid={true}
-            collapsable={false}
-          >
-            <LabelInfo label="new" />
-          </View>
-        )}
-
-        {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
-      </View>
-    );
-  },
+const TravellerSelectionWrapper = forwardRef<
+  any,
+  TravellerSelectionWrapperProps
+>(({condition, children, travellerSelectionOnPress, ...props}, ref) =>
+  condition ? (
+    <Section {...props}>
+      <GenericClickableSectionItem
+        onPress={travellerSelectionOnPress}
+        ref={ref}
+      >
+        {children}
+      </GenericClickableSectionItem>
+    </Section>
+  ) : (
+    <Section {...props}>
+      <GenericSectionItem>{children}</GenericSectionItem>
+    </Section>
+  ),
 );
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
@@ -180,6 +174,51 @@ export function TravellerSelection({
     ));
   };
 
+  const content = (
+    <View style={styles.sectionContentContainer}>
+      <View style={{flex: 1}}>
+        <ThemeText type="body__primary--bold">
+          {multipleTravellerCategoriesSelectedFrom
+            ? t(
+                PurchaseOverviewTexts.travellerSelection.travellers_title(
+                  totalTravellersCount,
+                ),
+              )
+            : travellersDetailsText}
+        </ThemeText>
+
+        {isOnBehalfOfToggle && (
+          <ThemeText type="body__secondary" color="secondary">
+            {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
+          </ThemeText>
+        )}
+
+        {multipleTravellerCategoriesSelectedFrom && (
+          <ThemeText
+            type="body__secondary"
+            color="secondary"
+            style={styles.multipleTravellersDetails}
+          >
+            {travellersDetailsText}
+          </ThemeText>
+        )}
+      </View>
+
+      {/* remove new label when requested */}
+      {isOnBehalfOfEnabled && canSelectUserProfile && (
+        <View
+          ref={onCloseFocusRef}
+          renderToHardwareTextureAndroid={true}
+          collapsable={false}
+        >
+          <LabelInfo label="new" />
+        </View>
+      )}
+
+      {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
+    </View>
+  );
+
   return (
     <View style={style}>
       <ContentHeading
@@ -193,84 +232,21 @@ export function TravellerSelection({
             : t(PurchaseOverviewTexts.travellerSelection.titleNotSelectable)
         }
       />
-      <TravellerSelectionWrapper
-        condition={canSelectUserProfile}
-        travellerSelectionOnPress={travellerSelectionOnPress}
-        ref={onCloseFocusRef}
-        {...accessibility}
-      >
-        <View style={styles.sectionContentContainer}>
-          <View style={{flex: 1}}>
-            <ThemeText type="body__primary--bold">
-              {multipleTravellerCategoriesSelectedFrom
-                ? t(
-                    PurchaseOverviewTexts.travellerSelection.travellers_title(
-                      totalTravellersCount,
-                    ),
-                  )
-                : travellersDetailsText}
-            </ThemeText>
-
-            {isOnBehalfOfToggle && (
-              <ThemeText type="body__secondary" color="secondary">
-                {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
-              </ThemeText>
-            )}
-
-            {multipleTravellerCategoriesSelectedFrom && (
-              <ThemeText
-                type="body__secondary"
-                color="secondary"
-                style={styles.multipleTravellersDetails}
-              >
-                {travellersDetailsText}
-              </ThemeText>
-            )}
-          </View>
-
-          {/* remove new label when requested */}
-          {isOnBehalfOfEnabled && canSelectUserProfile && (
-            <View
-              ref={onBehalfOfIndicatorRef}
-              renderToHardwareTextureAndroid={true}
-              collapsable={false}
-            >
-              <LabelInfo label="new" />
-            </View>
-          )}
-
-          {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
-        </View>
-      </TravellerSelectionWrapper>
+      <Section {...accessibility}>
+        {canSelectUserProfile ? (
+          <GenericClickableSectionItem
+            onPress={travellerSelectionOnPress}
+            ref={onCloseFocusRef}
+          >
+            {content}
+          </GenericClickableSectionItem>
+        ) : (
+          <GenericSectionItem>{content}</GenericSectionItem>
+        )}
+      </Section>
     </View>
   );
 }
-
-type TravellerSelectionWrapperProps = {
-  condition: boolean;
-  children: JSX.Element;
-  travellerSelectionOnPress: () => void;
-};
-
-const TravellerSelectionWrapper = forwardRef<
-  any,
-  TravellerSelectionWrapperProps
->(({condition, children, travellerSelectionOnPress, ...props}, ref) =>
-  condition ? (
-    <Section {...props}>
-      <GenericClickableSectionItem
-        onPress={travellerSelectionOnPress}
-        ref={ref}
-      >
-        {children}
-      </GenericClickableSectionItem>
-    </Section>
-  ) : (
-    <Section {...props}>
-      <GenericSectionItem>{children}</GenericSectionItem>
-    </Section>
-  ),
-);
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   multipleTravellersDetails: {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,9 +1,19 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {TravellerSelectionMode} from '@atb/configuration';
-import {GenericClickableSectionItem, Section} from '@atb/components/sections';
+import {
+  GenericClickableSectionItem,
+  GenericSectionItem,
+  Section,
+} from '@atb/components/sections';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 
 import {StyleSheet} from '@atb/theme';
@@ -44,7 +54,6 @@ export function TravellerSelection({
   isOnBehalfOfToggle,
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
-  const styles = useStyles();
   const {
     open: openBottomSheet,
     close: closeBottomSheet,
@@ -182,59 +191,122 @@ export function TravellerSelection({
             : t(PurchaseOverviewTexts.travellerSelection.titleNotSelectable)
         }
       />
-      <Section {...accessibility}>
-        <GenericClickableSectionItem
-          onPress={travellerSelectionOnPress}
-          disabled={!canSelectUserProfile}
-          ref={onCloseFocusRef}
-        >
-          <View style={styles.sectionContentContainer}>
-            <View style={{flex: 1}}>
-              <ThemeText type="body__primary--bold">
-                {multipleTravellerCategoriesSelectedFrom
-                  ? t(
-                      PurchaseOverviewTexts.travellerSelection.travellers_title(
-                        totalTravellersCount,
-                      ),
-                    )
-                  : travellersDetailsText}
-              </ThemeText>
-
-              {isOnBehalfOfToggle && (
-                <ThemeText type="body__secondary" color="secondary">
-                  {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
-                </ThemeText>
-              )}
-
-              {multipleTravellerCategoriesSelectedFrom && (
-                <ThemeText
-                  type="body__secondary"
-                  color="secondary"
-                  style={styles.multipleTravellersDetails}
-                >
-                  {travellersDetailsText}
-                </ThemeText>
-              )}
-            </View>
-
-            {/* remove new label when requested */}
-            {isOnBehalfOfEnabled && canSelectUserProfile && (
-              <View
-                ref={onBehalfOfIndicatorRef}
-                renderToHardwareTextureAndroid={true}
-                collapsable={false}
-              >
-                <LabelInfo label="new" />
-              </View>
-            )}
-
-            {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
-          </View>
-        </GenericClickableSectionItem>
-      </Section>
+      <SelectionContentWrapper
+        condition={canSelectUserProfile}
+        travellerSelectionOnPress={travellerSelectionOnPress}
+        ref={onCloseFocusRef}
+        {...accessibility}
+      >
+        <SelectionContent
+          multipleTravellerCategoriesSelectedFrom={
+            multipleTravellerCategoriesSelectedFrom
+          }
+          totalTravellersCount={totalTravellersCount}
+          travellersDetailsText={travellersDetailsText}
+          isOnBehalfOfToggle={isOnBehalfOfToggle}
+          isOnBehalfOfEnabled={isOnBehalfOfEnabled}
+          canSelectUserProfile={canSelectUserProfile}
+          ref={onBehalfOfIndicatorRef}
+        />
+      </SelectionContentWrapper>
     </View>
   );
 }
+
+type SelectionContentWrapperProps = {
+  condition: boolean;
+  children: JSX.Element;
+  travellerSelectionOnPress: () => void;
+};
+
+const SelectionContentWrapper = forwardRef<any, SelectionContentWrapperProps>(
+  ({condition, children, travellerSelectionOnPress, ...props}, ref) =>
+    condition ? (
+      <Section {...props}>
+        <GenericClickableSectionItem
+          onPress={travellerSelectionOnPress}
+          ref={ref}
+        >
+          {children}
+        </GenericClickableSectionItem>
+      </Section>
+    ) : (
+      <Section {...props}>
+        <GenericSectionItem>{children}</GenericSectionItem>
+      </Section>
+    ),
+);
+
+type SelectionContentProps = {
+  multipleTravellerCategoriesSelectedFrom: boolean;
+  totalTravellersCount: number;
+  travellersDetailsText: string;
+  isOnBehalfOfToggle: boolean;
+  isOnBehalfOfEnabled: boolean;
+  canSelectUserProfile: boolean;
+};
+
+const SelectionContent = forwardRef<any, SelectionContentProps>(
+  (
+    {
+      multipleTravellerCategoriesSelectedFrom,
+      totalTravellersCount,
+      travellersDetailsText,
+      isOnBehalfOfToggle,
+      isOnBehalfOfEnabled,
+      canSelectUserProfile,
+    },
+    onBehalfOfRef,
+  ) => {
+    const {t} = useTranslation();
+    const styles = useStyles();
+
+    return (
+      <View style={styles.sectionContentContainer}>
+        <View style={{flex: 1}}>
+          <ThemeText type="body__primary--bold">
+            {multipleTravellerCategoriesSelectedFrom
+              ? t(
+                  PurchaseOverviewTexts.travellerSelection.travellers_title(
+                    totalTravellersCount,
+                  ),
+                )
+              : travellersDetailsText}
+          </ThemeText>
+
+          {isOnBehalfOfToggle && (
+            <ThemeText type="body__secondary" color="secondary">
+              {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
+            </ThemeText>
+          )}
+
+          {multipleTravellerCategoriesSelectedFrom && (
+            <ThemeText
+              type="body__secondary"
+              color="secondary"
+              style={styles.multipleTravellersDetails}
+            >
+              {travellersDetailsText}
+            </ThemeText>
+          )}
+        </View>
+
+        {/* remove new label when requested */}
+        {isOnBehalfOfEnabled && canSelectUserProfile && (
+          <View
+            ref={onBehalfOfRef}
+            renderToHardwareTextureAndroid={true}
+            collapsable={false}
+          >
+            <LabelInfo label="new" />
+          </View>
+        )}
+
+        {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
+      </View>
+    );
+  },
+);
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   multipleTravellersDetails: {


### PR DESCRIPTION
context: https://github.com/AtB-AS/mittatb-app/pull/4362#discussion_r1508915274

This PR attempts to refactor and remove the disabled part of the `GenericClickableSectionItem`, and instead use a `GenericSectionItem` if it is not clickable. 

The `<Section>` component is needed to be put around on both `GenericClickableSectionItem` and `GenericSectionItem` to ensure that the corner rounding works properly. 

Open to suggestion on how to implement this in a better way 😊 

### Acceptance Criteria

- [ ] Traveller selection, when it is clickable, should behave normally, and visually the corners are rounded
- [ ] Traveller selection, when there's only 1 selectable profile, should not be clickable, and visually the corners are rounded
- [ ] Screenreader behaves as usual for the clickable part
- [ ] Screenreader says "Traveller" instead of "Selected Traveller" when it is not clickable