### PR TITLE
fix: update the colour of the spinner in the activity_indicator_overlay component

### DIFF
--- a/src/components/activity-indicator-overlay/ActivityIndicatorOverlay.tsx
+++ b/src/components/activity-indicator-overlay/ActivityIndicatorOverlay.tsx
@@ -14,7 +14,7 @@ export const ActivityIndicatorOverlay = () => {
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
+const useStyles = StyleSheet.createThemeHook(() => ({
   spinner: {
     position: 'absolute',
     left: 0,
@@ -27,6 +27,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     opacity: 0.4,
   },
   activityIndicator: {
-    backgroundColor: theme.static.background['background_accent_0'].text,
+    backgroundColor: 'white',
   },
 }));

--- a/src/components/activity-indicator-overlay/ActivityIndicatorOverlay.tsx
+++ b/src/components/activity-indicator-overlay/ActivityIndicatorOverlay.tsx
@@ -3,15 +3,18 @@ import {ActivityIndicator, View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 
 export const ActivityIndicatorOverlay = () => {
-  const style = useStyles();
+  const styles = useStyles();
   return (
-    <View style={style.spinner}>
-      <ActivityIndicator size="large" />
+    <View style={styles.spinner}>
+      <ActivityIndicator
+        size="large"
+        color={styles.activityIndicator.backgroundColor}
+      />
     </View>
   );
 };
 
-const useStyles = StyleSheet.createThemeHook(() => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   spinner: {
     position: 'absolute',
     left: 0,
@@ -22,5 +25,8 @@ const useStyles = StyleSheet.createThemeHook(() => ({
     justifyContent: 'center',
     backgroundColor: 'black',
     opacity: 0.4,
+  },
+  activityIndicator: {
+    backgroundColor: theme.static.background['background_accent_0'].text,
   },
 }));


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/9189

### Background

After updating the colour of the spinner in the <LoadingScreen/> in the PR: https://github.com/AtB-AS/mittatb-app/pull/4545 , the colours in the spinners in the <LoadingScreen/> and the <ActivityIndicatorOverlay/> components became different. This PR fixes this, by updating the colour of the spinner in the <ActivityIndicatorOverlay/> component, ensuring that the same colour is being used in both spinners.  

#### Illustrations
AtB on android emulator.

<details>
<summary>screenshots/light_mode</summary>


|   Light mode               |  Old  |  New |
|:---------:| :--------: | :-------: |
| ATB | ![atb_spinner_lightmode1](https://github.com/AtB-AS/mittatb-app/assets/59939294/897ad944-996c-458b-9f25-1838a9bf92e2) | ![atb_activityIndicatorOverlay_lightmode](https://github.com/AtB-AS/mittatb-app/assets/59939294/2d7bb20b-1b4f-485a-b536-f7026d931e9a)|

</details>

<details>
<summary>screenshots/dark_mode</summary>


|   Dark mode               |  Old  |  New |
|:---------:| :--------: | :-------: |
| ATB | ![atb_spinner_lightmode](https://github.com/AtB-AS/mittatb-app/assets/59939294/cf5c09b2-ad12-45ae-a72a-7465a143c66f) | ![atb_activityIndicatorOverlay_darkmode_](https://github.com/AtB-AS/mittatb-app/assets/59939294/77f96a11-02d5-4f2e-add1-4b73fe7d7358)|

</details>

### Proposed solution

Add the same colour to the <ActivityIndicatorOverlay/> spinner, as the spinner in the <LoadingScreen/>.

### Acceptance Criteria
 - [ ] The spinner in the  <ActivityIndicatorOverlay/> component and the <LoadingScreen/> component, uses the same colour. 

