### PR TITLE
fix: update colour loading spinner

### DIFF
--- a/src/loading-screen/LoadingScreen.tsx
+++ b/src/loading-screen/LoadingScreen.tsx
@@ -41,6 +41,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   loadingText: {textAlign: 'center', marginTop: theme.spacings.medium},
   activityIndicator: {
-    backgroundColor: theme.static.status.info.background,
+    backgroundColor: theme.static.background[themeColor].text,
   },
 }));

--- a/src/loading-screen/LoadingScreen.tsx
+++ b/src/loading-screen/LoadingScreen.tsx
@@ -9,6 +9,7 @@ const themeColor = 'background_accent_0';
 export const LoadingScreen = React.memo(() => {
   const styles = useStyles();
   const {t} = useTranslation();
+
   return (
     <View
       style={styles.container}
@@ -16,7 +17,10 @@ export const LoadingScreen = React.memo(() => {
       accessibilityLabel={t(dictionary.loading)}
       testID="loadingScreen"
     >
-      <ActivityIndicator size="large" />
+      <ActivityIndicator
+        size="large"
+        color={styles.activityIndicator.backgroundColor}
+      />
       <ThemeText
         style={styles.loadingText}
         type="body__primary"
@@ -36,4 +40,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.static.background[themeColor].background,
   },
   loadingText: {textAlign: 'center', marginTop: theme.spacings.medium},
+  activityIndicator: {
+    backgroundColor: theme.static.status.info.background,
+  },
 }));


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/9189

### Background

From @Reis-Nordland :

The contrast colour of the spinner on the loading screen is to weak and not visible enough. This is the case especially on android. 

Not critical, but it would have been nice to have it fixed.

#### Illustrations

##### Light mode
<details>
<summary>screenshots/light_mode</summary>


|   Light mode               |  Old  |  New |
|:---------:| :--------: | :-------: |
| FRAM    | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/1f9b5a3d-ed96-4d40-a8b8-c1c891480c48) | ![fram_new_spinner_light](https://github.com/AtB-AS/mittatb-app/assets/59939294/48f873ab-0e21-4aa6-aaf7-47947fb65986)| 
| NFK       | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/6168f7f0-dfa6-4717-86e5-1f1cb75c5945) |  ![nfk_new_spinner_light](https://github.com/AtB-AS/mittatb-app/assets/59939294/9d6cff23-51ee-4af8-928a-6518dcf77973)|
| TROMS | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/e0e543df-8323-4242-b9e0-174feabb54f0) | ![troms_new_spinner_light](https://github.com/AtB-AS/mittatb-app/assets/59939294/488b0381-b2eb-4b99-a98e-8f008a2a2a4a)|
| ATB | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/831eff48-6075-4d8b-9d93-f347bbfb795e) | ![atb_new_spinner_light](https://github.com/AtB-AS/mittatb-app/assets/59939294/168df72f-65da-4c1d-a094-a8e27b0f882b)|

</details>

##### Dark mode
<details>
<summary>screenshots/dark_mode</summary>

|   Dark mode               |  Old  |  New |
|:---------:| :--------: | :-------: |
| FRAM    | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/0294f29a-e786-4584-b261-9bee8a94d279) | ![fram_new_spinner_dark](https://github.com/AtB-AS/mittatb-app/assets/59939294/20ca8616-fad6-4d2c-a52a-6f785d9a4a57) | 
| NFK       | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/addb34d2-ae9e-4e7b-a8b8-6d3117ffbe13) | ![nfk_new_spinner_dark](https://github.com/AtB-AS/mittatb-app/assets/59939294/899e411e-7342-4adb-aff8-301e7c9fd672)|
| TROMS | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/a9115e79-2fd4-45f2-8036-1b9e6b6c271c) | ![troms_new_spinner_dark](https://github.com/AtB-AS/mittatb-app/assets/59939294/a99274ad-7059-461b-a4a6-3e67dbedd7b9)|
| ATB | ![Image](https://github.com/AtB-AS/kundevendt/assets/59939294/c2b2c1aa-3c09-4363-ad89-6622d168617c) | 
![atb_new_spinner_dark](https://github.com/AtB-AS/mittatb-app/assets/59939294/d7194a76-50ef-4c4f-9087-6fdf74dc525c)| 

</details>

### Proposed solution

Specify that the loading spinner to use the info status colour as background.

### Acceptance Criteria
- [ ] The spinner on the loading screen is visible on for all organizations, in both light and dark mode.  




