### PR TITLE
feat: support multiple PreassignedFareProducts per offer search

### DIFF
--- a/src/configuration/__tests__/utils.test.ts
+++ b/src/configuration/__tests__/utils.test.ts
@@ -1,0 +1,24 @@
+import {PreassignedFareProduct} from '..';
+import {removeProductAliasDuplicates} from '../utils';
+
+describe('removeProductAliasDuplicates', () => {
+  it('removes duplicates', () => {
+    const products = [
+      {productAliasId: 'id-1'},
+      {productAliasId: 'id-1'},
+      {productAliasId: 'id-2'},
+    ] as PreassignedFareProduct[];
+    const dedupedProducts = products.filter(removeProductAliasDuplicates);
+    expect(dedupedProducts.length).toEqual(2);
+  });
+
+  it('does not remove undefined', () => {
+    const products = [
+      {productAliasId: 'id-1'},
+      {productAliasId: undefined},
+      {productAliasId: undefined},
+    ] as PreassignedFareProduct[];
+    const dedupedProducts = products.filter(removeProductAliasDuplicates);
+    expect(dedupedProducts.length).toEqual(3);
+  });
+});

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -25,5 +25,6 @@ export {
   isProductSellableInApp,
   findReferenceDataById,
   getReferenceDataName,
+  removeProductAliasDuplicates,
 } from './utils';
 export {useFirestoreConfiguration} from './FirestoreConfigurationContext';

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -20,6 +20,7 @@ export type PreassignedFareProduct = {
   productDescription?: LanguageAndTextType[];
   warningMessage?: LanguageAndTextType[];
   type: string;
+  productAliasId?: string;
   productAlias?: LanguageAndTextType[];
   durationDays?: number;
   distributionChannel: DistributionChannel[];

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -59,3 +59,12 @@ export const isProductSellableInApp = (
 
   return product.distributionChannel.some((channel) => channel === 'app');
 };
+
+export const removeProductAliasDuplicates = (
+  val: PreassignedFareProduct,
+  i: number,
+  arr: PreassignedFareProduct[],
+): boolean => {
+  if (val.productAliasId === undefined) return true;
+  return arr.map((p) => p.productAliasId).indexOf(val.productAliasId) === i;
+};

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -21,7 +21,7 @@ import {
 import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {formatDecimalNumber} from '@atb/utils/numbers';
 import {addMinutes, parseISO} from 'date-fns';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -122,6 +122,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
 
   const isOnBehalfOf = !!recipient;
 
+  const preassignedFareProductAlternatives = useMemo(
+    () => [preassignedFareProduct],
+    [preassignedFareProduct],
+  );
+
   const {
     offerSearchTime,
     isSearchingOffer,
@@ -132,7 +137,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     userProfilesWithCountAndOffer,
   } = useOfferState(
     offerEndpoint,
-    preassignedFareProduct,
+    preassignedFareProductAlternatives,
     fromPlace,
     toPlace,
     userProfilesWithCount,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -181,7 +181,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const focusRefs = useFocusRefs(params.onFocusElement);
 
-  const userTypeStrings = userProfilesWithCountAndOffer.filter((u) => u.count > 0).map((u) => u.userTypeString);
+  const userTypeStrings = userProfilesWithCountAndOffer
+    .filter((u) => u.count > 0)
+    .map((u) => u.userTypeString);
 
   return (
     <FullScreenView

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -48,14 +48,18 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? 'isFree' in params.toPlace && !!params.toPlace.isFree
     : false;
 
-  const {preassignedFareProduct, selectableTravellers, fromPlace, toPlace} =
-    useOfferDefaults(
-      params.preassignedFareProduct,
-      params.fareProductTypeConfig.type,
-      params.userProfilesWithCount,
-      params.fromPlace,
-      params.toPlace,
-    );
+  const {
+    preassignedFareProductAlternatives,
+    selectableTravellers,
+    fromPlace,
+    toPlace,
+  } = useOfferDefaults(
+    params.preassignedFareProduct,
+    params.fareProductTypeConfig.type,
+    params.userProfilesWithCount,
+    params.fromPlace,
+    params.toPlace,
+  );
 
   const onSelectPreassignedFareProduct = (fp: PreassignedFareProduct) => {
     navigation.setParams({
@@ -114,13 +118,18 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     userProfilesWithCountAndOffer,
   } = useOfferState(
     offerEndpoint,
-    preassignedFareProduct,
+    preassignedFareProductAlternatives,
     fromPlace,
     toPlace,
     travellerSelection,
     isOnBehalfOfToggle,
     travelDate,
   );
+
+  const preassignedFareProduct =
+    preassignedFareProductAlternatives.find(
+      (p) => p.id === userProfilesWithCountAndOffer[0]?.offer.fare_product,
+    ) ?? preassignedFareProductAlternatives[0];
 
   const rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams =
     {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
@@ -12,6 +12,7 @@ import {
   PreassignedFareProduct,
   isProductSellableInApp,
   FareProductTypeConfig,
+  removeProductAliasDuplicates,
 } from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 import {ProductAliasChip} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip';
@@ -40,7 +41,8 @@ export function ProductSelectionByAlias({
 
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
-    .filter((product) => product.type === selectedProduct.type);
+    .filter((product) => product.type === selectedProduct.type)
+    .filter(removeProductAliasDuplicates);
 
   const title = useTextForLanguage(
     fareProductTypeConfig.configuration.productSelectionTitle,
@@ -66,7 +68,11 @@ export function ProductSelectionByAlias({
             <ProductAliasChip
               color={color}
               text={text}
-              selected={selectedProduct.id === fp.id}
+              selected={
+                selectedProduct.productAliasId
+                  ? selectedProduct.productAliasId === fp.productAliasId
+                  : selectedProduct.id === fp.id
+              }
               onPress={() => setSelectedProduct(fp)}
               key={i}
             />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -10,6 +10,7 @@ import {
   useFirestoreConfiguration,
   getReferenceDataName,
   isProductSellableInApp,
+  removeProductAliasDuplicates,
 } from '@atb/configuration';
 import {FareProductTypeConfig} from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
@@ -43,7 +44,9 @@ export function ProductSelectionByProducts({
 
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
-    .filter((product) => product.type === selectedProduct.type);
+    .filter((product) => product.type === selectedProduct.type)
+    .filter(removeProductAliasDuplicates);
+
   const [selected, setProduct] = useState(selectedProduct);
 
   const alias = (fareProduct: PreassignedFareProduct) =>
@@ -76,7 +79,7 @@ export function ProductSelectionByProducts({
           <ProductDescriptionToggle title={title} />
           <RadioGroupSection<PreassignedFareProduct>
             items={selectableProducts}
-            keyExtractor={(u) => u.id}
+            keyExtractor={(u) => u.productAliasId ?? u.id}
             itemToText={(fp) => productDisplayName(fp)}
             hideSubtext={hideProductDescriptions}
             itemToSubtext={(fp) => subText(fp)}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -9,7 +9,10 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {useTicketingState} from '@atb/ticketing';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {useDefaultTariffZone, useFilterTariffZone} from '@atb/stacks-hierarchy/utils';
+import {
+  useDefaultTariffZone,
+  useFilterTariffZone,
+} from '@atb/stacks-hierarchy/utils';
 import {useMemo} from 'react';
 import {useDefaultPreassignedFareProduct} from '@atb/fare-contracts/utils';
 import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
@@ -41,8 +44,12 @@ export function useOfferDefaults(
     preassignedFareProduct ?? defaultFareProduct;
 
   // Check for whitelisted zones
-  const allowedTariffZoneRefs = defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
-  const usableTariffZones = useFilterTariffZone(tariffZones, allowedTariffZoneRefs);
+  const allowedTariffZoneRefs =
+    defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
+  const usableTariffZones = useFilterTariffZone(
+    tariffZones,
+    allowedTariffZoneRefs,
+  );
 
   // Get default TariffZones
   const defaultTariffZone = useDefaultTariffZone(usableTariffZones);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -30,10 +30,11 @@ export function useOfferDefaults(
   toPlace?: TariffZoneWithMetadata | StopPlaceFragment,
 ) {
   const {data: fareProducts} = useGetFareProductsQuery();
-  const {tariffZones, userProfiles} = useFirestoreConfiguration();
+  const {tariffZones, userProfiles, preassignedFareProducts} =
+    useFirestoreConfiguration();
   const {customerProfile} = useTicketingState();
 
-  // Get default PreassignedFareProduct
+  // Get default PreassignedFareProduct alternatives
   const productType = preassignedFareProduct?.type ?? selectableProductType;
   const selectableProducts = fareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
@@ -42,6 +43,14 @@ export function useOfferDefaults(
     useDefaultPreassignedFareProduct(selectableProducts);
   const defaultPreassignedFareProduct =
     preassignedFareProduct ?? defaultFareProduct;
+  const defaultPreassignedFareProductAlternatives = useMemo(() => {
+    const productAliasId = defaultPreassignedFareProduct.productAliasId;
+    return productAliasId
+      ? preassignedFareProducts.filter(
+          (fp) => fp.productAliasId === productAliasId,
+        )
+      : [defaultPreassignedFareProduct];
+  }, [defaultPreassignedFareProduct, preassignedFareProducts]);
 
   // Check for whitelisted zones
   const allowedTariffZoneRefs =
@@ -84,7 +93,8 @@ export function useOfferDefaults(
   );
 
   return {
-    preassignedFareProduct: defaultPreassignedFareProduct,
+    preassignedFareProductAlternatives:
+      defaultPreassignedFareProductAlternatives,
     selectableTravellers: defaultSelectableTravellers,
     fromPlace: defaultFromPlace,
     toPlace: defaultToPlace,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -59,13 +59,13 @@ const getOfferForTraveller = (offers: Offer[], userTypeString: string) => {
   const offersForTraveller = offers.filter(
     (o) => o.traveller_id === userTypeString,
   );
+
+  // If there are multiple offers for the same traveller, use the cheapest one.
+  // This shouldn't happen in practice, but it's a sensible fallback.
   const offersSortedByPrice = offersForTraveller.sort(
     (a, b) =>
       getCurrencyAsFloat(a.prices, 'NOK') - getCurrencyAsFloat(b.prices, 'NOK'),
   );
-
-  // If there are multiple offers for the same traveller, use the cheapest one.
-  // This shouldn't happen in practice, but it's a sensible fallback.
   return offersSortedByPrice[0];
 };
 
@@ -98,13 +98,10 @@ const mapToUserProfilesWithCountAndOffer = (
   offers: Offer[],
 ): UserProfileWithCountAndOffer[] =>
   userProfileWithCounts
-    .map((u) => {
-      const offer = getOfferForTraveller(offers, u.userTypeString);
-      return {
-        ...u,
-        offer: offer,
-      };
-    })
+    .map((u) => ({
+      ...u,
+      offer: getOfferForTraveller(offers, u.userTypeString),
+    }))
     .filter((u): u is UserProfileWithCountAndOffer => u.offer != null);
 
 const getOfferReducer =
@@ -206,7 +203,6 @@ export function useOfferState(
             dispatch({type: 'CLEAR_OFFER'});
             return;
           }
-
           const placeParams =
             offerEndpoint === 'stop-places'
               ? {from: fromPlace.id, to: toPlace.id}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -1,10 +1,6 @@
 import {CancelToken as CancelTokenStatic} from '@atb/api';
 import {ErrorType, getAxiosErrorType} from '@atb/api/utils';
-import {
-  PreassignedFareProduct,
-  TariffZone,
-  useFirestoreConfiguration,
-} from '@atb/configuration';
+import {PreassignedFareProduct, TariffZone} from '@atb/configuration';
 import {
   FlexDiscountLadder,
   Offer,
@@ -170,14 +166,13 @@ const initialState: OfferState = {
 
 export function useOfferState(
   offerEndpoint: 'zones' | 'authority' | 'stop-places',
-  preassignedFareProduct: PreassignedFareProduct,
+  preassignedFareProductAlternatives: PreassignedFareProduct[],
   fromPlace: TariffZone | StopPlaceFragmentWithIsFree,
   toPlace: TariffZone | StopPlaceFragmentWithIsFree,
   userProfilesWithCount: UserProfileWithCount[],
   isOnBehalfOf: boolean = false,
   travelDate?: string,
 ) {
-  const {preassignedFareProducts} = useFirestoreConfiguration();
   const offerReducer = getOfferReducer(userProfilesWithCount);
   const [state, dispatch] = useReducer(offerReducer, initialState);
   const zones = useMemo(
@@ -212,13 +207,6 @@ export function useOfferState(
             return;
           }
 
-          const productAliasId = preassignedFareProduct.productAliasId;
-          const productAlternatives = productAliasId
-            ? preassignedFareProducts.filter(
-                (fp) => fp.productAliasId === productAliasId,
-              )
-            : [preassignedFareProduct];
-
           const placeParams =
             offerEndpoint === 'stop-places'
               ? {from: fromPlace.id, to: toPlace.id}
@@ -227,7 +215,7 @@ export function useOfferState(
             ...placeParams,
             is_on_behalf_of: isOnBehalfOf,
             travellers: offerTravellers,
-            products: productAlternatives.map((p) => p?.id),
+            products: preassignedFareProductAlternatives.map((p) => p.id),
             travel_date: travelDate,
           };
           dispatch({type: 'SEARCHING_OFFER'});
@@ -266,7 +254,7 @@ export function useOfferState(
     [
       dispatch,
       userProfilesWithCount,
-      preassignedFareProduct,
+      preassignedFareProductAlternatives,
       offerEndpoint,
       zones,
       travelDate,
@@ -284,7 +272,7 @@ export function useOfferState(
     dispatch,
     updateOffer,
     userProfilesWithCount,
-    preassignedFareProduct,
+    preassignedFareProductAlternatives,
     zones,
     travelDate,
   ]);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -92,10 +92,23 @@ const mapToUserProfilesWithCountAndOffer = (
   offers: Offer[],
 ): UserProfileWithCountAndOffer[] =>
   userProfileWithCounts
-    .map((u) => ({
-      ...u,
-      offer: offers.find((o) => o.traveller_id === u.userTypeString),
-    }))
+    .map((u) => {
+      const offerAlternatives = offers.filter(
+        (o) => o.traveller_id === u.userTypeString,
+      );
+      // If there are multiple offers for the same traveller, use the cheapest
+      // one. This shouldn't happen in practice, but it's here as a sensible
+      // fallback.
+      const offer = offerAlternatives.sort(
+        (a, b) =>
+          getCurrencyAsFloat(a.prices, 'NOK') -
+          getCurrencyAsFloat(b.prices, 'NOK'),
+      )[0];
+      return {
+        ...u,
+        offer: offer,
+      };
+    })
     .filter((u): u is UserProfileWithCountAndOffer => u.offer != null);
 
 const getOfferReducer =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -272,7 +272,7 @@ export function useOfferState(
       travelDate,
       fromPlace,
       toPlace,
-      isOnBehalfOf
+      isOnBehalfOf,
     ],
   );
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/use-recent-fare-contracts.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/use-recent-fare-contracts.ts
@@ -5,6 +5,7 @@ import {
   FareProductTypeConfig,
   useFirestoreConfiguration,
   findReferenceDataById,
+  isProductSellableInApp,
 } from '@atb/configuration';
 import {
   listRecentFareContracts,
@@ -93,7 +94,7 @@ const mapBackendRecentFareContracts = (
   userProfiles: UserProfile[],
 ): RecentFareContract | null => {
   const preassignedFareProduct = findReferenceDataById(
-    preassignedFareProducts,
+    preassignedFareProducts.filter((p) => isProductSellableInApp(p)),
     recentFareContract.products[0],
   );
 


### PR DESCRIPTION
This adds support for a new field in reference data, `productAliasId`. When doing offer searches, ids for all PreassignedFareProducts with the same productAliasId will be provided (named `preassignedFareProductAlternatives` in the code).

This does in theory allow more than one offer to be returned from the offer search, but in practice tickets should be configured to not overlap (e.g. for Troms, the Saturday boat ticket should apply only to Saturday, and the regular ticket should apply outside of Saturday). If there for some reason is more than one result, we use the cheapest option as a fallback.

closes https://github.com/AtB-AS/kundevendt/issues/18693