### PR TITLE
fix: prevent duplicate product group keys

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts.tsx
@@ -78,7 +78,10 @@ export const FareProducts = ({
               ? t(TicketingTexts.availableFareProducts.allTickets)
               : undefined
           }
-          key={group.transportModes.map((m) => m.mode).join('-')}
+          key={[
+            group.transportModes.map((m) => m.mode).join('-'),
+            group.heading?.[0]?.value,
+          ].join('-')}
           transportModes={group.transportModes}
           fareProducts={group.fareProducts}
           onProductSelect={onProductSelect}


### PR DESCRIPTION
This fixes a react native warning for Troms where several groups has the same transport modes.

Noticed while working on https://github.com/AtB-AS/kundevendt/issues/18693