### PR TITLE
fix: issue with non-transit legs trying to show ticket info

### DIFF
--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -175,6 +175,12 @@ function useTicketInfoFromTrip(
     return;
 
   const nonHumanLegs = getNonHumanLegs(tripPattern.legs);
+
+  if (!nonHumanLegs.length) {
+    // Non-transit route, so no tickets needed.
+    return;
+  }
+
   const ticketStartTime = calculateTicketStartTime(nonHumanLegs);
 
   const ticketInfoForBus = getTicketInfoForBus(
@@ -208,7 +214,8 @@ function getNonHumanLegs(legs: Leg[]) {
 }
 
 function calculateTicketStartTime(legs: Leg[]) {
-  const tripStartWithBuffer = addMinutes(parseISO(legs[0]?.aimedStartTime), -5);
+  if (!legs[0]) return undefined;
+  const tripStartWithBuffer = addMinutes(parseISO(legs[0].aimedStartTime), -5);
   return tripStartWithBuffer.getTime() <= Date.now()
     ? undefined
     : formatISO(tripStartWithBuffer);


### PR DESCRIPTION
Fixes issue reported in https://mittatb.slack.com/archives/C0116FMPX4Y/p1723289908783909


Can cherry-pick to `release/1.54` afterwards


Verified to be working for non-transit like walking, bike. Also routes without boat/bus (e.g. only train)

