### PR TITLE
fix: Wrong state for Abt Entur SDK when initializing timer

### DIFF
--- a/src/mobile-token/abtClientLogger.ts
+++ b/src/mobile-token/abtClientLogger.ts
@@ -10,7 +10,7 @@ export const localLogger: ClientConfig['localLogger'] = {
   },
   warn: (msg, err, metadata?) => {
     const onError = toOnErrorCallback('warning', msg, metadata);
-    Bugsnag.notify(err, onError);
+    if (err) Bugsnag.notify(err, onError);
   },
   error: (msg, err, metadata?) => {
     const onError = toOnErrorCallback('error', msg, metadata);

--- a/src/mobile-token/mobileTokenClient.ts
+++ b/src/mobile-token/mobileTokenClient.ts
@@ -12,18 +12,20 @@ const CONTEXT_ID = 'main';
 
 const TWELVE_HOURS_MS = 1000 * 60 * 60 * 12;
 
-export const abtContextIds = [CONTEXT_ID];
-
-export const abtAttestationConfig = {
-  attestationType: 'PlayIntegrityAPIAttestation',
-};
-
 const abtClient = createClient({
-  tokenContextIds: abtContextIds,
-  attestation: abtAttestationConfig,
+  tokenContextIds: [CONTEXT_ID],
+  attestation: {
+    attestationType: 'PlayIntegrityAPIAttestation',
+  },
   remoteTokenService: tokenService,
   localLogger,
   remoteLogger,
+  time: {
+    autoStart: true,
+    maxDelayInMilliSeconds: 1000,
+    parallelizationCount: 3,
+    host: 'time.google.com',
+  }
 });
 
 export const mobileTokenClient = {
@@ -48,4 +50,5 @@ export const mobileTokenClient = {
    */
   shouldRenew: (token: ActivatedToken) =>
     abtClient.shouldPreemptiveRenew(token, TWELVE_HOURS_MS, 10),
+  currentTimeMillis: () => abtClient.getCurrentTimeMillis(),
 };

--- a/src/mobile-token/mobileTokenClient.ts
+++ b/src/mobile-token/mobileTokenClient.ts
@@ -12,11 +12,15 @@ const CONTEXT_ID = 'main';
 
 const TWELVE_HOURS_MS = 1000 * 60 * 60 * 12;
 
+export const abtContextIds = [CONTEXT_ID];
+
+export const abtAttestationConfig = {
+  attestationType: 'PlayIntegrityAPIAttestation',
+};
+
 const abtClient = createClient({
-  tokenContextIds: [CONTEXT_ID],
-  attestation: {
-    attestationType: 'PlayIntegrityAPIAttestation',
-  },
+  tokenContextIds: abtContextIds,
+  attestation: abtAttestationConfig,
   remoteTokenService: tokenService,
   localLogger,
   remoteLogger,

--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -1,5 +1,6 @@
 import {useInterval} from '@atb/utils/use-interval';
 import {clock, startNativeModule as start} from '@entur-private/abt-token-state-react-native-lib';
+import {abtContextIds, abtAttestationConfig} from '@atb/mobile-token/mobileTokenClient';
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import {useServerTimeEnabled} from '@atb/time';
 
@@ -29,7 +30,7 @@ export const TimeContextProvider: React.FC = ({children}) => {
 
   useEffect(() => {
     if (serverTimeEnabled) {
-      start([], [], {
+      start(abtContextIds, abtAttestationConfig, {
         autoStart: true,
         maxDelayInMilliSeconds: 1000,
         parallelizationCount: 3,

--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -1,7 +1,6 @@
 import {useInterval} from '@atb/utils/use-interval';
-import {clock, startNativeModule as start} from '@entur-private/abt-token-state-react-native-lib';
-import {abtContextIds, abtAttestationConfig} from '@atb/mobile-token/mobileTokenClient';
-import React, {createContext, useContext, useEffect, useState} from 'react';
+import {mobileTokenClient} from '@atb/mobile-token/mobileTokenClient';
+import React, {createContext, useContext, useState} from 'react';
 import {useServerTimeEnabled} from '@atb/time';
 
 type TimeContextState = {
@@ -24,25 +23,13 @@ let serverDiff = 0;
 export const getServerNow = () => Date.now() - serverDiff;
 
 export const TimeContextProvider: React.FC = ({children}) => {
-  const [clockIsRunning, setClockIsRunning] = useState(false);
   const [serverNow, setServerNow] = useState(Date.now());
   const [serverTimeEnabled] = useServerTimeEnabled();
 
-  useEffect(() => {
-    if (serverTimeEnabled) {
-      start(abtContextIds, abtAttestationConfig, {
-        autoStart: true,
-        maxDelayInMilliSeconds: 1000,
-        parallelizationCount: 3,
-        host: 'time.google.com',
-      }).then(() => setClockIsRunning(true));
-    }
-  }, [serverTimeEnabled]);
-
   useInterval(
     () => {
-      if (serverTimeEnabled && clockIsRunning) {
-        clock.currentTimeMillis().then((ms) => {
+      if (serverTimeEnabled) {
+        mobileTokenClient.currentTimeMillis().then((ms) => {
           serverDiff = Date.now() - ms;
           setServerNow(ms);
         });
@@ -51,7 +38,7 @@ export const TimeContextProvider: React.FC = ({children}) => {
         setServerNow(Date.now());
       }
     },
-    [clockIsRunning, serverTimeEnabled],
+    [serverTimeEnabled],
     2500,
     false,
     true,


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/kundevendt/issues/18509

TimeContextProvider requires AbtClient to be initialized, this fix import some configurations as well initializes the AbtClient.