### PR TITLE
feat: Update buy-for-other screen according to Figma

### DIFF
--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
@@ -90,9 +90,7 @@ export const Root_ChooseTicketRecipientScreen: React.FC<Props> = ({
       />
       <KeyboardAvoidingView behavior="padding" style={styles.mainView}>
         <ScrollView
-          centerContent={true}
           keyboardShouldPersistTaps="handled"
-          style={styles.scrollView}
           contentContainerStyle={styles.contentContainerStyle}
         >
           <View accessible={true} accessibilityRole="header" ref={focusRef}>
@@ -139,7 +137,6 @@ export const Root_ChooseTicketRecipientScreen: React.FC<Props> = ({
           <View style={styles.buttonView}>
             {isSubmitting && (
               <ActivityIndicator
-                style={styles.activityIndicator}
                 size="large"
                 color={getStaticColor(themeName, themeColor).text}
               />
@@ -155,7 +152,6 @@ export const Root_ChooseTicketRecipientScreen: React.FC<Props> = ({
 
             {!isSubmitting && (
               <Button
-                style={styles.submitButton}
                 interactiveColor="interactive_0"
                 onPress={onNext}
                 text={t(PurchaseOverviewTexts.summary.button.payment)}
@@ -175,41 +171,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.static.background[themeColor].background,
     flex: 1,
   },
-  mainView: {
-    flex: 1,
-    justifyContent: 'center',
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  scrollView: {
-    paddingBottom: theme.spacings.xLarge,
-  },
-  contentContainerStyle: {
-    paddingHorizontal: theme.spacings.large,
-    paddingBottom: theme.spacings.xLarge,
-  },
-  header: {
-    alignContent: 'space-around',
-    textAlign: 'center',
-  },
-  subheader: {
-    textAlign: 'center',
-    marginTop: theme.spacings.medium,
-    marginBottom: theme.spacings.xLarge,
-  },
-  phoneInput: {
-    marginVertical: theme.spacings.xSmall,
-  },
-  activityIndicator: {
-    marginVertical: theme.spacings.large,
-  },
-  errorMessage: {
-    marginBottom: theme.spacings.medium,
-  },
-  buttonView: {
-    marginTop: theme.spacings.medium,
-  },
-  submitButton: {
-    marginTop: theme.spacings.medium,
-  },
+  mainView: {flex: 1},
+  contentContainerStyle: {paddingHorizontal: theme.spacings.medium},
+  header: {marginTop: theme.spacings.xLarge, textAlign: 'center'},
+  subheader: {textAlign: 'center', marginTop: theme.spacings.medium},
+  phoneInput: {marginTop: theme.spacings.xLarge},
+  errorMessage: {marginBottom: theme.spacings.medium},
+  buttonView: {marginTop: theme.spacings.xLarge},
 }));

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
@@ -7,18 +7,19 @@ import {useGetAccountIdByPhoneMutation} from '@atb/on-behalf-of/queries/use-get-
 import {GetAccountByPhoneErrorCode} from '@atb/on-behalf-of';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {StyleSheet, useTheme} from '@atb/theme';
-import {StaticColorByType, getStaticColor} from '@atb/theme/colors';
+import {getStaticColor, StaticColorByType} from '@atb/theme/colors';
 import {
+  OnBehalfOfTexts,
   PhoneInputTexts,
   PurchaseOverviewTexts,
   useTranslation,
-  OnBehalfOfTexts,
 } from '@atb/translations';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import phone from 'phone';
 import {useState} from 'react';
 import {ActivityIndicator, KeyboardAvoidingView, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
+import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 
 type Props = RootStackScreenProps<'Root_ChooseTicketRecipientScreen'>;
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
@@ -157,6 +158,7 @@ export const Root_ChooseTicketRecipientScreen: React.FC<Props> = ({
                 text={t(PurchaseOverviewTexts.summary.button.payment)}
                 disabled={!isValidPhoneNumber}
                 testID="toPaymentButton"
+                rightIcon={{svg: ArrowRight}}
               />
             )}
           </View>

--- a/src/translations/components/PhoneInput.ts
+++ b/src/translations/components/PhoneInput.ts
@@ -1,9 +1,8 @@
 import {translation as _} from '../commons';
-import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
 const PhoneInputTexts = {
   input: {
-    title: _('Mobilnummer', 'Phone number', 'Mobilnummer'),
+    title: _('Telefonnummer', 'Phone number', 'Telefonnummer'),
     placeholder: {
       login: _(
         'Skriv inn ditt telefonnummer',
@@ -41,10 +40,4 @@ const PhoneInputTexts = {
   },
 };
 
-export default orgSpecificTranslations(PhoneInputTexts, {
-  troms: {
-    input: {
-      title: _('Telefonnummer', 'Phone number', 'Telefonnummer'),
-    },
-  },
-});
+export default PhoneInputTexts;

--- a/src/translations/screens/subscreens/OnBehalfOf.ts
+++ b/src/translations/screens/subscreens/OnBehalfOf.ts
@@ -3,16 +3,16 @@ import {translation as _} from '../../commons';
 
 const OnBehalfOfTexts = {
   chooseReceiver: {
-    header: _('Kjøp til andre', 'Buy for others', 'Kjøp til andre'),
+    header: _('Kjøp for andre', 'Buy for others', 'Kjøp for andre'),
     title: _(
       'Hvem skal motta billetten?',
       'Who will receive the ticket?',
       'Kven skal få billetten?',
     ),
     subtitle: _(
-      'Den du kjøper billett til, må være innlogget i AtB-appen for å få billetten.',
-      'The person receiving the ticket must be logged in to the AtB app to get the ticket.',
-      'Den du kjøper billett til, må vere logga inn i AtB-appen for å få billetten.',
+      'Husk at mottakeren må ha AtB-appen for å få billetten.',
+      'Remember that the person receiving the ticket must have the AtB app to get the ticket.',
+      'Husk at mottakaren må ha AtB-appen for å få billetten.',
     ),
     errorText: _(
       'Ingen konto tilknyttet dette telefonnummeret',


### PR DESCRIPTION
Figma sketch:  
<img width="350" src="https://github.com/user-attachments/assets/aa6ae1b5-a3e1-4ba6-8ce2-891301386b55">
Before / After in app (without the save recipient checkbox yet)
<div>
<img width="350" src="https://github.com/user-attachments/assets/e8ec69c4-c471-4e5a-bb0b-d8cb81ba0173">  
<img width="350" src="https://github.com/user-attachments/assets/53cea28c-9d98-42b0-a786-1af06dddd7b8">
</div>

