### PR TITLE
feat: get saved card data from remote during payment confirmation

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentOptionsScreen.tsx
@@ -131,7 +131,8 @@ export const Profile_PaymentOptionsScreen = ({
             ))}
           </Section>
         )}
-        {!recurringPaymentLoading &&
+        {!recurringPaymentError &&
+          !recurringPaymentLoading &&
           (!recurringPayment || recurringPayment?.length == 0) && (
             <NoCardsInfo />
           )}

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -26,6 +26,8 @@ export function usePreviousPaymentMethod(): SavedPaymentOption | undefined {
             recurringPayment.id === savedMethod.recurringCard.id,
         );
         if (method) setPaymentMethod(savedMethod);
+      } else {
+        setPaymentMethod(savedMethod);
       }
     }
 

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -3,6 +3,7 @@ import {SavedPaymentOption} from './types';
 import {storage} from '@atb/storage';
 import Bugsnag from '@bugsnag/react-native';
 import {useAuthState} from '@atb/auth';
+import {useListRecurringPaymentsQuery} from '@atb/ticketing/use-list-recurring-payments-query';
 
 export function usePreviousPaymentMethod(): SavedPaymentOption | undefined {
   const [paymentMethod, setPaymentMethod] = useState<
@@ -10,10 +11,22 @@ export function usePreviousPaymentMethod(): SavedPaymentOption | undefined {
   >(undefined);
   const {userId} = useAuthState();
 
+  const {data: recurringPayments} = useListRecurringPaymentsQuery();
+
   useEffect(() => {
     async function run(uid: string) {
-      const method = await getPreviousPaymentMethodByUser(uid);
-      setPaymentMethod(method);
+      const savedMethod = await getPreviousPaymentMethodByUser(uid);
+      if (
+        recurringPayments &&
+        savedMethod &&
+        savedMethod.savedType === 'recurring'
+      ) {
+        const method = recurringPayments.find(
+          (recurringPayment) =>
+            recurringPayment.id === savedMethod.recurringCard.id,
+        );
+        if (method) setPaymentMethod(savedMethod);
+      }
     }
 
     if (!userId) {
@@ -22,7 +35,7 @@ export function usePreviousPaymentMethod(): SavedPaymentOption | undefined {
     } else {
       run(userId);
     }
-  }, [userId]);
+  }, [recurringPayments, userId]);
 
   return paymentMethod;
 }

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -52,7 +52,7 @@ export async function listRecurringPayments(): Promise<RecurringPayment[]> {
   const response = await client.get<RecurringPayment[]>(url, {
     authWithIdToken: true,
   });
-  return response.data;
+  return response.data.reverse();
 }
 
 export async function addPaymentMethod(paymentRedirectUrl: string) {

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -52,7 +52,7 @@ export async function listRecurringPayments(): Promise<RecurringPayment[]> {
   const response = await client.get<RecurringPayment[]>(url, {
     authWithIdToken: true,
   });
-  return response.data.reverse();
+  return response.data;
 }
 
 export async function addPaymentMethod(paymentRedirectUrl: string) {

--- a/src/ticketing/use-authorize-recurring-payment-mutation.tsx
+++ b/src/ticketing/use-authorize-recurring-payment-mutation.tsx
@@ -1,0 +1,18 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {authorizeRecurringPayment} from '@atb/ticketing';
+import {LIST_RECURRING_PAYMENTS_QUERY_KEY} from './use-list-recurring-payments-query';
+
+export const AUTHORIZE_RECURRING_PAYMENT_QUERY_KEY =
+  'authorizeRecurringPayment';
+
+export const useAuthorizeRecurringPaymentMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: [AUTHORIZE_RECURRING_PAYMENT_QUERY_KEY],
+    mutationFn: (recurringPaymentId: number) =>
+      authorizeRecurringPayment(recurringPaymentId),
+    onSuccess: () =>
+      queryClient.invalidateQueries([LIST_RECURRING_PAYMENTS_QUERY_KEY]),
+  });
+};

--- a/src/ticketing/use-cancel-recurring-payment-mutation.tsx
+++ b/src/ticketing/use-cancel-recurring-payment-mutation.tsx
@@ -1,0 +1,11 @@
+import {useMutation} from '@tanstack/react-query';
+import {cancelRecurringPayment} from '@atb/ticketing';
+
+export const CANCEL_RECURRING_PAYMENT_MUTATION_KEY = 'cancelRecurringPayment';
+
+export const useCancelRecurringPaymentMutation = () =>
+  useMutation({
+    mutationKey: [CANCEL_RECURRING_PAYMENT_MUTATION_KEY],
+    mutationFn: (recurringPaymentId: number) =>
+      cancelRecurringPayment(recurringPaymentId),
+  });

