### PR TITLE
feat: Consolidate radio button group

### DIFF
--- a/src/components/sections/RadioGroupSection.tsx
+++ b/src/components/sections/RadioGroupSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ActionSectionItem} from './items/ActionSectionItem';
+import {RadioSectionItem} from './items/RadioSectionItem.tsx';
 import {Section, SectionProps} from './Section';
 import {HeaderSectionItem} from './items/HeaderSectionItem';
 import {InteractiveColor} from '@atb/theme/colors';
@@ -36,14 +36,13 @@ export function RadioGroupSection<T>({
         const text = itemToText(item, index);
         const subtext = itemToSubtext ? itemToSubtext(item, index) : undefined;
         const a11yLabel = `${text}, ${hideSubtext ? '' : subtext}`;
-        const checked =
-          selected &&
+        const thisItemSelected =
+          !!selected &&
           keyExtractor(item, index) === keyExtractor(selected, index);
         return (
-          <ActionSectionItem
+          <RadioSectionItem
             key={keyExtractor(item, index)}
-            mode="check"
-            checked={checked}
+            selected={thisItemSelected}
             text={itemToText(item, index)}
             hideSubtext={hideSubtext}
             subtext={subtext}
@@ -51,7 +50,7 @@ export function RadioGroupSection<T>({
             testID={'radioButton' + itemToText(item, index)}
             color={color}
             accessibility={{
-              accessibilityHint: checked ? '' : accessibilityHint,
+              accessibilityHint: thisItemSelected ? '' : accessibilityHint,
               accessibilityLabel: a11yLabel,
             }}
           />

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -8,7 +8,7 @@ export {InternalLabeledSectionItem} from './items/InternalLabeledSectionItem';
 // Links and actions
 export {LinkSectionItem} from './items/LinkSectionItem';
 export {HeaderSectionItem} from './items/HeaderSectionItem';
-export {ActionSectionItem} from './items/ActionSectionItem';
+export {RadioSectionItem} from './items/RadioSectionItem.tsx';
 export {GenericSectionItem} from './items/GenericSectionItem';
 export {GenericClickableSectionItem} from './items/GenericClickableSectionItem';
 export {FavoriteSectionItem} from './items/FavoriteSectionItem';

--- a/src/components/sections/items/RadioSectionItem.tsx
+++ b/src/components/sections/items/RadioSectionItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {AccessibilityProps, AccessibilityRole, View} from 'react-native';
-import {Confirm} from '@atb/assets/svg/mono-icons/actions';
+import {AccessibilityProps, View} from 'react-native';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -10,6 +9,7 @@ import {useSectionStyle} from '../use-section-style';
 import {InteractiveColor} from '@atb/theme/colors';
 import {SvgProps} from 'react-native-svg';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {RadioIcon} from '@atb/components/radio';
 
 type ActionModes = 'check';
 type Props = SectionItemProps<{
@@ -18,19 +18,18 @@ type Props = SectionItemProps<{
   hideSubtext?: boolean;
   onPress(checked: boolean): void;
   leftIcon?: (props: SvgProps) => JSX.Element;
-  checked?: boolean;
+  selected: boolean;
   mode?: ActionModes;
   accessibility?: AccessibilityProps;
   color?: InteractiveColor;
 }>;
-export function ActionSectionItem({
+export function RadioSectionItem({
   text,
   subtext,
   hideSubtext,
   onPress,
   leftIcon,
-  mode = 'check',
-  checked = false,
+  selected,
   accessibility,
   testID,
   color,
@@ -40,39 +39,41 @@ export function ActionSectionItem({
   const style = useSectionStyle();
   const styles = useStyles();
   const {theme} = useTheme();
-  const interactiveColor =
-    color && checked ? theme.interactive[color].active : undefined;
+  const interactiveColor = color ? theme.interactive[color] : undefined;
 
-  const role: AccessibilityRole = mode === 'check' ? 'radio' : 'switch';
-  const stateName = mode === 'check' ? 'selected' : 'expanded';
+  const backgroundColor = interactiveColor
+    ? selected
+      ? interactiveColor.active.background
+      : interactiveColor.default.background
+    : topContainer.backgroundColor;
+
+  const textColor = interactiveColor
+    ? selected
+      ? interactiveColor.active.text
+      : interactiveColor.default.text
+    : theme.text.colors.primary;
+
+  const selectedRadioColor = interactiveColor
+    ? interactiveColor.outline.background
+    : theme.text.colors.primary;
 
   return (
     <PressableOpacity
-      onPress={() => onPress(!checked)}
-      style={[
-        style.spaceBetween,
-        topContainer,
-        {
-          backgroundColor: interactiveColor
-            ? interactiveColor.background
-            : topContainer.backgroundColor,
-        },
-      ]}
+      onPress={() => onPress(!selected)}
+      style={[style.spaceBetween, topContainer, {backgroundColor}]}
       testID={testID}
-      accessibilityRole={role}
-      accessibilityState={{
-        [stateName]: checked,
-      }}
+      accessibilityRole="radio"
+      accessibilityState={{selected: selected}}
       {...accessibility}
     >
+      <View style={styles.radioIcon}>
+        <RadioIcon checked={selected} color={selectedRadioColor || 'black'} />
+      </View>
       {leftIcon && <ThemeIcon svg={leftIcon} style={styles.leftIcon} />}
-      <View style={{flexShrink: 1}}>
+      <View style={styles.textContainer}>
         <ThemeText
           type="body__primary"
-          style={[
-            contentContainer,
-            interactiveColor ? {color: interactiveColor.text} : undefined,
-          ]}
+          style={[contentContainer, {color: textColor}]}
         >
           {text}
         </ThemeText>
@@ -86,40 +87,12 @@ export function ActionSectionItem({
           </ThemeText>
         )}
       </View>
-      <ActionModeIcon
-        mode={mode}
-        checked={checked}
-        color={interactiveColor ? color : undefined}
-      />
     </PressableOpacity>
   );
 }
 
-function ActionModeIcon({
-  mode,
-  checked,
-  color,
-}: Pick<Props, 'mode' | 'checked' | 'color'>) {
-  const {theme} = useTheme();
-
-  switch (mode) {
-    case 'check': {
-      return (
-        <ThemeIcon
-          svg={Confirm}
-          {...(color
-            ? {fill: theme.interactive[color].active.text}
-            : undefined)}
-          fillOpacity={checked ? 1 : 0}
-        />
-      );
-    }
-  }
-  return null;
-}
-
 const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
-  leftIcon: {
-    marginRight: theme.spacings.small,
-  },
+  radioIcon: {marginRight: theme.spacings.medium},
+  leftIcon: {marginRight: theme.spacings.small},
+  textContainer: {flex: 1},
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -25,7 +25,7 @@ import {dictionary, useTranslation} from '@atb/translations';
 import {Bus} from '@atb/assets/svg/mono-icons/transportation';
 import {useFontScale} from '@atb/utils/use-font-scale';
 import {
-  ActionSectionItem,
+  RadioSectionItem,
   ButtonSectionItem,
   ExpandableSectionItem,
   GenericSectionItem,
@@ -54,6 +54,7 @@ export const Profile_DesignSystemScreen = ({
   const fontScale = useFontScale();
   const {theme} = useTheme();
   const {t} = useTranslation();
+  const [selected, setSelected] = useState(false);
 
   const [segmentedSelection, setSegmentedSelection] = useState(0);
 
@@ -105,8 +106,7 @@ export const Profile_DesignSystemScreen = ({
   );
 
   const statusSwatches = Object.keys(theme.status).map((color) => {
-    const staticColor =
-      theme.status[color as StatusColor];
+    const staticColor = theme.status[color as StatusColor];
     return <Swatch color={staticColor.primary} name={color} key={color} />;
   });
 
@@ -967,25 +967,23 @@ export const Profile_DesignSystemScreen = ({
         </Section>
 
         <Section style={styles.section}>
-          <ActionSectionItem
-            text="Some very long text over here which goes over multiple lines"
-            subtext="With a subtext"
-            mode="check"
-            onPress={() => {}}
-            leftIcon={Bus}
-            checked
-          />
           <ToggleSectionItem
             text="Some short text"
             leftImage={<ThemeIcon svg={Bus} />}
             onValueChange={() => {}}
           />
-          <ActionSectionItem
-            text="Some short text"
-            mode="check"
-            checked
+          <RadioSectionItem
+            text="Some short text and interactive color"
+            selected={selected}
+            onPress={() => setSelected(!selected)}
+            color="interactive_2"
+          />
+          <RadioSectionItem
+            text="Some very long text over here which goes over multiple lines"
+            subtext="With a subtext and icon, no interactive color"
             leftIcon={Bus}
-            onPress={() => {}}
+            selected={selected}
+            onPress={() => setSelected(!selected)}
           />
         </Section>
 

--- a/src/storybook/stories/Section.stories.tsx
+++ b/src/storybook/stories/Section.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  ActionSectionItem,
+  RadioSectionItem,
   ButtonSectionItem,
   CounterSectionItem,
   DateInputSectionItem,
@@ -72,9 +72,10 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
                   label="ButtonSectionItem"
                   onPress={() => {}}
                 />
-                <ActionSectionItem
-                  text="ActionSectionItem"
+                <RadioSectionItem
+                  text="RadioSectionItem"
                   onPress={() => {}}
+                  selected={false}
                 />
                 <CounterSectionItem
                   text="CounterSectionItem"


### PR DESCRIPTION
### Background
The new sketches for saving recipient has a radio section group with the standard radio selection circle instead of using checkmarks as we did before. 

### Solution
To not have two different radio groups in the app I took the liberty to just rewrite the existing one, making every radio button group use the new design.

Originally this was done as part of https://github.com/AtB-AS/kundevendt/issues/17226, but I added the PR to the board as an individual issue so it can be tested on its own.

<details>
<summary>Screenshots of the change</summary>

**Figma**:
<div>
<img width="350" src="https://github.com/user-attachments/assets/642e7bfc-3410-4a87-9a2c-93aa9ba5fa53">
</div>

**Some before/after examples from the app**:
<div>
<img width="350" src="https://github.com/user-attachments/assets/e4a7bb69-52ee-4f7e-93f0-180125fccabf"/>
<img width="350" src="https://github.com/user-attachments/assets/c7410808-1503-48d6-a0ff-657066de1cfb"/>
</div>
<div>
<img width="350" src="https://github.com/user-attachments/assets/0ffed55a-a63b-469a-bb5f-63b912e582b4"/>
<img width="350" src="https://github.com/user-attachments/assets/23ce9455-b2c3-4bf8-86c6-07d78123ee8b"/>
</div>
<div>
<img width="350" src="https://github.com/user-attachments/assets/d26b8b14-1525-4c89-a6c9-0b62b03215a0"/>
<img width="350" src="https://github.com/user-attachments/assets/27685abb-df0d-4b76-a3f1-542e4a3ed172"/>
</div>
<div>
<img width="350" src="https://github.com/user-attachments/assets/0d8a677d-c568-4d25-98ed-7f392158adc4"/>
<img width="350" src="https://github.com/user-attachments/assets/2c0a36db-4ccc-4f85-b647-82e2de5931cb"/>
</div>
</details>

### Acceptance criteria
- [ ] Radio groups in the app should have a selection circle to the left instead of checkmark to the right.
- [ ] Radio groups in the app should behave as before, and work just as good with screen reader and large text. 

The places in the app where we have used the `RadioGroupSection`. Should be enough to test just some of them.
- Single traveller selection
- Product selection by product (as with AtB night ticket)
- Default start screen selection
- Default traveller selection
- App language selection
- T-card/Mobile token selection
- Date now/departure/arrival selection in trip search
- Mobile token selection in the "need-token-on-mobile" screen which shows up when trying to buy boat tickets while having t-card as inspectable token