### PR TITLE
feat: get color from FareProductGroups transportmodes instead of FareProductType

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductGroup.tsx
@@ -73,12 +73,14 @@ export const FareProductGroup = ({
             onPress={() => onProductSelect(firstConfig)}
             testID={`${firstConfig.type}FareProduct`}
             config={firstConfig}
+            productGroupTransportModes={transportModes}
           />
           {secondConfig && (
             <FareProductTile
               onPress={() => onProductSelect(secondConfig)}
               testID={`${secondConfig.type}FareProduct`}
               config={secondConfig}
+              productGroupTransportModes={transportModes}
             />
           )}
         </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import {FareProductTypeConfig} from '@atb/configuration';
+import {
+  FareProductTypeConfig,
+  ProductTypeTransportModes,
+} from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 
 import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
@@ -11,17 +14,17 @@ export const FareProductTile = ({
   onPress,
   testID,
   config,
+  productGroupTransportModes,
 }: {
   accented?: boolean;
   onPress: () => void;
   testID: string;
   config: FareProductTypeConfig;
+  productGroupTransportModes: ProductTypeTransportModes[];
 }) => {
-  const transportModes = config.transportModes;
-
   const transportColor = useThemeColorForTransportMode(
-    transportModes[0]?.mode,
-    transportModes[0]?.subMode,
+    productGroupTransportModes[0]?.mode,
+    productGroupTransportModes[0]?.subMode,
   );
   const title = useTextForLanguage(config.name);
   const description = useTextForLanguage(config.description);


### PR DESCRIPTION
For other tickets, we would like to show default color instead of the color associated with transport mode since this group of tickets might not be directly linked to one of the FareProductGroups. The current example is youth ticket wich does not belong to either FareProductGroup that we have now, but the transportmodes on their FareProductType is both boat and bus/tram.

<img src="https://github.com/AtB-AS/mittatb-app/assets/126664682/8fca0bf8-8cbe-499b-bc7a-43485020b0ff" width="200" />


Closes: https://github.com/AtB-AS/kundevendt/issues/17306