### PR TITLE
build: make brew overwrite while linking imagemagick

### DIFF
--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.MATCH_SSH_PRIVATE_KEY }}
       - name: Generate native assets
-        run: brew install imagemagick && yarn generate-native-assets
+        run: brew install --overwrite imagemagick && yarn generate-native-assets
       - name: Disable widget
         if: ${{ env.ENABLE_WIDGET != 'true' }}
         run: bundle exec configure_extensions remove ios/atb.xcodeproj app departureWidget AtbAppIntent


### PR DESCRIPTION
An attempt at fixing

```
 Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite python@3.12 --dry-run
```

in this build: https://github.com/AtB-AS/mittatb-app/actions/runs/8137564197/job/22236213199