### PR TITLE
fix: init intercom user creation regardless of login status

### DIFF
--- a/src/onboarding/OnboardingContext.tsx
+++ b/src/onboarding/OnboardingContext.tsx
@@ -8,7 +8,6 @@ import React, {
   useReducer,
 } from 'react';
 import RNBootSplash from 'react-native-bootsplash';
-import {register as registerChatUser} from '../chat/user';
 import {storage} from '@atb/storage';
 
 import {

--- a/src/onboarding/OnboardingContext.tsx
+++ b/src/onboarding/OnboardingContext.tsx
@@ -134,13 +134,7 @@ export const OnboardingContextProvider: React.FC = ({children}) => {
         ),
       );
 
-      if (
-        loadedOnboardingSections.find(
-          (lOS) => lOS.onboardingSectionId === 'userCreation',
-        )?.isOnboarded
-      ) {
-        registerChatUser();
-      }
+      registerChatUser();
 
       dispatch({
         type: 'LOAD_ONBOARDING_SETTINGS',

--- a/src/onboarding/OnboardingContext.tsx
+++ b/src/onboarding/OnboardingContext.tsx
@@ -134,8 +134,6 @@ export const OnboardingContextProvider: React.FC = ({children}) => {
         ),
       );
 
-      registerChatUser();
-
       dispatch({
         type: 'LOAD_ONBOARDING_SETTINGS',
         loadedOnboardingSections,

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -68,6 +68,7 @@ import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
 import {useOnboardingFlow} from '@atb/onboarding';
 import {useQueryClient} from '@tanstack/react-query';
 import {useAuthState} from '@atb/auth';
+import {register as registerChatUser} from '@atb/chat/user';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -90,6 +91,11 @@ export const RootStack = () => {
   useEffect(() => {
     queryClient.invalidateQueries();
   }, [userId, queryClient]);
+
+  // init Intercom user
+  useEffect(() => {
+    registerChatUser();
+  }, []);
 
   if (isLoadingAppState) {
     return null;


### PR DESCRIPTION
followup for issue in https://github.com/AtB-AS/kundevendt/issues/2269

If we use anonymous user, the `registerChatUser()` function doesn't get called, seems like the `userCreation` onboarding was not called for whatever reason :

```
       loadedOnboardingSections.find(
          (lOS) => lOS.onboardingSectionId === 'userCreation',
        )?.isOnboarded
```

so the solution is just to create the chat user regardless of whether the onboarding is done or not, since we don't use any data from the user anyways. Here's the snippet of the `registerChatUser()` function: 

```
export async function register() {
  await Intercom.loginUnidentifiedUser();
  await Intercom.setBottomPadding(Platform.OS === 'ios' ? 40 : 80);

  const installId = await storage.get('install_id');
  const buildNumber = DeviceInfo.getBuildNumber();
  const deviceId = DeviceInfo.getDeviceId();
  const isLocationEnabled = await DeviceInfo.isLocationEnabled();
  const appLocationStatus = await checkGeolocationPermission();
  const {width, height} = Dimensions.get('window');

  await updateMetadata({
    'AtB-Install-Id': installId ?? 'unknown',
    'AtB-Build-Number': buildNumber,
    'AtB-Device-Type': deviceId,
    'AtB-Device-Location-Enabled': isLocationEnabled,
    'AtB-App-Location-Status': appLocationStatus,
    'AtB-Platform-OS': Platform.OS,
    'AtB-OS-Font-Scale': PixelRatio.getFontScale(),
    'AtB-Screen-Size': `${width}x${height}`,
  });
}
```

We can see there that nothing is really tied down to the login status, so it should be safe to init a chat user regardless of the onboarding status.
