### PR TITLE
feat: add header text to SituationBottomSheet

### DIFF
--- a/src/situations/SituationBottomSheet.tsx
+++ b/src/situations/SituationBottomSheet.tsx
@@ -24,6 +24,7 @@ import {Time} from '@atb/assets/svg/mono-icons/time';
 import {screenReaderPause} from '@atb/components/text';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {getMsgTypeForMostCriticalSituationOrNotice} from './utils';
 
 type Props = {
   situation: SituationType;
@@ -38,10 +39,13 @@ export const SituationBottomSheet = forwardRef<View, Props>(
     const advice = getTextForLanguage(situation.advice, language);
     const infoLinks = filterInfoLinks(situation.infoLinks);
     const validityPeriodText = useValidityPeriodText(situation.validityPeriod);
+    const msgType = getMsgTypeForMostCriticalSituationOrNotice([situation]);
     const {close} = useBottomSheet();
 
     return (
-      <BottomSheetContainer>
+      <BottomSheetContainer
+        title={t(SituationsTexts.bottomSheet.title[msgType ?? 'info'])}
+      >
         <ScrollView centerContent={true}>
           <View>
             <Section style={styles.section}>

--- a/src/translations/components/SituationsTexts.ts
+++ b/src/translations/components/SituationsTexts.ts
@@ -11,6 +11,11 @@ const SituationsTexts = {
     info: _('Med ekstra info', 'With extra information', 'Med ekstra info'),
   },
   bottomSheet: {
+    title: {
+      info: _('Informasjon', 'Information', 'Informasjon'),
+      warning: _('Advarsel', 'Warning', 'Advarsel'),
+      error: _('Feil', 'Error', 'Feil'),
+    },
     button: _('Lukk', 'Close', 'Lukk'),
     validity: {
       from: (fromDate: string) =>


### PR DESCRIPTION
Adds a header to SituationBottomSheet based on the severity of the message. "Information", "Warning" or "Error".

<div>
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/3e385663-094b-4178-8914-cce712973528">
<img width="300px" src="https://github.com/AtB-AS/mittatb-app/assets/1774972/97f2a99c-fe7b-417f-ae37-c3cc65d9842d">
</div>


## Acceptance criteria

- [ ] All bottom sheets for disruption messages have headings
- [ ] The text corresponds to the message "color"
- [ ] Screen reader works better than before :)
