### PR TITLE
feat: Save recipient name

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -106,8 +106,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     userProfilesWithCount,
     travelDate,
     headerLeftButton,
-    phoneNumber,
-    destinationAccountId,
+    recipient,
   } = params;
 
   const {travellerSelectionMode, zoneSelectionMode} =
@@ -120,7 +119,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
       ? 'stop-places'
       : 'zones';
 
-  const isOnBehalfOf = !!phoneNumber && !!destinationAccountId;
+  const isOnBehalfOf = !!recipient;
 
   const {
     offerSearchTime,
@@ -152,7 +151,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const fromPlaceName = getPlaceName(fromPlace, language);
 
   const toPlaceName = getPlaceName(toPlace, language);
-  const vatAmount = totalPrice - (totalPrice / (1 + vatPercent / 100));
+  const vatAmount = totalPrice - totalPrice / (1 + vatPercent / 100);
 
   const vatAmountString = formatDecimalNumber(vatAmount, language);
   const vatPercentString = formatDecimalNumber(vatPercent, language);
@@ -186,7 +185,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           offers,
           preassignedFareProduct: params.preassignedFareProduct,
           paymentMethod: option,
-          destinationAccountId: destinationAccountId,
+          recipient,
         });
       }
     }
@@ -303,14 +302,18 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                 <ThemeText>
                   {getReferenceDataName(preassignedFareProduct, language)}
                 </ThemeText>
