### PR TITLE
chore: Update Android theme references for BootTheme

### DIFF
--- a/android/app/src/beacons/res/values/styles.xml
+++ b/android/app/src/beacons/res/values/styles.xml
@@ -1,5 +1,5 @@
 <resources>
-  <style name="BootTheme" parent="Theme.SplashScreen">
+  <style name="BootTheme" parent="Theme.BootSplash.TransparentStatus">
     <item name="bootSplashBackground">@color/bootsplash_background</item>
     <item name="bootSplashLogo">@drawable/bootsplash_logo</item>
     <item name="postBootSplashTheme">@style/AppTheme</item>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
-        android:theme="@style/BootTheme">
+        android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
         <item name="android:statusBarColor">@color/bootsplash_background</item>
     </style>
     <!-- BootTheme should inherit from Theme.SplashScreen -->
-    <style name="BootTheme" parent="Theme.SplashScreen">
+    <style name="BootTheme" parent="Theme.BootSplash.TransparentStatus">
         <item name="windowSplashScreenBackground">@color/bootsplash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/bootsplash_logo</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/16313

It fixes a wrong splash screen that makes the app to looks like the following.

![image](https://github.com/user-attachments/assets/f3e64d32-1a98-491f-9e9b-64248c0c8e59)


This fix avoids that by looking at the configurations on:

- https://github.com/zoontek/react-native-bootsplash/blob/master/example/android/app/src/main/AndroidManifest.xml
- https://github.com/zoontek/react-native-bootsplash/blob/master/example/android/app/src/main/res/values/styles.xml