### PR TITLE
feat: add new global message component on purchase confirmation screen

### DIFF
--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -11,7 +11,7 @@ export enum GlobalMessageContextEnum {
   appTicketing = 'app-ticketing',
   appPurchaseOverview = 'app-purchase-overview',
   appPurchaseConfirmation = 'app-purchase-confirmation',
-  appPurchaseInformation = 'app-purchase-information',
+  appPurchaseConfirmationBottom = 'app-purchase-confirmation-bottom',
   appFareContractDetails = 'app-fare-contract-details',
   appDepartureDetails = 'app-departure-details',
   appTripDetails = 'app-trip-details',

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -11,6 +11,7 @@ export enum GlobalMessageContextEnum {
   appTicketing = 'app-ticketing',
   appPurchaseOverview = 'app-purchase-overview',
   appPurchaseConfirmation = 'app-purchase-confirmation',
+  appPurchaseInformation = 'app-purchase-information',
   appFareContractDetails = 'app-fare-contract-details',
   appDepartureDetails = 'app-departure-details',
   appTripDetails = 'app-trip-details',

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -453,6 +453,14 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             isMarkdown={true}
           />
         )}
+        <GlobalMessage
+          style={styles.purchaseInformation}
+          globalMessageContext={GlobalMessageContextEnum.appPurchaseInformation}
+          textColor="secondary"
+          ruleVariables={{
+            preassignedFareProductType: preassignedFareProduct.type,
+          }}
+        />
         {isSearchingOffer ? (
           <ActivityIndicator
             size="large"
@@ -674,6 +682,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   globalMessage: {
     marginTop: theme.spacings.small,
+  },
+  purchaseInformation: {
+    marginBottom: theme.spacings.medium,
   },
   smallTopMargin: {
     marginTop: theme.spacings.xSmall,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -455,8 +455,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
         )}
         <GlobalMessage
           style={styles.purchaseInformation}
-          globalMessageContext={GlobalMessageContextEnum.appPurchaseInformation}
-          textColor="secondary"
+          globalMessageContext={GlobalMessageContextEnum.appPurchaseConfirmationBottom}
+          textColor="primary"
           ruleVariables={{
             preassignedFareProductType: preassignedFareProduct.type,
           }}


### PR DESCRIPTION
context: https://github.com/AtB-AS/kundevendt/issues/17075#issuecomment-2014785178

Straightforward PR, tried to add rule, but @gorandalum mentioned that it should be a different context. Suggestions to context naming are appreciated. :)