### PR TITLE
fix: don't show popover when the on-behalf-of toggle is visible

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -30,6 +30,7 @@ import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_
 import {Section, ToggleSectionItem} from '@atb/components/sections';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {ContentHeading} from '@atb/components/heading';
+import {isUserProfileSelectable} from './utils';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -129,9 +130,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? new Date(preassignedFareProduct.limitations.latestActivationDate * 1000)
     : undefined;
 
-  const canSelectUserProfile = !(
-    travellerSelectionMode === `none` ||
-    (travellerSelectionMode === `single` && selectableTravellers.length <= 1)
+  const canSelectUserProfile = isUserProfileSelectable(
+    travellerSelectionMode,
+    selectableTravellers,
   );
 
   const hasSelection =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -25,6 +25,7 @@ import {useOnBehalfOf} from '@atb/on-behalf-of';
 import {LabelInfoTexts} from '@atb/translations/components/LabelInfo';
 import {usePopOver} from '@atb/popover';
 import {useFocusEffect} from '@react-navigation/native';
+import {canSelectUserProfile, isUserProfileSelectable} from '../utils';
 
 type TravellerSelectionProps = {
   selectableUserProfiles: UserProfileWithCount[];
@@ -65,9 +66,9 @@ export function TravellerSelection({
     UserProfileWithCount[]
   >(selectableUserProfiles);
 
-  const canSelectUserProfile = !(
-    (selectionMode === `single` || selectionMode === 'none') &&
-    selectableUserProfiles.length <= 1
+  const canSelectUserProfile = isUserProfileSelectable(
+    selectionMode,
+    selectableUserProfiles,
   );
 
   useEffect(() => {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -25,7 +25,7 @@ import {useOnBehalfOf} from '@atb/on-behalf-of';
 import {LabelInfoTexts} from '@atb/translations/components/LabelInfo';
 import {usePopOver} from '@atb/popover';
 import {useFocusEffect} from '@react-navigation/native';
-import {canSelectUserProfile, isUserProfileSelectable} from '../utils';
+import {isUserProfileSelectable} from '../utils';
 
 type TravellerSelectionProps = {
   selectableUserProfiles: UserProfileWithCount[];

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -66,7 +66,8 @@ export function TravellerSelection({
   >(selectableUserProfiles);
 
   const canSelectUserProfile = !(
-    selectionMode === `single` && selectableUserProfiles.length <= 1
+    (selectionMode === `single` || selectionMode === 'none') &&
+    selectableUserProfiles.length <= 1
   );
 
   useEffect(() => {
@@ -92,13 +93,13 @@ export function TravellerSelection({
 
   useFocusEffect(
     useCallback(() => {
-      if (isOnBehalfOfEnabled && selectionMode !== 'none') {
+      if (isOnBehalfOfEnabled && canSelectUserProfile) {
         addPopOver({
           oneTimeKey: 'on-behalf-of-new-feature-introduction',
           target: onBehalfOfIndicatorRef,
         });
       }
-    }, [isOnBehalfOfEnabled, addPopOver, selectionMode]),
+    }, [isOnBehalfOfEnabled, addPopOver, canSelectUserProfile]),
   );
 
   if (selectionMode === 'none') {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/utils.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/utils.ts
@@ -1,0 +1,11 @@
+import {TravellerSelectionMode} from '@atb-as/config-specs';
+import {UserProfile} from '@atb/configuration';
+
+export const isUserProfileSelectable = (
+  travellerSelectionMode: TravellerSelectionMode,
+  selectableTravellers: UserProfile[],
+) =>
+  !(
+    travellerSelectionMode === `none` ||
+    (travellerSelectionMode === `single` && selectableTravellers.length <= 1)
+  );


### PR DESCRIPTION
Found a popover issue when opening the youth ticket, this PR will fix that issue, by not showing the popover when the on-behalf-of toggle is visible on the screen.

I have tested this fix on: 
- AtB (Night ticket, carnet ticket, periodic ticket, both boat tickets, single ticket, youth ticket)
- Fram (single ticket, periodic ticket, fram county periodic tickets)
- NFK (single ticket, night ticket, carnet ticket, Reis Youth, Travel Pass Nordland)  