### PR TITLE
fix: improve handling of redirection when adding payment card

### DIFF
--- a/src/stacks-hierarchy/Root_AddPaymentMethodScreen/Root_AddPaymentMethodScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddPaymentMethodScreen/Root_AddPaymentMethodScreen.tsx
@@ -1,6 +1,6 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
-import React, {useEffect, useState} from 'react';
-import {View} from 'react-native';
+import React, {useEffect, useRef, useState} from 'react';
+import {AppState, View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {useAddPaymentMethod} from '@atb/stacks-hierarchy/Root_AddPaymentMethodScreen/use-add-payment-method';
 import {dictionary, useTranslation} from '@atb/translations';
@@ -10,6 +10,8 @@ import AddPaymentMethodTexts from '@atb/translations/screens/subscreens/AddPayme
 import WebView from 'react-native-webview';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {Processing} from '@atb/components/loading';
+import {WebViewNavigationEvent} from 'react-native-webview/lib/RNCWebViewNativeComponent';
+import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 
 type Props = RootStackScreenProps<'Root_AddPaymentMethodScreen'>;
 
@@ -17,6 +19,10 @@ export const Root_AddPaymentMethodScreen = ({navigation}: Props) => {
   const styles = useStyles();
   const {t} = useTranslation();
   const [showWebView, setShowWebView] = useState<boolean>(true);
+  const [callbackUrl, setCallbackUrl] = useState<string>('');
+  const webViewRef = useRef<WebView>(null);
+  const appState = useAppStateStatus();
+
   const {
     terminalUrl,
     onWebViewLoadStart,
@@ -30,6 +36,56 @@ export const Root_AddPaymentMethodScreen = ({navigation}: Props) => {
     () => navigation.addListener('blur', () => setShowWebView(false)),
     [navigation],
   );
+
+  useEffect(() => {
+    /**
+     * Listens to app state change, if app comes back from backgrounded/inactive
+     * state, it will then trigger the webview to load the {@link callbackUrl}, 
+     * which will redirect the user to the main payment card screen, and triggers
+     * a reload, so the user can see their added card(s). 
+     */
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (appState.match(/inactive|background/) && nextAppState === 'active') {
+        webViewRef.current?.injectJavaScript(callbackUrl);
+      }
+    });
+
+    if (appState === 'active') {
+      webViewRef.current?.injectJavaScript(callbackUrl);
+    }
+
+    return () => {
+      subscription.remove();
+    };
+  }, [callbackUrl, appState]);
+
+  /**
+   * This function will intercept the webview navigation, when it receives the 
+   * redirection URL, it will intercept the URL, prepends it with `window.location =`
+   * and saves it into the {@link callbackUrl},
+   * 
+   * The resulting {@link callbackUrl} will then trigger the redirection, when
+   * the {@link appState} is 'active'.
+   * 
+   * This is done to prevent the app from loading the URL prematurely after any
+   * possible authentication flow when user adds a payment card. 
+   */
+  const handleNavigationStateChange = (newNavState: WebViewNavigationEvent) => {
+    const {url} = newNavState;
+    if (
+      url.includes('callback') &&
+      url.includes('redirectUrl') &&
+      url.includes('transactionId') &&
+      callbackUrl == ''
+    ) {
+      // 
+      const redirectTo = 'window.location = "' + url + '"';
+      setCallbackUrl(redirectTo);
+      return false;
+    }
+
+    return true;
+  };
 
   return (
     <View style={styles.container}>
@@ -66,12 +122,15 @@ export const Root_AddPaymentMethodScreen = ({navigation}: Props) => {
       >
         {terminalUrl && showWebView && (
           <WebView
+            ref={webViewRef}
             source={{
               uri: terminalUrl,
             }}
             onError={onWebViewError}
             onLoadStart={onWebViewLoadStart}
             onLoadEnd={onWebViewLoadEnd}
+            onShouldStartLoadWithRequest={handleNavigationStateChange}
+            onNavigationStateChange={handleNavigationStateChange}
           />
         )}
       </View>


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18722

Relevant Slack thread : https://mittatb.slack.com/archives/C02EEG7D8EL/p1723717797085529

This PR will change how we handle the callback URL after finishing the payment flow.

The old flow:
1. Submit card information
2. Auth from the card provider (if any, e.g. Bank ID, Mastercard, etc.)
3. Fetch the callback URL once auth successful
4. Redirect to Profile page

The new flow:
1. Submit card information
2. Auth from the card provider (if any, e.g. Bank ID, Mastercard, etc.)
3. Fetch the callback URL once auth successful
4. Add `window.location = ` to the URL, then save it to a variable called `callbackUrl`.
5. Send the `callbackUrl` to the `WebView` when `appState === 'active'`.

Video of the new flow: https://mittatb.slack.com/archives/C02EEG7D8EL/p1724166760528719?thread_ts=1723717797.085529&cid=C02EEG7D8EL