### PR TITLE
fix: Clear queries before id token fetch

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -128,10 +128,10 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   const [state, dispatch] = useReducer(authReducer, initialReducerState);
 
   const {resubscribe} = useSubscribeToAuthUserChange(dispatch);
+  useClearQueriesOnUserChange(state);
   useFetchIdTokenWithCustomClaims(state, dispatch);
 
   useUpdateAuthLanguageOnChange();
-  useClearQueriesOnUserChange(state);
 
   const retryAuth = useCallback(() => {
     if (state.authStatus === 'fetch-id-token-timeout') {

--- a/src/auth/use-fetch-id-token-with-custom-claims.ts
+++ b/src/auth/use-fetch-id-token-with-custom-claims.ts
@@ -59,6 +59,7 @@ export const useFetchIdTokenWithCustomClaims = (
   useEffect(() => {
     if (query.error) {
       notifyBugsnag(query.error as any, {
+        errorGroupHash: 'AuthError',
         metadata: {
           description: `No id token with custom claims received after ${RETRY_COUNT} retries`,
         },


### PR DESCRIPTION
Clearing queries on user change was introduced on master branch,
while using react-query for id token fetch was introduced on
release branch. When these two merged, the clearing of queries
happened after id token fetch, which led to errors.
