### PR TITLE
feat: Only request value code onPress, handle error

### DIFF
--- a/src/mobility/queries/use-value-code-query.tsx
+++ b/src/mobility/queries/use-value-code-query.tsx
@@ -2,11 +2,14 @@ import {useQuery} from '@tanstack/react-query';
 import {getValueCode} from '@atb/mobility/api/api';
 import {useAuthState} from '@atb/auth';
 
-export const useValueCodeQuery = (operatorId: string | undefined) => {
+export const useValueCodeQuery = (
+  operatorId: string | undefined,
+  enabled: boolean,
+) => {
   const {userId, authStatus} = useAuthState();
   return useQuery({
     queryKey: ['mobilityValueCode', userId, operatorId],
     queryFn: () => getValueCode(operatorId),
-    enabled: authStatus === 'authenticated',
+    enabled: authStatus === 'authenticated' && enabled,
   });
 };

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -93,6 +93,19 @@ export const MobilityTexts = {
     'Activate to show in map',
     'Aktiver for å sjå i kart',
   ),
+  errorLoadingValueCode: {
+    title: _(
+      'Henting av verdikode feilet',
+      'Fetching value code failed',
+      'Henting av verdikode feila',
+    ),
+    text: _(
+      'Et problem oppstod ved henting av verdikode. Denne er nødvendig for å få med fordelen over til den andre appen.',
+      'A problem occured while fetching the value code. This is required to get the benefits in the other app.',
+      'Et problem oppstod ved henting av verdikode. Denne er nødvendig for å få med fordelen over til den andre appen.',
+    ),
+    retry: _('Prøv igjen', 'Retry', 'Prøv igjen'),
+  },
 };
 
 export const ScooterTexts = {


### PR DESCRIPTION
In order to not consume unnecessarily many value codes, hold back the request until the user actually presses the app switch button.
Also an error state management is in place now.

### Acceptance Criteria

- [ ] It should request the value code onPress of the AppSwitchButton, and immediately switch app if successful
- [ ] If there is an error, there should be an error message and the retry button should do exactly the same as if you press the AppSwitchButton