### PR TITLE
fix: Only show login onboarding if not logged in

### DIFF
--- a/src/onboarding/onboarding-config.ts
+++ b/src/onboarding/onboarding-config.ts
@@ -23,7 +23,7 @@ export const onboardingSectionsInPrioritizedOrder: OnboardingSectionConfig[] =
         params: {},
       },
       shouldShowBeforeUserCreated: true,
-      shouldShowPredicate: () => true,
+      shouldShowPredicate: ({authenticationType}) => authenticationType === 'anonymous',
     },
     {
       isOnboardedStoreKey: '@ATB_location_when_in_use_permission_onboarded',


### PR DESCRIPTION
This was not ment to happen, and we are not really sure if it can
happen or not without messing with onboarding flags in the debug
menu. But the safeguard is added just in case.

### Acceptance criteria
- [ ] When resetting onboarding flags while logged in, the login onboarding should not show
