### PR TITLE
fix: update button text for bus live in map

### DIFF
--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -1,3 +1,4 @@
+import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
 import {translation as _} from '../../commons';
 
 const DepartureDetailsTexts = {
@@ -42,4 +43,9 @@ const DepartureDetailsTexts = {
     ),
   },
 };
-export default DepartureDetailsTexts;
+
+export default orgSpecificTranslations(DepartureDetailsTexts, {
+  fram: {
+    live: _('Se direkte', 'See live', 'Sjå direkte'),
+  },
+});

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -31,9 +31,9 @@ const DepartureDetailsTexts = {
   notOnTime: _(`Etter rutetid`, `Behind scheduled time`, `Etter rutetid`),
   live: (transportMode: string) =>
     _(
-      `Følg ${transportMode}`,
-      `Follow ${transportMode}`,
-      `Følg ${transportMode}`,
+      `Følg ${transportMode.toLowerCase()}`,
+      `Follow ${transportMode.toLowerCase()}`,
+      `Følg ${transportMode.toLowerCase()}`,
     ),
   map: _('Se reiserute', 'Show trip', 'Sjå reiserute'),
   messages: {

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -1,4 +1,3 @@
-import {orgSpecificTranslations} from '@atb/translations/orgSpecificTranslations';
 import {translation as _} from '../../commons';
 
 const DepartureDetailsTexts = {
@@ -43,9 +42,4 @@ const DepartureDetailsTexts = {
     ),
   },
 };
-
-export default orgSpecificTranslations(DepartureDetailsTexts, {
-  fram: {
-    live: _('Se direkte', 'See live', 'Sjå direkte'),
-  },
-});
+export default DepartureDetailsTexts;

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -29,8 +29,13 @@ const DepartureDetailsTexts = {
     ),
   onTime: _(`I rute`, `On time`, `I rute`),
   notOnTime: _(`Etter rutetid`, `Behind scheduled time`, `Etter rutetid`),
-  live: _('Se live', 'See live', 'Sjå direkte'),
-  map: _('Se i kart', 'Show in map', 'Sjå i kart'),
+  live: (transportMode: string) =>
+    _(
+      `Følg ${transportMode}`,
+      `Follow ${transportMode}`,
+      `Følg ${transportMode}`,
+    ),
+  map: _('Se reiserute', 'Show trip', 'Sjå reiserute'),
   messages: {
     loading: _('Laster detaljer', 'Loading details', 'Lastar detaljar'),
     noAlighting: _('Ingen avstigning', 'No disembarking', 'Ingen avstiging'),

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -387,6 +387,11 @@ const TripDetailsTexts = {
 };
 export default orgSpecificTranslations(TripDetailsTexts, {
   fram: {
+    trip: {
+      leg: {
+        live: _('Se direkte', 'See live', 'Sjå direkte'),
+      },
+    },
     messages: {
       correspondenceNotGuaranteed: _(
         'Kan ikke garantere korrespondanse.',

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -114,9 +114,9 @@ const TripDetailsTexts = {
       },
       live: (transportMode: string) =>
         _(
-          `Følg ${transportMode}`,
-          `Follow ${transportMode}`,
-          `Følg ${transportMode}`,
+          `Følg ${transportMode.toLowerCase()}`,
+          `Follow ${transportMode.toLowerCase()}`,
+          `Følg ${transportMode.toLowerCase()}`,
         ),
       intermediateStops: {
         a11yLabel: (count: number, duration: string) =>

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -112,7 +112,12 @@ const TripDetailsTexts = {
             `${modeName} linje ${lineName}`,
           ),
       },
-      live: _('Se live', 'See live', 'Sjå live'),
+      live: (transportMode: string) =>
+        _(
+          `Følg ${transportMode}`,
+          `Follow ${transportMode}`,
+          `Følg ${transportMode}`,
+        ),
       intermediateStops: {
         a11yLabel: (count: number, duration: string) =>
           _(
@@ -191,11 +196,7 @@ const TripDetailsTexts = {
     },
     summary: {
       showTripInMap: {
-        label: _(
-          'Vis reiserute i kart',
-          'Show trip in map',
-          'Vis reiserute i kart',
-        ),
+        label: _('Se reiserute', 'Show trip', 'Sjå reiserute'),
       },
       travelTime: {
         label: (time: string) =>

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -387,11 +387,6 @@ const TripDetailsTexts = {
 };
 export default orgSpecificTranslations(TripDetailsTexts, {
   fram: {
-    trip: {
-      leg: {
-        live: _('Se direkte', 'See live', 'Sjå direkte'),
-      },
-    },
     messages: {
       correspondenceNotGuaranteed: _(
         'Kan ikke garantere korrespondanse.',

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -190,9 +190,7 @@ export const DepartureDetailsScreenComponent = ({
                     style={realtimeText ? styles.liveButton : undefined}
                     text={t(
                       vehiclePosition
-                        ? DepartureDetailsTexts.live(
-                            t(translatedModeName).toLowerCase(),
-                          )
+                        ? DepartureDetailsTexts.live(t(translatedModeName))
                         : DepartureDetailsTexts.map,
                     )}
                     interactiveColor="interactive_1"

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -28,7 +28,10 @@ import {
 import {TravelDetailsMapScreenParams} from '@atb/travel-details-map-screen/TravelDetailsMapScreenComponent';
 import {animateNextChange} from '@atb/utils/animation';
 import {formatToVerboseFullDate, isWithinSameDate} from '@atb/utils/date';
-import {getQuayName} from '@atb/utils/transportation-names';
+import {
+  getQuayName,
+  getTranslatedModeName,
+} from '@atb/utils/transportation-names';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import React, {useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
@@ -111,6 +114,8 @@ export const DepartureDetailsScreenComponent = ({
     shouldShowLive ? [activeItem.serviceJourneyId] : undefined,
   );
 
+  const translatedModeName = getTranslatedModeName(mode);
+
   const vehiclePosition = vehiclePositions?.find(
     (s) => s.serviceJourney?.id === activeItem.serviceJourneyId,
   );
@@ -185,7 +190,9 @@ export const DepartureDetailsScreenComponent = ({
                     style={realtimeText ? styles.liveButton : undefined}
                     text={t(
                       vehiclePosition
-                        ? DepartureDetailsTexts.live
+                        ? DepartureDetailsTexts.live(
+                            t(translatedModeName).toLowerCase(),
+                          )
                         : DepartureDetailsTexts.map,
                     )}
                     interactiveColor="interactive_1"

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -141,6 +141,8 @@ export const TripSection: React.FC<TripSectionProps> = ({
     openBottomSheet(() => <FlexibleTransportBookingDetailsSheet leg={leg} />);
   }
 
+  const translatedModeName = getTranslatedModeName(leg.mode);
+
   const sectionOutput = (
     <>
       <View style={style.tripSection} testID={testID}>
@@ -295,7 +297,11 @@ export const TripSection: React.FC<TripSectionProps> = ({
             <Button
               type="small"
               leftIcon={{svg: Map}}
-              text={t(TripDetailsTexts.trip.leg.live)}
+              text={t(
+                TripDetailsTexts.trip.leg.live(
+                  t(translatedModeName).toLowerCase(),
+                ),
+              )}
               interactiveColor="interactive_3"
               onPress={() => onPressShowLive(mapData)}
             />

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -297,11 +297,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
             <Button
               type="small"
               leftIcon={{svg: Map}}
-              text={t(
-                TripDetailsTexts.trip.leg.live(
-                  t(translatedModeName).toLowerCase(),
-                ),
-              )}
+              text={t(TripDetailsTexts.trip.leg.live(t(translatedModeName)))}
               interactiveColor="interactive_3"
               onPress={() => onPressShowLive(mapData)}
             />


### PR DESCRIPTION
This PR modifies the 'Live in Map' button text to include the transport mode name. The changes also ensure consistency between the Assistant and Departure screens.

<details>
<summary>Screenshots</summary>

![image (72)](https://github.com/AtB-AS/mittatb-app/assets/43166974/abf24cd6-e803-4a65-aa54-0a3f2f8218e9)

![image (73)](https://github.com/AtB-AS/mittatb-app/assets/43166974/58a9bc2f-dce6-4a00-8711-87ec2c18d161)

![image (74)](https://github.com/AtB-AS/mittatb-app/assets/43166974/36f157f6-dc5a-4873-ace1-79676ef51198)

</details>

Fixes https://github.com/AtB-AS/kundevendt/issues/17501