### PR TITLE
fix: adds a11y prefix hint for message box criticality

### DIFF
--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -4,7 +4,7 @@ import {Statuses, StyleSheet, useTheme} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import MessageBoxTexts from '@atb/translations/components/MessageBox';
-import {useTranslation} from '@atb/translations';
+import {dictionary, useTranslation} from '@atb/translations';
 import {Close} from '@atb/assets/svg/mono-icons/actions';
 import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
 import {PressableOpacityOrView} from '@atb/components/touchable-opacity-or-view';
@@ -60,7 +60,8 @@ export const MessageInfoBox = ({
       ? onPressConfig.action
       : () => Linking.openURL(onPressConfig.url));
 
-  const a11yLabel = [title, message, onPressConfig?.text]
+  const a11yCriticalityPrefix = t(dictionary.messageTypes[type]);
+  const a11yLabel = [a11yCriticalityPrefix, title, message, onPressConfig?.text]
     .filter((s): s is string => !!s)
     .join(screenReaderPause);
 

--- a/src/translations/components/MessageBox.ts
+++ b/src/translations/components/MessageBox.ts
@@ -2,7 +2,11 @@ import {translation as _} from '../commons';
 
 const MessageBoxTexts = {
   a11yHintActionPrefix: _('Aktiver for å ', 'Activate to ', 'Aktiver for å'),
-  a11yHintUrlPrefix: _('Aktiver for å åpne lenke ', 'Activate to open link ', 'Aktiver for å opne lenke '),
+  a11yHintUrlPrefix: _(
+    'Aktiver for å åpne lenke ',
+    'Activate to open link ',
+    'Aktiver for å opne lenke ',
+  ),
   dismiss: {
     allyLabel: _('Lukk melding', 'Close message', 'Lukk melding'),
   },


### PR DESCRIPTION
Adds simple prefix message to a11y hint. Will be present at all times even if icon is not visible, as all non visually impaired people will get this indication by colour.

Note for future: I see that there isn't any live region or automatic reading of messages here. These components typically have some assertive/polite reading to them to make sure people with screen readers notice them. Should test and investigate the consequences of introducing this now.

Note: I don't have phone connected and can't test actual screen reader now only debug inspection. So would be nice to have this actually tested on device.


Fixes https://github.com/AtB-AS/kundevendt/issues/18138