### PR TITLE
refactor: Debug auth info not directly from Firebase Auth lib

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -28,7 +28,7 @@ import Bugsnag from '@bugsnag/react-native';
 import isEqual from 'lodash.isequal';
 import {mapAuthenticationType} from './utils';
 import {useClearQueriesOnUserChange} from './use-clear-queries-on-user-change';
-import {useUpdateIntercomOnUserChange} from "@atb/auth/use-update-intercom-on-user-change";
+import {useUpdateIntercomOnUserChange} from '@atb/auth/use-update-intercom-on-user-change';
 import {useIsBackendSmsAuthEnabled} from './use-is-backend-sms-auth-enabled';
 import {useLocaleContext} from '@atb/LocaleProvider';
 
@@ -133,6 +133,10 @@ type AuthContextState = {
     token: string,
   ) => Promise<VippsSignInErrorCode | undefined>;
   retryAuth: () => void;
+  debug: {
+    user?: FirebaseAuthTypes.User;
+    idTokenResult?: FirebaseAuthTypes.IdTokenResult;
+  };
 };
 
 const AuthContext = createContext<AuthContextState | undefined>(undefined);
@@ -148,7 +152,7 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   useFetchIdTokenWithCustomClaims(state, dispatch);
 
   useUpdateAuthLanguageOnChange();
-  useUpdateIntercomOnUserChange(state)
+  useUpdateIntercomOnUserChange(state);
 
   const retryAuth = useCallback(() => {
     dispatch({type: 'RESET_AUTH_STATUS'});
@@ -199,6 +203,10 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
         authenticationType: mapAuthenticationType(state.user),
         signInWithCustomToken: useCallback(authSignInWithCustomToken, []),
         retryAuth,
+        debug: {
+          user: state.user,
+          idTokenResult: state.idToken,
+        },
       }}
     >
       {children}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -6,7 +6,6 @@ import {Alert, Linking, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {useAuthState} from '@atb/auth';
-import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {KeyValuePair, storage, StorageModelKeysEnum} from '@atb/storage';
 import {useMobileTokenContextState} from '@atb/mobile-token';
 import {usePreferences, UserPreferences} from '@atb/preferences';
@@ -97,11 +96,7 @@ export const Profile_DebugInfoScreen = () => {
     getPrivacyTermsUrl,
   } = useBeaconsState();
   const {resetDismissedGlobalMessages} = useGlobalMessagesState();
-  const {userId} = useAuthState();
-  const user = auth().currentUser;
-  const [idToken, setIdToken] = useState<
-    FirebaseAuthTypes.IdTokenResult | undefined
-  >(undefined);
+  const {userId, retryAuth, debug: {user, idTokenResult}} = useAuthState();
 
   const flexibleTransportDebugOverride = useFlexibleTransportDebugOverride();
   const flexibleTransportAccessModeDebugOverride = useDebugOverride(
@@ -153,13 +148,6 @@ export const Profile_DebugInfoScreen = () => {
   const travelAidEnabledDebugOverride = useIsTravelAidEnabledDebugOverride();
   const travelAidStopButtonEnabledDebugOverride =
     useIsTravelAidStopButtonEnabledDebugOverride();
-
-  useEffect(() => {
-    (async function () {
-      const idToken = await user?.getIdTokenResult();
-      setIdToken(idToken);
-    })();
-  }, [user]);
 
   const {
     tokens,
@@ -289,8 +277,8 @@ export const Profile_DebugInfoScreen = () => {
           />
 
           <LinkSectionItem
-            text="Force refresh id token"
-            onPress={() => auth().currentUser?.getIdToken(true)}
+            text="Force refresh auth state"
+            onPress={retryAuth}
           />
 
           <LinkSectionItem
@@ -532,8 +520,8 @@ export const Profile_DebugInfoScreen = () => {
             showIconText={true}
             expandContent={
               <View>
-                {!!idToken ? (
-                  Object.entries(idToken).map(([key, value]) => (
+                {!!idTokenResult ? (
+                  Object.entries(idTokenResult).map(([key, value]) => (
                     <MapEntry key={key} title={key} value={value} />
                   ))
                 ) : (


### PR DESCRIPTION
This made the presentation of Firestore Auth data in the debug menu
be out of sync with what the user actually experienced.

Reused the pattern from MobileTokenContext where parameters only for
debugging in the debug screen is exported through a sub-field
'debug'.
