### PR TITLE
feat: delete payment card on local storage when payment card is removed from profile

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
@@ -31,6 +31,7 @@ import {destructiveAlert} from './utils';
 import {animateNextChange} from '@atb/utils/animation';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
+import {deleteSavedPaymentMethodByUser} from '@atb/stacks-hierarchy/saved-payment-utils';
 
 type PaymentOptionsProps = ProfileScreenProps<'Profile_PaymentOptionsScreen'>;
 
@@ -39,7 +40,7 @@ export const Profile_PaymentOptionsScreen = ({
 }: PaymentOptionsProps) => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {authenticationType} = useAuthState();
+  const {authenticationType, userId} = useAuthState();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [storedCards, setStoredCards] = useState<RecurringPayment[]>([]);
@@ -99,7 +100,9 @@ export const Profile_PaymentOptionsScreen = ({
   async function handleRemovePayment(paymentOption: RecurringPayment) {
     setIsLoading(true);
     try {
-      await deleteRecurringPayment(paymentOption.id);
+      await deleteRecurringPayment(paymentOption.id).then(() =>
+        deleteSavedPaymentMethodByUser(userId, paymentOption.id),
+      );
     } catch (error: any) {
     } finally {
       refreshCards();

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -54,6 +54,29 @@ async function getPreviousPaymentMethodByUser(
   return methods[userId];
 }
 
+export async function deleteSavedPaymentMethodByUser(
+  userId: string | undefined,
+  paymentId: number,
+): Promise<void> {
+  try {
+    if (userId) {
+      const methods = await getStoredMethods();
+      const paymentForUserId = methods[userId];
+      if (paymentForUserId && paymentForUserId.savedType === 'recurring') {
+        if (paymentForUserId.recurringCard.id === paymentId) {
+          delete methods[userId];
+          await storage.set(
+            '@ATB_saved_payment_methods',
+            JSON.stringify(methods),
+          );
+        }
+      }
+    }
+  } catch (err: any) {
+    Bugsnag.notify(err);
+  }
+}
+
 export async function savePreviousPaymentMethodByUser(
   userId: string,
   option: SavedPaymentOption,


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17817

This PR will remove the card saved in local storage when it is removed from profile. Removing other cards won't affect the saved card. 

Note that removal in webshop isn't handled since it doesn't have access to local storage in the app. As discussed with @tormoseng 