### PR TITLE
feat: custom translations for Troms

### DIFF
--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -432,6 +432,13 @@ export default orgSpecificTranslations(ProfileTexts, {
     sections: {
       settings: {
         linkSectionItems: {
+          userProfile: {
+            label: _(
+              'Standard billettkategori',
+              'Default ticket category',
+              'Standard billettkategori',
+            ),
+          },
           notifications: {
             pushToggle: {
               subText: _(

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -214,5 +214,10 @@ export default orgSpecificTranslations(PurchaseConfirmationTexts, {
         ),
       },
     },
+    travelDate: {
+      futureDate: (time: string) =>
+        _(`Start ${time}`, `Start time ${time}`, `Start ${time}`),
+      now: _('Start nå', 'Starting now', 'Start no'),
+    },
   },
 });

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -215,8 +215,6 @@ export default orgSpecificTranslations(PurchaseConfirmationTexts, {
       },
     },
     travelDate: {
-      futureDate: (time: string) =>
-        _(`Start ${time}`, `Start time ${time}`, `Start ${time}`),
       now: _('Start nå', 'Starting now', 'Start no'),
     },
   },

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -332,5 +332,9 @@ export default orgSpecificTranslations(PurchaseOverviewTexts, {
         'Den du kjøper billett til, må vere logga inn i Svipper-appen for å få billetten.',
       ),
     },
+    startTime: {
+      now: _('Start nå', 'Start now', 'Start no'),
+      later: _('Start senere', 'Start later', 'Start seinare'),
+    },
   },
 });

--- a/src/translations/screens/subscreens/UserProfileSettingsTexts.ts
+++ b/src/translations/screens/subscreens/UserProfileSettingsTexts.ts
@@ -1,4 +1,6 @@
 import {translation as _} from '../../commons';
+import {orgSpecificTranslations} from '../../orgSpecificTranslations';
+
 const UserProfileSettingsTexts = {
   header: {
     title: _('Standard reisende', 'Default traveller', 'Standard reisande'),
@@ -9,4 +11,14 @@ const UserProfileSettingsTexts = {
     'Vel ønska standardkategori for framtidige billettkjøp.',
   ),
 };
-export default UserProfileSettingsTexts;
+export default orgSpecificTranslations(UserProfileSettingsTexts, {
+  troms: {
+    header: {
+      title: _(
+        'Standard billettkategori',
+        'Default ticket category',
+        'Standard billettkategori',
+      ),
+    },
+  },
+});


### PR DESCRIPTION
I am creating this PR on behalf of @tft-kaare (currently out of office) because Troms has requested these changes with the new RC that we are making today.

This PR only updates the texts for Troms. Ideally, we should standardize the texts for all OMS partners. However, because the release deadline is so close, we don't have time to find texts and verify that it works for everyone right now.

Part of closing https://github.com/AtB-AS/kundevendt/issues/8280