### PR TITLE
feat: update purchase confirmation screen

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -26,7 +26,6 @@ import {
   ActivityIndicator,
   ScrollView,
   StyleProp,
-  Text,
   View,
   ViewStyle,
 } from 'react-native';
@@ -319,7 +318,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             <GenericSectionItem>
               <View accessible={true} style={styles.ticketInfoContainer}>
                 <ThemeText>
-                  {getReferenceDataName(preassignedFareProduct, language)}
+                  {getTextForLanguage(fareProductTypeConfig.name, language)}
                 </ThemeText>
                 {phoneNumber && (
                   <ThemeText
@@ -569,16 +568,12 @@ const PricePerUserProfile = ({
           <ThemeText
             type="body__tertiary"
             color="secondary"
-            style={styles.userProfileOriginalPriceText}
+            style={styles.userProfileOriginalPriceAmount}
           >
-            ({`${t(PurchaseConfirmationTexts.ordinaryPricePrefix)} `}
-            <Text style={styles.userProfileOriginalPriceAmount}>
-              {originalPriceString} kr
-            </Text>
-            )
+            {originalPriceString} kr
           </ThemeText>
         )}
-        <ThemeText color="secondary" type="body__secondary">
+        <ThemeText color="secondary" type="body__primary">
           {priceString} kr
         </ThemeText>
       </View>
@@ -627,11 +622,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   userProfileCountAndName: {marginRight: theme.spacings.small},
   userProfilePrice: {flexDirection: 'row', flexWrap: 'wrap'},
-  userProfileOriginalPriceText: {
-    marginRight: theme.spacings.small,
-    alignSelf: 'center',
-  },
   userProfileOriginalPriceAmount: {
+    marginEnd: theme.spacings.small,
+    alignSelf: 'flex-end',
     textDecorationLine: 'line-through',
   },
   paymentSummaryContainer: {

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -318,7 +318,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             <GenericSectionItem>
               <View accessible={true} style={styles.ticketInfoContainer}>
                 <ThemeText>
-                  {getTextForLanguage(fareProductTypeConfig.name, language)}
+                  {getReferenceDataName(preassignedFareProduct, language)}
                 </ThemeText>
                 {phoneNumber && (
                   <ThemeText

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -573,7 +573,7 @@ const PricePerUserProfile = ({
             {originalPriceString} kr
           </ThemeText>
         )}
-        <ThemeText color="secondary" type="body__primary">
+        <ThemeText color="secondary" type="body__secondary">
           {priceString} kr
         </ThemeText>
       </View>


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/18132

in this PR: 

- Update the original price display style.
- Update the ticket name display.

There are some style discrepancies between the design on the Figma link below and other ticket design. For example, passenger font style on the design for flexible ticket is `body--primary`, but the other text - and on the app - is still using `body--secondary`, based on what @hannahATB said, we should still follow the existing styles. 

[Figma link](https://www.figma.com/design/zdZwvobgpEWSagKt0tderx/App?node-id=26058-20433&t=Y2xIKRVKWdo4xIuD-4)

<details>
<summary>Reference screen</summary>
<img width="700" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/a87395ee-9921-4e5c-aed9-9c466375a75b" />
</details>

<details>
<summary>Old-New comparison</summary>
<img width="400" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/41eff54d-08af-4e62-acd5-fbf4b0c78d9f" />
<img width="400" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/3b663a0b-ba91-4ad1-aba2-7e133e13bcb2" />
</details>

