### PR TITLE
feat: geofencing zone explanations

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^3.25.0",
-    "@atb-as/generate-assets": "^12.1.0",
-    "@atb-as/theme": "^10.1.0",
+    "@atb-as/generate-assets": "^12.1.1",
+    "@atb-as/theme": "^10.2.0",
     "@bugsnag/react-native": "^7.21.0",
     "@bugsnag/source-maps": "^2.3.1",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.4",

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -31,6 +31,7 @@ export type {
   MapRegion,
   ParkingType,
   ParkingVehicleTypes,
+  GeofencingZoneExplanationsType,
 } from './types';
 export {
   useRealtimeMapEnabled,

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -20,6 +20,9 @@ import {z} from 'zod';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {Line} from '@atb/api/types/trips';
 
+import {TranslatedString} from '@atb/translations';
+import {GeofencingZoneKeys} from '@atb-as/theme';
+
 /**
  * MapSelectionMode: Parameter to decide how on-select/ on-click on the map
  * should behave
@@ -181,4 +184,13 @@ export type ParkingType = {
   entityType: 'Parking';
   parkingVehicleTypes: ParkingVehicleTypes;
   totalCapacity: number;
+};
+
+type GeofencingZoneExplanationType = {
+  title: TranslatedString;
+  description: TranslatedString;
+};
+
+export type GeofencingZoneExplanationsType = {
+  [GZKey in GeofencingZoneKeys | 'Unspecified']: GeofencingZoneExplanationType;
 };

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -4,7 +4,10 @@ import {
   FormFactor,
   PropulsionType,
 } from '@atb/api/types/generated/mobility-types_v2';
-import {ParkingVehicleTypes} from '@atb/components/map';
+import {
+  GeofencingZoneExplanationsType,
+  ParkingVehicleTypes,
+} from '@atb/components/map';
 
 export const MobilityTexts = {
   formFactor: (formFactor: FormFactor) => {
@@ -219,5 +222,84 @@ export const ParkAndRideTexts = {
     'Ukjent antall plasser',
     'Unknown number of spaces',
     'Ukjend antal plassar',
+  ),
+};
+
+export const GeofencingZoneExplanations: GeofencingZoneExplanationsType = {
+  Allowed: {
+    title: _('Tillatt område', 'Allowed Area', 'Tillatt område'),
+    description: _(
+      'Her kan du både kjøre og parkere',
+      'Here you can both drive and park',
+      'Her kan du både køyre og parkere',
+    ),
+  },
+  Slow: {
+    title: _('Saktesone', 'Slow Zone', 'Saktesone'),
+    description: _(
+      'Farten blir redusert i dette området',
+      'The speed will be reduced in this area',
+      'Farta vert redusert i dette området',
+    ),
+  },
+
+  /*** future features, pending support from Entur's Mobility API: ***/
+  // https://github.com/entur/lamassu/issues/448
+  // Parking: {
+  //   title: _('Parkeringssone', 'Parking Zone', 'Parkeringssone'),
+  //   description: _(
+  //     'Dette er et passende sted å parkere',
+  //     'This is a suitable place to park',
+  //     'Dette er ein passande stad å parkere',
+  //   ),
+  // },
+  // BonusParking: {
+  //   title: _(
+  //     'Bonusparkeringssone',
+  //     'Bonus Parking Zone',
+  //     'Bonusparkeringssone',
+  //   ),
+  //   description: _(
+  //     'Her får du rabatt for å parkere',
+  //     'By parking here you get a discount',
+  //     'Her får du rabatt for å parkere',
+  //   ),
+  // },
+
+  NoParking: {
+    title: _(
+      'Parkering forbudt-sone',
+      'No Parking Zone',
+      'Parkering forboden-sone',
+    ),
+    description: _(
+      'Du kan ikke parkere i dette området',
+      'You cannot park in this area',
+      'Du kan ikkje parkere i dette området',
+    ),
+  },
+  NoEntry: {
+    title: _('Kjøring forbudt-sone', 'No Riding Zone', 'Kjøring forboden-sone'),
+    description: _(
+      'Du kan ikke kjøre inn i dette området',
+      'You cannot ride in this area',
+      'Du kan ikkje køyre inn i dette området',
+    ),
+  },
+  Unspecified: {
+    title: _('Uspesifisert', 'Unspecified', 'Uspesifisert'),
+    description: _(
+      'Ingen regler angitt for dette området',
+      'No rules defined for this area',
+      'Ingen reglar angitt for dette området',
+    ),
+  },
+};
+
+export const GeofencingZoneExtraExplanations = {
+  isStationParking: _(
+    'Se etter parkeringssoner i kartet.',
+    'Look for parking zones on the map.',
+    'Se etter parkeringssoner i kartet.',
   ),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,22 +40,22 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-12.1.0.tgz#c7d84610436b256f27c3fc53c4b58c862099e3d4"
-  integrity sha512-T+fmP4Wz/W7gNjBvwjw+P11HGd1IGmdFwDUr0TzkLdLciJQhp7xjUxdpRVjmp8z5cjVNh71OtjfVz1utTKjIdQ==
+"@atb-as/generate-assets@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-12.1.1.tgz#8d288e37a8ffbac9a6ff6ed08ef7bae7c666fb2d"
+  integrity sha512-T9Yzd6IxkuC0W4O4Qgy4hWirtFnkwYvr2/kkYWt1aNjMCqoxFY0nHmzj6yIDrmONrIp0U3wHmGoUVg8floZnmQ==
   dependencies:
-    "@atb-as/theme" "^10.1.0"
+    "@atb-as/theme" "^10.2.0"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-10.1.0.tgz#50bbfcc8b8cab002b3f49044db187af2f19bfc3e"
-  integrity sha512-NYtJyfRUFXZtQVlpwc/j7eGLW+jFJkBpeUyvIiFe6AoRI40RENATt213Hbi81ttCI2v0CKPVf+o/L6H8+Cq8YA==
+"@atb-as/theme@^10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-10.2.0.tgz#ab8b1a6143d802b9f3816cec62d92b0e16ea5c08"
+  integrity sha512-afpB55WiXPdw/QlhQ5cikOYcMLyqDWl4W3tK1iJYlU1lBthHZXJoWkgv/8KZ38uAGgf3uNQtgRmBRmGkwspfeQ==
   dependencies:
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"


### PR DESCRIPTION
As can be read in the [new docs](https://github.com/AtB-AS/docs-private/pull/53), there are 4 types of geofencingZone features: `Allowed`, `Slow`, `NoParking` and `NoEntry`.
This adds an explanation for each of them.

Also explanations are added for `Unspecified`, for the case when a user presses on a location without a feature.
`GeofencingZoneExtraExplanations` is an extra explanation that is added if `isStation` is set to `true` for that feature. (The rule for `isStation` is also described in the docs).


<table>
  <tr>
    <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/393fcef4-d70e-4364-b7f5-6b6ecbf42a60" /></td>
    <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/e4566527-3272-47ae-a783-15f13f493926" /></td>
     <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/e269ba87-d423-43f7-9f3b-502e099b04e4" /></td>
      <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/d88671a4-5259-4d27-a826-2f01c7692100" /></td>
      <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/046b4116-064b-4a66-8fbb-00e12ec190db" /></td>
       <td><img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/9854ba7f-457b-40f4-84be-454e11d7d13c" /></td>
  </tr>
  <tr>
    <td>Allowed</td>
    <td>Slow</td>
    <td>No Parking, isStation=true</td>
    <td>No Parking, isStation=false</td>
    <td>No Entry</td>
    <td>Unspecified</td>
  </tr>
</table>

Resolves https://github.com/AtB-AS/kundevendt/issues/17614