### PR TITLE
test: e2e-myprofile tests

### DIFF
--- a/e2e/test/pageobjects/myProfile.page.ts
+++ b/e2e/test/pageobjects/myProfile.page.ts
@@ -1,5 +1,4 @@
 import AppHelper from '../utils/app.helper.ts';
-import {parseBoolean} from '../utils/utils.ts';
 
 class MyProfilePage {
   /**
@@ -10,15 +9,6 @@ class MyProfilePage {
     const reqId = `//*[@resource-id="${setting}Button"]`;
     await $(reqId).click();
     await AppHelper.pause();
-  }
-
-  /**
-   * Checks if notification toggle is checked or not
-   * @param type type of notification to check
-   */
-  async notificationIsEnabled(type: string) {
-    const reqId = `//*[@resource-id="${type}Toggle"]`;
-    return parseBoolean(await $(reqId).getAttribute('checked'));
   }
 }
 

--- a/e2e/test/pageobjects/myProfile.page.ts
+++ b/e2e/test/pageobjects/myProfile.page.ts
@@ -1,0 +1,25 @@
+import AppHelper from '../utils/app.helper.ts';
+import {parseBoolean} from '../utils/utils.ts';
+
+class MyProfilePage {
+  /**
+   * Open a setting from my profile
+   * @param setting the setting to open
+   */
+  async openSetting(setting: string) {
+    const reqId = `//*[@resource-id="${setting}Button"]`;
+    await $(reqId).click();
+    await AppHelper.pause();
+  }
+
+  /**
+   * Checks if notification toggle is checked or not
+   * @param type type of notification to check
+   */
+  async notificationIsEnabled(type: string) {
+    const reqId = `//*[@resource-id="${type}Toggle"]`;
+    return parseBoolean(await $(reqId).getAttribute('checked'));
+  }
+}
+
+export default new MyProfilePage();

--- a/e2e/test/pageobjects/notifications.page.ts
+++ b/e2e/test/pageobjects/notifications.page.ts
@@ -1,0 +1,44 @@
+import AppHelper from '../utils/app.helper.ts';
+import {parseBoolean} from '../utils/utils.ts';
+
+class NotificationsPage {
+  /**
+   * Checks if notification toggle is checked or not
+   * @param type type of notification to check
+   */
+  async notificationIsEnabled(type: string) {
+    const reqId = `//*[@resource-id="${type}Toggle"]`;
+    return parseBoolean(await $(reqId).getAttribute('checked'));
+  }
+
+  /**
+   * Toggle (enable/disable) data collection
+   */
+  async toggleEmailNotifications() {
+    const reqId = `//*[@resource-id="emailToggle"]`;
+    await $(reqId).click();
+    await AppHelper.pause();
+  }
+
+  /**
+   * Check if the info of missing requirements like login and email exists or not
+   * @param exists is true if exists, and false if not (default: true)
+   */
+  async missingLoginAndEmailInfoExists(exists: boolean = true) {
+    const reqId = `//*[@resource-id="messageBox"]`;
+    const titleId = `//*[@resource-id="title"]`;
+    if (exists) {
+      await expect(await $(reqId)).toExist();
+      await expect(await $$(reqId)[0].$(titleId).getText()).toContain(
+        'Login required',
+      );
+      await expect(await $$(reqId)[1].$(titleId).getText()).toContain(
+        'E-mail missing',
+      );
+    } else {
+      await expect(await $(reqId)).not.toExist();
+    }
+  }
+}
+
+export default new NotificationsPage();

