### PR TITLE
test: test-id for rental bikes in travel search

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
@@ -53,7 +53,11 @@ export const NonTransitResults = ({tripPatterns, onDetailsPressed}: Props) => {
             leftIcon={{svg: getTransportModeSvg(mode).svg}}
             rightIcon={{svg: arrowRight}}
             accessibilityLabel={`${modeText} ${duration}`}
-            testID={`${mode}Result`}
+            testID={
+              tripPattern.legs.some((leg) => leg.rentedBike)
+                ? 'rentalResult'
+                : `${mode}Result`
+            }
           />
         );
       })}


### PR DESCRIPTION
Change testId for rental bike suggestions in the travel search. To distinguish between `rentalResult` and `bicycleResult`. In addition we have `footResult`. Easier to hit the correct testId.