### PR TITLE
fix: Reset is timeout state on loading status change

### DIFF
--- a/src/loading-screen/__tests__/use-loading-state.test.ts
+++ b/src/loading-screen/__tests__/use-loading-state.test.ts
@@ -6,6 +6,7 @@ const DEFAULT_MOCK_STATE: LoadingParams = {
   isLoadingAppState: true,
   authStatus: 'loading',
   firestoreConfigStatus: 'loading',
+  userId: 'user1',
 };
 
 let mockState = DEFAULT_MOCK_STATE;
@@ -15,6 +16,7 @@ let mockRetryFirestoreConfigInvoked = false;
 
 jest.mock('@atb/auth', () => ({
   useAuthState: () => ({
+    userId: mockState.userId,
     authStatus: mockState.authStatus,
     retryAuth: () => {
       mockRetryAuthInvoked = true;
@@ -53,6 +55,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');
@@ -61,6 +64,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: true,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');
@@ -85,6 +89,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     expect(hook.result.current.status).toBe('success');
@@ -99,6 +104,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('success');
@@ -112,6 +118,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('success');
@@ -122,6 +129,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     expect(hook.result.current.status).toBe('success');
@@ -129,6 +137,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: true,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');
@@ -139,6 +148,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -147,6 +157,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('timeout');
@@ -157,6 +168,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(80));
@@ -165,6 +177,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('success');
@@ -178,6 +191,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -191,6 +205,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -199,6 +214,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     act(() => hook.result.current.retry());
     expect(hook.result.current.status).toBe('success');
@@ -209,6 +225,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'loading',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -227,6 +244,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: true,
       authStatus: 'fetching-id-token',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => hook.result.current.retry());
@@ -238,6 +256,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'fetching-id-token',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -251,6 +270,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'loading',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -264,6 +284,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: true,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -276,11 +297,32 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      userId: 'user1',
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
     expect(hook.result.current.status).toBe('timeout');
     act(() => hook.result.current.retry());
     expect(mockRetryFirestoreConfigInvoked).toBe(false);
+  });
+  it('User change should reset timeout status', async () => {
+    mockState = {
+      isLoadingAppState: false,
+      authStatus: 'loading',
+      firestoreConfigStatus: 'success',
+      userId: 'user1',
+    };
+    const hook = renderHook(() => useLoadingState(100));
+    act(() => jest.advanceTimersByTime(120));
+    hook.rerender();
+    expect(hook.result.current.status).toBe('timeout');
+    mockState = {
+      isLoadingAppState: false,
+      authStatus: 'loading',
+      firestoreConfigStatus: 'success',
+      userId: 'user2',
+    };
+    hook.rerender();
+    expect(hook.result.current.status).toBe('loading');
   });
 });

--- a/src/loading-screen/types.ts
+++ b/src/loading-screen/types.ts
@@ -5,6 +5,7 @@ import {FirestoreConfigStatus} from '@atb/configuration/types';
 export type LoadingStatus = 'loading' | 'success' | 'timeout';
 
 export type LoadingParams = {
+  userId?: string,
   isLoadingAppState: boolean;
   authStatus: AuthStatus;
   firestoreConfigStatus: FirestoreConfigStatus;

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -38,9 +38,7 @@ export const useLoadingState = (timeoutMs: number): LoadingState => {
   useEffect(() => {
     if (status === 'success') {
       setIsTimeout(false);
-    }
-
-    if (status === 'loading') {
+    } else if (status === 'loading') {
       const id = setTimeout(() => setIsTimeout(true), timeoutMs);
       return () => clearTimeout(id);
     }

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -6,11 +6,12 @@ import {useIsLoadingAppState} from '@atb/loading-screen';
 
 export const useLoadingState = (timeoutMs: number): LoadingState => {
   const isLoadingAppState = useIsLoadingAppState();
-  const {authStatus, retryAuth} = useAuthState();
+  const {userId, authStatus, retryAuth} = useAuthState();
   const [isTimeout, setIsTimeout] = useState(false);
   const {resubscribeFirestoreConfig, firestoreConfigStatus} =
     useFirestoreConfiguration();
   const paramsRef = useRef({
+    userId,
     isLoadingAppState,
     authStatus,
     firestoreConfigStatus,
@@ -23,15 +24,22 @@ export const useLoadingState = (timeoutMs: number): LoadingState => {
 
   const status = loadSuccessful ? 'success' : isTimeout ? 'timeout' : 'loading';
 
+  useEffect(() => setIsTimeout(false), [userId]);
+
   useEffect(() => {
     paramsRef.current = {
+      userId,
       isLoadingAppState,
       authStatus,
       firestoreConfigStatus,
     };
-  }, [isLoadingAppState, authStatus, firestoreConfigStatus]);
+  }, [userId, isLoadingAppState, authStatus, firestoreConfigStatus]);
 
   useEffect(() => {
+    if (status === 'success') {
+      setIsTimeout(false);
+    }
+
     if (status === 'loading') {
       const id = setTimeout(() => setIsTimeout(true), timeoutMs);
       return () => clearTimeout(id);


### PR DESCRIPTION
This is done both on user change, and on status being set to
success. The error was that the timeout state wasn't reset on user
change, which made the loading for the new user go immediately to
timeout state.
