### PR TITLE
feat: add converter to set default values and prevent unwanted crash

### DIFF
--- a/src/announcements/converters.ts
+++ b/src/announcements/converters.ts
@@ -1,5 +1,5 @@
 import {FirebaseFirestoreTypes} from '@react-native-firebase/firestore';
-import {AnnouncementRaw, AnnouncementType, ActionButton} from './types';
+import {AnnouncementRaw, AnnouncementType, ActionButton, ActionType} from './types';
 import {mapToLanguageAndTexts} from '@atb/utils/map-to-language-and-texts';
 import {APP_VERSION} from '@env';
 import {AppPlatformType} from '@atb/global-messages/types';
@@ -44,6 +44,7 @@ export const mapToAnnouncement = (
   if (!isAppPlatformValid(platforms)) return;
   if (appVersionMin && appVersionMin > APP_VERSION) return;
   if (appVersionMax && appVersionMax < APP_VERSION) return;
+  if (!actionButton) return;
 
   return {
     id,
@@ -78,11 +79,14 @@ function isAppPlatformValid(platforms: AppPlatformType[]) {
   );
 }
  
-function mapActionButton(data: any): ActionButton {
+function mapActionButton(data: any): ActionButton | undefined {
   const action = data ?? {};
   const labelWithLanguage = mapToLanguageAndTexts(action.label);
   const url = action.url;
   const actionType = mapToActionType(action.actionType);
+
+  if (!actionType) return;
+
   return {
     label: labelWithLanguage,
     url,
@@ -90,15 +94,6 @@ function mapActionButton(data: any): ActionButton {
   };
 }
 
-function mapToActionType(data:any, url?: string) {
-  const actionTypes = ['external', 'deeplink', 'bottom_sheet'];
-
-  if (url) {
-    if (url.startsWith('http')) return 'external';
-    return 'deeplink';
-  }
-  if (!data) return 'bottom_sheet';
-  if (typeof data !== 'string') return 'bottom_sheet';
-  if (!actionTypes.includes(data)) return 'bottom_sheet';
-  return data as ActionType;
+function mapToActionType(data:any): ActionType | undefined {
+  if (Object.values(ActionType).includes(data)) return data;
 }

--- a/src/announcements/converters.ts
+++ b/src/announcements/converters.ts
@@ -77,13 +77,28 @@ function isAppPlatformValid(platforms: AppPlatformType[]) {
     (platform) => platform.toLowerCase() === Platform.OS.toLowerCase(),
   );
 }
-
+ 
 function mapActionButton(data: any): ActionButton {
-  const {label = [], url, actionType = 'bottom_sheet'} = data ?? {};
-  const labelWithLanguage = mapToLanguageAndTexts(label);
+  const action = data ?? {};
+  const labelWithLanguage = mapToLanguageAndTexts(action.label);
+  const url = action.url;
+  const actionType = mapToActionType(action.actionType);
   return {
     label: labelWithLanguage,
     url,
     actionType,
   };
+}
+
+function mapToActionType(data:any, url?: string) {
+  const actionTypes = ['external', 'deeplink', 'bottom_sheet'];
+
+  if (url) {
+    if (url.startsWith('http')) return 'external';
+    return 'deeplink';
+  }
+  if (!data) return 'bottom_sheet';
+  if (typeof data !== 'string') return 'bottom_sheet';
+  if (!actionTypes.includes(data)) return 'bottom_sheet';
+  return data as ActionType;
 }

--- a/src/announcements/types.ts
+++ b/src/announcements/types.ts
@@ -5,15 +5,21 @@ import {Rule} from '@atb/rule-engine/rules';
 
 export type AnnouncementId = string;
 
+export enum ActionType {
+  'external',
+  'deeplink',
+  'bottom_sheet',
+}
+
 export type BottomSheetActionButton = {
   label?: LanguageAndTextType[];
-  actionType: 'bottom_sheet';
+  actionType: Extract<ActionType, ActionType.bottom_sheet>;
 };
 
 export type UrlActionButton = {
   label?: LanguageAndTextType[];
   url: string;
-  actionType: 'external' | 'deeplink';
+  actionType: Extract<ActionType, ActionType.external | ActionType.deeplink>;
 };
 
 export type ActionButton = BottomSheetActionButton | UrlActionButton;

--- a/src/announcements/types.ts
+++ b/src/announcements/types.ts
@@ -6,9 +6,9 @@ import {Rule} from '@atb/rule-engine/rules';
 export type AnnouncementId = string;
 
 export enum ActionType {
-  'external',
-  'deeplink',
-  'bottom_sheet',
+  external = 'external',
+  deeplink = 'deeplink',
+  bottom_sheet = 'bottom_sheet',
 }
 
 export type BottomSheetActionButton = {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -1,4 +1,4 @@
-import {AnnouncementType} from '@atb/announcements/types';
+import {ActionType, AnnouncementType} from '@atb/announcements/types';
 import {ThemeText} from '@atb/components/text';
 import {
   DashboardTexts,
@@ -102,7 +102,7 @@ export const Announcement = ({announcement, style}: Props) => {
           }
           textType="body__secondary"
           icon={
-            announcement.actionButton?.actionType === 'external'
+            announcement.actionButton?.actionType === ActionType.external
               ? 'external-link'
               : 'arrow-right'
           }
@@ -113,12 +113,12 @@ export const Announcement = ({announcement, style}: Props) => {
               ],
             ),
             accessibilityRole:
-              announcement.actionButton.actionType === 'bottom_sheet'
+              announcement.actionButton.actionType === ActionType.bottom_sheet
                 ? 'button'
                 : 'link',
           }}
           onPress={async () => {
-            if (announcement.actionButton.actionType === 'bottom_sheet') {
+            if (announcement.actionButton.actionType === ActionType.bottom_sheet) {
               openBottomSheet(() => (
                 <AnnouncementSheet announcement={announcement} />
               ));


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17839

The destructuring of `actionButton` from firestore causes the app to crash when the values are invalid (in this case, `actionType`). This PR adds type-checking during the conversion to add handling of invalid data. With this PR, issues related to `actionType` in the announcements (for example, mistyping), will result in the announcement to not be shown to users.

I added the enum to provide a centralized place for typing, and to help reducing typo during development. In the future if we need another type of action (maybe Snackbar?), then we can just add them to the enum, create another button type or just add it to existing button type, and add correct handling on the `Announcement.tsx`.

Documentation is also updated on https://github.com/AtB-AS/docs-private/pull/47