### PR TITLE
fix: map location on press fix

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -137,48 +137,58 @@ export const Map = (props: MapProps) => {
    * Step 2: decide feature to select
    * Step 3: selected the feature
    */
-  const onFeatureClick = async (feature: Feature) => {
-    if (!isFeaturePoint(feature)) return;
+  const onFeatureClick = useCallback(
+    async (feature: Feature) => {
+      if (!isFeaturePoint(feature)) return;
 
-    if (!showGeofencingZones) {
-      onMapClick({source: 'map-click', feature});
-      return;
-    }
-
-    const {coordinates: positionClicked} = feature.geometry;
-
-    const featuresAtClick = await getFeaturesAtClick(feature, mapViewRef);
-    if (!featuresAtClick || featuresAtClick.length === 0) return;
-    const featureToSelect = featuresAtClick.reduce((selected, currentFeature) =>
-      getFeatureWeight(currentFeature, positionClicked) >
-      getFeatureWeight(selected, positionClicked)
-        ? currentFeature
-        : selected,
-    );
-
-    /**
-     * this hides the Snackbar when a feature is clicked,
-     * unless the feature is a geofencingZone, in which case
-     * geofencingZoneOnPress will be called which sets it visible again
-     */
-    hideSnackbar();
-
-    if (isFeatureGeofencingZone(featureToSelect)) {
-      geofencingZoneOnPress(
-        featureToSelect?.properties?.geofencingZoneCustomProps,
-      );
-    } else {
-      if (isFeaturePoint(featureToSelect)) {
-        onMapClick({
-          source: 'map-click',
-          feature: featureToSelect,
-        });
-      } else if (isScooter(selectedFeature)) {
-        // outside of operational area, rules unspecified
-        geofencingZoneOnPress(undefined);
+      if (!showGeofencingZones) {
+        onMapClick({source: 'map-click', feature});
+        return;
       }
-    }
-  };
+
+      const {coordinates: positionClicked} = feature.geometry;
+
+      const featuresAtClick = await getFeaturesAtClick(feature, mapViewRef);
+      if (!featuresAtClick || featuresAtClick.length === 0) return;
+      const featureToSelect = featuresAtClick.reduce(
+        (selected, currentFeature) =>
+          getFeatureWeight(currentFeature, positionClicked) >
+          getFeatureWeight(selected, positionClicked)
+            ? currentFeature
+            : selected,
+      );
+
+      /**
+       * this hides the Snackbar when a feature is clicked,
+       * unless the feature is a geofencingZone, in which case
+       * geofencingZoneOnPress will be called which sets it visible again
+       */
+      hideSnackbar();
+
+      if (isFeatureGeofencingZone(featureToSelect)) {
+        geofencingZoneOnPress(
+          featureToSelect?.properties?.geofencingZoneCustomProps,
+        );
+      } else {
+        if (isFeaturePoint(featureToSelect)) {
+          onMapClick({
+            source: 'map-click',
+            feature: featureToSelect,
+          });
+        } else if (isScooter(selectedFeature)) {
+          // outside of operational area, rules unspecified
+          geofencingZoneOnPress(undefined);
+        }
+      }
+    },
+    [
+      geofencingZoneOnPress,
+      hideSnackbar,
+      onMapClick,
+      showGeofencingZones,
+      selectedFeature,
+    ],
+  );
 
   return (
     <View style={styles.container}>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -139,6 +139,12 @@ export const Map = (props: MapProps) => {
    */
   const onFeatureClick = async (feature: Feature) => {
     if (!isFeaturePoint(feature)) return;
+
+    if (!showGeofencingZones) {
+      onMapClick({source: 'map-click', feature});
+      return;
+    }
+
     const {coordinates: positionClicked} = feature.geometry;
 
     const featuresAtClick = await getFeaturesAtClick(feature, mapViewRef);


### PR DESCRIPTION
https://mittatb.slack.com/archives/C02EEG7D8EL/p1718886090430569?thread_ts=1718869819.941549&cid=C02EEG7D8EL

After the geofencing zones were added, the new on map click logic wasn't compatible with the map location selection mode.
Now the new logic is only applied when showing geofencingZones.

Two changes:
The fix: https://github.com/AtB-AS/mittatb-app/pull/4598/commits/50ac28f80f55cc231f2a06c6b9d8d31453aa739e
Wrapped `onFeatureClick` in a `useCallback`: https://github.com/AtB-AS/mittatb-app/pull/4598/commits/a9f1c9b100d26a08618c81bc67080c5c288437b5