### PR TITLE
build: add update-app-version script

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -11,7 +11,7 @@ Skip the first two steps of creating release-branch and bumping version number o
 ### Create release branch
 Branch out from master to a new branch with prefix `release/`, like `release/1.30`.
 
-### On master: Bump version number and register new version at Entur registry
+### On master: Bump version number
 
 Now that a release branch is created, the version-number on master should be increased. So if `release/1.30` is created, then master should be incremented to `1.31` as version number.
 
@@ -23,13 +23,18 @@ Bump the version number in these files:
 
 Do this in a commit with message "chore: Bump to version x.xx". You can check earlier commits with the message "chore: Bump to version x.xx" to see if all necessary files are bumped.
 
-After bumping the version number the new version should be registered at Entur for mobile token to work. 
+### Register new version at Entur registry
 
-Please make sure that you have [jq](https://jqlang.github.io/jq/) installed, you can run `brew install jq` (or [similar instructions](https://jqlang.github.io/jq/download/) on other environments) to install it.
+After bumping the version number the new version should be registered at Entur for mobile token to work.
+
+> [!NOTE]
+> Please make sure that you have [jq](https://jqlang.github.io/jq/) installed. You can run `brew install jq` (or [similar instructions](https://jqlang.github.io/jq/download/) on other environments) to install it.
 
 Finally, run this command:
 
-`./scripts/register-local-app-version.sh`
+```bash
+./scripts/register-local-app-version.sh
+```
 
 ### Create release candidate with the command line
 

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -15,13 +15,13 @@ Branch out from master to a new branch with prefix `release/`, like `release/1.3
 
 Now that a release branch is created, the version-number on master should be increased. So if `release/1.30` is created, then master should be incremented to `1.31` as version number.
 
-Bump the version number in these files:
+Version number can be updated by running the following command:
 
-- All .env-files
-- package.json
-- e2e/package.json
+```bash
+./scripts/update-app-version.sh x.xx`
+```
 
-Do this in a commit with message "chore: Bump to version x.xx". You can check earlier commits with the message "chore: Bump to version x.xx" to see if all necessary files are bumped.
+Then push your changes with commit message "chore: Bump to version x.xx".
 
 ### Register new version at Entur registry
 

--- a/scripts/update-app-version.sh
+++ b/scripts/update-app-version.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Updates the app version in all .env and package.json files.
+# See Release.md for more information on making releases of the app.
+
+if [ -z "$1" ]; then
+  echo "Updates the app version in all .env and package.json files."
+  echo "See Release.md for more information on making releases of the app."
+  echo ""
+  echo "Usage:	$0 <version>"
+  exit 1
+fi
+
+# If version string does not have a patch number, append ".0"
+withPatch=$1
+if [[ $withPatch != *.*.* ]]; then
+  withPatch="$1.0"
+  echo -e "\033[33mUsing \"$withPatch\" for package.json\033[0m"
+fi
+
+# .env
+echo "Updating version in .env"
+sed -i '' "s/APP_VERSION=.*/APP_VERSION=$1/" .env
+
+find env -name .env | while read -r file; do
+  echo "Updating version in $file"
+  sed -i '' "s/APP_VERSION=.*/APP_VERSION=$1/" "$file"
+done
+
+# package.json
+echo "Updating version in package.json"
+sed -i '' "s/\"version\": \".*\"/\"version\": \"$withPatch\"/" package.json
+
+echo "Updating version in e2e/package.json"
+sed -i '' "s/\"version\": \".*\"/\"version\": \"$withPatch\"/" e2e/package.json


### PR DESCRIPTION
Adds a script to bump version numbers in .env and package.json files, so we don't have to do it manually for every release 🥳 

![Screenshot 2024-07-02 at 15 57 34](https://github.com/AtB-AS/mittatb-app/assets/1774972/a7ba07c5-1580-4cbb-a083-b6d670cf46a3)
