### PR TITLE
fix: allow navigation to same favorite chips in departure

### DIFF
--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -76,6 +76,8 @@ export const NearbyStopPlacesScreenComponent = ({
     [data],
   );
 
+  const openLocationSearch = () => onPressLocationSearch(location);
+
   useEffect(() => {
     if (
       (location?.resultType == 'search' ||
@@ -85,8 +87,6 @@ export const NearbyStopPlacesScreenComponent = ({
       onSelectStopPlaceRef.current(location);
     }
   }, [location]);
-
-  const openLocationSearch = () => onPressLocationSearch(location);
 
   function setCurrentLocationAsFrom() {
     onUpdateLocation(

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -76,6 +76,16 @@ export const NearbyStopPlacesScreenComponent = ({
     [data],
   );
 
+  useEffect(() => {
+    if (
+      (location?.resultType == 'search' ||
+        location?.resultType === 'favorite') &&
+      location?.layer === 'venue'
+    ) {
+      onSelectStopPlaceRef.current(location);
+    }
+  }, [location]);
+
   const openLocationSearch = () => onPressLocationSearch(location);
 
   function setCurrentLocationAsFrom() {
@@ -120,17 +130,6 @@ export const NearbyStopPlacesScreenComponent = ({
         return;
     }
   };
-
-  useEffect(() => {
-    if (
-      (location?.resultType == 'search' ||
-        location?.resultType === 'favorite') &&
-      location?.layer === 'venue'
-    ) {
-      onSelectStopPlaceRef.current(location);
-    }
-  }, [location]);
-
 
   useEffect(() => {
     if (updatingLocation)

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -11,7 +11,7 @@ import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {StyleSheet} from '@atb/theme';
 import {DeparturesTexts, NearbyTexts, useTranslation} from '@atb/translations';
 import {useIsFocused} from '@react-navigation/native';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {Platform, RefreshControl, View} from 'react-native';
 import {StopPlacesMode} from './types';
 import {FullScreenView} from '@atb/components/screen-view';
@@ -58,8 +58,6 @@ export const NearbyStopPlacesScreenComponent = ({
 
   const screenHasFocus = useIsFocused();
 
-  const onSelectStopPlaceRef = useRef(onSelectStopPlace);
-
   useDoOnceWhen(
     setCurrentLocationAsFromIfEmpty,
     Boolean(currentLocation) && screenHasFocus,
@@ -84,9 +82,9 @@ export const NearbyStopPlacesScreenComponent = ({
         location?.resultType === 'favorite') &&
       location?.layer === 'venue'
     ) {
-      onSelectStopPlaceRef.current(location);
+      onSelectStopPlace(location);
     }
-  }, [location]);
+  }, [location, onSelectStopPlace]);
 
   function setCurrentLocationAsFrom() {
     onUpdateLocation(

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -11,7 +11,7 @@ import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {StyleSheet} from '@atb/theme';
 import {DeparturesTexts, NearbyTexts, useTranslation} from '@atb/translations';
 import {useIsFocused} from '@react-navigation/native';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {Platform, RefreshControl, View} from 'react-native';
 import {StopPlacesMode} from './types';
 import {FullScreenView} from '@atb/components/screen-view';
@@ -58,15 +58,7 @@ export const NearbyStopPlacesScreenComponent = ({
 
   const screenHasFocus = useIsFocused();
 
-  const handleLocationUpdate = useCallback(() => {
-    if (
-      (location?.resultType == 'search' ||
-        location?.resultType === 'favorite') &&
-      location?.layer === 'venue'
-    ) {
-      onSelectStopPlace(location);
-    }
-  }, [location])
+  const onSelectStopPlaceRef = useRef(onSelectStopPlace);
 
   useDoOnceWhen(
     setCurrentLocationAsFromIfEmpty,
@@ -130,8 +122,14 @@ export const NearbyStopPlacesScreenComponent = ({
   };
 
   useEffect(() => {
-    handleLocationUpdate();
-  }, [handleLocationUpdate]);
+    if (
+      (location?.resultType == 'search' ||
+        location?.resultType === 'favorite') &&
+      location?.layer === 'venue'
+    ) {
+      onSelectStopPlaceRef.current(location);
+    }
+  }, [location]);
 
 
   useEffect(() => {

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -162,7 +162,6 @@ export const NearbyStopPlacesScreenComponent = ({
         // Quick fix for iOS to fix stuck spinner by removing the RefreshControl when not focused
         isFocused || Platform.OS === 'android' ? (
           <RefreshControl
-            progressViewOffset={90}
             refreshing={Platform.OS === 'ios' ? false : isLoading}
             onRefresh={refresh}
           />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {DashboardScreenProps} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/navigation-types';
 import {StopPlace} from '@atb/api/types/departures';
 import {
@@ -34,13 +34,13 @@ export const Dashboard_NearbyStopPlacesScreen = ({
           initialLocation: location,
         })
       }
-      onSelectStopPlace={(place: StopPlace) => {
-        navigation.navigate('Dashboard_PlaceScreen', {
-          place,
-          mode: route.params.mode,
-          onCloseRoute: route.params.onCloseRoute,
-        });
-      }}
+      onSelectStopPlace={useCallback((place: StopPlace) => {
+          navigation.navigate('Dashboard_PlaceScreen', {
+            place,
+            mode: route.params.mode,
+            onCloseRoute: route.params.onCloseRoute,
+          });
+      }, [navigation, route.params.mode, route.params.onCloseRoute])}
       onUpdateLocation={(location) => navigation.setParams({location})}
       onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
     />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
@@ -1,7 +1,7 @@
 import {StopPlace} from '@atb/api/types/departures';
 import {useOnlySingleLocation} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
 import {DeparturesTexts, NearbyTexts, useTranslation} from '@atb/translations';
-import React from 'react';
+import React, { useCallback } from 'react';
 import {DeparturesStackProps} from './navigation-types';
 import {NearbyStopPlacesScreenComponent} from '@atb/nearby-stop-places';
 import {GlobalMessageContextEnum} from '@atb/global-messages';
@@ -33,12 +33,12 @@ export const Departures_NearbyStopPlacesScreen = ({
           initialLocation: location,
         })
       }
-      onSelectStopPlace={(place: StopPlace) => {
+      onSelectStopPlace={useCallback((place: StopPlace) => {
         navigation.navigate('Departures_PlaceScreen', {
           place,
           mode: route.params.mode,
         });
-      }}
+      }, [navigation, route.params.mode])}
       onUpdateLocation={(location) => navigation.setParams({location})}
       onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
     />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
@@ -1,5 +1,5 @@
 import {useOnlySingleLocation} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
-import React from 'react';
+import React, { useCallback } from 'react';
 import {ProfileScreenProps} from './navigation-types';
 import {StopPlace} from '@atb/api/types/departures';
 import {
@@ -32,12 +32,12 @@ export const Profile_NearbyStopPlacesScreen = ({navigation, route}: Props) => {
           initialLocation: location,
         })
       }
-      onSelectStopPlace={(place: StopPlace) => {
+      onSelectStopPlace={useCallback((place: StopPlace) => {
         navigation.navigate('Profile_PlaceScreen', {
           place,
           mode: route.params.mode,
         });
-      }}
+      }, [navigation, route.params.mode])}
       onUpdateLocation={(location) => navigation.setParams({location})}
       onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
     />


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17342

This PR will fix the issue where user couldn't navigate to the same favorite chip on the departure screen (and anywhere else). 

Other existing function should still function normally.

Also I added an offset for the refresh loading progress so it shows properly on the screen.

A question, can I use `useRef` to fix the issue on the other eslint issue in the same file?

https://github.com/user-attachments/assets/d0cbcf92-8ba2-408d-9dc1-7f856859babb

