### PR TITLE
fix: avoid ambiguous messages about whether correspondence can or cannot be guaranteed

### DIFF
--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -1,0 +1,87 @@
+//import {addMinutes} from 'date-fns';
+import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
+import {Leg} from '@atb/api/types/trips';
+
+describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
+  it('should be false if not short wait time', () => {
+    const legs = [
+      {expectedEndTime: '2024-10-31T14:55:00Z'},
+      {expectedStartTime: '2024-10-31T15:00:00Z'},
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+  });
+
+  it('should be true if short wait time and no guarenteed correspondance', () => {
+    const legs = [
+      {expectedEndTime: '2024-10-31T14:59:00Z'},
+      {expectedStartTime: '2024-10-31T15:00:00Z'},
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+
+  it('should be false if short wait time, but correspondance is guarenteed', () => {
+    const legs = [
+      {
+        expectedEndTime: '2024-10-31T14:59:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+      {expectedStartTime: '2024-10-31T15:00:00Z'},
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+  });
+
+  it('should be false if not short wait time and correspondance is guarenteed', () => {
+    const legs = [
+      {
+        expectedEndTime: '2024-10-31T14:55:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+      {expectedStartTime: '2024-10-31T15:00:00Z'},
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+  });
+
+  it('should be true if wait time between two legs are short and correspondance is not guranteed.', () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:59:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+      {
+        expectedStartTime: '2024-10-31T15:02:00Z',
+        expectedEndTime: '2024-10-31T15:10:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:12:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+
+  it('should be true as there are is short wait time at the stop before the departure of the last buss.', () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:06:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+});

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -86,8 +86,6 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s6);
   });
 
-  it(`should .`, () => {});
-
   const s7 = false;
   it(`should be ${s7} even if there is short wait time between bus and walking.`, () => {
     const legs = [

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -2,25 +2,28 @@ import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
 import {Leg} from '@atb/api/types/trips';
 
 describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
-  it('should be false if not short wait time', () => {
+  const s1 = false;
+  it(`should be ${s1} if not short wait time`, () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:55:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s1);
   });
 
-  it('should be true if short wait time and no guarenteed correspondance', () => {
+  const s2 = true;
+  it(`should be ${s2} if short wait time and no guarenteed correspondance`, () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:59:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s2);
   });
 
-  it('should be false if short wait time, but correspondance is guarenteed', () => {
+  const s3 = false;
+  it(`should be ${s3} if short wait time, but correspondance is guarenteed`, () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:59:00Z',
@@ -29,10 +32,11 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s3);
   });
 
-  it('should be false if not short wait time and correspondance is guarenteed', () => {
+  const s4 = false;
+  it(`should be ${s4} if not short wait time and correspondance is guarenteed`, () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:55:00Z',
@@ -41,10 +45,11 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s4);
   });
 
-  it('should be true if wait time between two legs are short and correspondance is not guranteed.', () => {
+  const s5 = true;
+  it(`should be ${s5} if wait time between two legs are short and correspondance is not guranteed.`, () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:59:00Z',
@@ -61,10 +66,51 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s5);
   });
 
-  it('should be true as there are is short wait time at the stop before the departure of the last buss.', () => {
+  const s6 = false;
+  it(`should be ${s6} as even when short wait time at before the next bus departure.`, () => {
+    const legs = [
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s6);
+  });
+
+  it(`should .`, () => {});
+
+  const s7 = false;
+  it(`should be ${s7} even if there is short wait time between bus and walking.`, () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:6:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s7);
+  });
+
+  const s8 = false;
+  it(`should be ${s8} even if there is short wait time between multiple bus and walking legs.`, () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -79,8 +125,17 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
         expectedStartTime: '2024-10-31T15:06:00Z',
         expectedEndTime: '2024-10-31T15:20:00Z',
       },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:25:00Z',
+        expectedEndTime: '2024-10-31T15:30:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:31:00Z',
+        expectedEndTime: '2024-10-31T15:40:00Z',
+      },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s8);
   });
 });

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -174,7 +174,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  it('should be true because of short wait time and no guarenteed correspondance.', () => {
+  it('should be false when foot leg is the initial leg.', () => {
     const legs = [
       {
         mode: 'foot',
@@ -187,7 +187,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
   it('should be true because of short wait time between third and forth leg.', () => {

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -2,7 +2,7 @@ import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
 import {Leg} from '@atb/api/types/trips';
 
 describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
-  it('should be false if not short wait time', () => {
+  it('should be false because no short wait time.', () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:55:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
@@ -11,7 +11,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be true if short wait time and no guarenteed correspondance', () => {
+  it('should be true because short wait time.', () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:59:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
@@ -20,7 +20,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  it('should be false if short wait time, but correspondance is guarenteed', () => {
+  it('should be false despite short wait time, because correspondance is guarenteed.', () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:59:00Z',
@@ -32,7 +32,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be false if not short wait time and correspondance is guarenteed', () => {
+  it('should be false because of no short wait time and correspondance is guarenteed.', () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:55:00Z',
@@ -43,8 +43,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
 
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
-
-  it('should be true if wait time between two legs are short and correspondance is not guranteed.', () => {
+  it('should be true because short wait time between second and third leg, with no correspondance guranteed.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:59:00Z',
@@ -64,23 +63,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  it('should be false as even when short wait time at before the next bus departure.', () => {
-    const legs = [
-      {
-        mode: 'foot',
-        expectedStartTime: '2024-10-31T14:45:00Z',
-        expectedEndTime: '2024-10-31T15:00:00Z',
-      },
-      {
-        expectedStartTime: '2024-10-31T15:00:00Z',
-        expectedEndTime: '2024-10-31T15:05:00Z',
-      },
-    ] as Leg[];
-
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
-  });
-
-  it('should be false even if there is short wait time between bus and walking.', () => {
+  it('should be false because short wait time between a pair of legs have no effect when the second leg of the pair have mode: foot.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -92,7 +75,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
         expectedEndTime: '2024-10-31T15:05:00Z',
       },
       {
-        expectedStartTime: '2024-10-31T15:6:00Z',
+        expectedStartTime: '2024-10-31T15:10:00Z',
         expectedEndTime: '2024-10-31T15:20:00Z',
       },
     ] as Leg[];
@@ -100,7 +83,36 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be false even if there is short wait time between multiple bus and walking legs.', () => {
+  it('should be false because short wait time between a pair of legs have no effect when the second leg of the pair have mode: foot.', () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:10:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:20:00Z',
+        expectedEndTime: '2024-10-31T15:30:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:35:00Z',
+        expectedEndTime: '2024-10-31T15:40:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+  });
+
+  it('should be true as there is short wait time between the second leg and the third leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -115,17 +127,119 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
         expectedStartTime: '2024-10-31T15:06:00Z',
         expectedEndTime: '2024-10-31T15:20:00Z',
       },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+
+  it('should be false despite short wait time between second and third leg, beacuse interchange is guarenteed first leg and mode equals foot in second leg.', () => {
+    const legs = [
       {
-        mode: 'foot',
-        expectedStartTime: '2024-10-31T15:25:00Z',
-        expectedEndTime: '2024-10-31T15:30:00Z',
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+        interchangeTo: {guaranteed: true},
       },
       {
-        expectedStartTime: '2024-10-31T15:31:00Z',
-        expectedEndTime: '2024-10-31T15:40:00Z',
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:06:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
       },
     ] as Leg[];
 
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
+  });
+
+  it('should be true because because of short wait time between second and third leg, and the mode in the second leg is not foot.', () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:06:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+
+  it('should be true because of short wait time and no guarenteed correspondance.', () => {
+    const legs = [
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+    ] as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+
+  it('should be true because of short wait time between third and forth leg.', () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+
+      {
+        expectedStartTime: '2024-10-31T15:06:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:21:00Z',
+        expectedEndTime: '2024-10-31T15:30:00Z',
+      },
+    ] as unknown as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
+  });
+
+  it('should be true because of short wait time between third and forth leg.', () => {
+    const legs = [
+      {
+        expectedStartTime: '2024-10-31T14:45:00Z',
+        expectedEndTime: '2024-10-31T15:00:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:05:00Z',
+      },
+
+      {
+        expectedStartTime: '2024-10-31T15:06:00Z',
+        expectedEndTime: '2024-10-31T15:20:00Z',
+      },
+      {
+        expectedStartTime: '2024-10-31T15:21:00Z',
+        expectedEndTime: '2024-10-31T15:30:00Z',
+        interchangeTo: {guaranteed: true},
+      },
+    ] as unknown as Leg[];
+
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 });

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -2,28 +2,25 @@ import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
 import {Leg} from '@atb/api/types/trips';
 
 describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
-  const s1 = false;
-  it(`should be ${s1} if not short wait time`, () => {
+  it('should be false if not short wait time', () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:55:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s1);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  const s2 = true;
-  it(`should be ${s2} if short wait time and no guarenteed correspondance`, () => {
+  it('should be true if short wait time and no guarenteed correspondance', () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:59:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s2);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  const s3 = false;
-  it(`should be ${s3} if short wait time, but correspondance is guarenteed`, () => {
+  it('should be false if short wait time, but correspondance is guarenteed', () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:59:00Z',
@@ -32,11 +29,10 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s3);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  const s4 = false;
-  it(`should be ${s4} if not short wait time and correspondance is guarenteed`, () => {
+  it('should be false if not short wait time and correspondance is guarenteed', () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:55:00Z',
@@ -45,11 +41,10 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       {expectedStartTime: '2024-10-31T15:00:00Z'},
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s4);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  const s5 = true;
-  it(`should be ${s5} if wait time between two legs are short and correspondance is not guranteed.`, () => {
+  it('should be true if wait time between two legs are short and correspondance is not guranteed.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:59:00Z',
@@ -66,11 +61,10 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s5);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  const s6 = false;
-  it(`should be ${s6} as even when short wait time at before the next bus departure.`, () => {
+  it('should be false as even when short wait time at before the next bus departure.', () => {
     const legs = [
       {
         mode: 'foot',
@@ -83,11 +77,10 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s6);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  const s7 = false;
-  it(`should be ${s7} even if there is short wait time between bus and walking.`, () => {
+  it('should be false even if there is short wait time between bus and walking.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -104,11 +97,10 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s7);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  const s8 = false;
-  it(`should be ${s8} even if there is short wait time between multiple bus and walking legs.`, () => {
+  it('should be false even if there is short wait time between multiple bus and walking legs.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -134,6 +126,6 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       },
     ] as Leg[];
 
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(s8);
+    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 });

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -2,7 +2,7 @@ import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
 import {Leg} from '@atb/api/types/trips';
 
 describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
-  it('should be false because no short wait time.', () => {
+  it('should be false when no short wait time.', () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:55:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
@@ -11,7 +11,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be true because short wait time.', () => {
+  it('should be true when short wait time.', () => {
     const legs = [
       {expectedEndTime: '2024-10-31T14:59:00Z'},
       {expectedStartTime: '2024-10-31T15:00:00Z'},
@@ -20,7 +20,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  it('should be false despite short wait time, because correspondance is guarenteed.', () => {
+  it('should be false when correspondance is guarenteed and short wait time.', () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:59:00Z',
@@ -32,7 +32,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be false because of no short wait time and correspondance is guarenteed.', () => {
+  it('should be false when correspondance is guarenteed and no short wait time.', () => {
     const legs = [
       {
         expectedEndTime: '2024-10-31T14:55:00Z',
@@ -43,7 +43,8 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
 
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
-  it('should be true because short wait time between second and third leg, with no correspondance guranteed.', () => {
+
+  it('should be true when no correspondance is guranteed, and short wait time between second and third leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:59:00Z',
@@ -63,7 +64,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  it('should be false because short wait time between a pair of legs have no effect when the second leg of the pair have mode: foot.', () => {
+  it('should be false despite short wait time between a pair of legs, because the second leg of the pair is a foot leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -83,7 +84,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be false because short wait time between a pair of legs have no effect when the second leg of the pair have mode: foot.', () => {
+  it('should be false despite short wait time between multiple pair of legs, because the second leg of each pair is a foot leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -112,7 +113,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be true as there is short wait time between the second leg and the third leg.', () => {
+  it('should be true when short wait time between a pair of legs , as the first leg of the pair is not the initial leg of the trip, and the second leg of the pair is not a foot leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -132,7 +133,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
   });
 
-  it('should be false despite short wait time between second and third leg, beacuse interchange is guarenteed first leg and mode equals foot in second leg.', () => {
+  it('should be false despite short wait time a pair of legs, as interchange in the leg prior to the pair is guarenteed, and the first leg of the pair is a foot leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -153,7 +154,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be true because because of short wait time between second and third leg, and the mode in the second leg is not foot.', () => {
+  it('should be true when short wait time in a pair of legs, despite guarenteed interchange in the leg prior to a pair, as the first leg of the pair is not a foot leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -190,7 +191,7 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
     expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(false);
   });
 
-  it('should be true because of short wait time between third and forth leg.', () => {
+  it('should be true when short wait time between a pair of legs, following a foot leg and a guranteed interchange from the leg prior to the foot leg.', () => {
     const legs = [
       {
         expectedStartTime: '2024-10-31T14:45:00Z',
@@ -210,33 +211,6 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
       {
         expectedStartTime: '2024-10-31T15:21:00Z',
         expectedEndTime: '2024-10-31T15:30:00Z',
-      },
-    ] as unknown as Leg[];
-
-    expect(hasShortWaitTimeAndNotGuaranteedCorrespondence(legs)).toBe(true);
-  });
-
-  it('should be true because of short wait time between third and forth leg.', () => {
-    const legs = [
-      {
-        expectedStartTime: '2024-10-31T14:45:00Z',
-        expectedEndTime: '2024-10-31T15:00:00Z',
-        interchangeTo: {guaranteed: true},
-      },
-      {
-        mode: 'foot',
-        expectedStartTime: '2024-10-31T15:00:00Z',
-        expectedEndTime: '2024-10-31T15:05:00Z',
-      },
-
-      {
-        expectedStartTime: '2024-10-31T15:06:00Z',
-        expectedEndTime: '2024-10-31T15:20:00Z',
-      },
-      {
-        expectedStartTime: '2024-10-31T15:21:00Z',
-        expectedEndTime: '2024-10-31T15:30:00Z',
-        interchangeTo: {guaranteed: true},
       },
     ] as unknown as Leg[];
 

--- a/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
+++ b/src/travel-details-screens/__tests__/has_short_wait_time_and_not_guaranteed_correspondance.test.ts
@@ -1,4 +1,3 @@
-//import {addMinutes} from 'date-fns';
 import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
 import {Leg} from '@atb/api/types/trips';
 

--- a/src/travel-details-screens/components/Trip.tsx
+++ b/src/travel-details-screens/components/Trip.tsx
@@ -252,7 +252,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-function getInterchangeDetails(
+export function getInterchangeDetails(
   legs: Leg[],
   id: string | undefined,
 ): InterchangeDetails | undefined {

--- a/src/travel-details-screens/components/Trip.tsx
+++ b/src/travel-details-screens/components/Trip.tsx
@@ -252,7 +252,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-export function getInterchangeDetails(
+function getInterchangeDetails(
   legs: Leg[],
   id: string | undefined,
 ): InterchangeDetails | undefined {

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -167,6 +167,7 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
     prevEndTime: Date | undefined;
     prevInterchangeGuaranteed: boolean;
     prevMode: string | undefined;
+    initalLeg: boolean;
   }>(
     (state, leg, idx) => {
       if (state.conclusion) return state;
@@ -176,6 +177,7 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
           ...state,
           prevEndTime: leg.expectedEndTime,
           prevMode: leg.mode,
+          initalLeg: idx === 0 ? true : false,
         };
       }
 
@@ -187,6 +189,7 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
       if (
         timeIsShort(waitTime) &&
         !state.prevInterchangeGuaranteed &&
+        !(state.initalLeg && state.prevMode) &&
         !(legs[idx].interchangeTo?.guaranteed && nextLegIsFootLeg(legs, idx))
       ) {
         return {
@@ -202,6 +205,7 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
         prevEndTime: leg.expectedEndTime,
         prevInterchangeGuaranteed: leg.interchangeTo?.guaranteed || false,
         prevMode: leg.mode,
+        initalLeg: idx === 0 ? true : false,
       };
     },
     {
@@ -209,6 +213,7 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
       prevEndTime: undefined,
       prevInterchangeGuaranteed: false,
       prevMode: undefined,
+      initalLeg: true,
     },
   ).conclusion;
 }

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -21,6 +21,7 @@ import {APP_ORG} from '@env';
 import {BookingArrangementFragment} from '@atb/api/types/generated/fragments/booking-arrangements';
 import {BookingStatus, TripPatternBookingStatus} from './types';
 import {Statuses} from '@atb-as/theme';
+import {getInterchangeDetails} from './components/Trip';
 
 const DEFAULT_THRESHOLD_AIMED_EXPECTED_IN_MINUTES = 1;
 
@@ -160,6 +161,7 @@ export function hasShortWaitTime(legs: Leg[]) {
 }
 
 export function hasShortWaitTimeAndNotGuaranteedCorrespondence(legs: Leg[]) {
+  if (hasGuaranteedCorrespondence(legs)) return false;
   return iterateWithNext(legs)
     .map((pair) => {
       if (pair.current.interchangeTo?.guaranteed) {
@@ -172,6 +174,18 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(legs: Leg[]) {
     })
     .filter((waitTime) => waitTime > 0)
     .some((waitTime) => timeIsShort(waitTime));
+}
+
+function hasGuaranteedCorrespondence(filteredLegs: Leg[]) {
+  return filteredLegs.some(
+    (leg) =>
+      leg.interchangeTo?.guaranteed &&
+      getInterchangeDetails(
+        filteredLegs,
+        leg.interchangeTo?.toServiceJourney?.id,
+      ) &&
+      leg.line,
+  );
 }
 
 function parseDateIfString(date: any): Date {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17624

### What is wrong, and what is expected behavior?

A user has asked us a question regarding ambiguous messages. The messages at the top of the app say that correspondence cannot be guaranteed, while the message a little further down says that there is correspondence between 340 and 341 (picture 1). This is confusing. 


### Proposed solution
Remove the last sentence "Kan ikke garantere korrespondanse.", if the message box "Korrespondanse mellom 340 og 341 på Volda sjukehus" appears.   


### Illustration Solution
<details>
<Summary>screenshots/video</Summary>

![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/2955fa05-a7e1-4297-8501-6e8b23ef10be)

![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/da398c48-a5b1-4549-8c7e-37084141e14d)

</details>
