### PR TITLE
test: check more results when filtering travel searches

### DIFF
--- a/e2e/test/pageobjects/travelsearch.overview.page.ts
+++ b/e2e/test/pageobjects/travelsearch.overview.page.ts
@@ -141,7 +141,7 @@ class TravelSearchOverviewPage {
    * NOTE! Only bus and rail modes
    * @param numberOfResults the number of results to check
    */
-  async getNumberOfTransportModesInSearch(numberOfResults: number = 5) {
+  async getNumberOfTransportModesInSearch(numberOfResults: number = 10) {
     let noBusLegs = 0;
     let noRailLegs = 0;
     // Loop through the search results and count the different modes
@@ -151,21 +151,25 @@ class TravelSearchOverviewPage {
       const railModeId = `//*[@resource-id="railLeg"]`;
 
       // Scroll down if trip result is not displayed
-      const resultExists = await ElementHelper.isElementExisting(
+      // Handle if the visible trip results are less than the default
+      let resultExists = await ElementHelper.isElementExisting(
         `tripSearchSearchResult${i}`,
-        2,
+        1,
       );
       if (!resultExists) {
-        await AppHelper.scrollDownUntilId(
-          'tripSearchContentView',
+        await AppHelper.scrollDown('tripSearchContentView');
+        resultExists = await ElementHelper.isElementExisting(
           `tripSearchSearchResult${i}`,
+          1,
         );
+        if (!resultExists) {
+          break;
+        }
       }
 
       noBusLegs += await $(tripId).$$(busModeId).length;
       noRailLegs += await $(tripId).$$(railModeId).length;
     }
-    await AppHelper.scrollUp('tripSearchContentView');
 
     // Find and return number of different transport modes
     const busLegsExists: number = noBusLegs > 0 ? 1 : 0;

--- a/e2e/test/specs/travelsearch.filter.e2e.ts
+++ b/e2e/test/specs/travelsearch.filter.e2e.ts
@@ -41,6 +41,7 @@ describe('Travel search filter', () => {
         await TravelsearchOverviewPage.getNumberOfTransportModesInSearch();
 
       // Filter out buses
+      await AppHelper.scrollUpUntilId('tripSearchContentView', 'filterButton');
       await TravelsearchFilterPage.openFilter();
       await TravelsearchFilterPage.toggleFilter('bus');
       await TravelsearchFilterPage.confirmFilter();
@@ -50,6 +51,10 @@ describe('Travel search filter', () => {
       const numberOfModesWithFilter =
         await TravelsearchOverviewPage.getNumberOfTransportModesInSearch();
       expect(numberOfModesWithFilter).toBeLessThan(numberOfModesInitial);
+      await AppHelper.scrollUpUntilId(
+        'tripSearchContentView',
+        'selectedFilterButton',
+      );
       await TravelsearchFilterPage.shouldShowSelectedFilter('6 of 7');
 
       // Remove the selected filters
@@ -60,6 +65,7 @@ describe('Travel search filter', () => {
       const numberOfModes =
         await TravelsearchOverviewPage.getNumberOfTransportModesInSearch();
       expect(numberOfModes).toEqual(numberOfModesInitial);
+      await AppHelper.scrollUpUntilId('tripSearchContentView', 'filterButton');
       await expect(TravelsearchFilterPage.selectedFilterButton).not.toExist();
     } catch (errMsg) {
       await AppHelper.screenshot('error_travelsearch_filter_transport_modes');


### PR DESCRIPTION
With the new bus schedule, there are more bus departures between my origin and destination when testing travel search filters. Have to check more search results to find results with both buses and trains.