### PR TITLE
fix: only render buy button if ticket is valid until the last interchange.

### DIFF
--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -169,7 +169,7 @@ function useGetTicketInfoFromTrip(tripPattern: TripPattern) {
     useGetFirstTariffZoneWeSellTicketFor(toTariffZones);
 
   const hasTooLongWaitTime = totalWaitTimeIsMoreThanAnHour(tripPattern.legs);
-  const ticketCoverEntirePeriod = ticketCoversEntireTrip(tripPattern.legs);
+  const ticketCoversEntirePeriod = ticketCoversEntireTrip(tripPattern.legs);
 
   const canSellCollab = canSellCollabTicket(tripPattern);
 
@@ -180,7 +180,7 @@ function useGetTicketInfoFromTrip(tripPattern: TripPattern) {
       toTariffZoneWeSellTicketFor
     ) ||
     hasTooLongWaitTime ||
-    ticketCoverEntirePeriod
+    !ticketCoversEntirePeriod
   )
     return;
 

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -20,7 +20,10 @@ import {Language, TripDetailsTexts, useTranslation} from '@atb/translations';
 import {TravelDetailsMapScreenParams} from '@atb/travel-details-map-screen';
 import {ServiceJourneyDeparture} from '@atb/travel-details-screens/types';
 import {useCurrentTripPatternWithUpdates} from '@atb/travel-details-screens/use-current-trip-pattern-with-updates';
-import {canSellCollabTicket} from '@atb/travel-details-screens/utils';
+import {
+  canSellCollabTicket,
+  ticketCoversEntireTrip,
+} from '@atb/travel-details-screens/utils';
 import {formatToClock, secondsBetween} from '@atb/utils/date';
 import analytics from '@react-native-firebase/analytics';
 import {addMinutes, formatISO, hoursToSeconds, parseISO} from 'date-fns';
