### PR TITLE
fix: decoration line for the interchange section

### DIFF
--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -523,6 +523,7 @@ function InterchangeSection({
   maximumWaitTime,
 }: InterchangeSectionProps) {
   const {t, language} = useTranslation();
+  const style = useSectionStyles();
 
   let text = '';
   if (publicCode) {
@@ -556,7 +557,7 @@ function InterchangeSection({
   }
 
   return (
-    <View>
+    <View style={style.interchangeSection}>
       <TripLegDecoration color={iconColor} hasStart={false} hasEnd={false} />
       <TripRow>
         <MessageInfoBox type="info" message={text} />
@@ -657,5 +658,8 @@ const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   },
   authoritySection: {
     rowGap: theme.spacings.medium,
+  },
+  interchangeSection: {
+    marginBottom: theme.spacings.large,
   },
 }));


### PR DESCRIPTION
@hanne-at-atb noticed that the decoration line for the interchange section is not correct. I've added a margin to the bottom to fix this. 

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/ac5453ac-166e-462a-b789-f4624adf9a41)

</details>

Fixes https://github.com/AtB-AS/kundevendt/issues/18410#issuecomment-2257857959