### PR TITLE
feat: Add snackbar to storybook

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -52,8 +52,9 @@ const getStories = () => {
     "./src/storybook/stories/MessageInfoBox.stories.tsx": require("../src/storybook/stories/MessageInfoBox.stories.tsx"),
     "./src/storybook/stories/MessageInfoText.stories.tsx": require("../src/storybook/stories/MessageInfoText.stories.tsx"),
     "./src/storybook/stories/Section.stories.tsx": require("../src/storybook/stories/Section.stories.tsx"),
-    "./src/storybook/stories/ThemeText.stories.tsx": require("../src/storybook/stories/ThemeText.stories.tsx"),
+    "./src/storybook/stories/Snackbar.stories.tsx": require("../src/storybook/stories/Snackbar.stories.tsx"),
     "./src/storybook/stories/ThemeIcon.stories.tsx": require("../src/storybook/stories/ThemeIcon.stories.tsx"),
+    "./src/storybook/stories/ThemeText.stories.tsx": require("../src/storybook/stories/ThemeText.stories.tsx"),
     "./src/storybook/stories/TileWithButton.stories.tsx": require("../src/storybook/stories/TileWithButton.stories.tsx"),
   };
 };

--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -24,7 +24,7 @@ export type SnackbarTextContent = {
   description?: string;
 };
 
-type SnackbarProps = {
+export type SnackbarProps = {
   textContent?: SnackbarTextContent;
   position: SnackbarPosition;
   /** Optional action button, only shown if this is provided */

--- a/src/components/snackbar/index.ts
+++ b/src/components/snackbar/index.ts
@@ -1,5 +1,9 @@
 export {Snackbar} from './Snackbar';
-export type {SnackbarPosition, SnackbarTextContent} from './Snackbar';
+export type {
+  SnackbarPosition,
+  SnackbarTextContent,
+  SnackbarProps,
+} from './Snackbar';
 export {useSnackbarVerticalPositionAnimation} from './use-snackbar-vertical-position-animation';
 export {useSnackbarIsVisible} from './use-snackbar-is-visible';
 export {useSnackbarScreenReaderFocus} from './use-snackbar-screen-reader-focus';

--- a/src/components/snackbar/use-snackbar-vertical-position-animation.ts
+++ b/src/components/snackbar/use-snackbar-vertical-position-animation.ts
@@ -4,6 +4,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {shadows} from '@atb/components/map';
 import {SnackbarPosition} from '@atb/components/snackbar';
 import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
+import {useTheme} from '@atb/theme';
 
 export const snackbarAnimationDurationMS = 300; // 0.3 seconds
 
@@ -13,7 +14,13 @@ export const useSnackbarVerticalPositionAnimation = (
 ) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
-  const {top, bottom} = useSafeAreaInsets();
+  const {theme} = useTheme();
+  const withSnackbarPadding = (safeAreaHeight: number) =>
+    Math.max(safeAreaHeight, theme.spacings.medium) + theme.spacings.small;
+
+  const {top: safeAreaTop, bottom: safeAreaBottom} = useSafeAreaInsets();
+  const top = withSnackbarPadding(safeAreaTop);
+  const bottom = withSnackbarPadding(safeAreaBottom);
 
   // the y position when visible and the animation is done
   const topOrBottomStyle = position === 'top' ? {top} : {bottom};

--- a/src/storybook/stories/Snackbar.stories.tsx
+++ b/src/storybook/stories/Snackbar.stories.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  Snackbar,
+  SnackbarProps,
+  SnackbarTextContent,
+} from '@atb/components/snackbar';
+import {View} from 'react-native';
+import {
+  ThemedStoryDecorator,
+  ThemedStoryProps,
+  themedStoryControls,
+  themedStoryDefaultArgs,
+} from '../ThemedStoryDecorator';
+import {Meta} from '@storybook/react-native';
+import {ThemeText} from '@atb/components/text';
+
+type MetaPropsInputLayer = SnackbarTextContent & {
+  actionButtonText: string;
+}; // to easily input title, description and action button text, define them directly as props, and map as input to Story
+
+type SnackbarMetaProps = SnackbarProps & ThemedStoryProps & MetaPropsInputLayer;
+
+const SnackbarMeta: Meta<SnackbarMetaProps> = {
+  title: 'Snackbar',
+  component: Snackbar,
+  argTypes: {
+    title: {type: 'string'},
+    description: {type: 'string'},
+    position: {
+      control: {type: 'radio'},
+      options: ['top', 'bottom'],
+    },
+    actionButtonText: {type: 'string'},
+    isDismissable: {type: 'boolean'},
+    customVisibleDurationMS: {
+      type: 'number',
+    },
+    ...themedStoryControls,
+  },
+  args: {
+    title: 'The Title',
+    description: 'An amazing description',
+    position: 'top',
+    actionButtonText: undefined,
+    isDismissable: false,
+    customVisibleDurationMS: undefined,
+    ...themedStoryDefaultArgs,
+  },
+  decorators: [
+    (Story, {args}) => (
+      <View
+        style={{
+          flex: 0.5,
+          backgroundColor: '#eee',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Story
+          args={{
+            ...args,
+            ...{
+              textContent: {
+                title: args.title,
+                description: args.description,
+              },
+            },
+            ...(args.actionButtonText
+              ? {actionButton: {onPress: () => {}, text: args.actionButtonText}}
+              : undefined),
+          }}
+        />
+        <ThemeText
+          color="secondary"
+          style={{
+            width: '50%',
+            textAlign: 'center',
+            opacity: 0.5,
+          }}
+        >
+          When the Snackbar shows outside of this gray area, it means that it is
+          not visible when in use in the app.
+        </ThemeText>
+      </View>
+    ),
+    ThemedStoryDecorator,
+  ],
+};
+
+export default SnackbarMeta;
+
+export const Minimal = {
+  args: {
+    title: undefined,
+    description: 'Some short description here',
+  },
+};
+
+export const Maximal = {
+  args: {
+    title: 'The Title',
+    description: 'Some rather long and detailed description right here',
+    isDismissable: true,
+    actionButton: {
+      text: 'Action',
+      onPress: () => {
+        // aaand action
+      },
+    },
+  },
+};

--- a/src/storybook/stories/Snackbar.stories.tsx
+++ b/src/storybook/stories/Snackbar.stories.tsx
@@ -51,7 +51,7 @@ const SnackbarMeta: Meta<SnackbarMetaProps> = {
       <View
         style={{
           flex: 0.5,
-          backgroundColor: '#eee',
+          backgroundColor: args.theme === 'light' ? '#eee' : '#333',
           alignItems: 'center',
           justifyContent: 'center',
         }}


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/17411

Two things in this PR:
- Add Snackbar to Storybook
- Fix a Snackbar padding issue https://github.com/AtB-AS/mittatb-app/pull/4549/commits/6998e87ebb94d645743e698b57eb5a83f9a633a9

What it looks like in Storybook:
<table>
  <tr>
    <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/9fcec1d5-1cb4-4edf-bbf7-fb1ee39f5ba5" /></td>
    <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/167d23b3-fd0c-4ee7-b916-e40aaaf86d63" /></td>
     <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/c7766006-a8c1-40ac-a967-1927c55e2769" /></td>
      <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/70a9c8b9-68ab-4ca7-849e-b587b875a36c" /></td>
  </tr>
  <tr>
    <td>Minimal. When visible.</td>
    <td>Minimal. When hidden.</td>
    <td>Maximal. When visible.</td>
    <td>Inputs.</td>
  </tr>
</table>