### PR TITLE
feat: adds feature toggle for boat ticket from trip details

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -36,6 +36,7 @@ export type RemoteConfig = {
   enable_show_valid_time_info: boolean;
   enable_ticket_information: boolean;
   enable_ticketing: boolean;
+  enable_from_trip_details_to_ticket_boat: boolean;
   enable_ticketing_assistant: boolean;
   enable_tips_and_information: boolean;
   enable_token_fallback: boolean;
@@ -99,6 +100,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_show_valid_time_info: true,
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
+  enable_from_trip_details_to_ticket_boat: false,
   enable_ticketing_assistant: false,
   enable_tips_and_information: false,
   enable_token_fallback: true,
@@ -216,6 +218,9 @@ export function getConfig(): RemoteConfig {
   const enable_ticketing_assistant =
     values['enable_ticketing_assistant']?.asBoolean() ??
     defaultRemoteConfig.enable_ticketing_assistant;
+  const enable_from_trip_details_to_ticket_boat =
+    values['enable_from_trip_details_to_ticket_boat']?.asBoolean() ??
+    defaultRemoteConfig.enable_from_trip_details_to_ticket_boat;
   const enable_tips_and_information =
     values['enable_tips_and_information']?.asBoolean() ??
     defaultRemoteConfig.enable_tips_and_information;
@@ -253,8 +258,8 @@ export function getConfig(): RemoteConfig {
     values['live_vehicle_stale_threshold']?.asNumber() ??
     defaultRemoteConfig.live_vehicle_stale_threshold;
   const minimum_app_version =
-      values['minimum_app_version']?.asString() ??
-      defaultRemoteConfig.minimum_app_version;
+    values['minimum_app_version']?.asString() ??
+    defaultRemoteConfig.minimum_app_version;
   const must_upgrade_ticketing =
     values['must_upgrade_ticketing']?.asBoolean() ?? false;
   const new_favourites_info_url =
@@ -325,6 +330,7 @@ export function getConfig(): RemoteConfig {
     enable_ticket_information,
     enable_ticketing,
     enable_ticketing_assistant,
+    enable_from_trip_details_to_ticket_boat,
     enable_tips_and_information,
     enable_token_fallback,
     enable_token_fallback_on_timeout,

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -22,6 +22,7 @@ export type RemoteConfig = {
   enable_extended_onboarding: boolean;
   enable_flexible_transport: boolean;
   enable_from_travel_search_to_ticket: boolean;
+  enable_from_travel_search_to_ticket_boat: boolean;
   enable_geofencing_zones: boolean;
   enable_intercom: boolean;
   enable_loading_error_screen: boolean;
@@ -36,7 +37,6 @@ export type RemoteConfig = {
   enable_show_valid_time_info: boolean;
   enable_ticket_information: boolean;
   enable_ticketing: boolean;
-  enable_from_trip_details_to_ticket_boat: boolean;
   enable_ticketing_assistant: boolean;
   enable_tips_and_information: boolean;
   enable_token_fallback: boolean;
@@ -100,7 +100,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_show_valid_time_info: true,
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
-  enable_from_trip_details_to_ticket_boat: false,
+  enable_from_travel_search_to_ticket_boat: false,
   enable_ticketing_assistant: false,
   enable_tips_and_information: false,
   enable_token_fallback: true,
@@ -218,9 +218,9 @@ export function getConfig(): RemoteConfig {
   const enable_ticketing_assistant =
     values['enable_ticketing_assistant']?.asBoolean() ??
     defaultRemoteConfig.enable_ticketing_assistant;
-  const enable_from_trip_details_to_ticket_boat =
-    values['enable_from_trip_details_to_ticket_boat']?.asBoolean() ??
-    defaultRemoteConfig.enable_from_trip_details_to_ticket_boat;
+  const enable_from_travel_search_to_ticket_boat =
+    values['enable_from_travel_search_to_ticket_boat']?.asBoolean() ??
+    defaultRemoteConfig.enable_from_travel_search_to_ticket_boat;
   const enable_tips_and_information =
     values['enable_tips_and_information']?.asBoolean() ??
     defaultRemoteConfig.enable_tips_and_information;
@@ -330,7 +330,7 @@ export function getConfig(): RemoteConfig {
     enable_ticket_information,
     enable_ticketing,
     enable_ticketing_assistant,
-    enable_from_trip_details_to_ticket_boat,
+    enable_from_travel_search_to_ticket_boat,
     enable_tips_and_information,
     enable_token_fallback,
     enable_token_fallback_on_timeout,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -40,7 +40,10 @@ import {
 import {useDebugOverride} from '@atb/debug';
 import {useCarSharingInMapDebugOverride} from '@atb/mobility/use-car-sharing-enabled';
 import {useGeofencingZonesDebugOverride} from '@atb/mobility/use-geofencing-zones-enabled';
-import {useFromTravelSearchToTicketDebugOverride} from '@atb/travel-details-screens/use_from_travel_search_to_ticket_enabled';
+import {
+  useFromTravelSearchToTicketDebugOverride,
+  useFromTravelSearchToTicketForBoatDebugOverride,
+} from '@atb/travel-details-screens/use_from_travel_search_to_ticket_enabled';
 import {useNonTransitTripSearchDebugOverride} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trip-search-enabled';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useLoadingScreenEnabledDebugOverride} from '@atb/loading-screen/use-loading-screen-enabled';
@@ -109,6 +112,8 @@ export const Profile_DebugInfoScreen = () => {
   );
   const fromTravelSearchToTicketDebugOverride =
     useFromTravelSearchToTicketDebugOverride();
+  const fromTravelSearchToTicketForBoatDebugOverride =
+    useFromTravelSearchToTicketForBoatDebugOverride();
   const vehiclesInMapDebugOverride = useVehiclesInMapDebugOverride();
   const cityBikesInMapDebugOverride = useCityBikesInMapDebugOverride();
   const carSharingInMapDebugOverride = useCarSharingInMapDebugOverride();
@@ -344,6 +349,12 @@ export const Profile_DebugInfoScreen = () => {
             <DebugOverride
               description="Enable from travel search to ticket purchase."
               override={fromTravelSearchToTicketDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable from travel search to ticket purchase specifically for boats."
+              override={fromTravelSearchToTicketForBoatDebugOverride}
             />
           </GenericSectionItem>
           <GenericSectionItem>

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -10,6 +10,7 @@ export enum StorageModelKeysEnum {
   EnableCityBikesInMapDebugOverride = 'ATB_enable_city_bikes_in_map_debug_override',
   EnableFlexibleTransportDebugOverride = '@ATB_enable_flexible_transport',
   EnableFromTravelSearchToTicketDebugOverride = '@ATB_enable_from_travel_search_to_ticket_debug_override',
+  EnableFromTravelSearchToTicketBoatDebugOverride = '@ATB_enable_from_travel_search_to_ticket_boat_debug_override',
   EnableGeofencingZonesDebugOverride = '@ATB_enable_geofencing_zones_debug_override',
   EnableLoadingScreenDebugOverride = '@ATB_loading_screen_debug_override',
   EnableLoadingErrorScreenDebugOverride = '@ATB_loading_error_screen_debug_override',

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -17,7 +17,10 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 // eslint-disable-next-line no-restricted-imports
 import {Root_PurchaseOverviewScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
-import {useFromTravelSearchToTicketEnabled} from './use_from_travel_search_to_ticket_enabled';
+import {
+  useFromTravelSearchToTicketEnabled,
+  useFromTravelSearchToTicketForBoatEnabled,
+} from './use_from_travel_search_to_ticket_enabled';
 import {StyleSheet} from '@atb/theme';
 import {StaticColorByType} from '@atb/theme/colors';
 import {Language, TripDetailsTexts, useTranslation} from '@atb/translations';
@@ -153,10 +156,11 @@ export const TripDetailsScreenComponent = ({
 function useTicketInfoFromTrip(
   tripPattern: TripPattern,
 ): TicketInfoForBus | TicketInfoForBoat | undefined {
-  const {enable_ticketing, enable_from_trip_details_to_ticket_boat} =
-    useRemoteConfig();
+  const {enable_ticketing} = useRemoteConfig();
   const isFromTravelSearchToTicketEnabled =
     useFromTravelSearchToTicketEnabled();
+  const isFromTravelSearchToTicketForBoatEnabled =
+    useFromTravelSearchToTicketForBoatEnabled();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
   const {tariffZones} = useFirestoreConfiguration();
   const {data: harbors} = useHarbors();
@@ -182,7 +186,7 @@ function useTicketInfoFromTrip(
   );
   if (ticketInfoForBus) return ticketInfoForBus;
 
-  if (!enable_from_trip_details_to_ticket_boat) {
+  if (!isFromTravelSearchToTicketForBoatEnabled) {
     // Boat ticket is disabled, avoid returning any ticket info
     return;
   }

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -153,7 +153,8 @@ export const TripDetailsScreenComponent = ({
 function useTicketInfoFromTrip(
   tripPattern: TripPattern,
 ): TicketInfoForBus | TicketInfoForBoat | undefined {
-  const {enable_ticketing} = useRemoteConfig();
+  const {enable_ticketing, enable_from_trip_details_to_ticket_boat} =
+    useRemoteConfig();
   const isFromTravelSearchToTicketEnabled =
     useFromTravelSearchToTicketEnabled();
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
@@ -180,6 +181,11 @@ function useTicketInfoFromTrip(
     ticketStartTime,
   );
   if (ticketInfoForBus) return ticketInfoForBus;
+
+  if (!enable_from_trip_details_to_ticket_boat) {
+    // Boat ticket is disabled, avoid returning any ticket info
+    return;
+  }
 
   const ticketInfoForBoat = getTicketInfoForBoat(
     tripPattern,

--- a/src/travel-details-screens/use_from_travel_search_to_ticket_enabled.ts
+++ b/src/travel-details-screens/use_from_travel_search_to_ticket_enabled.ts
@@ -18,3 +18,21 @@ export const useFromTravelSearchToTicketDebugOverride = () => {
     StorageModelKeysEnum.EnableFromTravelSearchToTicketDebugOverride,
   );
 };
+
+export const useFromTravelSearchToTicketForBoatEnabled = () => {
+  const [debugOverride] = useFromTravelSearchToTicketForBoatDebugOverride();
+  const {enable_from_travel_search_to_ticket_boat: enabledInRemoteConfig} =
+    useRemoteConfig();
+
+  if (debugOverride !== undefined) {
+    return debugOverride;
+  }
+  return enabledInRemoteConfig;
+};
+
+export const useFromTravelSearchToTicketForBoatDebugOverride = () => {
+  const ret = useDebugOverride(
+    StorageModelKeysEnum.EnableFromTravelSearchToTicketBoatDebugOverride,
+  );
+  return ret;
+};


### PR DESCRIPTION
Adds feature toggle `enable_from_trip_details_to_ticket_boat` that defaults to `false`. This will enable/disable the button to buy tickets in trip details for express boats.

Fixes issue after feedback in https://github.com/AtB-AS/kundevendt/issues/18556 by @hanne-at-atb 