### PR TITLE
fix: oms profile translations referring to atb

### DIFF
--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -365,22 +365,29 @@ export default orgSpecificTranslations(ProfileTexts, {
           notifications: {
             pushToggle: {
               subText: _(
-                'Tillat at Reisnordland sender varslinger til denne telefonen.',
-                'Allow Reisnordland to send notifications to this phone.',
-                'Tillet Reisnordland å sende varslingar til denne telefonen.',
+                'Tillat at Reis Nordland sender varslinger til denne telefonen.',
+                'Allow Reis Nordland to send notifications to this phone.',
+                'Tillet Reis Nordland å sende varslingar til denne telefonen.',
               ),
             },
             emailToggle: {
               subText: (email: string) =>
                 _(
-                  `Tillat at Reisnordland sender varslinger til ${email}`,
-                  `Allow Reisnordland to send notifications to ${email}`,
-                  `Tillet Reisnordland å sende varslingar til ${email}`,
+                  `Tillat at Reis Nordland sender varslinger til ${email}`,
+                  `Allow Reis Nordland to send notifications to ${email}`,
+                  `Tillet Reis Nordland å sende varslingar til ${email}`,
                 ),
               noEmailPlaceholder: _(
-                'Tillat at Reisnordland sender varslinger til e-posten din.',
-                'Allow Reisnordland to send notifications to your e-mail.',
-                'Tillet Reisnordland å sende varslingar til e-posten din.',
+                'Tillat at Reis Nordland sender varslinger til e-posten din.',
+                'Allow Reis Nordland to send notifications to your e-mail.',
+                'Tillet Reis Nordland å sende varslingar til e-posten din.',
+              ),
+            },
+            permissionRequired: {
+              message: _(
+                'Skru på varslinger i telefoninnstillingene for å motta varslinger fra Reis Nordland.',
+                'Enable notifications in Settings to receive notifications from Reis Nordland.',
+                'Skru på varslingar i telefoninnstillingane for å få varslingar frå Reis Nordland.',
               ),
             },
           },
@@ -421,6 +428,13 @@ export default orgSpecificTranslations(ProfileTexts, {
                 'Tillat at FRAM sender varslinger til e-posten din.',
                 'Allow FRAM to send notifications to your e-mail.',
                 'Tillet FRAM å sende varslingar til e-posten din.',
+              ),
+            },
+            permissionRequired: {
+              message: _(
+                'Skru på varslinger i telefoninnstillingene for å motta varslinger fra FRAM.',
+                'Enable notifications in Settings to receive notifications from FRAM.',
+                'Skru på varslingar i telefoninnstillingane for å få varslingar frå FRAM.',
               ),
             },
           },
@@ -470,6 +484,13 @@ export default orgSpecificTranslations(ProfileTexts, {
                 'Tillat at Svipper sender varslinger til e-posten din.',
                 'Allow Svipper to send notifications to your e-mail.',
                 'Tillet Svipper å sende varslingar til e-posten din.',
+              ),
+            },
+            permissionRequired: {
+              message: _(
+                'Skru på varslinger i telefoninnstillingene for å motta varslinger fra Svipper.',
+                'Enable notifications in Settings to receive notifications from Svipper.',
+                'Skru på varslingar i telefoninnstillingane for å få varslingar frå Svipper.',
               ),
             },
           },


### PR DESCRIPTION
I've added a new `orgSpecificTranslations` for a translation that made the app refer to AtB instead of Reis Nordland/FRAM/Svipper. Also changed "Reisnordland" to "Reis Nordland". 

Fixes https://github.com/AtB-AS/kundevendt/issues/18428