### PR TITLE
feat: confirm payment method selection in purchase flow

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -417,7 +417,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   interactiveColor="interactive_0"
                   disabled={!!error}
                   rightIcon={{
-                    svg: getPaymentOptionSvg(paymentMethod.paymentType),
+                    svg: getPaymentTypeSvg(paymentMethod.paymentType),
                   }}
                   onPress={() => {
                     analytics.logEvent(
@@ -555,7 +555,7 @@ function getPlaceName(
     : place.name;
 }
 
-function getPaymentOptionSvg(paymentType: PaymentType) {
+function getPaymentTypeSvg(paymentType: PaymentType) {
   switch (paymentType) {
     case PaymentType.Mastercard:
       return MasterCard;

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -187,14 +187,17 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
         <SelectPaymentMethodSheet
           recurringPaymentMethods={recurringPaymentMethods}
           onSelect={(
-            method: PaymentMethod,
+            paymentMethod: PaymentMethod,
             shouldSavePaymentMethod: boolean,
           ) => {
-            setSelectedPaymentMethod(method);
+            setSelectedPaymentMethod(paymentMethod);
             setShouldSavePaymentMethod(shouldSavePaymentMethod);
             closeBottomSheet();
           }}
-          currentPaymentMethod={paymentMethod}
+          currentOptions={{
+            paymentMethod,
+            shouldSavePaymentMethod,
+          }}
         />
       );
     });

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -414,12 +414,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   interactiveColor="interactive_0"
                   disabled={!!error}
                   rightIcon={{
-                    svg:
-                      paymentMethod.paymentType === PaymentType.Mastercard
-                        ? MasterCard
-                        : paymentMethod.paymentType === PaymentType.Vipps
-                        ? Vipps
-                        : Visa,
+                    svg: getPaymentOptionSvg(paymentMethod.paymentType),
                   }}
                   onPress={() => {
                     analytics.logEvent(
@@ -555,6 +550,17 @@ function getPlaceName(
   return 'geometry' in place
     ? getReferenceDataName(place, language)
     : place.name;
+}
+
+function getPaymentOptionSvg(paymentType: PaymentType) {
+  switch (paymentType) {
+    case PaymentType.Mastercard:
+      return MasterCard;
+    case PaymentType.Vipps:
+      return Vipps;
+    case PaymentType.Visa:
+      return Visa;
+  }
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -21,7 +21,7 @@ import {
 import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {formatDecimalNumber} from '@atb/utils/numbers';
 import {addMinutes} from 'date-fns';
-import React, {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -64,6 +64,10 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const analytics = useAnalytics();
 
   const inspectableTokenWarningText = useOtherDeviceIsInspectableWarning();
+  const [selectedPaymentMethod, setSelectedPaymentMethod] =
+    useState<PaymentMethod>();
+  const [shouldSavePaymentMethod, setShouldSavePaymentMethod] = useState(false);
+  const paymentMethod = selectedPaymentMethod ?? previousPaymentMethod;
 
   const {
     fareProductTypeConfig,
@@ -186,10 +190,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             method: PaymentMethod,
             shouldSavePaymentMethod: boolean,
           ) => {
-            goToPayment(method, shouldSavePaymentMethod);
+            setSelectedPaymentMethod(method);
+            setShouldSavePaymentMethod(shouldSavePaymentMethod);
             closeBottomSheet();
           }}
-          previousPaymentMethod={previousPaymentMethod}
+          currentPaymentMethod={paymentMethod}
         />
       );
     });
@@ -402,19 +407,17 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           />
         ) : (
           <View>
-            {previousPaymentMethod ? (
+            {paymentMethod ? (
               <View style={styles.flexColumn}>
                 <Button
-                  text={getPaymentMethodTexts(previousPaymentMethod)}
+                  text={getPaymentMethodTexts(paymentMethod)}
                   interactiveColor="interactive_0"
                   disabled={!!error}
                   rightIcon={{
                     svg:
-                      previousPaymentMethod.paymentType ===
-                      PaymentType.Mastercard
+                      paymentMethod.paymentType === PaymentType.Mastercard
                         ? MasterCard
-                        : previousPaymentMethod.paymentType ===
-                          PaymentType.Vipps
+                        : paymentMethod.paymentType === PaymentType.Vipps
                         ? Vipps
                         : Visa,
                   }}
@@ -423,11 +426,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                       'Ticketing',
                       'Pay with previous payment method clicked',
                       {
-                        paymentMethod: previousPaymentMethod?.paymentType,
+                        paymentMethod: paymentMethod?.paymentType,
                         mode: params.mode,
                       },
                     );
-                    goToPayment(previousPaymentMethod, false);
+                    goToPayment(paymentMethod, shouldSavePaymentMethod);
                   }}
                 />
                 <PressableOpacity
@@ -438,7 +441,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                       'Ticketing',
                       'Change payment method clicked',
                       {
-                        paymentMethod: previousPaymentMethod?.paymentType,
+                        paymentMethod: paymentMethod?.paymentType,
                         mode: params.mode,
                       },
                     );

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
@@ -3,7 +3,7 @@ import {ScrollView, View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {Button} from '@atb/components/button';
 import {PurchaseConfirmationTexts, useTranslation} from '@atb/translations';
-import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
+import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeText} from '@atb/components/text';
 import SelectPaymentMethodTexts from '@atb/translations/screens/subscreens/SelectPaymentMethodTexts';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
@@ -116,7 +116,7 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
               if (selectedMethod) onSelect(selectedMethod, shouldSave);
             }}
             disabled={!selectedMethod}
-            rightIcon={{svg: ArrowRight}}
+            rightIcon={{svg: Confirm}}
             testID="confirmButton"
           />
         </FullScreenFooter>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
@@ -21,19 +21,27 @@ import {useAuthState} from '@atb/auth';
 import {PaymentType} from '@atb/ticketing';
 
 type Props = {
-  onSelect: (value: PaymentMethod, save: boolean) => void;
-  currentPaymentMethod?: PaymentMethod;
+  onSelect: (
+    paymentMethod: PaymentMethod,
+    shouldSavePaymentMethod: boolean,
+  ) => void;
+  currentOptions?: {
+    shouldSavePaymentMethod?: boolean;
+    paymentMethod?: PaymentMethod;
+  };
   recurringPaymentMethods?: PaymentMethod[];
 };
 
 export const SelectPaymentMethodSheet: React.FC<Props> = ({
   onSelect,
-  currentPaymentMethod,
   recurringPaymentMethods,
+  currentOptions,
 }) => {
   const {t} = useTranslation();
   const styles = useStyles();
-  const [shouldSave, setShouldSave] = useState(false);
+  const [shouldSave, setShouldSave] = useState(
+    currentOptions?.shouldSavePaymentMethod ?? false,
+  );
 
   const {paymentTypes} = useFirestoreConfiguration();
   const defaultPaymentMethods: PaymentMethod[] = paymentTypes.map(
@@ -42,7 +50,9 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
       savedType: SavedPaymentMethodType.Normal,
     }),
   );
-  const [selectedMethod, setSelectedMethod] = useState(currentPaymentMethod);
+  const [selectedMethod, setSelectedMethod] = useState(
+    currentOptions?.paymentMethod,
+  );
 
   return (
     <BottomSheetContainer

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/SelectPaymentMethodSheet.tsx
@@ -22,13 +22,13 @@ import {PaymentType} from '@atb/ticketing';
 
 type Props = {
   onSelect: (value: PaymentMethod, save: boolean) => void;
-  previousPaymentMethod?: PaymentMethod;
+  currentPaymentMethod?: PaymentMethod;
   recurringPaymentMethods?: PaymentMethod[];
 };
 
 export const SelectPaymentMethodSheet: React.FC<Props> = ({
   onSelect,
-  previousPaymentMethod,
+  currentPaymentMethod,
   recurringPaymentMethods,
 }) => {
   const {t} = useTranslation();
@@ -42,7 +42,7 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
       savedType: SavedPaymentMethodType.Normal,
     }),
   );
-  const [selectedMethod, setSelectedMethod] = useState(previousPaymentMethod);
+  const [selectedMethod, setSelectedMethod] = useState(currentPaymentMethod);
 
   return (
     <BottomSheetContainer

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -178,7 +178,7 @@ const PurchaseOverviewTexts = {
   travellerSelectionSheet: {
     title: _('Reisende', 'Travellers', 'Reisande'),
     close: _('Lukk', 'Close', 'Lukk'),
-    confirm: _('Bekreft valg', 'Confirm choice', 'Stadfest val'),
+    confirm: _('Bekreft valg', 'Confirm selection', 'Bekreft val'),
   },
   startTime: {
     title: _(

--- a/src/translations/screens/subscreens/SelectPaymentMethodTexts.ts
+++ b/src/translations/screens/subscreens/SelectPaymentMethodTexts.ts
@@ -9,11 +9,11 @@ const SelectPaymentMethodTexts = {
     ),
   },
   confirm_button: {
-    text: _('Til betaling', 'Confirm option', 'Til betaling'),
+    text: _('Bekreft valg', 'Confirm selection', 'Bekreft val'),
     a11yhint: _(
-      'Aktiver for å gå videre til betaling',
-      'Activate to go ahead with payment with selected option',
-      'Aktiver for å gå vidare til betaling',
+      'Aktiver for å bekrefte valg av betalingsmåte',
+      'Activate to confirm payment method',
+      'Aktiver for å bekrefte val av betalingsmåte',
     ),
   },
   save_payment_method_description: {


### PR DESCRIPTION
related to https://github.com/AtB-AS/kundevendt/issues/18885

The current flow, where selecting a payment method completes a purchase, can be counter intuitive at best, and can lead to wrong purchases at worst. It also breaks with how other bottom sheets work in the app, where making a selection doesn't also submit the parent screen. So after a talk with designers, it was decided to change the flow to have the bottom sheet apply changes, but not complete the purchase.

[Updated sketches](https://www.figma.com/design/zdZwvobgpEWSagKt0tderx/App?node-id=28048-99792&node-type=INSTANCE&t=EkVYakSquEsRJVYY-0)

https://github.com/user-attachments/assets/7e29c38c-5696-4fe0-a1a0-5815edeabb3b

### Acceptance criteria

- [ ] The purchase flow is never completed directly from the bottom sheet, but by clicking the "Pay with [method]" button.
- [ ] Saving of payment method still work as before. (Should test both iOS and Android)
- [ ] Payment options are not shared between accounts.