### PR TITLE
feat: enable hjemjobbhjem ticket purchase in app

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^3.18.0",
+    "@atb-as/config-specs": "^3.19.0",
     "@atb-as/generate-assets": "^10.1.1",
     "@atb-as/theme": "^8.1.0",
     "@bugsnag/react-native": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^3.19.0",
+    "@atb-as/config-specs": "^3.20.0",
     "@atb-as/generate-assets": "^10.1.1",
     "@atb-as/theme": "^8.1.0",
     "@bugsnag/react-native": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.18.0",
-    "@atb-as/generate-assets": "^10.0.0",
-    "@atb-as/theme": "^8.0.0",
+    "@atb-as/generate-assets": "^10.1.1",
+    "@atb-as/theme": "^8.1.0",
     "@bugsnag/react-native": "^7.21.0",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-barcode-javascript-lib": "1.3.4",

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -26,6 +26,7 @@ export type PreassignedFareProduct = {
   zoneSelectionMode?: ZoneSelectionMode;
   limitations: {
     userProfileRefs: string[];
+    tariffZoneRefs?: string[];
     appVersionMin: string | undefined;
     appVersionMax: string | undefined;
     latestActivationDate?: number;

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -172,7 +172,6 @@ export const useTariffZoneSummary = (
   );
   const zoneSelectionModeDisabledForProduct =
     fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
-
   if (zoneSelectionModeDisabledForProduct) return undefined;
 
   return tariffZonesSummary(fromTariffZone, toTariffZone, language, t);

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -173,10 +173,10 @@ export const useTariffZoneSummary = (
   const zoneSelectionModeDisabledForProduct =
     fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
 
-  const usesZoneOfferEndpointForProduct =
-    fareProductTypeConfig?.configuration.offerEndpoint === 'zones';
+  const usesAuthorityOfferEndpointForProduct =
+    fareProductTypeConfig?.configuration.offerEndpoint === 'authority';
 
-  if (zoneSelectionModeDisabledForProduct && !usesZoneOfferEndpointForProduct) return undefined;
+  if (zoneSelectionModeDisabledForProduct && usesAuthorityOfferEndpointForProduct) return undefined;
 
   return tariffZonesSummary(fromTariffZone, toTariffZone, language, t);
 };

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -173,10 +173,7 @@ export const useTariffZoneSummary = (
   const zoneSelectionModeDisabledForProduct =
     fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
 
-  const usesAuthorityOfferEndpointForProduct =
-    fareProductTypeConfig?.configuration.offerEndpoint === 'authority';
-
-  if (zoneSelectionModeDisabledForProduct && usesAuthorityOfferEndpointForProduct) return undefined;
+  if (zoneSelectionModeDisabledForProduct) return undefined;
 
   return tariffZonesSummary(fromTariffZone, toTariffZone, language, t);
 };

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -172,7 +172,11 @@ export const useTariffZoneSummary = (
   );
   const zoneSelectionModeDisabledForProduct =
     fareProductTypeConfig?.configuration.zoneSelectionMode === 'none';
-  if (zoneSelectionModeDisabledForProduct) return undefined;
+
+  const usesZoneOfferEndpointForProduct =
+    fareProductTypeConfig?.configuration.offerEndpoint === 'zones';
+
+  if (zoneSelectionModeDisabledForProduct && !usesZoneOfferEndpointForProduct) return undefined;
 
   return tariffZonesSummary(fromTariffZone, toTariffZone, language, t);
 };

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -155,7 +155,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const fromPlaceName = getPlaceName(fromPlace, language);
 
   const toPlaceName = getPlaceName(toPlace, language);
-  const vatAmount = totalPrice - totalPrice / (1 + vatPercent / 100);
+  const vatAmount = totalPrice - (totalPrice / (1 + vatPercent / 100));
 
   const vatAmountString = formatDecimalNumber(vatAmount, language);
   const vatPercentString = formatDecimalNumber(vatPercent, language);

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -119,7 +119,12 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const {travellerSelectionMode, zoneSelectionMode} =
     fareProductTypeConfig.configuration;
 
-  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint;
+  const offerEndpoint =
+    zoneSelectionMode === 'none'
+      ? 'authority'
+      : zoneSelectionMode === 'multiple-stop-harbor'
+      ? 'stop-places'
+      : 'zones';
 
   const {
     offerSearchTime,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -119,9 +119,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const {travellerSelectionMode, zoneSelectionMode} =
     fareProductTypeConfig.configuration;
 
-  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint
-    ? params.fareProductTypeConfig.configuration.offerEndpoint
-    : 'zones';
+  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint;
 
   const {
     offerSearchTime,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -119,12 +119,9 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const {travellerSelectionMode, zoneSelectionMode} =
     fareProductTypeConfig.configuration;
 
-  const offerEndpoint =
-    zoneSelectionMode === 'none'
-      ? 'authority'
-      : zoneSelectionMode === 'multiple-stop-harbor'
-      ? 'stop-places'
-      : 'zones';
+  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint
+    ? params.fareProductTypeConfig.configuration.offerEndpoint
+    : 'zones';
 
   const {
     offerSearchTime,
@@ -155,7 +152,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const fromPlaceName = getPlaceName(fromPlace, language);
 
   const toPlaceName = getPlaceName(toPlace, language);
-  const vatAmount = totalPrice - (totalPrice / (1 + vatPercent / 100));
+  const vatAmount = totalPrice - totalPrice / (1 + vatPercent / 100);
 
   const vatAmountString = formatDecimalNumber(vatAmount, language);
   const vatPercentString = formatDecimalNumber(vatPercent, language);
@@ -455,7 +452,9 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
         )}
         <GlobalMessage
           style={styles.purchaseInformation}
-          globalMessageContext={GlobalMessageContextEnum.appPurchaseConfirmationBottom}
+          globalMessageContext={
+            GlobalMessageContextEnum.appPurchaseConfirmationBottom
+          }
           textColor="primary"
           ruleVariables={{
             preassignedFareProductType: preassignedFareProduct.type,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -95,9 +95,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const fareProductOnBehalfOfEnabled =
     params.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
-  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint
-    ? params.fareProductTypeConfig.configuration.offerEndpoint
-    : 'zones';
+  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint;
 
   const {
     isSearchingOffer,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -95,7 +95,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const fareProductOnBehalfOfEnabled =
     params.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
-  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint;
+  const offerEndpoint = zoneSelectionMode === 'none'
+    ? 'authority'
+    : zoneSelectionMode === 'multiple-stop-harbor'
+    ? 'stop-places'
+    : 'zones';
 
   const {
     isSearchingOffer,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -95,12 +95,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const fareProductOnBehalfOfEnabled =
     params.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
-  const offerEndpoint =
-    zoneSelectionMode === 'none'
-      ? 'authority'
-      : zoneSelectionMode === 'multiple-stop-harbor'
-      ? 'stop-places'
-      : 'zones';
+  const offerEndpoint = params.fareProductTypeConfig.configuration.offerEndpoint
+    ? params.fareProductTypeConfig.configuration.offerEndpoint
+    : 'zones';
 
   const {
     isSearchingOffer,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -16,7 +16,11 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
-import {GenericClickableSectionItem, Section} from '@atb/components/sections';
+import {
+  GenericClickableSectionItem,
+  GenericSectionItem,
+  Section,
+} from '@atb/components/sections';
 import {PreassignedFareProduct, getReferenceDataName} from '@atb/configuration';
 
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
@@ -56,18 +60,62 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
       zonesRef,
     }));
 
+    // Can select zone if there is no whitelisted zones, or there is more than 1 whitelisted zone
+    const canSelectZone =
+      preassignedFareProduct.limitations.tariffZoneRefs?.length !== 1;
+
     const accessibility: AccessibilityProps = {
       accessible: true,
-      accessibilityRole: 'button',
-      accessibilityLabel:
-        a11yLabel(fromTariffZone, toTariffZone, language, t) +
-        screenReaderPause,
-      accessibilityHint: t(PurchaseOverviewTexts.zones.a11yHint),
+      accessibilityRole: canSelectZone ? 'button' : 'none',
+      accessibilityLabel: canSelectZone
+        ? a11yLabel(fromTariffZone, toTariffZone, language, t) +
+          screenReaderPause
+        : t(
+            PurchaseOverviewTexts.travellerSelection
+              .a11yLabelPrefixNotSelectable,
+          ),
+      accessibilityHint: canSelectZone
+        ? t(PurchaseOverviewTexts.zones.a11yHint)
+        : undefined,
     };
 
     const displayAsOneZone =
       fromTariffZone.id === toTariffZone.id &&
       fromTariffZone.venueName === toTariffZone.venueName;
+
+    const content = (
+      <View style={styles.sectionContentContainer}>
+        <View>
+          {displayAsOneZone ? (
+            <ZoneLabel tariffZone={fromTariffZone} />
+          ) : (
+            <>
+              <View style={styles.fromZone}>
+                <ThemeText
+                  color="secondary"
+                  type="body__secondary"
+                  style={styles.toFromLabel}
+                >
+                  {t(PurchaseOverviewTexts.fromToLabel.from)}
+                </ThemeText>
+                <ZoneLabel tariffZone={fromTariffZone} />
+              </View>
+              <View style={styles.toZone}>
+                <ThemeText
+                  color="secondary"
+                  type="body__secondary"
+                  style={styles.toFromLabel}
+                >
+                  {t(PurchaseOverviewTexts.fromToLabel.to)}
+                </ThemeText>
+                <ZoneLabel tariffZone={toTariffZone} />
+              </View>
+            </>
+          )}
+        </View>
+        {canSelectZone && <ThemeIcon svg={Edit} size="normal" />}
+      </View>
+    );
 
     return (
       <View style={style}>
@@ -78,50 +126,24 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
           )}
         />
         <Section {...accessibility}>
-          <GenericClickableSectionItem
-            ref={zonesRef}
-            onPress={() =>
-              onSelect({
-                fromTariffZone,
-                toTariffZone,
-                fareProductTypeConfig,
-                preassignedFareProduct,
-              })
-            }
-            testID="selectZonesButton"
-          >
-            <View style={styles.sectionContentContainer}>
-              <View>
-                {displayAsOneZone ? (
-                  <ZoneLabel tariffZone={fromTariffZone}/>
-                ) : (
-                  <>
-                    <View style={styles.fromZone}>
-                      <ThemeText
-                        color="secondary"
-                        type="body__secondary"
-                        style={styles.toFromLabel}
-                      >
-                        {t(PurchaseOverviewTexts.fromToLabel.from)}
-                      </ThemeText>
-                      <ZoneLabel tariffZone={fromTariffZone} />
-                    </View>
-                    <View style={styles.toZone}>
-                      <ThemeText
-                        color="secondary"
-                        type="body__secondary"
-                        style={styles.toFromLabel}
-                      >
-                        {t(PurchaseOverviewTexts.fromToLabel.to)}
-                      </ThemeText>
-                      <ZoneLabel tariffZone={toTariffZone} />
-                    </View>
-                  </>
-                )}
-              </View>
-              <ThemeIcon svg={Edit} size="normal" />
-            </View>
-          </GenericClickableSectionItem>
+          {canSelectZone ? (
+            <GenericClickableSectionItem
+              ref={zonesRef}
+              onPress={() =>
+                onSelect({
+                  fromTariffZone,
+                  toTariffZone,
+                  fareProductTypeConfig,
+                  preassignedFareProduct,
+                })
+              }
+              testID="selectZonesButton"
+            >
+              {content}
+            </GenericClickableSectionItem>
+          ) : (
+            <GenericSectionItem>{content}</GenericSectionItem>
+          )}
         </Section>
       </View>
     );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -40,9 +40,11 @@ export function useOfferDefaults(
   const defaultPreassignedFareProduct =
     preassignedFareProduct ?? defaultFareProduct;
 
-  // Get default TariffZones
+  // Check for whitelisted zones
   const allowedTariffZones = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
   const usableTariffZones = useFilterTariffZone(tariffZones, allowedTariffZones);
+
+  // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(usableTariffZones);
   const defaultFromPlace = fromPlace ?? defaultTariffZone;
   const defaultToPlace = toPlace ?? defaultTariffZone;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -12,6 +12,7 @@ import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places'
 import {useDefaultTariffZone} from '@atb/stacks-hierarchy/utils';
 import {useMemo} from 'react';
 import {useDefaultPreassignedFareProduct} from '@atb/fare-contracts/utils';
+import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
 
 type UserProfileTypeWithCount = {
   userTypeString: string;
@@ -25,13 +26,13 @@ export function useOfferDefaults(
   fromPlace?: TariffZoneWithMetadata | StopPlaceFragment,
   toPlace?: TariffZoneWithMetadata | StopPlaceFragment,
 ) {
-  const {tariffZones, userProfiles, preassignedFareProducts} =
-    useFirestoreConfiguration();
+  const {data: fareProducts} = useGetFareProductsQuery();
+  const {tariffZones, userProfiles} = useFirestoreConfiguration();
   const {customerProfile} = useTicketingState();
 
   // Get default PreassignedFareProduct
   const productType = preassignedFareProduct?.type ?? selectableProductType;
-  const selectableProducts = preassignedFareProducts
+  const selectableProducts = fareProducts!
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
   const defaultFareProduct =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -41,8 +41,8 @@ export function useOfferDefaults(
     preassignedFareProduct ?? defaultFareProduct;
 
   // Get default TariffZones
-  const tariffZoneLimitations = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
-  const usableTariffZones = useFilterTariffZone(tariffZones, tariffZoneLimitations);
+  const allowedTariffZones = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
+  const usableTariffZones = useFilterTariffZone(tariffZones, allowedTariffZones);
   const defaultTariffZone = useDefaultTariffZone(usableTariffZones);
   const defaultFromPlace = fromPlace ?? defaultTariffZone;
   const defaultToPlace = toPlace ?? defaultTariffZone;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -32,7 +32,7 @@ export function useOfferDefaults(
 
   // Get default PreassignedFareProduct
   const productType = preassignedFareProduct?.type ?? selectableProductType;
-  const selectableProducts = fareProducts!
+  const selectableProducts = fareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
     .filter((product) => product.type === productType);
   const defaultFareProduct =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -41,8 +41,8 @@ export function useOfferDefaults(
     preassignedFareProduct ?? defaultFareProduct;
 
   // Check for whitelisted zones
-  const allowedTariffZones = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
-  const usableTariffZones = useFilterTariffZone(tariffZones, allowedTariffZones);
+  const allowedTariffZoneRefs = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
+  const usableTariffZones = useFilterTariffZone(tariffZones, allowedTariffZoneRefs);
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(usableTariffZones);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -9,7 +9,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {useTicketingState} from '@atb/ticketing';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {useDefaultTariffZone} from '@atb/stacks-hierarchy/utils';
+import {useDefaultTariffZone, useFilterTariffZone} from '@atb/stacks-hierarchy/utils';
 import {useMemo} from 'react';
 import {useDefaultPreassignedFareProduct} from '@atb/fare-contracts/utils';
 import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
@@ -41,7 +41,9 @@ export function useOfferDefaults(
     preassignedFareProduct ?? defaultFareProduct;
 
   // Get default TariffZones
-  const defaultTariffZone = useDefaultTariffZone(tariffZones);
+  const tariffZoneLimitations = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
+  const usableTariffZones = useFilterTariffZone(tariffZones, tariffZoneLimitations);
+  const defaultTariffZone = useDefaultTariffZone(usableTariffZones);
   const defaultFromPlace = fromPlace ?? defaultTariffZone;
   const defaultToPlace = toPlace ?? defaultTariffZone;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
@@ -16,6 +16,8 @@ import {
   TicketMultiple,
 } from '@atb/assets/svg/mono-icons/ticketing/';
 
+import {City} from '@atb/assets/svg/mono-icons/places/';
+
 const ticketingTileIllustrations = {
   Ticket,
   PeriodTicket: Date,
@@ -26,6 +28,7 @@ const ticketingTileIllustrations = {
   Carnet: Klippekort,
   Boat,
   TicketMultiple,
+  City,
 };
 
 type ticketingTileIllustrationType = keyof typeof ticketingTileIllustrations;
@@ -67,6 +70,8 @@ const getIllustrationFileName = (
       return 'PeriodTicket';
     case 'ticketMultiple':
       return 'TicketMultiple';
+    case 'city':
+      return 'City';
     default:
       return 'Ticket';
   }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
@@ -7,6 +7,7 @@ import {
   LanguageAndTextType,
   ProductTypeTransportModes,
   isProductSellableInApp,
+  PreassignedFareProduct,
 } from '@atb/configuration';
 import {flatMap} from '@atb/utils/array';
 import {
@@ -22,16 +23,18 @@ type GroupedFareProducts = {
 };
 
 export const FareProducts = ({
+  fareProducts,
   onProductSelect,
 }: {
+  fareProducts: PreassignedFareProduct[];
   onProductSelect: (config: FareProductTypeConfig) => void;
 }) => {
   const {t, language} = useTranslation();
-  const {preassignedFareProducts, fareProductTypeConfigs, fareProductGroups} =
+  const {fareProductTypeConfigs, fareProductGroups} =
     useFirestoreConfiguration();
   const {customerProfile} = useTicketingState();
 
-  const sellableProductsInApp = preassignedFareProducts.filter((product) =>
+  const sellableProductsInApp = fareProducts.filter((product) =>
     isProductSellableInApp(product, customerProfile),
   );
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -3,7 +3,7 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {AnonymousPurchaseWarning} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/AnonymousPurchaseWarning';
 import {FareProducts} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts';
 import {StyleSheet, useTheme} from '@atb/theme';
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import {ScrollView, View} from 'react-native';
 import {RecentFareContracts} from './Components/RecentFareContracts/RecentFareContracts';
 import {TicketTabNavScreenProps} from '../navigation-types';
@@ -11,8 +11,6 @@ import {UpgradeSplash} from './Components/UpgradeSplash';
 import {useRecentFareContracts} from './use-recent-fare-contracts';
 import {
   FareProductTypeConfig,
-  PreassignedFareProduct,
-  useFirestoreConfiguration,
 } from '@atb/configuration';
 import {RecentFareContract} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/types';
 import {useTicketingAssistantEnabled} from '@atb/stacks-hierarchy/Root_TicketAssistantStack/use-ticketing-assistant-enabled';
@@ -35,12 +33,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const {authenticationType} = useAuthState();
   const {theme} = useTheme();
   const {recentFareContracts, loading} = useRecentFareContracts();
-  const {data} = useGetFareProductsQuery();
-  const {preassignedFareProducts} = useFirestoreConfiguration();
-
-  const [fareProducts, setFareProducts] = useState<PreassignedFareProduct[]>(
-    preassignedFareProducts,
-  );
+  const {data: fareProducts} = useGetFareProductsQuery();
 
   const hasRecentFareContracts = !!recentFareContracts.length;
   const styles = useStyles();
@@ -53,12 +46,6 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const inspectableToken = tokens.find((t) => t.isInspectable);
   const hasInspectableMobileToken = inspectableToken?.type === 'mobile';
   const harborsQuery = useHarborsQuery();
-
-  useEffect(() => {
-    if (data) {
-      setFareProducts(data);
-    }
-  }, [data]);
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -70,6 +70,11 @@ export const useDefaultTariffZone = (
   }, [tariffZones, tariffZoneFromLocation]);
 };
 
+/**
+ * Checks for whitelisting of tariff zones, if there is no whitelisting,
+ * return the original tariff zones. If there is a whitelist, return the
+ * filtered zones.
+ */
 export const useFilterTariffZone = (
   tariffZones: TariffZone[],
   allowedTariffZones: string[],

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -77,14 +77,14 @@ export const useDefaultTariffZone = (
  */
 export const useFilterTariffZone = (
   tariffZones: TariffZone[],
-  allowedTariffZones: string[],
+  allowedTariffZoneRefs: string[],
 ): TariffZone[] => {
 
   return useMemo<TariffZone[]>(() => {
-    if (allowedTariffZones.length === 0) {
+    if (allowedTariffZoneRefs.length === 0) {
       return tariffZones;
     } 
   
-    return tariffZones.filter((tariffZone) => allowedTariffZones.some((allowedZone) => tariffZone.id === allowedZone));
-  }, [tariffZones, allowedTariffZones]);
+    return tariffZones.filter((tariffZone) => allowedTariffZoneRefs.some((allowedZone) => tariffZone.id === allowedZone));
+  }, [tariffZones, allowedTariffZoneRefs]);
 }

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -69,3 +69,17 @@ export const useDefaultTariffZone = (
     return {...tariffZones[0], resultType: 'zone'};
   }, [tariffZones, tariffZoneFromLocation]);
 };
+
+export const useFilterTariffZone = (
+  tariffZones: TariffZone[],
+  allowedTariffZones: string[],
+): TariffZone[] => {
+
+  return useMemo<TariffZone[]>(() => {
+    if (allowedTariffZones.length === 0) {
+      return tariffZones;
+    } 
+  
+    return tariffZones.filter((tariffZone) => allowedTariffZones.some((allowedZone) => tariffZone.id === allowedZone));
+  }, [tariffZones, allowedTariffZones]);
+}

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -11,6 +11,7 @@ import {
   ReserveOffer,
   SendReceiptResponse,
 } from './types';
+import {PreassignedFareProduct} from '@atb/configuration';
 
 export async function listRecentFareContracts(): Promise<
   RecentFareContractBackend[]
@@ -183,4 +184,13 @@ export async function cancelPayment(
       retry: true,
     },
   );
+}
+
+export async function getFareProducts(): Promise<PreassignedFareProduct[]> {
+  const url = 'product/v1';
+  const response = await client.get<PreassignedFareProduct[]>(url, {
+    authWithIdToken: true,
+  });
+
+  return response.data;
 }

--- a/src/ticketing/use-get-fare-products-query.tsx
+++ b/src/ticketing/use-get-fare-products-query.tsx
@@ -1,13 +1,15 @@
+import { useFirestoreConfiguration } from '@atb/configuration';
 import {getFareProducts} from '@atb/ticketing';
 import {useQuery} from '@tanstack/react-query';
 
 const ONE_HOUR_MS = 1000 * 60 * 60;
 
 export const useGetFareProductsQuery = () => {
+  const {preassignedFareProducts} = useFirestoreConfiguration();
   return useQuery({
+    initialData: preassignedFareProducts,
     queryKey: ['getProducts'],
     queryFn: getFareProducts,
-    staleTime: ONE_HOUR_MS,
     cacheTime: ONE_HOUR_MS,
   });
 };

--- a/src/ticketing/use-get-fare-products-query.tsx
+++ b/src/ticketing/use-get-fare-products-query.tsx
@@ -1,0 +1,13 @@
+import {getFareProducts} from '@atb/ticketing';
+import {useQuery} from '@tanstack/react-query';
+
+const ONE_HOUR_MS = 1000 * 60 * 60;
+
+export const useGetFareProductsQuery = () => {
+  return useQuery({
+    queryKey: ['getProducts'],
+    queryFn: getFareProducts,
+    staleTime: ONE_HOUR_MS,
+    cacheTime: ONE_HOUR_MS,
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^3.19.0":
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.19.0.tgz#fb3d020ca298748fe659c1a13c8bd0a92943fbc7"
-  integrity sha512-APzy+UQeRUTY5s1sP0korxQGzOaljuh8VN2O1MyLU3FlX9YA9i6L6oEq75a4KemygunTT0rgiwQ6K/sL0jq05A==
+"@atb-as/config-specs@^3.20.0":
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.20.0.tgz#7ee4f803fe50e97e4a0bebdff6bd005258eb5d4d"
+  integrity sha512-yrP3bTfcPfio6Cfrs8LuFqAJOljTH9U/qlYo0gErNyngg+YcGUGyNc3+VTtl4P0+k/ljwgoxlm6U+/AUxs+c9g==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.18.0.tgz#b5d46a02a2d962e7e30d7fdfc8206d9a1e39c9cf"
-  integrity sha512-OHXi47GGYGlIl4QUPqIzl2pmIL+0pqwhzwIWBdjCWx/g8y6857Y0cnFSL6dAmVlBu3mK9u35x77ypVj3vXcQNQ==
+"@atb-as/config-specs@^3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-3.19.0.tgz#fb3d020ca298748fe659c1a13c8bd0a92943fbc7"
+  integrity sha512-APzy+UQeRUTY5s1sP0korxQGzOaljuh8VN2O1MyLU3FlX9YA9i6L6oEq75a4KemygunTT0rgiwQ6K/sL0jq05A==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,22 +40,22 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-10.0.0.tgz#51cb2a8c9dc00f2223d7e661c979d896c89ce25a"
-  integrity sha512-NFXTYDyDnQcCmcEMudcyXeFXHy6cp76a0wBBhZDFfAyUaEsFMcPwRp+hyU71jyr+AyLiK2m3N8ugQr2lWhAl5A==
+"@atb-as/generate-assets@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-10.1.1.tgz#8c634026a1b9fb0fc9d535058fa9e1be162909ba"
+  integrity sha512-hYhqluNuql8l+bR47RNIVETsXCNkvyIKHSYW1+Rq/ul/+svrJqZrgJIBdtEZKgb+TRXnyoHaaKM5NAMRxUNELQ==
   dependencies:
-    "@atb-as/theme" "^8.0.0"
+    "@atb-as/theme" "^8.1.0"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-8.0.0.tgz#dec88c6983f235d5a18d9510665e10b7bb26de85"
-  integrity sha512-vh6Y2bXG0g4mt/qYlc6a4/h84wcoowAIY5FkTlBS65mBjleqNA9YHSX0Y7k9KUVQ7Iv4T9H4K4edYaRXyLMA4Q==
+"@atb-as/theme@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-8.1.0.tgz#b1318b9f4044db319634f230ffa30d1832c22b0f"
+  integrity sha512-vSul0l2HQXz9g3TUXuEFZpggcB03MCTiqR62lVHtTrnTvjAx+VxEUt+xIPXbuDOry9zEWcZiNBUHzLIaNCca1w==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17191

Changes in this PR: 
- Now uses product endpoint with fallback of firestore configuration to fetch the product list, used Tanstack react-query to call the endpoint.
- Re-introduced `offerEndpoint` setting in firestore.
- Added `City` image for HjemJobbHjem tickets.
- Updated dependencies for assets.