### PR TITLE
fix: use a different leg line color when the organization is fram.

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -59,6 +59,7 @@ import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useNow} from '@atb/utils/use-now';
 import {TripPatternBookingStatus} from '@atb/travel-details-screens/types';
+import {APP_ORG} from '@env';
 
 type ResultItemProps = {
   tripPattern: TripPattern;
@@ -401,7 +402,10 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flexGrow: 1,
   },
   legLine: {
-    backgroundColor: theme.static.background.background_3.background,
+    backgroundColor:
+      APP_ORG === 'fram'
+        ? theme.border.primary
+        : theme.static.background.background_3.background,
     flexDirection: 'row',
     borderRadius: theme.border.radius.regular,
     width: 5,
@@ -422,13 +426,20 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     width: theme.spacings.large,
   },
   destinationLine_grow: {
-    backgroundColor: theme.static.background.background_3.background,
+    backgroundColor:
+      APP_ORG === 'fram'
+        ? theme.border.primary
+        : theme.static.background.background_3.background,
     marginLeft: theme.spacings.xSmall,
     borderBottomLeftRadius: theme.border.radius.regular,
     borderTopLeftRadius: theme.border.radius.regular,
   },
   destinationLine: {
-    backgroundColor: theme.static.background.background_3.background,
+    backgroundColor:
+      APP_ORG === 'fram'
+        ? theme.border.primary
+        : theme.static.background.background_3.background,
+
     marginRight: theme.spacings.xSmall,
     borderBottomRightRadius: theme.border.radius.regular,
     borderTopRightRadius: theme.border.radius.regular,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/15463

#### Background
The leg line color in dark mode in the FRAM app is currently not visible.


#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

|      | Current solution |  Proposed solution    |
| :---:        |    :----:   |         :---: |
| Light mode      | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-22 at 10 19 18](https://github.com/AtB-AS/mittatb-app/assets/59939294/554f1495-1618-4204-a2e6-758cc727d7b0)      | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-22 at 10 19 49](https://github.com/AtB-AS/mittatb-app/assets/59939294/49de1519-b1cb-49a4-8dc1-d579af419eb3)   |
| Dark mode  | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-22 at 10 19 57](https://github.com/AtB-AS/mittatb-app/assets/59939294/207adb02-91c4-41af-a97d-72f230f7aae4)       |  ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-22 at 10 19 06](https://github.com/AtB-AS/mittatb-app/assets/59939294/65d9addf-3e82-4454-94ec-fa208051f892)  |






</details>

### Proposed solution
Use a different leg line color when the organization is FRAM. 

### Acceptance Criteria
- [ ] Leg line is visible in the FRAM app in both light and dark mode. 
- [ ] The fix does not affect the leg line color selection of other oragnaization than FRAM.   