### PR TITLE
fix: use correct icon size in FareContractStatusSymbol

### DIFF
--- a/src/fare-contracts/components/FareContractStatusSymbol.tsx
+++ b/src/fare-contracts/components/FareContractStatusSymbol.tsx
@@ -22,7 +22,6 @@ export const FareContractStatusSymbol = ({
         <ThemeIcon
           svg={TicketInvalid}
           colorType="error"
-          size="large"
           accessibilityLabel={t(
             TicketingTexts.ticketStatusSymbolA11yLabel[status],
           )}
@@ -33,7 +32,6 @@ export const FareContractStatusSymbol = ({
         <ThemeIcon
           svg={Time}
           colorType="primary"
-          size="large"
           accessibilityLabel={t(
             TicketingTexts.ticketStatusSymbolA11yLabel[status],
           )}


### PR DESCRIPTION
Noticed that none of the icons in FareContractStatusSymbol should have `size="large"`, according to [figma](https://www.figma.com/design/2QTjAdekdIPuLFovQhVrY3/Components?node-id=7415-26269) 🤓

<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/60e1f211-9364-427a-900f-59514de52440">
