### PR TITLE
chore: update SystemFragment type

### DIFF
--- a/src/api/types/generated/fragments/mobility-shared.ts
+++ b/src/api/types/generated/fragments/mobility-shared.ts
@@ -37,6 +37,7 @@ export type BrandAssetsFragment = {
 };
 
 export type SystemFragment = {
+  id: string;
   operator: OperatorFragment;
   name: TranslatedStringFragment;
   brandAssets?: BrandAssetsFragment;

--- a/src/api/types/generated/readme
+++ b/src/api/types/generated/readme
@@ -1,3 +1,3 @@
 These files are generated or manually imported.
-These files should not be edited by hand.
-Overrides, extensions or extractions should be done in parent directory
+These files should not be edited by typing. Instead, copy the generated type and paste it in.
+Overrides, extensions or extractions should be done in parent directory.

--- a/src/api/types/generated/readme
+++ b/src/api/types/generated/readme
@@ -1,3 +1,3 @@
 These files are generated or manually imported.
-These files should not be edited by typing. Instead, copy the generated type and paste it in.
+These files should not be edited by typing. Instead, copy the generated type from atb-bff and paste it in.
 Overrides, extensions or extractions should be done in parent directory.


### PR DESCRIPTION
Update the SystemFragment type after merging https://github.com/AtB-AS/atb-bff/pull/330 in the BFF.

Also included a change to the type readme as it was a bit confusing that these files "are generated" and should "not be edited by hand", while you actually have to copy paste it in..

Resolves https://github.com/AtB-AS/kundevendt/issues/17614