### PR TITLE
fix: fix crash due to wrong context pyramid

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,8 +84,8 @@ export const App = () => {
             <PreferencesContextProvider>
               <LocaleContextProvider>
                 <ReactQueryProvider>
-                  <AuthContextProvider>
-                    <RemoteConfigContextProvider>
+                  <RemoteConfigContextProvider>
+                    <AuthContextProvider>
                       <TimeContextProvider>
                         <AnalyticsContextProvider>
                           <AccessibilityContextProvider>
@@ -127,8 +127,8 @@ export const App = () => {
                           </AccessibilityContextProvider>
                         </AnalyticsContextProvider>
                       </TimeContextProvider>
-                    </RemoteConfigContextProvider>
-                  </AuthContextProvider>
+                    </AuthContextProvider>
+                  </RemoteConfigContextProvider>
                 </ReactQueryProvider>
               </LocaleContextProvider>
             </PreferencesContextProvider>


### PR DESCRIPTION
related to https://github.com/AtB-AS/mittatb-app/pull/4515

fixes the crash issue reported on Slack https://mittatb.slack.com/archives/C025NUF4WA0/p1715858438465089?thread_ts=1715712822.965299&cid=C025NUF4WA0

During auth, we call remote config to check the ´enable_intercom´ flag, since we want to update the Intercom user during auth. Therefore we need to swap the context to allow calling remote config inside auth context.