### PR TITLE
feat: Retry button on profile page resets auth

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -134,13 +134,9 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   useUpdateAuthLanguageOnChange();
 
   const retryAuth = useCallback(() => {
-    if (state.authStatus === 'fetch-id-token-timeout') {
-      dispatch({type: 'RETRY_FETCH_ID_TOKEN'});
-    } else if (state.authStatus === 'loading') {
-      dispatch({type: 'RESET_AUTH_STATUS'});
-      resubscribe();
-    }
-  }, [state.authStatus, resubscribe]);
+    dispatch({type: 'RESET_AUTH_STATUS'});
+    resubscribe();
+  }, [resubscribe]);
 
   return (
     <AuthContext.Provider

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -159,7 +159,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 messageType="error"
                 onPressConfig={{
                   action: () => {
-                    logEvent('Profile', 'Retry fetching id token');
+                    logEvent('Profile', 'Retry auth');
                     retryAuth();
                   },
                   text: t(dictionary.retry),


### PR DESCRIPTION
The retry button now resubscribes to Firestore auth, no matter what
auth status it has.
