### PR TITLE
chore: rename useOnBehalfOf to useOnBehalfOfEnabled

### DIFF
--- a/src/on-behalf-of/index.ts
+++ b/src/on-behalf-of/index.ts
@@ -1,4 +1,6 @@
 export {
-  useOnBehalfOf,
+  useOnBehalfOfEnabled,
   useOnBehalfOfEnabledDebugOverride,
-} from './use-on-behalf-of';
+} from './use-on-behalf-of-enabled';
+
+export type {GetAccountByPhoneErrorCode} from './types';

--- a/src/on-behalf-of/use-on-behalf-of-enabled.tsx
+++ b/src/on-behalf-of/use-on-behalf-of-enabled.tsx
@@ -2,7 +2,7 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {useDebugOverride} from '@atb/debug';
 import {StorageModelKeysEnum} from '@atb/storage';
 
-export const useOnBehalfOf = () => {
+export const useOnBehalfOfEnabled = () => {
   const {enable_on_behalf_of} = useRemoteConfig();
   const [debugOverride] = useOnBehalfOfEnabledDebugOverride();
   return debugOverride !== undefined ? debugOverride : enable_on_behalf_of;

--- a/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketReceiverScreen/Root_ChooseTicketReceiverScreen.tsx
@@ -4,7 +4,7 @@ import {FullScreenHeader} from '@atb/components/screen-header';
 import {PhoneInputSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {useGetAccountIdByPhoneMutation} from '@atb/on-behalf-of/queries/use-get-account-id-by-phone-query';
-import {GetAccountByPhoneErrorCode} from '@atb/on-behalf-of/types';
+import {GetAccountByPhoneErrorCode} from '@atb/on-behalf-of';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {StaticColorByType, getStaticColor} from '@atb/theme/colors';

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -31,7 +31,7 @@ import {Section, ToggleSectionItem} from '@atb/components/sections';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from './utils';
-import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -139,7 +139,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     selectableTravellers,
   );
 
-  const isOnBehalfOfEnabled = useOnBehalfOf() && fareProductOnBehalfOfEnabled;
+  const isOnBehalfOfEnabled =
+    useOnBehalfOfEnabled() && fareProductOnBehalfOfEnabled;
 
   const hasSelection =
     travellerSelection.some((u) => u.count) &&

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -24,7 +24,7 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {ContentHeading} from '@atb/components/heading';
 import {LabelInfo} from '@atb/components/label-info';
-import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
 import {LabelInfoTexts} from '@atb/translations/components/LabelInfo';
 import {usePopOver} from '@atb/popover';
 import {useFocusEffect} from '@react-navigation/native';
@@ -62,7 +62,8 @@ export function TravellerSelection({
   } = useBottomSheet();
 
   const isOnBehalfOfEnabled =
-    useOnBehalfOf() && fareProductTypeConfig.configuration.onBehalfOfEnabled;
+    useOnBehalfOfEnabled() &&
+    fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const {addPopOver} = usePopOver();
   const onBehalfOfIndicatorRef = useRef(null);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -15,7 +15,7 @@ import {
   ToggleSectionItem,
 } from '@atb/components/sections';
 import {UserProfileWithCount} from '@atb/fare-contracts';
-import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
 import {HoldingHands} from '@atb/assets/svg/color/images';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
@@ -35,7 +35,8 @@ export function MultipleTravellersSelection({
   const travellersModified = useRef(false);
 
   const isOnBehalfOfEnabled =
-    useOnBehalfOf() && fareProductTypeConfig.configuration.onBehalfOfEnabled;
+    useOnBehalfOfEnabled() &&
+    fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const addTraveller = (userTypeString: string) => {
     travellersModified.current = true;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -10,7 +10,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {HoldingHands} from '@atb/assets/svg/color/images';
-import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
 import {TravellerSelectionBottomSheetType} from './types';
 import {getTravellerInfoByFareProductType} from './../../utils';
 
@@ -26,7 +26,8 @@ export function SingleTravellerSelection({
   const styles = useStyles();
   const selectedProfile = userProfilesWithCount.find((u) => u.count);
   const isOnBehalfOfEnabled =
-    useOnBehalfOf() && fareProductTypeConfig.configuration.onBehalfOfEnabled;
+    useOnBehalfOfEnabled() &&
+    fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const select = (u: UserProfileWithCount) => {
     if (selectedProfile) {
@@ -42,7 +43,12 @@ export function SingleTravellerSelection({
         keyExtractor={(u) => u.userTypeString}
         itemToText={(u) => getReferenceDataName(u, language)}
         itemToSubtext={(u) =>
-          getTravellerInfoByFareProductType(fareProductTypeConfig.type, u, language, t)
+          getTravellerInfoByFareProductType(
+            fareProductTypeConfig.type,
+            u,
+            language,
+            t,
+          )
         }
         selected={selectedProfile}
         onSelect={select}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
@@ -7,7 +7,7 @@ import Ticketing, {
 } from '@atb/translations/screens/Ticketing';
 import {ProfileScreenProps} from './navigation-types';
 import {StyleSheet} from '@atb/theme';
-import {useOnBehalfOf} from '@atb/on-behalf-of';
+import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
 
 type Props = ProfileScreenProps<'Profile_TicketHistorySelectionScreen'>;
 
@@ -15,7 +15,7 @@ export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
   const styles = useStyles();
 
-  const isOnBehalfOfEnabled = useOnBehalfOf();
+  const isOnBehalfOfEnabled = useOnBehalfOfEnabled();
 
   return (
     <FullScreenView


### PR DESCRIPTION
This is just a small PR to keep naming consistency, renaming `useOnBehalfOf` to `useOnBehalfOfEnabled`.

Also exporting and importing the `GetAccountByPhoneErrorCode` type through the `index.ts` file instead.

Closes https://github.com/AtB-AS/kundevendt/issues/15552