### PR TITLE
fix: Not create new mobile token on logout

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -141,7 +141,6 @@ export const Profile_DebugInfoScreen = () => {
   const {
     tokens,
     retry,
-    wipeToken,
     mobileTokenStatus,
     isInspectable,
     nativeToken,
@@ -151,6 +150,7 @@ export const Profile_DebugInfoScreen = () => {
       validateToken,
       removeRemoteToken,
       renewToken,
+      wipeToken,
     },
   } = useMobileTokenContextState();
   const {serverNow} = useTimeContextState();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -53,7 +53,7 @@ type ProfileProps = ProfileScreenProps<'Profile_RootScreen'>;
 
 export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const {enable_ticketing} = useRemoteConfig();
-  const {wipeToken} = useMobileTokenContextState();
+  const {clearTokenAtLogout} = useMobileTokenContextState();
   const style = useProfileHomeStyle();
   const {t, language} = useTranslation();
   const analytics = useAnalytics();
@@ -221,7 +221,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                     setIsLoading(true);
                     try {
                       // On logout we delete the user's token
-                      await wipeToken();
+                      await clearTokenAtLogout();
                     } catch (err: any) {
                       Bugsnag.notify(err);
                     }


### PR DESCRIPTION
When logging out we delete the mobile token for the user, both
locally and remotely. However there was a race condition where if
the logout took some time, the app managed to create a new token
for the user after deleting the old one.

This is fixed by setting the MobileTokenContext in a 'logging-out'
state, where it will treat mobile tokens as disabled, and thus not
create new ones.
