### PR TITLE
Support tGlobal

### DIFF
--- a/eslint-rules/translations-warning.js
+++ b/eslint-rules/translations-warning.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   create: function (context) {
     const config = {
-      translateFunctionIdentifier: 't',
+      translateFunctionIdentifiers: ['t', 'tStatic'],
       translateModulePrefix: '@atb/translations',
     };
 
@@ -33,9 +33,9 @@ module.exports = {
       },
       Identifier(node) {
         if (!identifiers.hasOwnProperty(node.name)) return;
-        const validParent = parentCallExpressionWithIdentifier(
+        const validParent = parentCallExpressionWithIdentifiers(
           node.parent,
-          config.translateFunctionIdentifier,
+          config.translateFunctionIdentifiers,
         );
         if (node.parent.type !== 'MemberExpression' || validParent) {
           return;
@@ -48,7 +48,7 @@ module.exports = {
             'Expected {{ identifier }} to be argument of translate function {{ translateFunction }}',
           data: {
             identifier: name,
-            translateFunction: config.translateFunctionIdentifier,
+            translateFunction: config.translateFunctionIdentifiers.join(' or '),
           },
         });
       },
@@ -56,16 +56,16 @@ module.exports = {
   },
 };
 
-function parentCallExpressionWithIdentifier(node, identifier) {
+function parentCallExpressionWithIdentifiers(node, identifiers) {
   if (!node) return false;
   if (
     node.type === 'CallExpression' &&
     node.callee &&
-    node.callee.name === identifier
+    identifiers.includes(node.callee.name)
   ) {
     return node;
   }
-  return parentCallExpressionWithIdentifier(node.parent, identifier);
+  return parentCallExpressionWithIdentifiers(node.parent, identifiers);
 }
 
 function translationTextFullName(node) {

--- a/eslint-rules/translations-warning.js
+++ b/eslint-rules/translations-warning.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   create: function (context) {
     const config = {
-      translateFunctionIdentifiers: ['t', 'tStatic'],
+      translateFunctionIdentifiers: ['t', 'tGlobal'],
       translateModulePrefix: '@atb/translations',
     };
 

--- a/src/LocaleProvider.tsx
+++ b/src/LocaleProvider.tsx
@@ -6,8 +6,9 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_REGION,
   FALLBACK_LANGUAGE,
+  setStaticLanguage,
 } from '@atb/translations/commons';
-import { AppState } from 'react-native';
+import {AppState} from 'react-native';
 
 export type Locale = {
   language: Language;
@@ -68,6 +69,8 @@ function useLocale(): Locale {
       setLanguage(mapLanguageStringToEnum(userPreferencedLanguage));
     }
   }, [useSystemLanguage, userPreferencedLanguage, systemLocale]);
+
+  useEffect(() => setStaticLanguage(language), [language]);
 
   return {
     language: language,

--- a/src/LocaleProvider.tsx
+++ b/src/LocaleProvider.tsx
@@ -11,7 +11,6 @@ import {
 import {AppState} from 'react-native';
 
 let globalLanguage: Language = DEFAULT_LANGUAGE;
-export const getGlobalLanguage = () => globalLanguage;
 const setGlobalLanguage = (language: Language) => {
   globalLanguage = language;
 };

--- a/src/LocaleProvider.tsx
+++ b/src/LocaleProvider.tsx
@@ -63,14 +63,13 @@ function useLocale(): Locale {
 
   // listen for updates to language settings
   useEffect(() => {
-    if (useSystemLanguage) {
-      setLanguage(systemLocale.language);
-    } else {
-      setLanguage(mapLanguageStringToEnum(userPreferencedLanguage));
-    }
-  }, [useSystemLanguage, userPreferencedLanguage, systemLocale]);
+    const newLanguage = useSystemLanguage
+      ? systemLocale.language
+      : mapLanguageStringToEnum(userPreferencedLanguage);
 
-  useEffect(() => setStaticLanguage(language), [language]);
+    setStaticLanguage(newLanguage);
+    setLanguage(newLanguage);
+  }, [useSystemLanguage, userPreferencedLanguage, systemLocale]);
 
   return {
     language: language,

--- a/src/LocaleProvider.tsx
+++ b/src/LocaleProvider.tsx
@@ -11,9 +11,6 @@ import {
 import {AppState} from 'react-native';
 
 let globalLanguage: Language = DEFAULT_LANGUAGE;
-const setGlobalLanguage = (language: Language) => {
-  globalLanguage = language;
-};
 /**
  * tGlobal can be used instead of the t function for when you don't want
  * language changes to potentially retrigger an action (such as e.g. an alert box)
@@ -78,7 +75,7 @@ function useLocale(): Locale {
       ? systemLocale.language
       : mapLanguageStringToEnum(userPreferencedLanguage);
 
-    setGlobalLanguage(newLanguage);
+    globalLanguage = newLanguage;
     setLanguage(newLanguage);
   }, [useSystemLanguage, userPreferencedLanguage, systemLocale]);
 

--- a/src/LocaleProvider.tsx
+++ b/src/LocaleProvider.tsx
@@ -1,4 +1,5 @@
 import {getLocales} from 'react-native-localize';
+import {TFunc} from '@leile/lobo-t';
 import React, {createContext, useContext, useEffect, useState} from 'react';
 import {Language} from '@atb/translations';
 import {usePreferences} from '@atb/preferences';
@@ -6,9 +7,20 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_REGION,
   FALLBACK_LANGUAGE,
-  setStaticLanguage,
 } from '@atb/translations/commons';
 import {AppState} from 'react-native';
+
+let globalLanguage: Language = DEFAULT_LANGUAGE;
+export const getGlobalLanguage = () => globalLanguage;
+const setGlobalLanguage = (language: Language) => {
+  globalLanguage = language;
+};
+/**
+ * tGlobal can be used instead of the t function for when you don't want
+ * language changes to potentially retrigger an action (such as e.g. an alert box)
+ */
+export const tGlobal: TFunc<typeof Language> = (translatable) =>
+  translatable[globalLanguage];
 
 export type Locale = {
   language: Language;
@@ -67,7 +79,7 @@ function useLocale(): Locale {
       ? systemLocale.language
       : mapLanguageStringToEnum(userPreferencedLanguage);
 
-    setStaticLanguage(newLanguage);
+    setGlobalLanguage(newLanguage);
     setLanguage(newLanguage);
   }, [useSystemLanguage, userPreferencedLanguage, systemLocale]);
 

--- a/src/translations/commons.ts
+++ b/src/translations/commons.ts
@@ -24,6 +24,20 @@ export const useTranslation: typeof lobot.useTranslation = () => {
   };
 };
 
+let currentStaticLanguage: Language = DEFAULT_LANGUAGE;
+/**
+ * tStatic can be used instead of the t function for when you don't want
+ * language changes to potentially retrigger an action (such as e.g. an alert box)
+ */
+export const tStatic: TFunc<typeof Language> = (translatable) =>
+  translatable[currentStaticLanguage];
+/**
+ * update language for tStatic
+ */
+export const setStaticLanguage = (language: Language) => {
+  currentStaticLanguage = language;
+};
+
 export type TranslateFunction = TFunc<typeof Language>;
 export function translation(
   norwegian: string,

--- a/src/translations/commons.ts
+++ b/src/translations/commons.ts
@@ -24,20 +24,6 @@ export const useTranslation: typeof lobot.useTranslation = () => {
   };
 };
 
-let currentStaticLanguage: Language = DEFAULT_LANGUAGE;
-/**
- * tStatic can be used instead of the t function for when you don't want
- * language changes to potentially retrigger an action (such as e.g. an alert box)
- */
-export const tStatic: TFunc<typeof Language> = (translatable) =>
-  translatable[currentStaticLanguage];
-/**
- * update language for tStatic
- */
-export const setStaticLanguage = (language: Language) => {
-  currentStaticLanguage = language;
-};
-
 export type TranslateFunction = TFunc<typeof Language>;
 export function translation(
   norwegian: string,


### PR DESCRIPTION
As @gorandalum discovered [here](https://github.com/AtB-AS/mittatb-app/pull/4727#discussion_r1790061992), the current `t` function can be problematic when you don't want it to re-trigger an action.

This PR introduces a new function `tGlobal`, which will give the correct translation when called, but not re-trigger anything on language changes.

`tGlobal ` is _not_ required as part of dependency arrays.
