### PR TITLE
feat: handle fareProductTypeConfig onBehalfOfEnabled in app

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^3.16.0",
+    "@atb-as/config-specs": "^3.17.0",
     "@atb-as/generate-assets": "^10.0.0",
     "@atb-as/theme": "^8.0.0",
     "@bugsnag/react-native": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^3.17.0",
+    "@atb-as/config-specs": "^3.18.0",
     "@atb-as/generate-assets": "^10.0.0",
     "@atb-as/theme": "^8.0.0",
     "@bugsnag/react-native": "^7.21.0",

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -31,6 +31,7 @@ import {Section, ToggleSectionItem} from '@atb/components/sections';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from './utils';
+import {useOnBehalfOf} from '@atb/on-behalf-of';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -137,6 +138,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     travellerSelectionMode,
     selectableTravellers,
   );
+
+  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
 
   const hasSelection =
     travellerSelection.some((u) => u.count) &&
@@ -268,7 +271,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             setShowActivationDateWarning={setShowActivationDateWarning}
           />
 
-          {!canSelectUserProfile && fareProductOnBehalfOfEnabled && (
+          {isOnBehalfOfEnabled && !canSelectUserProfile && (
             <>
               <ContentHeading
                 text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -93,7 +93,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   } = params.fareProductTypeConfig.configuration;
 
   const fareProductOnBehalfOfEnabled =
-    params.fareProductTypeConfig.onBehalfOfEnabled;
+    params.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const offerEndpoint =
     zoneSelectionMode === 'none'
@@ -233,8 +233,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
           <TravellerSelection
             setTravellerSelection={setTravellerSelection}
-            fareProductType={preassignedFareProduct.type}
-            fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
+            fareProductTypeConfig={params.fareProductTypeConfig}
             selectionMode={travellerSelectionMode}
             selectableUserProfiles={selectableTravellers}
             style={styles.selectionComponent}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -91,6 +91,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     requiresTokenOnMobile,
   } = params.fareProductTypeConfig.configuration;
 
+  const fareProductOnBehalfOfEnabled =
+    params.fareProductTypeConfig.onBehalfOfEnabled;
+
   const offerEndpoint =
     zoneSelectionMode === 'none'
       ? 'authority'
@@ -228,6 +231,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           <TravellerSelection
             setTravellerSelection={setTravellerSelection}
             fareProductType={preassignedFareProduct.type}
+            fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
             selectionMode={travellerSelectionMode}
             selectableUserProfiles={selectableTravellers}
             style={styles.selectionComponent}
@@ -264,7 +268,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             setShowActivationDateWarning={setShowActivationDateWarning}
           />
 
-          {!canSelectUserProfile && (
+          {!canSelectUserProfile && fareProductOnBehalfOfEnabled && (
             <>
               <ContentHeading
                 text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -35,6 +35,7 @@ type TravellerSelectionProps = {
   style?: StyleProp<ViewStyle>;
   selectionMode: TravellerSelectionMode;
   fareProductType: string;
+  fareProductOnBehalfOfEnabled: boolean;
   setIsOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
   isOnBehalfOfToggle: boolean;
 };
@@ -45,6 +46,7 @@ export function TravellerSelection({
   selectableUserProfiles,
   selectionMode,
   fareProductType,
+  fareProductOnBehalfOfEnabled,
   setIsOnBehalfOfToggle,
   isOnBehalfOfToggle,
 }: TravellerSelectionProps) {
@@ -57,7 +59,7 @@ export function TravellerSelection({
     onCloseFocusRef,
   } = useBottomSheet();
 
-  const isOnBehalfOfEnabled = useOnBehalfOf();
+  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
 
   const {addPopOver} = usePopOver();
   const onBehalfOfIndicatorRef = useRef(null);
@@ -160,6 +162,7 @@ export function TravellerSelection({
       <TravellerSelectionSheet
         selectionMode={selectionMode}
         fareProductType={fareProductType}
+        fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
         selectableUserProfilesWithCountInit={userProfilesState}
         isOnBehalfOfToggle={isOnBehalfOfToggle}
         onConfirmSelection={(

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -2,7 +2,10 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
-import {TravellerSelectionMode} from '@atb/configuration';
+import {
+  FareProductTypeConfig,
+  TravellerSelectionMode,
+} from '@atb/configuration';
 import {
   GenericClickableSectionItem,
   GenericSectionItem,
@@ -34,8 +37,7 @@ type TravellerSelectionProps = {
   ) => void;
   style?: StyleProp<ViewStyle>;
   selectionMode: TravellerSelectionMode;
-  fareProductType: string;
-  fareProductOnBehalfOfEnabled: boolean;
+  fareProductTypeConfig: FareProductTypeConfig;
   setIsOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
   isOnBehalfOfToggle: boolean;
 };
@@ -45,8 +47,7 @@ export function TravellerSelection({
   style,
   selectableUserProfiles,
   selectionMode,
-  fareProductType,
-  fareProductOnBehalfOfEnabled,
+  fareProductTypeConfig,
   setIsOnBehalfOfToggle,
   isOnBehalfOfToggle,
 }: TravellerSelectionProps) {
@@ -59,7 +60,8 @@ export function TravellerSelection({
     onCloseFocusRef,
   } = useBottomSheet();
 
-  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
+  const isOnBehalfOfEnabled =
+    useOnBehalfOf() && fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const {addPopOver} = usePopOver();
   const onBehalfOfIndicatorRef = useRef(null);
@@ -92,7 +94,7 @@ export function TravellerSelection({
     );
     setTravellerSelection(filteredSelection);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fareProductType, selectionMode, userProfilesState]);
+  }, [selectionMode, userProfilesState]);
 
   useFocusEffect(
     useCallback(() => {
@@ -161,8 +163,7 @@ export function TravellerSelection({
     openBottomSheet(() => (
       <TravellerSelectionSheet
         selectionMode={selectionMode}
-        fareProductType={fareProductType}
-        fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
+        fareProductTypeConfig={fareProductTypeConfig}
         selectableUserProfilesWithCountInit={userProfilesState}
         isOnBehalfOfToggle={isOnBehalfOfToggle}
         onConfirmSelection={(

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -1,6 +1,9 @@
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
-import {TravellerSelectionMode} from '@atb/configuration';
+import {
+  FareProductTypeConfig,
+  TravellerSelectionMode,
+} from '@atb/configuration';
 import {ScrollView} from 'react-native';
 import React, {useState} from 'react';
 import {StyleSheet} from '@atb/theme';
@@ -14,8 +17,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 
 type TravellerSelectionSheetProps = {
   selectionMode: TravellerSelectionMode;
-  fareProductType: string;
-  fareProductOnBehalfOfEnabled: boolean;
+  fareProductTypeConfig: FareProductTypeConfig;
   selectableUserProfilesWithCountInit: UserProfileWithCount[];
   onConfirmSelection: (
     chosenSelectableUserProfiles: UserProfileWithCount[],
@@ -25,8 +27,7 @@ type TravellerSelectionSheetProps = {
 };
 export const TravellerSelectionSheet = ({
   selectionMode,
-  fareProductType,
-  fareProductOnBehalfOfEnabled,
+  fareProductTypeConfig,
   selectableUserProfilesWithCountInit,
   onConfirmSelection,
   isOnBehalfOfToggle,
@@ -54,8 +55,7 @@ export const TravellerSelectionSheet = ({
       <ScrollView style={style.container}>
         {selectionMode === 'multiple' ? (
           <MultipleTravellersSelection
-            fareProductType={fareProductType}
-            fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
+            fareProductTypeConfig={fareProductTypeConfig}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
             setIsTravelerOnBehalfOfToggle={setIsTravelerOnBehalfOfToggle}
@@ -63,8 +63,7 @@ export const TravellerSelectionSheet = ({
           />
         ) : (
           <SingleTravellerSelection
-            fareProductType={fareProductType}
-            fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
+            fareProductTypeConfig={fareProductTypeConfig}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
             setIsTravelerOnBehalfOfToggle={setIsTravelerOnBehalfOfToggle}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -15,6 +15,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 type TravellerSelectionSheetProps = {
   selectionMode: TravellerSelectionMode;
   fareProductType: string;
+  fareProductOnBehalfOfEnabled: boolean;
   selectableUserProfilesWithCountInit: UserProfileWithCount[];
   onConfirmSelection: (
     chosenSelectableUserProfiles: UserProfileWithCount[],
@@ -25,6 +26,7 @@ type TravellerSelectionSheetProps = {
 export const TravellerSelectionSheet = ({
   selectionMode,
   fareProductType,
+  fareProductOnBehalfOfEnabled,
   selectableUserProfilesWithCountInit,
   onConfirmSelection,
   isOnBehalfOfToggle,
@@ -53,6 +55,7 @@ export const TravellerSelectionSheet = ({
         {selectionMode === 'multiple' ? (
           <MultipleTravellersSelection
             fareProductType={fareProductType}
+            fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
             setIsTravelerOnBehalfOfToggle={setIsTravelerOnBehalfOfToggle}
@@ -61,6 +64,7 @@ export const TravellerSelectionSheet = ({
         ) : (
           <SingleTravellerSelection
             fareProductType={fareProductType}
+            fareProductOnBehalfOfEnabled={fareProductOnBehalfOfEnabled}
             {...userCountState}
             userProfilesWithCount={selectableUserProfilesWithCount}
             setIsTravelerOnBehalfOfToggle={setIsTravelerOnBehalfOfToggle}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -27,6 +27,7 @@ export function MultipleTravellersSelection({
   addCount,
   removeCount,
   fareProductType,
+  fareProductOnBehalfOfEnabled,
   setIsTravelerOnBehalfOfToggle,
   isTravelerOnBehalfOfToggle,
 }: UserCountState & TravelerOnBehalfOfProps) {
@@ -35,7 +36,7 @@ export function MultipleTravellersSelection({
 
   const travellersModified = useRef(false);
 
-  const isOnBehalfOfEnabled = useOnBehalfOf();
+  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
 
   const addTraveller = (userTypeString: string) => {
     travellersModified.current = true;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -1,5 +1,4 @@
 import React, {useRef} from 'react';
-import {UserCountState} from './use-user-count-state';
 import {
   getTextForLanguage,
   Language,
@@ -20,23 +19,23 @@ import {useOnBehalfOf} from '@atb/on-behalf-of';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {TravelerOnBehalfOfProps} from './types';
+import {TravellerSelectionBottomSheetType} from './types';
 
 export function MultipleTravellersSelection({
   userProfilesWithCount,
   addCount,
   removeCount,
-  fareProductType,
-  fareProductOnBehalfOfEnabled,
+  fareProductTypeConfig,
   setIsTravelerOnBehalfOfToggle,
   isTravelerOnBehalfOfToggle,
-}: UserCountState & TravelerOnBehalfOfProps) {
+}: TravellerSelectionBottomSheetType) {
   const {t, language} = useTranslation();
   const styles = useStyles();
 
   const travellersModified = useRef(false);
 
-  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
+  const isOnBehalfOfEnabled =
+    useOnBehalfOf() && fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const addTraveller = (userTypeString: string) => {
     travellersModified.current = true;
@@ -71,7 +70,7 @@ export function MultipleTravellersSelection({
               t(
                 TicketTravellerTexts.information(
                   u.userTypeString,
-                  fareProductType,
+                  fareProductTypeConfig.type,
                 ),
               ),
             ].join(' ')}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -24,6 +24,7 @@ export function SingleTravellerSelection({
   addCount,
   removeCount,
   fareProductType,
+  fareProductOnBehalfOfEnabled,
   setIsTravelerOnBehalfOfToggle,
   isTravelerOnBehalfOfToggle,
 }: UserCountState & TravelerOnBehalfOfProps) {
@@ -31,7 +32,7 @@ export function SingleTravellerSelection({
   const styles = useStyles();
   const selectedProfile = userProfilesWithCount.find((u) => u.count);
 
-  const isOnBehalfOfEnabled = useOnBehalfOf();
+  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
 
   const select = (u: UserProfileWithCount) => {
     if (selectedProfile) {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {UserCountState} from './use-user-count-state';
 import {
   useTranslation,
   TicketTravellerTexts,
@@ -17,22 +16,22 @@ import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {useOnBehalfOf} from '@atb/on-behalf-of';
-import {TravelerOnBehalfOfProps} from './types';
+import {TravellerSelectionBottomSheetType} from './types';
 
 export function SingleTravellerSelection({
   userProfilesWithCount,
   addCount,
   removeCount,
-  fareProductType,
-  fareProductOnBehalfOfEnabled,
+  fareProductTypeConfig,
   setIsTravelerOnBehalfOfToggle,
   isTravelerOnBehalfOfToggle,
-}: UserCountState & TravelerOnBehalfOfProps) {
+}: TravellerSelectionBottomSheetType) {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const selectedProfile = userProfilesWithCount.find((u) => u.count);
 
-  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
+  const isOnBehalfOfEnabled =
+    useOnBehalfOf() && fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const select = (u: UserProfileWithCount) => {
     if (selectedProfile) {
@@ -68,7 +67,7 @@ export function SingleTravellerSelection({
         keyExtractor={(u) => u.userTypeString}
         itemToText={(u) => getReferenceDataName(u, language)}
         itemToSubtext={(u) =>
-          travellerInfoByFareProductType(fareProductType, u)
+          travellerInfoByFareProductType(fareProductTypeConfig.type, u)
         }
         selected={selectedProfile}
         onSelect={select}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
@@ -1,5 +1,17 @@
+import {FareProductTypeConfig} from '@atb-as/config-specs';
+import {UserProfileWithCount} from '@atb/fare-contracts';
+
 export type TravelerOnBehalfOfProps = {
   setIsTravelerOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
   isTravelerOnBehalfOfToggle: boolean;
-  fareProductOnBehalfOfEnabled: boolean;
 };
+
+export type UserCountState = {
+  userProfilesWithCount: UserProfileWithCount[];
+  addCount: (userTypeString: string) => void;
+  removeCount: (userTypeString: string) => void;
+  updateSelectable: (selectableUserProfiles: UserProfileWithCount[]) => void;
+};
+
+export type TravellerSelectionBottomSheetType = UserCountState &
+  TravelerOnBehalfOfProps & {fareProductTypeConfig: FareProductTypeConfig};

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/types.ts
@@ -1,4 +1,5 @@
 export type TravelerOnBehalfOfProps = {
   setIsTravelerOnBehalfOfToggle: (onBehalfOfToggle: boolean) => void;
   isTravelerOnBehalfOfToggle: boolean;
+  fareProductOnBehalfOfEnabled: boolean;
 };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state.ts
@@ -1,5 +1,6 @@
 import {useCallback, useReducer} from 'react';
 import {UserProfileWithCount} from '@atb/fare-contracts';
+import {UserCountState} from './types';
 
 type ReducerState = {
   userProfilesWithCount: UserProfileWithCount[];
@@ -62,14 +63,6 @@ const countReducer: CountReducer = (prevState, action): ReducerState => {
       };
     }
   }
-};
-
-export type UserCountState = {
-  userProfilesWithCount: UserProfileWithCount[];
-  addCount: (userTypeString: string) => void;
-  removeCount: (userTypeString: string) => void;
-  updateSelectable: (selectableUserProfiles: UserProfileWithCount[]) => void;
-  fareProductType?: string;
 };
 
 export function useUserCountState(

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^3.17.0":
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.17.0.tgz#edae41792595391c103570e12a087af3ec36ba41"
-  integrity sha512-MB//KXjVPhsoL/eWah4QrIUpzsQQa/OxgSTkdJ0LB/bCLSt7jbYJ4OsPRp/QF1g/Th3cHcEsvX9aot3OF3X2kA==
+"@atb-as/config-specs@^3.18.0":
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.18.0.tgz#b5d46a02a2d962e7e30d7fdfc8206d9a1e39c9cf"
+  integrity sha512-OHXi47GGYGlIl4QUPqIzl2pmIL+0pqwhzwIWBdjCWx/g8y6857Y0cnFSL6dAmVlBu3mK9u35x77ypVj3vXcQNQ==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^3.16.0":
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.16.0.tgz#c0693176ad894283a99eca421c9d158436e9f9bb"
-  integrity sha512-+xmB4zKpAWumMjmbwu2Mpyzm5gkejZC2+f+dc1hFQrQnyCcv+6BOIfKfqUs52ziJqzeK2l4YSUlaqqB8lkrrkQ==
+"@atb-as/config-specs@^3.17.0":
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.17.0.tgz#edae41792595391c103570e12a087af3ec36ba41"
+  integrity sha512-MB//KXjVPhsoL/eWah4QrIUpzsQQa/OxgSTkdJ0LB/bCLSt7jbYJ4OsPRp/QF1g/Th3cHcEsvX9aot3OF3X2kA==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17193

This PR will handle the new `onBehalfOfEnabled` flag in `fareProductTypeConfig`.
Should be a pretty straightforward PR.