### PR TITLE
Create Shared Mobility endpoint hooks + test usage

### DIFF
--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -23,6 +23,8 @@ import {
   CarStationFragment,
 } from '@atb/api/types/generated/fragments/stations';
 import {
+  ShmoBooking,
+  ShmoBookingSchema,
   ViolationsReportQuery,
   ViolationsReportQueryResult,
   ViolationsReportingInitQuery,
@@ -127,13 +129,26 @@ export const getCarStation = (
 export const getGeofencingZones = (
   systemIds: string[],
   opts?: AxiosRequestConfig,
-): Promise<GeofencingZones[] | undefined> => {
-  if (systemIds.length < 1) return Promise.resolve(undefined);
+): Promise<GeofencingZones[] | null> => {
+  if (systemIds.length < 1) return Promise.resolve(null);
   const url = '/bff/v2/mobility/geofencing-zones';
   const query = qs.stringify({systemIds});
   return client
     .get<GetGeofencingZonesQuery>(stringifyUrl(url, query), opts)
-    .then((res) => res.data.geofencingZones);
+    .then((res) => res.data.geofencingZones ?? null);
+};
+
+export const getActiveShmoBooking = (
+  opts?: AxiosRequestConfig,
+): Promise<ShmoBooking | null> => {
+  return client
+    .get<ShmoBooking | null>('/mobility/v1/bookings/active', {
+      ...opts,
+      authWithIdToken: true,
+    })
+    .then((response) =>
+      response.data === null ? null : ShmoBookingSchema.parse(response.data),
+    );
 };
 
 export const initViolationsReporting = (

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -144,12 +144,14 @@ export const getGeofencingZones = (
 };
 
 export const getActiveShmoBooking = (
+  acceptLanguage: string,
   opts?: AxiosRequestConfig,
 ): Promise<ShmoBooking | null> => {
   return client
     .get<ShmoBooking | null>('/mobility/v1/bookings/active', {
       ...opts,
       authWithIdToken: true,
+      headers: {'Accept-Language': acceptLanguage},
     })
     .then((response) =>
       response.data === null ? null : ShmoBookingSchema.parse(response.data),
@@ -158,22 +160,26 @@ export const getActiveShmoBooking = (
 
 export const getShmoBooking = (
   bookingId: ShmoBooking['bookingId'],
+  acceptLanguage: string,
   opts?: AxiosRequestConfig,
 ): Promise<ShmoBooking> => {
   return client
     .get<ShmoBooking>(`/mobility/v1/bookings/${bookingId}`, {
       ...opts,
       authWithIdToken: true,
+      headers: {'Accept-Language': acceptLanguage},
     })
     .then((response) => ShmoBookingSchema.parse(response.data));
 };
 
 export const initShmoOneStopBooking = (
   reqBody: InitShmoOneStopBookingRequestBody,
+  acceptLanguage: string,
 ): Promise<ShmoBooking> => {
   return client
     .post<ShmoBooking>('/mobility/v1/bookings/one-stop', reqBody, {
       authWithIdToken: true,
+      headers: {'Accept-Language': acceptLanguage},
     })
     .then((response) => ShmoBookingSchema.parse(response.data));
 };
@@ -181,6 +187,7 @@ export const initShmoOneStopBooking = (
 export const sendShmoBookingEvent = (
   bookingId: ShmoBooking['bookingId'],
   shmoBookingEvent: ShmoBookingEvent,
+  acceptLanguage: string,
 ): Promise<ShmoBooking> => {
   return client
     .post<ShmoBooking>(
@@ -188,6 +195,7 @@ export const sendShmoBookingEvent = (
       shmoBookingEvent,
       {
         authWithIdToken: true,
+        headers: {'Accept-Language': acceptLanguage},
       },
     )
     .then((response) => ShmoBookingSchema.parse(response.data));
@@ -195,6 +203,7 @@ export const sendShmoBookingEvent = (
 
 export const getIdsFromQrCode = (
   params: IdsFromQrCodeQuery,
+  acceptLanguage: string,
   opts?: AxiosRequestConfig,
 ): Promise<IdsFromQrCodeResponse> => {
   params;
@@ -204,6 +213,7 @@ export const getIdsFromQrCode = (
     .get<IdsFromQrCodeResponse>(stringifyUrl(url, query), {
       ...opts,
       authWithIdToken: true,
+      headers: {'Accept-Language': acceptLanguage},
     })
     .then((response) => IdsFromQrCodeResponseSchema.parse(response.data));
 };

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -29,7 +29,6 @@ import {
   InitShmoOneStopBookingRequestBody,
   ShmoBooking,
   ShmoBookingEvent,
-  ShmoBookingEventType,
   ShmoBookingSchema,
   ViolationsReportQuery,
   ViolationsReportQueryResult,

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -23,8 +23,13 @@ import {
   CarStationFragment,
 } from '@atb/api/types/generated/fragments/stations';
 import {
+  IdsFromQrCodeQuery,
+  IdsFromQrCodeResponse,
+  IdsFromQrCodeResponseSchema,
   InitShmoOneStopBookingRequestBody,
   ShmoBooking,
+  ShmoBookingEvent,
+  ShmoBookingEventType,
   ShmoBookingSchema,
   ViolationsReportQuery,
   ViolationsReportQueryResult,
@@ -152,6 +157,18 @@ export const getActiveShmoBooking = (
     );
 };
 
+export const getShmoBooking = (
+  bookingId: ShmoBooking['bookingId'],
+  opts?: AxiosRequestConfig,
+): Promise<ShmoBooking> => {
+  return client
+    .get<ShmoBooking>(`/mobility/v1/bookings/${bookingId}`, {
+      ...opts,
+      authWithIdToken: true,
+    })
+    .then((response) => ShmoBookingSchema.parse(response.data));
+};
+
 export const initShmoOneStopBooking = (
   reqBody: InitShmoOneStopBookingRequestBody,
 ): Promise<ShmoBooking> => {
@@ -160,6 +177,36 @@ export const initShmoOneStopBooking = (
       authWithIdToken: true,
     })
     .then((response) => ShmoBookingSchema.parse(response.data));
+};
+
+export const sendShmoBookingEvent = (
+  bookingId: ShmoBooking['bookingId'],
+  shmoBookingEvent: ShmoBookingEvent,
+): Promise<ShmoBooking> => {
+  return client
+    .post<ShmoBooking>(
+      `/mobility/v1/bookings/${bookingId}/event`,
+      shmoBookingEvent,
+      {
+        authWithIdToken: true,
+      },
+    )
+    .then((response) => ShmoBookingSchema.parse(response.data));
+};
+
+export const getIdsFromQrCode = (
+  params: IdsFromQrCodeQuery,
+  opts?: AxiosRequestConfig,
+): Promise<IdsFromQrCodeResponse> => {
+  params;
+  const url = '/mobility/v1/asset/qr';
+  const query = qs.stringify(params);
+  return client
+    .get<IdsFromQrCodeResponse>(stringifyUrl(url, query), {
+      ...opts,
+      authWithIdToken: true,
+    })
+    .then((response) => IdsFromQrCodeResponseSchema.parse(response.data));
 };
 
 export const initViolationsReporting = (

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -23,6 +23,7 @@ import {
   CarStationFragment,
 } from '@atb/api/types/generated/fragments/stations';
 import {
+  InitShmoOneStopBookingRequestBody,
   ShmoBooking,
   ShmoBookingSchema,
   ViolationsReportQuery,
@@ -149,6 +150,16 @@ export const getActiveShmoBooking = (
     .then((response) =>
       response.data === null ? null : ShmoBookingSchema.parse(response.data),
     );
+};
+
+export const initShmoOneStopBooking = (
+  reqBody: InitShmoOneStopBookingRequestBody,
+): Promise<ShmoBooking> => {
+  return client
+    .post<ShmoBooking>('/mobility/v1/bookings/one-stop', reqBody, {
+      authWithIdToken: true,
+    })
+    .then((response) => ShmoBookingSchema.parse(response.data));
 };
 
 export const initViolationsReporting = (

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod';
+
 export type ViolationsReportingInitQuery = {
   lng: string;
   lat: string;
@@ -46,3 +48,83 @@ export type ViolationsReportQuery = {
 export type ViolationsReportQueryResult = {
   status: 'OK';
 };
+
+/** Note: The shared mobility types below come from the `mobility` and `entur-client` crates in the mobility service. */
+
+const ShmoPricingSegmentSchema = z.object({
+  start: z
+    .number()
+    .int()
+    .describe(
+      'The minute at which this segment rate starts being charged (inclusive)',
+    ),
+  end: z
+    .number()
+    .int()
+    .optional()
+    .nullable()
+    .describe(
+      'The minute at which the rate will no longer apply (exclusive). If not provided, the rate applies until the trip ends.',
+    ),
+  interval: z
+    .number()
+    .int()
+    .describe(
+      'Interval in minutes at which the rate of this segment is reapplied. An interval of 0 indicates the rate is only charged once.',
+    ),
+  rate: z
+    .number()
+    .describe(
+      'Rate that is charged for each minute interval after the start. Can be a negative number, indicating a discount.',
+    ),
+});
+
+const ShmoPricingPlanSchema = z.object({
+  currency: z.string().describe('Currency in ISO 4217 code'),
+  price: z.number().describe('Fare price in the specified currency'),
+  perMinPricing: z
+    .array(ShmoPricingSegmentSchema)
+    .optional()
+    .nullable()
+    .describe('Array of pricing segments, optional'),
+});
+
+export enum ShmoBookingState {
+  NOT_STARTED = 'NOT_STARTED',
+  IN_USE = 'IN_USE',
+  PAUSED = 'PAUSED',
+  FINISHING = 'FINISHING',
+  FINISHED = 'FINISHED',
+  CANCELLED = 'CANCELLED',
+}
+
+// Inferring schema from enum instead of the other way around
+// this allows the enums to be used directly
+const ShmoBookingStateSchema = z.enum(
+  Object.values(ShmoBookingState) as [ShmoBookingState, ...ShmoBookingState[]],
+);
+
+const ShmoPricingSchema = z.object({
+  currentAmount: z.number(),
+  finalAmount: z.number().optional().nullable(),
+});
+
+const ShmoOperatorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const ShmoBookingSchema = z.object({
+  bookingId: z.string().uuid(),
+  state: ShmoBookingStateSchema,
+  orderId: z.string(),
+  pricingPlan: ShmoPricingPlanSchema,
+  departureTime: z.coerce.date().optional().nullable(),
+  arrivalTime: z.coerce.date().optional().nullable(),
+  operator: ShmoOperatorSchema,
+  stateOfCharge: z.number().int().optional().nullable(),
+  currentRangeKm: z.number().int().optional().nullable(),
+  pricing: ShmoPricingSchema,
+});
+
+export type ShmoBooking = z.infer<typeof ShmoBookingSchema>;

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -151,7 +151,6 @@ const InitShmoOneStopBookingRequestBodySchema = z.object({
     .string()
     .optional()
     .describe('This is the same id as vehicleId from the mobility API'),
-  preferredLanguageCode: z.string().optional(), // preferredLanguageCode will be replaced by Accept-Language headers
 });
 
 export type InitShmoOneStopBookingRequestBody = z.infer<

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -128,3 +128,23 @@ export const ShmoBookingSchema = z.object({
 });
 
 export type ShmoBooking = z.infer<typeof ShmoBookingSchema>;
+
+const ShmoCoordinatesSchema = z.object({
+  longitude: z.number(),
+  latitude: z.number(),
+  altitude: z.number().optional().nullable(),
+});
+
+const InitShmoOneStopBookingRequestBodySchema = z.object({
+  recurringPaymentId: z.number().int(),
+  coordinates: ShmoCoordinatesSchema,
+  assetId: z
+    .string()
+    .optional()
+    .describe('This is the same id as vehicleId from the mobility API'),
+  preferredLanguageCode: z.string().optional(), // preferredLanguageCode will be replaced by Accept-Language headers
+});
+
+export type InitShmoOneStopBookingRequestBody = z.infer<
+  typeof InitShmoOneStopBookingRequestBodySchema
+>;

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -129,9 +129,18 @@ export const ShmoBookingSchema = z.object({
 
 export type ShmoBooking = z.infer<typeof ShmoBookingSchema>;
 
+const longitude = z
+  .number()
+  .min(-180, {message: 'longitude must be greater than or equal to -180'})
+  .max(180, {message: 'longitude must be less than or equal to 180'});
+const latitude = z
+  .number()
+  .min(-90, {message: 'latitude must be greater than or equal to -90'})
+  .max(90, {message: 'latitude must be less than or equal to 90'});
+
 const ShmoCoordinatesSchema = z.object({
-  longitude: z.number(),
-  latitude: z.number(),
+  longitude,
+  latitude,
   altitude: z.number().optional().nullable(),
 });
 
@@ -148,3 +157,39 @@ const InitShmoOneStopBookingRequestBodySchema = z.object({
 export type InitShmoOneStopBookingRequestBody = z.infer<
   typeof InitShmoOneStopBookingRequestBodySchema
 >;
+
+export enum ShmoBookingEventType {
+  START_FINISHING = 'START_FINISHING',
+  FINISH = 'FINISH',
+}
+
+const ShmoImageFileSchema = z.object({
+  fileName: z.string(),
+  fileType: z.string(),
+  fileData: z.string().describe('base64 encoded image data'),
+});
+
+type StartFinishingEvent = {event: ShmoBookingEventType.START_FINISHING};
+type FinishEvent = {
+  event: ShmoBookingEventType.FINISH;
+} & z.infer<typeof ShmoImageFileSchema>;
+
+export type ShmoBookingEvent = StartFinishingEvent | FinishEvent;
+
+export const IdsFromQrCodeResponseSchema = z.object({
+  operatorId: z.string(),
+  vehicleId: z.string().nullable().optional(),
+  stationId: z.string().nullable().optional(),
+});
+
+export type IdsFromQrCodeResponse = z.infer<typeof IdsFromQrCodeResponseSchema>;
+
+export const IdsFromQrCodeQuerySchema = z.object({
+  qrCodeUrl: z
+    .string()
+    .min(1, {message: 'qrCodeUrl must be at least 1 character long'}),
+  longitude,
+  latitude,
+});
+
+export type IdsFromQrCodeQuery = z.infer<typeof IdsFromQrCodeQuerySchema>;

--- a/src/api/use-accept-language.ts
+++ b/src/api/use-accept-language.ts
@@ -1,0 +1,8 @@
+import {useTranslation} from '@atb/translations';
+
+export const useAcceptLanguage = () => {
+  // All the current app language codes ('nb', 'en', 'nn') can be used directly as Accept-Language headers.
+  // However, we might want to map these into e.g. nb-NO, en-US and nn-NO.
+  const {language: acceptLanguage} = useTranslation();
+  return acceptLanguage;
+};

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -36,6 +36,8 @@ import {isBicycle, isScooter} from '@atb/mobility';
 import {isCarStation, isStation} from '@atb/mobility/utils';
 
 import {Snackbar, useSnackbar} from '../snackbar';
+import {useShmoDeepIntegrationEnabled} from '@atb/mobility/use-shmo-deep-integration-enabled';
+import {ShmoTesting} from './components/mobility/ShmoTesting';
 
 export const Map = (props: MapProps) => {
   const {initialLocation, includeSnackbar} = props;
@@ -71,6 +73,14 @@ export const Map = (props: MapProps) => {
 
   const {getGeofencingZoneTextContent} = useGeofencingZoneTextContent();
   const {snackbarProps, showSnackbar, hideSnackbar} = useSnackbar();
+
+  const [
+    shmoDeepIntegrationEnabled,
+    shmoDeepIntegrationEnabledDebugOverrideReady,
+  ] = useShmoDeepIntegrationEnabled();
+
+  const showShmoTesting =
+    shmoDeepIntegrationEnabled && shmoDeepIntegrationEnabledDebugOverrideReady;
 
   useEffect(() => {
     // hide the snackbar when the bottom sheet is closed
@@ -226,6 +236,10 @@ export const Map = (props: MapProps) => {
             <GeofencingZones
               selectedVehicleId={selectedFeature.properties.id}
             />
+          )}
+
+          {showShmoTesting && (
+            <ShmoTesting selectedVehicleId={selectedFeature?.properties?.id} />
           )}
 
           {mapLines && <MapRoute lines={mapLines} />}

--- a/src/components/map/components/mobility/ShmoTesting.tsx
+++ b/src/components/map/components/mobility/ShmoTesting.tsx
@@ -12,7 +12,6 @@ import {useSendShmoBookingEventMutation} from '@atb/mobility/queries/use-send-sh
 import {useShmoBookingQuery} from '@atb/mobility/queries/use-shmo-booking-query';
 // eslint-disable-next-line no-restricted-imports
 import {usePreviousPaymentMethod} from '@atb/stacks-hierarchy/saved-payment-utils';
-import {useTranslation} from '@atb/translations';
 import {useCallback, useState} from 'react';
 import {useWindowDimensions, View} from 'react-native';
 import {Button} from '@atb/components/button';
@@ -32,7 +31,6 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
     previousPaymentMethod?.savedType === 'recurring'
       ? previousPaymentMethod?.recurringCard?.id
       : '';
-  const {language} = useTranslation();
 
   const {data: activeShmoBooking} = useActiveShmoBookingQuery();
   const {data: shmoBooking} = useShmoBookingQuery(previousBookingId);
@@ -70,11 +68,10 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
         recurringPaymentId,
         coordinates: {latitude: 0, longitude: 0},
         assetId: selectedVehicleId,
-        preferredLanguageCode: language,
       };
       initShmoOneStopBooking(initReqBody);
     }
-  }, [language, recurringPaymentId, initShmoOneStopBooking, selectedVehicleId]);
+  }, [recurringPaymentId, initShmoOneStopBooking, selectedVehicleId]);
 
   const startFinishingShmoBooking = useCallback(() => {
     if (activeShmoBooking?.bookingId) {

--- a/src/components/map/components/mobility/ShmoTesting.tsx
+++ b/src/components/map/components/mobility/ShmoTesting.tsx
@@ -1,0 +1,257 @@
+import {
+  InitShmoOneStopBookingRequestBody,
+  ShmoBookingEvent,
+  ShmoBookingEventType,
+} from '@atb/api/types/mobility';
+import {StyleSheet} from '@atb/theme';
+import {ThemeText} from '@atb/components/text';
+import {useActiveShmoBookingQuery} from '@atb/mobility/queries/use-active-shmo-booking-query';
+import {useGetIdsFromQrCodeMutation} from '@atb/mobility/queries/use-get-ids-from-qr-code-mutation';
+import {useInitShmoOneStopBookingMutation} from '@atb/mobility/queries/use-init-shmo-one-stop-booking-mutation';
+import {useSendShmoBookingEventMutation} from '@atb/mobility/queries/use-send-shmo-booking-event-mutation';
+import {useShmoBookingQuery} from '@atb/mobility/queries/use-shmo-booking-query';
+// eslint-disable-next-line no-restricted-imports
+import {usePreviousPaymentMethod} from '@atb/stacks-hierarchy/saved-payment-utils';
+import {useTranslation} from '@atb/translations';
+import {useCallback, useState} from 'react';
+import {useWindowDimensions, View} from 'react-native';
+import {Button} from '@atb/components/button';
+import {ScrollView} from 'react-native-gesture-handler';
+
+type ShmoTestingProps = {selectedVehicleId?: string};
+
+export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
+  const [previousBookingId, setPreviousBookingId] = useState<string>();
+  const [vehicleId, setVehicleId] = useState<string>();
+
+  const styles = useStyles();
+  const {height: windowHeight} = useWindowDimensions();
+
+  const previousPaymentMethod = usePreviousPaymentMethod();
+  const recurringPaymentId =
+    previousPaymentMethod?.savedType === 'recurring'
+      ? previousPaymentMethod?.recurringCard?.id
+      : '';
+  const {language} = useTranslation();
+
+  const {data: activeShmoBooking} = useActiveShmoBookingQuery();
+  const {data: shmoBooking} = useShmoBookingQuery(previousBookingId);
+
+  const {
+    mutateAsync: getIdsFromQrCode,
+    isLoading: getIdsFromQrCodeIsLoading,
+    isError: getIdsFromQrCodeIsError,
+  } = useGetIdsFromQrCodeMutation();
+
+  const {
+    mutateAsync: initShmoOneStopBooking,
+    isLoading: initShmoOneStopBookingIsLoading,
+    isError: initShmoOneStopBookingIsError,
+  } = useInitShmoOneStopBookingMutation();
+
+  const {
+    mutateAsync: sendShmoBookingEvent,
+    isLoading: sendShmoBookingEventIsLoading,
+    isError: sendShmoBookingEventIsError,
+  } = useSendShmoBookingEventMutation();
+
+  const getVehicleIdFromQrCode = async () => {
+    const idsFromQrCode = await getIdsFromQrCode({
+      qrCodeUrl: 'https://open.voi.com/scan/EN57',
+      latitude: 0,
+      longitude: 0,
+    });
+    return idsFromQrCode.vehicleId;
+  };
+
+  const initShmoBooking = useCallback(() => {
+    if (!!recurringPaymentId && !!selectedVehicleId) {
+      const initReqBody: InitShmoOneStopBookingRequestBody = {
+        recurringPaymentId,
+        coordinates: {latitude: 0, longitude: 0},
+        assetId: selectedVehicleId,
+        preferredLanguageCode: language,
+      };
+      initShmoOneStopBooking(initReqBody);
+    }
+  }, [language, recurringPaymentId, initShmoOneStopBooking, selectedVehicleId]);
+
+  const startFinishingShmoBooking = useCallback(() => {
+    if (activeShmoBooking?.bookingId) {
+      const startFinishingEvent: ShmoBookingEvent = {
+        event: ShmoBookingEventType.START_FINISHING,
+      };
+      sendShmoBookingEvent({
+        bookingId: activeShmoBooking?.bookingId,
+        shmoBookingEvent: startFinishingEvent,
+      });
+    }
+  }, [activeShmoBooking?.bookingId, sendShmoBookingEvent]);
+
+  const finishShmoBooking = useCallback(() => {
+    if (activeShmoBooking?.bookingId) {
+      const finishEvent: ShmoBookingEvent = {
+        event: ShmoBookingEventType.FINISH,
+        fileName: 'evidence.png',
+        fileType: 'image/png',
+        fileData: 'c2FkZmRzZmFzZmJ2Cg==',
+      };
+      sendShmoBookingEvent({
+        bookingId: activeShmoBooking?.bookingId,
+        shmoBookingEvent: finishEvent,
+      });
+      setPreviousBookingId(activeShmoBooking.bookingId);
+    }
+  }, [activeShmoBooking?.bookingId, sendShmoBookingEvent]);
+
+  const ShmoTestingButtons = (
+    <View
+      style={{
+        paddingLeft: 5,
+        pointerEvents: 'auto',
+      }}
+    >
+      <Button
+        style={styles.filterButton}
+        type="medium"
+        compact={true}
+        interactiveColor={
+          initShmoOneStopBookingIsError
+            ? 'interactive_destructive'
+            : 'interactive_2'
+        }
+        accessibilityRole="button"
+        onPress={() => {
+          //analytics.logEvent('Map', 'Init Booking Pressed');
+          initShmoBooking();
+        }}
+        text="Init Booking"
+        loading={initShmoOneStopBookingIsLoading}
+        hasShadow={true}
+      />
+
+      <Button
+        style={styles.filterButton}
+        type="medium"
+        compact={true}
+        interactiveColor={
+          sendShmoBookingEventIsError
+            ? 'interactive_destructive'
+            : 'interactive_2'
+        }
+        accessibilityRole="button"
+        onPress={() => {
+          //analytics.logEvent('Map', 'Start Finishing Pressed');
+          startFinishingShmoBooking();
+        }}
+        text="Start Finishing"
+        loading={sendShmoBookingEventIsLoading}
+        hasShadow={true}
+      />
+
+      <Button
+        style={styles.filterButton}
+        type="medium"
+        compact={true}
+        interactiveColor={
+          sendShmoBookingEventIsError
+            ? 'interactive_destructive'
+            : 'interactive_2'
+        }
+        accessibilityRole="button"
+        onPress={() => {
+          //analytics.logEvent('Map', 'Finish Pressed');
+          finishShmoBooking();
+        }}
+        text="Finish"
+        loading={sendShmoBookingEventIsLoading}
+        hasShadow={true}
+      />
+
+      <Button
+        style={styles.filterButton}
+        type="medium"
+        compact={true}
+        interactiveColor={
+          getIdsFromQrCodeIsError ? 'interactive_destructive' : 'interactive_2'
+        }
+        accessibilityRole="button"
+        onPress={async () => {
+          //analytics.logEvent('Map', 'Qr to Ids Pressed');
+          const vehicleIdFromQrCode = await getVehicleIdFromQrCode();
+          setVehicleId(vehicleIdFromQrCode || '');
+        }}
+        text="Qr to Ids"
+        loading={getIdsFromQrCodeIsLoading}
+        hasShadow={true}
+      />
+    </View>
+  );
+
+  return (
+    <>
+      <View
+        style={{
+          position: 'absolute',
+          left: 0,
+          width: '50%',
+          paddingTop: 50,
+        }}
+      >
+        <ScrollView
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(255,255,255,0.75)',
+            height: windowHeight,
+            pointerEvents: 'auto',
+          }}
+        >
+          <ThemeText>RecurringPaymentId: {recurringPaymentId}</ThemeText>
+
+          <View style={{backgroundColor: 'rgba(0,255,0,0.25)'}}>
+            <ThemeText>VehicleId: {selectedVehicleId}</ThemeText>
+          </View>
+          <View style={{backgroundColor: 'rgba(100,100,100,0.25)'}}>
+            <ThemeText>VehicleIdFromQr: {vehicleId}</ThemeText>
+          </View>
+
+          <View style={{backgroundColor: 'rgba(0,0,255,0.25)'}}>
+            <ThemeText>
+              Active Booking:
+              {'\n' + JSON.stringify(activeShmoBooking)}
+            </ThemeText>
+          </View>
+          <View
+            style={{
+              paddingTop: 5,
+              backgroundColor: 'rgba(255,0,0,0.25)',
+              marginBottom: 10,
+            }}
+          >
+            <ThemeText>
+              Previous Booking:
+              {'\n' + JSON.stringify(shmoBooking)}
+            </ThemeText>
+          </View>
+          <View style={{height: windowHeight * 0.75, pointerEvents: 'none'}} />
+        </ScrollView>
+      </View>
+      <View
+        style={{
+          position: 'absolute',
+          paddingTop: 50,
+          right: 0,
+        }}
+      >
+        {ShmoTestingButtons}
+      </View>
+    </>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  filterButton: {
+    marginBottom: theme.spacings.small,
+    pointerEvents: 'auto',
+  },
+}));

--- a/src/components/map/geofencing-zone-utils.ts
+++ b/src/components/map/geofencing-zone-utils.ts
@@ -24,7 +24,7 @@ function getApplicableGeofencingZoneRules(
 }
 
 export function filterOutFeaturesNotApplicableForCurrentVehicle(
-  geofencingZones?: GeofencingZones[],
+  geofencingZones?: GeofencingZones[] | null,
   vehicleTypeId?: string,
 ): GeofencingZones[] {
   if (!vehicleTypeId || !geofencingZones) {

--- a/src/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-active-shmo-booking-query.tsx
@@ -2,9 +2,13 @@ import {useQuery} from '@tanstack/react-query';
 import {getActiveShmoBooking} from '@atb/api/mobility';
 import {ONE_MINUTE_MS} from '@atb/utils/durations.ts';
 
+export const GET_ACTIVE_SHMO_BOOKING_QUERY_KEY = [
+  'GET_ACTIVE_SHMO_BOOKING_QUERY_KEY',
+];
+
 export const useActiveShmoBookingQuery = () => {
   return useQuery({
-    queryKey: ['getActiveShmoBooking'],
+    queryKey: GET_ACTIVE_SHMO_BOOKING_QUERY_KEY,
     queryFn: ({signal}) => getActiveShmoBooking({signal}),
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,

--- a/src/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-active-shmo-booking-query.tsx
@@ -1,15 +1,18 @@
 import {useQuery} from '@tanstack/react-query';
 import {getActiveShmoBooking} from '@atb/api/mobility';
 import {ONE_MINUTE_MS} from '@atb/utils/durations.ts';
+import {useAcceptLanguage} from '@atb/api/use-accept-language';
 
-export const GET_ACTIVE_SHMO_BOOKING_QUERY_KEY = [
+export const getActiveShmoBookingQueryKey = (acceptLanguage: string) => [
   'GET_ACTIVE_SHMO_BOOKING_QUERY_KEY',
+  acceptLanguage,
 ];
 
 export const useActiveShmoBookingQuery = () => {
+  const acceptLanguage = useAcceptLanguage();
   return useQuery({
-    queryKey: GET_ACTIVE_SHMO_BOOKING_QUERY_KEY,
-    queryFn: ({signal}) => getActiveShmoBooking({signal}),
+    queryKey: getActiveShmoBookingQueryKey(acceptLanguage),
+    queryFn: ({signal}) => getActiveShmoBooking(acceptLanguage, {signal}),
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
   });

--- a/src/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-active-shmo-booking-query.tsx
@@ -1,0 +1,12 @@
+import {useQuery} from '@tanstack/react-query';
+import {getActiveShmoBooking} from '@atb/api/mobility';
+import {ONE_MINUTE_MS} from '@atb/utils/durations.ts';
+
+export const useActiveShmoBookingQuery = () => {
+  return useQuery({
+    queryKey: ['getActiveShmoBooking'],
+    queryFn: ({signal}) => getActiveShmoBooking({signal}),
+    staleTime: ONE_MINUTE_MS,
+    cacheTime: ONE_MINUTE_MS,
+  });
+};

--- a/src/mobility/queries/use-get-ids-from-qr-code-mutation.tsx
+++ b/src/mobility/queries/use-get-ids-from-qr-code-mutation.tsx
@@ -1,10 +1,12 @@
 import {getIdsFromQrCode} from '@atb/api/mobility';
 import {IdsFromQrCodeQuery} from '@atb/api/types/mobility';
+import {useAcceptLanguage} from '@atb/api/use-accept-language';
 import {useMutation} from '@tanstack/react-query';
 
 export const useGetIdsFromQrCodeMutation = () => {
+  const acceptLanguage = useAcceptLanguage();
   return useMutation({
     mutationFn: (idsFromQrCodeQuery: IdsFromQrCodeQuery) =>
-      getIdsFromQrCode(idsFromQrCodeQuery),
+      getIdsFromQrCode(idsFromQrCodeQuery, acceptLanguage),
   });
 };

--- a/src/mobility/queries/use-get-ids-from-qr-code-mutation.tsx
+++ b/src/mobility/queries/use-get-ids-from-qr-code-mutation.tsx
@@ -1,0 +1,10 @@
+import {getIdsFromQrCode} from '@atb/api/mobility';
+import {IdsFromQrCodeQuery} from '@atb/api/types/mobility';
+import {useMutation} from '@tanstack/react-query';
+
+export const useGetIdsFromQrCodeMutation = () => {
+  return useMutation({
+    mutationFn: (idsFromQrCodeQuery: IdsFromQrCodeQuery) =>
+      getIdsFromQrCode(idsFromQrCodeQuery),
+  });
+};

--- a/src/mobility/queries/use-init-shmo-one-stop-booking-mutation.tsx
+++ b/src/mobility/queries/use-init-shmo-one-stop-booking-mutation.tsx
@@ -1,0 +1,16 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {initShmoOneStopBooking} from '@atb/api/mobility';
+import {GET_ACTIVE_SHMO_BOOKING_QUERY_KEY} from './use-active-shmo-booking-query';
+
+export const useInitShmoOneStopBookingMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: initShmoOneStopBooking,
+    onSuccess: (data) => {
+      // as long as you can only have one shmo booking at a time,
+      // the new booking should always be the active ones
+      queryClient.setQueryData(GET_ACTIVE_SHMO_BOOKING_QUERY_KEY, data);
+    },
+  });
+};

--- a/src/mobility/queries/use-init-shmo-one-stop-booking-mutation.tsx
+++ b/src/mobility/queries/use-init-shmo-one-stop-booking-mutation.tsx
@@ -1,17 +1,26 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {initShmoOneStopBooking} from '@atb/api/mobility';
-import {GET_ACTIVE_SHMO_BOOKING_QUERY_KEY} from './use-active-shmo-booking-query';
-import {ShmoBooking} from '@atb/api/types/mobility';
+import {getActiveShmoBookingQueryKey} from './use-active-shmo-booking-query';
+import {
+  InitShmoOneStopBookingRequestBody,
+  ShmoBooking,
+} from '@atb/api/types/mobility';
+import {useAcceptLanguage} from '@atb/api/use-accept-language';
 
 export const useInitShmoOneStopBookingMutation = () => {
   const queryClient = useQueryClient();
+  const acceptLanguage = useAcceptLanguage();
 
   return useMutation({
-    mutationFn: initShmoOneStopBooking,
+    mutationFn: (reqBody: InitShmoOneStopBookingRequestBody) =>
+      initShmoOneStopBooking(reqBody, acceptLanguage),
     onSuccess: (data: ShmoBooking) => {
       // as long as you can only have one shmo booking at a time,
       // the new booking should always be the active one
-      queryClient.setQueryData(GET_ACTIVE_SHMO_BOOKING_QUERY_KEY, data);
+      queryClient.setQueryData(
+        getActiveShmoBookingQueryKey(acceptLanguage),
+        data,
+      );
     },
   });
 };

--- a/src/mobility/queries/use-init-shmo-one-stop-booking-mutation.tsx
+++ b/src/mobility/queries/use-init-shmo-one-stop-booking-mutation.tsx
@@ -1,15 +1,16 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {initShmoOneStopBooking} from '@atb/api/mobility';
 import {GET_ACTIVE_SHMO_BOOKING_QUERY_KEY} from './use-active-shmo-booking-query';
+import {ShmoBooking} from '@atb/api/types/mobility';
 
 export const useInitShmoOneStopBookingMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: initShmoOneStopBooking,
-    onSuccess: (data) => {
+    onSuccess: (data: ShmoBooking) => {
       // as long as you can only have one shmo booking at a time,
-      // the new booking should always be the active ones
+      // the new booking should always be the active one
       queryClient.setQueryData(GET_ACTIVE_SHMO_BOOKING_QUERY_KEY, data);
     },
   });

--- a/src/mobility/queries/use-send-shmo-booking-event-mutation.tsx
+++ b/src/mobility/queries/use-send-shmo-booking-event-mutation.tsx
@@ -1,0 +1,39 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {sendShmoBookingEvent} from '@atb/api/mobility';
+import {GET_ACTIVE_SHMO_BOOKING_QUERY_KEY} from './use-active-shmo-booking-query';
+import {
+  ShmoBooking,
+  ShmoBookingEvent,
+  ShmoBookingEventType,
+} from '@atb/api/types/mobility';
+import {getShmoBookingQueryKey} from './use-shmo-booking-query';
+
+type BookingEventArgs = {
+  bookingId: ShmoBooking['bookingId'];
+  shmoBookingEvent: ShmoBookingEvent;
+};
+
+export const useSendShmoBookingEventMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({bookingId, shmoBookingEvent}: BookingEventArgs) =>
+      sendShmoBookingEvent(bookingId, shmoBookingEvent),
+
+    onSuccess: (data: ShmoBooking, arg: BookingEventArgs) => {
+      switch (arg.shmoBookingEvent.event) {
+        case ShmoBookingEventType.START_FINISHING:
+          queryClient.setQueryData(GET_ACTIVE_SHMO_BOOKING_QUERY_KEY, data);
+          break;
+        case ShmoBookingEventType.FINISH:
+          queryClient.setQueryData(
+            getShmoBookingQueryKey(data.bookingId),
+            data,
+          );
+          break;
+        default:
+          break;
+      }
+    },
+  });
+};

--- a/src/mobility/queries/use-send-shmo-booking-event-mutation.tsx
+++ b/src/mobility/queries/use-send-shmo-booking-event-mutation.tsx
@@ -30,6 +30,7 @@ export const useSendShmoBookingEventMutation = () => {
             getShmoBookingQueryKey(data.bookingId),
             data,
           );
+          queryClient.invalidateQueries(GET_ACTIVE_SHMO_BOOKING_QUERY_KEY);
           break;
         default:
           break;

--- a/src/mobility/queries/use-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-shmo-booking-query.tsx
@@ -8,11 +8,14 @@ export const getShmoBookingQueryKey = (bookingId: ShmoBooking['bookingId']) => [
   bookingId,
 ];
 
-export const useShmoBookingQuery = (bookingId: ShmoBooking['bookingId']) => {
+export const useShmoBookingQuery = (bookingId?: ShmoBooking['bookingId']) => {
+  const bookingIdString = bookingId || '';
+  const isValidBookingId = !!bookingId && bookingIdString.trim() !== '';
   return useQuery({
-    queryKey: getShmoBookingQueryKey(bookingId),
-    queryFn: ({signal}) => getShmoBooking(bookingId, {signal}),
+    queryKey: getShmoBookingQueryKey(bookingIdString),
+    queryFn: ({signal}) => getShmoBooking(bookingIdString, {signal}),
     staleTime: ONE_HOUR_MS,
     cacheTime: ONE_HOUR_MS,
+    enabled: isValidBookingId,
   });
 };

--- a/src/mobility/queries/use-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-shmo-booking-query.tsx
@@ -2,18 +2,23 @@ import {useQuery} from '@tanstack/react-query';
 import {getShmoBooking} from '@atb/api/mobility';
 import {ONE_HOUR_MS} from '@atb/utils/durations.ts';
 import {ShmoBooking} from '@atb/api/types/mobility';
+import {useAcceptLanguage} from '@atb/api/use-accept-language';
 
-export const getShmoBookingQueryKey = (bookingId: ShmoBooking['bookingId']) => [
-  'GET_SHMO_BOOKING_QUERY_KEY',
-  bookingId,
-];
+export const getShmoBookingQueryKey = (
+  bookingId: ShmoBooking['bookingId'],
+  acceptLanguage: string,
+) => ['GET_SHMO_BOOKING_QUERY_KEY', bookingId, acceptLanguage];
 
 export const useShmoBookingQuery = (bookingId?: ShmoBooking['bookingId']) => {
+  const acceptLanguage = useAcceptLanguage();
+
   const bookingIdString = bookingId || '';
   const isValidBookingId = !!bookingId && bookingIdString.trim() !== '';
+
   return useQuery({
-    queryKey: getShmoBookingQueryKey(bookingIdString),
-    queryFn: ({signal}) => getShmoBooking(bookingIdString, {signal}),
+    queryKey: getShmoBookingQueryKey(bookingIdString, acceptLanguage),
+    queryFn: ({signal}) =>
+      getShmoBooking(bookingIdString, acceptLanguage, {signal}),
     staleTime: ONE_HOUR_MS,
     cacheTime: ONE_HOUR_MS,
     enabled: isValidBookingId,

--- a/src/mobility/queries/use-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-shmo-booking-query.tsx
@@ -1,0 +1,18 @@
+import {useQuery} from '@tanstack/react-query';
+import {getShmoBooking} from '@atb/api/mobility';
+import {ONE_HOUR_MS} from '@atb/utils/durations.ts';
+import {ShmoBooking} from '@atb/api/types/mobility';
+
+export const getShmoBookingQueryKey = (bookingId: ShmoBooking['bookingId']) => [
+  'GET_SHMO_BOOKING_QUERY_KEY',
+  bookingId,
+];
+
+export const useShmoBookingQuery = (bookingId: ShmoBooking['bookingId']) => {
+  return useQuery({
+    queryKey: getShmoBookingQueryKey(bookingId),
+    queryFn: ({signal}) => getShmoBooking(bookingId, {signal}),
+    staleTime: ONE_HOUR_MS,
+    cacheTime: ONE_HOUR_MS,
+  });
+};


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18891

<img width="200" src="https://github.com/user-attachments/assets/a2db62a7-a0a2-4e12-9eb7-b2b04fcef902" />

The endpoints are as described in the issue.
One extra added for getting a booking based on id instead of just the active one: `/mobility/v1/bookings/${bookingId}`.
This is needed because the summary of a booking should be shown when it is no longer active.

A new test feature has been added behind the `shmoDeepIntegrationEnabled` flag, which can be turned on in the debug menu and restarting the app.