### PR TITLE
fix: save payment method whenever payment is completed

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-purchase-callback-listener.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-purchase-callback-listener.tsx
@@ -1,58 +1,13 @@
 import {useEffect} from 'react';
 import {Linking} from 'react-native';
-import {savePreviousPaymentMethodByUser} from '@atb/stacks-hierarchy/saved-payment-utils';
-import {PaymentType, listRecurringPayments} from '@atb/ticketing';
-import {useAuthState} from '@atb/auth';
-import {SavedPaymentMethodType} from '@atb/stacks-hierarchy/types';
 
-export const usePurchaseCallbackListener = (
-  onCallback: () => void,
-  paymentType?: PaymentType,
-  recurringPaymentId?: number,
-) => {
-  const {userId} = useAuthState();
+export const usePurchaseCallbackListener = (onCallback: () => void) => {
   useEffect(() => {
     const {remove: unsub} = Linking.addEventListener('url', async (event) => {
       if (event.url.includes('purchase-callback')) {
-        if (paymentType) {
-          await saveLastUsedPaymentMethod(
-            userId,
-            paymentType,
-            recurringPaymentId,
-          );
-        }
         onCallback();
       }
     });
     return () => unsub();
-  }, [onCallback, userId, paymentType, recurringPaymentId]);
-};
-
-const saveLastUsedPaymentMethod = async (
-  userId: string | undefined,
-  paymentType: PaymentType,
-  recurringPaymentId?: number,
-) => {
-  if (!userId) return;
-
-  if (!recurringPaymentId) {
-    await savePreviousPaymentMethodByUser(userId, {
-      savedType: SavedPaymentMethodType.Normal,
-      paymentType: paymentType,
-    });
-  } else {
-    try {
-      const recurringPaymentCards = await listRecurringPayments();
-      const card = recurringPaymentCards.find((c) => {
-        return c.id === recurringPaymentId;
-      });
-      if (card) {
-        await savePreviousPaymentMethodByUser(userId, {
-          savedType: SavedPaymentMethodType.Recurring,
-          paymentType: card.payment_type,
-          recurringCard: card,
-        });
-      }
-    } catch {} // Just fail silently, as saving payment method is not critical
-  }
+  }, [onCallback]);
 };


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/18885#issuecomment-2357887414

This fixes an issue introduced after I started using the openAuth in-app-browser and forgot to call saving of payment methods. To make this harder to miss in the future, this PR gathers saving payment method and closing the in-app-browser into one `onPaymentCompleted` callback function. This also means payment method is saved when fare contracts appear in the background, and the regular payment flow isn't completed.

I also moved the saveLastUsedPaymentMethod into saved-payment-utils, and renamed it to `saveLastUsedRecurringPaymentOrType` as I thought that made more sense together with `savePreviousPaymentMethodByUser`.