### PR TITLE
refactor: Remove FirebaseAuth import in OnboardContext

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -4,4 +4,5 @@ export type {
   PhoneSignInErrorCode,
   VippsSignInErrorCode,
   AuthStatus,
+  AuthStateChangeListenerCallback,
 } from './types';

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -33,3 +33,7 @@ export type VippsSignInErrorCode =
   | 'access_denied'
   | 'outdated_app_version'
   | 'unknown_error';
+
+export type AuthStateChangeListenerCallback = (
+    user: FirebaseAuthTypes.User | null,
+) => void;

--- a/src/auth/use-subscribe-to-auth-user-change.ts
+++ b/src/auth/use-subscribe-to-auth-user-change.ts
@@ -1,6 +1,6 @@
 import {Dispatch, useEffect} from 'react';
-import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
-import {AuthReducerAction} from './types';
+import auth from '@react-native-firebase/auth';
+import {AuthReducerAction, AuthStateChangeListenerCallback} from './types';
 import Bugsnag from '@bugsnag/react-native';
 import {useResubscribeToggle} from '@atb/utils/use-resubscribe-toggle';
 
@@ -38,7 +38,7 @@ export const useSubscribeToAuthUserChange = (
 };
 
 export const useOnAuthStateChanged = (
-  callback: (user: FirebaseAuthTypes.User | null) => void,
+  callback: AuthStateChangeListenerCallback,
 ) => {
   useEffect(() => {
     const unsubscribe = auth().onAuthStateChanged(callback);

--- a/src/onboarding/OnboardingContext.tsx
+++ b/src/onboarding/OnboardingContext.tsx
@@ -24,11 +24,10 @@ import {
   usePushNotificationsEnabled,
 } from '@atb/notifications';
 import {useGeolocationState} from '@atb/GeolocationContext';
-import {useAuthState} from '@atb/auth';
+import {AuthStateChangeListenerCallback, useAuthState} from '@atb/auth';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {useShouldShowShareTravelHabitsScreen} from '@atb/beacons/use-should-show-share-travel-habits-screen';
 import {useMobileTokenContextState} from '@atb/mobile-token';
-import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {useOnAuthStateChanged} from '@atb/auth/use-subscribe-to-auth-user-change';
 
 export type OnboardingState = {
@@ -175,8 +174,8 @@ export const OnboardingContextProvider: React.FC = ({children}) => {
     [loadedOnboardingSections],
   );
 
-  const onAuthStateChanged = useCallback(
-    (user: FirebaseAuthTypes.User | null) => {
+  const onAuthStateChanged: AuthStateChangeListenerCallback = useCallback(
+    (user) => {
       if (user && !user.isAnonymous) {
         completeOnboardingSection('userCreation');
       }


### PR DESCRIPTION
This is done to improve encapsulation of Firebase Auth in the
auth module.
