### PR TITLE
chore: update build tools version on script

### DIFF
--- a/scripts/android/replace-bundle.sh
+++ b/scripts/android/replace-bundle.sh
@@ -55,8 +55,8 @@ else
     apktool b decompiled-apk -o temp-$APK_FILE_NAME
 
     echo "The APK must be aligned to 4 byte boundaries to work on Android"
-    /usr/local/lib/android/sdk/build-tools/33.0.0/zipalign -p -f 4 temp-$APK_FILE_NAME $APK_FILE_NAME
+    /usr/local/lib/android/sdk/build-tools/34.0.0/zipalign -p -f 4 temp-$APK_FILE_NAME $APK_FILE_NAME
 
     echo "Re-sign APK"
-    /usr/local/lib/android/sdk/build-tools/33.0.0/apksigner sign --ks $KEYSTORE_PATH --ks-pass pass:"$KEYSTORE_PASS" --key-pass pass:"$KEY_PASS" --ks-key-alias $KEY_ALIAS $APK_FILE_NAME
+    /usr/local/lib/android/sdk/build-tools/34.0.0/apksigner sign --ks $KEYSTORE_PATH --ks-pass pass:"$KEYSTORE_PASS" --key-pass pass:"$KEY_PASS" --ks-key-alias $KEY_ALIAS $APK_FILE_NAME
 fi


### PR DESCRIPTION
Possible fix for build issue such as https://github.com/AtB-AS/mittatb-app/actions/runs/11272142291

The current build-tools version we use is 34.0.0, so we probably should also update the version on the script.

<img width="279" alt="image" src="https://github.com/user-attachments/assets/86671647-d021-49ba-b40e-42cc39300243">
