### PR TITLE
refactor: refactor usePreviousPaymentMethods

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -35,7 +35,7 @@ import {
   UserProfileWithCountAndOffer,
 } from '../Root_PurchaseOverviewScreen/use-offer-state';
 import {SelectPaymentMethodSheet} from './components/SelectPaymentMethodSheet';
-import {usePreviousPaymentMethod} from '../saved-payment-utils';
+import {usePreviousPaymentMethods} from '../saved-payment-utils';
 import {PaymentMethod, SavedPaymentOption} from '../types';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {GenericSectionItem, Section} from '@atb/components/sections';
@@ -93,7 +93,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const previousPaymentMethod = usePreviousPaymentMethod();
+  const {savedPaymentMethod: previousPaymentMethod} =
+    usePreviousPaymentMethods();
   const isShowValidTimeInfoEnabled = useShowValidTimeInfoEnabled();
   const analytics = useAnalytics();
 

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -93,7 +93,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const {savedPaymentMethod: previousPaymentMethod} =
+  const {savedPaymentMethod: previousPaymentMethod, recurringPayments} =
     usePreviousPaymentMethods();
   const isShowValidTimeInfoEnabled = useShowValidTimeInfoEnabled();
   const analytics = useAnalytics();
@@ -224,6 +224,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     openBottomSheet(() => {
       return (
         <SelectPaymentMethodSheet
+          recurringPayments={recurringPayments}
           onSelect={(option: PaymentMethod) => {
             goToPayment(option);
             closeBottomSheet();

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -93,7 +93,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [previousMethod, setPreviousMethod] = useState<
     PaymentMethod | undefined
   >(undefined);
-  const {savedPaymentMethod: previousPaymentMethod, recurringPayments} =
+  const {previousPaymentMethod, recurringPayments} =
     usePreviousPaymentMethods();
   const isShowValidTimeInfoEnabled = useShowValidTimeInfoEnabled();
   const analytics = useAnalytics();

--- a/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchasePaymentScreen/use-reserve-offer-mutation.ts
@@ -22,21 +22,11 @@ export const useReserveOfferMutation = ({
 
   return useMutation({
     mutationFn: async (): Promise<OfferReservation> => {
-      const {paymentType} = paymentMethod;
-
-      const recurringPaymentId =
-        'recurringPaymentId' in paymentMethod
-          ? paymentMethod.recurringPaymentId
-          : undefined;
-
-      const saveRecurringCard =
-        'save' in paymentMethod ? paymentMethod.save : false;
-
       return reserveOffers({
         offers,
-        paymentType: paymentType,
-        recurringPaymentId: recurringPaymentId,
-        savePaymentMethod: saveRecurringCard,
+        paymentType: paymentMethod.paymentType,
+        recurringPaymentId: paymentMethod.recurringPaymentId,
+        savePaymentMethod: paymentMethod.save ?? false,
         opts: {retry: true},
         scaExemption: true,
         customerAccountId: recipient?.accountId || abtCustomerId!,

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -87,6 +87,7 @@ type Root_PurchasePaymentScreenParams = {
   offers: ReserveOffer[];
   preassignedFareProduct: PreassignedFareProduct;
   paymentMethod: PaymentMethod;
+  savePaymentMethod: boolean;
   recipient?: TicketRecipientType;
 };
 

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -8,26 +8,26 @@ import {RecurringPayment} from '@atb/ticketing';
 
 export function usePreviousPaymentMethods(): {
   recurringPayments: RecurringPayment[] | undefined;
-  savedPaymentMethod: SavedPaymentOption | undefined;
+  previousPaymentMethod: SavedPaymentOption | undefined;
 } {
   const {userId} = useAuthState();
   const {data: recurringPayments} = useListRecurringPaymentsQuery();
-  const [savedPaymentMethod, setSavedPaymentMethod] =
+  const [previousPaymentMethod, setPreviousPaymentMethod] =
     useState<SavedPaymentOption>();
 
   useEffect(() => {
     if (!userId) {
-      setSavedPaymentMethod(undefined);
+      setPreviousPaymentMethod(undefined);
     } else {
       getPreviousPaymentMethodByUser(userId).then((method) => {
-        setSavedPaymentMethod(method);
+        setPreviousPaymentMethod(method);
       });
     }
   }, [userId]);
 
   return {
     recurringPayments,
-    savedPaymentMethod,
+    previousPaymentMethod,
   };
 }
 

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -19,8 +19,17 @@ export function usePreviousPaymentMethods(): {
     if (!userId) {
       setPreviousPaymentMethod(undefined);
     } else {
-      getPreviousPaymentMethodByUser(userId).then((method) => {
-        setPreviousPaymentMethod(method);
+      getPreviousPaymentMethodByUser(userId).then((storedMethod) => {
+        // Since the stored payment could have been deleted, we need to check if
+        // it is still in the list of recurring payments.
+        if (!storedMethod || !('recurringCard' in storedMethod)) return;
+        const isInRecurringPayments = !!recurringPayments?.find(
+          (recurringPayment) =>
+            recurringPayment.id === storedMethod.recurringCard.id,
+        );
+        setPreviousPaymentMethod(
+          isInRecurringPayments ? storedMethod : undefined,
+        );
       });
     }
   }, [userId]);

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -20,6 +20,14 @@ export function usePreviousPaymentOptions(): {
   const validPaymentOption = (paymentOption: PaymentOption | undefined) => {
     if (!paymentOption) return;
 
+    // Since the stored payment could have been deleted, we need to check if
+    // it is still in the list of recurring payments.
+    const isInRecurringPayments = !!recurringPayments?.find(
+      (recurringPayment) =>
+        recurringPayment.id === paymentOption.recurringCard?.id,
+    );
+    if (!isInRecurringPayments) return;
+
     // Payment type is not enabled
     if (!paymentTypes.includes(paymentOption.paymentType)) return;
 
@@ -38,17 +46,6 @@ export function usePreviousPaymentOptions(): {
       return;
     }
     getPreviousPaymentMethodByUser(userId).then((storedMethod) => {
-      // Since the stored payment could have been deleted, we need to check if
-      // it is still in the list of recurring payments.
-      if (!storedMethod || !('recurringCard' in storedMethod)) return;
-      const isInRecurringPayments = !!recurringPayments?.find(
-        (recurringPayment) =>
-          recurringPayment.id === storedMethod.recurringCard?.id,
-      );
-      setPreviousPaymentOption(
-        isInRecurringPayments ? storedMethod : undefined,
-      );
-
       setPreviousPaymentOption(validPaymentOption(storedMethod));
     });
   }, [userId, recurringPayments]);

--- a/src/stacks-hierarchy/saved-payment-utils.ts
+++ b/src/stacks-hierarchy/saved-payment-utils.ts
@@ -32,7 +32,7 @@ export function usePreviousPaymentMethods(): {
         );
       });
     }
-  }, [userId]);
+  }, [userId, recurringPayments]);
 
   return {
     recurringPayments,

--- a/src/stacks-hierarchy/types.ts
+++ b/src/stacks-hierarchy/types.ts
@@ -1,17 +1,10 @@
 import {PaymentType} from '@atb/ticketing';
 
-export type CardPaymentMethod =
-  | {paymentType: PaymentType.Visa | PaymentType.Mastercard; save: boolean}
-  | {
-      paymentType: PaymentType.Visa | PaymentType.Mastercard;
-      recurringPaymentId: number;
-    };
-
-export type VippsPaymentMethod = {
-  paymentType: PaymentType.Vipps;
+export type PaymentMethod = {
+  paymentType: PaymentType;
+  recurringPaymentId?: number;
+  save?: boolean;
 };
-
-export type PaymentMethod = VippsPaymentMethod | CardPaymentMethod;
 
 export type SavedRecurringPayment = {
   id: number;
@@ -20,17 +13,11 @@ export type SavedRecurringPayment = {
   payment_type: number;
 };
 
-export type DefaultPaymentOption = {
-  savedType: 'normal';
+export type PaymentOption = {
+  savedType: 'normal' | 'recurring';
   paymentType: PaymentType;
+  recurringCard?: SavedRecurringPayment;
 };
-export type RecurringPaymentOption = {
-  savedType: 'recurring';
-  paymentType: PaymentType.Visa | PaymentType.Mastercard;
-  recurringCard: SavedRecurringPayment;
-};
-
-export type SavedPaymentOption = DefaultPaymentOption | RecurringPaymentOption;
 
 export type PaymentProcessorStatus = 'loading' | 'success' | 'error';
 


### PR DESCRIPTION
There was a lot of redundant logic in the purchase flow that could be removed by having more sensible types for payment options. 

See the changes in src/stacks-hierarchy/types.ts for my proposed solution to this.
- Combines SavedPaymentOption, RecurringPaymentOption, DefaultPaymentOption into PaymentOption
- Combines VippsPaymentMethod and CardPaymentMethod into PaymentMethod
