### PR TITLE
feat: Support enable_shmo_deep_integration remote config flag

### DIFF
--- a/src/mobility/use-shmo-deep-integration-enabled.tsx
+++ b/src/mobility/use-shmo-deep-integration-enabled.tsx
@@ -1,0 +1,21 @@
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useDebugOverride} from '@atb/debug';
+import {StorageModelKeysEnum} from '@atb/storage';
+
+export const useShmoDeepIntegrationEnabled = () => {
+  const [debugOverride, _, debugOverrideReady] =
+    useShmoDeepIntegrationDebugOverride();
+  const {enable_shmo_deep_integration: enabledInRemoteConfig} =
+    useRemoteConfig();
+
+  return [
+    debugOverride === undefined ? enabledInRemoteConfig : debugOverride,
+    debugOverrideReady,
+  ];
+};
+
+export const useShmoDeepIntegrationDebugOverride = () => {
+  return useDebugOverride(
+    StorageModelKeysEnum.EnableShmoDeepIntegrationDebugOverride,
+  );
+};

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -45,6 +45,7 @@ export type RemoteConfig = {
   enable_vehicles_in_map: boolean;
   enable_vipps_login: boolean;
   enable_save_ticket_recipients: boolean;
+  enable_shmo_deep_integration: boolean;
   favourite_departures_poll_interval: number;
   feedback_questions: string;
   flex_booking_number_of_days_available: number;
@@ -109,6 +110,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_vehicles_in_map: false,
   enable_vipps_login: false,
   enable_save_ticket_recipients: false,
+  enable_shmo_deep_integration: false,
   favourite_departures_poll_interval: 30000,
   feedback_questions: '',
   flex_booking_number_of_days_available: 7,
@@ -242,6 +244,9 @@ export function getConfig(): RemoteConfig {
   const enable_save_ticket_recipients =
     values['enable_save_ticket_recipients']?.asBoolean() ??
     defaultRemoteConfig.enable_save_ticket_recipients;
+  const enable_shmo_deep_integration =
+    values['enable_shmo_deep_integration']?.asBoolean() ??
+    defaultRemoteConfig.enable_shmo_deep_integration;
   const favourite_departures_poll_interval =
     values['favourite_departures_poll_interval']?.asNumber() ??
     defaultRemoteConfig.favourite_departures_poll_interval;
@@ -338,6 +343,7 @@ export function getConfig(): RemoteConfig {
     enable_vehicles_in_map,
     enable_vipps_login,
     enable_save_ticket_recipients,
+    enable_shmo_deep_integration,
     favourite_departures_poll_interval,
     feedback_questions,
     flex_booking_number_of_days_available,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -40,6 +40,7 @@ import {
 import {useDebugOverride} from '@atb/debug';
 import {useCarSharingInMapDebugOverride} from '@atb/mobility/use-car-sharing-enabled';
 import {useGeofencingZonesDebugOverride} from '@atb/mobility/use-geofencing-zones-enabled';
+import {useShmoDeepIntegrationDebugOverride} from '@atb/mobility/use-shmo-deep-integration-enabled';
 import {
   useFromTravelSearchToTicketDebugOverride,
   useFromTravelSearchToTicketForBoatDebugOverride,
@@ -117,6 +118,9 @@ export const Profile_DebugInfoScreen = () => {
   const cityBikesInMapDebugOverride = useCityBikesInMapDebugOverride();
   const carSharingInMapDebugOverride = useCarSharingInMapDebugOverride();
   const geofencingZonesDebugOverride = useGeofencingZonesDebugOverride();
+  const shmoDeepIntegrationDebugOverride =
+    useShmoDeepIntegrationDebugOverride();
+
   const realtimeMapDebugOverride = useRealtimeMapDebugOverride();
   const ticketingAssistantOverride = useTicketingAssistantDebugOverride();
   const tipsAndInformationOverride = useTipsAndInformationDebugOverride();
@@ -376,6 +380,12 @@ export const Profile_DebugInfoScreen = () => {
             <DebugOverride
               description="Enable geofencing zones"
               override={geofencingZonesDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable shared mobility deep integration"
+              override={shmoDeepIntegrationDebugOverride}
             />
           </GenericSectionItem>
           <GenericSectionItem>

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -26,6 +26,7 @@ export enum StorageModelKeysEnum {
   EnableTipsAndInformationOverride = '@ATB_enable_tips_and_information_override',
   EnableVehiclesInMapDebugOverride = '@ATB_enable_vehicles_in_map_debug_override',
   EnableSaveTicketRecipientsDebugOverride = '@ATB_enable_save_ticket_recipients_debug_override',
+  EnableShmoDeepIntegrationDebugOverride = '@ATB_enable_shmo_deep_integration_debug_override',
   OneTimePopOver = '@ATB_one_time_popovers_seen',
   ShowValidTimeInfoDebugOverride = '@ATB_show_valid_time_info_debug_override',
   UseFlexibleTransportAccessModeDebugOverride = '@ATB_use_flexible_on_accessMode',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18946

During the development of shared mobility deep integration (starting with e-scooters only), that functionality should only be available behind this flag.
