### PR TITLE
fix: mobile token onboarding will only show on authenticated users

### DIFF
--- a/src/onboarding/onboarding-config.ts
+++ b/src/onboarding/onboarding-config.ts
@@ -72,8 +72,8 @@ export const onboardingSectionsInPrioritizedOrder: OnboardingSectionConfig[] =
       initialScreen: {
         name: 'Root_ConsiderTravelTokenChangeScreen',
       },
-      shouldShowPredicate: ({mobileTokenStatus, travelCardDisabled}) =>
-        mobileTokenStatus === 'success-not-inspectable' && !travelCardDisabled,
+      shouldShowPredicate: ({mobileTokenStatus, travelCardDisabled, authenticationType}) =>
+        mobileTokenStatus === 'success-not-inspectable' && !travelCardDisabled && authenticationType === 'phone',
     },
     {
       isOnboardedStoreKey: '@ATB_mobile_token_without_travelcard_onboarded',
@@ -81,7 +81,7 @@ export const onboardingSectionsInPrioritizedOrder: OnboardingSectionConfig[] =
       initialScreen: {
         name: 'Root_ConsiderTravelTokenChangeScreen',
       },
-      shouldShowPredicate: ({mobileTokenStatus, travelCardDisabled}) =>
-        mobileTokenStatus === 'success-not-inspectable' && travelCardDisabled,
+      shouldShowPredicate: ({mobileTokenStatus, travelCardDisabled, authenticationType}) =>
+        mobileTokenStatus === 'success-not-inspectable' && travelCardDisabled && authenticationType === 'phone',
     },
   ];


### PR DESCRIPTION
closes: https://github.com/AtB-AS/kundevendt/issues/18445

Attempt fix the mobile token onboarding that appears after logout. I added the `authenticationType === 'phone` to `shouldShowPredicate` function, so that the onboarding will only show for authenticated users.