### PR TITLE
fix: remove unnecessary ScreenHeader from FullScreenErrorView

### DIFF
--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -57,7 +57,6 @@ export function FullScreenErrorView({onRestartApp, errorCode}: ErrorProps) {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   safearea: {
     flex: 1,
-    paddingTop: 44,
     backgroundColor: theme.static.background.background_2.background,
   },
   svgContainer: {

--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -58,6 +58,7 @@ export function FullScreenErrorView({onRestartApp, errorCode}: ErrorProps) {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   safearea: {
     flex: 1,
+    paddingTop: 44,
     backgroundColor: theme.static.background.background_2.background,
   },
   svgContainer: {

--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -1,6 +1,5 @@
 import {Crash} from '@atb/assets/svg/color/images';
 import {Button} from '@atb/components/button';
-import {ScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
 import {useLocalConfig} from '@atb/utils/use-local-config';

--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -21,7 +21,6 @@ export function FullScreenErrorView({onRestartApp, errorCode}: ErrorProps) {
 
   return (
     <SafeAreaView style={styles.safearea}>
-      <ScreenHeader title="" />
       <View style={styles.svgContainer}>
         <Crash width="100%" height="100%" />
       </View>


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/17839

On the announcement crash issue, the app doesn't show the usual crash screen. If we run the debug version of the app and trigger the crash, the issue shown would be `useAuthState must be used within a AuthContextProvider`, which is not the actual issue. 

After some investigation, it is because the `FullScreenErrorView` was calling the `ScreenHeader` component, which contains a `GlobalMessage` component. This `GlobalMessage` component reads `AuthState`, after it got updated recently on this issue https://github.com/AtB-AS/mittatb-app/issues/4456. Since the `ErrorBoundary` is the parent of `AuthContextProvider`, the app crashes due to `useAuthState` being called while the current context is the `ErrorBoundary`.

Therefore the solution was to remove `ScreenHeader` from the crash screen, it doesn't really have any purpose when I compared the before & after. There was no title, no icons, and cannot be interacted with, so it should be safe to remove.

Comparison below (before vs after):

<img src="https://github.com/AtB-AS/mittatb-app/assets/1777333/41a8b38c-0941-424e-9c2c-ecfdc9071e40" width="350" />

<img src="https://github.com/AtB-AS/mittatb-app/assets/1777333/bc21b8be-e870-4506-864b-c96eb9374050" width="350" />