--- a/src/ticketing/use-delete-recurring-payment-mutation.tsx
+++ b/src/ticketing/use-delete-recurring-payment-mutation.tsx
@@ -1,0 +1,16 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {deleteRecurringPayment} from '@atb/ticketing';
+import { LIST_RECURRING_PAYMENTS_QUERY_KEY } from './use-list-recurring-payments-query';
+
+export const DELETE_RECURRING_PAYMENT_MUTATION_KEY = 'deleteRecurringPayment';
+
+export const useDeleteRecurringPaymentMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: [DELETE_RECURRING_PAYMENT_MUTATION_KEY],
+    mutationFn: (recurringPaymentId: number) =>
+      deleteRecurringPayment(recurringPaymentId),
+    onSuccess: () => queryClient.invalidateQueries([LIST_RECURRING_PAYMENTS_QUERY_KEY]) 
+  });
+}

--- a/src/ticketing/use-delete-recurring-payment-mutation.tsx
+++ b/src/ticketing/use-delete-recurring-payment-mutation.tsx
@@ -2,13 +2,10 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {deleteRecurringPayment} from '@atb/ticketing';
 import { LIST_RECURRING_PAYMENTS_QUERY_KEY } from './use-list-recurring-payments-query';
 
-export const DELETE_RECURRING_PAYMENT_MUTATION_KEY = 'deleteRecurringPayment';
-
 export const useDeleteRecurringPaymentMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: [DELETE_RECURRING_PAYMENT_MUTATION_KEY],
     mutationFn: (recurringPaymentId: number) =>
       deleteRecurringPayment(recurringPaymentId),
     onSuccess: () => queryClient.invalidateQueries([LIST_RECURRING_PAYMENTS_QUERY_KEY]) 

--- a/src/ticketing/use-list-recurring-payments-query.tsx
+++ b/src/ticketing/use-list-recurring-payments-query.tsx
@@ -1,0 +1,18 @@
+import {useAuthState} from '@atb/auth';
+import {listRecurringPayments} from '@atb/ticketing';
+import {useQuery} from '@tanstack/react-query';
+
+const ONE_HOUR_MS = 1000 * 60 * 60;
+
+export const LIST_RECURRING_PAYMENTS_QUERY_KEY = 'getListRecurringPayments';
+
+export const useListRecurringPaymentsQuery = () => {
+  const {authenticationType} = useAuthState();
+
+  return useQuery({
+    queryKey: [LIST_RECURRING_PAYMENTS_QUERY_KEY],
+    queryFn: listRecurringPayments,
+    cacheTime: ONE_HOUR_MS,
+    enabled: authenticationType === 'phone',
+  });
+};

--- a/src/ticketing/use-list-recurring-payments-query.tsx
+++ b/src/ticketing/use-list-recurring-payments-query.tsx
@@ -12,11 +12,10 @@ export const useListRecurringPaymentsQuery = () => {
   return useQuery({
     queryKey: [LIST_RECURRING_PAYMENTS_QUERY_KEY, abtCustomerId, authenticationType],
     queryFn: async () => {
-      if (authenticationType !== 'phone') {
-        return undefined
+      if (authenticationType === 'phone') {
+        return await listRecurringPayments();          
       }
-      const list = await listRecurringPayments();
-      return list;
+      return [];
     },
     cacheTime: ONE_HOUR_MS,
   });

--- a/src/ticketing/use-list-recurring-payments-query.tsx
+++ b/src/ticketing/use-list-recurring-payments-query.tsx
@@ -7,12 +7,17 @@ const ONE_HOUR_MS = 1000 * 60 * 60;
 export const LIST_RECURRING_PAYMENTS_QUERY_KEY = 'getListRecurringPayments';
 
 export const useListRecurringPaymentsQuery = () => {
-  const {authenticationType} = useAuthState();
+  const {authenticationType, abtCustomerId} = useAuthState();
 
   return useQuery({
-    queryKey: [LIST_RECURRING_PAYMENTS_QUERY_KEY],
-    queryFn: listRecurringPayments,
+    queryKey: [LIST_RECURRING_PAYMENTS_QUERY_KEY, abtCustomerId, authenticationType],
+    queryFn: async () => {
+      if (authenticationType !== 'phone') {
+        return undefined
+      }
+      const list = await listRecurringPayments();
+      return list;
+    },
     cacheTime: ONE_HOUR_MS,
-    enabled: authenticationType === 'phone',
   });
 };


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17817

old PR for reference : https://github.com/AtB-AS/mittatb-app/pull/4564

On this PR:
- Refactor calling payment cards API to `useQuery` and `useMutation`.
- Call API to check when getting saved card, to check if the saved card is still available on API or not.