### PR TITLE
fix: add missing translation when no token for troms

### DIFF
--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -37,7 +37,7 @@ const TravelTokenBoxTexts = {
 
 export default orgSpecificTranslations(TravelTokenBoxTexts, {
   nfk: {
-    tcardName: _('reisekort', 'travelcard', 'reisekort'),
+    tcardName: _('reisekort', 'travel card', 'reisekort'),
     errorMessages: {
       tokensNotLoadedTitle: _(
         'Klarer ikke hente informasjon om reisekort / mobil.',
@@ -57,7 +57,7 @@ export default orgSpecificTranslations(TravelTokenBoxTexts, {
     },
   },
   fram: {
-    tcardName: _('reisekort', 'travelcard', 'reisekort'),
+    tcardName: _('reisekort', 'travel card', 'reisekort'),
     errorMessages: {
       tokensNotLoadedTitle: _(
         'Klarer ikke hente informasjon om reisekort / mobil.',
@@ -77,7 +77,7 @@ export default orgSpecificTranslations(TravelTokenBoxTexts, {
     },
   },
   troms: {
-    tcardName: _('reisekort', 'travelcard', 'reisekort'),
+    tcardName: _('reisekort', 'travel card', 'reisekort'),
     errorMessages: {
       tokensNotLoadedTitle: _(
         'Klarer ikke hente informasjon om reisekort / mobil.',

--- a/src/translations/components/TravelTokenBox.ts
+++ b/src/translations/components/TravelTokenBox.ts
@@ -76,4 +76,24 @@ export default orgSpecificTranslations(TravelTokenBoxTexts, {
       ),
     },
   },
+  troms: {
+    tcardName: _('reisekort', 'travelcard', 'reisekort'),
+    errorMessages: {
+      tokensNotLoadedTitle: _(
+        'Klarer ikke hente informasjon om reisekort / mobil.',
+        'Unable to retrieve information about your travel card / phone.',
+        'Klarer ikkje hente informasjon om reisekort / mobil.',
+      ),
+      tokensNotLoaded: _(
+        'Billetter må brukes på enten et reisekort eller en mobil, men akkurat nå klarer vi ikke finne ut hvor den er i bruk. Sjekk at du har tilgang på nett der du er.',
+        `Tickets must be used on either a travel card or phone, but right now we are unable to find where the ticket is in use. Check that you have internet access.`,
+        'Billettar må brukast på enten eit reisekort eller ein mobil, men nett no klarar vi ikkje finne ut kvar den er i bruk. Sjekk at du har tilgang på nett der du er.',
+      ),
+      noInspectableToken: _(
+        'Billetter må brukes på enten et reisekort eller en mobil, og det ser ikke ut som du har valgt en av dem.\n\nGå til **Min bruker, Bytt mellom reisekort / mobil** for å velge.',
+        `Tickets must be used on either a travel card or a phone, and it looks like you haven't chosen one. Go to **My user, switch between travel card / phone** to select`,
+        'Billettar må brukast på enten eit reisekort eller ein mobil, og det ser ikkje ut som du har valgt ein av dei.\n\nGå til **Min brukar, Bytt mellom reisekort / mobil** for å velje.',
+      ),
+    },
+  },
 });


### PR DESCRIPTION
Added translations for the error messages when there is an issue with the token tochange the reference from "t:card" to "travel card".

These errors should in theory not be shown when `disable_travelcard` is set to `true`, so for Troms it shouldn't be shown unless there's e.g. an issue with the token server.

https://github.com/AtB-AS/kundevendt/issues/18118