### PR TITLE
fix: compare keys instead of objects for ProductSelection

### DIFF
--- a/src/components/sections/RadioGroupSection.tsx
+++ b/src/components/sections/RadioGroupSection.tsx
@@ -36,7 +36,9 @@ export function RadioGroupSection<T>({
         const text = itemToText(item, index);
         const subtext = itemToSubtext ? itemToSubtext(item, index) : undefined;
         const a11yLabel = `${text}, ${hideSubtext ? '' : subtext}`;
-        const checked = item === selected;
+        const checked =
+          selected &&
+          keyExtractor(item, index) === keyExtractor(selected, index);
         return (
           <ActionSectionItem
             key={keyExtractor(item, index)}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
@@ -66,7 +66,7 @@ export function ProductSelectionByAlias({
             <ProductAliasChip
               color={color}
               text={text}
-              selected={selectedProduct == fp}
+              selected={selectedProduct.id === fp.id}
               onPress={() => setSelectedProduct(fp)}
               key={i}
             />


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/17810

I didn't really find the root cause of why this started happening in the previous release, but it is due to how we compared objects, which is a flaky way to do it. With this change, we use FareProduct ID and the `keyExtractor` in RadioGroupSection to find the selected item.