### PR TITLE
chore: increase FareProductGroup heading marginTop

### DIFF
--- a/src/components/heading/ContentHeading.tsx
+++ b/src/components/heading/ContentHeading.tsx
@@ -20,7 +20,7 @@ export function ContentHeading({
   const styles = useStyles();
 
   return (
-    <View style={[style, styles.container]}>
+    <View style={[styles.container, style]}>
       <ThemeText
         type="body__secondary"
         color={color}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
@@ -91,6 +91,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   heading: {
     margin: theme.spacings.medium,
     marginLeft: theme.spacings.xLarge,
+    marginTop: theme.spacings.large,
   },
   fareProductsContainer: {
     flex: 1,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -191,5 +191,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   heading: {
     margin: theme.spacings.medium,
     marginLeft: theme.spacings.xLarge,
+    marginTop: theme.spacings.large,
   },
 }));


### PR DESCRIPTION
To more clearly indicate that the FareProductGroup heading belongs to the content below it and not above it, the marginTop is increased. As discussed with @ckbilstad, this was the original intention of the design.
UPDATE: The same done to the ticketAssistantTile heading after a good catch by @rosvik.

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/62675079-e9fb-44c9-9114-07219043824a" /> | <img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/89900410-6640-4d8b-ab54-ba69bb921ed7" /> |

