### PR TITLE
refactor: Mutation for renewal check

### DIFF
--- a/src/mobile-token/hooks/usePreemptiveRenewTokenMutation.tsx
+++ b/src/mobile-token/hooks/usePreemptiveRenewTokenMutation.tsx
@@ -1,0 +1,43 @@
+import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import Bugsnag from '@bugsnag/react-native';
+import {v4 as uuid} from 'uuid';
+import {mobileTokenClient} from '@atb/mobile-token/mobileTokenClient';
+import {LIST_REMOTE_TOKENS_QUERY_KEY} from '@atb/mobile-token/hooks/useListRemoteTokensQuery';
+import {Dispatch} from 'react';
+import {TokenReducerAction} from '@atb/mobile-token/tokenReducer';
+
+export const usePreemptiveRenewTokenMutation = (
+  dispatch: Dispatch<TokenReducerAction>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (
+      token?: ActivatedToken,
+    ): Promise<ActivatedToken | undefined> => {
+      if (!token) return undefined;
+      Bugsnag.leaveBreadcrumb(
+        `Checking if token (id: ${token!.tokenId}, validityEnd: ${
+          token!.validityEnd
+        }) should be renewed`,
+      );
+      const traceId = uuid();
+      const shouldRenew = await mobileTokenClient.shouldRenew(token);
+      if (shouldRenew) {
+        Bugsnag.leaveBreadcrumb(`Renewing token (id: ${token.tokenId})`);
+        const renewedToken = await mobileTokenClient.renew(token, traceId);
+        Bugsnag.leaveBreadcrumb(
+          `Token (new id: ${renewedToken.tokenId}) renewed successfully`,
+        );
+        return renewedToken;
+      }
+      return undefined;
+    },
+    onSuccess: (renewedToken) => {
+      if (renewedToken) {
+        queryClient.invalidateQueries([LIST_REMOTE_TOKENS_QUERY_KEY]);
+        dispatch({type: 'SUCCESS', nativeToken: renewedToken});
+      }
+    },
+  });
+};

--- a/src/mobile-token/tokenReducer.ts
+++ b/src/mobile-token/tokenReducer.ts
@@ -6,7 +6,7 @@ export type TokenReducerState = {
   status: MobileTokenStatus;
 };
 
-type TokenReducerAction =
+export type TokenReducerAction =
   | {type: 'LOADING'}
   | {type: 'SUCCESS'; nativeToken: ActivatedToken}
   | {type: 'CLEAR_TOKENS'}


### PR DESCRIPTION
Now using mutation from react-query for the renewal check which
happens every 6 hours. In line with earlier changes.
