### PR TITLE
feat: extend notifications to inform about transportation that mus be booket in advance

### DIFF
--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -54,6 +54,9 @@ export type TripFragment = {
         quay: {publicCode?: string; name: string};
         notices: Array<{id: string; text?: string}>;
       };
+      toEstimatedCall?: {
+        notices: Array<{id: string; text?: string}>;
+      };
       situations: Array<{
         id: string;
         situationNumber?: string;

--- a/src/api/types/generated/fragments/trips.ts
+++ b/src/api/types/generated/fragments/trips.ts
@@ -31,6 +31,9 @@ export type TripPatternFragment = {
       quay: {publicCode?: string; name: string};
       notices: Array<{id: string; text?: string}>;
     };
+    toEstimatedCall?: {
+      notices: Array<{id: string; text?: string}>;
+    };
     situations: Array<{
       id: string;
       situationNumber?: string;

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -35,6 +35,7 @@ import {
   significantWaitTime,
   significantWalkTime,
   TimeValues,
+  filterNotices,
 } from '../utils';
 import {Time} from './Time';
 import {TripLegDecoration} from './TripLegDecoration';
@@ -113,6 +114,9 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const {startTimes, endTimes} = mapLegToTimeValues(leg);
 
   const notices = getNoticesForLeg(leg);
+  const toEstimatedCallNotices = filterNotices([
+    ...(leg.toEstimatedCall?.notices || []),
+  ]);
 
   const realtimeText = useRealtimeText(leg.serviceJourneyEstimatedCalls);
 
@@ -341,6 +345,11 @@ export const TripSection: React.FC<TripSectionProps> = ({
             </ThemeText>
           </TripRow>
         )}
+        {toEstimatedCallNotices.map((notice) => (
+          <TripRow key={notice.id}>
+            <MessageInfoBox type="info" message={notice.text} />
+          </TripRow>
+        ))}
       </View>
       {showInterchangeSection && (
         <InterchangeSection

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -57,6 +57,7 @@ export const getNoticesForLeg = (leg: Leg) =>
     ...(leg.serviceJourney?.notices || []),
     ...(leg.serviceJourney?.journeyPattern?.notices || []),
     ...(leg.fromEstimatedCall?.notices || []),
+    ...(leg.toEstimatedCall?.notices || []),
   ]);
 
 export const getNoticesForServiceJourney = (

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -57,7 +57,6 @@ export const getNoticesForLeg = (leg: Leg) =>
     ...(leg.serviceJourney?.notices || []),
     ...(leg.serviceJourney?.journeyPattern?.notices || []),
     ...(leg.fromEstimatedCall?.notices || []),
-    ...(leg.toEstimatedCall?.notices || []),
   ]);
 
 export const getNoticesForServiceJourney = (


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/4203

### Background
It seems that the app is currently not handling notices on the EstimatedCall on which a trip ends: https://github.com/AtB-AS/mittatb-app/blob/51ea34a7b69f8aca381aac5ffc94fa36a88086ae/src/travel-details-screens/utils.ts#L44-L50

This results, among other things, in that users are not notified about trips that must be booked in advance (behovsanløp).
#### Illustrations
<details>
<summary>screenshots/video/figma</summary>

| either fromEstimatedCall or toEstimatedCall |  both fromEstimatedCall and toEstimatedCall |
| -------- | ------- |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-20 at 10 51 18](https://github.com/user-attachments/assets/ddd3c3e8-565c-4de3-a28c-75491d3995d5)| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-20 at 12 50 02](https://github.com/user-attachments/assets/da96b0b3-8e76-4679-994a-3490ab0b4b47)|
|![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-20 at 10 50 59](https://github.com/user-attachments/assets/c47ab6c8-6e36-4fc3-aa5c-3382e7e68189)||


### Proposed solution
To solve, we should probably extend the code above to also include notices from ToEstimatedCall.

### Acceptance Criteria
- [ ] Notices from estimated call are displayed. 

### Test input
- [ ] Tromsø Prostneset hurtigbåtkai - Lauksundskaret ferjekai
- [ ] Terråk hurtigbåtkai - Skotnes hurtigbåtkai