### PR TITLE
feat: Set hitboxCoveringIconOnly on ShapeSources

### DIFF
--- a/src/components/map/components/mobility/Bicycles.tsx
+++ b/src/components/map/components/mobility/Bicycles.tsx
@@ -5,6 +5,7 @@ import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
+import {hitboxCoveringIconOnly} from '@atb/components/map';
 
 type Props = {
   bicycles: FeatureCollection<GeoJSON.Point, VehicleBasicFragment>;
@@ -27,6 +28,7 @@ export const Bicycles = ({bicycles, onClusterClick}: Props) => {
         shape={bicycles}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
         maxZoomLevel={22}
         clusterMaxZoomLevel={21}
         onPress={(e) => onClusterClick(e, clustersSource)}
@@ -72,6 +74,7 @@ export const Bicycles = ({bicycles, onClusterClick}: Props) => {
         shape={bicycles}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
         maxZoomLevel={22}
         clusterMaxZoomLevel={21}
       >

--- a/src/components/map/components/mobility/BikeStations.tsx
+++ b/src/components/map/components/mobility/BikeStations.tsx
@@ -4,6 +4,7 @@ import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import React, {RefObject, useRef} from 'react';
 import {StationsWithCount} from './Stations';
+import {hitboxCoveringIconOnly} from '@atb/components/map';
 
 type Props = {
   stations: StationsWithCount;
@@ -39,6 +40,7 @@ export const BikeStations = ({stations, onClusterClick}: Props) => {
         shape={stations}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
       >
         <MapboxGL.SymbolLayer
           id="bikeStationPin"
@@ -56,6 +58,7 @@ export const BikeStations = ({stations, onClusterClick}: Props) => {
         ref={clustersSource}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
         clusterProperties={{
           sum: ['+', ['get', 'count']],
         }}

--- a/src/components/map/components/mobility/CarStations.tsx
+++ b/src/components/map/components/mobility/CarStations.tsx
@@ -4,6 +4,7 @@ import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import React, {RefObject, useRef} from 'react';
 import {StationsWithCount} from './Stations';
+import {hitboxCoveringIconOnly} from '@atb/components/map';
 
 type Props = {
   stations: StationsWithCount;
@@ -41,6 +42,7 @@ export const CarStations = ({stations, onClusterClick}: Props) => {
         shape={stations}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
       >
         <MapboxGL.SymbolLayer
           id="carStationPin"
@@ -58,6 +60,7 @@ export const CarStations = ({stations, onClusterClick}: Props) => {
         shape={stations}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
         clusterProperties={{
           sum: ['+', ['get', 'count']],
         }}

--- a/src/components/map/components/mobility/Scooters.tsx
+++ b/src/components/map/components/mobility/Scooters.tsx
@@ -5,6 +5,7 @@ import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
+import {hitboxCoveringIconOnly} from '@atb/components/map';
 
 type Props = {
   scooters: FeatureCollection<GeoJSON.Point, VehicleBasicFragment>;
@@ -27,6 +28,7 @@ export const Scooters = ({scooters, onClusterClick}: Props) => {
         shape={scooters}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
         maxZoomLevel={22}
         clusterMaxZoomLevel={21}
         clusterRadius={40}
@@ -73,6 +75,7 @@ export const Scooters = ({scooters, onClusterClick}: Props) => {
         shape={scooters}
         tolerance={0}
         cluster
+        hitbox={hitboxCoveringIconOnly}
         maxZoomLevel={22}
         clusterRadius={40}
         clusterMaxZoomLevel={21}

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -15,6 +15,7 @@ export {
   toFeatureCollection,
   toFeaturePoint,
   toFeaturePoints,
+  hitboxCoveringIconOnly,
 } from './utils';
 export type {
   FormFactorFilterType,

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -20,6 +20,8 @@ import {
 import distance from '@turf/distance';
 import {isStation} from '@atb/mobility/utils';
 
+export const hitboxCoveringIconOnly = {width: 1, height: 1};
+
 export async function zoomIn(
   mapViewRef: RefObject<MapboxGL.MapView>,
   mapCameraRef: RefObject<MapboxGL.Camera>,

--- a/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
+++ b/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
@@ -6,6 +6,7 @@ import {Language, TariffZonesTexts, useTranslation} from '@atb/translations';
 import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
 import {
   flyToLocation,
+  hitboxCoveringIconOnly,
   MapCameraConfig,
   MapViewConfig,
   PositionArrow,
@@ -131,7 +132,7 @@ const TariffZonesSelectorMap = ({
             <MapboxGL.ShapeSource
               id="tariffZonesShape"
               shape={featureCollection}
-              hitbox={{width: 1, height: 1}} // to not be able to hit multiple zones with one click
+              hitbox={hitboxCoveringIconOnly} // to not be able to hit multiple zones with one click
               onPress={selectFeature}
             >
               <MapboxGL.FillLayer


### PR DESCRIPTION
Default hitbox is 44x44 pixels for `ShapeSource`. Sometimes this causes them to capture onPress events even when pressing on the side of the icon.
Using 1x1 still captures the event when the icon is pressed, but not when pressing on the side of it.

Resolves https://github.com/AtB-AS/kundevendt/issues/17614