### PR TITLE
refactor: Add more logging to auth and mobile token requests

### DIFF
--- a/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
+++ b/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
@@ -10,7 +10,8 @@ import {
 import {Token} from '@atb/mobile-token/types';
 
 import {v4 as uuid} from 'uuid';
-import {useAuthState} from "@atb/auth";
+import {useAuthState} from '@atb/auth';
+import {logToBugsnag} from '@atb/utils/bugsnag-utils.ts';
 
 export const LIST_REMOTE_TOKENS_QUERY_KEY = 'listRemoteTokens';
 
@@ -21,7 +22,10 @@ export const useListRemoteTokensQuery = (
   const {userId} = useAuthState();
   return useQuery({
     queryKey: [MOBILE_TOKEN_QUERY_KEY, LIST_REMOTE_TOKENS_QUERY_KEY, userId],
-    queryFn: () => tokenService.listTokens(uuid()),
+    queryFn: () => {
+      logToBugsnag('Listing tokens for user ' + userId);
+      return tokenService.listTokens(uuid());
+    },
     enabled,
     select: (tokens) =>
       tokens.map(


### PR DESCRIPTION
Mainly some more logging in the fetch id token flow, and changed
the notify Bugsnag event to always be the same message, and the
actual error message is set in the description.

Also added Bugsnag breadcrumb when listing tokens for a user.
