### PR TITLE
build: change register-app-version script to use new host + audience

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -118,6 +118,5 @@ jobs:
       - name: Register app version
         run: bash ./scripts/android/register-app-version.sh
         env:
-          ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_STAGING }}
-          ENTUR_CLIENT_SECRET: ${{ secrets.ABT_ENTUR_CLIENT_SECRET_STAGING }}
+          ENTUR_PUBLISH_CLIENT: ${{ secrets.ABT_ENTUR_PUBLISH_CLIENT_STAGING }}
           DISABLE_LISTED_ON_PLAY_STORE: true

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -127,5 +127,4 @@ jobs:
       - name: Register app version
         run: sh ./scripts/ios/register-app-version.sh
         env:
-          ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_STAGING}}
-          ENTUR_CLIENT_SECRET: ${{ secrets.ABT_ENTUR_CLIENT_SECRET_STAGING}}
+          ENTUR_PUBLISH_CLIENT: ${{ secrets.ABT_ENTUR_PUBLISH_CLIENT_STAGING}}

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -106,6 +106,5 @@ jobs:
       - name: Register app version
         run: bash ./scripts/android/register-app-version.sh
         env:
-          ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_PRODUCTION }}
-          ENTUR_CLIENT_SECRET: ${{ secrets.ABT_ENTUR_CLIENT_SECRET_PRODUCTION }}
+          ENTUR_PUBLISH_CLIENT: ${{ secrets.ABT_ENTUR_PUBLISH_CLIENT_PRODUCTION }}
           DISABLE_LISTED_ON_PLAY_STORE: false

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -93,5 +93,4 @@ jobs:
       - name: Register app version
         run: sh ./scripts/ios/register-app-version.sh
         env:
-          ENTUR_CLIENT_ID: ${{ secrets.ABT_ENTUR_CLIENT_ID_PRODUCTION}}
-          ENTUR_CLIENT_SECRET: ${{ secrets.ABT_ENTUR_CLIENT_SECRET_PRODUCTION}}
+          ENTUR_PUBLISH_CLIENT: ${{ secrets.ABT_ENTUR_PUBLISH_CLIENT_PRODUCTION}}

--- a/scripts/ios/register-app-version.sh
+++ b/scripts/ios/register-app-version.sh
@@ -6,8 +6,7 @@
 
 # Check for config and secrets from env vars
 if [[
-    -z "${ENTUR_CLIENT_ID}"
-    || -z "${ENTUR_CLIENT_SECRET}"
+    -z "${ENTUR_PUBLISH_CLIENT}"
     || -z "${APP_ENVIRONMENT}"
     || -z "${IOS_BUNDLE_IDENTIFIER}"
     || -z "${IOS_DEVELOPMENT_TEAM_ID}"
@@ -15,9 +14,8 @@ if [[
     || -z "${AUTHORITY}"
    ]]; then
     echo "Argument error!"
-    echo "Expected the following 7 env variables to be set:
-  - ENTUR_CLIENT_ID
-  - ENTUR_CLIENT_SECRET
+    echo "Expected the following 6 env variables to be set:
+  - ENTUR_PUBLISH_CLIENT
   - APP_ENVIRONMENT
   - IOS_BUNDLE_IDENTIFIER
   - IOS_DEVELOPMENT_TEAM_ID
@@ -29,7 +27,7 @@ fi
 # Get values based on environment
 case $APP_ENVIRONMENT in
   staging)
-    token_url="https://partner-abt.staging.entur.org/oauth/token"
+    token_url="https://partner.staging.entur.org/oauth/token"
     abt_url="https://core-abt-abt.staging.entur.io"
     ;;
   store)
@@ -42,6 +40,10 @@ case $APP_ENVIRONMENT in
     ;;
 esac
 
+ENTUR_CLIENT_ID=$(echo $ENTUR_PUBLISH_CLIENT | jq -r '.clientId')
+ENTUR_CLIENT_SECRET=$(echo $ENTUR_PUBLISH_CLIENT | jq -r '.clientSecret')
+AUDIENCE=$(echo $ENTUR_PUBLISH_CLIENT | jq -r '.endpointParams.audience[0]')
+
 # App login for register call
 login=$(curl --silent \
   --request POST \
@@ -50,7 +52,7 @@ login=$(curl --silent \
   --data grant_type="client_credentials" \
   --data client_id="$ENTUR_CLIENT_ID" \
   --data client_secret="$ENTUR_CLIENT_SECRET" \
-  --data audience="https://v2.api.entur.no")
+  --data audience="$AUDIENCE")
 
 login_status=$?
 if [ $login_status -ne 0 ]; then

--- a/scripts/register-local-app-version.sh
+++ b/scripts/register-local-app-version.sh
@@ -10,8 +10,7 @@ export $(grep -v '^#' .env | xargs -0 -n1 echo) > /dev/null 2>&1
 credentials=$(gcloud secrets versions access --project atb-staging-c420 --secret=entur-client-credentials-publish latest)
 
 export APP_ENVIRONMENT=staging
-export ENTUR_CLIENT_ID=$(echo $credentials | jq '.clientId' -r)
-export ENTUR_CLIENT_SECRET=$(echo $credentials | jq '.clientSecret' -r)
+export ENTUR_PUBLISH_CLIENT=$credentials
 export BUILD_ID=1
 export DISABLE_LISTED_ON_PLAY_STORE=true
 


### PR DESCRIPTION
This PR updates the register-app-version.sh script to accommodate recent changes made by Entur. Specifically, the host and audience for the ABT publish clients have changed, and the ones in use now are deprecated. Since Troms only has the new client, we need to make this change now to register the app with Entur for Troms.

I've also simplified how we handle secrets on GitHub. Instead of having two secrets for each client in each environment, we now just use one JSON object for both staging and production. This is in line with what we do in the GCP secret manager. 

If these changes are approved we should update the Github secrets before merging the PR. I'll also create a PR to update the [docs](https://github.com/AtB-AS/docs-private/blob/main/secrets.md).

Closes https://github.com/AtB-AS/kundevendt/issues/17778