### PR TITLE
Lower slow zone maximum speed

### DIFF
--- a/src/components/map/geofencing-zone-utils.ts
+++ b/src/components/map/geofencing-zone-utils.ts
@@ -130,7 +130,7 @@ export function addGeofencingZoneCustomProps(
           isSlowArea =
             rule.maximumSpeedKph !== undefined &&
             rule.maximumSpeedKph !== null &&
-            Number(rule.maximumSpeedKph) < 20;
+            Number(rule.maximumSpeedKph) < 13;
           isStationParking = !!rule.stationParking;
         }
 


### PR DESCRIPTION
15km/h is still pretty fast, so only show zones as slow if < 13km/h.

Edit: closer considerations needed. May need to talk to operators first.