### PR TITLE
chore: remove metro warning for non-serializable values on navigation

### DIFF
--- a/src/stacks-hierarchy/Root_LoginActiveFareContractWarningScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginActiveFareContractWarningScreen.tsx
@@ -14,7 +14,6 @@ import {
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {useTimeContextState} from '@atb/time';
-import {TransitionPresets} from '@react-navigation/stack';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
 
@@ -42,9 +41,7 @@ export const Root_LoginActiveFareContractWarningScreen = ({
         showGoBack: true,
       });
     } else {
-      navigation.navigate('Root_LoginPhoneInputScreen', {
-        transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
-      });
+      navigation.navigate('Root_LoginPhoneInputScreen');
     }
   };
 

--- a/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
@@ -14,7 +14,6 @@ import {useTextForLanguage} from '@atb/translations/utils';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
-import {TransitionPresets} from '@react-navigation/stack';
 import {useHasReservationOrActiveFareContract} from '@atb/ticketing';
 
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
@@ -36,14 +35,11 @@ export const Root_LoginRequiredForFareProductScreen = ({
 
   const onNext = async () => {
     if (hasReservationOrActiveFareContract) {
-      navigation.navigate('Root_LoginActiveFareContractWarningScreen', {
-        transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
-      });
+      navigation.navigate('Root_LoginActiveFareContractWarningScreen');
     } else {
       if (enable_vipps_login) {
         navigation.navigate('Root_LoginOptionsScreen', {
           showGoBack: true,
-          transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
         });
       } else {
         navigation.navigate('Root_LoginPhoneInputScreen', {});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -46,7 +46,6 @@ import {useBeaconsState} from '@atb/beacons/BeaconsContext';
 import {useStorybookContext} from '@atb/storybook/StorybookContext';
 import {ContentHeading} from '@atb/components/heading';
 import {FullScreenView} from '@atb/components/screen-view';
-import {TransitionPresets} from '@react-navigation/stack';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -196,8 +196,6 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   } else if (enable_vipps_login) {
                     navigation.navigate('Root_LoginOptionsScreen', {
                       showGoBack: true,
-                      transitionPreset:
-                        TransitionPresets.ModalSlideFromBottomIOS,
                     });
                   } else {
                     navigation.navigate('Root_LoginPhoneInputScreen', {});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -21,7 +21,6 @@ import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places'
 import {TariffZone} from '@atb/configuration';
 import {ThemeText} from '@atb/components/text';
 import {TicketingTexts, useTranslation} from '@atb/translations';
-import {TransitionPresets} from '@react-navigation/stack';
 import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
 
 type Props = TicketTabNavScreenProps<'TicketTabNav_PurchaseTabScreen'>;
@@ -43,7 +42,8 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const {tokens, mobileTokenStatus} = useMobileTokenContextState();
   const inspectableToken = tokens.find((t) => t.isInspectable);
   const hasInspectableMobileToken = inspectableToken?.type === 'mobile';
-  const hasMobileTokenError = mobileTokenStatus === 'fallback' || mobileTokenStatus === 'error';
+  const hasMobileTokenError =
+    mobileTokenStatus === 'fallback' || mobileTokenStatus === 'error';
   const harborsQuery = useHarborsQuery();
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
@@ -159,7 +159,6 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
                 'Root_PurchaseAsAnonymousConsequencesScreen',
                 {
                   showLoginButton: true,
-                  transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
                 },
               )
             }


### PR DESCRIPTION
Not related to any issues.

Found the issue during the debugging of loading boundary and tried to logout-login multiple times to test mobile token.

This PR will remove the console warning when you select "Log in" from profile screen, the warning is: 

`Non-serializable values were found in the navigation state`

I removed the `transitionPreset` from navigation call and the warning no longer shows, and tested on both simulator and emulator, the animation still works fine.