### PR TITLE
fix: update the notice of line number change to display the correct order

### DIFF
--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -532,8 +532,8 @@ function InterchangeSection({
   if (publicCode && staySeated) {
     text = t(
       TripDetailsTexts.messages.lineChangeStaySeated(
-        interchangeDetails.publicCode,
         publicCode,
+        interchangeDetails.publicCode,
       ),
     );
   } else if (publicCode) {


### PR DESCRIPTION
### What is wrong, and what is expected behavior?

The message notifying the travellers about the line change is incorrect. The message currently describes line change in reverse order. 

![358527050-43cbf696-3d29-4751-93aa-290cc20577b9](https://github.com/user-attachments/assets/311e74b3-6c50-4d43-9b12-2967e2d4ab86)


### Illustration after update
<details>
<Summary>screenshots/video</Summary>

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-19 at 09 50 09](https://github.com/user-attachments/assets/30e32966-d537-4f1a-b996-7d823f015770)


</details>

### Acceptance criteria
- [ ] Line change displayed in the correct order. 
