### PR TITLE
build: replace gxargs with xargs

### DIFF
--- a/scripts/ios/override-config-files.sh
+++ b/scripts/ios/override-config-files.sh
@@ -5,12 +5,8 @@ echo "Copy .netrc file for mapbox api token"
 cat .netrc >> ~/.netrc
 chmod 600 ~/.netrc
 
-echo "Installing pre-build dependencies"
-brew install findutils # for git-crypt
-# findutils for gxargs which is used to load environment variables from .env file
-
 echo "Loading all env variables from .env file"
-export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
+export $(grep -v '^#' .env | xargs -0 -n1 echo) > /dev/null 2>&1
 
 echo "Currently set ios bundle id: $IOS_BUNDLE_IDENTIFIER"
 

--- a/scripts/register-local-app-version.sh
+++ b/scripts/register-local-app-version.sh
@@ -5,7 +5,7 @@
 # use of gcloud secrets and the project name to get ABT client credentials
 
 echo "Loading all env variables from .env file"
-export $(grep -v '^#' .env | gxargs -d '\n') > /dev/null 2>&1
+export $(grep -v '^#' .env | xargs -0 -n1 echo) > /dev/null 2>&1
 
 credentials=$(gcloud secrets versions access --project atb-staging-c420 --secret=entur-client-credentials-publish latest)
 


### PR DESCRIPTION
When trying to run register-local-app-version.sh, me and @hanne-at-atb spent some time looking at what "gxargs" is, where to install it, and how it differs from "xargs". While doing so, we found a alternative solution that uses xargs instead ([source](https://superuser.com/questions/467176/replacement-for-xargs-d-in-osx#comment581887_467192)). Since it comes pre-installed on macOS, this means we don't have to install it for CI, or when running register-local-app-version.sh locally!

An alternative solution would be to add docs for running `brew install findutils` while setting up the project, but I think this is nicer. :)
