### PR TITLE
feat: Slightly increase notification icon size

### DIFF
--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -75,13 +75,13 @@ const getIndicatorSize = (
 ) => {
   switch (size) {
     case 'xSmall':
-      return (hasBorder ? 6 : 4) * fontScale;
+      return (hasBorder ? 6 : 5) * fontScale;
     case 'small':
-      return (hasBorder ? 8 : 6) * fontScale;
+      return (hasBorder ? 8 : 7) * fontScale;
     case 'normal':
-      return (hasBorder ? 10 : 6) * fontScale;
+      return (hasBorder ? 11 : 9) * fontScale;
     case 'large':
-      return (hasBorder ? 12 : 8) * fontScale;
+      return (hasBorder ? 13 : 11) * fontScale;
   }
 };
 


### PR DESCRIPTION
The notification indicator icon was a little small, so the sizes are increased a little bit.

A part of https://github.com/AtB-AS/kundevendt/issues/18947

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/d16fa9ea-9bf0-45f2-ae7b-803faa8bb3bd" /> | <img width="200" src="https://github.com/user-attachments/assets/ae499231-1462-482e-891c-7b9a99ac8e4d" /> |
