### PR TITLE
feat: update CouterIconBox styling and behavior

### DIFF
--- a/src/components/icon-box/CounterIconBox.tsx
+++ b/src/components/icon-box/CounterIconBox.tsx
@@ -4,6 +4,7 @@ import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {iconSizes} from '@atb-as/theme';
 import {getTransportationColor, TextNames} from '@atb/theme/colors';
+import {useFontScale} from '@atb/utils/use-font-scale';
 
 interface CounterStyling {
   padding: number;
@@ -22,6 +23,7 @@ export const CounterIconBox = ({
 } & AccessibilityProps) => {
   const styles = useStyles();
   const {theme, themeName} = useTheme();
+  const fontScale = useFontScale();
 
   if (count < 1) return null;
 
@@ -38,9 +40,9 @@ export const CounterIconBox = ({
   };
 
   const normalStyling: CounterStyling = {
-    padding: theme.spacings.small,
+    padding: theme.spacings.xSmall,
     lineHeight: iconSizes.normal,
-    type: 'body__primary--bold',
+    type: 'body__secondary',
   };
 
   const largeStyling: CounterStyling = {
@@ -82,7 +84,10 @@ export const CounterIconBox = ({
         type={styling().type}
         testID="tripLegMore"
         style={{
+          height: styling().lineHeight * fontScale,
+          minWidth: styling().lineHeight * fontScale,
           lineHeight: styling().lineHeight,
+          textAlign: 'center',
         }}
       >
         +{count}

--- a/src/components/icon-box/CounterIconBox.tsx
+++ b/src/components/icon-box/CounterIconBox.tsx
@@ -6,63 +6,26 @@ import {iconSizes} from '@atb-as/theme';
 import {getTransportationColor, TextNames} from '@atb/theme/colors';
 import {useFontScale} from '@atb/utils/use-font-scale';
 
-interface CounterStyling {
-  padding: number;
-  lineHeight: number;
-  type: TextNames;
-}
 export const CounterIconBox = ({
   count,
+  textType,
   size = 'normal',
+  spacing = 'compact',
   style,
   ...a11yProps
 }: {
   count: number;
+  textType: TextNames;
   size?: keyof Theme['icon']['size'];
+  spacing?: 'compact' | 'standard';
   style?: StyleProp<ViewStyle>;
 } & AccessibilityProps) => {
   const styles = useStyles();
   const {theme, themeName} = useTheme();
   const fontScale = useFontScale();
+  const lineHeight = iconSizes[size];
 
   if (count < 1) return null;
-
-  const xSmallStyling: CounterStyling = {
-    padding: theme.spacings.xSmall,
-    lineHeight: iconSizes.xSmall,
-    type: 'label__uppercase',
-  };
-
-  const smallStyling: CounterStyling = {
-    padding: theme.spacings.xSmall,
-    lineHeight: iconSizes.small,
-    type: 'label__uppercase',
-  };
-
-  const normalStyling: CounterStyling = {
-    padding: theme.spacings.xSmall,
-    lineHeight: iconSizes.normal,
-    type: 'body__secondary',
-  };
-
-  const largeStyling: CounterStyling = {
-    padding: theme.spacings.small,
-    lineHeight: iconSizes.large,
-    type: 'body__primary--big',
-  };
-
-  const styling = (): CounterStyling => {
-    switch (size) {
-      case 'xSmall':
-        return xSmallStyling;
-      case 'small':
-        return smallStyling;
-      case 'normal':
-        return normalStyling;
-      case 'large':
-        return largeStyling;
-    }
-  };
 
   return (
     <View
@@ -70,7 +33,10 @@ export const CounterIconBox = ({
         styles.counterContainer,
         style,
         {
-          padding: styling().padding,
+          padding:
+            spacing === 'compact'
+              ? theme.spacings.xSmall
+              : theme.spacings.small,
         },
       ]}
       {...a11yProps}
@@ -81,12 +47,12 @@ export const CounterIconBox = ({
           'transport_other',
           'secondary',
         )}
-        type={styling().type}
+        type={textType}
         testID="tripLegMore"
         style={{
-          height: styling().lineHeight * fontScale,
-          minWidth: styling().lineHeight * fontScale,
-          lineHeight: styling().lineHeight,
+          height: lineHeight * fontScale,
+          minWidth: lineHeight * fontScale,
+          lineHeight: lineHeight,
           textAlign: 'center',
         }}
       >

--- a/src/components/icon-box/TransportationIconBoxList.tsx
+++ b/src/components/icon-box/TransportationIconBoxList.tsx
@@ -8,20 +8,24 @@ import {CounterIconBox} from './CounterIconBox';
 
 type Props = {
   modes: TransportModePair[];
-  modesDisplayLimit?: number;
+  maxNumberOfBoxes?: number;
   iconSize?: keyof Theme['icon']['size'];
   disabled?: boolean;
 };
 
 export const TransportationIconBoxList = ({
   modes,
-  modesDisplayLimit = 2,
+  maxNumberOfBoxes = 2,
   iconSize,
   disabled,
 }: Props) => {
   const styles = useStyles({iconSize})();
   const {t} = useTranslation();
-  const modesCount: number = modes.length;
+  const numberOfModes: number = modes.length;
+  const hasOverflow = numberOfModes > maxNumberOfBoxes;
+  const numberOfModesToDisplay = hasOverflow
+    ? maxNumberOfBoxes - 1
+    : numberOfModes;
   const modesToDisplay = modes
     .filter(removeDuplicatesByIconNameFilter)
     .slice(0, numberOfModesToDisplay);
@@ -38,14 +42,14 @@ export const TransportationIconBoxList = ({
           disabled={disabled}
         />
       ))}
-      {modesCount > modesDisplayLimit && (
+      {hasOverflow && (
         <CounterIconBox
-          count={modesCount - modesDisplayLimit}
+          count={numberOfModes - numberOfModesToDisplay}
           style={styles.icon}
           size={iconSize}
           accessibilityLabel={t(
             FareContractTexts.transportModes.a11yLabelMultipleTravelModes(
-              modesCount,
+              numberOfModes,
             ),
           )}
         />

--- a/src/components/icon-box/TransportationIconBoxList.tsx
+++ b/src/components/icon-box/TransportationIconBoxList.tsx
@@ -23,8 +23,8 @@ export const TransportationIconBoxList = ({
   const {t} = useTranslation();
   const modesCount: number = modes.length;
   const modesToDisplay = modes
-    .slice(0, modesDisplayLimit)
-    .filter(removeDuplicatesByIconNameFilter);
+    .filter(removeDuplicatesByIconNameFilter)
+    .slice(0, numberOfModesToDisplay);
 
   return (
     <>

--- a/src/components/icon-box/TransportationIconBoxList.tsx
+++ b/src/components/icon-box/TransportationIconBoxList.tsx
@@ -47,6 +47,9 @@ export const TransportationIconBoxList = ({
           count={numberOfModes - numberOfModesToDisplay}
           style={styles.icon}
           size={iconSize}
+          textType={
+            iconSize === 'xSmall' ? 'label__uppercase' : 'body__secondary'
+          }
           accessibilityLabel={t(
             FareContractTexts.transportModes.a11yLabelMultipleTravelModes(
               numberOfModes,

--- a/src/components/icon-box/TransportationIconBoxList.tsx
+++ b/src/components/icon-box/TransportationIconBoxList.tsx
@@ -41,7 +41,8 @@ export const TransportationIconBoxList = ({
       {modesCount > modesDisplayLimit && (
         <CounterIconBox
           count={modesCount - modesDisplayLimit}
-          size="xSmall"
+          style={styles.icon}
+          size={iconSize}
           accessibilityLabel={t(
             FareContractTexts.transportModes.a11yLabelMultipleTravelModes(
               modesCount,

--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -74,7 +74,7 @@ export const TransportModes = ({
     <View style={[styles.transportationMode, style]}>
       <TransportationIconBoxList
         modes={modes}
-        modesDisplayLimit={2}
+        maxNumberOfBoxes={2}
         iconSize={iconSize}
         disabled={disabled}
       />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -307,7 +307,11 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                   <LegDash />
                 </View>
               ) : null}
-              <CounterIconBox count={collapsedLegs.length} />
+              <CounterIconBox
+                count={collapsedLegs.length}
+                spacing="standard"
+                textType="body__primary--bold"
+              />
             </View>
             <View style={[styles.destinationLineContainer_grow, iconHeight]}>
               <View style={[styles.destinationLine_grow, lineHeight]} />


### PR DESCRIPTION
- Updates logic for limit in TransportationIconBoxList to match sketches
- Makes sure that CounterIconBox uses the exact same styling as TransportationIcons, with font scale taken into consideration, except that the box is allowed to grow horizontally if the number is wider than it is tall.
	- `textType` is added as a required param since there isn't a "correct" text type for a given size
	- `spacing` as an optional param, to make it work in ResultItems.


<div>
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/498b40e3-7e92-496c-8ad5-bb0575840f3a">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/19a7c86b-bade-4fc0-862a-51d8268199e4">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/3f9693a2-9b66-4eb9-8bbc-b4763abfc524">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/566f36c4-fd66-4a18-af52-210fcba291f0">
</div>

closes https://github.com/AtB-AS/kundevendt/issues/17076