### PR TITLE
chore: add breadcrumbs to fetching firebase ID token process

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -49,7 +49,7 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
       if (sameUser) {
         return prevState;
       } else {
-        Bugsnag.leaveBreadcrumb('Auth user change', {userId: action.user.uid});
+        Bugsnag.leaveBreadcrumb('Auth user change', {userId: action.user.uid, authType: mapAuthenticationType(action.user)});
         return {user: action.user, authStatus: 'fetching-id-token'};
       }
     }

--- a/src/auth/use-fetch-id-token-with-custom-claims.ts
+++ b/src/auth/use-fetch-id-token-with-custom-claims.ts
@@ -18,6 +18,7 @@ export const useFetchIdTokenWithCustomClaims = (
     if (state.authStatus === 'fetching-id-token') {
       let retryCount = 0;
       const intervalId = setInterval(async () => {
+        Bugsnag.leaveBreadcrumb(`Fetching ID token with Custom Claims`);
         const idToken = await state.user?.getIdTokenResult(!!retryCount); // First try without force refresh from server
         if (idToken?.claims['customer_number']) {
           Bugsnag.leaveBreadcrumb(

--- a/src/auth/use-subscribe-to-auth-user-change.ts
+++ b/src/auth/use-subscribe-to-auth-user-change.ts
@@ -16,6 +16,7 @@ export const useSubscribeToAuthUserChange = (
     let signInInitiated = false;
     const unsubscribe = auth().onAuthStateChanged((user) => {
       if (user) {
+        Bugsnag.leaveBreadcrumb(`Auth state changed, sign-in type : ${mapAuthenticationType(user)}`);
         updateMetadata({
           'AtB-Firebase-Auth-Id': user?.uid,
           'AtB-Auth-Type': mapAuthenticationType(user),
@@ -27,6 +28,7 @@ export const useSubscribeToAuthUserChange = (
         subscription did not include user data. In other words, user was not
         previously signed in.
          */
+        Bugsnag.leaveBreadcrumb('Signing-in anonymously');
         auth()
           .signInAnonymously()
           .then(() => {

--- a/src/auth/use-subscribe-to-auth-user-change.ts
+++ b/src/auth/use-subscribe-to-auth-user-change.ts
@@ -16,7 +16,6 @@ export const useSubscribeToAuthUserChange = (
     let signInInitiated = false;
     const unsubscribe = auth().onAuthStateChanged((user) => {
       if (user) {
-        Bugsnag.leaveBreadcrumb(`Auth state changed, sign-in type : ${mapAuthenticationType(user)}`);
         updateMetadata({
           'AtB-Firebase-Auth-Id': user?.uid,
           'AtB-Auth-Type': mapAuthenticationType(user),


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17734

Adds some breadcrumbs for clearer logging of bugsnag errors. Right now we only have these logs on `Loading boundary timeout` issue, which aren't very helpful:

<img width="500" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/4280b644-5729-4fe1-9bd9-ad2d9a37faf0" />

We are adding some more breadcrumbs to see when the actual fetching of id token happens, so we can check during which process the timeout occurs.