### PR TITLE
fix: add missing rowgap on edit favourite location

### DIFF
--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -248,6 +248,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   buttonContainer: {
     marginBottom: theme.spacings.large,
+    rowGap: theme.spacings.medium,
   },
   emojiContainer: {
     width: '50%',


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17633

before and after comparison:

<img width="250" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/bd9a4b43-3896-4762-b73b-45b286e2520c">

<img width="250" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/01eb2d92-a832-40d7-9199-074dac52b977">

