### PR TITLE
fix: Show situations icon on dashboard favorites

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -336,7 +336,7 @@ const useItemStyles = StyleSheet.createThemeHook((theme) => ({
 export const getSvgForDeparture = (departure: DepartureTime) => {
   const msgTypeForSituationOrNotice =
     getMsgTypeForMostCriticalSituationOrNotice(
-      [],
+      departure.situations,
       filterNotices(departure.notices || []),
       departure.cancellation,
     );


### PR DESCRIPTION
A bug was introduced when showing warning icon for departures
with booking info, which made the app no longer show warning/info
icon for situation messages on dashboard favorites.
