### PR TITLE
feat: extend travel search to ticketing functionality to include single ticket boat

### DIFF
--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -230,7 +230,7 @@ function getTicketInfoForBus(
     tariffZones,
   );
 
-  if (!fromTariffZone || !fromTariffZone) return;
+  if (!fromTariffZone || !toTariffZone) return;
 
   const fareProductTypeConfig = fareProductTypeConfigs.find(
     (config) => config.type === 'single',

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -150,7 +150,9 @@ export const TripDetailsScreenComponent = ({
   );
 };
 
-function useTicketInfoFromTrip(tripPattern: TripPattern) {
+function useTicketInfoFromTrip(
+  tripPattern: TripPattern,
+): TicketInfoForBus | TicketInfoForBoat | undefined {
   const {enable_ticketing} = useRemoteConfig();
   const isFromTravelSearchToTicketEnabled =
     useFromTravelSearchToTicketEnabled();
@@ -202,13 +204,20 @@ function calculateTicketStartTime(legs: Leg[]) {
     : formatISO(tripStartWithBuffer);
 }
 
+type TicketInfoForBus = {
+  fromPlace: TariffZoneWithMetadata;
+  toPlace: TariffZoneWithMetadata;
+  ticketStartTime: string | undefined;
+  fareProductTypeConfig: FareProductTypeConfig;
+};
+
 function getTicketInfoForBus(
   tripPattern: TripPattern,
   nonHumanLegs: Leg[],
   fareProductTypeConfigs: FareProductTypeConfig[],
   tariffZones: TariffZone[],
   ticketStartTime?: string,
-) {
+): TicketInfoForBus | undefined {
   const canSellCollab = canSellCollabTicket(tripPattern);
   const hasOnlyValidBusLegs = !hasLegsWeCantSellTicketsFor(tripPattern, [
     'cityTram',
@@ -245,13 +254,20 @@ function getTicketInfoForBus(
   };
 }
 
+type TicketInfoForBoat = {
+  fromPlace: StopPlaceFragment;
+  toPlace: StopPlaceFragment;
+  ticketStartTime: string | undefined;
+  fareProductTypeConfig: FareProductTypeConfig;
+};
+
 function getTicketInfoForBoat(
   tripPattern: TripPattern,
   nonHumanLegs: Leg[],
   fareProductTypeConfigs: FareProductTypeConfig[],
   harbors: StopPlaceFragment[],
   ticketStartTime?: string,
-) {
+): TicketInfoForBoat | undefined {
   const hasOnlyValidBoatLegs = !hasLegsWeCantSellTicketsFor(tripPattern, [
     'highSpeedPassengerService',
     'highSpeedVehicleService',

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -59,7 +59,7 @@ export const TripDetailsScreenComponent = ({
   const {updatedTripPattern, error} =
     useCurrentTripPatternWithUpdates(tripPattern);
 
-  const tripTicketDetails = useGetTicketInfoFromTrip(updatedTripPattern);
+  const tripTicketDetails = useTicketInfoFromTrip(updatedTripPattern);
   const fromToNames = getFromToName(updatedTripPattern.legs);
   const startEndTime = getStartEndTime(updatedTripPattern, language);
 
@@ -150,7 +150,7 @@ export const TripDetailsScreenComponent = ({
   );
 };
 
-function useGetTicketInfoFromTrip(tripPattern: TripPattern) {
+function useTicketInfoFromTrip(tripPattern: TripPattern) {
   const {enable_ticketing} = useRemoteConfig();
   const isFromTravelSearchToTicketEnabled =
     useFromTravelSearchToTicketEnabled();


### PR DESCRIPTION
This PR extends the travel search to ticketing functionality by including single ticket boat for boat trips. Similar to bus ticket suggestions, the boat ticket option will be displayed only if the entire journey is composed exclusively of boat legs and there are no significant wait times between legs.

Closes https://github.com/AtB-AS/kundevendt/issues/18556