### PR TITLE
refactor: Clear queries on user change

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -3,6 +3,7 @@ import React, {
   PropsWithChildren,
   useCallback,
   useContext,
+  useEffect,
   useReducer,
 } from 'react';
 import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
@@ -25,6 +26,8 @@ import {useFetchIdTokenWithCustomClaims} from './use-fetch-id-token-with-custom-
 import Bugsnag from '@bugsnag/react-native';
 import isEqual from 'lodash.isequal';
 import {mapAuthenticationType} from '@atb/auth/utils';
+import {useQueryClient} from '@tanstack/react-query';
+import {useClearQueriesOnUserChange} from "@atb/auth/use-clear-queries-on-user-change";
 
 export type AuthReducerState = {
   authStatus: AuthStatus;
@@ -130,6 +133,7 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   useFetchIdTokenWithCustomClaims(state, dispatch);
 
   useUpdateAuthLanguageOnChange();
+  useClearQueriesOnUserChange(state);
 
   const retryAuth = useCallback(() => {
     if (state.authStatus === 'fetch-id-token-timeout') {

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -3,7 +3,6 @@ import React, {
   PropsWithChildren,
   useCallback,
   useContext,
-  useEffect,
   useReducer,
 } from 'react';
 import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
@@ -15,7 +14,7 @@ import {
   ConfirmationErrorCode,
   PhoneSignInErrorCode,
   VippsSignInErrorCode,
-} from '@atb/auth/types';
+} from './types';
 import {
   authConfirmCode,
   authSignInWithCustomToken,
@@ -25,9 +24,8 @@ import {useUpdateAuthLanguageOnChange} from './use-update-auth-language-on-chang
 import {useFetchIdTokenWithCustomClaims} from './use-fetch-id-token-with-custom-claims';
 import Bugsnag from '@bugsnag/react-native';
 import isEqual from 'lodash.isequal';
-import {mapAuthenticationType} from '@atb/auth/utils';
-import {useQueryClient} from '@tanstack/react-query';
-import {useClearQueriesOnUserChange} from "@atb/auth/use-clear-queries-on-user-change";
+import {mapAuthenticationType} from './utils';
+import {useClearQueriesOnUserChange} from './use-clear-queries-on-user-change';
 
 export type AuthReducerState = {
   authStatus: AuthStatus;

--- a/src/auth/use-clear-queries-on-user-change.ts
+++ b/src/auth/use-clear-queries-on-user-change.ts
@@ -1,0 +1,8 @@
+import {useEffect} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
+import {AuthReducerState} from '@atb/auth/AuthContext';
+
+export const useClearQueriesOnUserChange = (state: AuthReducerState) => {
+  const queryClient = useQueryClient();
+  useEffect(() => queryClient.clear(), [state.user?.uid, queryClient]);
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,18 +83,18 @@ export const App = () => {
           <ErrorBoundary type="full-screen">
             <PreferencesContextProvider>
               <LocaleContextProvider>
-                <AuthContextProvider>
-                  <RemoteConfigContextProvider>
-                    <TimeContextProvider>
-                      <AnalyticsContextProvider>
-                        <AccessibilityContextProvider>
-                          <ThemeContextProvider>
-                            <FavoritesContextProvider>
-                              <FiltersContextProvider>
-                                <SearchHistoryContextProvider>
-                                  <FirestoreConfigurationContextProvider>
-                                    <TicketingContextProvider>
-                                      <ReactQueryProvider>
+                <ReactQueryProvider>
+                  <AuthContextProvider>
+                    <RemoteConfigContextProvider>
+                      <TimeContextProvider>
+                        <AnalyticsContextProvider>
+                          <AccessibilityContextProvider>
+                            <ThemeContextProvider>
+                              <FavoritesContextProvider>
+                                <FiltersContextProvider>
+                                  <SearchHistoryContextProvider>
+                                    <FirestoreConfigurationContextProvider>
+                                      <TicketingContextProvider>
                                         <MobileTokenContextProvider>
                                           <AppLanguageProvider>
                                             <GeolocationContextProvider>
@@ -118,18 +118,18 @@ export const App = () => {
                                             </GeolocationContextProvider>
                                           </AppLanguageProvider>
                                         </MobileTokenContextProvider>
-                                      </ReactQueryProvider>
-                                    </TicketingContextProvider>
-                                  </FirestoreConfigurationContextProvider>
-                                </SearchHistoryContextProvider>
-                              </FiltersContextProvider>
-                            </FavoritesContextProvider>
-                          </ThemeContextProvider>
-                        </AccessibilityContextProvider>
-                      </AnalyticsContextProvider>
-                    </TimeContextProvider>
-                  </RemoteConfigContextProvider>
-                </AuthContextProvider>
+                                      </TicketingContextProvider>
+                                    </FirestoreConfigurationContextProvider>
+                                  </SearchHistoryContextProvider>
+                                </FiltersContextProvider>
+                              </FavoritesContextProvider>
+                            </ThemeContextProvider>
+                          </AccessibilityContextProvider>
+                        </AnalyticsContextProvider>
+                      </TimeContextProvider>
+                    </RemoteConfigContextProvider>
+                  </AuthContextProvider>
+                </ReactQueryProvider>
               </LocaleContextProvider>
             </PreferencesContextProvider>
           </ErrorBoundary>

--- a/src/mobile-token/hooks/useListRemoteTokensQuery.tsx
+++ b/src/mobile-token/hooks/useListRemoteTokensQuery.tsx
@@ -10,15 +10,17 @@ import {
 import {Token} from '@atb/mobile-token/types';
 
 import {v4 as uuid} from 'uuid';
+import {useAuthState} from "@atb/auth";
 
 export const LIST_REMOTE_TOKENS_QUERY_KEY = 'listRemoteTokens';
 
 export const useListRemoteTokensQuery = (
   enabled: boolean,
   nativeToken?: ActivatedToken,
-) =>
-  useQuery({
-    queryKey: [MOBILE_TOKEN_QUERY_KEY, LIST_REMOTE_TOKENS_QUERY_KEY],
+) => {
+  const {userId} = useAuthState();
+  return useQuery({
+    queryKey: [MOBILE_TOKEN_QUERY_KEY, LIST_REMOTE_TOKENS_QUERY_KEY, userId],
     queryFn: () => tokenService.listTokens(uuid()),
     enabled,
     select: (tokens) =>
@@ -32,3 +34,4 @@ export const useListRemoteTokensQuery = (
         }),
       ),
   });
+};

--- a/src/mobility/queries/use-fare-product-benefits-query.tsx
+++ b/src/mobility/queries/use-fare-product-benefits-query.tsx
@@ -1,15 +1,19 @@
 import {useQuery} from '@tanstack/react-query';
 import {PreassignedFareProductId} from '@atb/configuration/types';
 import {getFareProductBenefits} from '@atb/mobility/api/api';
+import {useAuthState} from '@atb/auth';
 
 const ONE_HOUR = 1000 * 60 * 60;
 
 export const useFareProductBenefitsQuery = (
   productId: PreassignedFareProductId | undefined,
-) =>
-  useQuery({
-    queryKey: ['fare-product-benefits', {productId}],
+) => {
+  const {userId, authStatus} = useAuthState();
+  return useQuery({
+    queryKey: ['fare-product-benefits', userId, productId],
     queryFn: () => (productId ? getFareProductBenefits(productId) : []),
     staleTime: ONE_HOUR,
     cacheTime: ONE_HOUR,
+    enabled: authStatus === 'authenticated',
   });
+};

--- a/src/mobility/queries/use-user-benefits-query.tsx
+++ b/src/mobility/queries/use-user-benefits-query.tsx
@@ -1,5 +1,6 @@
 import {useQuery} from '@tanstack/react-query';
 import {getBenefitsForUser} from '@atb/mobility/api/api';
+import {useAuthState} from '@atb/auth';
 
 // Caching user benefits for one minute will provide some performance gains, as benefits do not have to be
 // reloaded while the user is navigating in the map and clicking different vehicles or stations.
@@ -7,11 +8,13 @@ import {getBenefitsForUser} from '@atb/mobility/api/api';
 // ticket that is eligible for benefits.
 const ONE_MINUTE = 1000 * 60;
 
-export const useUserBenefitsQuery = (enabled: boolean) =>
-  useQuery({
-    queryKey: ['mobilityUserBenefits'],
+export const useUserBenefitsQuery = (enabled: boolean) => {
+  const {userId, authStatus} = useAuthState();
+  return useQuery({
+    queryKey: ['mobilityUserBenefits', userId],
     queryFn: getBenefitsForUser,
     staleTime: ONE_MINUTE,
     cacheTime: ONE_MINUTE,
-    enabled,
+    enabled: enabled && authStatus === 'authenticated',
   });
+};

--- a/src/mobility/queries/use-value-code-query.tsx
+++ b/src/mobility/queries/use-value-code-query.tsx
@@ -1,8 +1,12 @@
 import {useQuery} from '@tanstack/react-query';
 import {getValueCode} from '@atb/mobility/api/api';
+import {useAuthState} from '@atb/auth';
 
-export const useValueCodeQuery = (operatorId: string | undefined) =>
-  useQuery({
-    queryKey: ['mobilityValueCode', operatorId],
+export const useValueCodeQuery = (operatorId: string | undefined) => {
+  const {userId, authStatus} = useAuthState();
+  return useQuery({
+    queryKey: ['mobilityValueCode', userId, operatorId],
     queryFn: () => getValueCode(operatorId),
+    enabled: authStatus === 'authenticated',
   });
+};

--- a/src/notifications/use-notification-config.tsx
+++ b/src/notifications/use-notification-config.tsx
@@ -4,19 +4,23 @@ import {
   NotificationConfigUpdate,
   updateNotificationConfig,
 } from './api';
+import {useAuthState} from '@atb/auth';
+
+const QUERY_PARENT_KEY = 'notification/config';
 
 export const useNotificationConfig = () => {
   const queryClient = useQueryClient();
+  const {authStatus, userId} = useAuthState();
 
-  const queryKey = ['notification/config'];
   const query = useQuery({
-    queryKey,
+    queryKey: [QUERY_PARENT_KEY, userId],
     queryFn: getNotificationConfig,
+    enabled: authStatus === 'authenticated',
   });
   const mutation = useMutation({
     mutationFn: (update: NotificationConfigUpdate) =>
       updateNotificationConfig(update),
-    onSuccess: () => queryClient.invalidateQueries(queryKey),
+    onSuccess: () => queryClient.invalidateQueries([QUERY_PARENT_KEY]),
   });
 
   return {query, mutation};

--- a/src/queries/get-profile-query.ts
+++ b/src/queries/get-profile-query.ts
@@ -1,10 +1,13 @@
 import {useQuery} from '@tanstack/react-query';
 import {getProfile} from '@atb/api';
+import {useAuthState} from '@atb/auth';
 
 export const getProfileQueryKey = 'getProfile';
 export const useProfileQuery = () => {
+  const {userId, authStatus} = useAuthState();
   return useQuery({
-    queryKey: [getProfileQueryKey],
+    queryKey: [getProfileQueryKey, userId],
     queryFn: getProfile,
+    enabled: authStatus === 'authenticated',
   });
 };

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -11,7 +11,7 @@ import {
   useNavigationContainerRef,
 } from '@react-navigation/native';
 import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
-import React, {useEffect} from 'react';
+import React from 'react';
 import {StatusBar} from 'react-native';
 import {Host} from 'react-native-portalize';
 import {Root_TabNavigatorStack} from './Root_TabNavigatorStack';
@@ -66,8 +66,6 @@ import {Root_TicketInformationScreen} from '@atb/stacks-hierarchy/Root_TicketInf
 import {Root_ChooseTicketReceiverScreen} from '@atb/stacks-hierarchy/Root_ChooseTicketReceiverScreen';
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
 import {useOnboardingFlow} from '@atb/onboarding';
-import {useQueryClient} from '@tanstack/react-query';
-import {useAuthState} from '@atb/auth';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -80,16 +78,10 @@ export const RootStack = () => {
   const {getInitialNavigationContainerState} = useOnboardingFlow();
   const {theme} = useTheme();
   const navRef = useNavigationContainerRef<RootStackParamList>();
-  const {userId} = useAuthState();
-  const queryClient = useQueryClient();
   useFlipper(navRef);
 
   useBeaconsState();
   useTestIds();
-
-  useEffect(() => {
-    queryClient.invalidateQueries();
-  }, [userId, queryClient]);
 
   if (isLoadingAppState) {
     return null;

--- a/src/ticketing/use-get-fare-products-query.tsx
+++ b/src/ticketing/use-get-fare-products-query.tsx
@@ -1,15 +1,18 @@
-import { useFirestoreConfiguration } from '@atb/configuration';
+import {useFirestoreConfiguration} from '@atb/configuration';
 import {getFareProducts} from '@atb/ticketing';
 import {useQuery} from '@tanstack/react-query';
+import {useAuthState} from '@atb/auth';
 
 const ONE_HOUR_MS = 1000 * 60 * 60;
 
 export const useGetFareProductsQuery = () => {
   const {preassignedFareProducts} = useFirestoreConfiguration();
+  const {userId, authStatus} = useAuthState();
   return useQuery({
     initialData: preassignedFareProducts,
-    queryKey: ['getProducts'],
+    queryKey: ['getProducts', userId],
     queryFn: getFareProducts,
     cacheTime: ONE_HOUR_MS,
+    enabled: authStatus === 'authenticated',
   });
 };


### PR DESCRIPTION
### Background
Inspecting network requests we see that some requests are triggered more times than expected on user change, and some are also triggered before the user account is fully created, giving 401 responses.

The reason for this is that there are race conditions between the use-query hooks and the invalidate queries statement. Invalidating queries on user change was done in the RootStack, meaning that it happened after contexts had triggered based on user change, but before components had triggered based on user change.

This means that when the RootStack triggered invalidation of queries, existing queries was rerun for the old user, since the user isn't updated in the child-components yet. But it is injected with the new id-token in the axios client, which gives 401 since the request is for the old user, but with the id-token for the new user.

### Solution
Instead of invalidating queries, which makes the immediately refetch,
the query cache is instead cleared on user change. Clearing queries
doesn't automatically refetch them, so queries that should be
refetched after user change needs to have user id in query key.

Also we enable queries after auth status is 'authenticated', as doing
the requests before this gives 401 from the backend.

### Acceptance criteria
- [ ] There should be no requests which responds with 401 after user change
- [ ] Requests which require auth should not be done before the user is authenticated (has id token with custom claims)

### Things to test
- [ ] Touched GET-endpoints:  `/tokens/v4/list`, `/mobility/v1/benefits/${productId}`, `/mobility/benefits`, `/mobility/code/${operatorId}`, `/notification/v1/config`, `/profile/v1`, `product/v1`.
- [ ] All above-mentioned endpoints should be refetched after new user is authenticated. Either immediately, or when opening the appropriate component which needs the data.