### PR TITLE
fix: catch intercom registration issue

### DIFF
--- a/src/chat/user.ts
+++ b/src/chat/user.ts
@@ -6,7 +6,11 @@ import {checkGeolocationPermission} from '@atb/GeolocationContext';
 import {updateMetadata} from './metadata';
 
 export async function register() {
-  await Intercom.loginUnidentifiedUser();
+  try {
+    await Intercom.loginUnidentifiedUser();
+  } catch (error: any){
+    // do nothing
+  }
   await Intercom.setBottomPadding(Platform.OS === 'ios' ? 40 : 80);
 
   const installId = await storage.get('install_id');


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18085

Catches the failed registration issue and discards it so it doesn't get sent to bugsnag. The issue will still show in the log, but at least it is not sent to Bugsnag.

Old PR for reference : https://github.com/AtB-AS/mittatb-app/pull/4513