### PR TITLE
fix: add boat-carnet ticket illustration type

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTileIllustration.tsx
@@ -68,6 +68,8 @@ const getIllustrationFileName = (
       return 'Ticket';
     case 'boat-period':
       return 'PeriodTicket';
+    case 'boat-carnet':
+      return 'TicketMultiple';
     case 'ticketMultiple':
       return 'TicketMultiple';
     case 'city':


### PR DESCRIPTION
This (in addition to changing fare-product-type-config) makes boat carnets show the boat illustration instead of bus.