### PR TITLE
perf: use memo on useValidRightNowFareContract

### DIFF
--- a/src/notifications/use-has-fare-contract-with-activated-notification.tsx
+++ b/src/notifications/use-has-fare-contract-with-activated-notification.tsx
@@ -2,8 +2,7 @@ import {
   findReferenceDataById,
   useFirestoreConfiguration,
 } from '@atb/configuration';
-
-import {useValidRightNowFareContract} from '@atb/ticketing/use-valid-right-now-fare-contracts';
+import {useValidRightNowFareContract} from '@atb/ticketing';
 import {useNotifications} from '@atb/notifications';
 
 export function useHasFareContractWithActivatedNotification(): boolean {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
@@ -3,10 +3,7 @@ import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurati
 import {CompactFareContractInfo} from '@atb/fare-contracts/CompactFareContractInfo';
 import {getFareContractInfoDetails} from '@atb/fare-contracts/FareContractInfo';
 import {StyleSheet} from '@atb/theme';
-import {
-  filterValidRightNowFareContracts,
-  useTicketingState,
-} from '@atb/ticketing';
+import {useValidRightNowFareContract} from '@atb/ticketing';
 import {
   DashboardTexts,
   TicketingTexts,
@@ -31,11 +28,7 @@ export const CompactFareContracts: React.FC<Props> = ({
   const itemStyle = useStyles();
 
   const {serverNow} = useTimeContextState();
-  const {fareContracts} = useTicketingState();
-  const validFareContracts = filterValidRightNowFareContracts(
-    fareContracts,
-    serverNow,
-  );
+  const validFareContracts = useValidRightNowFareContract();
 
   const {t} = useTranslation();
   const {tariffZones, userProfiles, preassignedFareProducts} =

--- a/src/ticketing/index.ts
+++ b/src/ticketing/index.ts
@@ -1,5 +1,6 @@
 export {TicketingContextProvider, useTicketingState} from './TicketingContext';
 export {useHasReservationOrActiveFareContract} from './use-has-reservation-or-active-fare-contract';
+export {useValidRightNowFareContract} from './use-valid-right-now-fare-contracts';
 
 export * from './api';
 export * from './types';

--- a/src/ticketing/use-valid-right-now-fare-contracts.tsx
+++ b/src/ticketing/use-valid-right-now-fare-contracts.tsx
@@ -4,10 +4,13 @@ import {
   filterValidRightNowFareContracts,
   FareContract,
 } from '@atb/ticketing';
+import {useMemo} from 'react';
 
 export function useValidRightNowFareContract(): FareContract[] {
   const {serverNow} = useTimeContextState();
   const {fareContracts} = useTicketingState();
-
-  return filterValidRightNowFareContracts(fareContracts, serverNow);
+  return useMemo(
+    () => filterValidRightNowFareContracts(fareContracts, serverNow),
+    [serverNow, fareContracts],
+  );
 }


### PR DESCRIPTION
While working on https://github.com/AtB-AS/kundevendt/issues/15528, I noticed that `filterValidRightNowFareContracts` is called a lot (especially on startup) and since there is a lot of filtering/mapping on all fare contacts from ticketing state, I thought it was worth memoing it.