@@ -166,6 +169,8 @@ function useGetTicketInfoFromTrip(tripPattern: TripPattern) {
     useGetFirstTariffZoneWeSellTicketFor(toTariffZones);
 
   const hasTooLongWaitTime = totalWaitTimeIsMoreThanAnHour(tripPattern.legs);
+  const ticketCoverEntirePeriod = ticketCoversEntireTrip(tripPattern.legs);
+
   const canSellCollab = canSellCollabTicket(tripPattern);
 
   if (
@@ -174,7 +179,8 @@ function useGetTicketInfoFromTrip(tripPattern: TripPattern) {
       fromTariffZoneWeSellSingleTicketsFor &&
       toTariffZoneWeSellTicketFor
     ) ||
-    hasTooLongWaitTime
+    hasTooLongWaitTime ||
+    ticketCoverEntirePeriod
   )
     return;
 

--- a/src/travel-details-screens/__tests__/get_number_of_zones_in_trip.test.ts
+++ b/src/travel-details-screens/__tests__/get_number_of_zones_in_trip.test.ts
@@ -1,0 +1,52 @@
+import {Leg} from '@atb/api/types/trips';
+import {getNumberOfZonesThroughoutTrip} from '../utils';
+
+describe('getNumberOfZonesInTrip', () => {
+  const r1 = 1;
+  it(`should be ${r1} if whithin one zone throghout the trip.`, () => {
+    const legs = [
+      {
+        fromPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+        toPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+      },
+      {
+        fromPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+        toPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+      },
+    ] as Leg[];
+
+    expect(getNumberOfZonesThroughoutTrip(legs)).toBe(r1);
+  });
+
+  const r2 = 2;
+  it(`should be ${r2} if whithin two zones throghout the trip.`, () => {
+    const legs = [
+      {
+        fromPlace: {quay: {tariffZones: [{name: 'Søre Sunnmøre'}]}},
+        toPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+      },
+      {
+        fromPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+        toPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+      },
+    ] as Leg[];
+
+    expect(getNumberOfZonesThroughoutTrip(legs)).toBe(r2);
+  });
+
+  const r3 = 3;
+  it(`should be ${r2} if whithin three zones throghout the trip.`, () => {
+    const legs = [
+      {
+        fromPlace: {quay: {tariffZones: [{name: 'Søre Sunnmøre'}]}},
+        toPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+      },
+      {
+        fromPlace: {quay: {tariffZones: [{name: 'Molde'}]}},
+        toPlace: {quay: {tariffZones: [{name: 'Kristiansund'}]}},
+      },
+    ] as Leg[];
+
+    expect(getNumberOfZonesThroughoutTrip(legs)).toBe(r3);
+  });
+});

--- a/src/travel-details-screens/__tests__/get_unique_tariff_zones.test.ts
+++ b/src/travel-details-screens/__tests__/get_unique_tariff_zones.test.ts
@@ -1,0 +1,63 @@
+import {getUniqueTariffZones} from '../utils';
+import {TariffZone} from '@atb/api/types/generated/journey_planner_v3_types';
+
+describe('getUniqueTariffZones', () => {
+  const r1 = ['Kristiansund'];
+  it(`should return array containing: ${r1}.`, () => {
+    const tariffZones = [
+      {
+        id: '1',
+        name: 'Kristiansund',
+      },
+      // Add more test data here if needed
+    ] as TariffZone[];
+
+    expect(getUniqueTariffZones(tariffZones, [])).toStrictEqual(r1);
+  });
+
+  const r2 = ['Kristiansund'];
+  it(`should return array containing: ${r2}.`, () => {
+    const tariffZones = [
+      {
+        id: '1',
+        name: 'Kristiansund',
+      },
+      {
+        id: '2',
+        name: 'Kristiansund',
+      },
+      // Add more test data here if needed
+    ] as TariffZone[];
+
+    expect(getUniqueTariffZones(tariffZones, [])).toStrictEqual(r2);
+  });
+
+  const r3 = ['Kristiansund', 'Molde'];
+  it(`should return array containing: ${r3[0]} and ${r3[1]}`, () => {
+    const tariffZones = [
+      {
+        id: '1',
+        name: 'Kristiansund',
+      },
+      {
+        id: '2',
+        name: 'Molde',
+      },
+      // Add more test data here if needed
+    ] as TariffZone[];
+
+    expect(getUniqueTariffZones(tariffZones, [])).toStrictEqual(r3);
+  });
+
+  const r4: string[] = [];
+  it(`should return empty array: [${r4}].`, () => {
+    const tariffZones = [
+      {
+        id: '1',
+      },
+      // Add more test data here if needed
+    ] as TariffZone[];
+
+    expect(getUniqueTariffZones(tariffZones, [])).toStrictEqual(r4);
+  });
+});

--- a/src/travel-details-screens/__tests__/ticket_covers_entire_trip.test.ts
+++ b/src/travel-details-screens/__tests__/ticket_covers_entire_trip.test.ts
@@ -1,0 +1,63 @@
+import {Leg} from '@atb/api/types/trips';
+import {ticketCoversEntireTrip} from '../utils';
+
+describe('ticketCoversEntireTrip', () => {
+  const s1 = true;
+  it(`should be ${s1} if ticket is valid before the last buss interchange.`, () => {
+    const legs = [
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T15:15:00Z',
+      },
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T15:20:00Z',
+        expectedEndTime: '2024-10-31T17:40:00Z',
+      },
+    ] as Leg[];
+
+    expect(ticketCoversEntireTrip(legs)).toBe(s1);
+  });
+
+  const s2 = false;
+  it(`should be ${s2} if ticket is not valid before the last buss interchange.`, () => {
+    const legs = [
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T16:00:00Z',
+      },
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T16:35:00Z',
+        expectedEndTime: '2024-10-31T17:00:00Z',
+      },
+    ] as Leg[];
+
+    expect(ticketCoversEntireTrip(legs)).toBe(s2);
+  });
+
+  const s3 = true;
+  it(`should be ${s2} if ticket is valid before the last buss interchange and the trip continious with more legs after the last bus interchange.`, () => {
+    const legs = [
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T15:00:00Z',
+        expectedEndTime: '2024-10-31T16:00:00Z',
+      },
+      {
+        mode: 'bus',
+        expectedStartTime: '2024-10-31T16:25:00Z',
+        expectedEndTime: '2024-10-31T17:00:00Z',
+      },
+      {
+        mode: 'foot',
+        expectedStartTime: '2024-10-31T17:00:00Z',
+        expectedEndTime: '2024-10-31T17:10:00Z',
+      },
+    ] as Leg[];
+
+    expect(ticketCoversEntireTrip(legs)).toBe(s3);
+  });
+});

