### PR TITLE
feat: prevent login retires for 10s after too many attempts

### DIFF
--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -39,6 +39,7 @@ export const Root_LoginPhoneInputScreen = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<PhoneSignInErrorCode>();
   const {themeName} = useTheme();
+  const [isRateLimited, setIsRateLimited] = useState(false);
 
   const phoneValidationParams = {
     strictDetection: true,
@@ -53,6 +54,7 @@ export const Root_LoginPhoneInputScreen = ({
   const isValidPhoneNumber = phoneValidation.isValid;
 
   const onNext = async () => {
+    if (isRateLimited) return;
     setIsSubmitting(true);
     if (!phoneValidation.phoneNumber) {
       setIsSubmitting(false);
@@ -65,6 +67,10 @@ export const Root_LoginPhoneInputScreen = ({
     setIsSubmitting(false);
 
     if (result) {
+      if (result === 'too_many_attempts') {
+        setIsRateLimited(true);
+        setTimeout(() => setIsRateLimited(false), 10000);
+      }
       setError(result);
     } else {
       setError(undefined);
@@ -152,7 +158,7 @@ export const Root_LoginPhoneInputScreen = ({
                 interactiveColor="interactive_0"
                 onPress={onNext}
                 text={t(LoginTexts.phoneInput.mainButton)}
-                disabled={!isValidPhoneNumber}
+                disabled={!isValidPhoneNumber || isRateLimited}
                 testID="sendCodeButton"
                 rightIcon={{svg: ArrowRight}}
               />

--- a/src/translations/components/PhoneInput.ts
+++ b/src/translations/components/PhoneInput.ts
@@ -29,9 +29,9 @@ const PhoneInputTexts = {
       'Ingen konto knytta til dette telefonnummeret',
     ),
     too_many_attempts: _(
-      'Du har prøvd for mange ganger. Vennligst vent litt før du prøver igjen.',
-      'You have tried too many times. Please wait a bit before trying again.',
-      'Du har prøvd for mange gangar. Ver venleg og vent litt før du prøver igjen.',
+      'Du har prøvd for mange ganger. Vennligst vent noen minutter før du prøver igjen.',
+      'You have tried too many times. Please wait a few minutes before trying again.',
+      'Du har prøvd for mange gangar. Ver venleg og vent nokon minutt før du prøver igjen.',
     ),
     unknown_error: _(
       'Oops - noe gikk galt. Supert om du prøver på nytt 🤞',


### PR DESCRIPTION
When the app receives a 429 error (too_many_attempts) from the identity service, buttons to retry requests to /identity are disabled for 10 seconds. The error message "You have tried too many times. Please wait a bit before trying again." is shown as before.

This is just a suggestion for how to add some sort of limit on the amount of times the user can spam the submit buttons, so open for alternative solutions. But I think this is an ok solution because:

- It doesn't affect regular use (no 10s delay unless you're already rate limited by identity/Twilio)
- The logic in the app is simple, and easy to reason about. More complex logic should probably be on the backend.

closes https://github.com/AtB-AS/kundevendt/issues/18555
