### PR TITLE
fix: Typo in recipient name error msg

### DIFF
--- a/src/translations/screens/subscreens/OnBehalfOf.ts
+++ b/src/translations/screens/subscreens/OnBehalfOf.ts
@@ -70,7 +70,7 @@ const OnBehalfOfTexts = {
     ),
     name_already_exists: _(
       'Navnet er allerede tilknyttet en annen mottaker',
-      'The phone number is used for another recipient',
+      'The name is already used for another recipient',
       'Namnet er allerede knytta til ein annan mottakar',
     ),
   },


### PR DESCRIPTION
No wonder I couldn't replicate it on my device with Norwegian translations 😅 

Resolves https://github.com/AtB-AS/kundevendt/issues/17226