### PR TITLE
feat: show multimodal stop places in location search

### DIFF
--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -26,6 +26,7 @@ export async function autocomplete(
       tariff_zone_authorities: onlyLocalTariffZoneAuthority
         ? TARIFF_ZONE_AUTHORITY
         : null,
+      multiModal: 'parent'
     },
     {skipNull: true},
   );


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16260

Shows the multimodal stop place properly when searching, instead of showing a separate stop place.

#### Before vs After

<img width="350" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/e1812a81-c30a-450e-bb69-10e125557dec" />
<img width="350" src="https://github.com/AtB-AS/mittatb-app/assets/1777333/65777491-2c35-4026-89f6-df7099336f85" />
