### PR TITLE
fix: Update Android play console error

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Removed as part of https://github.com/AtB-AS/kundevendt/issues/18747 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" tools:node="remove"/>
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/18747

During pushing the app to the play store, we got:

`Google Api Error: Invalid request - You must let us know whether your app uses any Foreground Service permissions.`

The solution is removed some permissions as Kogenta team pointed.

```
<uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
<uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" tools:node="remove"/>
```