### PR TITLE
fix: update transportation icon a11y labels

### DIFF
--- a/src/components/icon-box/CounterIconBox.tsx
+++ b/src/components/icon-box/CounterIconBox.tsx
@@ -1,5 +1,5 @@
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
-import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
+import {StyleProp, View, ViewStyle} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {iconSizes} from '@atb-as/theme';
@@ -12,14 +12,13 @@ export const CounterIconBox = ({
   size = 'normal',
   spacing = 'compact',
   style,
-  ...a11yProps
 }: {
   count: number;
   textType: TextNames;
   size?: keyof Theme['icon']['size'];
   spacing?: 'compact' | 'standard';
   style?: StyleProp<ViewStyle>;
-} & AccessibilityProps) => {
+}) => {
   const styles = useStyles();
   const {theme, themeName} = useTheme();
   const fontScale = useFontScale();
@@ -39,7 +38,7 @@ export const CounterIconBox = ({
               : theme.spacings.small,
         },
       ]}
-      {...a11yProps}
+      importantForAccessibility="no-hide-descendants"
     >
       <ThemeText
         color={getTransportationColor(

--- a/src/components/icon-box/TransportationIconBoxList.tsx
+++ b/src/components/icon-box/TransportationIconBoxList.tsx
@@ -1,23 +1,28 @@
-import {TransportModePair} from '@atb/components/transportation-modes';
+import {
+  TransportModePair,
+  getTransportModeText,
+} from '@atb/components/transportation-modes';
 import {TransportationIconBox} from './TransportationIconBox';
-import {FareContractTexts, useTranslation} from '@atb/translations';
+import {useTranslation} from '@atb/translations';
 import React from 'react';
 import {getTransportModeSvg} from './utils';
 import {StyleSheet, Theme} from '@atb/theme';
 import {CounterIconBox} from './CounterIconBox';
+import {AccessibilityProps, View} from 'react-native';
 
 type Props = {
   modes: TransportModePair[];
   maxNumberOfBoxes?: number;
   iconSize?: keyof Theme['icon']['size'];
   disabled?: boolean;
-};
+} & AccessibilityProps;
 
 export const TransportationIconBoxList = ({
   modes,
   maxNumberOfBoxes = 2,
   iconSize,
   disabled,
+  ...props
 }: Props) => {
   const styles = useStyles({iconSize})();
   const {t} = useTranslation();
@@ -31,7 +36,12 @@ export const TransportationIconBoxList = ({
     .slice(0, numberOfModesToDisplay);
 
   return (
-    <>
+    <View
+      accessible={true}
+      accessibilityLabel={getTransportModeText(modes, t)}
+      style={{flexDirection: 'row'}}
+      {...props}
+    >
       {modesToDisplay.map(({mode, subMode}) => (
         <TransportationIconBox
           style={styles.icon}
@@ -50,14 +60,9 @@ export const TransportationIconBoxList = ({
           textType={
             iconSize === 'xSmall' ? 'label__uppercase' : 'body__secondary'
           }
-          accessibilityLabel={t(
-            FareContractTexts.transportModes.a11yLabelMultipleTravelModes(
-              numberOfModes,
-            ),
-          )}
         />
       )}
-    </>
+    </View>
   );
 };
 

--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -28,14 +28,8 @@ const removeDuplicateStringsFilter = (
 export const getTransportModeText = (
   modes: TransportModePair[],
   t: TranslateFunction,
-  modesDisplayLimit: number = 2,
 ): string => {
-  const modesCount: number = modes.length;
-
   if (!modes) return '';
-  if (modesCount > modesDisplayLimit) {
-    return t(FareContractTexts.transportModes.multipleTravelModes);
-  }
   return _.capitalize(
     modes
       .map((tm) => t(FareContractTexts.transportMode(tm.mode, tm.subMode)))
@@ -64,33 +58,37 @@ export const TransportModes = ({
   const styles = useStyles();
   const {t} = useTranslation();
 
-  const transportModeText: string = getTransportModeText(
-    modes,
-    t,
-    modesDisplayLimit,
-  );
+  const transportModeText: string = getTransportModeText(modes, t);
+
+  const description =
+    modes.length > modesDisplayLimit
+      ? t(FareContractTexts.transportModes.more)
+      : transportModeText;
 
   return (
-    <View style={[styles.transportationMode, style]}>
+    <View
+      style={[styles.transportationMode, style]}
+      accessibilityLabel={t(
+        customTransportModeText
+          ? FareContractTexts.transportModes.a11yLabelWithCustomText(
+              transportModeText,
+              customTransportModeText,
+            )
+          : FareContractTexts.transportModes.a11yLabel(transportModeText),
+      )}
+      accessible={true}
+    >
       <TransportationIconBoxList
         modes={modes}
-        maxNumberOfBoxes={2}
+        maxNumberOfBoxes={modesDisplayLimit}
         iconSize={iconSize}
         disabled={disabled}
       />
       <ThemeText
         type={textType ?? 'label__uppercase'}
         color={textColor ?? 'secondary'}
-        accessibilityLabel={t(
-          customTransportModeText
-            ? FareContractTexts.transportModes.a11yLabelWithCustomText(
-                transportModeText,
-                customTransportModeText,
-              )
-            : FareContractTexts.transportModes.a11yLabel(transportModeText),
-        )}
       >
-        {customTransportModeText ? customTransportModeText : transportModeText}
+        {customTransportModeText ?? description}
       </ThemeText>
     </View>
   );

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -286,11 +286,7 @@ const FareContractTexts = {
     unnamedDevice: _('Enhet uten navn', 'Unnamed device', 'Ukjent eining'),
   },
   transportModes: {
-    multipleTravelModes: _(
-      'Flere reisemåter',
-      'Several travel modes',
-      'Fleire reisemåtar',
-    ),
+    more: _('Flere', 'More', 'Fleire'),
     a11yLabel: (transportModes: string) =>
       _(
         `Billetten gjelder ${transportModes}`,
@@ -302,12 +298,6 @@ const FareContractTexts = {
         `Billetten gjelder ${transportModes}, produktgruppen heter ${customText}`,
         `Ticket is valid on ${transportModes}, product group is called ${customText}`,
         `Billetten gjeld ${transportModes}, produktgruppa heiter ${customText}`,
-      ),
-    a11yLabelMultipleTravelModes: (count: number) =>
-      _(
-        `Totalt ${count} reisemåter`,
-        `In total ${count} travel modes`,
-        `Totalt ${count} reisemåtar`,
       ),
     concatListWord: _('og', 'and', 'og'),
   },


### PR DESCRIPTION
ref. https://github.com/AtB-AS/kundevendt/issues/17076#issuecomment-2031962208

This changes how transportation icons are handled for screen reader. Instead of handling the case where some transport modes are hidden, we instead always read out every mode.

Also changes the text "Several travel modes" to "more"