### PR TITLE
fix: use light status bar content for auth browser

### DIFF
--- a/src/in-app-browser/in-app-browser.tsx
+++ b/src/in-app-browser/in-app-browser.tsx
@@ -2,6 +2,10 @@ import {StatusBar} from 'react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import {notifyBugsnag} from '../utils/bugsnag-utils';
 
+/**
+ * Wrapper around `react-native-inappbrowser-reborn`. See docs at:
+ * https://github.com/proyecto26/react-native-inappbrowser
+ */
 export async function openInAppBrowser(
   url: string,
   dismissButtonStyle: 'cancel' | 'close' | 'done',
@@ -9,7 +13,7 @@ export async function openInAppBrowser(
   onSuccess?: (url: string) => void,
 ) {
   const statusBarStyle = StatusBar.pushStackEntry({
-    barStyle: 'dark-content',
+    barStyle: successUrl ? 'light-content' : 'dark-content',
     animated: true,
   });
   try {


### PR DESCRIPTION
Follow up to https://github.com/AtB-AS/mittatb-app/pull/4711

On iOS, the status bar content should always be light when using the auth browser. On android the setting is ignored.

![Screenshot 2024-09-18 at 12 34 14](https://github.com/user-attachments/assets/8bdedb12-cda5-41b6-9db3-2ceded364fab)
