### PR TITLE
build: Split update devices job to be run in serial

### DIFF
--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -28,9 +28,11 @@ runs:
         env:
           GIT_CRYPT_KEY: ${{ inputs.git-crypt-key }}
       - name: Copy Development files
+        shell: bash
         if: ${{ inputs.app-environment=='development' }}
         run: cp env/${{ inputs.app-org }}/dev/.env fastlane/.env.default
       - name: Copy Adhoc files
+        shell: bash
         if: ${{ inputs.app-environment=='adhoc' }}
         run: cp env/${{ inputs.app-org }}/staging/.env fastlane/.env.default
       - name: Setup ruby and bundle install

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -25,7 +25,9 @@ runs:
   steps:
       - name: Set global env vars
         shell: bash
-        run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+          echo "APP_ENVIRONMENT=${{ inputs.app-environment }}" >> $GITHUB_ENV
       - name: Decrypt env files
         shell: bash
         run: sh ./scripts/git-crypt-unlock.sh

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -1,5 +1,5 @@
 name: Update devices
-description: 'Updates devices and provisioning profiles for development and adhoc environments'
+description: 'Updates devices and provisioning profile'
 inputs:
   app-environment:
     default: "adhoc"

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -7,6 +7,15 @@ inputs:
   app-org:
     default: "atb"
     required: true
+  git-crypt-key:
+    description: "The gitcrypt key to unlock the repository files with"
+    required: true
+  app-store-connect-api-key:
+    description: "The App Store Connect API key"
+    required: true
+  match-deploy-key:
+    description: "The Match deploy key"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -15,7 +24,7 @@ runs:
       - name: Decrypt env files
         run: sh ./scripts/git-crypt-unlock.sh
         env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+          GIT_CRYPT_KEY: ${{ inputs.git-crypt-key }}
       - name: Copy Development files
         if: ${{ inputs.app-environment=='development' }}
         run: cp env/${{ inputs.app-org }}/dev/.env fastlane/.env.default
@@ -29,9 +38,9 @@ runs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Update devices and provisioning profiles
         run: |
-          echo ${{ secrets.APP_STORE_CONNECT_API_KEY }} | base64 --decode > app-store-connect-api-key.json
+          echo ${{ inputs.app-store-connect-api-key }} | base64 --decode > app-store-connect-api-key.json
           bundle exec fastlane ios update_devices
         env:
           APPCONNECT_API_KEY_PATH: app-store-connect-api-key.json
           FASTLANE_MATCH_TYPE: ${{ inputs.app-environment }}
-          MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
+          MATCH_DEPLOY_KEY: ${{ inputs.match-deploy-key }}

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -20,8 +20,10 @@ runs:
   using: "composite"
   steps:
       - name: Set global env vars
+        shell: bash
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
       - name: Decrypt env files
+        shell: bash
         run: sh ./scripts/git-crypt-unlock.sh
         env:
           GIT_CRYPT_KEY: ${{ inputs.git-crypt-key }}
@@ -32,11 +34,13 @@ runs:
         if: ${{ inputs.app-environment=='adhoc' }}
         run: cp env/${{ inputs.app-org }}/staging/.env fastlane/.env.default
       - name: Setup ruby and bundle install
+        shell: bash
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Update devices and provisioning profiles
+        shell: bash
         run: |
           echo ${{ inputs.app-store-connect-api-key }} | base64 --decode > app-store-connect-api-key.json
           bundle exec fastlane ios update_devices

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -10,8 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Checkout project
-        uses: actions/checkout@v3
       - name: Set global env vars
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
       - name: Decrypt env files

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -1,0 +1,39 @@
+name: Update devices
+description: 'Updates devices and provisioning profiles for development and adhoc environments'
+inputs:
+  app-environment:
+    default: "adhoc"
+    required: true
+  app-org:
+    default: "atb"
+    required: true
+runs:
+  using: "composite"
+  steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+      - name: Set global env vars
+        run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+      - name: Decrypt env files
+        run: sh ./scripts/git-crypt-unlock.sh
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Copy Development files
+        if: ${{ inputs.app-environment=='development' }}
+        run: cp env/${{ inputs.app-org }}/dev/.env fastlane/.env.default
+      - name: Copy Adhoc files
+        if: ${{ inputs.app-environment=='adhoc' }}
+        run: cp env/${{ inputs.app-org }}/staging/.env fastlane/.env.default
+      - name: Setup ruby and bundle install
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.6'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Update devices and provisioning profiles
+        run: |
+          echo ${{ secrets.APP_STORE_CONNECT_API_KEY }} | base64 --decode > app-store-connect-api-key.json
+          bundle exec fastlane ios update_devices
+        env:
+          APPCONNECT_API_KEY_PATH: app-store-connect-api-key.json
+          FASTLANE_MATCH_TYPE: ${{ inputs.app-environment }}
+          MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -16,6 +16,10 @@ inputs:
   match-deploy-key:
     description: "The Match deploy key"
     required: true
