### PR TITLE
test: accept travel time variations

### DIFF
--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -236,7 +236,7 @@ describe('Travel search', () => {
   /**
    * Walking and bike travels are shown separately depending on the travel search
    */
-  it.only('should show walk and bike options', async () => {
+  it('should show walk and bike options', async () => {
     const longDeparture = 'Prinsens gate';
     const longArrival = 'Melhus skysstasjon';
     const shortDeparture = 'Prinsens gate';

--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -236,7 +236,7 @@ describe('Travel search', () => {
   /**
    * Walking and bike travels are shown separately depending on the travel search
    */
-  it('should show walk and bike options', async () => {
+  it.only('should show walk and bike options', async () => {
     const longDeparture = 'Prinsens gate';
     const longArrival = 'Melhus skysstasjon';
     const shortDeparture = 'Prinsens gate';
@@ -254,9 +254,14 @@ describe('Travel search', () => {
       await TravelsearchOverviewPage.waitForTravelSearchResults();
 
       await expect(TravelsearchOverviewPage.bikeResult).toExist();
-      await expect(await TravelsearchOverviewPage.bikeResultText).toContain(
-        'Bike 1 h 30 min',
-      );
+      // "Bike 1 h 30 min"
+      await expect(
+        TimeHelper.isAcceptableMinVariation(
+          await TravelsearchOverviewPage.bikeResultText,
+          30,
+          2,
+        ),
+      ).toBe(true);
       await expect(TravelsearchOverviewPage.walkResult).not.toExist();
 
       // Details
@@ -282,9 +287,14 @@ describe('Travel search', () => {
 
       await expect(TravelsearchOverviewPage.bikeResult).toExist();
       await expect(TravelsearchOverviewPage.walkResult).toExist();
-      await expect(await TravelsearchOverviewPage.walkResultText).toContain(
-        'Walk 19 min',
-      );
+      // "Walk 19 min"
+      await expect(
+        TimeHelper.isAcceptableMinVariation(
+          await TravelsearchOverviewPage.walkResultText,
+          19,
+          2,
+        ),
+      ).toBe(true);
 
       // Details
       await TravelsearchOverviewPage.walkResult.click();

--- a/e2e/test/utils/time.helper.ts
+++ b/e2e/test/utils/time.helper.ts
@@ -36,6 +36,25 @@ class TimeHelper {
     endDate.setHours(endHr, endMin);
     return initDate <= endDate;
   }
+
+  /**
+   * Helper method to parse the minutes from a non-transit travel. Checks if the minutes are acceptable.
+   * E.g. "Bike 1 h 30 min" and "Walk 19 min"
+   * @param travelTime The travel time from the button text
+   * @param expectedMins The expected minutes
+   * @param minVariation Acceptable variation in minutes
+   */
+  isAcceptableMinVariation(
+    travelTime: string,
+    expectedMins: number,
+    minVariation: number,
+  ): boolean {
+    const travelTimeMin = parseInt(/\s(\d+)\smin/.exec(travelTime)[0]);
+    return (
+      travelTimeMin <= expectedMins + minVariation &&
+      travelTimeMin >= expectedMins - minVariation
+    );
+  }
 }
 
 export default new TimeHelper();


### PR DESCRIPTION
When assessing travel times for bike and foot, there are sometimes small variations in minutes. Added a check that accepts small variations in minutes.

Note! Want to have a check that takes an expected value to not succeed on large variations to the expected one.