### PR TITLE
fix: fixed scroll of ActiveTokenOnPhoneRequiredForFareProductScreen

### DIFF
--- a/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
@@ -19,7 +19,6 @@ import MobileTokenOnboarding from '@atb/translations/screens/subscreens/MobileTo
 import Ticketing from '@atb/translations/screens/Ticketing';
 import {getDeviceNameWithUnitInfo} from '@atb/select-travel-token-screen/utils';
 import {useToggleTokenMutation} from '@atb/mobile-token';
-import {FullScreenFooter} from '@atb/components/screen-footer';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -135,8 +134,6 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
         >
           {t(ActiveTokenRequiredTexts.actionMessage)}
         </ThemeText>
-      </ScrollView>
-      <FullScreenFooter>
         {toggleMutation.isLoading ? (
           <ActivityIndicator size="large" />
         ) : (
@@ -146,9 +143,10 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
             interactiveColor="interactive_0"
             disabled={!selectedToken}
             testID="confirmSelectionButton"
+            style={styles.buttonStyle}
           />
         )}
-      </FullScreenFooter>
+      </ScrollView>
     </View>
   );
 };
@@ -174,5 +172,8 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   },
   errorMessageBox: {
     marginBottom: theme.spacings.medium,
+  },
+  buttonStyle: {
+    paddingVertical: theme.spacings.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
@@ -19,6 +19,7 @@ import MobileTokenOnboarding from '@atb/translations/screens/subscreens/MobileTo
 import Ticketing from '@atb/translations/screens/Ticketing';
 import {getDeviceNameWithUnitInfo} from '@atb/select-travel-token-screen/utils';
 import {useToggleTokenMutation} from '@atb/mobile-token';
+import {FullScreenFooter} from '@atb/components/screen-footer';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -134,7 +135,8 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
         >
           {t(ActiveTokenRequiredTexts.actionMessage)}
         </ThemeText>
-
+      </ScrollView>
+      <FullScreenFooter>
         {toggleMutation.isLoading ? (
           <ActivityIndicator size="large" />
         ) : (
@@ -146,14 +148,14 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
             testID="confirmSelectionButton"
           />
         )}
-      </ScrollView>
+      </FullScreenFooter>
     </View>
   );
 };
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    flexGrow: 1,
+    flex: 1,
     backgroundColor: theme.static.background[themeColor].background,
   },
   mainView: {


### PR DESCRIPTION
When you have toggled to t:card and want to purchase for instance boat or youth ticket you have to toggle to phone. In order to do so we prompt the user to do it by showing a screen. If a user has increased the font size on their device they might not be able to currently read the whole info text or select the confirm "bytt til mobil" button. 

_Acceptance criteria_
- [ ] The user can read all info in the screen and proceed with doing the swap to use token on mobile.

_Before_ <img src="https://github.com/AtB-AS/mittatb-app/assets/126664682/f1292290-539d-4c0b-bbd7-fdf481c9175d" width="200" /> 👉🏼 👉🏼 👉🏼   _After_ <img src="https://github.com/AtB-AS/mittatb-app/assets/126664682/399aa349-1433-479e-b95b-459abc0759e1" width="200" />

Note: This shows the entire screen possible to scroll to, meaning scrolled all the way down. So the bottom text is cut and the button is not visible and clickable in our current solution. 