+  ruby-version:
+    description: "The ruby version to use"
+    default: "2.7.6"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -36,10 +40,10 @@ runs:
         if: ${{ inputs.app-environment=='adhoc' }}
         run: cp env/${{ inputs.app-org }}/staging/.env fastlane/.env.default
       - name: Setup ruby and bundle install
-        shell: bash
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.6'
+          ruby-version: ${{ inputs.ruby-version }}
+          cache-version: 1
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Update devices and provisioning profiles
         shell: bash

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -15,6 +15,8 @@ jobs:
     name: development
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
       - name: development
         uses: ./.github/actions/update-devices
         with:
@@ -26,6 +28,8 @@ jobs:
     needs: update-devices-development
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
       - name: adhoc
         uses: ./.github/actions/update-devices
         with:

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -11,40 +11,23 @@ on:
           - fram
           - nfk
 jobs:
-  update-devices:
-    name: Update new devices and provisioning profiles
-    strategy:
-      fail-fast: false
-      matrix:
-        type: [development, adhoc]
-    environment: ${{ inputs.org }}
-    timeout-minutes: 180
+  update-devices-development:
+    name: Update new devices and provisioning profiles for development
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v3
-      - name: Set global env vars
-        run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-      - name: Decrypt env files
-        run: sh ./scripts/git-crypt-unlock.sh
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
-      - name: Copy Development files
-        if: ${{ matrix.type=='development'}}
-        run: cp env/${{ inputs.org }}/dev/.env fastlane/.env.default
-      - name: Copy Adhoc files
-        if: ${{ matrix.type=='adhoc'}}
-        run: cp env/${{ inputs.org }}/staging/.env fastlane/.env.default
-      - name: Setup ruby and bundle install
-        uses: ruby/setup-ruby@v1
+      - name: development
+        uses: ./.github/actions/ios-build-setup
         with:
-          ruby-version: '2.7.6'
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Update devices and provisioning profiles
-        run: |
-          echo ${{ secrets.APP_STORE_CONNECT_API_KEY}} | base64 --decode > app-store-connect-api-key.json
-          bundle exec fastlane ios update_devices
-        env:
-          APPCONNECT_API_KEY_PATH: app-store-connect-api-key.json
-          FASTLANE_MATCH_TYPE: ${{ matrix.type }}
-          MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
+          app-environment: development
+          app-org: ${{ inputs.org }}
+
+  update-devices-adhoc:
+    name: adhoc
+    needs: update-devices-development
+    runs-on: ubuntu-latest
+    steps:
+      - name: adhoc
+        uses: ./.github/actions/ios-build-setup
+        with:
+          app-environment: adhoc
+          app-org: ${{ inputs.org }}

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           app-environment: development
           app-org: ${{ inputs.org }}
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+          app-store-connect-api-key: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          match-deploy-key: ${{ secrets.MATCH_DEPLOY_KEY }}
 
   update-devices-adhoc:
     name: adhoc
@@ -35,3 +38,6 @@ jobs:
         with:
           app-environment: adhoc
           app-org: ${{ inputs.org }}
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+          app-store-connect-api-key: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          match-deploy-key: ${{ secrets.MATCH_DEPLOY_KEY }}

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -14,6 +14,7 @@ jobs:
   update-devices-development:
     name: development
     runs-on: ubuntu-latest
+    environment: ${{ inputs.org }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       org:
-        description: 'App organization to update provisioning profiles'
+        description: 'App organization to update devices for'
         required: true
         type: choice
         options:
@@ -12,11 +12,11 @@ on:
           - nfk
 jobs:
   update-devices-development:
-    name: Update new devices and provisioning profiles for development
+    name: development
     runs-on: ubuntu-latest
     steps:
       - name: development
-        uses: ./.github/actions/ios-build-setup
+        uses: ./.github/actions/update-devices
         with:
           app-environment: development
           app-org: ${{ inputs.org }}
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: adhoc
-        uses: ./.github/actions/ios-build-setup
+        uses: ./.github/actions/update-devices
         with:
           app-environment: adhoc
           app-org: ${{ inputs.org }}

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -31,6 +31,7 @@ jobs:
     name: adhoc
     needs: update-devices-development
     runs-on: ubuntu-latest
+    environment: ${{ inputs.org }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/.github/workflows/update-devices.yml
+++ b/.github/workflows/update-devices.yml
@@ -10,6 +10,7 @@ on:
           - atb
           - fram
           - nfk
+          - troms
 jobs:
   update-devices-development:
     name: development


### PR DESCRIPTION
There was an issue while update devices ran at the same time to update provisioning profiles, it was separated in order to make it serialized, first development then adhoc.

Before:

<img width="384" alt="image" src="https://github.com/user-attachments/assets/1c69e361-974c-4024-93dd-1a22c1ec5577">

Now:

<img width="583" alt="image" src="https://github.com/user-attachments/assets/9ca65ae2-5bf2-4968-bc06-dfecb4e9ef2c">
