### PR TITLE
feat: add auth retry when there is no customer number

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -6,7 +6,7 @@ import {
 } from '@atb/assets/svg/mono-icons/tab-bar';
 import {MapPin} from '../../assets/svg/mono-icons/map';
 import {ThemeText} from '@atb/components/text';
-import {ThemeIcon} from '@atb/components/theme-icon';
+import {ThemeIcon, ThemeIconProps} from '@atb/components/theme-icon';
 import {usePreferenceItems} from '@atb/preferences';
 import {TabNav_DashboardStack} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack';
 import {TabNav_DeparturesStack} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack';
@@ -29,6 +29,7 @@ import {useOnPushNotificationOpened} from '@atb/notifications';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '../navigation-types';
 import {useOnboardingFlow, useOnboardingNavigation} from '@atb/onboarding';
+import {useAuthState} from '@atb/auth';
 
 const Tab = createBottomTabNavigator<TabNavigatorStackParams>();
 
@@ -44,6 +45,7 @@ export const Root_TabNavigatorStack = () => {
 
   const {nextOnboardingSection} = useOnboardingFlow(true); // assumeUserCreationOnboarded true to ensure outdated userCreationOnboarded value not used
   const {goToScreen} = useOnboardingNavigation();
+  const {customerNumber} = useAuthState();
 
   useEffect(() => {
     if (!navigation.isFocused()) return; // only show onboarding screens from Root_TabNavigatorStack path
@@ -122,6 +124,7 @@ export const Root_TabNavigatorStack = () => {
           Profile,
           lineHeight,
           'profileTab',
+          customerNumber === undefined ? {color: 'error'} : undefined,
         )}
       />
     </Tab.Navigator>
@@ -148,6 +151,7 @@ function tabSettings(
   Icon: (svg: SvgProps) => JSX.Element,
   lineHeight: number,
   testID: string,
+  notification?: ThemeIconProps['notification'],
 ): TabSettings {
   return {
     tabBarLabel: ({color}) => (
@@ -160,6 +164,8 @@ function tabSettings(
         {tabBarLabel}
       </ThemeText>
     ),
-    tabBarIcon: ({color}) => <ThemeIcon svg={Icon} fill={color} />,
+    tabBarIcon: ({color}) => (
+      <ThemeIcon svg={Icon} fill={color} notification={notification} />
+    ),
   };
 }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -94,6 +94,8 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const isPushNotificationsEnabled = usePushNotificationsEnabled();
   const {isBeaconsSupported} = useBeaconsState();
 
+  const {logEvent} = useAnalytics();
+
   const {open: openBottomSheet} = useBottomSheet();
   async function selectFavourites() {
     openBottomSheet(() => {
@@ -145,7 +147,10 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               message={t(ProfileTexts.sections.account.infoItems.claimsError)}
               messageType="error"
               onPressConfig={{
-                action: retryAuth,
+                action: () => {
+                  logEvent('Profile', 'Retry fetching id token');
+                  retryAuth();
+                },
                 text: t(dictionary.retry),
               }}
             />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -26,7 +26,7 @@ import {useLocalConfig} from '@atb/utils/use-local-config';
 import Bugsnag from '@bugsnag/react-native';
 import {IS_QA_ENV} from '@env';
 import parsePhoneNumber from 'libphonenumber-js';
-import React, {useEffect} from 'react';
+import React from 'react';
 import {Linking, View} from 'react-native';
 import {getBuildNumber, getVersion} from 'react-native-device-info';
 import {ProfileScreenProps} from './navigation-types';
@@ -106,14 +106,6 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
       );
     });
   }
-
-  useEffect(() => {
-    if (authStatus === 'fetching-id-token') {
-      setIsLoading(true);
-    } else {
-      setIsLoading(false);
-    }
-  }, [authStatus, setIsLoading]);
 
   return (
     <FullScreenView
@@ -551,7 +543,9 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
           )}
         </View>
       </View>
-      {isLoading && <ActivityIndicatorOverlay />}
+      {(isLoading || authStatus === 'fetching-id-token') && (
+        <ActivityIndicatorOverlay />
+      )}
     </FullScreenView>
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -16,6 +16,7 @@ import {
   useHasReservationOrActiveFareContract,
 } from '@atb/ticketing';
 import {
+  dictionary,
   getTextForLanguage,
   ProfileTexts,
   useTranslation,
@@ -25,7 +26,7 @@ import {useLocalConfig} from '@atb/utils/use-local-config';
 import Bugsnag from '@bugsnag/react-native';
 import {IS_QA_ENV} from '@env';
 import parsePhoneNumber from 'libphonenumber-js';
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Linking, View} from 'react-native';
 import {getBuildNumber, getVersion} from 'react-native-device-info';
 import {ProfileScreenProps} from './navigation-types';
@@ -64,6 +65,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
     phoneNumber: authPhoneNumber,
     customerNumber,
     retryAuth,
+    authStatus,
   } = useAuthState();
   const config = useLocalConfig();
   const {customerProfile} = useTicketingState();
@@ -105,6 +107,14 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
     });
   }
 
