### PR TITLE
test: e2e ticket fix

### DIFF
--- a/e2e/test/pageobjects/frontpage.page.ts
+++ b/e2e/test/pageobjects/frontpage.page.ts
@@ -1,5 +1,4 @@
 import ElementHelper from '../utils/element.helper.ts';
-import AppHelper from '../utils/app.helper.ts';
 
 class FrontPagePage {
   /**
@@ -110,25 +109,6 @@ class FrontPagePage {
   get noFavoriteInfo() {
     const noMsgId = `//*[@resource-id="noFavoriteWidget"]`;
     return $(noMsgId);
-  }
-
-  /**
-   * Remove dismissible global messages
-   */
-  async removeGlobalMessages() {
-    const closeId = `//*[@resource-id="globalMessageClose"]`;
-    // Check for n sec
-    const exists = await ElementHelper.isElementExisting(
-      'globalMessageClose',
-      3,
-    );
-    if (exists) {
-      const noGMs = await $$(closeId).length;
-      for (let i = 0; i < noGMs; i++) {
-        await $$(closeId)[0].click();
-        await AppHelper.pause(100);
-      }
-    }
   }
 
   /**

--- a/e2e/test/pageobjects/purchase.overview.page.ts
+++ b/e2e/test/pageobjects/purchase.overview.page.ts
@@ -109,20 +109,24 @@ class PurchaseOverviewPage {
     // Open
     await $(openZoneSelectorId).click();
 
-    // Note! Not working at the moment
-    await OnboardingPage.denyLocation();
-    await AlertHelper.alertCancel.click();
+    // Deny to share location
+    await OnboardingPage.denyLocationAndDontAskAgain();
+    await AlertHelper.systemSettingsCancel.click();
 
     // Set from zone
     await ElementHelper.waitForElement('text', 'Select stops/zones');
     await $(searchFromId).click();
     await ElementHelper.waitForElement('id', `tariffZone${zoneFrom}Button`);
+    // One click to opt out of the search input field
+    await $(zoneFromId).click();
     await $(zoneFromId).click();
     await ElementHelper.waitForElement('text', 'Select stops/zones');
 
     // Set to zone
     await $(searchToId).click();
     await ElementHelper.waitForElement('id', `tariffZone${zoneTo}Button`);
+    // One click to opt out of the search input field
+    await $(zoneToId).click();
     await $(zoneToId).click();
     await ElementHelper.waitForElement('id', `saveZonesButton`);
 

--- a/e2e/test/specs/frontpage.e2e.ts
+++ b/e2e/test/specs/frontpage.e2e.ts
@@ -27,7 +27,7 @@ describe('Frontpage', () => {
    */
   it('should remove messages', async () => {
     try {
-      await FrontPagePage.removeGlobalMessages();
+      await AppHelper.removeGlobalMessages();
       await AppHelper.pause(1000);
       await FrontPagePage.removeAnnouncements();
     } catch (errMsg) {

--- a/e2e/test/specs/ticket.e2e.ts
+++ b/e2e/test/specs/ticket.e2e.ts
@@ -68,6 +68,7 @@ describe('Ticket', () => {
       await TicketPage.chooseFareProduct('single');
       await AppHelper.removePopover();
       await ElementHelper.waitForElement('text', 'Single ticket, bus and tram');
+      await AppHelper.removeGlobalMessages();
 
       // Pre
       expect(await PurchaseOverviewPage.getZone()).toContain('Zone A');
@@ -78,11 +79,9 @@ describe('Ticket', () => {
       await PurchaseOverviewPage.decreaseTravellerCount('adult');
       await PurchaseOverviewPage.increaseTravellerCount('child');
       await PurchaseOverviewPage.confirmTravellers();
-      // Note! Not working at the moment due to the location prompts
-      /*
-        await PurchaseOverviewPage.setZones('B2', 'B2')
-        expect(await PurchaseOverviewPage.getZone()).toContain('Zone B2')
-     */
+      await PurchaseOverviewPage.setZones('B2', 'B2');
+      expect(await PurchaseOverviewPage.getZone()).toContain('Zone B2');
+
       expect(await PurchaseOverviewPage.getTraveller()).toContain('1 Child');
 
       const totalPrice: number = await PurchaseOverviewPage.getTotalPrice();
@@ -93,7 +92,9 @@ describe('Ticket', () => {
 
         // Ticket summary
         await ElementHelper.waitForElement('text', 'Ticket summary');
-        //expect(await PurchaseSummaryPage.summaryText.getText()).toContain('Valid in zone B2')
+        expect(await PurchaseSummaryPage.summaryText.getText()).toContain(
+          'Valid in zone B2',
+        );
         expect(
           await PurchaseSummaryPage.userProfileCountAndName.getText(),
         ).toContain('1 Child');

--- a/e2e/test/specs/ticket.e2e.ts
+++ b/e2e/test/specs/ticket.e2e.ts
@@ -146,6 +146,7 @@ describe('Ticket', () => {
       await TicketPage.chooseFareProduct('single');
       await AppHelper.removePopover();
       await ElementHelper.waitForElement('text', 'Single ticket, bus and tram');
+      await AppHelper.removeGlobalMessages();
 
       // Check on-behalf-of
       await PurchaseOverviewPage.selectTraveller();
@@ -173,6 +174,7 @@ describe('Ticket', () => {
       await TicketPage.chooseFareProduct('single');
       await AppHelper.removePopover();
       await ElementHelper.waitForElement('text', 'Single ticket, bus and tram');
+      await AppHelper.removeGlobalMessages();
 
       expect(await PurchaseOverviewPage.getTraveller()).toContain('1 Adult');
 

--- a/e2e/test/utils/alert.helper.ts
+++ b/e2e/test/utils/alert.helper.ts
@@ -25,6 +25,14 @@ class AlertHelper {
     const id = `//*[@resource-id="android:id/button2"]`;
     return $(id);
   }
+
+  /**
+   * Cancel button in system settings modal
+   */
+  get systemSettingsCancel() {
+    const id = `//*[@resource-id="android:id/button1"]`;
+    return $(id);
+  }
 }
 
 export default new AlertHelper();

--- a/e2e/test/utils/app.helper.ts
+++ b/e2e/test/utils/app.helper.ts
@@ -57,6 +57,26 @@ class AppHelper {
   }
 
   /**
+   * Remove dismissible global messages
+   */
+  async removeGlobalMessages() {
+    const closeId = `//*[@resource-id="globalMessageClose"]`;
+    // Check for n sec
+    const exists = await ElementHelper.isElementExisting(
+      'globalMessageClose',
+      3,
+    );
+    if (exists) {
+      const noGMs = await $$(closeId).length;
+      for (let i = 0; i < noGMs; i++) {
+        await $$(closeId)[0].click();
+        await this.pause(100);
+      }
+    }
+    await this.pause(200);
+  }
+
+  /**
    * Wait until the loading screen is finished
    * @param numberOfRetries used internally to count retries, max = 2
    */


### PR DESCRIPTION
The e2e-tests are currently failing (https://github.com/AtB-AS/mittatb-app/actions/runs/11119572718) since there are so many global messages on the ticket purchase screen in Staging (the purchase button is not visible). This PR:
- removes global messages before running the tests
- enables zone selection to the tests as I found the correct id to use in the location deny prompts