### PR TITLE
refactor: Global var instead of ref for current coordinates

### DIFF
--- a/src/GeolocationContext.tsx
+++ b/src/GeolocationContext.tsx
@@ -4,7 +4,6 @@ import React, {
   useContext,
   useEffect,
   useReducer,
-  useRef,
 } from 'react';
 import {Alert, Linking, Platform} from 'react-native';
 import {isLocationEnabled} from 'react-native-device-info';
@@ -146,7 +145,6 @@ export const GeolocationContextProvider: React.FC = ({children}) => {
   const appStatus = useAppStateStatus();
   const {t} = useTranslation();
   const geoLocationName = t(dictionary.myPosition); // TODO: Other place for this fallback
-  const currentCoordinatesRef = useRef<Coordinates | undefined>();
   const {updateMetadata} = useIntercomMetadata();
 
   const openSettingsAlert = useCallback(() => {
@@ -285,17 +283,13 @@ export const GeolocationContextProvider: React.FC = ({children}) => {
     }
   }, [state.status, updateMetadata]);
 
-  useEffect(() => {
-    currentCoordinatesRef.current = state.location?.coordinates;
-  }, [state.location?.coordinates]);
-
   const getCurrentCoordinates = useCallback(
     (
       askForPermissionIfBlocked: boolean | undefined = false,
     ): Promise<Coordinates | undefined> => {
       return new Promise(async (resolve) => {
-        if (currentCoordinatesRef.current) {
-          resolve(currentCoordinatesRef.current);
+        if (currentCoordinatesGlobal) {
+          resolve(currentCoordinatesGlobal);
         } else {
           if (state.status === 'blocked' && !askForPermissionIfBlocked) {
             resolve(undefined);

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,4 +1,7 @@
-import {useGeolocationState} from '@atb/GeolocationContext';
+import {
+  getCurrentCoordinatesGlobal,
+  useGeolocationState,
+} from '@atb/GeolocationContext';
 import {FOCUS_ORIGIN} from '@atb/api/geocoder';
 import {StyleSheet} from '@atb/theme';
 import {MapRoute} from '@atb/travel-details-map-screen/components/MapRoute';
@@ -41,7 +44,7 @@ import {ShmoTesting} from './components/mobility/ShmoTesting';
 
 export const Map = (props: MapProps) => {
   const {initialLocation, includeSnackbar} = props;
-  const {currentCoordinatesRef, getCurrentCoordinates} = useGeolocationState();
+  const {getCurrentCoordinates} = useGeolocationState();
   const mapCameraRef = useRef<MapboxGL.Camera>(null);
   const mapViewRef = useRef<MapboxGL.MapView>(null);
   const styles = useMapStyles();
@@ -51,8 +54,8 @@ export const Map = (props: MapProps) => {
     () =>
       initialLocation && initialLocation?.resultType !== 'geolocation'
         ? initialLocation.coordinates
-        : currentCoordinatesRef?.current || FOCUS_ORIGIN,
-    [currentCoordinatesRef, initialLocation],
+        : getCurrentCoordinatesGlobal() || FOCUS_ORIGIN,
+    [initialLocation],
   );
 
   const {mapLines, selectedCoordinates, onMapClick, selectedFeature} =


### PR DESCRIPTION
Using a global variable is easier for clients since they don't need
to go through the context. Also they don't need to provide the ref
in the dependency array of hooks, which the linter demands even
though it doesn't make a difference.
