### PR TITLE
feat: get and use geofencing zones

### DIFF
--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -14,6 +14,10 @@ import {
   GetStationsQuery,
   GetStationsQueryVariables,
 } from '@atb/api/types/generated/StationsQuery';
+
+import {GeofencingZones} from '@atb/api/types/generated/mobility-types_v2';
+import {GetGeofencingZonesQuery} from '@atb/api/types/generated/GeofencingZonesQuery';
+
 import {
   BikeStationFragment,
   CarStationFragment,
@@ -118,6 +122,18 @@ export const getCarStation = (
   return client
     .get<GetCarStationQuery>(stringifyUrl(url, query), opts)
     .then((res) => res.data.stations?.[0]);
+};
+
+export const getGeofencingZones = (
+  systemIds: string[],
+  opts?: AxiosRequestConfig,
+): Promise<GeofencingZones[] | undefined> => {
+  if (systemIds.length < 1) return Promise.resolve(undefined);
+  const url = '/bff/v2/mobility/geofencing-zones';
+  const query = qs.stringify({systemIds});
+  return client
+    .get<GetGeofencingZonesQuery>(stringifyUrl(url, query), opts)
+    .then((res) => res.data.geofencingZones);
 };
 
 export const initViolationsReporting = (

--- a/src/api/types/generated/GeofencingZonesQuery.ts
+++ b/src/api/types/generated/GeofencingZonesQuery.ts
@@ -1,0 +1,25 @@
+export type GetGeofencingZonesQuery = {
+  geofencingZones?: Array<{
+    systemId?: string;
+    geojson?: {
+      type?: string;
+      features?: Array<{
+        type?: string;
+        geometry?: {type?: string};
+        properties?: {
+          name?: string;
+          start?: number;
+          end?: number;
+          polylineEncodedMultiPolygon?: Array<Array<string>>;
+          rules?: Array<{
+            vehicleTypeIds?: Array<string>;
+            rideAllowed: boolean;
+            rideThroughAllowed: boolean;
+            maximumSpeedKph?: number;
+            stationParking?: boolean;
+          }>;
+        };
+      }>;
+    };
+  }>;
+};

--- a/src/mobility/queries/use-geofencing-zones.tsx
+++ b/src/mobility/queries/use-geofencing-zones.tsx
@@ -2,7 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 import {getGeofencingZones} from '@atb/api/mobility';
 import {useGeofencingZonesEnabled} from '../use-geofencing-zones-enabled';
 
-const ONE_MINUTE = 1000 * 60;
+const TWELVE_HOURS_MS = 1000 * 60 * 60 * 12;
 
 export const useGeofencingZonesQuery = (systemIds: string[]) => {
   const [geofencingZonesEnabled, geofencingZonesEnabledDebugOverrideReady] =
@@ -14,7 +14,7 @@ export const useGeofencingZonesQuery = (systemIds: string[]) => {
       geofencingZonesEnabledDebugOverrideReady,
     queryKey: ['getGeofencingZones', ...systemIds],
     queryFn: ({signal}) => getGeofencingZones(systemIds, {signal}),
-    staleTime: ONE_MINUTE,
-    cacheTime: ONE_MINUTE,
+    staleTime: TWELVE_HOURS_MS,
+    cacheTime: TWELVE_HOURS_MS,
   });
 };

--- a/src/mobility/queries/use-geofencing-zones.tsx
+++ b/src/mobility/queries/use-geofencing-zones.tsx
@@ -1,0 +1,20 @@
+import {useQuery} from '@tanstack/react-query';
+import {getGeofencingZones} from '@atb/api/mobility';
+import {useGeofencingZonesEnabled} from '../use-geofencing-zones-enabled';
+
+const ONE_MINUTE = 1000 * 60;
+
+export const useGeofencingZonesQuery = (systemIds: string[]) => {
+  const [geofencingZonesEnabled, geofencingZonesEnabledDebugOverrideReady] =
+    useGeofencingZonesEnabled();
+  return useQuery({
+    enabled:
+      systemIds.length > 0 &&
+      geofencingZonesEnabled &&
+      geofencingZonesEnabledDebugOverrideReady,
+    queryKey: ['getGeofencingZones', ...systemIds],
+    queryFn: ({signal}) => getGeofencingZones(systemIds, {signal}),
+    staleTime: ONE_MINUTE,
+    cacheTime: ONE_MINUTE,
+  });
+};

--- a/src/mobility/queries/use-geofencing-zones.tsx
+++ b/src/mobility/queries/use-geofencing-zones.tsx
@@ -1,17 +1,10 @@
 import {useQuery} from '@tanstack/react-query';
 import {getGeofencingZones} from '@atb/api/mobility';
-import {useGeofencingZonesEnabled} from '../use-geofencing-zones-enabled';
 
 const TWELVE_HOURS_MS = 1000 * 60 * 60 * 12;
 
 export const useGeofencingZonesQuery = (systemId?: string) => {
-  const [geofencingZonesEnabled, geofencingZonesEnabledDebugOverrideReady] =
-    useGeofencingZonesEnabled();
   return useQuery({
-    enabled:
-      systemId !== undefined &&
-      geofencingZonesEnabled &&
-      geofencingZonesEnabledDebugOverrideReady,
     queryKey: ['getGeofencingZones', systemId],
     queryFn: ({signal}) =>
       getGeofencingZones(systemId !== undefined ? [systemId] : [], {signal}),

--- a/src/mobility/queries/use-geofencing-zones.tsx
+++ b/src/mobility/queries/use-geofencing-zones.tsx
@@ -4,16 +4,17 @@ import {useGeofencingZonesEnabled} from '../use-geofencing-zones-enabled';
 
 const TWELVE_HOURS_MS = 1000 * 60 * 60 * 12;
 
-export const useGeofencingZonesQuery = (systemIds: string[]) => {
+export const useGeofencingZonesQuery = (systemId?: string) => {
   const [geofencingZonesEnabled, geofencingZonesEnabledDebugOverrideReady] =
     useGeofencingZonesEnabled();
   return useQuery({
     enabled:
-      systemIds.length > 0 &&
+      systemId !== undefined &&
       geofencingZonesEnabled &&
       geofencingZonesEnabledDebugOverrideReady,
-    queryKey: ['getGeofencingZones', ...systemIds],
-    queryFn: ({signal}) => getGeofencingZones(systemIds, {signal}),
+    queryKey: ['getGeofencingZones', systemId],
+    queryFn: ({signal}) =>
+      getGeofencingZones(systemId !== undefined ? [systemId] : [], {signal}),
     staleTime: TWELVE_HOURS_MS,
     cacheTime: TWELVE_HOURS_MS,
   });


### PR DESCRIPTION
Create hook `useGeofencingZonesQuery`, using `getGeofencingZones` and `GetGeofencingZonesQuery`.

This hook returns the geofencing zones data using the bff endpoint.

This is the first of a series of PRs on the way to support geofencing zones. You can take a look at https://github.com/AtB-AS/mittatb-app/pull/4572/files if you want to see how it is used.

Resolves https://github.com/AtB-AS/kundevendt/issues/17614