### PR TITLE
test: e2e tests for travel search

### DIFF
--- a/e2e/test/pageobjects/onboarding.page.ts
+++ b/e2e/test/pageobjects/onboarding.page.ts
@@ -90,7 +90,6 @@ class OnboardingPage {
     try {
       await ElementHelper.waitForElement('id', 'useAppAnonymouslyButton');
       await this.useAppAnonymously.click();
-      //await AppHelper.pause(10000, true);
       await ElementHelper.waitForElement('id', 'acceptLimitationsButton');
       await this.acceptLimitations.click();
       await ElementHelper.waitForElement(

--- a/e2e/test/pageobjects/travelsearch.details.page.ts
+++ b/e2e/test/pageobjects/travelsearch.details.page.ts
@@ -1,3 +1,6 @@
+import ElementHelper from '../utils/element.helper.js';
+import {$} from '@wdio/globals';
+
 class TravelSearchDetailsPage {
   /**
    * Get the travel time
@@ -5,6 +8,19 @@ class TravelSearchDetailsPage {
   get travelTime() {
     const reqId = `//*[@resource-id="travelTime"]`;
     return $(reqId);
+  }
+
+  /**
+   * Check that the single leg returned is @mode
+   * @param mode mode to check for (bike, foot)
+   */
+  async hasSingleLeg(mode: 'bike' | 'foot') {
+    const legId_0 = `//*[@resource-id="legContainer0"]`;
+    const legId_1 = `//*[@resource-id="legContainer1"]`;
+    const modeId = `//*[@resource-id="${mode}Leg"]`;
+    await ElementHelper.waitForElement('id', 'tripDetailsContentView');
+    expect(await $(legId_1).isExisting()).toBe(false);
+    return await $(legId_0).$(modeId).isExisting();
   }
 
   /**

--- a/e2e/test/pageobjects/travelsearch.filter.page.ts
+++ b/e2e/test/pageobjects/travelsearch.filter.page.ts
@@ -1,0 +1,118 @@
+import ElementHelper from '../utils/element.helper.ts';
+import AppHelper from '../utils/app.helper.ts';
+import TravelsearchOverviewPage from './travelsearch.overview.page.js';
+
+class TravelSearchFilterPage {
+  /**
+   * Return the selected filter button (when transport modes are removed from trip search)
+   */
+  get selectedFilterButton() {
+    const reqId = `//*[@resource-id="selectedFilterButton"]`;
+    return $(reqId);
+  }
+
+  /**
+   * Return the search button within time chooser
+   */
+  get searchButton() {
+    const reqId = `//*[@resource-id="searchButton"]`;
+    return $(reqId);
+  }
+
+  /**
+   * Open the time picker on the travel search results
+   */
+  async openTravelSearchTimePicker() {
+    const reqId = `//*[@resource-id="dashboardDateTimePicker"]`;
+    await $(reqId).click();
+    await ElementHelper.waitForElement('id', `radioButtonNow`);
+  }
+
+  /**
+   * Choose what to base the search on
+   * @param basedOn what to base on (Now | Departure | Arrival)
+   */
+  async chooseSearchBasedOn(basedOn: 'Now' | 'Departure' | 'Arrival') {
+    const reqId = `//*[@resource-id="radioButton${basedOn}"]`;
+    await $(reqId).click();
+    if (basedOn !== 'Now') {
+      await ElementHelper.waitForElement('id', `timePicker`);
+    }
+  }
+
+  /**
+   * Open the native time picker
+   */
+  async openNativeTimePicker() {
+    const reqId = `//*[@resource-id="timePicker"]`;
+    await $(reqId).click();
+    await ElementHelper.waitForElement('id', `android:id/toggle_mode`);
+  }
+
+  /**
+   * Open the travel search filter
+   */
+  async openFilter() {
+    const reqId = `//*[@resource-id="filterButton"]`;
+    await $(reqId).click();
+    await ElementHelper.waitForElement('text', `Filter`);
+  }
+
+  /**
+   * Toggle on of the filters (or the 'all' option)
+   * @param type type of filter to toggle (default: allModes)
+   */
+  async toggleFilter(type: string = 'allModes') {
+    const reqId = `//*[@resource-id="${type}Toggle"]`;
+    await $(reqId).click();
+    await AppHelper.pause();
+  }
+
+  /**
+   * Confirm the chosen filter options
+   * @param saveFilter possibility to save the filter (default: false)
+   */
+  async confirmFilter(saveFilter: boolean = false) {
+    const reqId = `//*[@resource-id="confirmButton"]`;
+    const saveId = `//*[@resource-id="saveFilterCheckbox"]`;
+    // Save filter or not
+    if (saveFilter) {
+      await AppHelper.scrollDownUntilId('filterView', 'saveFilterCheckbox');
+      await $(saveId).click();
+    }
+    await $(reqId).click();
+    await AppHelper.pause();
+  }
+
+  /**
+   * Check that filters are changed and a "filter-box" is shown
+   * @param expectedText text that should be contained in the "filter-box"
+   */
+  async shouldShowSelectedFilter(expectedText: string) {
+    const reqId = `//*[@resource-id="selectedFilterButton"]`;
+    const textId = `//*[@resource-id="buttonText"]`;
+    await ElementHelper.waitForElement('id', `selectedFilterButton`);
+    await expect(await $(reqId).$(textId).getText()).toContain(expectedText);
+  }
+
+  /**
+   * Remove the selected filter, i.e. the "filter-box"
+   */
+  async removeSelectedFilter() {
+    const reqId = `//*[@resource-id="selectedFilterButton"]`;
+    await $(reqId).click();
+  }
+
+  /**
+   * Remove the selected filter - if it exists, i.e. the "filter-box"
+   */
+  async removeSelectedFilterIfExists() {
+    const reqId = `//*[@resource-id="selectedFilterButton"]`;
+    const exists: boolean = await $(reqId).isExisting();
+    if (exists) {
+      await $(reqId).click();
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+    }
+  }
+}
+export default new TravelSearchFilterPage();

--- a/e2e/test/pageobjects/travelsearch.overview.page.ts
+++ b/e2e/test/pageobjects/travelsearch.overview.page.ts
@@ -1,4 +1,5 @@
 import ElementHelper from '../utils/element.helper.ts';
+import AppHelper from '../utils/app.helper.js';
 
 class TravelSearchOverviewPage {
   /**
@@ -7,6 +8,41 @@ class TravelSearchOverviewPage {
   get firstTripResult() {
     const reqId = `//*[@resource-id="tripSearchSearchResult0"]`;
     return $(reqId);
+  }
+
+  /**
+   * Get the travel suggestion - for bike
+   */
+  get bikeResult() {
+    const reqId = `//*[@resource-id="bicycleResult"]`;
+    return $(reqId);
+  }
+
+  /**
+   * Get the travel suggestion text - for bike
+   */
+  get bikeResultText() {
+    const reqId = `//*[@resource-id="bicycleResult"]`;
+    const textId = `//*[@resource-id="buttonText"]`;
+    //return await $(reqId).$(textId).getText();
+    return $(reqId).$(textId).getText();
+  }
+
+  /**
+   * Get the travel suggestion - for walking
+   */
+  get walkResult() {
+    const reqId = `//*[@resource-id="footResult"]`;
+    return $(reqId);
+  }
+
+  /**
+   * Get the travel suggestion text - for walking
+   */
+  get walkResultText() {
+    const reqId = `//*[@resource-id="footResult"]`;
+    const textId = `//*[@resource-id="buttonText"]`;
+    return $(reqId).$(textId).getText();
   }
 
   /**
@@ -98,6 +134,43 @@ class TravelSearchOverviewPage {
     const durationId = `//*[@resource-id="resultDuration"]`;
     const duration = await $(searchResultId).$(durationId).getText();
     return duration.split(' ')[0];
+  }
+
+  /**
+   * Get number of transport modes from X first travel search results
+   * NOTE! Only bus and rail modes
+   * @param numberOfResults the number of results to check
+   */
+  async getNumberOfTransportModesInSearch(numberOfResults: number = 5) {
+    let noBusLegs = 0;
+    let noRailLegs = 0;
+    // Loop through the search results and count the different modes
+    for (let i = 0; i < numberOfResults; i++) {
+      const tripId = `//*[@resource-id="tripSearchSearchResult${i}"]`;
+      const busModeId = `//*[@resource-id="busLeg"]`;
+      const railModeId = `//*[@resource-id="railLeg"]`;
+
+      // Scroll down if trip result is not displayed
+      const resultExists = await ElementHelper.isElementExisting(
+        `tripSearchSearchResult${i}`,
+        2,
+      );
+      if (!resultExists) {
+        await AppHelper.scrollDownUntilId(
+          'tripSearchContentView',
+          `tripSearchSearchResult${i}`,
+        );
+      }
+
+      noBusLegs += await $(tripId).$$(busModeId).length;
+      noRailLegs += await $(tripId).$$(railModeId).length;
+    }
+    await AppHelper.scrollUp('tripSearchContentView');
+
+    // Find and return number of different transport modes
+    const busLegsExists: number = noBusLegs > 0 ? 1 : 0;
+    const railLegsExists: number = noRailLegs > 0 ? 1 : 0;
+    return busLegsExists + railLegsExists;
   }
 }
 export default new TravelSearchOverviewPage();

--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -6,6 +6,9 @@ import SearchPage from '../pageobjects/search.page.ts';
 import TravelsearchOverviewPage from '../pageobjects/travelsearch.overview.page.ts';
 import TravelsearchDetailsPage from '../pageobjects/travelsearch.details.page.ts';
 import NavigationHelper from '../utils/navigation.helper.ts';
+import TravelsearchFilterPage from '../pageobjects/travelsearch.filter.page.js';
+import TimeHelper from '../utils/time.helper.js';
+import {stringToNumArray} from '../utils/utils.js';
 
 describe('Travel search', () => {
   before(async () => {
@@ -31,8 +34,6 @@ describe('Travel search', () => {
      */
 
     try {
-      timeIsCorrect('28 min', 'Times is: 29 minutes');
-
       await ElementHelper.waitForElement('id', 'searchFromButton');
       await FrontPagePage.searchFrom.click();
       await SearchPage.setSearchLocation(departure);
@@ -143,10 +144,157 @@ describe('Travel search', () => {
         noLegs - 1,
       );
       expect(endLocation).toContain(arrival);
+
+      await NavigationHelper.back();
     } catch (errMsg) {
       await AppHelper.screenshot(
         'error_travelsearch_should_have_correct_legs_in_the_details',
       );
+      throw errMsg;
+    }
+  });
+
+  /**
+   * Changing departure time should give correct travel search results
+   */
+  it('should search based on time', async () => {
+    const departure = 'Prinsens gate';
+    const arrival = 'Melhus skysstasjon';
+    const depTimeHr = 21;
+    const depTimeMin = 0;
+
+    try {
+      // Search and get start times of 3 first trip results
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(departure);
+
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(arrival);
+
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+      const initStartTime_1: string =
+        await TravelsearchOverviewPage.getStartTime(0);
+      const initStartTime_2: string =
+        await TravelsearchOverviewPage.getStartTime(1);
+      const initStartTime_3: string =
+        await TravelsearchOverviewPage.getStartTime(2);
+
+      // Set new departure time
+      await TravelsearchFilterPage.openTravelSearchTimePicker();
+      await TravelsearchFilterPage.chooseSearchBasedOn('Departure');
+      await TravelsearchFilterPage.openNativeTimePicker();
+      await AppHelper.setTimePickerTime(depTimeHr, depTimeMin);
+      await TravelsearchFilterPage.searchButton.click();
+
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      const endStartTime_1: string =
+        await TravelsearchOverviewPage.getStartTime(0);
+      const endStartTime_2: string =
+        await TravelsearchOverviewPage.getStartTime(1);
+      const endStartTime_3: string =
+        await TravelsearchOverviewPage.getStartTime(2);
+
+      // Departure times are changed
+      await expect(initStartTime_1).not.toEqual(endStartTime_1);
+      await expect(initStartTime_2).not.toEqual(endStartTime_2);
+      await expect(initStartTime_3).not.toEqual(endStartTime_3);
+
+      // Departure times are after search time
+      expect(
+        TimeHelper.gtTime(
+          depTimeHr,
+          depTimeMin,
+          stringToNumArray(endStartTime_1)[0],
+          stringToNumArray(endStartTime_1)[1],
+        ),
+      ).toBe(true);
+      expect(
+        TimeHelper.gtTime(
+          depTimeHr,
+          depTimeMin,
+          stringToNumArray(endStartTime_2)[0],
+          stringToNumArray(endStartTime_2)[1],
+        ),
+      ).toBe(true);
+      expect(
+        TimeHelper.gtTime(
+          depTimeHr,
+          depTimeMin,
+          stringToNumArray(endStartTime_3)[0],
+          stringToNumArray(endStartTime_3)[1],
+        ),
+      ).toBe(true);
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_travelsearch_departure_time');
+      throw errMsg;
+    }
+  });
+
+  /**
+   * Walking and bike travels are shown separately depending on the travel search
+   */
+  it('should show walk and bike options', async () => {
+    const longDeparture = 'Prinsens gate';
+    const longArrival = 'Melhus skysstasjon';
+    const shortDeparture = 'Prinsens gate';
+    const shortArrival = 'Solsiden';
+
+    try {
+      // Search "long": only bike
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(longDeparture);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(longArrival);
+
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      await expect(TravelsearchOverviewPage.bikeResult).toExist();
+      await expect(await TravelsearchOverviewPage.bikeResultText).toContain(
+        'Bike 1 h 30 min',
+      );
+      await expect(TravelsearchOverviewPage.walkResult).not.toExist();
+
+      // Details
+      await TravelsearchOverviewPage.bikeResult.click();
+      await expect(await TravelsearchDetailsPage.hasSingleLeg('bike')).toBe(
+        true,
+      );
+
+      // Reset
+      await NavigationHelper.back();
+      await NavigationHelper.tapMenu('assistant');
+      await NavigationHelper.tapMenu('assistant');
+
+      // Search "short": walk + bike
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(shortDeparture);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(shortArrival);
+
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      await expect(TravelsearchOverviewPage.bikeResult).toExist();
+      await expect(TravelsearchOverviewPage.walkResult).toExist();
+      await expect(await TravelsearchOverviewPage.walkResultText).toContain(
+        'Walk 19 min',
+      );
+
+      // Details
+      await TravelsearchOverviewPage.walkResult.click();
+      await expect(await TravelsearchDetailsPage.hasSingleLeg('foot')).toBe(
+        true,
+      );
+
+      await NavigationHelper.back();
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_travelsearch_walk_bike_travels');
       throw errMsg;
     }
   });

--- a/e2e/test/specs/travelsearch.filter.e2e.ts
+++ b/e2e/test/specs/travelsearch.filter.e2e.ts
@@ -1,0 +1,176 @@
+import OnboardingPage from '../pageobjects/onboarding.page.ts';
+import AppHelper from '../utils/app.helper.ts';
+import ElementHelper from '../utils/element.helper.ts';
+import FrontPagePage from '../pageobjects/frontpage.page.ts';
+import SearchPage from '../pageobjects/search.page.ts';
+import TravelsearchOverviewPage from '../pageobjects/travelsearch.overview.page.ts';
+import NavigationHelper from '../utils/navigation.helper.ts';
+import TravelsearchFilterPage from '../pageobjects/travelsearch.filter.page.js';
+
+describe('Travel search filter', () => {
+  before(async () => {
+    await AppHelper.waitOnLoadingScreen();
+    await OnboardingPage.skipOnboarding('travelsearch');
+    await AppHelper.pause(5000, true);
+  });
+  beforeEach(async () => {
+    await NavigationHelper.tapMenu('assistant');
+    await NavigationHelper.tapMenu('assistant');
+  });
+
+  /**
+   * Filter which travel mode to use
+   * Note! One danger is if the search is unlucky and only get bus options in the initial search
+   */
+  it('should filter transport modes correctly', async () => {
+    const departure = 'Prinsens gate';
+    const arrival = 'Melhus skysstasjon';
+
+    try {
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(departure);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(arrival);
+
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Check number of transport modes
+      const numberOfModesInitial =
+        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch();
+
+      // Filter out buses
+      await TravelsearchFilterPage.openFilter();
+      await TravelsearchFilterPage.toggleFilter('bus');
+      await TravelsearchFilterPage.confirmFilter();
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Verify
+      const numberOfModesWithFilter =
+        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch();
+      expect(numberOfModesWithFilter).toBeLessThan(numberOfModesInitial);
+      await TravelsearchFilterPage.shouldShowSelectedFilter('6 of 7');
+
+      // Remove the selected filters
+      await TravelsearchFilterPage.removeSelectedFilter();
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Verify
+      const numberOfModes =
+        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch();
+      expect(numberOfModes).toEqual(numberOfModesInitial);
+      await expect(TravelsearchFilterPage.selectedFilterButton).not.toExist();
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_travelsearch_filter_transport_modes');
+      throw errMsg;
+    }
+  });
+
+  /**
+   * Saving the filter choice should use the saved filter for new searches
+   */
+  it('should save filter choices', async () => {
+    const departure = 'Prinsens gate';
+    const arrival = 'Melhus skysstasjon';
+
+    try {
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(departure);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(arrival);
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Filter out buses
+      await TravelsearchFilterPage.openFilter();
+      await TravelsearchFilterPage.toggleFilter('bus');
+      await TravelsearchFilterPage.confirmFilter(true);
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Filters are enabled
+      await expect(
+        await TravelsearchFilterPage.selectedFilterButton.isExisting(),
+      ).toBe(true);
+
+      await NavigationHelper.tapMenu('assistant');
+      await NavigationHelper.tapMenu('assistant');
+      await ElementHelper.expectText('Travel search');
+
+      // New search
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(departure);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(arrival);
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Filters are enabled
+      await expect(
+        await TravelsearchFilterPage.selectedFilterButton.isExisting(),
+      ).toBe(true);
+
+      // Remove filter
+      await TravelsearchFilterPage.removeSelectedFilter();
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_travelsearch_save_filter');
+      throw errMsg;
+    }
+  });
+
+  /**
+   * Not saving the filter choice should NOT use the last filter for new searches
+   */
+  it('should not save filter choices', async () => {
+    const departure = 'Prinsens gate';
+    const arrival = 'Melhus skysstasjon';
+
+    try {
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(departure);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(arrival);
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Fallback if filters are enabled from last test
+      await TravelsearchFilterPage.removeSelectedFilterIfExists();
+
+      // Filter out buses
+      await TravelsearchFilterPage.openFilter();
+      await TravelsearchFilterPage.toggleFilter('bus');
+      await TravelsearchFilterPage.confirmFilter(false);
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Filters are enabled
+      expect(
+        await TravelsearchFilterPage.selectedFilterButton.isExisting(),
+      ).toBe(true);
+
+      await NavigationHelper.tapMenu('assistant');
+      await NavigationHelper.tapMenu('assistant');
+      await ElementHelper.expectText('Travel search');
+
+      // New search
+      await ElementHelper.waitForElement('id', 'searchFromButton');
+      await FrontPagePage.searchFrom.click();
+      await SearchPage.setSearchLocation(departure);
+      await ElementHelper.waitForElement('id', 'searchToButton');
+      await FrontPagePage.searchTo.click();
+      await SearchPage.setSearchLocation(arrival);
+      await TravelsearchOverviewPage.waitForTravelSearchResults();
+
+      // Filters are NOT enabled
+      expect(
+        await TravelsearchFilterPage.selectedFilterButton.isExisting(),
+      ).toBe(false);
+    } catch (errMsg) {
+      await AppHelper.screenshot('error_travelsearch_not_save_filter');
+      throw errMsg;
+    }
+  });
+});

--- a/e2e/test/utils/app.helper.ts
+++ b/e2e/test/utils/app.helper.ts
@@ -1,5 +1,6 @@
 import ElementHelper from './element.helper.ts';
 import {driver} from '@wdio/globals';
+import {numberToStringWithZeros} from './utils.js';
 
 const screenshotsFolder: string = './screenshots';
 
@@ -137,6 +138,33 @@ class AppHelper {
       j++;
     }
     await expect(elem).toBeDisplayed({wait: 200, interval: 100});
+  }
+
+  /**
+   * Set the time in the time picker once it's opened
+   * @param hours set the hours
+   * @param minutes set the minutes
+   */
+  async setTimePickerTime(hours: number, minutes: number) {
+    const hoursS = numberToStringWithZeros(hours);
+    const minutesS = numberToStringWithZeros(minutes);
+
+    // Open keyboard input
+    await ElementHelper.waitForElement('id', 'android:id/timePicker');
+    const toggle = await ElementHelper.getElement('android:id/toggle_mode');
+    await toggle.click();
+    await this.pause(500);
+    // Set values
+    const inputHour = await ElementHelper.getElement('android:id/input_hour');
+    const inputMin = await ElementHelper.getElement('android:id/input_minute');
+    await inputHour.click();
+    await inputHour.setValue(hoursS);
+    await inputMin.click();
+    await inputMin.setValue(minutesS);
+    // Confirm
+    const okButton = await ElementHelper.getElement('android:id/button1');
+    await okButton.click();
+    await this.pause(1000);
   }
 }
 

--- a/e2e/test/utils/time.helper.ts
+++ b/e2e/test/utils/time.helper.ts
@@ -1,5 +1,3 @@
-//import {number} from "prop-types";
-
 /**
  * Different helper methods related to time calculations
  */
@@ -22,6 +20,21 @@ class TimeHelper {
         : new Date(0).setHours(end[0], end[1]);
 
     return (endDate - startDate) / (1000 * 60);
+  }
+
+  /**
+   * Checks if end time is gt initial time
+   * @param initialHr hours initially
+   * @param initialMin mins initially
+   * @param endHr hours at the end
+   * @param endMin mins at the end
+   */
+  gtTime(initialHr: number, initialMin: number, endHr: number, endMin: number) {
+    let initDate = new Date();
+    let endDate = new Date();
+    initDate.setHours(initialHr, initialMin);
+    endDate.setHours(endHr, endMin);
+    return initDate <= endDate;
   }
 }
 

--- a/e2e/test/utils/utils.ts
+++ b/e2e/test/utils/utils.ts
@@ -7,3 +7,28 @@ export function parseBoolean(str: string | undefined | null) {
   if (str === 'false') return false;
   return undefined;
 }
+
+/**
+ * From number to string with prefill of '0'. E.g. 6 -> "06" with two chars
+ * @param input number to convert
+ * @param noChars how many chars the string should be
+ */
+export function numberToStringWithZeros(input: number, noChars: number = 2) {
+  let toString: string = input.toString();
+  while (toString.length < noChars) {
+    toString = '0' + toString;
+  }
+  return toString;
+}
+
+/**
+ * Converts a string to an array of numbers
+ * @param inputString string to be separated into a number array
+ * @param separator separator (default: ':')
+ */
+export function stringToNumArray(
+  inputString: string,
+  separator: string = ':',
+): number[] {
+  return inputString.split(separator).map((el) => parseInt(el));
+}

--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -49,7 +49,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
       type="body__primary--bold"
       color={transportationColor}
       style={styles.lineNumberText}
-      testID={testID}
+      testID="lineNumber"
     >
       {lineNumber}
     </ThemeText>

--- a/src/journey-date-picker/JourneyDatePickerScreenComponent.tsx
+++ b/src/journey-date-picker/JourneyDatePickerScreenComponent.tsx
@@ -85,8 +85,16 @@ export const JourneyDatePickerScreenComponent = ({
 
         {option !== 'now' && (
           <Section style={styles.section} testID="dateTimePickerSection">
-            <DateInputSectionItem value={dateString} onChange={setDate} />
-            <TimeInputSectionItem value={timeString} onChange={setTime} />
+            <DateInputSectionItem
+              value={dateString}
+              onChange={setDate}
+              testID="datePicker"
+            />
+            <TimeInputSectionItem
+              value={timeString}
+              onChange={setTime}
+              testID="timePicker"
+            />
           </Section>
         )}
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -32,7 +32,7 @@ import {HoldingHands} from '@atb/assets/svg/color/images';
 import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from './utils';
 import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
-import { useAuthState } from '@atb/auth';
+import {useAuthState} from '@atb/auth';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -98,11 +98,12 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const fareProductOnBehalfOfEnabled =
     params.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
-  const offerEndpoint = zoneSelectionMode === 'none'
-    ? 'authority'
-    : zoneSelectionMode === 'multiple-stop-harbor'
-    ? 'stop-places'
-    : 'zones';
+  const offerEndpoint =
+    zoneSelectionMode === 'none'
+      ? 'authority'
+      : zoneSelectionMode === 'multiple-stop-harbor'
+      ? 'stop-places'
+      : 'zones';
 
   const {
     isSearchingOffer,
@@ -293,6 +294,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                   onValueChange={(checked) => {
                     setIsOnBehalfOfToggle(checked);
                   }}
+                  testID="onBehalfOfToggle"
                 />
               </Section>
             </>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/SingleTravellerSelection.tsx
@@ -73,6 +73,7 @@ export function SingleTravellerSelection({
             onValueChange={(checked) => {
               setIsTravelerOnBehalfOfToggle(checked);
             }}
+            testID="onBehalfOfToggle"
           />
         </Section>
       )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -362,7 +362,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                     type="medium"
                     compact={true}
                     onPress={filtersState.openBottomSheet}
-                    testID="dashboardDateTimePicker"
+                    testID="filterButton"
                     rightIcon={{
                       svg: Filter,
                       notification: filtersState.anyFiltersApplied

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
@@ -53,6 +53,7 @@ export const NonTransitResults = ({tripPatterns, onDetailsPressed}: Props) => {
             leftIcon={{svg: getTransportModeSvg(mode).svg}}
             rightIcon={{svg: arrowRight}}
             accessibilityLabel={`${modeText} ${duration}`}
+            testID={`${mode}Result`}
           />
         );
       })}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -565,7 +565,7 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
       : t(TripSearchTexts.results.resultItem.footLeg.walkLabel(walkDuration));
 
   return (
-    <View style={styles.walkContainer} testID="fLeg">
+    <View style={styles.walkContainer} testID="footLeg">
       <ThemeIcon accessibilityLabel={a11yText} svg={Walk} />
       <Text style={styles.walkDuration}>{secondsToMinutes(leg.duration)}</Text>
     </View>
@@ -587,7 +587,7 @@ const TransportationLeg = ({
       isFlexible={isLineFlexibleTransport(leg.line)}
       lineNumber={leg.line?.publicCode}
       type="standard"
-      testID="trLeg"
+      testID={`${leg.mode}Leg`}
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/SelectedFiltersButtons.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/SelectedFiltersButtons.tsx
@@ -47,6 +47,7 @@ export const SelectedFiltersButtons = ({
         active={true}
         leftIcon={{svg: Bus}}
         rightIcon={{svg: Close}}
+        testID="selectedFilterButton"
       />
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
@@ -87,7 +87,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
       maxHeightValue={0.9}
       title={t(TripSearchTexts.filters.bottomSheet.heading)}
     >
-      <ScrollView style={styles.filtersContainer} ref={focusRef}>
+      <ScrollView style={styles.filtersContainer} ref={focusRef} testID="filterView">
         <Section>
           <HeaderSectionItem
             text={t(TripSearchTexts.filters.bottomSheet.modes.heading)}
@@ -103,6 +103,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
                 })),
               );
             }}
+            testID="allModesToggle"
           />
           {filtersSelection.transportModes?.map((option) => {
             const text = getTextForLanguage(option.text, language);
@@ -136,6 +137,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
                     ),
                   );
                 }}
+                testID={`${option.id}Toggle`}
               />
             ) : null;
           })}
@@ -202,6 +204,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
                           .save,
                   ),
                 }}
+                testID="saveFilter"
               />
               <ThemeText type="body__secondary" color="secondary">
                 {t(TripSearchTexts.filters.bottomSheet.saveFilters.text)}
@@ -216,6 +219,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
           text={t(TripSearchTexts.filters.bottomSheet.use)}
           onPress={save}
           rightIcon={{svg: Confirm}}
+          testID="confirmButton"
         />
       </FullScreenFooter>
     </BottomSheetContainer>


### PR DESCRIPTION
Added some e2e tests for travel search (in the `e2e/test/specs` folder):
- Should see walk and bike non-transit results
- Should be able to filter on departure time
- Should be able to filter on transport modes
- Should save filter options
- Should not save filter options

Also, added a test scenario after changing that on-behalf-of is only for logged-in users:
- Should not see on-behalf-of as anonymous

NOTE: Added some test-ids related to filter and date/time-picker + on-behalf-of toggle