### PR TITLE
fix: hide originalPrice when it's not relevant

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
@@ -59,7 +59,7 @@ export function Summary({
           {t(PurchaseOverviewTexts.summary.price(formattedPrice))}
         </ThemeText>
       )}
-      {originalPrice !== price && (
+      {!isLoading && originalPrice !== price && (
         <ThemeText
           type="body__tertiary--strike"
           style={styles.originalPrice}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -119,6 +119,7 @@ const getOfferReducer =
           offerSearchTime: undefined,
           isSearchingOffer: false,
           totalPrice: 0,
+          originalPrice: 0,
           error: undefined,
           userProfilesWithCountAndOffer: [],
         };


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18978

- Sets originalPrice to 0 when CLEAR_OFFER is called, which fixes the issue from https://github.com/AtB-AS/kundevendt/issues/18978
- Hides the originalPrice text while loading offers. The normal price is hidden in that state, so it made sense to hide originalPrice as well.