### PR TITLE
fix(troms): remove "Bike" from traveller extensions

### DIFF
--- a/src/translations/screens/subscreens/TicketTraveller.ts
+++ b/src/translations/screens/subscreens/TicketTraveller.ts
@@ -44,6 +44,13 @@ const SpecificExtensions = orgSpecificTranslations(SpecificExtensionsInternal, {
     periodStudent: _('', '', ''),
     periodSenior: _('', '', ''),
   },
+  troms: {
+    singleChild: _('', '', ''),
+    periodAdult: _('', '', ''),
+    periodChild: _('', '', ''),
+    periodStudent: _('', '', ''),
+    periodSenior: _('', '', ''),
+  },
 });
 
 function specificOverrides(


### PR DESCRIPTION
"Bike" was added as an extension when it should not have been. Removed it and set it to blank, similar to how it's done for both NFK and FRAM.

Closes https://github.com/AtB-AS/kundevendt/issues/18093