### PR TITLE
feat: add app-login and app-login-phone global message contexts

### DIFF
--- a/src/global-messages/GlobalMessagesContext.tsx
+++ b/src/global-messages/GlobalMessagesContext.tsx
@@ -63,11 +63,6 @@ const GlobalMessagesContextProvider: React.FC = ({children}) => {
       firestore()
         .collection<GlobalMessageRaw>('globalMessagesV2')
         .where('active', '==', true)
-        .where(
-          'context',
-          'array-contains-any',
-          Object.values(GlobalMessageContextEnum),
-        )
         .onSnapshot(
           async (snapshot) => {
             const newGlobalMessages = mapToGlobalMessages(snapshot.docs);

--- a/src/global-messages/types.ts
+++ b/src/global-messages/types.ts
@@ -16,6 +16,8 @@ export enum GlobalMessageContextEnum {
   appDepartureDetails = 'app-departure-details',
   appTripDetails = 'app-trip-details',
   appServiceDisruptions = 'app-service-disruptions',
+  appLogin = 'app-login',
+  appLoginPhone = 'app-login-phone',
 }
 
 export type GlobalMessageRaw = {

--- a/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
@@ -24,6 +24,7 @@ import {getStaticColor, StaticColorByType} from '@atb/theme/colors';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useOnboardingState} from '@atb/onboarding';
+import {GlobalMessageContextEnum} from '@atb/global-messages';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -71,6 +72,7 @@ export const Root_LoginConfirmCodeScreen = ({route}: Props) => {
         setFocusOnLoad={false}
         color={themeColor}
         title={t(LoginTexts.logInOptions.title)}
+        globalMessageContext={GlobalMessageContextEnum.appLoginPhone}
       />
 
       <KeyboardAvoidingView behavior="padding" style={styles.mainView}>

--- a/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
@@ -31,6 +31,7 @@ import {TransitionPresets} from '@react-navigation/stack';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {APP_ORG} from '@env';
 import {useOnboardingState} from '@atb/onboarding';
+import {GlobalMessageContextEnum} from '@atb/global-messages';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -158,6 +159,7 @@ export const Root_LoginOptionsScreen = ({
         }
         color={themeColor}
         title={t(LoginTexts.logInOptions.title)}
+        globalMessageContext={GlobalMessageContextEnum.appLogin}
       />
       <ScrollView contentContainerStyle={styles.scrollView} bounces={false}>
         <View accessible={true} accessibilityRole="header">

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -20,6 +20,7 @@ import {PhoneInputSectionItem, Section} from '@atb/components/sections';
 import {Button} from '@atb/components/button';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import phone from 'phone';
+import {GlobalMessageContextEnum} from '@atb/global-messages';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
 
@@ -86,6 +87,7 @@ export const Root_LoginPhoneInputScreen = ({
         setFocusOnLoad={false}
         color={themeColor}
         title={t(LoginTexts.phoneInput.title)}
+        globalMessageContext={GlobalMessageContextEnum.appLoginPhone}
       />
 
       <KeyboardAvoidingView behavior="padding" style={styles.mainView}>


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17783

Related documentation changes: https://github.com/AtB-AS/docs-private/pull/41

<div>

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/edd8de5d-6694-459a-ad2e-e7ff9ef0ee3f">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/dd23163d-c9c1-4470-a433-1159f0054e9f">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/ad291887-4837-4447-b8d2-3222793d0256">
</div>