### PR TITLE
feat: show reservation buy-for-others

### DIFF
--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -26,7 +26,7 @@ export const TicketHistoryScreenComponent = ({
     fareContracts,
     sentFareContracts,
     isRefreshingFareContracts,
-    rejectedReservations,
+    reservations,
     resubscribeFirestoreListeners,
   } = useTicketingState();
 
@@ -65,7 +65,7 @@ export const TicketHistoryScreenComponent = ({
           )}
           reservations={displayReservations(
             mode,
-            rejectedReservations,
+            reservations,
             customerAccountId,
           )}
           now={serverNow}


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18129

In this PR, Rejected reservation and Ongoing/pending reservation will be shown on sent-to-others ticket history screen.

Discussed with @Aliaaen and he said that both reservation (rejected & ongoing) status should show on both screens.

<img width="300" src="https://github.com/AtB-AS/kundevendt/assets/1777333/f60cded8-d5d7-48d0-bb68-1fdcd95da80a" />

<img width="300" src="https://github.com/AtB-AS/kundevendt/assets/1777333/f3569855-d7cd-4810-b6d9-e2cd7c63d6de" />