### PR TITLE
feat: add condition to check whether passengers should stay seated between leg interchanges. 

### DIFF
--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -127,7 +127,12 @@ export type TripFragment = {
         notices: Array<{id: string; text?: string}>;
         journeyPattern?: {notices: Array<{id: string; text?: string}>};
       };
-      interchangeTo?: {guaranteed?: boolean; toServiceJourney?: {id: string}; maximumWaitTime?: number};
+      interchangeTo?: {
+        guaranteed?: boolean;
+        toServiceJourney?: {id: string};
+        maximumWaitTime?: number;
+        staySeated?: boolean | undefined;
+      };
       pointsOnLink?: {points?: string; length?: number};
       intermediateEstimatedCalls: Array<{
         date: any;

--- a/src/api/types/generated/fragments/trips.ts
+++ b/src/api/types/generated/fragments/trips.ts
@@ -104,7 +104,11 @@ export type TripPatternFragment = {
       notices: Array<{id: string; text?: string}>;
       journeyPattern?: {notices: Array<{id: string; text?: string}>};
     };
-    interchangeTo?: {guaranteed?: boolean; toServiceJourney?: {id: string}};
+    interchangeTo?: {
+      guaranteed?: boolean;
+      toServiceJourney?: {id: string};
+      staySeated?: boolean | undefined;
+    };
     pointsOnLink?: {points?: string; length?: number};
     intermediateEstimatedCalls: Array<{
       date: any;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -203,6 +203,11 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   };
   const lineHeight = {height: (theme.spacings.xSmall / 2) * fontScale};
 
+  const staySeated = (idx: number) => {
+    const previousLeg = expandedLegs[idx - 1];
+    return previousLeg && previousLeg.interchangeTo?.staySeated === true;
+  };
+
   return (
     <PressableOpacity
       accessibilityLabel={tripSummary(
@@ -253,7 +258,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                     <View testID="tripLeg">
                       {leg.mode === 'foot' ? (
                         <FootLeg leg={leg} nextLeg={filteredLegs[i + 1]} />
-                      ) : (
+                      ) : staySeated(i) ? null : (
                         <TransportationLeg
                           leg={leg}
                           style={
@@ -264,20 +269,22 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                         />
                       )}
                       <View style={styles.departureTimes}>
-                        <ThemeText
-                          type="body__tertiary"
-                          color="primary"
-                          testID={'schTime' + i}
-                        >
-                          {(isLineFlexibleTransport(leg.line)
-                            ? t(dictionary.missingRealTimePrefix)
-                            : '') +
-                            formatToClock(
-                              leg.expectedStartTime,
-                              language,
-                              'floor',
-                            )}
-                        </ThemeText>
+                        {staySeated(i) ? null : (
+                          <ThemeText
+                            type="body__tertiary"
+                            color="primary"
+                            testID={'schTime' + i}
+                          >
+                            {(isLineFlexibleTransport(leg.line)
+                              ? t(dictionary.missingRealTimePrefix)
+                              : '') +
+                              formatToClock(
+                                leg.expectedStartTime,
+                                language,
+                                'floor',
+                              )}
+                          </ThemeText>
+                        )}
                         {isSignificantDifference(leg) && (
                           <ThemeText
                             style={styles.scheduledTime}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -203,10 +203,13 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
   };
   const lineHeight = {height: (theme.spacings.xSmall / 2) * fontScale};
 
-  const staySeated = (idx: number) => {
+  const staySeated = (idx: number): boolean => {
     const previousLeg = expandedLegs[idx - 1];
     return previousLeg && previousLeg.interchangeTo?.staySeated === true;
   };
+
+  const displayLegDash = (idx: number): boolean =>
+    idx < expandedLegs.length - 1 && !staySeated(idx + 1);
 
   return (
     <PressableOpacity
@@ -301,7 +304,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                         )}
                       </View>
                     </View>
-                    {i < expandedLegs.length - 1 ? (
+                    {displayLegDash(i) ? (
                       <View style={[styles.dashContainer, iconHeight]}>
                         <LegDash />
                       </View>

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -313,6 +313,12 @@ const TripDetailsTexts = {
         `Waiting up to ${maxWaitTime}.`,
         `Ventar i opp til ${maxWaitTime}.`,
       ),
+    lineChangeStaySeated: (fromPublicCode: string, toPublicCode: string) =>
+      _(
+        `Bli sittende. Linjenummeret endres fra ${fromPublicCode} til ${toPublicCode}.`,
+        `Stay seated. The line number is changing from ${fromPublicCode} to ${toPublicCode}.`,
+        `Bli sittande. Linjenummeret endrar seg frå ${fromPublicCode} til ${toPublicCode}.`,
+      ),
   },
   flexibleTransport: {
     needsBookingWhatIsThisTitle: (publicCode: string) =>

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -348,6 +348,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
           publicCode={publicCode}
           interchangeDetails={interchangeDetails}
           maximumWaitTime={leg.interchangeTo?.maximumWaitTime}
+          staySeated={leg.interchangeTo?.staySeated}
         />
       )}
     </>
@@ -515,18 +516,27 @@ type InterchangeSectionProps = {
   publicCode: string;
   interchangeDetails: InterchangeDetails;
   maximumWaitTime?: number;
+  staySeated?: boolean;
 };
 function InterchangeSection({
   iconColor,
   publicCode,
   interchangeDetails,
   maximumWaitTime,
+  staySeated,
 }: InterchangeSectionProps) {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
 
   let text = '';
-  if (publicCode) {
+  if (publicCode && staySeated) {
+    text = t(
+      TripDetailsTexts.messages.lineChangeStaySeated(
+        interchangeDetails.publicCode,
+        publicCode,
+      ),
+    );
+  } else if (publicCode) {
     text = t(
       TripDetailsTexts.messages.interchange(
         publicCode,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18758

### Background 
In https://github.com/AtB-AS/kundevendt/issues/18588, travel planner web was updated with a feature to clarify when the travellers should stay seated during a bus line number change.  Currently, the app does not distinguish between how a bus line change and an actual bus interchange is displayed. This can be confusing for the users and might lead some to get of the bus when they are supposed to stay seated.



#### Illustrations

<details>
<summary>screenshots/video/reis-nordland</summary>

| Trip view  | Detailed view |
| -------- | ------- |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-12 at 14 25 36](https://github.com/user-attachments/assets/737d1ad5-d215-4574-bfcf-21d3ac1e0922)  |  ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-12 at 14 27 29](https://github.com/user-attachments/assets/1543ef71-8ad4-4895-b81e-faed7a8e3995) |

</details>






### Proposed solution

Update the app to display bus line number changes the same way as currently displayed in travel planner web, to avoid confusion and to maintain equal view in app and travel planner web. 

### Acceptance Criteria
- [ ] This update should not affect how any trips are being displayed other than the one where staySeated: true.

### Test input
- [ ] Some trips from Mosjøen sentrum to Søvik are lines where staySeated: true.



