### PR TITLE
chore: remove unused `enable_flex_ticket` remote config flag

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -20,7 +20,6 @@ export type RemoteConfig = {
   enable_car_sharing_in_map: boolean;
   enable_city_bikes_in_map: boolean;
   enable_extended_onboarding: boolean;
-  enable_flex_tickets: boolean;
   enable_flexible_transport: boolean;
   enable_from_travel_search_to_ticket: boolean;
   enable_geofencing_zones: boolean;
@@ -83,7 +82,6 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_car_sharing_in_map: false,
   enable_city_bikes_in_map: false,
   enable_extended_onboarding: false,
-  enable_flex_tickets: false,
   enable_flexible_transport: false,
   enable_from_travel_search_to_ticket: false,
   enable_geofencing_zones: false,
@@ -170,9 +168,6 @@ export function getConfig(): RemoteConfig {
   const enable_extended_onboarding =
     values['enable_extended_onboarding']?.asBoolean() ??
     defaultRemoteConfig.enable_extended_onboarding;
-  const enable_flex_tickets =
-    values['enable_flex_tickets']?.asBoolean() ??
-    defaultRemoteConfig.enable_flex_tickets;
   const enable_flexible_transport =
     values['enable_flexible_transport']?.asBoolean() ??
     defaultRemoteConfig.enable_flexible_transport;
@@ -308,7 +303,6 @@ export function getConfig(): RemoteConfig {
     enable_car_sharing_in_map,
     enable_city_bikes_in_map,
     enable_extended_onboarding,
-    enable_flex_tickets,
     enable_flexible_transport,
     enable_from_travel_search_to_ticket,
     enable_geofencing_zones,


### PR DESCRIPTION
reference : https://github.com/AtB-AS/kundevendt/issues/18132#issuecomment-2147412737

slack thread: https://mittatb.slack.com/archives/C074CKTCFQW/p1717493402857439

Frontend doesn't use the remote config flag, since we distinguish the status of flexible ticket based on the response we get from the back-end. If we get `flex_discount_ladder` on the offer response, then the flexible ticket is active, otherwise, it is disabled. 

This flag is therefore useless, since Backend didn't use it either.