+  useEffect(() => {
+    if (authStatus === 'fetching-id-token') {
+      setIsLoading(true);
+    } else {
+      setIsLoading(false);
+    }
+  }, [authStatus, setIsLoading]);
+
   return (
     <FullScreenView
       headerProps={{
@@ -143,14 +153,8 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               message={t(ProfileTexts.sections.account.infoItems.claimsError)}
               messageType="error"
               onPressConfig={{
-                action: async () => {
-                  setIsLoading(true);
-                  await retryAuth();
-                  setIsLoading(false);
-                },
-                text: t(
-                  ProfileTexts.sections.account.infoItems.claimsErrorAction,
-                ),
+                action: retryAuth,
+                text: t(dictionary.retry),
               }}
             />
           )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -34,6 +34,7 @@ import {useIsLoading} from '@atb/utils/use-is-loading';
 import {
   GenericSectionItem,
   LinkSectionItem,
+  MessageSectionItem,
   Section,
 } from '@atb/components/sections';
 
@@ -62,6 +63,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
     signOut,
     phoneNumber: authPhoneNumber,
     customerNumber,
+    retryAuth,
   } = useAuthState();
   const config = useLocalConfig();
   const {customerProfile} = useTicketingState();
@@ -123,7 +125,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               </ThemeText>
             </GenericSectionItem>
           )}
-          {customerNumber && (
+          {customerNumber ? (
             <GenericSectionItem>
               <ThemeText style={style.customerNumberHeading}>
                 {t(ProfileTexts.sections.account.infoItems.customerNumber)}
@@ -136,6 +138,21 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 {customerNumber}
               </ThemeText>
             </GenericSectionItem>
+          ) : (
+            <MessageSectionItem
+              message={t(ProfileTexts.sections.account.infoItems.claimsError)}
+              messageType="error"
+              onPressConfig={{
+                action: async () => {
+                  setIsLoading(true);
+                  await retryAuth();
+                  setIsLoading(false);
+                },
+                text: t(
+                  ProfileTexts.sections.account.infoItems.claimsErrorAction,
+                ),
+              }}
+            />
           )}
 
           {authenticationType == 'phone' && (

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -47,9 +47,9 @@ const ProfileTexts = {
         customerNumber: _('Kundenummer', 'Customer number', 'Kundenummer'),
         phoneNumber: _('Telefonnummer', 'Phone number', 'Telefonnummer'),
         claimsError: _(
-          'Det oppstod et problem med lasting av kontoen din. Trykk for å prøve igjen, eller kontakt kundeservice hvis problemet vedvarer.',
-          'There was a problem loading your account. Tap to try again, or contact customer service if the problem persists.',
-          'Det oppstod eit problem med lasting av kontoen din. Trykk for å prøve igjen, eller kontakt kundeservice hvis problemet blir verande.',
+          'Det oppstod et problem med lasting av kontoen din. Trykk for å laste inn på nytt, eller kontakt kundeservice hvis problemet vedvarer.',
+          'There was a problem loading your account. Tap to reload, or contact customer service if the problem persists.',
+          'Det oppstod eit problem med lasting av kontoen din. Trykk for å laste inn på nytt, eller kontakt kundeservice hvis problemet blir verande.',
         ),
       },
     },

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -46,6 +46,12 @@ const ProfileTexts = {
       infoItems: {
         customerNumber: _('Kundenummer', 'Customer number', 'Kundenummer'),
         phoneNumber: _('Telefonnummer', 'Phone number', 'Telefonnummer'),
+        claimsError: _(
+          'Det oppstod et problem med lasting av kontoen din. Trykk for å prøve igjen, eller kontakt kundeservice hvis problemet vedvarer.',
+          'There was a problem loading your account. Tap to try again, or contact customer service if the problem persists.',
+          'Det oppstod eit problem med lasting av kontoen din. Trykk for å prøve igjen, eller kontakt kundeservice hvis problemet blir verande.',
+        ),
+        claimsErrorAction: _('Prøv igjen', 'Try again', 'Prøv igjen'),
       },
     },
     newFeatures: {

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -51,7 +51,6 @@ const ProfileTexts = {
           'There was a problem loading your account. Tap to try again, or contact customer service if the problem persists.',
           'Det oppstod eit problem med lasting av kontoen din. Trykk for å prøve igjen, eller kontakt kundeservice hvis problemet blir verande.',
         ),
-        claimsErrorAction: _('Prøv igjen', 'Try again', 'Prøv igjen'),
       },
     },
     newFeatures: {


### PR DESCRIPTION
Made while investigating https://github.com/AtB-AS/kundevendt/issues/17733

- Added message section item if there is no customer number, with action to retry auth.
- Added a red notification dot if there the message box is there, to make it more discoverable. 
- Retries are logged to posthog

ref. https://mittatb.slack.com/archives/CSFC6PG23/p1714987182087399

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/cc7bed2a-fd38-429f-8ed0-5cbb09f594d5">

### Acceptance criteria

Not sure how easy this is to test, but

- [ ] For an account without claims / customer number, the error message shows up on my profile
- [ ] The message doesn't normally show up when logging in and out
- [ ] The red dot shows up at the same time as the error message
- [ ] Retries are logged to posthog