### PR TITLE
fix: Loading boundary based on derived state

### DIFF
--- a/src/loading-screen/__tests__/use-loading-state.test.ts
+++ b/src/loading-screen/__tests__/use-loading-state.test.ts
@@ -88,6 +88,7 @@ describe('useLoadingState', () => {
     };
     const hook = renderHook(() => useLoadingState(100));
     expect(hook.result.current.status).toBe('success');
+    expect(hook.result.all.length).toBe(1); // Should not return once with state 'loading' on first render
   });
 
   it('Should go from loading to success', async () => {


### PR DESCRIPTION
### Background
Found after investingating https://github.com/AtB-AS/mittatb-app/pull/4476#issuecomment-2100058427

The reason for the multiple calls to the lookup endpoint was that the user id was changed, while the loading boundary hadn't kicked in yet and the old tickets where still rendered. This means that every rendered ticket would be considered sent-to-others since customer id on ticket wasn't the same as the user id from Auth, which made the app try to look up the phone numbers.

The issue could be observed by logging user id and loading state in the `LoadingScreenBoundary`.

Added:
```ts
useEffect(() => {
  console.log(userId, status);
}, [userId, status]);
```

Logs on user change:
```
LOG  x2ZdOrOXdgMg2OQv27bJ8K6xPmz1 success <-- Old user
LOG  gZoYiLYEBjccfHOHPny4s0ZBsJp1 success <-- User change, but with outdated loading state 'success'
LOG  gZoYiLYEBjccfHOHPny4s0ZBsJp1 loading <-- Here the loading boundary kicks in
LOG  gZoYiLYEBjccfHOHPny4s0ZBsJp1 success
```

A blog post describing the problem:
https://julvo.com/posts/react/derived-state/

### Solution
In the old implementation the loading state had its own React
state, but setting it triggered another render cycle before the
actual status was updated and the loading boundary kicked in. This
means that components and hooks triggering on user id change did
kick in once before the loading boundary took over.

With the new implementation the loading state is derived directly
from the parameters, and won't cause an unnecessary render cycle.

After this change the logs are like these:
Logs on user change:
```
 LOG  x2ZdOrOXdgMg2OQv27bJ8K6xPmz1 success <-- Old user
 LOG  af46PnzrV2eENjQqGk8D4MapnVx2 loading <-- User change, straight to 'loading' state and loading boundary kicks in
 LOG  af46PnzrV2eENjQqGk8D4MapnVx2 success
```

### Acceptance criteria
- [ ] Directly after user change there should be no requests to the `/profile/v1/lookup` endpoint.