--- a/e2e/test/pageobjects/onboarding.page.ts
+++ b/e2e/test/pageobjects/onboarding.page.ts
@@ -66,6 +66,24 @@ class OnboardingPage {
   }
 
   /**
+   * Deny use of location - and don't ask again
+   * Possible other values:
+   * - com.android.permissioncontroller:id/permission_allow_foreground_only_button
+   * - com.android.permissioncontroller:id/permission_allow_one_time_button
+   */
+  async denyLocationAndDontAskAgain() {
+    await ElementHelper.waitForElement(
+      'id',
+      'com.android.permissioncontroller:id/permission_deny_and_dont_ask_again_button',
+    );
+    await driver
+      .$(
+        '//*[@resource-id="com.android.permissioncontroller:id/permission_deny_and_dont_ask_again_button"]',
+      )
+      .click();
+  }
+
+  /**
    * Tap through the onboarding
    */
   async skipOnboarding(testName: string = '') {

--- a/e2e/test/pageobjects/privacy.page.ts
+++ b/e2e/test/pageobjects/privacy.page.ts
@@ -1,0 +1,40 @@
+import AppHelper from '../utils/app.helper.ts';
+import {parseBoolean} from '../utils/utils.ts';
+
+class PrivacyPage {
+  /**
+   * Checks if data collection toggle is checked or not
+   */
+  async dataCollectionIsEnabled() {
+    const reqId = `//*[@resource-id="toggleCollectData"]`;
+    return parseBoolean(await $(reqId).getAttribute('checked'));
+  }
+
+  /**
+   * Toggle (enable/disable) data collection
+   */
+  async toggleDataCollection() {
+    const reqId = `//*[@resource-id="toggleCollectData"]`;
+    await $(reqId).click();
+    await AppHelper.pause();
+  }
+
+  /**
+   * Check if the missing permission info exists or not
+   * @param exists is true if exists, and false if not (default: true)
+   */
+  async permissionRequiredInfoExists(exists: boolean = true) {
+    const reqId = `//*[@resource-id="messageBox"]`;
+    const titleId = `//*[@resource-id="title"]`;
+    if (exists) {
+      await expect(await $(reqId)).toExist();
+      await expect(await $(reqId).$(titleId).getText()).toContain(
+        'Permission required',
+      );
+    } else {
+      await expect(await $(reqId)).not.toExist();
+    }
+  }
+}
+
+export default new PrivacyPage();

--- a/e2e/test/specs/myProfile.e2e.ts
+++ b/e2e/test/specs/myProfile.e2e.ts
@@ -1,0 +1,130 @@
+import AppHelper from '../utils/app.helper.ts';
+import OnboardingPage from '../pageobjects/onboarding.page.ts';
+import NavigationHelper from '../utils/navigation.helper.ts';
+import ElementHelper from '../utils/element.helper.ts';
+import MyProfilePage from '../pageobjects/myProfile.page.ts';
+import AlertHelper from '../utils/alert.helper.ts';
+import PrivacyPage from '../pageobjects/privacy.page.ts';
+
+describe('My profile', () => {
+  before(async () => {
+    await AppHelper.waitOnLoadingScreen();
+    await OnboardingPage.skipOnboarding('myProfile');
+    await AppHelper.pause(5000, true);
+  });
+  beforeEach(async () => {
+    await NavigationHelper.tapMenu('profile');
+    await NavigationHelper.tapMenu('profile');
+    await ElementHelper.waitForElement('text', 'My profile');
+  });
+
+  // Check the default options for notifications
+  it('should have correct default notification options', async () => {
+    const defaultSettings = {
+      email: false,
+      push: true,
+      single: false,
+      period: true,
+      night: false,
+      carnet: false,
+      'on-behalf-of': true,
+    };
+    try {
+      await MyProfilePage.openSetting('notifications');
+      await ElementHelper.waitForElement('text', 'Notifications');
+      await ElementHelper.waitForElement('id', 'emailToggle');
+
+      expect(await MyProfilePage.notificationIsEnabled('email')).toBe(
+        defaultSettings.email,
+      );
+      expect(await MyProfilePage.notificationIsEnabled('push')).toBe(
+        defaultSettings.push,
+      );
+      expect(await MyProfilePage.notificationIsEnabled('single')).toBe(
+        defaultSettings.single,
+      );
+      expect(await MyProfilePage.notificationIsEnabled('period')).toBe(
+        defaultSettings.period,
+      );
+      // Scroll
+      await AppHelper.scrollDownUntilId(
+        'notificationsView',
+        'on-behalf-ofToggle',
+      );
+      expect(await MyProfilePage.notificationIsEnabled('night')).toBe(
+        defaultSettings.night,
+      );
+      expect(await MyProfilePage.notificationIsEnabled('carnet')).toBe(
+        defaultSettings.carnet,
+      );
+      expect(await MyProfilePage.notificationIsEnabled('on-behalf-of')).toBe(
+        defaultSettings['on-behalf-of'],
+      );
+
+      await NavigationHelper.back();
+      await AppHelper.pause();
+    } catch (errMsg) {
+      await AppHelper.screenshot(
+        'error_myProfile_default_notification_options',
+      );
+      throw errMsg;
+    }
+  });
+
+  // Check that data collection is not enabled as default
+  it('should collect data only when enabled', async () => {
+    try {
+      await MyProfilePage.openSetting('privacy');
+      await ElementHelper.waitForElement('text', 'Privacy');
+
+      // Default
+      await expect(await PrivacyPage.dataCollectionIsEnabled()).toBe(false);
+      await expect(await ElementHelper.getElement('privacyButton')).toExist();
+      await expect(
+        await ElementHelper.getElement('controlPanelButton'),
+      ).toExist();
+      await expect(
+        await ElementHelper.getElement('deleteLocalSearchDataButton'),
+      ).toExist();
+      await expect(
+        await ElementHelper.getElement('deleteCollectedDataButton'),
+      ).toExist();
+      await expect(
+        await ElementHelper.getElement('dataSharingInfoButton'),
+      ).not.toExist();
+      await PrivacyPage.permissionRequiredInfoExists(false);
+
+      // Enable data collection
+      await PrivacyPage.toggleDataCollection();
+
+      // Permission prompts
+      await expect(await AlertHelper.alertTitle).toContain('Bluetooth');
+      await AlertHelper.alertConfirm.click();
+      await OnboardingPage.denyLocationAndDontAskAgain();
+      await AppHelper.pause();
+
+      // Verify
+      await expect(await PrivacyPage.dataCollectionIsEnabled()).toBe(true);
+      await expect(
+        await ElementHelper.getElement('dataSharingInfoButton'),
+      ).toExist();
+      await PrivacyPage.permissionRequiredInfoExists();
+
+      // Disable data collection
+      await PrivacyPage.toggleDataCollection();
+
+      // Verify
+      await expect(await PrivacyPage.dataCollectionIsEnabled()).toBe(false);
+      await expect(
+        await ElementHelper.getElement('dataSharingInfoButton'),
+      ).not.toExist();
+      await PrivacyPage.permissionRequiredInfoExists(false);
+
+      await NavigationHelper.back();
+      await AppHelper.pause();
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_myProfile_privacy_data_collection');
+      throw errMsg;
+    }
+  });
+});

--- a/e2e/test/specs/myProfile.e2e.ts
+++ b/e2e/test/specs/myProfile.e2e.ts
@@ -5,6 +5,7 @@ import ElementHelper from '../utils/element.helper.ts';
 import MyProfilePage from '../pageobjects/myProfile.page.ts';
 import AlertHelper from '../utils/alert.helper.ts';
 import PrivacyPage from '../pageobjects/privacy.page.ts';
+import NotificationsPage from '../pageobjects/notifications.page.ts';
 
 describe('My profile', () => {
   before(async () => {
@@ -34,16 +35,16 @@ describe('My profile', () => {
       await ElementHelper.waitForElement('text', 'Notifications');
       await ElementHelper.waitForElement('id', 'emailToggle');
 
-      expect(await MyProfilePage.notificationIsEnabled('email')).toBe(
+      expect(await NotificationsPage.notificationIsEnabled('email')).toBe(
         defaultSettings.email,
       );
-      expect(await MyProfilePage.notificationIsEnabled('push')).toBe(
+      expect(await NotificationsPage.notificationIsEnabled('push')).toBe(
         defaultSettings.push,
       );
-      expect(await MyProfilePage.notificationIsEnabled('single')).toBe(
+      expect(await NotificationsPage.notificationIsEnabled('single')).toBe(
         defaultSettings.single,
       );
-      expect(await MyProfilePage.notificationIsEnabled('period')).toBe(
+      expect(await NotificationsPage.notificationIsEnabled('period')).toBe(
         defaultSettings.period,
       );
       // Scroll
@@ -51,15 +52,15 @@ describe('My profile', () => {
         'notificationsView',
         'on-behalf-ofToggle',
       );
-      expect(await MyProfilePage.notificationIsEnabled('night')).toBe(
+      expect(await NotificationsPage.notificationIsEnabled('night')).toBe(
         defaultSettings.night,
       );
-      expect(await MyProfilePage.notificationIsEnabled('carnet')).toBe(
+      expect(await NotificationsPage.notificationIsEnabled('carnet')).toBe(
         defaultSettings.carnet,
       );
-      expect(await MyProfilePage.notificationIsEnabled('on-behalf-of')).toBe(
-        defaultSettings['on-behalf-of'],
-      );
+      expect(
+        await NotificationsPage.notificationIsEnabled('on-behalf-of'),
+      ).toBe(defaultSettings['on-behalf-of']);
 
       await NavigationHelper.back();
       await AppHelper.pause();
@@ -67,6 +68,39 @@ describe('My profile', () => {
       await AppHelper.screenshot(
         'error_myProfile_default_notification_options',
       );
+      throw errMsg;
+    }
+  });
+
+  // Verify that login is required and email is missing for email notifications
+  it('should show login and missing email info for email notifications', async () => {
+    try {
+      await MyProfilePage.openSetting('notifications');
+      await ElementHelper.waitForElement('text', 'Notifications');
+      await ElementHelper.waitForElement('id', 'emailToggle');
+
+      // Pre
+      expect(await NotificationsPage.notificationIsEnabled('email')).toBe(
+        false,
+      );
+      await NotificationsPage.missingLoginAndEmailInfoExists(false);
+
+      // On
+      await NotificationsPage.toggleEmailNotifications();
+      expect(await NotificationsPage.notificationIsEnabled('email')).toBe(true);
+      await NotificationsPage.missingLoginAndEmailInfoExists(true);
+
+      // Off
+      await NotificationsPage.toggleEmailNotifications();
+      expect(await NotificationsPage.notificationIsEnabled('email')).toBe(
+        false,
+      );
+      await NotificationsPage.missingLoginAndEmailInfoExists(false);
+
+      await NavigationHelper.back();
+      await AppHelper.pause();
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_myProfile_email_notification_info');
       throw errMsg;
     }
   });

--- a/e2e/test/specs/onboarding.e2e.ts
+++ b/e2e/test/specs/onboarding.e2e.ts
@@ -1,7 +1,6 @@
 import OnboardingPage from '../pageobjects/onboarding.page.ts';
 import AppHelper from '../utils/app.helper.ts';
 import ElementHelper from '../utils/element.helper.ts';
-import {HeadingTexts} from '../texts/index.ts';
 
 describe('Onboarding', () => {
   before(async () => {
@@ -29,7 +28,7 @@ describe('Onboarding', () => {
       await OnboardingPage.denyLocation();
 
       await ElementHelper.waitForElement('id', 'dashboardScrollView');
-      await ElementHelper.expectText(HeadingTexts.travelsearch);
+      await ElementHelper.expectText('Travel search');
     } catch (errMsg) {
       await AppHelper.screenshot('error_onboarding_should_onboard');
       throw errMsg;

--- a/e2e/test/texts/index.ts
+++ b/e2e/test/texts/index.ts
@@ -1,3 +1,0 @@
-export const HeadingTexts = {
-  travelsearch: ['Travel search', 'Reisesøk'],
-};

--- a/e2e/test/utils/alert.helper.ts
+++ b/e2e/test/utils/alert.helper.ts
@@ -11,6 +11,14 @@ class AlertHelper {
   }
 
   /**
+   * Title of the pop-up alert
+   */
+  get alertTitle() {
+    const id = `//*[@resource-id="android:id/alertTitle"]`;
+    return $(id).getText();
+  }
+
+  /**
    * Cancel button in pop-up alerts
    */
   get alertCancel() {

--- a/e2e/test/utils/element.helper.ts
+++ b/e2e/test/utils/element.helper.ts
@@ -124,18 +124,13 @@ class ElementHelper {
   }
 
   /**
-   * Checks if the provided text exists - either a string or one of the strings
-   * in an array
-   * @param text String or array of strings
+   * Checks if the provided text exists
+   * @param text String to check
    */
-  async expectText(text: string | string[]) {
-    if (Array.isArray(text)) {
-      await expect(this.getElementFromTextArray(text)).toHaveTextContaining(
-        text,
-      );
-    } else {
-      await expect(this.getElementText(text)).toHaveTextContaining(text);
-    }
+  async expectText(text: string) {
+    await expect(this.getElementText(text)).toHaveText(
+      expect.stringContaining(text),
+    );
   }
 
   /**

--- a/e2e/test/utils/utils.ts
+++ b/e2e/test/utils/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Parses a string to a boolean
+ * @param str input string ('true' | 'false')
+ */
+export function parseBoolean(str: string | undefined | null) {
+  if (str === 'true') return true;
+  if (str === 'false') return false;
+  return undefined;
+}

--- a/src/components/sections/items/MessageSectionItem.tsx
+++ b/src/components/sections/items/MessageSectionItem.tsx
@@ -68,6 +68,7 @@ export function MessageSectionItem({
             type="body__primary--bold"
             style={styles.title}
             color={messageType}
+            testID="title"
           >
             {title}
           </ThemeText>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
@@ -103,7 +103,7 @@ export const Profile_NotificationsScreen = ({
       {permissionStatus === 'loading' || profileQuery.isLoading ? (
         <Processing message={t(dictionary.loading)} />
       ) : (
-        <View style={style.content}>
+        <View style={style.content} testID="notificationsView">
           <ContentHeading
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.notifications
@@ -130,6 +130,7 @@ export const Profile_NotificationsScreen = ({
               }
               value={mailEnabled}
               onValueChange={(enabled) => handleModeToggle('mail', enabled)}
+              testID="emailToggle"
             />
             {mailEnabled && authenticationType === 'anonymous' && (
               <MessageSectionItem
@@ -178,6 +179,7 @@ export const Profile_NotificationsScreen = ({
               )}
               value={pushEnabled}
               onValueChange={(enabled) => handleModeToggle('push', enabled)}
+              testID="pushToggle"
             />
             {shouldPromptForPushPermission && (
               <MessageSectionItem
@@ -258,6 +260,7 @@ export const Profile_NotificationsScreen = ({
                   onValueChange={(enabled) =>
                     handleGroupToggle(group.id, enabled)
                   }
+                  testID={`${group.id}Toggle`}
                 />
               ))}
           </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -153,7 +153,7 @@ export const Profile_PrivacyScreen = () => {
                 ),
                 accessibilityRole: 'link',
               }}
-              testID="privacyButton"
+              testID="controlPanelButton"
               onPress={async () => {
                 const privacyDashboardUrl = await getPrivacyDashboardUrl();
                 privacyDashboardUrl &&
@@ -211,7 +211,7 @@ export const Profile_PrivacyScreen = () => {
                 },
               })
             }
-            testID="deleteLocalSearchData"
+            testID="deleteLocalSearchDataButton"
           />
           {isBeaconsSupported && (
             <Button
@@ -239,7 +239,7 @@ export const Profile_PrivacyScreen = () => {
                   },
                 });
               }}
-              testID="deleteLocalSearchData"
+              testID="deleteCollectedDataButton"
             />
           )}
         </Section>


### PR DESCRIPTION
Added e2e-tests for
- the data collection (i.e. beacons/privacy page)
- notifications (default values + missing login/email)

Also removed a deprecated function from webdriverio.

**Note!** Added some test-ids for the privacy and notifications pages.

<details>
<summary>Privacy test</summary>

https://github.com/AtB-AS/mittatb-app/assets/5812433/a9f195e0-5402-4054-b908-4fcf6742cce9

</details>