--- a/src/travel-details-screens/__tests__/ticket_covers_entire_trip.test.ts
+++ b/src/travel-details-screens/__tests__/ticket_covers_entire_trip.test.ts
@@ -3,7 +3,7 @@ import {ticketCoversEntireTrip} from '../utils';
 
 describe('ticketCoversEntireTrip', () => {
   const s1 = true;
-  it(`should be ${s1} if ticket is valid before the last buss interchange.`, () => {
+  it(`should be ${s1} if ticket is valid before the last bus interchange.`, () => {
     const legs = [
       {
         mode: 'bus',
@@ -21,7 +21,7 @@ describe('ticketCoversEntireTrip', () => {
   });
 
   const s2 = false;
-  it(`should be ${s2} if ticket is not valid before the last buss interchange.`, () => {
+  it(`should be ${s2} if ticket is not valid before the last bus interchange.`, () => {
     const legs = [
       {
         mode: 'bus',
@@ -39,7 +39,7 @@ describe('ticketCoversEntireTrip', () => {
   });
 
   const s3 = true;
-  it(`should be ${s2} if ticket is valid before the last buss interchange and the trip continious with more legs after the last bus interchange.`, () => {
+  it(`should be ${s2} if ticket is valid before the last bus interchange and the trip continious with more legs after the last bus interchange.`, () => {
     const legs = [
       {
         mode: 'bus',

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -490,7 +490,7 @@ export const ticketCoversEntireTrip = (legs: Leg[]): boolean => {
 
   // Ticket for initial zone lasts 90 minutes. Add 60 minutes per additional zone.
   const ticketValidityPeriod =
-    90 + 60 * (1 - getNumberOfZonesThroughoutTrip(legs));
+    90 + 60 * Math.abs(1 - getNumberOfZonesThroughoutTrip(legs));
   invalidTicketEndTime.setMinutes(ticketValidityPeriod);
 
   const lastInterchangeTime = parseDateIfString(
@@ -504,5 +504,6 @@ export const ticketCoversEntireTrip = (legs: Leg[]): boolean => {
           leg.mode !== 'bicycle',
       )?.expectedStartTime,
   );
+
   return lastInterchangeTime < invalidTicketEndTime;
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/17325

### Background
When planning trips with several interchanges within the same zone, and with longer traveling time than the ticket is valid,
users are getting mislead to belive that they can buy one ticket for the whole trip. The users are chaught of guard when they have to buy a new ticket, when the validity period of their initial ticket has expired before the last interchange.

The users should not be able to buy tickets to a trip, if the tickets is not valid until the last interchange.

#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

Before             | After    
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-04-23 at 16 24 51](https://github.com/AtB-AS/mittatb-app/assets/59939294/0e9f87a0-ae63-4d1b-a99a-1c9d64111efa) |  ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-04-23 at 16 26 58](https://github.com/AtB-AS/mittatb-app/assets/59939294/711ddd51-fad0-4a42-8870-d17870c50bdc)

</details>

### Proposed solution

Extend useGetTicketInfoFromTripc() with a condition to only render buy ticket button if one singel ticket covers the intire trip.

### Acceptance Criteria
- [ ] The button 'Buy ticket ', should not appear if the ticket is not valid until the last bus change on the trip. Otherwise, the render of the buy button should act work as usual.   


### Test input

-  Trip Steinshavn - Moa Trafikkterminal. Buy button should not render if ticket is invalid (1 hour and 30 minutes), before the last bus inter change.
- Kristiansund - Molde. Buy button should render.  


