### PR TITLE
feat: dynamically set transport modes for harbors query based on fare…

### DIFF
--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -4,6 +4,7 @@ import {
   getReferenceDataName,
   PreassignedFareProduct,
   TariffZone,
+  useFirestoreConfiguration,
   UserProfile,
 } from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
@@ -71,6 +72,7 @@ export const FareContractInfoHeader = ({
 }: FareContractInfoProps) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const {fareProductTypeConfigs} = useFirestoreConfiguration();
   const {startPointRef: fromStopPlaceId, endPointRef: toStopPlaceId} =
     travelRight;
 
@@ -93,6 +95,13 @@ export const FareContractInfoHeader = ({
   const recipientName =
     phoneNumber &&
     onBehalfOfAccounts?.find((a) => a.phoneNumber === phoneNumber)?.name;
+
+  const fareProductTypeConfig = preassignedFareProduct
+    ? fareProductTypeConfigs.find(
+        (fareProductTypeConfig) =>
+          fareProductTypeConfig.type === preassignedFareProduct.type,
+      )
+    : undefined;
 
   return (
     <View style={styles.header}>
@@ -119,6 +128,7 @@ export const FareContractInfoHeader = ({
           fromStopPlaceId={fromStopPlaceId}
           toStopPlaceId={toStopPlaceId}
           showTwoWayIcon={showTwoWayIcon}
+          transportModes={fareProductTypeConfig?.transportModes}
         />
       )}
       {phoneNumber && (

--- a/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
+++ b/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
@@ -7,20 +7,23 @@ import {dictionary, FareContractTexts, useTranslation} from '@atb/translations';
 import {ArrowUpDown} from '@atb/assets/svg/mono-icons/navigation';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useHarbors} from '@atb/harbors';
+import {ProductTypeTransportModes} from '@atb-as/config-specs';
 
 export function FareContractHarborStopPlaces({
   fromStopPlaceId,
   toStopPlaceId,
   showTwoWayIcon,
+  transportModes,
 }: {
   fromStopPlaceId?: string;
   toStopPlaceId?: string;
   showTwoWayIcon: boolean;
+  transportModes?: ProductTypeTransportModes[];
 }) {
   const {theme} = useTheme();
   const styles = useStyles();
   const {t} = useTranslation();
-  const harborsQuery = useHarbors();
+  const harborsQuery = useHarbors({transportModes});
 
   if (!fromStopPlaceId || !toStopPlaceId) return null;
   if (harborsQuery.isLoading)

--- a/src/harbors/use-harbors.tsx
+++ b/src/harbors/use-harbors.tsx
@@ -1,4 +1,7 @@
-import {HarborConnectionOverrideType} from '@atb/configuration';
+import {
+  HarborConnectionOverrideType,
+  ProductTypeTransportModes,
+} from '@atb/configuration';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {useHarborConnectionOverrides} from '@atb/harbors/use-harbor-connection-overrides';
 import {useHarborsQuery} from '@atb/queries';
@@ -6,9 +9,15 @@ import {isDefined} from '@atb/utils/presence';
 import _ from 'lodash';
 import {StopPlaceFragmentWithIsFree} from './types';
 
-export const useHarbors = (fromHarborId?: string) => {
-  const harborsQuery = useHarborsQuery();
-  const connectionsQuery = useHarborsQuery(fromHarborId);
+export const useHarbors = ({
+  fromHarborId,
+  transportModes,
+}: {
+  fromHarborId?: string;
+  transportModes?: ProductTypeTransportModes[];
+} = {}) => {
+  const harborsQuery = useHarborsQuery({fromHarborId, transportModes});
+  const connectionsQuery = useHarborsQuery({fromHarborId, transportModes});
   const overrides = useHarborConnectionOverrides(fromHarborId);
 
   const isLoading = harborsQuery.isLoading || connectionsQuery.isLoading;

--- a/src/queries/use-harbors-query.ts
+++ b/src/queries/use-harbors-query.ts
@@ -7,21 +7,57 @@ import {
   TransportMode,
   TransportSubmode,
 } from '@atb/api/types/generated/journey_planner_v3_types';
-import {ONE_HOUR_MS} from "@atb/utils/durations.ts";
+import {ONE_HOUR_MS} from '@atb/utils/durations.ts';
+import {ProductTypeTransportModes} from '@atb-as/config-specs';
+import {onlyUniques} from '@atb/utils/only-uniques';
 
-export const useHarborsQuery = (fromHarborId?: string) =>
-  useQuery({
-    queryKey: ['harbors', {connectionFrom: fromHarborId}],
+export const useHarborsQuery = ({
+  fromHarborId,
+  transportModes,
+}: {
+  fromHarborId?: string;
+  transportModes?: ProductTypeTransportModes[];
+} = {}) => {
+  const defaultModes = [TransportMode.Water];
+  const defaultSubmodes = [
+    TransportSubmode.HighSpeedPassengerService,
+    TransportSubmode.HighSpeedVehicleService,
+  ];
+
+  const uniqueModes = transportModes
+    ? transportModes
+        .map((tm) => tm.mode)
+        .filter(onlyUniques)
+        .filter(isValidTransportMode)
+    : defaultModes;
+
+  const uniqueSubmodes = transportModes
+    ? transportModes
+        .map((tm) => tm.subMode)
+        .filter(onlyUniques)
+        .filter(isValidTransportSubmode)
+    : defaultSubmodes;
+
+  return useQuery({
+    queryKey: [
+      'harbors',
+      {connectionFrom: fromHarborId},
+      uniqueModes,
+      uniqueSubmodes,
+    ],
     queryFn: () =>
       fromHarborId
         ? getStopPlaceConnections(fromHarborId)
-        : getStopPlacesByMode(
-            [TransportMode.Water],
-            [
-              TransportSubmode.HighSpeedPassengerService,
-              TransportSubmode.HighSpeedVehicleService,
-            ],
-          ),
+        : getStopPlacesByMode(uniqueModes, uniqueSubmodes),
     staleTime: ONE_HOUR_MS,
     cacheTime: ONE_HOUR_MS,
   });
+};
+
+function isValidTransportMode(mode: any): mode is TransportMode {
+  return Object.values(TransportMode).includes(mode);
+}
+
+function isValidTransportSubmode(subMode: any): subMode is TransportSubmode {
+  return Object.values(TransportSubmode).includes(subMode);
+}

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -54,8 +54,10 @@ export const Root_PurchaseHarborSearchScreen = ({navigation, route}: Props) => {
   useEffect(() => {
     isFocused && giveFocus(inputRef);
   }, [isFocused]);
-
-  const harborsQuery = useHarbors(fromHarbor?.id);
+  const harborsQuery = useHarbors({
+    fromHarborId: fromHarbor?.id,
+    transportModes: fareProductTypeConfig.transportModes,
+  });
 
   const debouncedText = useDebounce(text, 200);
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
@@ -21,12 +21,14 @@ import {useHarborsQuery} from '@atb/queries';
 import {TravelRightDirection} from '@atb/ticketing';
 import {BorderedInfoBox} from '@atb/components/bordered-info-box';
 import {TileWithButton} from '@atb/components/tile';
+import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 
 type RecentFareContractProps = {
   recentFareContract: RecentFareContract;
   onSelect: (
     rfc: RecentFareContract,
     fareProductTypeConfig: FareProductTypeConfig,
+    harbors?: StopPlaceFragment[],
   ) => void;
   testID: string;
 };
@@ -144,7 +146,9 @@ export const RecentFareContractComponent = ({
       buttonText={t(RecentFareContractsTexts.repeatPurchase.label)}
       interactiveColor="interactive_2"
       mode="spacious"
-      onPress={() => onSelect(recentFareContract, fareProductTypeConfig)}
+      onPress={() =>
+        onSelect(recentFareContract, fareProductTypeConfig, harborsQuery.data)
+      }
       style={{minWidth: width * 0.6}}
     >
       <View style={styles.travelModeWrapper}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
@@ -54,12 +54,14 @@ export const RecentFareContractComponent = ({
   const toZoneName = toTariffZone?.name.value;
   const {width} = Dimensions.get('window');
 
-  const harborsQuery = useHarborsQuery();
-
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
   const fareProductTypeConfig = fareProductTypeConfigs.find(
     (c) => c.type === recentFareContract.preassignedFareProduct.type,
   );
+
+  const harborsQuery = useHarborsQuery({
+    transportModes: fareProductTypeConfig?.transportModes,
+  });
 
   if (!fareProductTypeConfig) return null;
   const returnAccessibilityLabel = () => {
@@ -168,6 +170,7 @@ export const RecentFareContractComponent = ({
             showTwoWayIcon={showTwoWayIcon}
             fromStopPlaceId={pointToPointValidity?.fromPlace}
             toStopPlaceId={pointToPointValidity?.toPlace}
+            transportModes={fareProductTypeConfig.transportModes}
           />
         </View>
       )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
@@ -12,6 +12,7 @@ import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {RecentFareContractComponent} from './RecentFareContractComponent';
 import {RecentFareContract} from '../../types';
 import {useTicketingState} from '@atb/ticketing';
+import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 
 type Props = {
   recentFareContracts: RecentFareContract[];
@@ -19,6 +20,7 @@ type Props = {
   onSelect: (
     rfc: RecentFareContract,
     fareProductTypeConfig: FareProductTypeConfig,
+    harbors?: StopPlaceFragment[],
   ) => void;
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -15,7 +15,6 @@ import {useTicketingAssistantEnabled} from '@atb/stacks-hierarchy/Root_TicketAss
 import {TicketAssistantTile} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Assistant/TicketAssistantTile';
 import {useAnalytics} from '@atb/analytics';
 import {useMobileTokenContextState} from '@atb/mobile-token';
-import {useHarborsQuery} from '@atb/queries';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {TariffZone} from '@atb/configuration';
@@ -44,7 +43,6 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const inspectableToken = tokens.find((t) => t.isInspectable);
   const hasInspectableMobileToken = inspectableToken?.type === 'mobile';
   const hasMobileTokenError = mobileTokenStatus === 'fallback' || mobileTokenStatus === 'error';
-  const harborsQuery = useHarborsQuery();
 
   if (must_upgrade_ticketing) return <UpgradeSplash />;
 
@@ -100,6 +98,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const onFareContractSelect = (
     rfc: RecentFareContract,
     fareProductTypeConfig: FareProductTypeConfig,
+    harbors?: StopPlaceFragment[],
   ) => {
     analytics.logEvent('Ticketing', 'Recently used fare product selected', {
       type: fareProductTypeConfig.type,
@@ -109,7 +108,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
       zone: TariffZone | undefined,
     ): TariffZoneWithMetadata | StopPlaceFragment | undefined => {
       if (pointToPointValidityPlace !== undefined) {
-        const fromName = harborsQuery.data?.find(
+        const fromName = harbors?.find(
           (sp) => sp.id === pointToPointValidityPlace,
         )?.name;
         return fromName


### PR DESCRIPTION
… product type

To let Troms be able to sell express boat tickets for ferry lines, we need to add the option to configure which harbors are listed. This configuration can be determined by the fare product type, defaulting to the existing harbors if none is specified. This PR implements this functionality.

### TODO
- [x] Ensure the correct harbors are set when using the repeat purchase functionality and navigating to the purchase screen.


<details>
<summary>Screenshots</summary>

<img width="388" alt="image" src="https://github.com/user-attachments/assets/fec1d68d-c435-4c67-aea9-50ba7337b1cd">

<img width="383" alt="image" src="https://github.com/user-attachments/assets/af3023d1-37b4-4d2e-b3a2-a4fe34e7f8c8">

<img width="383" alt="image" src="https://github.com/user-attachments/assets/9d8a1f68-ef5e-4231-84df-fde9a4edf09e">

<img width="375" alt="image" src="https://github.com/user-attachments/assets/811b02c6-6be5-4960-b2d0-d3c4c5c602ce">

<img width="382" alt="image" src="https://github.com/user-attachments/assets/1b6abd52-98da-479e-b2c3-764a0c8c70cc">

</details>

Closes https://github.com/AtB-AS/kundevendt/issues/18966