### PR TITLE
fix: don't call intercom methods when remote config flag is false

### DIFF
--- a/src/GeolocationContext.tsx
+++ b/src/GeolocationContext.tsx
@@ -27,6 +27,7 @@ import {useAppStateStatus} from './utils/use-app-state-status';
 import {GeoLocation} from '@atb/favorites';
 import {dictionary, GeoLocationTexts, useTranslation} from '@atb/translations';
 import {Coordinates} from '@atb/sdk';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 const config: GeoOptions = {
   enableHighAccuracy: true,
@@ -134,6 +135,7 @@ export const GeolocationContextProvider: React.FC = ({children}) => {
   const {t} = useTranslation();
   const geoLocationName = t(dictionary.myPosition); // TODO: Other place for this fallback
   const currentCoordinatesRef = useRef<Coordinates | undefined>();
+  const {enable_intercom} = useRemoteConfig();
 
   const openSettingsAlert = useCallback(() => {
     Alert.alert(
@@ -256,12 +258,14 @@ export const GeolocationContextProvider: React.FC = ({children}) => {
 
         if (state.status != status) {
           dispatch({type: 'PERMISSION_CHANGED', status, locationEnabled});
-          await updateChatUserMetadata({'AtB-App-Location-Status': status});
+          if (enable_intercom) {
+            await updateChatUserMetadata({'AtB-App-Location-Status': status});
+          }
         }
       }
     }
     checkPermission();
-  }, [appStatus, state.status]);
+  }, [appStatus, state.status, enable_intercom]);
 
   useEffect(() => {
     currentCoordinatesRef.current = state.location?.coordinates;

--- a/src/auth/use-subscribe-to-auth-user-change.ts
+++ b/src/auth/use-subscribe-to-auth-user-change.ts
@@ -5,21 +5,25 @@ import {AuthReducerAction} from './types';
 import {mapAuthenticationType} from './utils';
 import Bugsnag from '@bugsnag/react-native';
 import {useResubscribeToggle} from '@atb/utils/use-resubscribe-toggle';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 export const useSubscribeToAuthUserChange = (
   dispatch: Dispatch<AuthReducerAction>,
 ) => {
   const {resubscribeToggle, resubscribe} = useResubscribeToggle();
+  const {enable_intercom} = useRemoteConfig();
 
   useEffect(() => {
     Bugsnag.leaveBreadcrumb('Subscribing to auth user changes');
     let signInInitiated = false;
     const unsubscribe = auth().onAuthStateChanged((user) => {
       if (user) {
-        updateMetadata({
-          'AtB-Firebase-Auth-Id': user?.uid,
-          'AtB-Auth-Type': mapAuthenticationType(user),
-        });
+        if (enable_intercom) {
+          updateMetadata({
+            'AtB-Firebase-Auth-Id': user?.uid,
+            'AtB-Auth-Type': mapAuthenticationType(user),
+          });
+        }
         dispatch({type: 'SET_USER', user});
       } else if (!signInInitiated) {
         /*
@@ -36,7 +40,7 @@ export const useSubscribeToAuthUserChange = (
       }
     });
     return () => unsubscribe();
-  }, [resubscribeToggle, dispatch]);
+  }, [resubscribeToggle, dispatch, enable_intercom]);
 
   return {
     resubscribe: resubscribe,

--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -82,6 +82,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
 
   const {token_timeout_in_seconds} = useRemoteConfig();
   const mobileTokenEnabled = hasEnabledMobileToken();
+  const {enable_intercom} = useRemoteConfig();
 
   const [isTimeout, setTimout] = useState(false);
 
@@ -95,7 +96,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
     !isLoggingOut;
 
   const {data: nativeToken, status: nativeTokenStatus} =
-    useLoadNativeTokenQuery(enabled, userId);
+    useLoadNativeTokenQuery(enabled, userId, enable_intercom);
 
   const {data: remoteTokens, status: remoteTokensStatus} =
     useListRemoteTokensQuery(enabled, nativeToken);

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -67,6 +67,7 @@ import {Root_ChooseTicketReceiverScreen} from '@atb/stacks-hierarchy/Root_Choose
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
 import {useOnboardingFlow} from '@atb/onboarding';
 import {register as registerChatUser} from '@atb/chat/user';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -79,6 +80,8 @@ export const RootStack = () => {
   const {getInitialNavigationContainerState} = useOnboardingFlow();
   const {theme} = useTheme();
   const navRef = useNavigationContainerRef<RootStackParamList>();
+  const {enable_intercom} = useRemoteConfig();
+
   useFlipper(navRef);
 
   useBeaconsState();
@@ -86,8 +89,10 @@ export const RootStack = () => {
 
   // init Intercom user
   useEffect(() => {
-    registerChatUser();
-  }, []);
+    if (enable_intercom) {
+      registerChatUser();
+    }
+  }, [enable_intercom]);
 
   if (isLoadingAppState) {
     return null;


### PR DESCRIPTION
fixes the crash that happens on OMS-partners regarding Intercom.

closes https://github.com/AtB-AS/kundevendt/issues/2939 as well.

This PR wraps every Intercom-related call with a check to ensure that Intercom is enabled on remote config, to prevent it from getting called when the config is false.