### PR TITLE
refactor: replace custom rounding of minutes with date-fns

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -249,15 +249,15 @@ describe('Date rounding', () => {
   });
 
   it('formatToClock rounds to nearest', () => {
-    expectStringEqual(formatToClock(upper, lang, 'nearest'), '12:47');
-    expectStringEqual(formatToClock(lower, lang, 'nearest'), '12:46');
-    expectStringEqual(formatToClock(mid, lang, 'nearest'), '12:47');
+    expectStringEqual(formatToClock(upper, lang, 'round'), '12:47');
+    expectStringEqual(formatToClock(lower, lang, 'round'), '12:46');
+    expectStringEqual(formatToClock(mid, lang, 'round'), '12:47');
   });
 
   it('formatToClock stays exact', () => {
     const shouldRoundTo = '12:46';
     expectStringEqual(formatToClock(exact, lang, 'ceil'), shouldRoundTo);
     expectStringEqual(formatToClock(exact, lang, 'floor'), shouldRoundTo);
-    expectStringEqual(formatToClock(exact, lang, 'nearest'), shouldRoundTo);
+    expectStringEqual(formatToClock(exact, lang, 'round'), shouldRoundTo);
   });
 });

--- a/src/travel-details-screens/components/Time.tsx
+++ b/src/travel-details-screens/components/Time.tsx
@@ -1,11 +1,12 @@
 import {AccessibleText} from '@atb/components/text';
 import {ThemeText} from '@atb/components/text';
 import {dictionary, useTranslation} from '@atb/translations';
-import {formatToClock, RoundingMethod} from '@atb/utils/date';
+import {formatToClock} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
 import {getTimeRepresentationType, TimeValues} from '../utils';
 import {usePreferences} from '@atb/preferences';
+import {RoundingMethod} from 'date-fns';
 
 export const Time: React.FC<{
   timeValues: TimeValues;

--- a/src/travel-details-screens/use-realtime-text.ts
+++ b/src/travel-details-screens/use-realtime-text.ts
@@ -22,7 +22,7 @@ export const useRealtimeText = (
         formatToClock(
           lastPassedStop.actualDepartureTime,
           language,
-          'nearest',
+          'round',
           debugShowSeconds,
         ),
       ),

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,6 +2,7 @@ import {Language, TranslateFunction, dictionary} from '@atb/translations';
 import {
   FormatOptions,
   Locale,
+  RoundingMethod,
   addHours,
   differenceInCalendarDays,
   differenceInMinutes,
@@ -19,6 +20,7 @@ import {
   isWithinInterval,
   parse,
   parseISO,
+  roundToNearestMinutes,
   set,
 } from 'date-fns';
 import {
@@ -153,7 +155,9 @@ export function formatToClock(
   showSeconds?: boolean,
 ) {
   const parsed = parseIfNeeded(isoDate);
-  const rounded = !showSeconds ? roundMinute(parsed, roundingMethod) : parsed;
+  const rounded = !showSeconds
+    ? roundToNearestMinutes(parsed, {roundingMethod})
+    : parsed;
   const seconds = showSeconds ? ':' + format(parsed, 'ss') : '';
 
   return formatLocaleTime(rounded, language) + seconds;
@@ -564,26 +568,4 @@ function getHumanizer(
   };
 
   return humanizer(ms, opts);
-}
-
-export type RoundingMethod = 'ceil' | 'floor' | 'nearest';
-
-/**
- * date-fns also has a rounding function, `roundToNearestMinutes`, but it
- * doesn't work correctly: https://github.com/date-fns/date-fns/issues/3129
- *
- * TODO: Replace with date-fns `roundToNearestMinutes`
- */
-function roundMinute(date: Date, roundingMethod: RoundingMethod) {
-  // Round based on minutes (60000 milliseconds)
-  const coeff = 1000 * 60;
-
-  switch (roundingMethod) {
-    case 'nearest':
-      return new Date(Math.round(date.getTime() / coeff) * coeff);
-    case 'ceil':
-      return new Date(Math.ceil(date.getTime() / coeff) * coeff);
-    case 'floor':
-      return new Date(Math.floor(date.getTime() / coeff) * coeff);
-  }
 }


### PR DESCRIPTION
After [the upgrade of date-fns](https://github.com/AtB-AS/mittatb-app/pull/4638), a bug in roundToNearestMinutes was fixed, allowing us to use it instead of rolling our own.

The existing tests on formatToClock, that failed with the old version of date-fns, now passes!