### PR TITLE
Create useSnackbar

### DIFF
--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -28,7 +28,7 @@ export type SnackbarTextContent = {
 
 export type SnackbarProps = {
   textContent?: SnackbarTextContent;
-  position: SnackbarPosition;
+  position?: SnackbarPosition;
   /** Optional action button, only shown if this is provided */
   actionButton?: ButtonProps;
   /** Whether to show the close x button */
@@ -39,7 +39,7 @@ export type SnackbarProps = {
 
 export const Snackbar = ({
   textContent,
-  position,
+  position = 'top',
   actionButton,
   isDismissable,
   customVisibleDurationMS,

--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -22,6 +22,8 @@ export type SnackbarPosition = 'top' | 'bottom';
 export type SnackbarTextContent = {
   title?: string;
   description?: string;
+  /** Unique key for the message. Makes it possible to re-show the exact same message */
+  messageKey?: number;
 };
 
 export type SnackbarProps = {

--- a/src/components/snackbar/index.ts
+++ b/src/components/snackbar/index.ts
@@ -4,6 +4,7 @@ export type {
   SnackbarTextContent,
   SnackbarProps,
 } from './Snackbar';
+export {useSnackbar} from './use-snackbar';
 export {useSnackbarVerticalPositionAnimation} from './use-snackbar-vertical-position-animation';
 export {useSnackbarIsVisible} from './use-snackbar-is-visible';
 export {useSnackbarScreenReaderFocus} from './use-snackbar-screen-reader-focus';

--- a/src/components/snackbar/use-snackbar.tsx
+++ b/src/components/snackbar/use-snackbar.tsx
@@ -1,0 +1,25 @@
+import {useState} from 'react';
+import {SnackbarTextContent} from './Snackbar';
+import {getSnackbarHasTextContent} from './utils';
+
+export const useSnackbar = () => {
+  const [textContent, setTextContent] = useState<SnackbarTextContent>();
+  const [messageKey, setMessageKey] = useState(0);
+
+  const showSnackbar = (textContent?: SnackbarTextContent) => {
+    setMessageKey((messageKey) => messageKey + 1);
+    setTextContent(textContent);
+  };
+  const hideSnackbar = () => setTextContent(undefined);
+
+  return {
+    snackbarTextContent: getSnackbarHasTextContent(textContent)
+      ? {
+          ...textContent,
+          messageKey,
+        }
+      : undefined,
+    showSnackbar,
+    hideSnackbar,
+  };
+};

--- a/src/components/snackbar/use-snackbar.tsx
+++ b/src/components/snackbar/use-snackbar.tsx
@@ -1,24 +1,28 @@
 import {useState} from 'react';
-import {SnackbarTextContent} from './Snackbar';
+import {SnackbarProps} from './Snackbar';
 import {getSnackbarHasTextContent} from './utils';
 
 export const useSnackbar = () => {
-  const [textContent, setTextContent] = useState<SnackbarTextContent>();
+  const [snackbarProps, setSnackbarProps] = useState<SnackbarProps>();
   const [messageKey, setMessageKey] = useState(0);
 
-  const showSnackbar = (textContent?: SnackbarTextContent) => {
+  const showSnackbar = (snackbarProps?: SnackbarProps) => {
     setMessageKey((messageKey) => messageKey + 1);
-    setTextContent(textContent);
+    setSnackbarProps(snackbarProps);
   };
-  const hideSnackbar = () => setTextContent(undefined);
+  const hideSnackbar = () => setSnackbarProps(undefined);
+
+  const snackbarTextContent = getSnackbarHasTextContent(
+    snackbarProps?.textContent,
+  )
+    ? {
+        ...snackbarProps?.textContent,
+        messageKey, // add unique key to each message
+      }
+    : undefined;
 
   return {
-    snackbarTextContent: getSnackbarHasTextContent(textContent)
-      ? {
-          ...textContent,
-          messageKey,
-        }
-      : undefined,
+    snackbarProps: {...snackbarProps, snackbarTextContent},
     showSnackbar,
     hideSnackbar,
   };


### PR DESCRIPTION
An issue with the Snackbar was discovered - showing the exact same message two or more times in a row, is not possible. This is because the diff check for the textContent says no change.
To solve this, a unique key must be provided for each new textContent to display.

Since managing this key is likely to always be desirable, and since @gorandalum had [a good suggestion](https://github.com/AtB-AS/mittatb-app/pull/4534#pullrequestreview-2080538074) for a `useSnackbar` hook, I have added it here.

Example of how to use:
```ts
// init
const {snackbarProps, showSnackbar, hideSnackbar} = useSnackbar();

// show
const textContent = {title: 'My Title', description: 'Some description here'}
showSnackbar({textContent, position: 'top'});

// if force hiding is needed (otherwise it will hide by itself after the default duration)
hideSnackbar()

// add to DOM
<Snackbar {...snackbarProps} />
```

Resolves https://github.com/AtB-AS/kundevendt/issues/17411