### PR TITLE
feat: only allow consumption on non-activated ticket for carnets.

### DIFF
--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -178,6 +178,7 @@ export function isCanBeConsumedNowFareContract(
   currentUserId: string | undefined,
 ) {
   if (f.customerAccountId !== currentUserId) return false;
+  if (f.state !== 1) return false;
   if (!isCarnet(f)) return false;
   const travelRights = f.travelRights.filter(isCarnetTravelRight);
 

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -178,7 +178,7 @@ export function isCanBeConsumedNowFareContract(
   currentUserId: string | undefined,
 ) {
   if (f.customerAccountId !== currentUserId) return false;
-  if (f.state !== 1) return false;
+  if (f.state !== FareContractState.NotActivated) return false;
   if (!isCarnet(f)) return false;
   const travelRights = f.travelRights.filter(isCarnetTravelRight);
 


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17595

Don't show carnet consumption button on refunded/cancelled tickets, so basically only show it on a non-activated carnet ticket.
