### PR TITLE
chore: update release document about bump version

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -23,7 +23,11 @@ Bump the version number in these files:
 
 Do this in a commit with message "chore: Bump to version x.xx". You can check earlier commits with the message "chore: Bump to version x.xx" to see if all necessary files are bumped.
 
-After bumping the version number the new version should be registered at Entur for mobile token to work. This is done by running this command:
+After bumping the version number the new version should be registered at Entur for mobile token to work. 
+
+Please make sure that you have [jq](https://jqlang.github.io/jq/) installed, you can run `brew install jq` (or [similar instructions](https://jqlang.github.io/jq/download/) on other environments) to install it.
+
+Finally, run this command:
 
 `./scripts/register-local-app-version.sh`
 


### PR DESCRIPTION
Added instruction for missing jq command, which will cause the following error when running the script:

<img width="700" alt="image" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/66cfb7ac-29ac-40d4-aa6b-0f9fdb2bf706">
