### PR TITLE
feat: add activate now button to fare contracts

### DIFF
--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -28,9 +28,11 @@ import {
   isCanBeConsumedNowFareContract,
   isSentOrReceivedFareContract,
   FareContract,
+  isCanBeActivatedNowFareContract,
 } from '@atb/ticketing';
 import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetSectionItem';
 import {StyleSheet} from '@atb/theme';
+import {ActivateNowSectionItem} from './components/ActivateNowSectionItem';
 
 type Props = {
   now: number;
@@ -177,6 +179,9 @@ export const FareContractView: React.FC<Props> = ({
       )}
       {isCanBeConsumedNowFareContract(fareContract, now, currentUserId) && (
         <ConsumeCarnetSectionItem fareContractId={fareContract.id} />
+      )}
+      {isCanBeActivatedNowFareContract(fareContract, now, currentUserId) && (
+        <ActivateNowSectionItem fareContractId={fareContract.id} />
       )}
     </Section>
   );

--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -33,6 +33,7 @@ import {
 import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetSectionItem';
 import {StyleSheet} from '@atb/theme';
 import {ActivateNowSectionItem} from './components/ActivateNowSectionItem';
+import {useIsActivateTicketNowEnabled} from './use-is-activate-now-enabled';
 
 type Props = {
   now: number;
@@ -51,6 +52,7 @@ export const FareContractView: React.FC<Props> = ({
 }) => {
   const {abtCustomerId: currentUserId} = useAuthState();
   const {isInspectable} = useMobileTokenContextState();
+  const isActivateTicketNowEnabled = useIsActivateTicketNowEnabled();
 
   const {t} = useTranslation();
   const styles = useStyles();
@@ -180,9 +182,10 @@ export const FareContractView: React.FC<Props> = ({
       {isCanBeConsumedNowFareContract(fareContract, now, currentUserId) && (
         <ConsumeCarnetSectionItem fareContractId={fareContract.id} />
       )}
-      {isCanBeActivatedNowFareContract(fareContract, now, currentUserId) && (
-        <ActivateNowSectionItem fareContractId={fareContract.id} />
-      )}
+      {isActivateTicketNowEnabled &&
+        isCanBeActivatedNowFareContract(fareContract, now, currentUserId) && (
+          <ActivateNowSectionItem fareContractId={fareContract.id} />
+        )}
     </Section>
   );
 };

--- a/src/fare-contracts/components/ActivateNowBottomSheet.tsx
+++ b/src/fare-contracts/components/ActivateNowBottomSheet.tsx
@@ -9,7 +9,7 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
-import {activateFareContract} from '@atb/ticketing';
+import {activateFareContractNow} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import Bugsnag from '@bugsnag/react-native';
 import React, {useState} from 'react';
@@ -30,7 +30,7 @@ export const ActivateNowBottomSheet = ({fareContractId}: Props) => {
   const onActivate = async () => {
     setIsLoading(true);
     try {
-      await activateFareContract(fareContractId);
+      await activateFareContractNow(fareContractId);
       close();
     } catch (e: any) {
       const errorData = getAxiosErrorMetadata(e);

--- a/src/fare-contracts/components/ActivateNowBottomSheet.tsx
+++ b/src/fare-contracts/components/ActivateNowBottomSheet.tsx
@@ -1,0 +1,91 @@
+import {getAxiosErrorMetadata} from '@atb/api/utils';
+import {Confirm} from '@atb/assets/svg/mono-icons/actions';
+import {
+  BottomSheetContainer,
+  useBottomSheet,
+} from '@atb/components/bottom-sheet';
+import {Button} from '@atb/components/button';
+import {MessageInfoBox} from '@atb/components/message-info-box';
+import {GenericSectionItem, Section} from '@atb/components/sections';
+import {ThemeText} from '@atb/components/text';
+import {StyleSheet} from '@atb/theme';
+import {activateFareContract} from '@atb/ticketing';
+import {FareContractTexts, useTranslation} from '@atb/translations';
+import Bugsnag from '@bugsnag/react-native';
+import React, {useState} from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+
+type Props = {
+  fareContractId: string;
+};
+
+export const ActivateNowBottomSheet = ({fareContractId}: Props) => {
+  const styles = useStyles();
+  const {t} = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<boolean>(false);
+  const {close} = useBottomSheet();
+
+  const onActivate = async () => {
+    setIsLoading(true);
+    try {
+      await activateFareContract(fareContractId);
+      close();
+    } catch (e: any) {
+      const errorData = getAxiosErrorMetadata(e);
+      Bugsnag.notify({
+        name: `${errorData.responseStatus} error when activating fare contract ahead of time`,
+        message: `Error: ${JSON.stringify(errorData)}`,
+      });
+      setError(true);
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <BottomSheetContainer
+      title={t(FareContractTexts.activateNow.bottomSheetTitle)}
+      focusTitleOnLoad={true}
+    >
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.contentContainer}
+      >
+        {error && (
+          <MessageInfoBox
+            message={t(FareContractTexts.activateNow.genericError)}
+            type="error"
+          />
+        )}
+        <Section>
+          <GenericSectionItem type="spacious">
+            <ThemeText>
+              {t(FareContractTexts.activateNow.bottomSheetDescription)}
+            </ThemeText>
+          </GenericSectionItem>
+        </Section>
+        <Button
+          onPress={onActivate}
+          text={t(FareContractTexts.activateNow.confirm)}
+          rightIcon={{svg: Confirm}}
+          loading={isLoading}
+        />
+      </ScrollView>
+    </BottomSheetContainer>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => {
+  const {bottom} = useSafeAreaInsets();
+  return {
+    container: {
+      backgroundColor: theme.static.background.background_1.background,
+      marginHorizontal: theme.spacings.medium,
+      marginBottom: Math.max(bottom, theme.spacings.medium),
+    },
+    contentContainer: {
+      rowGap: theme.spacings.medium,
+    },
+  };
+});

--- a/src/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -1,0 +1,40 @@
+import {TicketValid} from '@atb/assets/svg/mono-icons/ticketing';
+import {useBottomSheet} from '@atb/components/bottom-sheet';
+import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {useTheme} from '@atb/theme';
+import {FareContractTexts, useTranslation} from '@atb/translations';
+import React from 'react';
+import {ActivateNowBottomSheet} from './ActivateNowBottomSheet';
+
+type ActivateNowSectionItemProps = SectionItemProps<{
+  fareContractId: string;
+}>;
+
+export function ActivateNowSectionItem({
+  fareContractId,
+  ...sectionProps
+}: ActivateNowSectionItemProps): JSX.Element {
+  const {t} = useTranslation();
+  const {theme} = useTheme();
+
+  const {open} = useBottomSheet();
+  const onPress = () => {
+    open(() => <ActivateNowBottomSheet fareContractId={fareContractId} />);
+  };
+
+  return (
+    <LinkSectionItem
+      text={t(FareContractTexts.activateNow.startNow)}
+      onPress={onPress}
+      icon={
+        <ThemeIcon
+          svg={TicketValid}
+          fill={theme.interactive.interactive_0.default.text}
+        />
+      }
+      interactiveColor="interactive_0"
+      {...sectionProps}
+    />
+  );
+}

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   FareContract,
+  isCanBeActivatedNowFareContract,
   isCanBeConsumedNowFareContract,
   isPreActivatedTravelRight,
   isSentOrReceivedFareContract,
@@ -47,6 +48,7 @@ import {useOperatorBenefitsForFareProduct} from '@atb/mobility/use-operator-bene
 import {ValidityLine} from '../ValidityLine';
 import {ValidityHeader} from '../ValidityHeader';
 import {ConsumeCarnetSectionItem} from '../components/ConsumeCarnetSectionItem';
+import {ActivateNowSectionItem} from '../components/ActivateNowSectionItem';
 
 type Props = {
   fareContract: FareContract;
@@ -240,6 +242,9 @@ export const DetailsContent: React.FC<Props> = ({
         />
         {isCanBeConsumedNowFareContract(fc, now, currentUserId) && (
           <ConsumeCarnetSectionItem fareContractId={fc.id} />
+        )}
+        {isCanBeActivatedNowFareContract(fc, now, currentUserId) && (
+          <ActivateNowSectionItem fareContractId={fc.id} />
         )}
       </Section>
     );

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -49,6 +49,7 @@ import {ValidityLine} from '../ValidityLine';
 import {ValidityHeader} from '../ValidityHeader';
 import {ConsumeCarnetSectionItem} from '../components/ConsumeCarnetSectionItem';
 import {ActivateNowSectionItem} from '../components/ActivateNowSectionItem';
+import {useIsActivateTicketNowEnabled} from '../use-is-activate-now-enabled';
 
 type Props = {
   fareContract: FareContract;
@@ -72,6 +73,7 @@ export const DetailsContent: React.FC<Props> = ({
   const {t} = useTranslation();
   const styles = useStyles();
   const {findGlobalMessages} = useGlobalMessagesState();
+  const isActivateTicketNowEnabled = useIsActivateTicketNowEnabled();
 
   const {
     isCarnetFareContract,
@@ -243,9 +245,10 @@ export const DetailsContent: React.FC<Props> = ({
         {isCanBeConsumedNowFareContract(fc, now, currentUserId) && (
           <ConsumeCarnetSectionItem fareContractId={fc.id} />
         )}
-        {isCanBeActivatedNowFareContract(fc, now, currentUserId) && (
-          <ActivateNowSectionItem fareContractId={fc.id} />
-        )}
+        {isActivateTicketNowEnabled &&
+          isCanBeActivatedNowFareContract(fc, now, currentUserId) && (
+            <ActivateNowSectionItem fareContractId={fc.id} />
+          )}
       </Section>
     );
   } else {

--- a/src/fare-contracts/use-is-activate-now-enabled.tsx
+++ b/src/fare-contracts/use-is-activate-now-enabled.tsx
@@ -1,0 +1,18 @@
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useDebugOverride} from '@atb/debug';
+import {StorageModelKeysEnum} from '@atb/storage';
+
+export const useIsActivateTicketNowEnabled = () => {
+  const {enable_activate_ticket_now} = useRemoteConfig();
+  const [debugOverride, _, _debugOverrideReady] =
+    useActivateTicketNowEnabledDebugOverride();
+  return debugOverride !== undefined
+    ? debugOverride
+    : enable_activate_ticket_now;
+};
+
+export const useActivateTicketNowEnabledDebugOverride = () => {
+  return useDebugOverride(
+    StorageModelKeysEnum.EnableActivateTicketNowDebugOverride,
+  );
+};

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -60,6 +60,7 @@ export type RemoteConfig = {
    * transaction.
    */
   enable_auto_sale: boolean;
+  enable_activate_ticket_now: boolean;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -120,6 +121,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_posthog: false,
   enable_server_time: true,
   enable_auto_sale: false,
+  enable_activate_ticket_now: false,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -317,6 +319,10 @@ export function getConfig(): RemoteConfig {
     values['enable_auto_sale']?.asBoolean() ??
     defaultRemoteConfig.enable_auto_sale;
 
+  const enable_activate_ticket_now =
+    values['enable_activate_ticket_now']?.asBoolean() ??
+    defaultRemoteConfig.enable_activate_ticket_now;
+
   return {
     enable_ticketing,
     enable_intercom,
@@ -371,6 +377,7 @@ export function getConfig(): RemoteConfig {
     enable_posthog,
     enable_server_time,
     enable_auto_sale,
+    enable_activate_ticket_now,
   };
 }
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -62,6 +62,7 @@ import {usePosthogEnabledDebugOverride} from '@atb/analytics/use-is-posthog-enab
 import {useOnboardingState} from '@atb/onboarding';
 import {useServerTimeEnabledDebugOverride} from '@atb/time';
 import Bugsnag from '@bugsnag/react-native';
+import {useActivateTicketNowEnabledDebugOverride} from '@atb/fare-contracts/use-is-activate-now-enabled';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -130,6 +131,8 @@ export const Profile_DebugInfoScreen = () => {
     useTicketInformationEnabledDebugOverride();
   const posthogEnabledDebugOverride = usePosthogEnabledDebugOverride();
   const serverTimeEnabledDebugOverride = useServerTimeEnabledDebugOverride();
+  const activateTicketNowEnabledDebugOverride =
+    useActivateTicketNowEnabledDebugOverride();
 
   useEffect(() => {
     (async function () {
@@ -443,6 +446,12 @@ export const Profile_DebugInfoScreen = () => {
             <DebugOverride
               description="Enable server time"
               override={serverTimeEnabledDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable activate ticket now"
+              override={activateTicketNowEnabledDebugOverride}
             />
           </GenericSectionItem>
         </Section>

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -27,6 +27,7 @@ export enum StorageModelKeysEnum {
   EnableTicketInformationDebugOverride = '@ATB_enable_ticket_information_debug_override',
   EnablePosthogDebugOverride = '@ATB_enable_posthog_debug_override',
   EnableServerTimeDebugOverride = '@ATB_server_time_debug_override',
+  EnableActivateTicketNowDebugOverride = '@ATB_enable_activate_ticket_now_debug_override',
 }
 
 type StorageModelKeysTypes = keyof typeof StorageModelKeysEnum;

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -93,7 +93,7 @@ export async function consumeCarnet(fareContractId: string) {
   return response.data;
 }
 
-export async function activateFareContract(fareContractId: string) {
+export async function activateFareContractNow(fareContractId: string) {
   const url = `ticket/v4/start-time`;
   const response = await client.put<void>(
     url,

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -93,6 +93,18 @@ export async function consumeCarnet(fareContractId: string) {
   return response.data;
 }
 
+export async function activateFareContract(fareContractId: string) {
+  const url = `ticket/v4/start-time`;
+  const response = await client.put<void>(
+    url,
+    {
+      fareContractId,
+    },
+    {authWithIdToken: true},
+  );
+  return response.data;
+}
+
 type ReserveOfferParams = {
   offers: ReserveOffer[];
   paymentType: PaymentType;

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -89,6 +89,13 @@ export function isValidRightNowFareContract(
   return false;
 }
 
+export function willBeValidInTheFutureTravelRight(
+  travelRight: PreActivatedTravelRight,
+  now: number,
+): boolean {
+  return travelRight.startDateTime.getTime() > now;
+}
+
 export function isSentOrReceivedFareContract(fc: FareContract) {
   return fc.customerAccountId !== fc.purchasedBy;
 }
@@ -191,6 +198,20 @@ export function isCanBeConsumedNowFareContract(
     hasUsableCarnetTravelRight(travelRights, now) &&
     !hasActiveCarnetTravelRight(travelRights, now)
   );
+}
+
+export function isCanBeActivatedNowFareContract(
+  f: FareContract,
+  now: number,
+  currentUserId: string | undefined,
+) {
+  if (f.customerAccountId !== currentUserId) return false;
+  if (!isOrWillBeActivatedFareContract(f)) return false;
+  if (isCarnet(f)) return false;
+  const travelRights = f.travelRights
+    .filter(isPreActivatedTravelRight)
+    .filter((tr) => willBeValidInTheFutureTravelRight(tr, now));
+  return travelRights.length > 0;
 }
 
 export const filterActiveOrCanBeUsedFareContracts = (

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -166,6 +166,25 @@ const FareContractTexts = {
       'Aktivér for å gå til billetinformasjon',
     ),
   },
+  activateNow: {
+    startNow: _('Start billett nå', 'Start ticket now', 'Start billett no'),
+    bottomSheetTitle: _(
+      'Vil du starte billetten?',
+      'Do you want to start the ticket?',
+      'Vil du starte billetten?',
+    ),
+    bottomSheetDescription: _(
+      'Billetten blir gyldig med en gang du starter den.',
+      'The ticket becomes valid immediately after you start it.',
+      'Billetten blir gyldig med ein gong du startar han.',
+    ),
+    confirm: _('Bekreft og start', 'Confirm and start', 'Bekreft og start'),
+    genericError: _(
+      'En feil har oppstått under aktivering av billetten. Vennligst prøv igjen.',
+      'An error occurred while activating the ticket. Please try again.',
+      'Ein feil har oppstått under aktivering av billetten. Ver venleg og prøv igjen.',
+    ),
+  },
   carnet: {
     numberOfUsedAccessesRemaining: (count: number) =>
       _(


### PR DESCRIPTION
Mostly copied over code from carnet activation, but with different texts and making the API call to `ticket/v4/start-time`. 

I send no start time to the back end, so that we don't have to trust the client clock. Default seems to be that it starts immediately. (If that's an ok solution, @adriawh?)

https://github.com/AtB-AS/mittatb-app/assets/1774972/6295f59a-2eb8-4f56-95ab-1ab4b47465df

closes https://github.com/AtB-AS/kundevendt/issues/16878