### PR TITLE
fix: add bottom margin and move view below date

### DIFF
--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -221,14 +221,6 @@ export const DepartureDetailsScreenComponent = ({
           style={styles.scrollView__content}
           testID="departureDetailsContentView"
         >
-          {subMode === TransportSubmode.RailReplacementBus && (
-            <MessageInfoBox
-              type="warning"
-              message={t(
-                TripDetailsTexts.messages.departureIsRailReplacementBus,
-              )}
-            />
-          )}
           {screenReaderEnabled ? ( // Let users navigate other departures if screen reader is enabled
             activeItem ? (
               <PaginatedDetailsHeader
@@ -255,7 +247,19 @@ export const DepartureDetailsScreenComponent = ({
               <Divider style={styles.border} />
             </>
           ) : null}
+
+          {subMode === TransportSubmode.RailReplacementBus && (
+            <MessageInfoBox
+              type="warning"
+              message={t(
+                TripDetailsTexts.messages.departureIsRailReplacementBus,
+              )}
+              style={styles.messageBox}
+            />
+          )}
+
           {activeItem?.isTripCancelled && <CancelledDepartureMessage />}
+
           {situations.map((situation) => (
             <SituationMessageBox
               key={situation.id}
@@ -263,6 +267,7 @@ export const DepartureDetailsScreenComponent = ({
               style={styles.messageBox}
             />
           ))}
+
           {notices.map(
             (notice) =>
               notice.text && (


### PR DESCRIPTION
reference : https://mittatb.slack.com/archives/C0116FMPX4Y/p1709638158570159
issue : https://github.com/AtB-AS/kundevendt/issues/16259

This PR will move the "Buss for tog" message box below the date, and add styling so there's enough gap when there are multiple message boxes showing.