### PR TITLE
fix: Wrong class name on Android `ReactNativeFlipperInitializer`

### DIFF
--- a/android/app/src/store/java/no/mittatb/ReactNativeFlipperInitializer.java
+++ b/android/app/src/store/java/no/mittatb/ReactNativeFlipperInitializer.java
@@ -11,7 +11,7 @@ import com.facebook.react.ReactInstanceManager;
  * Class responsible of loading Flipper inside your React Native application. This is the release
  * flavor of it so it's empty as we don't want to load Flipper.
  */
-public class ReactNativeFlipper {
+public class ReactNativeFlipperInitializer {
   public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
     // Do nothing as we don't want to initialize Flipper on Release.
   }


### PR DESCRIPTION
The name of the file where `ReactNativeFlipperInitializer` must be placed was changed, but the class was still referencing a wrong name, therefore not findable during compilation time for the store profile.