### PR TITLE
refactor: refactor usePreviousPaymentMethods

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -35,7 +35,7 @@ import {
   UserProfileWithCountAndOffer,
 } from '../Root_PurchaseOverviewScreen/use-offer-state';
 import {SelectPaymentMethodSheet} from './components/SelectPaymentMethodSheet';
-import {usePreviousPaymentMethod} from '../saved-payment-utils';
+import {usePreviousPaymentMethods} from '../saved-payment-utils';
 import {PaymentMethod, SavedPaymentOption} from '../types';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {GenericSectionItem, Section} from '@atb/components/sections';
@@ -93,7 +93,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const previousPaymentMethod = usePreviousPaymentMethod();
+  const {savedPaymentMethod: previousPaymentMethod} =
+    usePreviousPaymentMethods();
   const isShowValidTimeInfoEnabled = useShowValidTimeInfoEnabled();
   const analytics = useAnalytics();
 

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -93,7 +93,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const {savedPaymentMethod: previousPaymentMethod} =
+  const {savedPaymentMethod: previousPaymentMethod, recurringPayments} =
     usePreviousPaymentMethods();
   const isShowValidTimeInfoEnabled = useShowValidTimeInfoEnabled();
   const analytics = useAnalytics();
@@ -224,6 +224,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     openBottomSheet(() => {
       return (
         <SelectPaymentMethodSheet
+          recurringPayments={recurringPayments}
           onSelect={(option: PaymentMethod) => {
             goToPayment(option);
             closeBottomSheet();

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -93,7 +93,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const {savedPaymentMethod: previousPaymentMethod, recurringPayments} =
+  const {previousPaymentMethod, recurringPayments} =
     usePreviousPaymentMethods();
   const isShowValidTimeInfoEnabled = useShowValidTimeInfoEnabled();
   const analytics = useAnalytics();

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -22,14 +22,15 @@ export function usePreviousPaymentMethods(): {
       getPreviousPaymentMethodByUser(userId).then((storedMethod) => {
         // Since the stored payment could have been deleted, we need to check if
         // it is still in the list of recurring payments.
-        if (!storedMethod || !('recurringCard' in storedMethod)) return;
-        const isInRecurringPayments = !!recurringPayments?.find(
-          (recurringPayment) =>
-            recurringPayment.id === storedMethod.recurringCard.id,
-        );
-        setPreviousPaymentMethod(
-          isInRecurringPayments ? storedMethod : undefined,
-        );
+        if (!storedMethod) return;
+        const shouldUseStored =
+          'recurringCard' in storedMethod
+            ? !!recurringPayments?.find(
+                (recurringPayment) =>
+                  recurringPayment.id === storedMethod.recurringCard.id,
+              )
+            : true;
+        setPreviousPaymentMethod(shouldUseStored ? storedMethod : undefined);
       });
     }
   }, [userId, recurringPayments]);

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -8,26 +8,26 @@ import {RecurringPayment} from '@atb/ticketing';
 
 export function usePreviousPaymentMethods(): {
   recurringPayments: RecurringPayment[] | undefined;
-  savedPaymentMethod: SavedPaymentOption | undefined;
+  previousPaymentMethod: SavedPaymentOption | undefined;
 } {
   const {userId} = useAuthState();
   const {data: recurringPayments} = useListRecurringPaymentsQuery();
-  const [savedPaymentMethod, setSavedPaymentMethod] =
+  const [previousPaymentMethod, setPreviousPaymentMethod] =
     useState<SavedPaymentOption>();
 
   useEffect(() => {
     if (!userId) {
-      setSavedPaymentMethod(undefined);
+      setPreviousPaymentMethod(undefined);
     } else {
       getPreviousPaymentMethodByUser(userId).then((method) => {
-        setSavedPaymentMethod(method);
+        setPreviousPaymentMethod(method);
       });
     }
   }, [userId]);
 
   return {
     recurringPayments,
-    savedPaymentMethod,
+    previousPaymentMethod,
   };
 }
 

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -19,8 +19,17 @@ export function usePreviousPaymentMethods(): {
     if (!userId) {
       setPreviousPaymentMethod(undefined);
     } else {
-      getPreviousPaymentMethodByUser(userId).then((method) => {
-        setPreviousPaymentMethod(method);
+      getPreviousPaymentMethodByUser(userId).then((storedMethod) => {
+        // Since the stored payment could have been deleted, we need to check if
+        // it is still in the list of recurring payments.
+        if (!storedMethod || !('recurringCard' in storedMethod)) return;
+        const isInRecurringPayments = !!recurringPayments?.find(
+          (recurringPayment) =>
+            recurringPayment.id === storedMethod.recurringCard.id,
+        );
+        setPreviousPaymentMethod(
+          isInRecurringPayments ? storedMethod : undefined,
+        );
       });
     }
   }, [userId]);

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -32,7 +32,7 @@ export function usePreviousPaymentMethods(): {
         );
       });
     }
-  }, [userId]);
+  }, [userId, recurringPayments]);
 
   return {
     recurringPayments,


### PR DESCRIPTION
By passing `recurringPayments` as a prop to SelectPaymentMethodSheet, we don't have to do an extra API call to fetch the list of saved payments. This removes the loading state from the page, and means we can remove some state logic.

Also refactored the usePreviousPaymentMethods hook a bit.

related to https://github.com/AtB-AS/kundevendt/issues/18885