### PR TITLE
refactor: Use react-query for listing tokens

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -44,7 +44,6 @@ import {
   LIST_REMOTE_TOKENS_QUERY_KEY,
   useListRemoteTokensQuery,
 } from '@atb/mobile-token/hooks/useListRemoteTokensQuery';
-import {LOAD_NATIVE_TOKEN_QUERY_KEY} from '@atb/mobile-token/hooks/useLoadNativeTokenQuery';
 
 const SIX_HOURS_MS = 1000 * 60 * 60 * 6;
 
@@ -182,7 +181,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
         if (shouldRenew) {
           Bugsnag.leaveBreadcrumb(`Renewing token (id: ${token.tokenId})`);
           const renewedToken = await mobileTokenClient.renew(token, traceId);
-          queryClient.invalidateQueries([LOAD_NATIVE_TOKEN_QUERY_KEY]);
+          queryClient.invalidateQueries([LIST_REMOTE_TOKENS_QUERY_KEY]);
 
           Bugsnag.leaveBreadcrumb(
             `Token (new id: ${renewedToken.tokenId}) renewed successfully`,

--- a/src/mobile-token/__tests__/tokenReducer.test.ts
+++ b/src/mobile-token/__tests__/tokenReducer.test.ts
@@ -19,45 +19,17 @@ describe('tokenReducer', () => {
   it('should set state to success', function () {
     const prevState: TokenReducerState = {status: 'loading'};
     const nativeToken = {} as any;
-    const remoteTokens = [] as any;
     const newState = tokenReducer(prevState, {
       type: 'SUCCESS',
       nativeToken,
-      remoteTokens,
     });
     expect(newState.status).toEqual('success');
     expect(newState.nativeToken).toBe(nativeToken);
-    expect(newState.remoteTokens).toBe(remoteTokens);
-  });
-  it('should update remote tokens if success', function () {
-    const prevState: TokenReducerState = {
-      status: 'success',
-      nativeToken: {} as any,
-      remoteTokens: [],
-    };
-    const remoteTokens = [] as any;
-    const newState = tokenReducer(prevState, {
-      type: 'UPDATE_REMOTE_TOKENS',
-      remoteTokens,
-    });
-    expect(newState.status).toEqual(prevState.status);
-    expect(newState.nativeToken).toBe(prevState.nativeToken);
-    expect(newState.remoteTokens).toBe(remoteTokens);
-  });
-  it('should not update remote tokens if not success', function () {
-    const prevState: TokenReducerState = {status: 'loading'};
-    const remoteTokens = [] as any;
-    const newState = tokenReducer(prevState, {
-      type: 'UPDATE_REMOTE_TOKENS',
-      remoteTokens,
-    });
-    expect(newState).toEqual(prevState);
   });
   it('should clear tokens', function () {
     const prevState: TokenReducerState = {
       status: 'success',
       nativeToken: {} as any,
-      remoteTokens: [],
     };
     const newState = tokenReducer(prevState, {type: 'CLEAR_TOKENS'});
     expect(newState).toEqual({status: 'none'});

--- a/src/mobile-token/hooks/useListRemoteTokensQuery.tsx
+++ b/src/mobile-token/hooks/useListRemoteTokensQuery.tsx
@@ -1,0 +1,33 @@
+import {useQuery} from '@tanstack/react-query';
+import {tokenService} from '@atb/mobile-token/tokenService';
+import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
+import {
+  getTravelCardId,
+  isInspectable,
+  isTravelCardToken,
+} from '@atb/mobile-token/utils';
+import {Token} from '@atb/mobile-token/types';
+
+import {v4 as uuid} from 'uuid';
+
+export const LIST_REMOTE_TOKENS_QUERY_KEY = 'listRemoteTokens';
+
+export const useListRemoteTokensQuery = (
+  enabled: boolean,
+  nativeToken?: ActivatedToken,
+) =>
+  useQuery({
+    queryKey: [LIST_REMOTE_TOKENS_QUERY_KEY, nativeToken?.tokenId],
+    queryFn: async () => tokenService.listTokens(uuid()),
+    enabled,
+    select: (tokens) =>
+      tokens.map(
+        (t): Token => ({
+          ...t,
+          isThisDevice: t.id === nativeToken?.tokenId,
+          isInspectable: isInspectable(t),
+          type: isTravelCardToken(t) ? 'travel-card' : 'mobile',
+          travelCardId: getTravelCardId(t),
+        }),
+      ),
+  });

--- a/src/mobile-token/tokenReducer.ts
+++ b/src/mobile-token/tokenReducer.ts
@@ -1,16 +1,14 @@
 import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
-import {MobileTokenStatus, RemoteToken} from '@atb/mobile-token/types';
+import {MobileTokenStatus} from '@atb/mobile-token/types';
 
 export type TokenReducerState = {
   nativeToken?: ActivatedToken;
-  remoteTokens?: RemoteToken[];
   status: MobileTokenStatus;
 };
 
 type TokenReducerAction =
   | {type: 'LOADING'}
-  | {type: 'SUCCESS'; nativeToken: ActivatedToken; remoteTokens: RemoteToken[]}
-  | {type: 'UPDATE_REMOTE_TOKENS'; remoteTokens: RemoteToken[]}
+  | {type: 'SUCCESS'; nativeToken: ActivatedToken}
   | {type: 'CLEAR_TOKENS'}
   | {type: 'ERROR'}
   | {type: 'TIMEOUT'};
@@ -31,12 +29,7 @@ export const tokenReducer: TokenReducer = (
       return {
         status: 'success',
         nativeToken: action.nativeToken,
-        remoteTokens: action.remoteTokens,
       };
-    case 'UPDATE_REMOTE_TOKENS':
-      return prevState.status === 'success'
-        ? {...prevState, remoteTokens: action.remoteTokens}
-        : prevState;
     case 'CLEAR_TOKENS':
       return {status: 'none'};
     case 'ERROR':


### PR DESCRIPTION
This is to enable more fine-grained error handling in mobile
token flow when updating the sdk. When we have decoupled the
different requests they can have their own error handling.

Without this change we would need a stored state specifying where
in the flow the error happened, so the correct step was retried.
