### PR TITLE
feat: show maximum interchange time in trip details if data is provided

### DIFF
--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -127,7 +127,7 @@ export type TripFragment = {
         notices: Array<{id: string; text?: string}>;
         journeyPattern?: {notices: Array<{id: string; text?: string}>};
       };
-      interchangeTo?: {guaranteed?: boolean; toServiceJourney?: {id: string}};
+      interchangeTo?: {guaranteed?: boolean; toServiceJourney?: {id: string}; maximumWaitTime?: number};
       pointsOnLink?: {points?: string; length?: number};
       intermediateEstimatedCalls: Array<{
         date: any;

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -307,6 +307,12 @@ const TripDetailsTexts = {
         `Correspondance with ${toPublicCode} on ${location}.`,
         `Korrespondanse med ${toPublicCode} på ${location}.`,
       ),
+    interchangeMaxWait: (maxWaitTime: string) =>
+      _(
+        `Venter inntil ${maxWaitTime}.`,
+        `Waiting up to ${maxWaitTime}.`,
+        `Ventar i opp til ${maxWaitTime}.`,
+      ),
   },
   flexibleTransport: {
     needsBookingWhatIsThisTitle: (publicCode: string) =>


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/18410

Example of it is shown with interchange:
![Screenshot 2024-06-27 at 10 49 38](https://github.com/AtB-AS/mittatb-app/assets/606374/a4bda73a-9e3f-4381-a173-51386ef40d63)

Related change in BFF: https://github.com/AtB-AS/atb-bff/pull/337
Release of BFF is required to show maximum wait time, but it is backwards compatible.
