### PR TITLE
fix: correct Firebase ios app id for Troms

### DIFF
--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -46,7 +46,7 @@
 				<string>com.googleusercontent.apps.939812594010-cb697rhj3ifghgjq3flv7e67l1a18jma</string>
 				<string>com.googleusercontent.apps.793301954236-2umj9ofp91902ra1p816dtlh15gf7lev</string>
 				<string>app-1-312905478211-ios-a4f79f22f778f506efa4f6</string>
-				<string>app-1-973624729382-ios-e87f2dc4ebc19729e12be7</string>
+				<string>app-1-973624729382-ios-930c02d2ab71e75ee12be7</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
This PR resolves a login issue on the iOS app for Troms caused by an incorrect app ID. The current app ID is for the debug app and this PR replaces it with the staging app ID. 