### PR TITLE
fix: Support no start / end date on travel right

### DIFF
--- a/src/ticketing/firestore.ts
+++ b/src/ticketing/firestore.ts
@@ -23,8 +23,8 @@ export function setupFirestoreListeners(
   const mapTravelRight = (travelRight: FirebaseFirestoreTypes.DocumentData): FirebaseFirestoreTypes.DocumentData => {
     return {
       ...travelRight,
-      startDateTime: (travelRight.startDateTime as FirebaseFirestoreTypes.Timestamp).toDate(),
-      endDateTime: (travelRight.endDateTime as FirebaseFirestoreTypes.Timestamp).toDate(),
+      startDateTime: (travelRight.startDateTime as FirebaseFirestoreTypes.Timestamp)?.toDate(),
+      endDateTime: (travelRight.endDateTime as FirebaseFirestoreTypes.Timestamp)?.toDate(),
       ...travelRight.usedAccesses && {
         usedAccesses: travelRight.usedAccesses.map(mapUsedAccesses),
       },
@@ -47,7 +47,7 @@ export function setupFirestoreListeners(
     return {
       ...fareContract,
       created: (fareContract.created as FirebaseFirestoreTypes.Timestamp).toDate(),
-      ...fareContract.travelRights && { 
+      ...fareContract.travelRights && {
           travelRights: fareContract.travelRights.map(mapTravelRight),
       },
     };


### PR DESCRIPTION
As of now only doing a superficial fix. When removing the
TravelRight.type logic this will be slightly cleaner.

Should then probably talk to platform team and create correct
raw-types in the app to use for the data from Firestore before
mapping.
