### PR TITLE
fix: remove unwanted widget padding for iOS 17 and above

### DIFF
--- a/ios/departureWidget/DepartureWidget.swift
+++ b/ios/departureWidget/DepartureWidget.swift
@@ -14,10 +14,16 @@ struct DepartureWidgetEntryView: View {
     }
 
     var body: some View {
-        ZStack {
-            Color("WidgetBackgroundColor")
-            WidgetInfoView(widgetFamily: family, viewModel: viewModel)
-        }.widgetURL(URL(string: viewModel.deepLink(departure: nil)))
+      if #available(iOSApplicationExtension 17.0, *) {
+        WidgetInfoView(widgetFamily: family, viewModel: viewModel)
+          .containerBackground(Color("WidgetBackgroundColor"), for: .widget)
+          .widgetURL(URL(string: viewModel.deepLink(departure: nil)))
+      } else {
+        WidgetInfoView(widgetFamily: family, viewModel: viewModel)
+          .padding(16)
+          .background(Color("WidgetBackgroundColor"))
+          .widgetURL(URL(string: viewModel.deepLink(departure: nil)))
+      }
     }
 }
 

--- a/ios/departureWidget/Views/DepartureTimesView.swift
+++ b/ios/departureWidget/Views/DepartureTimesView.swift
@@ -18,7 +18,7 @@ struct DepartureTimesView: View {
     let deepLink: String
 
     var width: CGFloat {
-        parentSize.width - K.padding * 2
+        parentSize.width
     }
 
     var departuresWidth: CGFloat {

--- a/ios/departureWidget/Views/NoFavoriteViewMedium.swift
+++ b/ios/departureWidget/Views/NoFavoriteViewMedium.swift
@@ -11,6 +11,6 @@ struct NoFavoriteViewMedium: View {
                 .foregroundColor(Color("LineInformationTextColor"))
                 .lineLimit(2)
                 .minimumScaleFactor(0.1)
-        }.padding(16)
+        }
     }
 }

--- a/ios/departureWidget/Views/NoFavoriteViewSmall.swift
+++ b/ios/departureWidget/Views/NoFavoriteViewSmall.swift
@@ -9,6 +9,6 @@ struct NoFavoriteViewSmall: View {
                 .foregroundColor(Color("LineInformationTextColor"))
                 .lineLimit(2)
                 .minimumScaleFactor(0.1)
-        }.padding(16)
+        }
     }
 }

--- a/ios/departureWidget/Views/WidgetInfoView.swift
+++ b/ios/departureWidget/Views/WidgetInfoView.swift
@@ -41,12 +41,12 @@ struct WidgetInfoView: View {
                         let quayName = viewModel.quayName ?? NSLocalizedString("no_quay_name", comment: "")
                         Text("From \(quayName)")
                             .lineLimit(1)
-                            .frame(width: geometry.size.width - (K.padding * 2), alignment: widgetFamily == .systemMedium ? .leading : .center)
+                            .frame(width: geometry.size.width, alignment: widgetFamily == .systemMedium ? .leading : .center)
                             .font(DefaultFonts.boldHeader)
 
                         Spacer()
                         if widgetFamily == .systemMedium {
-                            Divider().frame(width: geometry.size.width - (K.padding * 2))
+                            Divider().frame(width: geometry.size.width)
                             Spacer()
                         }
 
@@ -55,7 +55,7 @@ struct WidgetInfoView: View {
                             Text(viewModel.lineDetails ?? noLineInfoText)
                                 .lineLimit(2)
                                 .multilineTextAlignment(.center)
-                                .frame(width: geometry.size.width - (K.padding * 2), alignment: .center)
+                                .frame(width: geometry.size.width, alignment: .center)
                                 .foregroundColor(K.lineInformationColor)
                         } else {
                             HStack {
@@ -91,7 +91,6 @@ struct WidgetInfoView: View {
                             DepartureTimesView(departures: departures, parentSize: geometry.size, deepLink: viewModel.deepLink(departure: nil))
                         }
                     }
-                    .padding(K.padding)
                 }
             }
         }


### PR DESCRIPTION
This was caused by not using the containerBackground API (introduced in iOS 17.0), and instead relying on padding inside DepartureTimesView.

See https://developer.apple.com/documentation/widgetkit/preparing-widgets-for-additional-contexts-and-appearances

fixes https://github.com/AtB-AS/kundevendt/issues/18640

### iOS 15

<img width="344" alt="Screenshot 2024-07-17 at 11 08 32" src="https://github.com/user-attachments/assets/5b14793d-24e2-4c06-a518-e4a05027c2b8">

### iOS 17

<img width="344" alt="Screenshot 2024-07-17 at 11 08 43" src="https://github.com/user-attachments/assets/7c6615ec-ebfc-4e4f-a045-85a5df5e6786">
