### PR TITLE
refactor: Toggle token as mutation

### DIFF
--- a/src/mobile-token/hooks/use-toggle-token-mutation.tsx
+++ b/src/mobile-token/hooks/use-toggle-token-mutation.tsx
@@ -1,0 +1,21 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {tokenService} from '../tokenService';
+import {v4 as uuid} from 'uuid';
+import {GET_TOKEN_TOGGLE_DETAILS_QUERY_KEY} from '../use-token-toggle-details';
+import {LIST_REMOTE_TOKENS_QUERY_KEY} from './useListRemoteTokensQuery';
+
+type Args = {
+  tokenId: string;
+  bypassRestrictions: boolean;
+};
+export const useToggleTokenMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({tokenId, bypassRestrictions}: Args) =>
+      tokenService.toggle(tokenId, uuid(), bypassRestrictions),
+    onSuccess: (tokens) => {
+      queryClient.setQueryData([LIST_REMOTE_TOKENS_QUERY_KEY], tokens);
+      queryClient.invalidateQueries([GET_TOKEN_TOGGLE_DETAILS_QUERY_KEY]);
+    },
+  });
+};

--- a/src/mobile-token/hooks/useListRemoteTokensQuery.tsx
+++ b/src/mobile-token/hooks/useListRemoteTokensQuery.tsx
@@ -17,8 +17,8 @@ export const useListRemoteTokensQuery = (
   nativeToken?: ActivatedToken,
 ) =>
   useQuery({
-    queryKey: [LIST_REMOTE_TOKENS_QUERY_KEY, nativeToken?.tokenId],
-    queryFn: async () => tokenService.listTokens(uuid()),
+    queryKey: [LIST_REMOTE_TOKENS_QUERY_KEY],
+    queryFn: () => tokenService.listTokens(uuid()),
     enabled,
     select: (tokens) =>
       tokens.map(

--- a/src/mobile-token/index.ts
+++ b/src/mobile-token/index.ts
@@ -3,3 +3,4 @@ export {
   useMobileTokenContextState,
 } from './MobileTokenContext';
 export type {Token, DeviceInspectionStatus} from './types';
+export {useToggleTokenMutation} from './hooks/use-toggle-token-mutation';

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -68,7 +68,7 @@ export type Root_LoginRequiredForFareProductScreenParams = {
 };
 
 export type Root_ActiveTokenOnPhoneRequiredForFareProductScreenParams = {
-  nextScreen?:
+  nextScreen:
     | NextScreenParams<'Root_TabNavigatorStack'>
     | NextScreenParams<'Root_PurchaseOverviewScreen'>;
 };


### PR DESCRIPTION
This also has the added benefit that screens doing toggling now
don't need to have their own internal state for loading/error, they
can use the mutation state.

Also removed token id as key in the list tokens query, as it didn't
really make sense to provide the token id when setting query data
through the client provider. Instead added a useEffect in
MobileTokenContext which invalidates the list tokens query when
native token id changes.
