### PR TITLE
test: accept time difference

### DIFF
--- a/e2e/test/specs/travelsearch.e2e.ts
+++ b/e2e/test/specs/travelsearch.e2e.ts
@@ -61,7 +61,9 @@ describe('Travel search', () => {
         'start',
         0,
       );
-      expect(startTime).toEqual(startTimeInDetails);
+      expect(
+        TimeHelper.timeIsEqualWithMargin(startTime, startTimeInDetails),
+      ).toBe(true);
       const departureInDetails = await TravelsearchDetailsPage.getLocation(
         'start',
         0,
@@ -74,7 +76,9 @@ describe('Travel search', () => {
         'end',
         noLegs - 1,
       );
-      expect(endTime).toEqual(endTimeInDetails);
+      expect(TimeHelper.timeIsEqualWithMargin(endTime, endTimeInDetails)).toBe(
+        true,
+      );
       const arrivalInDetails = await TravelsearchDetailsPage.getLocation(
         'end',
         noLegs - 1,

--- a/e2e/test/utils/time.helper.ts
+++ b/e2e/test/utils/time.helper.ts
@@ -38,6 +38,25 @@ class TimeHelper {
   }
 
   /**
+   * Check if two times (HH:MM) are equal within an allowed margin
+   * @param time1 HH:MM of first time
+   * @param time2 HH:MM of second time
+   * @param minMargin allowed margin in min (default: 2 min)
+   */
+  timeIsEqualWithMargin(time1: string, time2: string, minMargin: number = 2) {
+    const hr1 = parseInt(time1.split(':')[0]);
+    const min1 = parseInt(time1.split(':')[1]);
+    const hr2 = parseInt(time2.split(':')[0]);
+    const min2 = parseInt(time2.split(':')[1]);
+    let date1 = new Date();
+    let date2 = new Date();
+    date1.setHours(hr1, min1);
+    date2.setHours(hr2, min2);
+
+    return Math.abs(date1.getTime() - date2.getTime()) <= minMargin * 60 * 1000;
+  }
+
+  /**
    * Helper method to parse the minutes from a non-transit travel. Checks if the minutes are acceptable.
    * E.g. "Bike 1 h 30 min" and "Walk 19 min"
    * @param travelTime The travel time from the button text


### PR DESCRIPTION
Sometimes checking a start time or end time of a travel suggestion will differ by a minute when looking at the details. Most probably, this is due to the realtime where the single trip search is made after the trip search. In case this happens, the test need to cope with this.

E.g. from a test run ([ref](https://github.com/AtB-AS/mittatb-app/actions/runs/10466163914)):
```
Test:
expect(startTime).toEqual(startTimeInDetails);

Result:
1) Travel search should do a travel search and have correct travel times in the details
expect(received).toEqual(expected) // deep equality

Expected: "08:48"
Received: "08:49"
Error: expect(received).toEqual(expected) // deep equality
```
