### PR TITLE
fix: only show rejected reservation on expired ticket

### DIFF
--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -27,6 +27,7 @@ export const TicketHistoryScreenComponent = ({
     sentFareContracts,
     isRefreshingFareContracts,
     reservations,
+    rejectedReservations,
     resubscribeFirestoreListeners,
   } = useTicketingState();
 
@@ -66,6 +67,7 @@ export const TicketHistoryScreenComponent = ({
           reservations={displayReservations(
             mode,
             reservations,
+            rejectedReservations,
             customerAccountId,
           )}
           now={serverNow}
@@ -95,11 +97,12 @@ const displayFareContracts = (
 const displayReservations = (
   mode: TicketHistoryMode,
   reservations: Reservation[],
+  rejectedReservations: Reservation[],
   customerAccountId?: string,
 ) => {
   switch (mode) {
     case 'expired':
-      return reservations.filter(
+      return rejectedReservations.filter(
         (reservation) => reservation.customerAccountId === customerAccountId,
       );
     case 'sent':


### PR DESCRIPTION
ref: https://github.com/AtB-AS/kundevendt/issues/18129#issuecomment-2185844922

only show `rejectedReservation` on `Utløpte billetter`