### PR TITLE
build: use source maps from generated folder instead of intermediates

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -392,7 +392,7 @@ platform :android do
     sh("cp", "../android/app/build/outputs/apk/#{app_flavor}/#{build_type}/app-#{app_flavor}-#{build_type}.apk", "../#{ENV["APK_FILE_NAME"]}")
     sh("mkdir", "-p", "../bundle")
     sh("cp", "../android/app/build/generated/assets/createBundle#{app_flavor.capitalize}#{build_type.capitalize}JsAndAssets/index.android.bundle", "../bundle")
-    sh("cp", "../android/app/build/intermediates/sourcemaps/react/#{app_flavor}#{build_type.capitalize}/index.android.bundle.packager.map", "../bundle/index.android.bundle.map")
+    sh("cp", "../android/app/build/generated/sourcemaps/react/#{app_flavor}#{build_type.capitalize}/index.android.bundle.map", "../bundle/index.android.bundle.map")
   end
 
   lane :build_aab do
@@ -417,7 +417,7 @@ platform :android do
       sh("cp", "../android/app/build/outputs/bundle/#{app_flavor}#{build_type.capitalize}/app-#{app_flavor}-#{build_type}.aab", "../#{ENV["AAB_FILE_NAME"]}")
       sh("mkdir", "-p", "../bundle")
       sh("cp", "../android/app/build/generated/assets/createBundle#{app_flavor.capitalize}#{build_type.capitalize}JsAndAssets/index.android.bundle", "../bundle")
-      sh("cp", "../android/app/build/intermediates/sourcemaps/react/#{app_flavor}#{build_type.capitalize}/index.android.bundle.packager.map", "../bundle/index.android.bundle.map")
+      sh("cp", "../android/app/build/generated/sourcemaps/react/#{app_flavor}#{build_type.capitalize}/index.android.bundle.map", "../bundle/index.android.bundle.map")
   end
 
   lane :firebase_distribution_staging do


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/16314

The source maps from the generated folder seems to be "less wrong" than from intermediates, so updating to use them instead. We might see stack traces point to the wrong part of the code, but while looking for solutions to the Bugsnag issues, that's more helpful than the stream of random characters we have from before 😅