### PR TITLE
Fix: use correct text for camera permission request

### DIFF
--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -76,7 +76,7 @@
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
-	<key>NSBluetoothPeripheralUsageDescription</key>
+	<key>Privacy - Bluetooth Peripheral Usage Description</key>
 	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>

--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -76,7 +76,7 @@
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
-	<key>Privacy - Bluetooth Peripheral Usage Description</key>
+	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>I tillegg til å kunne vise din posisjon i kart og til å planlegge reiser, vil vi få verdifull læring om hvor du og andre kunder reiser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.</string>

--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -12,4 +12,4 @@
 
 "NSCameraUsageDescription" = "We use camera to capture the image of wrongfully parked electric scooters, and scan the QR code on the electric scooters.";
 
-"NSPhotoLibraryUsageDescription" = "We need access to photo gallery so you can select and send image(s) to help resolve issues in the app.";
+"NSPhotoLibraryUsageDescription" = "Send pictures to help solve problems in the app.";

--- a/ios/en.lproj/InfoPlist.strings
+++ b/ios/en.lproj/InfoPlist.strings
@@ -9,3 +9,7 @@
 "NSBluetoothPeripheralUsageDescription" = "You give us permission to recognize buses and bus stops nearby. This enables us to analyze where you and other customers travel, and to send you relevant surveys. The data is used to improve our services to make them better for you.";
 
 "NSMotionUsageDescription" = "You give us permission to use this data to learn more about your travel habits. For example, we can see whether customers choose to cycle, walk or drive a car rather than take the bus. The data is used to improve our services to make them better for you.";
+
+"NSCameraUsageDescription" = "We use camera to capture the image of wrongfully parked electric scooters, and scan the QR code on the electric scooters.";
+
+"NSPhotoLibraryUsageDescription" = "We need access to photo gallery so you can select and send image(s) to help resolve issues in the app.";

--- a/ios/nb.lproj/InfoPlist.strings
+++ b/ios/nb.lproj/InfoPlist.strings
@@ -9,3 +9,7 @@
 "NSBluetoothPeripheralUsageDescription" = "Du gir oss lov til å gjenkjenne busser og bussholdeplasser i nærheten. Det gjør at vi kan analysere hvor du og andre kunder reiser, og til å sende deg relevante undersøkelser. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";
 
 "NSMotionUsageDescription" = "Du gir oss lov til å bruke disse dataene for å lære mer om dine reisevaner. Vi kan for eksempel se om kunder velger å sykle, gå eller kjøre bil fremfor å busse. Det vil hjelpe oss til å kunne forbedre ditt reisetilbud.";
+
+"NSCameraUsageDescription" = "Vi bruker kamera til å ta bilde av feilparkerte elsparkesykler, og å skanne QR-koden på elsparkesykler.";
+
+"NSPhotoLibraryUsageDescription" = "Send bilder for å hjelpe til med å løse problemer i appen.";

--- a/ios/nn.lproj/InfoPlist.strings
+++ b/ios/nn.lproj/InfoPlist.strings
@@ -9,3 +9,7 @@
 "NSBluetoothPeripheralUsageDescription" = "Du gir oss løyve til å kjenne att bussar og busshaldeplassar i nærleiken. Dette gjer at vi kan analysere kvar du og andre kundar reiser, og til å sende deg relevante undersøkingar. Det vil hjelpe oss til å kunne betre reisetilbodet ditt.";
 
 "NSMotionUsageDescription" = "Du gir oss løyve til å bruke disse dataene for å læra meir om dine reisevaner. Vi kan for eksempel se om kunder veljer å sykle, gå eller kjøre bil framan å busse. Det vil hjelpe oss til å kunne forbetre reisetilbodet ditt.";
+
+"NSCameraUsageDescription" = "Vi bruker kamera til å ta bilete av feilparkerte elsparkesyklar og å skanne QR-koden på elsparkesyklar.";
+
+"NSPhotoLibraryUsageDescription" = "Send bilete for å hjelpe til med å løyse problem i appen.";


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/16202

Adds correct text for camera permission request, see screenshots below.

Also contains some change for the photo library permission request, but that's only a placeholder, since we don't use them for the app at the moment. The only usage for photo library in the app right now is for Intercom chat, and it is already handled by the Intercom SDK (App only have access to the selected photos that we send through Intercom, not the entire gallery).

#### Old text (same for all language)
<img src="https://github.com/user-attachments/assets/e1c124c8-e5a0-47a9-99b0-0309694a9a9e" width=300 />


#### New text

English | Norsk Bokmål | Norsk Nynorsk
--------|---------------|--------------- 
<img src="https://github.com/user-attachments/assets/f4c1a0a7-7eed-4138-aa25-f80815dc9067" width=300 /> | <img src="https://github.com/user-attachments/assets/248e3f36-5326-439f-b620-163bfbed47ad" width=300 /> | <img src="https://github.com/user-attachments/assets/3624a6af-d7be-473d-a76a-6850f87ff55f" width=300 />