### PR TITLE
feat: remove check for several carnets to show consume button

### DIFF
--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -189,11 +189,6 @@ export function isCanBeConsumedNowFareContract(
   if (!isCarnet(f)) return false;
   const travelRights = f.travelRights.filter(isCarnetTravelRight);
 
-  // @TODO: This is a temporary limitation because of issues with consumption of
-  // carnets with more than one travel right. Should be removed once there is a
-  // solution for this in the backend.
-  if (travelRights.length > 1) return false;
-
   return (
     hasUsableCarnetTravelRight(travelRights, now) &&
     !hasActiveCarnetTravelRight(travelRights, now)


### PR DESCRIPTION
Since the back end now supports consume of carnets with more than one travel right, we can remove the check!