### PR TITLE
fix(troms): remove harbor summary text

### DIFF
--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -61,7 +61,7 @@ const PurchaseConfirmationTexts = {
         `Billettvarigheit ${validTime} frå oppstart`,
       ),
   },
-  sendingTo: (phoneNumber: string) => 
+  sendingTo: (phoneNumber: string) =>
     _(
       `Sendes til ${phoneNumber}`,
       `Sending to ${phoneNumber}`,
@@ -207,11 +207,7 @@ export default orgSpecificTranslations(PurchaseConfirmationTexts, {
   troms: {
     validityTexts: {
       harbor: {
-        messageInHarborZones: _(
-          'Gjelder for buss i sonene du reiser til og fra',
-          'Applies for bus in departure and destination zones',
-          'Gjeld for buss i sonene du reiser til og frå',
-        ),
+        messageInHarborZones: _('', '', ''),
       },
     },
     travelDate: {


### PR DESCRIPTION
This text only applies to AtB and should be removed for Troms (same as for FRAM and NFK). 

Part of closing https://github.com/AtB-AS/kundevendt/issues/8280