### PR TITLE
feat: add travel aid remote config flag

### DIFF
--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -41,6 +41,8 @@ export type RemoteConfig = {
   enable_tips_and_information: boolean;
   enable_token_fallback: boolean;
   enable_token_fallback_on_timeout: boolean;
+  enable_travel_aid: boolean;
+  enable_travel_aid_stop_button: boolean;
   enable_vehicle_operator_logo: boolean;
   enable_vehicles_in_map: boolean;
   enable_vipps_login: boolean;
@@ -107,6 +109,8 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_tips_and_information: false,
   enable_token_fallback: true,
   enable_token_fallback_on_timeout: true,
+  enable_travel_aid: false,
+  enable_travel_aid_stop_button: false,
   enable_vehicle_operator_logo: false,
   enable_vehicles_in_map: false,
   enable_vipps_login: false,
@@ -234,6 +238,12 @@ export function getConfig(): RemoteConfig {
   const enable_token_fallback_on_timeout =
     values['enable_token_fallback_on_timeout']?.asBoolean() ??
     defaultRemoteConfig.enable_token_fallback_on_timeout;
+  const enable_travel_aid =
+    values['enable_travel_aid']?.asBoolean() ??
+    defaultRemoteConfig.enable_travel_aid;
+  const enable_travel_aid_stop_button =
+    values['enable_travel_aid_stop_button']?.asBoolean() ??
+    defaultRemoteConfig.enable_travel_aid_stop_button;
   const enable_vehicle_operator_logo =
     values['enable_vehicle_operator_logo']?.asBoolean() ??
     defaultRemoteConfig.enable_vehicle_operator_logo;
@@ -344,6 +354,8 @@ export function getConfig(): RemoteConfig {
     enable_tips_and_information,
     enable_token_fallback,
     enable_token_fallback_on_timeout,
+    enable_travel_aid,
+    enable_travel_aid_stop_button,
     enable_vehicle_operator_logo,
     enable_vehicles_in_map,
     enable_vipps_login,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -70,7 +70,7 @@ import {useActivateTicketNowEnabledDebugOverride} from '@atb/fare-contracts/use-
 import {useBackendSmsAuthEnabledDebugOverride} from '@atb/auth/use-is-backend-sms-auth-enabled';
 import {useOnlyStopPlacesCheckboxEnabledDebugOverride} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen/use-only-stop-places-checkbox-enabled.tsx';
 import {useIsTravelAidEnabledDebugOverride} from '@atb/travel-aid/use-is-travel-aid-enabled';
-import {useIsTravelAidEnabledStopButtonDebugOverride} from '@atb/travel-aid/use-is-travel-aid-stop-button-enabled';
+import {useIsTravelAidStopButtonEnabledDebugOverride} from '@atb/travel-aid/use-is-travel-aid-stop-button-enabled';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -152,7 +152,7 @@ export const Profile_DebugInfoScreen = () => {
     useOnlyStopPlacesCheckboxEnabledDebugOverride();
   const travelAidEnabledDebugOverride = useIsTravelAidEnabledDebugOverride();
   const travelAidStopButtonEnabledDebugOverride =
-    useIsTravelAidEnabledStopButtonDebugOverride();
+    useIsTravelAidStopButtonEnabledDebugOverride();
 
   useEffect(() => {
     (async function () {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -69,6 +69,8 @@ import Bugsnag from '@bugsnag/react-native';
 import {useActivateTicketNowEnabledDebugOverride} from '@atb/fare-contracts/use-is-activate-now-enabled';
 import {useBackendSmsAuthEnabledDebugOverride} from '@atb/auth/use-is-backend-sms-auth-enabled';
 import {useOnlyStopPlacesCheckboxEnabledDebugOverride} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen/use-only-stop-places-checkbox-enabled.tsx';
+import {useIsTravelAidEnabledDebugOverride} from '@atb/travel-aid/use-is-travel-aid-enabled';
+import {useIsTravelAidEnabledStopButtonDebugOverride} from '@atb/travel-aid/use-is-travel-aid-stop-button-enabled';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -148,6 +150,9 @@ export const Profile_DebugInfoScreen = () => {
     useBackendSmsAuthEnabledDebugOverride();
   const onlyStopPlacesCheckboxEnabledDebugOverride =
     useOnlyStopPlacesCheckboxEnabledDebugOverride();
+  const travelAidEnabledDebugOverride = useIsTravelAidEnabledDebugOverride();
+  const travelAidStopButtonEnabledDebugOverride =
+    useIsTravelAidEnabledStopButtonDebugOverride();
 
   useEffect(() => {
     (async function () {
@@ -491,6 +496,18 @@ export const Profile_DebugInfoScreen = () => {
             <DebugOverride
               description="Enable only stop places checkbox"
               override={onlyStopPlacesCheckboxEnabledDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable travel aid feature"
+              override={travelAidEnabledDebugOverride}
+            />
+          </GenericSectionItem>
+          <GenericSectionItem>
+            <DebugOverride
+              description="Enable travel aid stop button"
+              override={travelAidStopButtonEnabledDebugOverride}
             />
           </GenericSectionItem>
         </Section>

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -24,6 +24,8 @@ export enum StorageModelKeysEnum {
   EnableTicketInformationDebugOverride = '@ATB_enable_ticket_information_debug_override',
   EnableTicketingAssistantOverride = '@ATB_enable_ticketing_assistant_override',
   EnableTipsAndInformationOverride = '@ATB_enable_tips_and_information_override',
+  EnableTravelAid = '@ATB_enable_travel_aid_debug_override',
+  EnableTravelAidStopButton = '@ATB_enable_travel_aid_stop_button_debug_override',
   EnableVehiclesInMapDebugOverride = '@ATB_enable_vehicles_in_map_debug_override',
   EnableSaveTicketRecipientsDebugOverride = '@ATB_enable_save_ticket_recipients_debug_override',
   EnableShmoDeepIntegrationDebugOverride = '@ATB_enable_shmo_deep_integration_debug_override',

--- a/src/travel-aid/use-is-travel-aid-enabled.tsx
+++ b/src/travel-aid/use-is-travel-aid-enabled.tsx
@@ -1,0 +1,17 @@
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useDebugOverride} from '@atb/debug';
+import {StorageModelKeysEnum} from '@atb/storage';
+
+export const useIsTravelAidEnabled = () => {
+  const {enable_travel_aid} = useRemoteConfig();
+  const [debugOverride, _, debugOverrideReady] =
+    useIsTravelAidEnabledDebugOverride();
+  return [
+    debugOverride !== undefined ? debugOverride : enable_travel_aid,
+    debugOverrideReady,
+  ];
+};
+
+export const useIsTravelAidEnabledDebugOverride = () => {
+  return useDebugOverride(StorageModelKeysEnum.EnableTravelAid);
+};

--- a/src/travel-aid/use-is-travel-aid-stop-button-enabled.tsx
+++ b/src/travel-aid/use-is-travel-aid-stop-button-enabled.tsx
@@ -5,13 +5,13 @@ import {StorageModelKeysEnum} from '@atb/storage';
 export const useIsTravelAidStopButtonEnabled = () => {
   const {enable_travel_aid_stop_button} = useRemoteConfig();
   const [debugOverride, _, debugOverrideReady] =
-    useIsTravelAidEnabledStopButtonDebugOverride();
+    useIsTravelAidStopButtonEnabledDebugOverride();
   return [
     debugOverride !== undefined ? debugOverride : enable_travel_aid_stop_button,
     debugOverrideReady,
   ];
 };
 
-export const useIsTravelAidEnabledStopButtonDebugOverride = () => {
+export const useIsTravelAidStopButtonEnabledDebugOverride = () => {
   return useDebugOverride(StorageModelKeysEnum.EnableTravelAidStopButton);
 };

--- a/src/travel-aid/use-is-travel-aid-stop-button-enabled.tsx
+++ b/src/travel-aid/use-is-travel-aid-stop-button-enabled.tsx
@@ -1,0 +1,17 @@
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
+import {useDebugOverride} from '@atb/debug';
+import {StorageModelKeysEnum} from '@atb/storage';
+
+export const useIsTravelAidStopButtonEnabled = () => {
+  const {enable_travel_aid_stop_button} = useRemoteConfig();
+  const [debugOverride, _, debugOverrideReady] =
+    useIsTravelAidEnabledStopButtonDebugOverride();
+  return [
+    debugOverride !== undefined ? debugOverride : enable_travel_aid_stop_button,
+    debugOverrideReady,
+  ];
+};
+
+export const useIsTravelAidEnabledStopButtonDebugOverride = () => {
+  return useDebugOverride(StorageModelKeysEnum.EnableTravelAidStopButton);
+};


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/17891

- Adds `enable_travel_aid` and `enable_travel_aid_stop_button` to remote config staging.
- Adds related hook, default value, and debug override to app. (see screenshots below)

### Debug Override screen
<img src="https://github.com/user-attachments/assets/c745b0c6-c53e-4f47-91ed-be1a6dacc380" width="300" />

### Remote config status
<img src="https://github.com/user-attachments/assets/18e34e10-d3d6-4225-8eb9-fcb5d7714d89" width="300" />
