### PR TITLE
feat: hide payment method and price on refunded tickets

### DIFF
--- a/src/fare-contracts/details/OrderDetails.tsx
+++ b/src/fare-contracts/details/OrderDetails.tsx
@@ -68,7 +68,7 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
           color="secondary"
           style={style.marginTop}
         >
-          {t(FareContractTexts.details.totalPrice(priceString))}
+          {t(FareContractTexts.details.totalPrice(priceString))}
         </ThemeText>
       )}
       {fareContract.state !== FareContractState.Refunded && (

--- a/src/fare-contracts/details/OrderDetails.tsx
+++ b/src/fare-contracts/details/OrderDetails.tsx
@@ -1,4 +1,8 @@
-import {FareContract, isNormalTravelRight} from '@atb/ticketing';
+import {
+  FareContract,
+  FareContractState,
+  isNormalTravelRight,
+} from '@atb/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
@@ -16,10 +20,9 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
     FareContractTexts.details.orderId(fareContract.orderId),
   );
   const firstTravelRight = fareContract.travelRights[0];
-  const priceString =
-    fareContract.totalAmount
-      ? formatDecimalNumber(parseFloat(fareContract.totalAmount), language, 2)
-      : undefined;
+  const priceString = fareContract.totalAmount
+    ? formatDecimalNumber(parseFloat(fareContract.totalAmount), language, 2)
+    : undefined;
 
   return (
     <View accessible={true}>
@@ -59,21 +62,23 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
           </ThemeText>
         </>
       )}
-      <ThemeText
-        type="body__secondary"
-        color="secondary"
-        style={style.marginTop}
-      >
-        {t(FareContractTexts.details.paymentMethod)}
-        {_.capitalize(fareContract?.paymentType?.join(', '))}
-      </ThemeText>
-      {priceString && (
+      {fareContract.state !== FareContractState.Refunded && priceString && (
         <ThemeText
           type="body__secondary"
           color="secondary"
           style={style.marginTop}
         >
-          {t(FareContractTexts.details.totalPrice(priceString))}
+          {t(FareContractTexts.details.totalPrice(priceString))}
+        </ThemeText>
+      )}
+      {fareContract.state !== FareContractState.Refunded && (
+        <ThemeText
+          type="body__secondary"
+          color="secondary"
+          style={style.marginTop}
+        >
+          {t(FareContractTexts.details.paymentMethod)}
+          {_.capitalize(fareContract?.paymentType?.join(', '))}
         </ThemeText>
       )}
       <ThemeText style={style.marginTop}>{orderIdText}</ThemeText>


### PR DESCRIPTION
additional fix for https://github.com/AtB-AS/kundevendt/issues/17139

ref comment : https://github.com/AtB-AS/kundevendt/issues/17139#issuecomment-2188764253

- Removes the price text on refunded tickets.
- Removes the payment method text on refunded tickets.
- Switches the position of the price and payment method on the detail screen.