### PR TITLE
fix: rework intercom registration for the new package

### DIFF
--- a/src/chat/use-register-intercom-user.ts
+++ b/src/chat/use-register-intercom-user.ts
@@ -32,10 +32,8 @@ async function register() {
 export function useRegisterIntercomUser() {
   useEffect(() => {
     storage.get(StorageModelKeysEnum.IntercomUserRegistered).then((it) => {
-      console.log('Intercom storage', it);
       if (it !== 'true') {
         register().then(() => {
-          console.log('Intercom registration done');
           storage.set(StorageModelKeysEnum.IntercomUserRegistered, 'true');
         });
       }

--- a/src/chat/use-register-intercom-user.ts
+++ b/src/chat/use-register-intercom-user.ts
@@ -1,11 +1,12 @@
 import Intercom from '@intercom/intercom-react-native';
 import {Dimensions, PixelRatio, Platform} from 'react-native';
 import DeviceInfo from 'react-native-device-info';
-import {storage} from '@atb/storage';
+import {StorageModelKeysEnum, storage} from '@atb/storage';
 import {checkGeolocationPermission} from '@atb/GeolocationContext';
 import {updateMetadata} from './metadata';
+import {useEffect} from 'react';
 
-export async function register() {
+async function register() {
   await Intercom.loginUnidentifiedUser();
   await Intercom.setBottomPadding(Platform.OS === 'ios' ? 40 : 80);
 
@@ -26,4 +27,18 @@ export async function register() {
     'AtB-OS-Font-Scale': PixelRatio.getFontScale(),
     'AtB-Screen-Size': `${width}x${height}`,
   });
+}
+
+export function useRegisterIntercomUser() {
+  useEffect(() => {
+    storage.get(StorageModelKeysEnum.IntercomUserRegistered).then((it) => {
+      console.log('Intercom storage', it);
+      if (it !== 'true') {
+        register().then(() => {
+          console.log('Intercom registration done');
+          storage.set(StorageModelKeysEnum.IntercomUserRegistered, 'true');
+        });
+      }
+    });
+  }, []);
 }

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -11,7 +11,7 @@ import {
   useNavigationContainerRef,
 } from '@react-navigation/native';
 import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
-import React, {useEffect} from 'react';
+import React from 'react';
 import {StatusBar} from 'react-native';
 import {Host} from 'react-native-portalize';
 import {Root_TabNavigatorStack} from './Root_TabNavigatorStack';
@@ -66,7 +66,7 @@ import {Root_TicketInformationScreen} from '@atb/stacks-hierarchy/Root_TicketInf
 import {Root_ChooseTicketReceiverScreen} from '@atb/stacks-hierarchy/Root_ChooseTicketReceiverScreen';
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
 import {useOnboardingFlow} from '@atb/onboarding';
-import {register as registerChatUser} from '@atb/chat/user';
+import {useRegisterIntercomUser} from '@atb/chat/use-register-intercom-user';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -85,9 +85,7 @@ export const RootStack = () => {
   useTestIds();
 
   // init Intercom user
-  useEffect(() => {
-    registerChatUser();
-  }, []);
+  useRegisterIntercomUser();
 
   if (isLoadingAppState) {
     return null;

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -28,6 +28,7 @@ export enum StorageModelKeysEnum {
   EnablePosthogDebugOverride = '@ATB_enable_posthog_debug_override',
   EnableServerTimeDebugOverride = '@ATB_server_time_debug_override',
   EnableActivateTicketNowDebugOverride = '@ATB_enable_activate_ticket_now_debug_override',
+  IntercomUserRegistered = '@ATB_intercom_user_registered'
 }
 
 type StorageModelKeysTypes = keyof typeof StorageModelKeysEnum;


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18085

relevant info from official intercom community page : https://community.intercom.com/mobile-sdks-24/error-failed-to-register-user-we-already-have-a-regsitered-user-if-you-are-attempting-to-register-a-new-user-call-logout-before-this-3909

The official library/package from Intercom handles registration differently compared to the old package. In this new package, the library doesn't handle registration in Android quite well, we need to really check for Intercom registration status before registering a new unidentified user. Therefore the solution in this PR is to save the registration status into the async storage, and then only registers if the async storage hasn't been set yet.

Why is the value for the async storage never false? because we never log out the Intercom user. The `logout()` function from Intercom should only be called when registering an _identified user_, since we never registers an _identified user_, we don't need to call the `logout()` function [as mentioned in the guideline](https://developers.intercom.com/installing-intercom/react-native/using-intercom/#how-to-logout-an-identified-user)