### PR TITLE
fix: Presented sent date should show the created date

### DIFF
--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -117,6 +117,7 @@ export const FareContractView: React.FC<Props> = ({
           <ValidityHeader
             status={fareContractValidityStatus}
             now={now}
+            createdDate={fareContract.created.toMillis()}
             validFrom={fareContractValidFrom}
             validTo={fareContractValidTo}
             fareProductType={preassignedFareProduct?.type}

--- a/src/fare-contracts/ValidityHeader.tsx
+++ b/src/fare-contracts/ValidityHeader.tsx
@@ -19,10 +19,11 @@ import {useMobileTokenContextState} from '@atb/mobile-token';
 export const ValidityHeader: React.FC<{
   status: ValidityStatus;
   now: number;
+  createdDate: number;
   validFrom: number;
   validTo: number;
   fareProductType: string | undefined;
-}> = ({status, now, validFrom, validTo, fareProductType}) => {
+}> = ({status, now, createdDate, validFrom, validTo, fareProductType}) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
@@ -34,6 +35,7 @@ export const ValidityHeader: React.FC<{
   const validityTime: string = validityTimeText(
     status,
     now,
+    createdDate,
     validFrom,
     validTo,
     t,
@@ -75,6 +77,7 @@ export const ValidityHeader: React.FC<{
 function validityTimeText(
   status: ValidityStatus,
   now: number,
+  createdDate: number,
   validFrom: number,
   validTo: number,
   t: TranslateFunction,
@@ -117,7 +120,7 @@ function validityTimeText(
     case 'reserving':
       return t(FareContractTexts.validityHeader.reserving);
     case 'sent':
-      const dateTime = formatToLongDateTime(toDate(validFrom), language);
+      const dateTime = formatToLongDateTime(toDate(createdDate), language);
       return t(FareContractTexts.validityHeader.sent(dateTime));
     case 'unknown':
     default:

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -150,6 +150,7 @@ export const DetailsContent: React.FC<Props> = ({
             <ValidityHeader
               status={fareContractValidityStatus}
               now={now}
+              createdDate={fc.created.toMillis()}
               validFrom={fareContractValidFrom}
               validTo={fareContractValidTo}
               fareProductType={preassignedFareProduct?.type}


### PR DESCRIPTION
### Background
It was using the valid from date, which doesn't work when
purchasing a ticket with a future start date.

### Solution
Using the created date as the sent date.

Before/After (Notice the difference between "Sendt" and "Kjøpt" dates in the before picture)
<div>
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/114f8227-2585-4881-8796-09893eca5819" />
<img width=350 src="https://github.com/AtB-AS/mittatb-app/assets/675421/500987dd-f137-4989-ae14-211fe9873877" />
</div>

### Acceptance criteria
- [ ] When purchasing a ticket for others with a future start date, the sent date on the sent tickets screen is the purchase date.
