### PR TITLE
feat: implement flex ticket

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -121,7 +121,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
       : 'zones';
 
   const isOnBehalfOf = !!phoneNumber && !!destinationAccountId;
-  
+
   const {
     offerSearchTime,
     isSearchingOffer,
@@ -136,8 +136,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     fromPlace,
     toPlace,
     userProfilesWithCount,
+    isOnBehalfOf,
     travelDate,
-    isOnBehalfOf
   );
 
   const offerExpirationTime =

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -120,6 +120,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
       ? 'stop-places'
       : 'zones';
 
+  const isOnBehalfOf = !!phoneNumber && !!destinationAccountId;
+  
   const {
     offerSearchTime,
     isSearchingOffer,
@@ -135,6 +137,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     toPlace,
     userProfilesWithCount,
     travelDate,
+    isOnBehalfOf
   );
 
   const offerExpirationTime =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -118,8 +118,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     fromPlace,
     toPlace,
     travellerSelection,
+    isOnBehalfOfToggle,
     travelDate,
-    isOnBehalfOfToggle
   );
 
   const rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -119,6 +119,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     toPlace,
     travellerSelection,
     travelDate,
+    isOnBehalfOfToggle
   );
 
   const rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -35,8 +35,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
   const {appTexts} = useFirestoreConfiguration();
   const {flex_ticket_url} = useRemoteConfig();
 
-
-  if (!userProfiles.every((u) => u.offer.flex_discount_ladder)) return null;
+  if (!userProfiles.some((u) => u.offer.flex_discount_ladder)) return null;
 
   const description =
     getTextForLanguage(appTexts?.discountInfo, language) ||
@@ -67,7 +66,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
 
             const userProfileName = getReferenceDataName(u, language);
             const discountText =
-              discountPercent &&
+              (discountPercent !== undefined) &&
               t(
                 PurchaseOverviewTexts.flexDiscount.discountPercentage(
                   discountPercent.toFixed(0),

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -79,11 +79,13 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                 2,
               ) + ' kr';
 
+            const accessibilityLabel = `${userProfileName}, ${discountText ? discountText : ''}, ${priceText}`
+
             return (
               <GenericSectionItem
                 accessibility={{
                   accessible: true,
-                  accessibilityLabel: `${userProfileName}, ${discountText}, ${priceText}`,
+                  accessibilityLabel: accessibilityLabel,
                 }}
                 key={u.id}
               >

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
@@ -35,7 +35,11 @@ export function Summary({
   const {t, language} = useTranslation();
 
   const formattedPrice = formatDecimalNumber(price, language, 2);
-  const formattedOriginalPrice = formatDecimalNumber(originalPrice, language, 2);
+  const formattedOriginalPrice = formatDecimalNumber(
+    originalPrice,
+    language,
+    2,
+  );
   const hasSelection = userProfilesWithCount.some((u) => u.count);
 
   const toPaymentFunction = () => {
@@ -60,6 +64,11 @@ export function Summary({
           type="body__tertiary--strike"
           style={styles.originalPrice}
           testID="offerTotalPriceText"
+          accessibilityLabel={t(
+            PurchaseOverviewTexts.summary.ordinaryPriceA11yLabel(
+              formattedOriginalPrice,
+            ),
+          )}
         >
           {t(PurchaseOverviewTexts.summary.price(formattedOriginalPrice))}
         </ThemeText>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -155,8 +155,8 @@ export function useOfferState(
   fromPlace: TariffZone | StopPlaceFragmentWithIsFree,
   toPlace: TariffZone | StopPlaceFragmentWithIsFree,
   userProfilesWithCount: UserProfileWithCount[],
-  travelDate?: string,
   isOnBehalfOf: boolean = false,
+  travelDate?: string,
 ) {
   const offerReducer = getOfferReducer(userProfilesWithCount);
   const [state, dispatch] = useReducer(offerReducer, initialState);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -156,6 +156,7 @@ export function useOfferState(
   toPlace: TariffZone | StopPlaceFragmentWithIsFree,
   userProfilesWithCount: UserProfileWithCount[],
   travelDate?: string,
+  isOnBehalfOf: boolean = false,
 ) {
   const offerReducer = getOfferReducer(userProfilesWithCount);
   const [state, dispatch] = useReducer(offerReducer, initialState);
@@ -196,6 +197,7 @@ export function useOfferState(
               : {zones};
           const params = {
             ...placeParams,
+            is_on_behalf_of: isOnBehalfOf,
             travellers: offerTravellers,
             products: [preassignedFareProduct.id],
             travel_date: travelDate,
@@ -242,6 +244,7 @@ export function useOfferState(
       travelDate,
       fromPlace,
       toPlace,
+      isOnBehalfOf
     ],
   );
 

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -27,6 +27,7 @@ export type OfferSearchParams = SearchParams &
   (ZoneOfferSearchParams | StopPlaceOfferSearchParams);
 
 type SearchParams = {
+  is_on_behalf_of: boolean;
   travellers: Traveller[];
   products: string[];
   travel_date?: string;

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -228,6 +228,12 @@ const PurchaseOverviewTexts = {
       payment: _('Til betaling', 'To payment', 'Til betaling'),
       sendToOthers: _('Gå videre', 'Continue', 'Gå vidare'),
     },
+    ordinaryPriceA11yLabel: (priceString: string) =>
+      _(
+        `Ordinær pris ${priceString} kr`,
+        `Ordinary price ${priceString} kr`,
+        `Ordinær pris ${priceString} kr`,
+      ),
   },
   flexDiscount: {
     heading: _('Rabatt', 'Discount', 'Rabatt'),


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18132

handles the latest change from back-end from https://github.com/AtB-AS/team-platform/issues/610.

In this PR : 
- Adds `is_on_behalf_of` parameter to "Offer search" endpoint.
- Fix discount layout not showing on combined ticket (e.g. Adult + Senior ticket purchase).
- Fix discount layout not showing 0% discount on first purchase.