### PR TITLE
chore: upgrade atb-as/theme package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.23.0",
     "@atb-as/generate-assets": "^10.1.1",
-    "@atb-as/theme": "^8.1.0",
+    "@atb-as/theme": "^8.2.1",
     "@bugsnag/react-native": "^7.21.0",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-barcode-javascript-lib": "1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,14 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
+"@atb-as/theme@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-8.2.1.tgz#82a60be93d5d72c29c01fe7954faca02d0b9d4a5"
+  integrity sha512-yy2G1nOaqeWNmRu/leA+QWoY/rN3A0eG7+X6b7f3dupALPOgffn0r9NG/qqzkBhVxZV1f9rTI8wpSoiGVV2blA==
+  dependencies:
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"


### PR DESCRIPTION
This updates the @atb-as/theme package to 8.2.1 that includes the new Svipper-colors 🎉 

![image](https://github.com/AtB-AS/mittatb-app/assets/43166974/3503af9a-928f-4491-ad05-6dec77f89bf6)

Part of closing https://github.com/AtB-AS/kundevendt/issues/8280