### PR TITLE
feat: filter empty fare product groups on ticket selection screen

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
@@ -39,23 +39,16 @@ export const FareProducts = ({
     (config) => sellableProductsInApp.some((p) => p.type === config.type),
   );
 
-  let groupedFareProducts: GroupedFareProducts[] = fareProductGroups.reduce<
-    GroupedFareProducts[]
-  >(function (result, item) {
-    const filteredFareProducts =
-      sellableFareProductTypeConfigs.filter((fareProduct) =>
-        item.types.includes(fareProduct.type),
-      ) ?? [];
-
-    if (filteredFareProducts.length > 0) {
-      result.push({
-        transportModes: item.transportModes,
-        fareProducts: filteredFareProducts,
-        heading: item.heading,
-      });
-    }
-    return result;
-  }, []);
+  let groupedFareProducts: GroupedFareProducts[] = fareProductGroups.map(
+    (group) => ({
+      transportModes: group.transportModes,
+      fareProducts:
+        sellableFareProductTypeConfigs.filter((fareProduct) =>
+          group.types.includes(fareProduct.type),
+        ) ?? [],
+      heading: group.heading,
+    }),
+  );
 
   const otherProducts = sellableFareProductTypeConfigs.filter(
     (p) => !flatMap(groupedFareProducts, (g) => g.fareProducts).includes(p),
@@ -63,7 +56,7 @@ export const FareProducts = ({
 
   if (otherProducts.length > 0) {
     groupedFareProducts = [
-      ...groupedFareProducts,
+      ...groupedFareProducts.filter((group) => group.fareProducts.length > 0),
       {
         transportModes: [],
         fareProducts: otherProducts,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
@@ -39,16 +39,23 @@ export const FareProducts = ({
     (config) => sellableProductsInApp.some((p) => p.type === config.type),
   );
 
-  let groupedFareProducts: GroupedFareProducts[] = fareProductGroups.map(
-    (group) => ({
-      transportModes: group.transportModes,
-      fareProducts:
-        sellableFareProductTypeConfigs.filter((fareProduct) =>
-          group.types.includes(fareProduct.type),
-        ) ?? [],
-      heading: group.heading,
-    }),
-  );
+  let groupedFareProducts: GroupedFareProducts[] = fareProductGroups.reduce<
+    GroupedFareProducts[]
+  >(function (result, item) {
+    const filteredFareProducts =
+      sellableFareProductTypeConfigs.filter((fareProduct) =>
+        item.types.includes(fareProduct.type),
+      ) ?? [];
+
+    if (filteredFareProducts.length > 0) {
+      result.push({
+        transportModes: item.transportModes,
+        fareProducts: filteredFareProducts,
+        heading: item.heading,
+      });
+    }
+    return result;
+  }, []);
 
   const otherProducts = sellableFareProductTypeConfigs.filter(
     (p) => !flatMap(groupedFareProducts, (g) => g.fareProducts).includes(p),


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17365

This PR will filter out empty fare product groups introduced by https://github.com/AtB-AS/firestore-configuration/pull/497.

For users without the ability to purchase HjemJobbHjem tickets, they won't have any products in that group, resulting in an empty group and weird display.

After this PR is merged, the empty product group should not be shown.