### PR TITLE
feat: add error grouping hash to bugsnag reporting

### DIFF
--- a/src/loading-screen/__tests__/use-notify-bugsnag-on-timeout-status.test.ts
+++ b/src/loading-screen/__tests__/use-notify-bugsnag-on-timeout-status.test.ts
@@ -8,8 +8,8 @@ import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
 let mockBugsnagNotification: Parameters<typeof notifyBugsnag> | undefined;
 
 jest.mock('@atb/utils/bugsnag-utils', () => ({
-  notifyBugsnag: (error: string, metadata: any) => {
-    mockBugsnagNotification = [error, metadata];
+  notifyBugsnag: (error: string, errorGroupHash: string, metadata: any) => {
+    mockBugsnagNotification = [error, errorGroupHash, metadata];
   },
 }));
 
@@ -27,6 +27,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
     renderHook(() => useNotifyBugsnagOnTimeoutStatus('timeout', ref));
     expect(mockBugsnagNotification).toEqual([
       jestExpect.stringMatching('Loading boundary timeout'),
+      jestExpect.stringMatching('LoadingBoundaryTimeoutError'),
       jestExpect.objectContaining({
         isLoadingAppState: true,
         authStatus: 'loading',
@@ -62,6 +63,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
     hook.rerender({status: 'timeout'});
     expect(mockBugsnagNotification).toEqual([
       jestExpect.stringMatching('Loading boundary timeout'),
+      jestExpect.stringMatching('LoadingBoundaryTimeoutError'),
       jestExpect.objectContaining({
         isLoadingAppState: true,
         authStatus: 'loading',
@@ -76,6 +78,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
     );
     expect(mockBugsnagNotification).toEqual([
       jestExpect.stringMatching('Loading boundary timeout'),
+      jestExpect.stringMatching('LoadingBoundaryTimeoutError'),
       jestExpect.objectContaining({
         isLoadingAppState: true,
         authStatus: 'loading',
@@ -103,6 +106,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
     hook.rerender({status: 'timeout'});
     expect(mockBugsnagNotification).toEqual([
       jestExpect.stringMatching('Loading boundary timeout'),
+      jestExpect.stringMatching('LoadingBoundaryTimeoutError'),
       jestExpect.objectContaining({
         isLoadingAppState: true,
         authStatus: 'fetching-id-token',
@@ -117,6 +121,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
     );
     expect(mockBugsnagNotification).toEqual([
       jestExpect.stringMatching('Loading boundary timeout'),
+      jestExpect.stringMatching('LoadingBoundaryTimeoutError'),
       jestExpect.objectContaining({
         isLoadingAppState: true,
         authStatus: 'loading',

--- a/src/loading-screen/use-notify-bugsnag-on-timeout-status.ts
+++ b/src/loading-screen/use-notify-bugsnag-on-timeout-status.ts
@@ -8,7 +8,7 @@ export const useNotifyBugsnagOnTimeoutStatus = (
 ) => {
   useEffect(() => {
     if (status === 'timeout') {
-      notifyBugsnag('Loading boundary timeout', {...paramsRef.current});
+      notifyBugsnag('Loading boundary timeout', 'LoadingBoundaryTimeoutError', {...paramsRef.current});
     }
   }, [status, paramsRef]);
 };

--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -37,6 +37,7 @@ import {
   LOAD_NATIVE_TOKEN_QUERY_KEY,
   useLoadNativeTokenQuery,
 } from '@atb/mobile-token/hooks/use-load-native-token-query';
+import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
 
 const SIX_HOURS_MS = 1000 * 60 * 60 * 6;
 
@@ -107,14 +108,13 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
         // and set state that indicates timeout.
         setTimout(true);
 
-        Bugsnag.notify(
+        notifyBugsnag(
           new Error(
             `Token loading timed out after ${token_timeout_in_seconds} seconds`,
           ),
-          (event) => {
-            event.addMetadata('token', {
-              description: 'Native and remote tokens took too long to load.',
-            });
+          'TokenLoadingTimeoutError',
+          {
+            description: 'Native and remote tokens took too long to load.',
           },
         );
       }, token_timeout_in_seconds);

--- a/src/mobile-token/hooks/useGetSignedTokenQuery.tsx
+++ b/src/mobile-token/hooks/useGetSignedTokenQuery.tsx
@@ -22,7 +22,7 @@ export const useGetSignedTokenQuery = () => {
       try {
         return await mobileTokenClient.encode(nativeToken);
       } catch (err: any) {
-        notifyBugsnag(err, `GetSignedTokenError - ${err}`, {
+        notifyBugsnag(err, 'GetSignedTokenError', {
           tokenId: nativeToken.tokenId,
           description: 'Error encoding signed token',
         });

--- a/src/mobile-token/hooks/useGetSignedTokenQuery.tsx
+++ b/src/mobile-token/hooks/useGetSignedTokenQuery.tsx
@@ -22,7 +22,7 @@ export const useGetSignedTokenQuery = () => {
       try {
         return await mobileTokenClient.encode(nativeToken);
       } catch (err: any) {
-        notifyBugsnag(err, {
+        notifyBugsnag(err, `GetSignedTokenError - ${err}`, {
           tokenId: nativeToken.tokenId,
           description: 'Error encoding signed token',
         });

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/WebViewTerminal.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/WebViewTerminal.tsx
@@ -27,7 +27,7 @@ export const WebViewTerminal = ({
         <WebView
           source={{uri: offerReservation.url}}
           onError={(e: any) => {
-            notifyBugsnag(e, `WebViewReservationError - ${e}`);
+            notifyBugsnag(e, 'WebViewReservationError');
             onWebViewStatusChange('error');
           }}
           onLoadStart={(event) =>

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/WebViewTerminal.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/WebViewTerminal.tsx
@@ -27,7 +27,7 @@ export const WebViewTerminal = ({
         <WebView
           source={{uri: offerReservation.url}}
           onError={(e: any) => {
-            notifyBugsnag(e);
+            notifyBugsnag(e, `WebViewReservationError - ${e}`);
             onWebViewStatusChange('error');
           }}
           onLoadStart={(event) =>

--- a/src/utils/bugsnag-utils.ts
+++ b/src/utils/bugsnag-utils.ts
@@ -1,16 +1,34 @@
-/*
-This utils is a slightly simpler to use facade against Bugsnag, and is
-easier to mock when needing to mock or test Bugsnag notifications.
- */
 import Bugsnag, {Event, NotifiableError} from '@bugsnag/react-native';
 
 type MetaData = {[key: string]: any};
 
-export const notifyBugsnag = (error: NotifiableError, metadata?: MetaData) =>
+/**
+ * A utility function that acts as a facade against Bugsnag,
+ * ensures that the correct grouping is provided,
+ * and is easier to mock for testing Bugsnag notifications.
+ *
+ * Please see 
+ * {@link https://github.com/AtB-AS/docs-private/blob/main/bugsnag.md|bugsnag.md}
+ *
+ * @param error error object (@see {@link NotifiableError})
+ * 
+ * @param errorGroupHash error group hash, determines the grouping of issues 
+ * ({@link https://docs.bugsnag.com/product/error-grouping/#custom-grouping-hash|see official docs} for more info)
+ * 
+ * @param metadata metadata to send with the error report.
+ * 
+ * @returns
+ */
+export const notifyBugsnag = (
+  error: NotifiableError,
+  errorGroupHash: string,
+  metadata?: MetaData,
+) =>
   Bugsnag.notify(
     error,
     metadata
       ? (event: Event) => {
+          event.groupingHash = errorGroupHash;
           event.addMetadata('metadata', metadata);
         }
       : undefined,


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/5352

This PR will try to improve the error grouping in Bugsnag dashboard.

### Problem
Currently, if we open an error in the Bugsnag dashboard, it will show the screen below (example):
<img width=500 src="https://github.com/AtB-AS/mittatb-app/assets/1777333/09051cb7-7824-4c2a-b66a-cd7b656a2893"/>

We can see that while the error name is the same: `MainActivity`, the list of error shows that it can originate from different source, in this case we have both `network error` and `token loading timeout` in the same error category.

Check these links for more examples:
- https://app.bugsnag.com/atb-as/mittatb/errors/6615013360afa8000813aa21
- https://app.bugsnag.com/atb-as/mittatb/errors/6269b17a4d18f800088b523a
- https://app.bugsnag.com/atb-as/mittatb/errors/657bef1e901ded000850a86f 

We can also see that the list of error types in main `Inbox` page have lots of similar issues which could be grouped together. There are multiple `auth/network-request-failed` that could have been grouped together, but instead there are several different items with the same issue.
<img width=500 src="https://github.com/AtB-AS/mittatb-app/assets/1777333/27322909-177f-4bfd-b31f-241c07d12811"/>

### Why did the problem occur?
These grouping is the default behavior from Bugsnag, see their [official documentation about issues grouping](https://docs.bugsnag.com/product/error-grouping/#default-grouping). 

### Solution in PR
Bugsnag has provided a [custom grouping](https://docs.bugsnag.com/product/error-grouping/#custom-grouping) solution that can be used to group issues together. They provided 2 premade solution: using `Error class` and `Error context`, while this might work for a smaller app, we usually have similar `Error class` across issues (using the `Error` class). For `Error context` it might work but still unsure about how Bugsnag would group the error(s).

Therefore I opted to use the `Custom grouping hash` solution provided by Bugsnag. This will allow us to set the grouping of errors together, and therefore it should be easier to track them and pinpoint where the issue occurs.

In this PR I used the `notifyBugsnag()` function from `bugsnag-utils.ts`, which I think should be used for all bugsnag reporting going forward. I added the `errorGroupHash` parameter to specify the grouping. Currently, there are several grouping which can be accessed in the document in this PR https://github.com/AtB-AS/docs-private/pull/39.

### Review notes

Please let me know what do you think about the grouping, particularly errors that might need to be grouped together, but may have different error specification, such as the `GetSignedTokenError`, should we put the error type on the group (to differentiate them), or should we put the error type on the metadata instead (to group all of them together).

Also, if there are any suggestions for what other errors should be logged and grouped, feel free to notify and I will add them to the code (preferably also suggest the group hash).