### PR TITLE
fix: defaults intercom remote-config to false

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -65,7 +65,7 @@ export type RemoteConfig = {
 
 export const defaultRemoteConfig: RemoteConfig = {
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
-  enable_intercom: true,
+  enable_intercom: false,
   feedback_questions: '',
   must_upgrade_ticketing: false,
   customer_service_url: CUSTOMER_SERVICE_URL,
@@ -129,7 +129,7 @@ export type RemoteConfigKeys = keyof RemoteConfig;
 export function getConfig(): RemoteConfig {
   const values = remoteConfig().getAll();
   const enable_ticketing = values['enable_ticketing']?.asBoolean() ?? false;
-  const enable_intercom = values['enable_intercom']?.asBoolean() ?? true;
+  const enable_intercom = values['enable_intercom']?.asBoolean() ?? false;
   const enable_flex_tickets =
     values['enable_flex_tickets']?.asBoolean() ??
     defaultRemoteConfig.enable_flex_tickets;


### PR DESCRIPTION
Fixes the crash on OMS partners.

followup to https://github.com/AtB-AS/kundevendt/issues/2939 and PR https://github.com/AtB-AS/mittatb-app/pull/4515

The problem here is the Intercom code is called before the remote-config for intercom is fetched, because the default is `true`, the call will fail because Intercom is not initialized. 

In this PR, I changed the default to false, and then tested on both FRAM (without the intercom API keys), and AtB (with intercom API keys, and testing Intercom interface), everything works on debug, but will test in staging to confirm.