### PR TITLE
feat: add action to global messages when there are links and screenreader is enabled

### DIFF
--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -24,7 +24,6 @@ import {PressableOpacity} from '@atb/components/pressable-opacity';
  */
 export type OnPressConfig = {
   text: string;
-  hideText?: boolean;
 } & ({action: () => void} | {url: string});
 
 export type MessageInfoBoxProps = {
@@ -36,7 +35,6 @@ export type MessageInfoBoxProps = {
   isMarkdown?: boolean;
   style?: StyleProp<ViewStyle>;
   onPressConfig?: OnPressConfig;
-  isInlineOnPressText?: boolean;
   testID?: string;
 };
 export const MessageInfoBox = ({
@@ -64,11 +62,7 @@ export const MessageInfoBox = ({
       ? onPressConfig.action
       : () => Linking.openURL(onPressConfig.url));
 
-  const a11yLabel = [
-    title,
-    message,
-    onPressConfig?.hideText ? '' : onPressConfig?.text,
-  ]
+  const a11yLabel = [title, message, onPressConfig?.text]
     .filter((s): s is string => !!s)
     .join(screenReaderPause);
 
@@ -100,7 +94,9 @@ export const MessageInfoBox = ({
         accessibilityLabel={a11yLabel}
         accessibilityHint={
           onPressConfig &&
-          t(MessageBoxTexts.a11yHintPrefix) + onPressConfig.text
+          ('action' in onPressConfig
+            ? t(MessageBoxTexts.a11yHintActionPrefix)
+            : t(MessageBoxTexts.a11yHintUrlPrefix)) + onPressConfig.text
         }
       >
         {title && (
@@ -116,7 +112,7 @@ export const MessageInfoBox = ({
         <ThemeText color={type} type="body__primary" isMarkdown={isMarkdown}>
           {message}
         </ThemeText>
-        {!onPressConfig?.hideText && onPressConfig?.text && (
+        {onPressConfig?.text && (
           <ThemeText
             color={type}
             style={styles.linkText}

--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -24,6 +24,7 @@ import {PressableOpacity} from '@atb/components/pressable-opacity';
  */
 export type OnPressConfig = {
   text: string;
+  hideText?: boolean;
 } & ({action: () => void} | {url: string});
 
 export type MessageInfoBoxProps = {
@@ -46,7 +47,6 @@ export const MessageInfoBox = ({
   title,
   isMarkdown = false,
   onPressConfig,
-  isInlineOnPressText = false,
   onDismiss,
   testID,
 }: MessageInfoBoxProps) => {
@@ -64,7 +64,7 @@ export const MessageInfoBox = ({
       ? onPressConfig.action
       : () => Linking.openURL(onPressConfig.url));
 
-  const a11yLabel = [title, message, !isInlineOnPressText ?? onPressConfig?.text]
+  const a11yLabel = [title, message, onPressConfig?.hideText ? '' : onPressConfig?.text]
     .filter((s): s is string => !!s)
     .join(screenReaderPause);
 
@@ -112,7 +112,7 @@ export const MessageInfoBox = ({
         <ThemeText color={type} type="body__primary" isMarkdown={isMarkdown}>
           {message}
         </ThemeText>
-        {!isInlineOnPressText && onPressConfig?.text && (
+        {!onPressConfig?.hideText && onPressConfig?.text && (
           <ThemeText
             color={type}
             style={styles.linkText}

--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -35,6 +35,7 @@ export type MessageInfoBoxProps = {
   isMarkdown?: boolean;
   style?: StyleProp<ViewStyle>;
   onPressConfig?: OnPressConfig;
+  isInlineOnPressText?: boolean;
   testID?: string;
 };
 export const MessageInfoBox = ({
@@ -45,6 +46,7 @@ export const MessageInfoBox = ({
   title,
   isMarkdown = false,
   onPressConfig,
+  isInlineOnPressText = false,
   onDismiss,
   testID,
 }: MessageInfoBoxProps) => {
@@ -62,7 +64,7 @@ export const MessageInfoBox = ({
       ? onPressConfig.action
       : () => Linking.openURL(onPressConfig.url));
 
-  const a11yLabel = [title, message, onPressConfig?.text]
+  const a11yLabel = [title, message, !isInlineOnPressText ?? onPressConfig?.text]
     .filter((s): s is string => !!s)
     .join(screenReaderPause);
 
@@ -110,7 +112,7 @@ export const MessageInfoBox = ({
         <ThemeText color={type} type="body__primary" isMarkdown={isMarkdown}>
           {message}
         </ThemeText>
-        {onPressConfig?.text && (
+        {!isInlineOnPressText && onPressConfig?.text && (
           <ThemeText
             color={type}
             style={styles.linkText}

--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -64,7 +64,11 @@ export const MessageInfoBox = ({
       ? onPressConfig.action
       : () => Linking.openURL(onPressConfig.url));
 
-  const a11yLabel = [title, message, onPressConfig?.hideText ? '' : onPressConfig?.text]
+  const a11yLabel = [
+    title,
+    message,
+    onPressConfig?.hideText ? '' : onPressConfig?.text,
+  ]
     .filter((s): s is string => !!s)
     .join(screenReaderPause);
 

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -60,8 +60,10 @@ const GlobalMessage = ({
         .filter((gm) => isWithinTimeRange(gm, now))
         .map((globalMessage: GlobalMessageType) => {
           const message = getTextForLanguage(globalMessage.body, language);
-          const onPressAction = globalMessage.link
-            ? {text: globalMessage.link, url: globalMessage.link}
+          const link = getTextForLanguage(globalMessage.link, language);
+          const linkText = getTextForLanguage(globalMessage.linkText, language);
+          const onPressAction = link
+            ? {text: linkText ? linkText : link, url: link}
             : undefined;
           if (!message) return null;
 

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -63,11 +63,8 @@ const GlobalMessage = ({
         .filter((gm) => isWithinTimeRange(gm, now))
         .map((globalMessage: GlobalMessageType) => {
           const message = getTextForLanguage(globalMessage.body, language);
+          const link = globalMessage.link;
           if (!message) return null;
-          const displayMessageAndAction = getMessageAndAction(
-            message,
-            isScreenReaderEnabled,
-          );
 
           return (
             <>
@@ -89,7 +86,7 @@ const GlobalMessage = ({
                     globalMessage.title ?? [],
                     language,
                   )}
-                  message={displayMessageAndAction.message}
+                  message={message}
                   type={globalMessage.type}
                   isMarkdown={true}
                   onDismiss={
@@ -97,8 +94,7 @@ const GlobalMessage = ({
                       ? () => dismissGlobalMessage(globalMessage)
                       : undefined
                   }
-                  onPressConfig={displayMessageAndAction.action}
-                  isInlineOnPressText={isScreenReaderEnabled}
+                  onPressConfig={{text: link, url: link}}
                   testID="globalMessage"
                 />
               )}
@@ -107,37 +103,6 @@ const GlobalMessage = ({
         })}
     </>
   );
-};
-
-const markdownLinkRegex = /\[([^\[]+)\]\((.*)\)/;
-
-const parseLink = (message: string) => {
-  const parsedArray = message.match(markdownLinkRegex) || [];
-  const [full, text, url] = parsedArray;
-  return {full, text, url};
-};
-
-const getMessageAndAction = (
-  message: string,
-  isScreenReaderEnabled: boolean,
-): {message: string; action: OnPressConfig | undefined} => {
-  const parsedLink = parseLink(message);
-  const trimmedMessage = parsedLink.full
-    ? message.replace(parsedLink.full, parsedLink.text)
-    : message;
-  if (isScreenReaderEnabled) {
-    return {
-      message: parsedLink.full ? trimmedMessage : message,
-      action: parsedLink
-        ? {text: parsedLink.text, hideText: true, url: parsedLink.url}
-        : undefined,
-    };
-  }
-
-  return {
-    message: message,
-    action: undefined,
-  };
 };
 
 export {GlobalMessage};

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -60,7 +60,9 @@ const GlobalMessage = ({
         .filter((gm) => isWithinTimeRange(gm, now))
         .map((globalMessage: GlobalMessageType) => {
           const message = getTextForLanguage(globalMessage.body, language);
-          const link = globalMessage.link;
+          const onPressAction = globalMessage.link
+            ? {text: globalMessage.link, url: globalMessage.link}
+            : undefined;
           if (!message) return null;
 
           return (
@@ -91,7 +93,7 @@ const GlobalMessage = ({
                       ? () => dismissGlobalMessage(globalMessage)
                       : undefined
                   }
-                  onPressConfig={{text: link, url: link}}
+                  onPressConfig={onPressAction}
                   testID="globalMessage"
                 />
               )}

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -65,39 +65,32 @@ const GlobalMessage = ({
             : undefined;
           if (!message) return null;
 
-          return (
-            <>
-              {globalMessage.subtle ? (
-                <MessageInfoText
-                  key={globalMessage.id}
-                  type={globalMessage.type}
-                  message={message}
-                  textColor={textColor}
-                  isMarkdown={true}
-                  style={style}
-                  testID="globalMessage"
-                />
-              ) : (
-                <MessageInfoBox
-                  key={globalMessage.id}
-                  style={style}
-                  title={getTextForLanguage(
-                    globalMessage.title ?? [],
-                    language,
-                  )}
-                  message={message}
-                  type={globalMessage.type}
-                  isMarkdown={true}
-                  onDismiss={
-                    globalMessage.isDismissable && !includeDismissed
-                      ? () => dismissGlobalMessage(globalMessage)
-                      : undefined
-                  }
-                  onPressConfig={onPressAction}
-                  testID="globalMessage"
-                />
-              )}
-            </>
+          return globalMessage.subtle ? (
+            <MessageInfoText
+              key={globalMessage.id}
+              type={globalMessage.type}
+              message={message}
+              textColor={textColor}
+              isMarkdown={true}
+              style={style}
+              testID="globalMessage"
+            />
+          ) : (
+            <MessageInfoBox
+              key={globalMessage.id}
+              style={style}
+              title={getTextForLanguage(globalMessage.title ?? [], language)}
+              message={message}
+              type={globalMessage.type}
+              isMarkdown={true}
+              onDismiss={
+                globalMessage.isDismissable && !includeDismissed
+                  ? () => dismissGlobalMessage(globalMessage)
+                  : undefined
+              }
+              onPressConfig={onPressAction}
+              testID="globalMessage"
+            />
           );
         })}
     </>

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useTranslation} from '@atb/translations';
 import {useGlobalMessagesState} from '@atb/global-messages/GlobalMessagesContext';
-import {MessageInfoBox} from '@atb/components/message-info-box';
+import {MessageInfoBox, OnPressConfig} from '@atb/components/message-info-box';
 import {StyleProp, ViewStyle} from 'react-native';
 import {
   GlobalMessageContextEnum,
@@ -95,7 +95,7 @@ const GlobalMessage = ({
                       : undefined
                   }
                   onPressConfig={displayMessageAndAction.action}
-                  isInlineOnPressText={true}
+                  isInlineOnPressText={isScreenReaderEnabled}
                   testID="globalMessage"
                 />
               )}
@@ -116,8 +116,8 @@ const parseLink = (message: string) => {
 
 const getMessageAndAction = (
   message: string,
-  isScreenReaderEnabled: boolean,
-) => {
+  isScreenReaderEnabled: boolean
+) : {message: string, action: OnPressConfig | undefined}=> {
   const parsedLink = parseLink(message);
   const trimmedMessage = parsedLink.full
     ? message.replace(parsedLink.full, parsedLink.text)
@@ -126,7 +126,7 @@ const getMessageAndAction = (
     return {
       message: parsedLink.full ? trimmedMessage : message,
       action: parsedLink
-        ? {text: parsedLink.text, url: parsedLink.url}
+        ? {text: parsedLink.text, hideText: true, url: parsedLink.url}
         : undefined,
     };
   }

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -64,7 +64,10 @@ const GlobalMessage = ({
         .map((globalMessage: GlobalMessageType) => {
           const message = getTextForLanguage(globalMessage.body, language);
           if (!message) return null;
-          const displayMessageAndAction = getMessageAndAction(message, isScreenReaderEnabled);
+          const displayMessageAndAction = getMessageAndAction(
+            message,
+            isScreenReaderEnabled,
+          );
 
           return (
             <>
@@ -116,8 +119,8 @@ const parseLink = (message: string) => {
 
 const getMessageAndAction = (
   message: string,
-  isScreenReaderEnabled: boolean
-) : {message: string, action: OnPressConfig | undefined}=> {
+  isScreenReaderEnabled: boolean,
+): {message: string; action: OnPressConfig | undefined} => {
   const parsedLink = parseLink(message);
   const trimmedMessage = parsedLink.full
     ? message.replace(parsedLink.full, parsedLink.text)
@@ -133,8 +136,8 @@ const getMessageAndAction = (
 
   return {
     message: message,
-    action: undefined
-  }
+    action: undefined,
+  };
 };
 
 export {GlobalMessage};

--- a/src/global-messages/GlobalMessage.tsx
+++ b/src/global-messages/GlobalMessage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useTranslation} from '@atb/translations';
 import {useGlobalMessagesState} from '@atb/global-messages/GlobalMessagesContext';
-import {MessageInfoBox, OnPressConfig} from '@atb/components/message-info-box';
+import {MessageInfoBox} from '@atb/components/message-info-box';
 import {StyleProp, ViewStyle} from 'react-native';
 import {
   GlobalMessageContextEnum,
@@ -13,7 +13,6 @@ import {isWithinTimeRange} from '@atb/utils/is-within-time-range';
 import {RuleVariables} from '../rule-engine/rules';
 import {StaticColor, TextColor} from '@atb/theme/colors';
 import {MessageInfoText} from '@atb/components/message-info-text';
-import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
 
 type Props = {
   globalMessageContext?: GlobalMessageContextEnum;
@@ -37,8 +36,6 @@ const GlobalMessage = ({
     dismissedGlobalMessages,
     addDismissedGlobalMessages,
   } = useGlobalMessagesState();
-
-  const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   if (!globalMessageContext) return null;
 

--- a/src/global-messages/converters.ts
+++ b/src/global-messages/converters.ts
@@ -31,7 +31,8 @@ function mapToGlobalMessage(
   const title = mapToLanguageAndTexts(result.title);
   const context = mapToContexts(result.context);
   const type = mapToMessageType(result.type);
-  const link = result.link;
+  const link = mapToLanguageAndTexts(result.link);
+  const linkText = mapToLanguageAndTexts(result.linkText);
   const subtle = result.subtle;
   const isDismissable = result.isDismissable;
   const appVersionMin = result.appVersionMin;
@@ -59,6 +60,7 @@ function mapToGlobalMessage(
     body,
     title,
     link,
+    linkText,
     isDismissable,
     startDate,
     endDate,

--- a/src/global-messages/converters.ts
+++ b/src/global-messages/converters.ts
@@ -31,6 +31,7 @@ function mapToGlobalMessage(
   const title = mapToLanguageAndTexts(result.title);
   const context = mapToContexts(result.context);
   const type = mapToMessageType(result.type);
+  const link = result.link;
   const subtle = result.subtle;
   const isDismissable = result.isDismissable;
   const appVersionMin = result.appVersionMin;
@@ -57,6 +58,7 @@ function mapToGlobalMessage(
     context,
     body,
     title,
+    link,
     isDismissable,
     startDate,
     endDate,

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -23,7 +23,8 @@ export type GlobalMessageRaw = {
   active: boolean;
   title?: LanguageAndTextType[];
   body: LanguageAndTextType[];
-  link?: string;
+  link?: LanguageAndTextType[];
+  linkText?: LanguageAndTextType[];
   type: Statuses;
   subtle?: boolean;
   context: GlobalMessageContextEnum[];

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -23,7 +23,7 @@ export type GlobalMessageRaw = {
   active: boolean;
   title?: LanguageAndTextType[];
   body: LanguageAndTextType[];
-  link: string;
+  link?: string;
   type: Statuses;
   subtle?: boolean;
   context: GlobalMessageContextEnum[];

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -23,6 +23,7 @@ export type GlobalMessageRaw = {
   active: boolean;
   title?: LanguageAndTextType[];
   body: LanguageAndTextType[];
+  link: string;
   type: Statuses;
   subtle?: boolean;
   context: GlobalMessageContextEnum[];

--- a/src/translations/components/MessageBox.ts
+++ b/src/translations/components/MessageBox.ts
@@ -1,7 +1,8 @@
 import {translation as _} from '../commons';
 
 const MessageBoxTexts = {
-  a11yHintPrefix: _('Aktiver for å ', 'Activate to ', 'Aktiver for å'),
+  a11yHintActionPrefix: _('Aktiver for å ', 'Activate to ', 'Aktiver for å'),
+  a11yHintUrlPrefix: _('Aktiver for å åpne lenke ', 'Activate to open link ', 'Aktiver for å opne lenke '),
   dismiss: {
     allyLabel: _('Lukk melding', 'Close message', 'Lukk melding'),
   },


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/2459

This PR will allow the screenreader to "read" global message links, and allows the global message to be activated to follow the URL to the specified link. For example, [this message in firestore](https://console.firebase.google.com/u/1/project/atb-mobility-platform-staging/firestore/databases/-default-/data/~2FglobalMessagesV2~2FMessage%20with%20scheduled%20timer).

~~When the screenreader is on, the action text that shows at the bottom (like the one in anonymous ticket purchase message), is hidden. Instead, the message text is replaced with the parsed text from the link markdown. This ensures that the message is read correctly by the screen reader and there are no redundant information being read aloud. The `onPressAction` will only be activated when the screenreader is active.~~

Following the suggestion from @gorandalum , I added `link` field to Global Message firestore, and use it as the action for the `MessageInfoBox onPressConfig`. I also modified the a11y hint a bit to differentiate between action and link, since it is weird to listen "Activate to https://atb.no/avvik". Also updated the documentation here https://github.com/AtB-AS/docs-private/pull/40.

There's also a fix for issue in metro where it complaints about missing `key`.

Open to suggestions if there are better implementation. 😊 
