### PR TITLE
chore: remove withpadding parameters from <Section>

### DIFF
--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -1,14 +1,10 @@
 import React, {PropsWithChildren} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
-import {StyleSheet, Theme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {ContainerSizingType} from './types';
 import {BaseSectionItemProps} from './use-section-item';
 
 export type SectionProps = PropsWithChildren<{
-  withPadding?: boolean;
-  withFullPadding?: boolean;
-  withTopPadding?: boolean;
-  withBottomPadding?: boolean;
   type?: ContainerSizingType;
   style?: StyleProp<ViewStyle>;
   testID?: string;
@@ -17,10 +13,6 @@ export type SectionProps = PropsWithChildren<{
 
 export function Section({
   children,
-  withPadding = false,
-  withFullPadding = false,
-  withTopPadding = false,
-  withBottomPadding = false,
   type = 'block',
   style,
   ...props
@@ -31,16 +23,8 @@ export function Section({
   const firstIndex = validChildren.indexOf(true);
   const lastIndex = validChildren.lastIndexOf(true);
 
-  const containerStyle: Array<StyleProp<ViewStyle> | undefined> = [
-    style,
-    withPadding ? styles.container__padded : undefined,
-    withFullPadding ? styles.container__fullPadded : undefined,
-    withTopPadding ? styles.container__topPadded : undefined,
-    withBottomPadding ? styles.container__bottomPadded : undefined,
-  ];
-
   return (
-    <View style={containerStyle} {...props}>
+    <View style={style} {...props}>
       {React.Children.map(children, (child, index) => {
         if (!React.isValidElement(child)) return child;
         if (child == null) return child;
@@ -79,7 +63,7 @@ function toRadius(index: number, lastIndex: number, firstIndex: number) {
   return undefined;
 }
 
-const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   separator: {
     flexGrow: 0,
     backgroundColor: theme.static.background.background_2.background,

--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -69,17 +69,4 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.static.background.background_2.background,
     height: 1,
   },
-  container__padded: {
-    marginHorizontal: theme.spacings.medium,
-    marginBottom: theme.spacings.small,
-  },
-  container__fullPadded: {
-    margin: theme.spacings.medium,
-  },
-  container__topPadded: {
-    marginTop: theme.spacings.large,
-  },
-  container__bottomPadded: {
-    marginBottom: theme.spacings.large,
-  },
 }));

--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -30,6 +30,7 @@ import {
   FareContract,
 } from '@atb/ticketing';
 import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetSectionItem';
+import {StyleSheet} from '@atb/theme';
 
 type Props = {
   now: number;
@@ -50,6 +51,7 @@ export const FareContractView: React.FC<Props> = ({
   const {isInspectable} = useMobileTokenContextState();
 
   const {t} = useTranslation();
+  const styles = useStyles();
 
   const {
     isCarnetFareContract,
@@ -101,7 +103,7 @@ export const FareContractView: React.FC<Props> = ({
   );
 
   return (
-    <Section withBottomPadding testID={testID}>
+    <Section style={styles.section} testID={testID}>
       <GenericSectionItem>
         {/* TODO: Should remove UsedAccessValidityHeader, and instead only rely on ValidityHeader */}
         {isCarnetFareContract &&
@@ -179,3 +181,9 @@ export const FareContractView: React.FC<Props> = ({
     </Section>
   );
 };
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginBottom: theme.spacings.large,
+  },
+}));

--- a/src/fare-contracts/UnknownFareContract.tsx
+++ b/src/fare-contracts/UnknownFareContract.tsx
@@ -4,12 +4,14 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ValidityLine} from './ValidityLine';
 import {GenericSectionItem, Section} from '@atb/components/sections';
+import { StyleSheet } from '@atb/theme';
 
 export function UnknownFareContract({fc}: {fc: FareContract}) {
   const {t} = useTranslation();
+  const styles = useStyles();
 
   return (
-    <Section withBottomPadding>
+    <Section style={styles.section}>
       <GenericSectionItem>
         <ValidityLine status="unknown" />
         <ThemeText>
@@ -24,3 +26,9 @@ export function UnknownFareContract({fc}: {fc: FareContract}) {
     </Section>
   );
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginBottom: theme.spacings.large,
+  },
+}));

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -134,7 +134,7 @@ export const DetailsContent: React.FC<Props> = ({
       benefits && benefits.length > 0 && validityStatus === 'valid';
 
     return (
-      <Section withBottomPadding>
+      <Section style={styles.section}>
         <GenericSectionItem>
           {/* TODO: Should remove UsedAccessValidityHeader, and instead only rely on ValidityHeader */}
           {isCarnetFareContract &&
@@ -171,18 +171,17 @@ export const DetailsContent: React.FC<Props> = ({
             sentToCustomerAccountId={isSent ? fc.customerAccountId : undefined}
           />
         </GenericSectionItem>
-        {isInspectable &&
-          validityStatus === 'valid' && (
-            <GenericSectionItem
-              style={
-                mobileTokenStatus === 'staticQr'
-                  ? styles.enlargedWhiteBarcodePaddingView
-                  : undefined
-              }
-            >
-              <Barcode validityStatus={validityStatus} fc={fc} />
-            </GenericSectionItem>
-          )}
+        {isInspectable && validityStatus === 'valid' && (
+          <GenericSectionItem
+            style={
+              mobileTokenStatus === 'staticQr'
+                ? styles.enlargedWhiteBarcodePaddingView
+                : undefined
+            }
+          >
+            <Barcode validityStatus={validityStatus} fc={fc} />
+          </GenericSectionItem>
+        )}
         <GenericSectionItem>
           <FareContractInfoDetails
             fromTariffZone={fromTariffZone}
@@ -253,6 +252,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   globalMessages: {
     flex: 1,
     rowGap: theme.spacings.medium,
+  },
+  section: {
+    marginBottom: theme.spacings.large,
   },
   enlargedWhiteBarcodePaddingView: {
     backgroundColor: '#ffffff',

--- a/src/fare-contracts/details/UnknownFareContractDetails.tsx
+++ b/src/fare-contracts/details/UnknownFareContractDetails.tsx
@@ -4,11 +4,14 @@ import {ValidityLine} from '@atb/fare-contracts/ValidityLine';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {GenericSectionItem, Section} from '@atb/components/sections';
+import {StyleSheet} from '@atb/theme';
 
 export function UnknownFareContractDetails({fc}: {fc: FareContract}) {
   const {t} = useTranslation();
+  const styles = useStyles();
+
   return (
-    <Section withBottomPadding>
+    <Section style={styles.section}>
       <GenericSectionItem>
         <ValidityLine status="unknown" />
       </GenericSectionItem>
@@ -20,3 +23,9 @@ export function UnknownFareContractDetails({fc}: {fc: FareContract}) {
     </Section>
   );
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginBottom: theme.spacings.large,
+  },
+}));

--- a/src/journey-date-picker/JourneyDatePickerScreenComponent.tsx
+++ b/src/journey-date-picker/JourneyDatePickerScreenComponent.tsx
@@ -78,13 +78,13 @@ export const JourneyDatePickerScreenComponent = ({
           selected={option ?? dateItems[0]}
           keyExtractor={(s: string) => s}
           items={dateItems}
-          withBottomPadding
+          style={styles.section}
           onSelect={setOption}
           itemToText={(s: DateOptionType) => getDateOptionText(s, t)}
         />
 
         {option !== 'now' && (
-          <Section withBottomPadding testID="dateTimePickerSection">
+          <Section style={styles.section} testID="dateTimePickerSection">
             <DateInputSectionItem value={dateString} onChange={setDate} />
             <TimeInputSectionItem value={timeString} onChange={setTime} />
           </Section>
@@ -95,7 +95,7 @@ export const JourneyDatePickerScreenComponent = ({
           interactiveColor="interactive_0"
           text={t(JourneyDatePickerTexts.searchButton.text)}
           testID="searchButton"
-         />
+        />
       </ScrollView>
     </View>
   );
@@ -111,6 +111,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   dateOptions: {
     margin: theme.spacings.medium,
+  },
+  section: {
+    marginBottom: theme.spacings.large,
   },
 }));
 

--- a/src/place-screen/components/DepartureTimeSheet.tsx
+++ b/src/place-screen/components/DepartureTimeSheet.tsx
@@ -58,7 +58,7 @@ export const DepartureTimeSheet = forwardRef<ScrollView, Props>(
           style={{paddingBottom: keyboardHeight}}
           ref={focusRef}
         >
-          <Section withBottomPadding>
+          <Section style={styles.section}>
             <DateInputSectionItem value={date} onChange={setDate} />
             <TimeInputSectionItem value={time} onChange={setTime} />
           </Section>
@@ -84,6 +84,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
   return {
     contentContainer: {
       padding: theme.spacings.medium,
+    },
+    section: {
+      marginBottom: theme.spacings.large,
     },
   };
 });

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -10,7 +10,7 @@ import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useFavorites} from '@atb/favorites';
 import {useOnlySingleLocation} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
-import {StyleSheet, Theme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {AddEditFavoriteTexts, useTranslation} from '@atb/translations';
 import React, {useEffect, useState} from 'react';
 import {Alert, Keyboard, ScrollView, View} from 'react-native';
@@ -30,7 +30,7 @@ export type Props = RootStackScreenProps<'Root_AddEditFavoritePlaceScreen'>;
 const themeColor: StaticColorByType<'background'> = 'background_3';
 
 export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
-  const css = useScreenStyle();
+  const styles = useStyles();
   const {
     addFavoriteLocation: addFavorite,
     removeFavoriteLocation: removeFavorite,
@@ -137,7 +137,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
   };
 
   return (
-    <View style={css.container}>
+    <View style={styles.container}>
       <FullScreenHeader
         title={
           editItem
@@ -147,17 +147,17 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
         leftButton={{type: !!editItem ? 'close' : 'back'}}
       />
 
-      <ScrollView style={css.innerContainer}>
+      <ScrollView style={styles.innerContainer}>
         <ScreenReaderAnnouncement message={errorMessage} />
         {errorMessage && (
           <MessageInfoBox
-            style={css.errorMessageBox}
+            style={styles.errorMessageBox}
             message={errorMessage}
             type="error"
           />
         )}
 
-        <Section withPadding>
+        <Section style={styles.section}>
           <LocationInputSectionItem
             label={t(AddEditFavoriteTexts.fields.location.label)}
             location={location}
@@ -174,7 +174,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
           />
         </Section>
 
-        <Section withPadding>
+        <Section style={styles.section}>
           <TextInputSectionItem
             label={t(AddEditFavoriteTexts.fields.name.label)}
             onChangeText={setName}
@@ -187,7 +187,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
           />
         </Section>
 
-        <Section withPadding style={css.emojiContainer}>
+        <Section style={[styles.emojiContainer, styles.section]}>
           <ButtonSectionItem
             onPress={openEmojiPopup}
             accessibilityLabel={t(AddEditFavoriteTexts.fields.icon.a11yLabel)}
@@ -218,7 +218,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
       </ScrollView>
 
       <FullScreenFooter avoidKeyboard={true}>
-        <View style={css.buttonContainer}>
+        <View style={styles.buttonContainer}>
           {editItem && (
             <Button
               onPress={deleteItem}
@@ -241,16 +241,20 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
     </View>
   );
 };
-const useScreenStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
     backgroundColor: theme.static.background[themeColor].background,
   },
   buttonContainer: {
-    marginBottom: theme.spacings.medium,
+    marginBottom: theme.spacings.large,
   },
   emojiContainer: {
     width: '50%',
+  },
+  section: {
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
   },
   innerContainer: {
     flex: 1,

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/JourneyHistory.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/JourneyHistory.tsx
@@ -7,6 +7,7 @@ import {View} from 'react-native';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {useFilteredJourneySearch} from '../utils';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {StyleSheet} from '@atb/theme';
 
 type JourneyHistoryProps = {
   searchText?: string;
@@ -18,6 +19,7 @@ const DEFAULT_HISTORY_LIMIT = 3;
 
 export function JourneyHistory({searchText, onSelect}: JourneyHistoryProps) {
   const {t} = useTranslation();
+  const styles = useStyles();
   const journeyHistory = useFilteredJourneySearch(searchText);
 
   if (!journeyHistory.length) {
@@ -25,7 +27,7 @@ export function JourneyHistory({searchText, onSelect}: JourneyHistoryProps) {
   }
 
   return (
-    <Section withTopPadding withBottomPadding>
+    <Section style={styles.section}>
       <HeaderSectionItem
         transparent
         text={t(
@@ -67,6 +69,13 @@ export function JourneyHistory({searchText, onSelect}: JourneyHistoryProps) {
     </Section>
   );
 }
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginTop: theme.spacings.large,
+    marginBottom: theme.spacings.large,
+  },
+}));
 
 function mapToVisibleSearchResult(entry: JourneySearchHistoryEntry) {
   const [from, to] = entry;

--- a/src/stacks-hierarchy/Root_ReceiptScreen.tsx
+++ b/src/stacks-hierarchy/Root_ReceiptScreen.tsx
@@ -92,7 +92,7 @@ export function Root_ReceiptScreen({route}: Props) {
             {...translateStateToMessage(state, t, email, reference)}
           />
         </View>
-        <Section withTopPadding withBottomPadding>
+        <Section style={styles.section}>
           {profileStatus === 'loading' ? (
             <ActivityIndicator />
           ) : (
@@ -164,4 +164,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   content: {
     padding: theme.spacings.medium,
   },
+  section: {
+    marginTop: theme.spacings.large,
+    marginBottom: theme.spacings.large,
+  }
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_AppearanceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_AppearanceScreen.tsx
@@ -1,5 +1,5 @@
 import {Section, ToggleSectionItem} from '@atb/components/sections';
-import {useTheme} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {AppearanceSettingsTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {Platform, View} from 'react-native';
@@ -16,6 +16,7 @@ export const Profile_AppearanceScreen = () => {
     updateAndroidFontOverride,
   } = useTheme();
   const {t} = useTranslation();
+  const styles = useStyles();
 
   return (
     <FullScreenView
@@ -31,7 +32,7 @@ export const Profile_AppearanceScreen = () => {
       )}
     >
       <View>
-        <Section withTopPadding withPadding>
+        <Section style={styles.section}>
           <ToggleSectionItem
             text={t(AppearanceSettingsTexts.actions.usePhoneTheme)}
             value={!overrideSystemAppearance}
@@ -49,7 +50,7 @@ export const Profile_AppearanceScreen = () => {
           )}
         </Section>
         {Platform.OS === 'android' && (
-          <Section withTopPadding withPadding>
+          <Section style={styles.section}>
             <ToggleSectionItem
               text={t(AppearanceSettingsTexts.actions.useSystemFont)}
               value={useAndroidSystemFont}
@@ -61,3 +62,11 @@ export const Profile_AppearanceScreen = () => {
     </FullScreenView>
   );
 };
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
+    marginTop: theme.spacings.large,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -1,6 +1,6 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet, Theme} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import React, {useEffect, useState} from 'react';
 import {Alert, Linking, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
@@ -68,7 +68,7 @@ function setClipboard(content: string) {
 }
 
 export const Profile_DebugInfoScreen = () => {
-  const style = useProfileHomeStyle();
+  const styles = useStyles();
 
   const {
     onboardingSections,
@@ -182,14 +182,14 @@ export const Profile_DebugInfoScreen = () => {
   const {showTestIds, debugShowSeconds} = preferences;
 
   return (
-    <View style={style.container}>
+    <View style={styles.container}>
       <FullScreenHeader
         title="Debug info"
         leftButton={{type: 'back'}}
         rightButton={{type: 'chat'}}
       />
       <ScrollView testID="debugInfoScrollView">
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ButtonSectionItem
             label="Restart all onboarding sections"
             onPress={() => restartAllOnboardingSections()}
@@ -209,7 +209,7 @@ export const Profile_DebugInfoScreen = () => {
             })}
           />
         </Section>
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <LinkSectionItem
             text="Reset shareTravelHabits session counter"
             onPress={() => storage.set(shareTravelHabitsSessionCountKey, '0')}
@@ -299,7 +299,7 @@ export const Profile_DebugInfoScreen = () => {
             onPress={() => storage.remove(StorageModelKeysEnum.OneTimePopOver)}
           />
         </Section>
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem
             text="Remote config override"
             subtitle="If undefined the value
@@ -439,7 +439,7 @@ export const Profile_DebugInfoScreen = () => {
           </GenericSectionItem>
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Firebase Auth user info"
             showIconText={true}
@@ -453,7 +453,7 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Firebase Auth user claims"
             showIconText={true}
@@ -471,7 +471,7 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Remote config"
             showIconText={true}
@@ -493,7 +493,7 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Notifications"
             showIconText={true}
@@ -503,17 +503,17 @@ export const Profile_DebugInfoScreen = () => {
                   Notification status: {pushNotificationPermissionStatus}
                 </ThemeText>
                 <Button
-                  style={style.button}
+                  style={styles.button}
                   onPress={requestPushNotificationPermissions}
                   text="Request permissions"
                 />
                 <Button
-                  style={style.button}
+                  style={styles.button}
                   onPress={checkPushNotificationPermissions}
                   text="Check permissions"
                 />
                 <Button
-                  style={style.button}
+                  style={styles.button}
                   onPress={() =>
                     registerNotifications(
                       pushNotificationPermissionStatus === 'granted',
@@ -527,7 +527,7 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Storage"
             showIconText={true}
@@ -548,7 +548,7 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Preferences"
             showIconText={true}
@@ -575,7 +575,7 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Mobile token state"
             showIconText={true}
@@ -600,27 +600,27 @@ export const Profile_DebugInfoScreen = () => {
                   serverNow,
                 ).toISOString()}`}</ThemeText>
                 <Button
-                  style={style.button}
+                  style={styles.button}
                   text="Reload token(s)"
                   onPress={retry}
                 />
                 {nativeToken && (
                   <Button
-                    style={style.button}
+                    style={styles.button}
                     text="Wipe token"
                     onPress={wipeToken}
                   />
                 )}
                 {nativeToken && (
                   <Button
-                    style={style.button}
+                    style={styles.button}
                     text="Validate token"
                     onPress={validateToken}
                   />
                 )}
                 {nativeToken && (
                   <Button
-                    style={style.button}
+                    style={styles.button}
                     text="Renew token"
                     onPress={renewToken}
                   />
@@ -629,7 +629,7 @@ export const Profile_DebugInfoScreen = () => {
                   text="Remote tokens"
                   showIconText={true}
                   expandContent={tokens?.map((token) => (
-                    <View key={token.id} style={style.remoteToken}>
+                    <View key={token.id} style={styles.remoteToken}>
                       {keys(token).map((k) => (
                         <ThemeText key={token.id + k}>
                           {k + ': ' + JSON.stringify(get(token, k))}
@@ -648,7 +648,7 @@ export const Profile_DebugInfoScreen = () => {
         </Section>
 
         {isBeaconsSupported && (
-          <Section withPadding withTopPadding>
+          <Section style={styles.section}>
             <ExpandableSectionItem
               text="Beacons"
               showIconText={true}
@@ -672,7 +672,7 @@ export const Profile_DebugInfoScreen = () => {
                       Alert.alert('Onboarding', `Access granted: ${granted}`);
                     }}
                     disabled={isConsentGranted}
-                    style={style.button}
+                    style={styles.button}
                     text="Onboard and give consent"
                   />
                   <Button
@@ -680,7 +680,7 @@ export const Profile_DebugInfoScreen = () => {
                     onPress={async () => {
                       await revokeBeacons();
                     }}
-                    style={style.button}
+                    style={styles.button}
                     disabled={!isConsentGranted}
                     text="Revoke"
                   />
@@ -689,7 +689,7 @@ export const Profile_DebugInfoScreen = () => {
                     onPress={async () => {
                       await deleteCollectedData();
                     }}
-                    style={style.button}
+                    style={styles.button}
                     text="Delete Collected Data"
                   />
                   <Button
@@ -700,7 +700,7 @@ export const Profile_DebugInfoScreen = () => {
                       privacyDashboardUrl &&
                         Linking.openURL(privacyDashboardUrl);
                     }}
-                    style={style.button}
+                    style={styles.button}
                     disabled={!isConsentGranted}
                     text="Open Privacy Dashboard"
                   />
@@ -710,7 +710,7 @@ export const Profile_DebugInfoScreen = () => {
                       const privacyTermsUrl = await getPrivacyTermsUrl();
                       privacyTermsUrl && Linking.openURL(privacyTermsUrl);
                     }}
-                    style={style.button}
+                    style={styles.button}
                     disabled={!isConsentGranted}
                     text="Open Privacy Terms"
                   />
@@ -766,7 +766,7 @@ function MapValue({value}: {value: any}) {
 }
 
 function MapEntry({title, value}: {title: string; value: any}) {
-  const styles = useProfileHomeStyle();
+  const styles = useStyles();
   const isLongString =
     !!value && typeof value === 'string' && value.length > 300;
   const [isExpanded, setIsExpanded] = useState<boolean>(!isLongString);
@@ -810,13 +810,18 @@ function MapEntry({title, value}: {title: string; value: any}) {
   }
 }
 
-const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     backgroundColor: theme.static.background.background_1.background,
     flex: 1,
   },
   icons: {
     flexDirection: 'row',
+  },
+  section: {
+    marginTop: theme.spacings.large,
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
   },
   buttons: {
     marginHorizontal: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -1,7 +1,7 @@
 import {deleteProfile} from '@atb/api/profile';
 import {Delete} from '@atb/assets/svg/mono-icons/actions';
 import {useAuthState} from '@atb/auth';
-import {StyleSheet, Theme, useTheme} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {
   filterActiveOrCanBeUsedFareContracts,
   useTicketingState,
@@ -19,7 +19,7 @@ import {useTimeContextState} from '@atb/time';
 import {useBeaconsState} from '@atb/beacons/BeaconsContext';
 
 export const Profile_DeleteProfileScreen = () => {
-  const style = useStyle();
+  const styles = useStyles();
   const {t} = useTranslation();
   const {signOut, customerNumber} = useAuthState();
   const {fareContracts} = useTicketingState();
@@ -94,18 +94,18 @@ export const Profile_DeleteProfileScreen = () => {
       <MessageInfoBox
         message={t(DeleteProfileTexts.deleteInfo)}
         type="info"
-        style={style.contentMargin}
+        style={styles.contentMargin}
       />
 
       {activeFareContracts && (
         <MessageInfoBox
           message={t(DeleteProfileTexts.unableToDeleteWithFareContracts)}
           type="warning"
-          style={{...style.contentMargin, marginTop: 0}}
+          style={{...styles.contentMargin, marginTop: 0}}
         />
       )}
 
-      <Section withPadding>
+      <Section style={styles.section}>
         <LinkSectionItem
           subtitle={`${customerNumber}`}
           text={t(DeleteProfileTexts.customerNumber)}
@@ -123,12 +123,16 @@ export const Profile_DeleteProfileScreen = () => {
   );
 };
 
-const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     backgroundColor: theme.static.background.background_1.background,
     flex: 1,
   },
   contentMargin: {
     margin: theme.spacings.medium,
+  },
+  section: {
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -9,7 +9,7 @@ import {FullScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {TransportationIconBox} from '@atb/components/icon-box';
-import {StyleSheet, Theme, useTheme} from '@atb/theme';
+import {StyleSheet, useTheme} from '@atb/theme';
 import {
   InteractiveColor,
   StaticColorByType,
@@ -49,7 +49,7 @@ type DesignSystemScreenProps = ProfileScreenProps<'Profile_DesignSystemScreen'>;
 export const Profile_DesignSystemScreen = ({
   navigation,
 }: DesignSystemScreenProps) => {
-  const style = useProfileHomeStyle();
+  const styles = useStyles();
   const fontScale = useFontScale();
   const {theme} = useTheme();
   const {t} = useTranslation();
@@ -151,7 +151,7 @@ export const Profile_DesignSystemScreen = ({
   // @TODO: add display of static colors
 
   return (
-    <View style={style.container}>
+    <View style={styles.container}>
       <FullScreenHeader
         title="Design System"
         leftButton={{type: 'back'}}
@@ -159,7 +159,7 @@ export const Profile_DesignSystemScreen = ({
       />
 
       <ScrollView>
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem
             text={'Current font scale: ' + fontScale.toFixed(3)}
           />
@@ -168,11 +168,11 @@ export const Profile_DesignSystemScreen = ({
             onPress={() => navigation.navigate('Profile_FareContractsScreen')}
           />
         </Section>
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem text="Icons" />
 
           <GenericSectionItem>
-            <View style={style.icons}>
+            <View style={styles.icons}>
               <ThemeIcon svg={Check} />
               <ThemeIcon svg={Check} colorType="info" />
               <ThemeIcon svg={Check} colorType="warning" />
@@ -182,7 +182,7 @@ export const Profile_DesignSystemScreen = ({
               <ThemeIcon svg={Ticket} colorType="error" />
               <ThemeIcon svg={Ticket} size="large" />
             </View>
-            <View style={style.icons}>
+            <View style={styles.icons}>
               <ThemeText style={{marginRight: 12}}>
                 With notification indicators:
               </ThemeText>
@@ -213,7 +213,7 @@ export const Profile_DesignSystemScreen = ({
                 notification={{color: 'error'}}
               />
             </View>
-            <View style={style.icons}>
+            <View style={styles.icons}>
               <ThemeText style={{marginRight: 12}}>
                 And notification spacing:
               </ThemeText>
@@ -247,16 +247,16 @@ export const Profile_DesignSystemScreen = ({
                 notification={{color: 'error', backgroundColor: 'background_0'}}
               />
             </View>
-            <View style={style.icons}>
+            <View style={styles.icons}>
               <TransportationIconBox
-                style={style.transportationIcon}
+                style={styles.transportationIcon}
                 mode={Mode.Bus}
                 subMode={TransportSubmode.LocalBus}
               />
               {Object.values(Mode).map((mode) => (
                 <TransportationIconBox
                   key={mode}
-                  style={style.transportationIcon}
+                  style={styles.transportationIcon}
                   mode={mode}
                 />
               ))}
@@ -264,7 +264,7 @@ export const Profile_DesignSystemScreen = ({
           </GenericSectionItem>
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem text="Message Info Box" />
 
           <GenericSectionItem>
@@ -361,7 +361,7 @@ export const Profile_DesignSystemScreen = ({
             />
           </GenericSectionItem>
         </Section>
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem text="Message Info Text" />
 
           <GenericSectionItem>
@@ -415,7 +415,7 @@ export const Profile_DesignSystemScreen = ({
           </GenericSectionItem>
         </Section>
 
-        <Section style={style.section}>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="LabelInfo"
             showIconText={false}
@@ -435,7 +435,7 @@ export const Profile_DesignSystemScreen = ({
           />
         </Section>
 
-        <Section style={style.section}>
+        <Section style={styles.section}>
           <ExpandableSectionItem
             text="Buttons"
             showIconText={false}
@@ -448,7 +448,7 @@ export const Profile_DesignSystemScreen = ({
                 >
                   Primary - block - interactive/0
                 </ThemeText>
-                <View style={style.buttonContainer}>
+                <View style={styles.buttonContainer}>
                   <Button
                     text="Default"
                     onPress={presser}
@@ -484,7 +484,7 @@ export const Profile_DesignSystemScreen = ({
                 >
                   Primary - block - interactive/1
                 </ThemeText>
-                <View style={style.buttonContainer}>
+                <View style={styles.buttonContainer}>
                   <Button
                     text="Default - block"
                     onPress={presser}
@@ -520,7 +520,7 @@ export const Profile_DesignSystemScreen = ({
                 >
                   Primary - block - interactive/2
                 </ThemeText>
-                <View style={style.buttonContainer}>
+                <View style={styles.buttonContainer}>
                   <Button
                     text="Default"
                     onPress={presser}
@@ -556,7 +556,7 @@ export const Profile_DesignSystemScreen = ({
                 >
                   Primary - block - interactive/destructive
                 </ThemeText>
-                <View style={style.buttonContainer}>
+                <View style={styles.buttonContainer}>
                   <Button
                     text="Default"
                     onPress={presser}
@@ -592,7 +592,7 @@ export const Profile_DesignSystemScreen = ({
                 >
                   Secondary - block
                 </ThemeText>
-                <View style={style.buttonContainer}>
+                <View style={styles.buttonContainer}>
                   <Button text="Default" onPress={presser} mode="secondary" />
                   <Button
                     text="Active"
@@ -620,7 +620,7 @@ export const Profile_DesignSystemScreen = ({
                 >
                   tertiary - block
                 </ThemeText>
-                <View style={style.buttonContainer}>
+                <View style={styles.buttonContainer}>
                   <Button text="Default" onPress={presser} mode="tertiary" />
                   <Button
                     text="Active"
@@ -965,7 +965,7 @@ export const Profile_DesignSystemScreen = ({
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ActionSectionItem
             text="Some very long text over here which goes over multiple lines"
             subtext="With a subtext"
@@ -988,7 +988,7 @@ export const Profile_DesignSystemScreen = ({
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <LocationInputSectionItem
             label="Label"
             placeholder="My very long placeholder over here. Yes over multiple lines"
@@ -1001,7 +1001,7 @@ export const Profile_DesignSystemScreen = ({
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <ButtonSectionItem
             label="Label"
             placeholder="My very long placeholder over here. Yes over multiple lines"
@@ -1036,7 +1036,7 @@ export const Profile_DesignSystemScreen = ({
           <LinkSectionItem text="Link with label" label="new" />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <TextInputSectionItem
             label="Input"
             placeholder="My very long placeholder over here. Yes over multiple lines"
@@ -1076,7 +1076,7 @@ export const Profile_DesignSystemScreen = ({
           />
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem text="Texts" />
 
           <GenericSectionItem>
@@ -1090,7 +1090,7 @@ export const Profile_DesignSystemScreen = ({
           </GenericSectionItem>
         </Section>
 
-        <Section withPadding withTopPadding>
+        <Section style={styles.section}>
           <HeaderSectionItem text="Message section items" />
 
           <MessageSectionItem
@@ -1124,15 +1124,15 @@ export const Profile_DesignSystemScreen = ({
           />
         </Section>
 
-        <View style={style.section}>
-          <View style={style.buttonContainer}>{buttons}</View>
+        <View style={styles.section}>
+          <View style={styles.buttonContainer}>{buttons}</View>
         </View>
 
-        <View style={style.swatchGroup}>{backgroundSwatches}</View>
-        <View style={style.swatchGroup}>{transportSwatches}</View>
-        <View style={style.swatchGroup}>{secondaryTransportSwatches}</View>
-        <View style={style.swatchGroup}>{statusSwatches}</View>
-        <View style={style.swatchGroup}>
+        <View style={styles.swatchGroup}>{backgroundSwatches}</View>
+        <View style={styles.swatchGroup}>{transportSwatches}</View>
+        <View style={styles.swatchGroup}>{secondaryTransportSwatches}</View>
+        <View style={styles.swatchGroup}>{statusSwatches}</View>
+        <View style={styles.swatchGroup}>
           <ThemeText>Text colors:</ThemeText>
           {textSwatches}
         </View>
@@ -1150,7 +1150,7 @@ function presser() {
   Alert.alert('Heyo');
 }
 
-const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     backgroundColor: theme.static.background.background_1.background,
     flex: 1,
@@ -1167,7 +1167,9 @@ const useProfileHomeStyle = StyleSheet.createThemeHook((theme: Theme) => ({
     flexWrap: 'wrap',
   },
   section: {
-    margin: theme.spacings.medium,
+    marginTop: theme.spacings.large,
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
   },
   swatchGroup: {
     margin: theme.spacings.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -136,7 +136,7 @@ export const Profile_EditProfileScreen = ({
             </View>
           ) : (
             <>
-              <Section withPadding>
+              <Section style={styles.section}>
                 <TextInputSectionItem
                   editable={!isLoadingOrSubmittingProfile}
                   value={firstName}
@@ -150,7 +150,7 @@ export const Profile_EditProfileScreen = ({
                   autoCapitalize="words"
                 />
               </Section>
-              <Section withPadding>
+              <Section style={styles.section}>
                 <TextInputSectionItem
                   editable={!isLoadingOrSubmittingProfile}
                   value={surname}
@@ -177,26 +177,26 @@ export const Profile_EditProfileScreen = ({
                   </ThemeText>
                 </View>
               ) : (
-                  <Section withPadding withBottomPadding>
-                    <TextInputSectionItem
-                        editable={!isLoadingOrSubmittingProfile}
-                        value={email}
-                        onChangeText={(value) => {
-                          setEmail(value);
-                          setInvalidEmail(false);
-                        }}
-                        label={t(EditProfileTexts.personalDetails.email.label)}
-                        placeholder={t(
-                            EditProfileTexts.personalDetails.email.placeholder,
-                        )}
-                        keyboardType="email-address"
-                        autoComplete="email"
-                        showClear={!isLoadingOrSubmittingProfile}
-                        errorText={getEmailErrorText(invalidEmail, errorUpdate)}
-                        inlineLabel={false}
-                        autoCapitalize="none"
-                    />
-                  </Section>
+                <Section style={[styles.section, styles.sectionBottomPadding]}>
+                  <TextInputSectionItem
+                    editable={!isLoadingOrSubmittingProfile}
+                    value={email}
+                    onChangeText={(value) => {
+                      setEmail(value);
+                      setInvalidEmail(false);
+                    }}
+                    label={t(EditProfileTexts.personalDetails.email.label)}
+                    placeholder={t(
+                      EditProfileTexts.personalDetails.email.placeholder,
+                    )}
+                    keyboardType="email-address"
+                    autoComplete="email"
+                    showClear={!isLoadingOrSubmittingProfile}
+                    errorText={getEmailErrorText(invalidEmail, errorUpdate)}
+                    inlineLabel={false}
+                    autoCapitalize="none"
+                  />
+                </Section>
               )}
               <View style={styles.phone}>
                 <ThemeText>
@@ -308,6 +308,13 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   submitContent: {
     marginBottom: theme.spacings.medium,
+  },
+  section: {
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
+  },
+  sectionBottomPadding: {
+    marginBottom: theme.spacings.large,
   },
   profileContainer: {
     marginHorizontal: theme.spacings.xLarge,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SelectStartScreenScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SelectStartScreenScreen.tsx
@@ -12,6 +12,7 @@ import {
 import React from 'react';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
+import {StyleSheet} from '@atb/theme';
 
 const identity = (s: string) => s;
 function toName(
@@ -34,6 +35,7 @@ export const Profile_SelectStartScreenScreen = () => {
     preferences: {startScreen},
   } = usePreferences();
   const {t} = useTranslation();
+  const styles = useStyles();
   const items = Array.from(preference_screenAlternatives);
 
   return (
@@ -50,8 +52,7 @@ export const Profile_SelectStartScreenScreen = () => {
       )}
     >
       <RadioGroupSection<Preference_ScreenAlternatives>
-        withPadding
-        withTopPadding
+        style={styles.section}
         items={items}
         keyExtractor={identity}
         itemToText={(alt) => toName(alt, t)}
@@ -61,3 +62,11 @@ export const Profile_SelectStartScreenScreen = () => {
     </FullScreenView>
   );
 };
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  section: {
+    marginHorizontal: theme.spacings.medium,
+    marginBottom: theme.spacings.small,
+    marginTop: theme.spacings.large,
+  },
+}));

--- a/src/storybook/stories/Section.stories.tsx
+++ b/src/storybook/stories/Section.stories.tsx
@@ -41,10 +41,6 @@ const SectionMeta: Meta<SectionMetaProps> = {
   component: Section,
   argTypes: {
     ...themedStoryControls,
-    withPadding: {control: 'boolean'},
-    withFullPadding: {control: 'boolean'},
-    withTopPadding: {control: 'boolean'},
-    withBottomPadding: {control: 'boolean'},
     type: {
       control: 'select',
       options: containerSizingType,
@@ -58,7 +54,7 @@ const SectionMeta: Meta<SectionMetaProps> = {
 export default SectionMeta;
 
 export const ListedSectionItems: Meta<SectionMetaProps> = {
-  args: {withFullPadding: true, backgroundColor: 'background_2'},
+  args: {style: {margin: 12}, backgroundColor: 'background_2'},
   decorators: [
     (Story, {args}) => (
       <ScrollView>
@@ -159,7 +155,7 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
 };
 
 export const OneSectionItem: Meta<SectionMetaProps> = {
-  args: {withFullPadding: true},
+  args: {style: {margin: 12}},
   decorators: [
     (Story, {args}) => (
       <View style={{backgroundColor: 'pink'}}>
@@ -184,7 +180,7 @@ export const OneSectionItem: Meta<SectionMetaProps> = {
 };
 
 export const RadioSection: Meta<SectionMetaProps> = {
-  args: {withFullPadding: true, backgroundColor: 'background_1'},
+  args: {style: {margin: 12}, backgroundColor: 'background_1'},
   decorators: [
     (Story, {args}) => (
       <Story


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/15884

Removes `withPadding`, `withTopPadding`, `withBottomPadding`, and `withFullPadding` from `<Section>`, and replaces them with style.

Also adds some `prettier` auto-formatting, and replaces some style hooks with `const style = useStyles()` for consistency.