### PR TITLE
refactor: Improve error handling and retry logic when fetching id token

### DIFF
--- a/src/auth/use-fetch-id-token-with-custom-claims.ts
+++ b/src/auth/use-fetch-id-token-with-custom-claims.ts
@@ -1,43 +1,67 @@
 import {Dispatch, useEffect} from 'react';
 import {AuthReducerAction} from './types';
-import Bugsnag from '@bugsnag/react-native';
 import {AuthReducerState} from '@atb/auth/AuthContext';
+import {useQuery} from '@tanstack/react-query';
+import {logToBugsnag, notifyBugsnag} from '@atb/utils/bugsnag-utils';
 
-/*
+const RETRY_COUNT = 3;
+
+/**
+ * Variable signalling whether the next fetch id token request should be force
+ * refreshed or not. The first request should not be force refreshed, but
+ * retries should.
+ */
+let shouldForceRefresh = false;
+
+/**
  * Fetch the id token for the user. The id token is only "accepted" if it
  * contains custom claims (checked by looking up the 'customer-number' claim).
  *
- * If the custom claim is not present on the id token, it will try to force
- * refetch up to 10 times with an interval of 1 second.
+ * If the custom claim is not present on the id token, or fetching fails, it
+ * will try to force refresh id token up to 3 times with a linear backoff
+ * starting at 3 seconds.
  */
 export const useFetchIdTokenWithCustomClaims = (
   state: AuthReducerState,
   dispatch: Dispatch<AuthReducerAction>,
 ) => {
   useEffect(() => {
-    if (state.authStatus === 'fetching-id-token') {
-      let retryCount = 0;
-      const intervalId = setInterval(async () => {
-        const idToken = await state.user?.getIdTokenResult(!!retryCount); // First try without force refresh from server
-        if (idToken?.claims['customer_number']) {
-          Bugsnag.leaveBreadcrumb(
-            `Received id token with custom claims after ${
-              retryCount + 1
-            } tries`,
-          );
-          dispatch({type: 'SET_ID_TOKEN', idToken});
-          clearInterval(intervalId);
-        } else if (retryCount >= 10) {
-          Bugsnag.leaveBreadcrumb(
-            `No id token with custom claims received after 10 tries`,
-          );
-          dispatch({type: 'SET_FETCH_ID_TOKEN_TIMEOUT'});
-          clearInterval(intervalId);
-        } else {
-          retryCount += 1;
-        }
-      }, 1000);
-      return () => clearInterval(intervalId);
+    shouldForceRefresh = false;
+  }, [state.user]);
+
+  const query = useQuery({
+    queryKey: ['FETCH_ID_TOKEN'],
+    queryFn: async () => {
+      logToBugsnag(
+        `Fetching id token with force refresh ${
+          shouldForceRefresh ? 'on' : 'off'
+        } ${state.authStatus} ${state.user?.uid}`,
+      );
+      const idToken = await state.user?.getIdTokenResult(shouldForceRefresh); // Force refresh from server if retry
+      const isMissingCustomClaims = !idToken?.claims['customer_number'];
+      if (isMissingCustomClaims) {
+        shouldForceRefresh = true;
+        throw new Error("Token doesn't contain custom claims");
+      }
+      return idToken;
+    },
+    enabled: state.authStatus === 'fetching-id-token',
+    retry: RETRY_COUNT,
+    retryDelay: (attempt) => (attempt + 1) * 3000,
+  });
+
+  useEffect(() => {
+    if (query.data) {
+      dispatch({type: 'SET_ID_TOKEN', idToken: query.data});
     }
-  }, [state.user, state.authStatus, dispatch]);
+  }, [dispatch, query.data]);
+
+  useEffect(() => {
+    if (query.error) {
+      notifyBugsnag(query.error as any, {
+        description: `No id token with custom claims received after ${RETRY_COUNT} retries`,
+      });
+      dispatch({type: 'SET_FETCH_ID_TOKEN_TIMEOUT'});
+    }
+  }, [dispatch, query.error]);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,19 +82,19 @@ export const App = () => {
         <StorybookContextProvider>
           <ErrorBoundary type="full-screen">
             <PreferencesContextProvider>
-              <LocaleContextProvider>
-                <AuthContextProvider>
-                  <RemoteConfigContextProvider>
-                    <TimeContextProvider>
-                      <AnalyticsContextProvider>
-                        <AccessibilityContextProvider>
-                          <ThemeContextProvider>
-                            <FavoritesContextProvider>
-                              <FiltersContextProvider>
-                                <SearchHistoryContextProvider>
-                                  <FirestoreConfigurationContextProvider>
-                                    <TicketingContextProvider>
-                                      <ReactQueryProvider>
+              <ReactQueryProvider>
+                <LocaleContextProvider>
+                  <AuthContextProvider>
+                    <RemoteConfigContextProvider>
+                      <TimeContextProvider>
+                        <AnalyticsContextProvider>
+                          <AccessibilityContextProvider>
+                            <ThemeContextProvider>
+                              <FavoritesContextProvider>
+                                <FiltersContextProvider>
+                                  <SearchHistoryContextProvider>
+                                    <FirestoreConfigurationContextProvider>
+                                      <TicketingContextProvider>
                                         <MobileTokenContextProvider>
                                           <AppLanguageProvider>
                                             <GeolocationContextProvider>
@@ -118,19 +118,19 @@ export const App = () => {
                                             </GeolocationContextProvider>
                                           </AppLanguageProvider>
                                         </MobileTokenContextProvider>
-                                      </ReactQueryProvider>
-                                    </TicketingContextProvider>
-                                  </FirestoreConfigurationContextProvider>
-                                </SearchHistoryContextProvider>
-                              </FiltersContextProvider>
-                            </FavoritesContextProvider>
-                          </ThemeContextProvider>
-                        </AccessibilityContextProvider>
-                      </AnalyticsContextProvider>
-                    </TimeContextProvider>
-                  </RemoteConfigContextProvider>
-                </AuthContextProvider>
-              </LocaleContextProvider>
+                                      </TicketingContextProvider>
+                                    </FirestoreConfigurationContextProvider>
+                                  </SearchHistoryContextProvider>
+                                </FiltersContextProvider>
+                              </FavoritesContextProvider>
+                            </ThemeContextProvider>
+                          </AccessibilityContextProvider>
+                        </AnalyticsContextProvider>
+                      </TimeContextProvider>
+                    </RemoteConfigContextProvider>
+                  </AuthContextProvider>
+                </LocaleContextProvider>
+              </ReactQueryProvider>
             </PreferencesContextProvider>
           </ErrorBoundary>
         </StorybookContextProvider>


### PR DESCRIPTION
Now started to use useQuery for fetching id token to get more control
over the flow. Now we:
- Only retry 3 times
- Both errors and custom claims not found lead to retry
- Have a linear backoff starting a 3 seconds before retries. That
means that the first retry (after 3 seconds) and second retry (after
6 more seconds) will both be done before getting the loading boundary
timeout.
