### PR TITLE
feat: update badge color and add badge to flex discount section

### DIFF
--- a/src/components/label-info/LabelInfo.tsx
+++ b/src/components/label-info/LabelInfo.tsx
@@ -21,7 +21,7 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
   return (
     <View style={linkSectionItemStyle.flag}>
-      <ThemeText color="background_accent_3" type="body__tertiary">
+      <ThemeText color="info" type="body__tertiary">
         {flagTranslated}
       </ThemeText>
     </View>
@@ -30,7 +30,7 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   flag: {
-    backgroundColor: theme.static.background.background_accent_3.background,
+    backgroundColor: theme.static.status.info.background,
     marginRight: theme.spacings.medium,
     paddingHorizontal: theme.spacings.small,
     paddingVertical: theme.spacings.xSmall,

--- a/src/components/label-info/LabelInfo.tsx
+++ b/src/components/label-info/LabelInfo.tsx
@@ -21,7 +21,7 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
   return (
     <View style={linkSectionItemStyle.flag}>
-      <ThemeText color="info" type="body__tertiary">
+      <ThemeText color="background_accent_3" type="body__tertiary">
         {flagTranslated}
       </ThemeText>
     </View>
@@ -30,7 +30,7 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   flag: {
-    backgroundColor: theme.static.status.info.background,
+    backgroundColor: theme.static.background.background_accent_3.background,
     marginRight: theme.spacings.medium,
     paddingHorizontal: theme.spacings.small,
     paddingVertical: theme.spacings.xSmall,

--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -11,11 +11,14 @@ import {useSectionStyle} from '../use-section-style';
 import {animateNextChange} from '@atb/utils/animation';
 import {TextNames} from '@atb/theme/colors';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {LabelType} from '@atb-as/config-specs';
+import {LabelInfo} from '@atb/components/label-info';
 
 type Props = SectionItemProps<
   {
     text: string;
     textType?: TextNames;
+    label?: LabelType;
     showIconText?: boolean;
     testID?: string;
     accessibility?: AccessibilityProps;
@@ -41,6 +44,7 @@ export function ExpandableSectionItem({
   text,
   textType,
   showIconText = false,
+  label,
   accessibility,
   testID,
   ...props
@@ -90,6 +94,7 @@ export function ExpandableSectionItem({
         <ThemeText style={contentContainer} type={textType}>
           {text}
         </ThemeText>
+        {label && <LabelInfo label={label} />}
         <ExpandIcon expanded={expanded} showText={showIconText} />
       </PressableOpacity>
       {expanded && 'expandContent' in props && (

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -35,7 +35,6 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
   const {appTexts} = useFirestoreConfiguration();
   const {flex_ticket_url} = useRemoteConfig();
 
-  if (!userProfiles.some((u) => u.offer.flex_discount_ladder)) return null;
   const description =
     getTextForLanguage(appTexts?.discountInfo, language) ||
     t(PurchaseOverviewTexts.flexDiscount.description);
@@ -47,6 +46,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
         <ExpandableSectionItem
           text={t(PurchaseOverviewTexts.flexDiscount.expandableLabel)}
           textType="heading__component"
+          label="new"
           expanded={expanded}
           onPress={setExpanded}
         />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -35,6 +35,8 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
   const {appTexts} = useFirestoreConfiguration();
   const {flex_ticket_url} = useRemoteConfig();
 
+  if (!userProfiles.some((u) => u.offer.flex_discount_ladder)) return null;
+  
   const description =
     getTextForLanguage(appTexts?.discountInfo, language) ||
     t(PurchaseOverviewTexts.flexDiscount.description);


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/18132

Contents of this PR:

- Add the "label" property to `ExpandableSectionItem`.
- Add "new"/"ny" label to Flex discount section.
- ~~Update the color of both "new"/"ny" and "beta" badge. See below for comparison. [Figma component](https://www.figma.com/design/2QTjAdekdIPuLFovQhVrY3/Components?node-id=8344-45773&t=XZMNfCJIx11Rs0LM-4)~~

Color change is reverted and will be done on separate PR.

Added badge:
![image](https://github.com/AtB-AS/mittatb-app/assets/1777333/b767ca34-102f-4ac2-bbe8-9d2571c73e2b)

