### PR TITLE
fix: filter out successful reservations for sent to other tickets.

### DIFF
--- a/src/ticketing/TicketingContext.tsx
+++ b/src/ticketing/TicketingContext.tsx
@@ -83,10 +83,14 @@ const ticketingReducer: TicketingReducer = (
       const currentFareContractOrderIds = prevState.fareContracts.map(
         (fc) => fc.orderId,
       );
+      const sentToOthersFareContractOrderIds = prevState.sentFareContracts.map(
+        (fc) => fc.orderId,
+      )
+      const combinedOrderIds = [...currentFareContractOrderIds, ...sentToOthersFareContractOrderIds];
       return {
         ...prevState,
         reservations: action.reservations.filter(
-          (r) => !currentFareContractOrderIds.includes(r.orderId),
+          (r) => !combinedOrderIds.includes(r.orderId),
         ),
       };
     }


### PR DESCRIPTION
reference: https://mittatb.slack.com/archives/C0116FMPX4Y/p1718956797385489?thread_ts=1718794154.952519&cid=C0116FMPX4Y

This will fix a bug where successful sent-to-others reservation showing incorrectly on the "My Tickets" page. 

Repro steps on buggy version: 

1. successfully purchase a sent-to-others ticket
2. buy another sent-to-others ticket, but hold off the payment (easiest to test using vipps)
3. go back to the my ticket screen
4. the reservation of the pending payment (on step 2) and successful purchase (on step 1), is now shown on my ticket screen.


#### Acceptance criteria:

- [ ] Successful reservation for sent-to-others ticket no longer shows in my ticket screen.