### PR TITLE
feat: new feature flag for backend sms auth

### DIFF
--- a/src/auth/use-is-backend-sms-auth-enabled.tsx
+++ b/src/auth/use-is-backend-sms-auth-enabled.tsx
@@ -1,0 +1,17 @@
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useDebugOverride} from '@atb/debug';
+import {StorageModelKeysEnum} from '@atb/storage';
+
+export const useIsBackendSmsAuthEnabled = () => {
+  const {enable_backend_sms_auth} = useRemoteConfig();
+  const [debugOverride, _, debugOverrideReady] =
+  useBackendSmsAuthEnabledDebugOverride();
+  return [
+    debugOverride !== undefined ? debugOverride : enable_backend_sms_auth,
+    debugOverrideReady,
+  ];
+};
+
+export const useBackendSmsAuthEnabledDebugOverride = () => {
+  return useDebugOverride(StorageModelKeysEnum.EnableBackendSmsAuth);
+};

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -15,6 +15,7 @@ export type RemoteConfig = {
    * transaction.
    */
   enable_auto_sale: boolean;
+  enable_backend_sms_auth: boolean;
   enable_beacons: boolean;
   enable_car_sharing_in_map: boolean;
   enable_city_bikes_in_map: boolean;
@@ -76,6 +77,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   disable_travelcard: false,
   enable_activate_ticket_now: false,
   enable_auto_sale: false,
+  enable_backend_sms_auth: false,
   enable_beacons: false,
   enable_car_sharing_in_map: false,
   enable_city_bikes_in_map: false,
@@ -152,6 +154,9 @@ export function getConfig(): RemoteConfig {
   const enable_auto_sale =
     values['enable_auto_sale']?.asBoolean() ??
     defaultRemoteConfig.enable_auto_sale;
+  const enable_backend_sms_auth =
+    values['enable_backend_sms_auth']?.asBoolean() ??
+    defaultRemoteConfig.enable_backend_sms_auth;
   const enable_beacons =
     values['enable_beacons']?.asBoolean() ?? defaultRemoteConfig.enable_beacons;
   const enable_car_sharing_in_map =
@@ -293,6 +298,7 @@ export function getConfig(): RemoteConfig {
     disable_travelcard,
     enable_activate_ticket_now,
     enable_auto_sale,
+    enable_backend_sms_auth,
     enable_beacons,
     enable_car_sharing_in_map,
     enable_city_bikes_in_map,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -63,6 +63,7 @@ import {useOnboardingState} from '@atb/onboarding';
 import {useServerTimeEnabledDebugOverride} from '@atb/time';
 import Bugsnag from '@bugsnag/react-native';
 import {useActivateTicketNowEnabledDebugOverride} from '@atb/fare-contracts/use-is-activate-now-enabled';
+import {useBackendSmsAuthEnabledDebugOverride} from '@atb/auth/use-is-backend-sms-auth-enabled';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -133,6 +134,8 @@ export const Profile_DebugInfoScreen = () => {
   const serverTimeEnabledDebugOverride = useServerTimeEnabledDebugOverride();
   const activateTicketNowEnabledDebugOverride =
     useActivateTicketNowEnabledDebugOverride();
+  const backendSmsAuthEnabledDebugOverride =
+    useBackendSmsAuthEnabledDebugOverride();
 
   useEffect(() => {
     (async function () {
@@ -452,6 +455,12 @@ export const Profile_DebugInfoScreen = () => {
             <DebugOverride
               description="Enable activate ticket now"
               override={activateTicketNowEnabledDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable new backend sms auth"
+              override={backendSmsAuthEnabledDebugOverride}
             />
           </GenericSectionItem>
         </Section>

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -4,6 +4,7 @@ import {Platform} from 'react-native';
 
 export enum StorageModelKeysEnum {
   EnableActivateTicketNowDebugOverride = '@ATB_enable_activate_ticket_now_debug_override',
+  EnableBackendSmsAuth = '@ATB_backend_sms_auth',
   EnableBeaconsDebugOverride = '@ATB_beacons_debug_override',
   EnableCarSharingInMapDebugOverride = 'ATB_enable_car_sharing_in_map_debug_override',
   EnableCityBikesInMapDebugOverride = 'ATB_enable_city_bikes_in_map_debug_override',


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/18127

Adds a feature flag for the new SMS auth through our backend (it uses Twilio - https://github.com/AtB-AS/team-platform/issues/599). Also added the debug menu to override remote config setting.

If the flag is:

- **true**: use the new SMS auth through our back-end.
- **false**: use the default SMS auth flow using Firebase.