### PR TITLE
fix: use correct text color on UnknownProvider icon

### DIFF
--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ProviderLogo.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ProviderLogo.tsx
@@ -48,7 +48,9 @@ const UnknownProvider = ({height, width}: {height: number; width: number}) => {
         justifyContent: 'center',
       }}
     >
-      <ThemeText type="body__primary--big--bold">?</ThemeText>
+      <ThemeText type="body__primary--big--bold" color="background_accent_0">
+        ?
+      </ThemeText>
     </View>
   );
 };


### PR DESCRIPTION
Fixes some bad contrast in light mode. ([Previously it looked like this](https://mittatb.slack.com/archives/C0116FMPX4Y/p1715598607170289?thread_ts=1715346138.109749&cid=C0116FMPX4Y))

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/d07b3dfd-25a2-4da7-a4de-69f28803a2f1">
