### PR TITLE
fix: Add includeSnackbar prop to Map

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -36,7 +36,7 @@ import {isCarStation, isStation} from '@atb/mobility/utils';
 import {Snackbar, useSnackbar} from '../snackbar';
 
 export const Map = (props: MapProps) => {
-  const {initialLocation} = props;
+  const {initialLocation, includeSnackbar} = props;
   const {currentCoordinatesRef, getCurrentCoordinates} = useGeolocationState();
   const mapCameraRef = useRef<MapboxGL.Camera>(null);
   const mapViewRef = useRef<MapboxGL.MapView>(null);
@@ -264,7 +264,7 @@ export const Map = (props: MapProps) => {
           />
         </View>
 
-        <Snackbar {...snackbarProps} />
+        {includeSnackbar && <Snackbar {...snackbarProps} />}
       </View>
     </View>
   );

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -92,6 +92,7 @@ export type MapProps = {
   initialLocation?: Location;
   vehicles?: VehiclesState;
   stations?: StationsState;
+  includeSnackbar?: boolean;
 } & (
   | {
       selectionMode: 'ExploreLocation';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
@@ -78,6 +78,7 @@ export const Map_RootScreen = ({
         navigateToQuay={navigateToQuay}
         navigateToDetails={navigateToDetails}
         navigateToTripSearch={navigateToTripSearch}
+        includeSnackbar={true}
       />
     </>
   );


### PR DESCRIPTION
https://mittatb.slack.com/archives/C02EEG7D8EL/p1718869819941549

Quick fix for when the `Snackbar` container is not at the top.
<img width="200" src="https://github.com/AtB-AS/mittatb-app/assets/134292729/f74d533f-d296-44df-bd78-c6bda90eb0b3" />

For the future, the `Snackbar` should probably be put inside a ContextProvider just like `BottomSheet` is in `BottomSheetProvider` instead.