### PR TITLE
feat: Show recipient name

### DIFF
--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -38,6 +38,7 @@ import {UserProfileWithCount} from './types';
 import {FareContractHarborStopPlaces} from './components/FareContractHarborStopPlaces';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {useGetPhoneByAccountIdQuery} from '@atb/on-behalf-of/queries/use-get-phone-by-account-id-query';
+import {useFetchOnBehalfOfAccountsQuery} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 
 export type FareContractInfoProps = {
   travelRight: NormalTravelRight;
@@ -85,6 +86,13 @@ export const FareContractInfoHeader = ({
     sentToCustomerAccountId,
   );
 
+  const {data: onBehalfOfAccounts} = useFetchOnBehalfOfAccountsQuery({
+    enabled: !!phoneNumber,
+  });
+  const recipientName =
+    phoneNumber &&
+    onBehalfOfAccounts?.find((a) => a.phoneNumber === phoneNumber)?.name;
+
   return (
     <View style={styles.header}>
       {productName && (
@@ -115,7 +123,9 @@ export const FareContractInfoHeader = ({
       {phoneNumber && (
         <MessageInfoText
           type="warning"
-          message={t(FareContractTexts.details.sentTo(phoneNumber))}
+          message={t(
+            FareContractTexts.details.sentTo(recipientName || phoneNumber),
+          )}
         />
       )}
       {status === 'valid' && warning && (

--- a/src/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts
+++ b/src/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts
@@ -1,23 +1,27 @@
 import {useAuthState} from '@atb/auth';
 import {useQuery} from '@tanstack/react-query';
 import {fetchOnBehalfOfAccounts} from '@atb/api/profile.ts';
-import {ExistingRecipientType} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts';
 import {HALF_DAY_MS} from '@atb/utils/durations.ts';
+import {OnBehalfOfAccountType} from '@atb/on-behalf-of/types.ts';
 
-export const FETCH_RECIPIENTS_QUERY_KEY = 'FETCH_RECIPIENTS';
+export const FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY =
+  'FETCH_ON_BEHALF_OF_ACCOUNTS';
 
-export const useFetchRecipientsQuery = () => {
+type Params = {enabled: boolean};
+
+export const useFetchOnBehalfOfAccountsQuery = ({enabled}: Params) => {
   const {userId} = useAuthState();
 
   return useQuery({
-    queryKey: [FETCH_RECIPIENTS_QUERY_KEY, userId],
+    queryKey: [FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY, userId],
     queryFn: fetchOnBehalfOfAccounts,
     retry: 0,
     staleTime: HALF_DAY_MS,
     cacheTime: HALF_DAY_MS,
+    enabled,
     select: (data) =>
       data.map(
-        (r): ExistingRecipientType => ({
+        (r): OnBehalfOfAccountType => ({
           accountId: r.sentToAccountId,
           name: r.sentToAlias,
           phoneNumber: r.sentToPhoneNumber,

--- a/src/on-behalf-of/types.ts
+++ b/src/on-behalf-of/types.ts
@@ -2,3 +2,9 @@ export type GetAccountByPhoneErrorCode =
   | 'invalid_phone'
   | 'no_associated_account'
   | 'unknown_error';
+
+export type OnBehalfOfAccountType = {
+    accountId: string;
+    phoneNumber: string;
+    name: string;
+};

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
@@ -13,9 +13,9 @@ import {SaveRecipientToggle} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipi
 import {ExistingRecipientsList} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/ExistingRecipientsList.tsx';
 import {PhoneAndNameInputSection} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/PhoneAndNameInputSection.tsx';
 import {TitleAndDescription} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/TitleAndDescription.tsx';
-import {FETCH_RECIPIENTS_QUERY_KEY} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-fetch-recipients-query.ts';
 import {useQueryClient} from '@tanstack/react-query';
 import {SendToOtherButton} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SendToOtherButton.tsx';
+import {FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 
 type Props = RootStackScreenProps<'Root_ChooseTicketRecipientScreen'>;
 const themeColor: StaticColorByType<'background'> = 'background_accent_0';
@@ -46,7 +46,9 @@ export const Root_ChooseTicketRecipientScreen = ({
           refreshControl={
             <RefreshControl
               onRefresh={() =>
-                queryClient.resetQueries([FETCH_RECIPIENTS_QUERY_KEY])
+                queryClient.resetQueries([
+                  FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY,
+                ])
               }
               refreshing={false}
               tintColor={getStaticColor(themeName, themeColor).text}

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/ExistingRecipientsList.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/ExistingRecipientsList.tsx
@@ -1,9 +1,5 @@
-import {
-  ExistingRecipientType,
-  RecipientSelectionState,
-} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts';
+import {RecipientSelectionState} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts';
 import {dictionary, useTranslation} from '@atb/translations';
-import {useFetchRecipientsQuery} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-fetch-recipients-query.ts';
 import {useEffect, useLayoutEffect} from 'react';
 import {ActivityIndicator} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
@@ -15,6 +11,8 @@ import {Delete} from '@atb/assets/svg/mono-icons/actions';
 import {useDeleteRecipientMutation} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-delete-recipient-mutation.ts';
 import {animateNextChange} from '@atb/utils/animation.ts';
 import {screenReaderPause} from '@atb/components/text';
+import {useFetchOnBehalfOfAccountsQuery} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
+import {OnBehalfOfAccountType} from '@atb/on-behalf-of/types.ts';
 
 export const ExistingRecipientsList = ({
   state: {recipient},
@@ -23,7 +21,7 @@ export const ExistingRecipientsList = ({
   themeColor,
 }: {
   state: RecipientSelectionState;
-  onSelect: (r?: ExistingRecipientType) => void;
+  onSelect: (r?: OnBehalfOfAccountType) => void;
   onEmptyRecipients: () => void;
   themeColor: StaticColor;
 }) => {
@@ -31,7 +29,7 @@ export const ExistingRecipientsList = ({
   const {t} = useTranslation();
   const {theme, themeName} = useTheme();
 
-  const recipientsQuery = useFetchRecipientsQuery();
+  const recipientsQuery = useFetchOnBehalfOfAccountsQuery({enabled: true});
   const {mutation: deleteMutation, activeDeletions} =
     useDeleteRecipientMutation();
 
@@ -45,7 +43,7 @@ export const ExistingRecipientsList = ({
     }
   }, [recipientsQuery.status, recipientsQuery.data, onEmptyRecipients]);
 
-  const onDelete = ({accountId}: ExistingRecipientType) => {
+  const onDelete = ({accountId}: OnBehalfOfAccountType) => {
     if (recipient?.accountId === accountId) {
       onSelect(undefined);
     }

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SaveRecipientToggle.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SaveRecipientToggle.tsx
@@ -4,9 +4,9 @@ import {Checkbox} from '@atb/components/checkbox';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
 import {StaticColor} from '@atb/theme/colors.ts';
-import {useFetchRecipientsQuery} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-fetch-recipients-query.ts';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {useFetchOnBehalfOfAccountsQuery} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 
 const MAX_RECIPIENTS = 10;
 
@@ -21,7 +21,7 @@ export const SaveRecipientToggle = ({
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {data: recipients} = useFetchRecipientsQuery();
+  const {data: recipients} = useFetchOnBehalfOfAccountsQuery({enabled: true});
   if (!settingPhone) return null;
 
   const isAtMaxRecipients = (recipients?.length || 0) >= MAX_RECIPIENTS;

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SubmitButton.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SubmitButton.tsx
@@ -1,8 +1,8 @@
 import {
-  ExistingRecipientType,
   OnBehalfOfErrorCode,
   RecipientSelectionState,
 } from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts';
+import {OnBehalfOfAccountType} from '@atb/on-behalf-of/types.ts';
 import {TicketRecipientType} from '@atb/stacks-hierarchy/types.ts';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
@@ -19,7 +19,7 @@ import {getStaticColor, StaticColor} from '@atb/theme/colors.ts';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
-import {FETCH_RECIPIENTS_QUERY_KEY} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-fetch-recipients-query.ts';
+import {FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 import {useQueryClient} from '@tanstack/react-query';
 import {useAuthState} from '@atb/auth';
 
@@ -75,8 +75,8 @@ export const SubmitButton = ({
       return;
     }
 
-    const recipients = queryClient.getQueryData<ExistingRecipientType[]>([
-      FETCH_RECIPIENTS_QUERY_KEY,
+    const recipients = queryClient.getQueryData<OnBehalfOfAccountType[]>([
+      FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY,
       userId,
     ]);
 

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts
@@ -1,7 +1,5 @@
 import {GetAccountByPhoneErrorCode} from '@atb/on-behalf-of';
-import {TicketRecipientType} from '@atb/stacks-hierarchy/types.ts';
-
-export type ExistingRecipientType = Required<TicketRecipientType>;
+import {OnBehalfOfAccountType} from "@atb/on-behalf-of/types.ts";
 
 export type OnBehalfOfErrorCode =
   | GetAccountByPhoneErrorCode
@@ -13,7 +11,7 @@ export type OnBehalfOfErrorCode =
 export type RecipientSelectionState = {
   settingPhone: boolean;
   settingName: boolean;
-  recipient?: ExistingRecipientType;
+  recipient?: OnBehalfOfAccountType;
   phone?: string;
   prefix: string;
   name?: string;

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-delete-recipient-mutation.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-delete-recipient-mutation.ts
@@ -1,9 +1,9 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {deleteOnBehalfOfAccount} from '@atb/api/profile.ts';
 import {useAuthState} from '@atb/auth';
-import {FETCH_RECIPIENTS_QUERY_KEY} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-fetch-recipients-query.ts';
 import {OnBehalfOfAccountsResponse} from '@atb/api/types/profile.ts';
 import {useState} from 'react';
+import {FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 
 export const useDeleteRecipientMutation = () => {
   const {userId} = useAuthState();
@@ -16,7 +16,7 @@ export const useDeleteRecipientMutation = () => {
     onSuccess: (_, accountId) => {
       removeActive(accountId);
       queryClient.setQueryData(
-        [FETCH_RECIPIENTS_QUERY_KEY, userId],
+        [FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY, userId],
         (oldData?: OnBehalfOfAccountsResponse) =>
           oldData?.filter((r) => r.sentToAccountId !== accountId),
       );

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-recipient-selection-state.ts
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-recipient-selection-state.ts
@@ -1,12 +1,12 @@
 import {Dispatch, useReducer} from 'react';
 import {
-  ExistingRecipientType,
   OnBehalfOfErrorCode,
   RecipientSelectionState,
 } from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/types.ts';
+import {OnBehalfOfAccountType} from "@atb/on-behalf-of/types.ts";
 
 type RecipientSelectionAction =
-  | {type: 'SELECT_RECIPIENT'; recipient?: ExistingRecipientType}
+  | {type: 'SELECT_RECIPIENT'; recipient?: OnBehalfOfAccountType}
   | {type: 'SELECT_SEND_TO_OTHER'}
   | {type: 'SET_PREFIX'; prefix: string}
   | {type: 'SET_PHONE'; phoneNumber: string}

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -311,7 +311,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   >
                     {t(
                       PurchaseConfirmationTexts.sendingTo(
-                        recipient.phoneNumber,
+                        recipient.name || recipient.phoneNumber,
                       ),
                     )}
                   </ThemeText>

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
@@ -3,7 +3,7 @@ import {OfferReservation, ReserveOffer, reserveOffers} from '@atb/ticketing';
 import {useAuthState} from '@atb/auth';
 import {PaymentMethod, TicketRecipientType} from '@atb/stacks-hierarchy/types';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
-import {FETCH_RECIPIENTS_QUERY_KEY} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/use-fetch-recipients-query.ts';
+import {FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 
 type Args = {
   offers: ReserveOffer[];
@@ -47,7 +47,7 @@ export const useReserveOfferMutation = ({
     },
     onSuccess: () => {
       if (recipient?.name) {
-        queryClient.invalidateQueries([FETCH_RECIPIENTS_QUERY_KEY]);
+        queryClient.invalidateQueries([FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY]);
       }
     },
   });


### PR DESCRIPTION
Show it on the confirmation screen and on the confirmation screen
and on sent-to-others tickets.

Needed a refactor where the fetch recipients query was moved to a
place it could be reused, so it was rebranded to an
on-behalf-of-accounts-query, which is more inline with the api
naming.

<div>
<img width=300 src="https://github.com/user-attachments/assets/ee0e472f-fb89-4c7c-8f9c-854853a5f6a1" />
<img width=300 src="https://github.com/user-attachments/assets/cbb809c7-f6b3-4e83-ad88-bf7b17708acc" />
</div>
