### PR TITLE
feat: Axios client not use Firebase Auth directly

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -35,7 +35,7 @@ import {useLocaleContext} from '@atb/LocaleProvider';
 export type AuthReducerState = {
   authStatus: AuthStatus;
   user?: FirebaseAuthTypes.User;
-  idToken?: FirebaseAuthTypes.IdTokenResult;
+  idTokenResult?: FirebaseAuthTypes.IdTokenResult;
   phoneNumberToBeVerified?: string;
   /** @deprecated Remove once legacy login is removed */
   confirmationHandler?: FirebaseAuthTypes.ConfirmationResult;
@@ -75,7 +75,7 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
       }
     }
     case 'SET_ID_TOKEN': {
-      const tokenSub = action.idToken.claims['sub'];
+      const tokenSub = action.idTokenResult.claims['sub'];
       if (tokenSub !== prevState.user?.uid) {
         /*
         This is a precaution against race conditions. It might be that there has
@@ -91,16 +91,16 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
         );
         return prevState;
       }
-      const customerNumber = action.idToken.claims['customer_number'];
+      const customerNumber = action.idTokenResult.claims['customer_number'];
       const authStatus = customerNumber ? 'authenticated' : 'creating-account';
       Bugsnag.leaveBreadcrumb('Retrieved id token', {
         customerNumber,
         authStatus,
       });
-      idTokenGlobal = action.idToken.token;
+      idTokenGlobal = action.idTokenResult.token;
       return {
         ...prevState,
-        idToken: action.idToken,
+        idTokenResult: action.idTokenResult,
         authStatus: 'authenticated',
       };
     }
@@ -170,8 +170,8 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
         authStatus: state.authStatus,
         userId: state.user?.uid,
         phoneNumber: state.user?.phoneNumber || undefined,
-        customerNumber: state.idToken?.claims['customer_number'],
-        abtCustomerId: state.idToken?.claims['abt_id'],
+        customerNumber: state.idTokenResult?.claims['customer_number'],
+        abtCustomerId: state.idTokenResult?.claims['abt_id'],
         signInWithPhoneNumber: useCallback(
           async (phoneNumberWithPrefix: string, forceResend?: boolean) => {
             if (!backendSmsEnabled) {

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -28,7 +28,7 @@ import Bugsnag from '@bugsnag/react-native';
 import isEqual from 'lodash.isequal';
 import {mapAuthenticationType} from './utils';
 import {useClearQueriesOnUserChange} from './use-clear-queries-on-user-change';
-import {useUpdateIntercomOnUserChange} from "@atb/auth/use-update-intercom-on-user-change";
+import {useUpdateIntercomOnUserChange} from '@atb/auth/use-update-intercom-on-user-change';
 import {useIsBackendSmsAuthEnabled} from './use-is-backend-sms-auth-enabled';
 import {useLocaleContext} from '@atb/LocaleProvider';
 
@@ -45,6 +45,12 @@ type AuthReducer = (
   prevState: AuthReducerState,
   action: AuthReducerAction,
 ) => AuthReducerState;
+
+let idTokenGlobal: string | undefined = undefined;
+export const getIdTokenGlobal = () => idTokenGlobal;
+
+let currentUserIdGlobal: string | undefined = undefined;
+export const getCurrentUserIdGlobal = () => currentUserIdGlobal;
 
 const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
   switch (action.type) {
@@ -63,6 +69,8 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
           userId: action.user.uid,
           authType: mapAuthenticationType(action.user),
         });
+        currentUserIdGlobal = action.user.uid;
+        idTokenGlobal = undefined;
         return {user: action.user, authStatus: 'fetching-id-token'};
       }
     }
@@ -89,6 +97,7 @@ const authReducer: AuthReducer = (prevState, action): AuthReducerState => {
         customerNumber,
         authStatus,
       });
+      idTokenGlobal = action.idToken.token;
       return {
         ...prevState,
         idToken: action.idToken,
@@ -148,7 +157,7 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   useFetchIdTokenWithCustomClaims(state, dispatch);
 
   useUpdateAuthLanguageOnChange();
-  useUpdateIntercomOnUserChange(state)
+  useUpdateIntercomOnUserChange(state);
 
   const retryAuth = useCallback(() => {
     dispatch({type: 'RESET_AUTH_STATUS'});

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -15,7 +15,7 @@ export type AuthReducerAction =
       confirmationHandler: FirebaseAuthTypes.ConfirmationResult;
     }
   | {type: 'SET_USER'; user: FirebaseAuthTypes.User}
-  | {type: 'SET_ID_TOKEN'; idToken: FirebaseAuthTypes.IdTokenResult}
+  | {type: 'SET_ID_TOKEN'; idTokenResult: FirebaseAuthTypes.IdTokenResult}
   | {type: 'SET_FETCH_ID_TOKEN_TIMEOUT'}
   | {type: 'RETRY_FETCH_ID_TOKEN'}
   | {type: 'RESET_AUTH_STATUS'};

--- a/src/auth/use-fetch-id-token-with-custom-claims.ts
+++ b/src/auth/use-fetch-id-token-with-custom-claims.ts
@@ -62,7 +62,7 @@ export const useFetchIdTokenWithCustomClaims = (
 
   useEffect(() => {
     if (query.data) {
-      dispatch({type: 'SET_ID_TOKEN', idToken: query.data});
+      dispatch({type: 'SET_ID_TOKEN', idTokenResult: query.data});
     }
   }, [dispatch, query.data]);
 


### PR DESCRIPTION
Use the Auth state values from the FirebaseAuthContext. They are
exported using the global variable pattern, to not make client
dependant on the React state.