-                {phoneNumber && (
+                {recipient && (
                   <ThemeText
                     type="body__secondary"
                     color="secondary"
                     style={styles.sendingToText}
                     testID="onBehalfOfText"
                   >
-                    {t(PurchaseConfirmationTexts.sendingTo(phoneNumber))}
+                    {t(
+                      PurchaseConfirmationTexts.sendingTo(
+                        recipient.phoneNumber,
+                      ),
+                    )}
                   </ThemeText>
                 )}
                 {fareProductTypeConfig.direction &&
@@ -404,7 +407,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             </View>
           </GenericSectionItem>
         </Section>
-        {inspectableTokenWarningText && !phoneNumber && (
+        {inspectableTokenWarningText && !recipient && (
           <MessageInfoBox
             type="warning"
             message={inspectableTokenWarningText}

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
@@ -13,6 +13,9 @@ export type Root_PurchaseConfirmationScreenParams = {
   travelDate?: string;
   headerLeftButton: LeftButtonProps;
   mode?: 'TravelSearch' | 'Ticket';
-  phoneNumber?: string;
-  destinationAccountId?: string;
+  recipient?: {
+    phoneNumber: string;
+    accountId: string;
+    name?: string;
+  };
 };

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/Root_PurchasePaymentScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/Root_PurchasePaymentScreen.tsx
@@ -24,7 +24,7 @@ type Props = RootStackScreenProps<'Root_PurchasePaymentScreen'>;
 export const Root_PurchasePaymentScreen = ({route, navigation}: Props) => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {offers, destinationAccountId, paymentMethod} = route.params;
+  const {offers, recipient, paymentMethod} = route.params;
   const analytics = useAnalytics();
   const {fareContracts, sentFareContracts} = useTicketingState();
   const [paymentProcessorStatus, setPaymentProcessorStatus] =
@@ -43,7 +43,7 @@ export const Root_PurchasePaymentScreen = ({route, navigation}: Props) => {
   const reserveMutation = useReserveOfferMutation({
     offers,
     paymentMethod,
-    destinationAccountId,
+    recipient,
   });
   const cancelPaymentMutation = useCancelPaymentMutation();
   usePurchaseCallbackListener(

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
@@ -9,6 +9,7 @@ type Args = {
   paymentMethod: PaymentMethod;
   recipient?: {
     accountId: string;
+    phoneNumber: string;
     name?: string;
   };
 };
@@ -42,6 +43,7 @@ export const useReserveOfferMutation = ({
         scaExemption: true,
         customerAccountId: recipient?.accountId || abtCustomerId!,
         customerAlias: recipient?.name,
+        phoneNumber: recipient?.phoneNumber,
         autoSale,
       });
     },

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
@@ -7,13 +7,16 @@ import {useRemoteConfig} from '@atb/RemoteConfigContext';
 type Args = {
   offers: ReserveOffer[];
   paymentMethod: PaymentMethod;
-  destinationAccountId: string | undefined;
+  recipient?: {
+    accountId: string;
+    name?: string;
+  };
 };
 
 export const useReserveOfferMutation = ({
   offers,
   paymentMethod,
-  destinationAccountId,
+  recipient,
 }: Args) => {
   const {abtCustomerId} = useAuthState();
   const {enable_auto_sale: autoSale} = useRemoteConfig();
@@ -37,7 +40,8 @@ export const useReserveOfferMutation = ({
         savePaymentMethod: saveRecurringCard,
         opts: {retry: true},
         scaExemption: true,
-        customerAccountId: destinationAccountId || abtCustomerId!,
+        customerAccountId: recipient?.accountId || abtCustomerId!,
+        customerAlias: recipient?.name,
         autoSale,
       });
     },

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -89,6 +89,7 @@ type Root_PurchasePaymentScreenParams = {
   paymentMethod: PaymentMethod;
   recipient?: {
     accountId: string;
+    phoneNumber: string;
     name?: string;
   };
 };

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -86,8 +86,11 @@ type Root_PurchaseAsAnonymousConsequencesScreenParams = {
 type Root_PurchasePaymentScreenParams = {
   offers: ReserveOffer[];
   preassignedFareProduct: PreassignedFareProduct;
-  destinationAccountId?: string;
   paymentMethod: PaymentMethod;
+  recipient?: {
+    accountId: string;
+    name?: string;
+  };
 };
 
 type Root_ConfirmationScreenParams = {

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -116,6 +116,7 @@ type ReserveOfferParams = {
   recurringPaymentId?: number;
   autoSale: boolean;
   customerAlias?: string;
+  phoneNumber?: string;
 };
 
 export async function searchOffers(
@@ -153,6 +154,7 @@ export async function reserveOffers({
   customerAccountId,
   autoSale,
   customerAlias,
+  phoneNumber,
   ...rest
 }: ReserveOfferParams): Promise<OfferReservation> {
   const url = 'ticket/v3/reserve';
@@ -166,6 +168,7 @@ export async function reserveOffers({
     customer_account_id: customerAccountId,
     auto_sale: autoSale,
     customer_alias: customerAlias,
+    phone_number: phoneNumber,
   };
   const response = await client.post<OfferReservation>(url, body, {
     ...opts,

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -115,6 +115,7 @@ type ReserveOfferParams = {
   savePaymentMethod: boolean;
   recurringPaymentId?: number;
   autoSale: boolean;
+  customerAlias?: string;
 };
 
 export async function searchOffers(
@@ -151,6 +152,7 @@ export async function reserveOffers({
   scaExemption,
   customerAccountId,
   autoSale,
+  customerAlias,
   ...rest
 }: ReserveOfferParams): Promise<OfferReservation> {
   const url = 'ticket/v3/reserve';
@@ -163,6 +165,7 @@ export async function reserveOffers({
     sca_exemption: scaExemption,
     customer_account_id: customerAccountId,
     auto_sale: autoSale,
+    customer_alias: customerAlias,
   };
   const response = await client.post<OfferReservation>(url, body, {
     ...opts,

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -181,6 +181,7 @@ export type ReserveOfferRequestBody = {
   sca_exemption: boolean;
   customer_account_id: string;
   customer_alias: string | undefined;
+  phone_number: string | undefined;
   auto_sale: boolean;
 };
 

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -180,6 +180,7 @@ export type ReserveOfferRequestBody = {
   recurring_payment_id: number | undefined;
   sca_exemption: boolean;
   customer_account_id: string;
+  customer_alias: string | undefined;
   auto_sale: boolean;
 };
 

--- a/src/translations/screens/subscreens/OnBehalfOf.ts
+++ b/src/translations/screens/subscreens/OnBehalfOf.ts
@@ -20,6 +20,20 @@ const OnBehalfOfTexts = {
       'Ingen konto knytta til dette telefonnummeret',
     ),
   },
+  nameInputLabel: _('Navn', 'Name', 'Namn'),
+  nameInputPlaceholder: _('Skriv inn navn', 'Enter name', 'Skriv inn namn'),
+  saveCheckBoxLabel: _(
+    'Lagre denne mottakeren til senere',
+    'Save this recipient for later',
+    'Lagre denne mottakaren til seinare',
+  ),
+  errors: {
+    missing_recipient_name: _(
+      'Du må legge inn navn på mottaker',
+      'You need too add recipient name',
+      'Du må leggja inn namn på mottakar',
+    ),
+  },
 };
 
 export default orgSpecificTranslations(OnBehalfOfTexts, {


### PR DESCRIPTION
Added a checkbox and text input for saving recipient name in the on
behalf of purchase process. The recipient name is sent to the
backend when reserving the offer.

Figma sketches:
<img width="496" alt="Screenshot 2024-08-02 at 13 43 41" src="https://github.com/user-attachments/assets/c8429e5a-bec2-4d06-8161-324c2bc8b6b1">

Screenshots from app:
<div>
<img width=300 src="https://github.com/user-attachments/assets/eed7a7b7-0a0d-40dc-9bce-7effe71ec1eb"/>
<img width=300 src="https://github.com/user-attachments/assets/a8ec1456-5ae1-498b-bcb2-d402d302033d"/>
<img width=300 src="https://github.com/user-attachments/assets/485a133d-d316-49f5-acdd-930ac4756265"/>
<img width=300 src="https://github.com/user-attachments/assets/bef1a89a-15b1-4f27-bebe-c4017bc72c9f"/>
</div>
