### PR TITLE
fix: make skoleskyss not resolve to NormalTravelRight

### DIFF
--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -256,9 +256,6 @@ export const useDefaultPreassignedFareProduct = (
   return preAssignedFareProducts[0];
 };
 
-export const getFareProductRef = (fc: FareContract) =>
-  fc.travelRights[0]?.fareProductRef;
-
 type FareContractInfoProps = {
   isCarnetFareContract: boolean;
   travelRights: NormalTravelRight[];

--- a/src/notifications/use-has-fare-contract-with-activated-notification.tsx
+++ b/src/notifications/use-has-fare-contract-with-activated-notification.tsx
@@ -2,7 +2,10 @@ import {
   findReferenceDataById,
   useFirestoreConfiguration,
 } from '@atb/configuration';
-import {useValidRightNowFareContract} from '@atb/ticketing';
+import {
+  isNormalTravelRight,
+  useValidRightNowFareContract,
+} from '@atb/ticketing';
 import {useNotifications} from '@atb/notifications';
 
 export function useHasFareContractWithActivatedNotification(): boolean {
@@ -13,15 +16,19 @@ export function useHasFareContractWithActivatedNotification(): boolean {
   if (!notificationsConfig) return false;
 
   return validFareContracts.some((validFareContract) => {
-    const fareProductRef = validFareContract.travelRights[0]?.fareProductRef;
+    const firstTravelRight = validFareContract.travelRights[0];
 
-    if (!fareProductRef) {
+    if (!isNormalTravelRight(firstTravelRight)) {
+      return false;
+    }
+
+    if (!firstTravelRight.fareProductRef) {
       return false;
     }
 
     const preassignedFareProduct = findReferenceDataById(
       preassignedFareProducts,
-      fareProductRef,
+      firstTravelRight.fareProductRef,
     );
 
     return notificationsConfig?.groups.some(

--- a/src/ticketing/TicketingContext.tsx
+++ b/src/ticketing/TicketingContext.tsx
@@ -3,7 +3,7 @@ import {useAuthState} from '../auth';
 import {Reservation, FareContract, PaymentStatus} from './types';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {differenceInMinutes} from 'date-fns';
-import {CustomerProfile} from '.';
+import {CustomerProfile, isNormalTravelRight} from '.';
 import {setupFirestoreListeners} from './firestore';
 import {useResubscribeToggle} from '@atb/utils/use-resubscribe-toggle';
 import {logToBugsnag, notifyBugsnag} from '@atb/utils/bugsnag-utils';
@@ -53,9 +53,13 @@ const ticketingReducer: TicketingReducer = (
       const currentFareContractOrderIds = action.fareContracts.map(
         (fc) => fc.orderId,
       );
+      // Filter out fare contracts that doesn't have any normal travel rights
+      const fareContracts = action.fareContracts.filter((fc) =>
+        fc.travelRights.some((tr) => isNormalTravelRight(tr)),
+      );
       return {
         ...prevState,
-        fareContracts: action.fareContracts,
+        fareContracts,
         reservations: prevState.reservations.filter(
           (r) => !currentFareContractOrderIds.includes(r.orderId),
         ),

--- a/src/ticketing/__tests__/fixtures/skoleskyss-travelright.ts
+++ b/src/ticketing/__tests__/fixtures/skoleskyss-travelright.ts
@@ -1,0 +1,7 @@
+export const skoleskyssTravelRight = {
+  customerAccountId: 'ATB:CustomerAccount:KE0HD6YxnZdczQ4kxc63VAMFb7m2',
+  endDateTime: undefined,
+  id: 'ATB:CustomerPurchasePackage:ea8d2936-64e3-4876-bf64-e89bc9c58cc9',
+  startDateTime: undefined,
+  type: 'UnknownTicket',
+};

--- a/src/ticketing/__tests__/travelrights.test.ts
+++ b/src/ticketing/__tests__/travelrights.test.ts
@@ -5,6 +5,7 @@ import {periodBoatTravelRight} from './fixtures/period-boat-travelright';
 import {singleTravelRight} from './fixtures/single-travelright';
 import {singleBoatTravelRight} from './fixtures/single-boat-travelright';
 import {youthTravelRight} from './fixtures/youth-travelright';
+import {skoleskyssTravelRight} from './fixtures/skoleskyss-travelright';
 
 import {CarnetTravelRight, TravelRight} from '../types';
 import {
@@ -45,6 +46,10 @@ describe('Travelright type', () => {
 
   it('carnet should resolve to carnet', async () => {
     expect(isCarnetTravelRight(carnetTravelRight)).toBe(true);
+  });
+
+  it('skoleskyss should not resolve to normal', async () => {
+    expect(isNormalTravelRight(skoleskyssTravelRight)).toBe(false);
   });
 });
 

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -22,14 +22,12 @@ export enum TravelRightDirection {
 
 export type TravelRight = {
   id: string;
-  status: TravelRightStatus;
   type: string;
-  fareProductRef: string;
-  direction?: TravelRightDirection;
 };
 
 export type NormalTravelRight = TravelRight & {
-  fareProductRef: string;
+  fareProductRef?: string;
+  status: TravelRightStatus;
   startDateTime: Date;
   endDateTime: Date;
   usageValidityPeriodRef: string;
@@ -37,6 +35,7 @@ export type NormalTravelRight = TravelRight & {
   tariffZoneRefs?: string[];
   startPointRef?: string;
   endPointRef?: string;
+  direction?: TravelRightDirection;
 };
 
 export type CarnetTravelRightUsedAccess = {

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -26,7 +26,7 @@ export type TravelRight = {
 };
 
 export type NormalTravelRight = TravelRight & {
-  fareProductRef?: string;
+  fareProductRef: string;
   status: TravelRightStatus;
   startDateTime: Date;
   endDateTime: Date;

--- a/src/ticketing/utils.ts
+++ b/src/ticketing/utils.ts
@@ -24,7 +24,11 @@ export function isCarnet(fareContract: FareContract): boolean {
 export function isNormalTravelRight(
   travelRight: TravelRight | undefined,
 ): travelRight is NormalTravelRight {
-  return !!travelRight && 'startDateTime' in travelRight;
+  return (
+    !!travelRight &&
+    'startDateTime' in travelRight &&
+    !!travelRight.startDateTime
+  );
 }
 
 function isOrWillBeActivatedFareContract(f: FareContract): boolean {


### PR DESCRIPTION
- Fixes a bug in `isNormalTravelRight` that doesn't catch `startDateTime: undefined`
- Filters out fare contracts that doesn't have any "normal" travel rights. This was needed to make some "firstTravelRight" logic work which assumes every fare contract has a travel right.
- Adds a test for a skoleskyss travelright.

fixes https://github.com/AtB-AS/kundevendt/issues/15528#issuecomment-2176504199