### PR TITLE
fix: rejected reservations show on the correct screen

### DIFF
--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -27,7 +27,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
       await Linking.openURL(vippsUrl);
     } catch (err: any) {
       Bugsnag.notify(err);
-    } 
+    }
   }
   const getStatus = () => {
     const paymentStatus = reservation.paymentStatus;
@@ -41,11 +41,13 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
     }
   };
 
+  const isSubAccountReservation = customerProfile?.subAccounts?.some(
+    (id) => id === reservation.customerAccountId,
+  );
+  
   // filter out reservations for subaccount
-  const subaccounts = customerProfile?.subAccounts;
-  if (subaccounts) {
-    const subaccountReservation = subaccounts.filter((subaccountId) => subaccountId === reservation.customerAccountId);
-    if (subaccountReservation.length > 0) return null;
+  if (isSubAccountReservation) {
+    return null;
   }
 
   const status = getStatus();

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -10,7 +10,6 @@ import {ValidityLine} from './ValidityLine';
 import {FareContractStatusSymbol} from './components/FareContractStatusSymbol';
 import {formatToLongDateTime} from '@atb/utils/date';
 import {fromUnixTime} from 'date-fns';
-import {useAuthState} from '@atb/auth';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 
 type Props = {
@@ -20,7 +19,6 @@ type Props = {
 export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
   const styles = useStyles();
   const {theme} = useTheme();
-  const {abtCustomerId} = useAuthState();
   const {t, language} = useTranslation();
 
   async function openVippsUrl(vippsUrl: string) {
@@ -41,9 +39,6 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
         return 'reserving';
     }
   };
-
-  // Filter out reservations for subaccounts
-  if (reservation.customerAccountId !== abtCustomerId) return null;
 
   const status = getStatus();
 

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -1,7 +1,7 @@
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {Reservation, PaymentType} from '@atb/ticketing';
+import {Reservation, PaymentType, useTicketingState} from '@atb/ticketing';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import Bugsnag from '@bugsnag/react-native';
 import React from 'react';
@@ -19,6 +19,7 @@ type Props = {
 export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
   const styles = useStyles();
   const {theme} = useTheme();
+  const {customerProfile} = useTicketingState();
   const {t, language} = useTranslation();
 
   async function openVippsUrl(vippsUrl: string) {
@@ -26,7 +27,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
       await Linking.openURL(vippsUrl);
     } catch (err: any) {
       Bugsnag.notify(err);
-    }
+    } 
   }
   const getStatus = () => {
     const paymentStatus = reservation.paymentStatus;
@@ -39,6 +40,13 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
         return 'reserving';
     }
   };
+
+  // filter out reservations for subaccount
+  const subaccounts = customerProfile?.subAccounts;
+  if (subaccounts) {
+    const subaccountReservation = subaccounts.filter((subaccountId) => subaccountId === reservation.customerAccountId);
+    if (subaccountReservation.length > 0) return null;
+  }
 
   const status = getStatus();
 

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -4,6 +4,7 @@ import {FareContractAndReservationsList} from '@atb/fare-contracts';
 import {StyleSheet} from '@atb/theme';
 import {
   FareContract,
+  Reservation,
   filterExpiredFareContracts,
   useTicketingState,
 } from '@atb/ticketing';
@@ -16,6 +17,7 @@ import {
   TicketHistoryScreenParams,
 } from '@atb/ticket-history';
 import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
+import {useAuthState} from '@atb/auth';
 
 export const TicketHistoryScreenComponent = ({
   mode,
@@ -27,6 +29,8 @@ export const TicketHistoryScreenComponent = ({
     rejectedReservations,
     resubscribeFirestoreListeners,
   } = useTicketingState();
+
+  const {abtCustomerId: customerAccountId} = useAuthState();
 
   const {serverNow} = useTimeContextState();
   const {t} = useTranslation();
@@ -59,7 +63,11 @@ export const TicketHistoryScreenComponent = ({
             sentFareContracts,
             serverNow,
           )}
-          reservations={rejectedReservations}
+          reservations={displayReservations(
+            mode,
+            rejectedReservations,
+            customerAccountId,
+          )}
           now={serverNow}
           mode={mode}
           emptyStateTitleText={t(TicketingTexts.ticketHistory.emptyState)}
@@ -81,6 +89,23 @@ const displayFareContracts = (
       return filterExpiredFareContracts(fareContracts, serverNow);
     case 'sent':
       return sentFareContracts;
+  }
+};
+
+const displayReservations = (
+  mode: TicketHistoryMode,
+  reservations: Reservation[],
+  customerAccountId?: string,
+) => {
+  switch (mode) {
+    case 'expired':
+      return reservations.filter(
+        (reservation) => customerAccountId === reservation.customerAccountId,
+      );
+    case 'sent':
+      return reservations.filter(
+        (reservation) => reservation.customerAccountId !== customerAccountId,
+      );
   }
 };
 

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -100,7 +100,7 @@ const displayReservations = (
   switch (mode) {
     case 'expired':
       return reservations.filter(
-        (reservation) => customerAccountId === reservation.customerAccountId,
+        (reservation) => reservation.customerAccountId === customerAccountId,
       );
     case 'sent':
       return reservations.filter(

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -217,6 +217,7 @@ export type CustomerProfile = {
   id?: string;
   surname?: string;
   debug?: boolean;
+  subAccounts?: string[];
 };
 
 export type TravelCard = {


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17689

This PR will fix rejected reservations showing on both `Expired Tickets` and `Tickets sent to others`, by filtering the reservations based on the `customerAccountId`. Since we are removing the filtering of sent-to-other reservations, I also added filtering for subaccount purchases, so reservations for subaccount shouldn't be shown on the list.