### PR TITLE
feat: Accept onlyOnce param for useDoOnceWhen and add tests

### DIFF
--- a/src/utils/use-do-once-when.ts
+++ b/src/utils/use-do-once-when.ts
@@ -1,19 +1,36 @@
 import {useEffect, useRef} from 'react';
+/**
+ * @param fn The function to run.
+ * @param condition fn will be run when condition is true, unless it has already run once and onlyOnce is true.
+ * @param onlyOnce Set to true if fn should not be re-run after condition goes back between true and false.
+ */
+export function useDoOnceWhen(
+  fn: () => void,
+  condition: boolean,
+  onlyOnce?: boolean,
+) {
+  const hasRunRef = useRef(false);
 
-export function useDoOnceWhen(fn: () => void, condition: boolean) {
-  const firstTimeRef = useRef(true);
   const fnRef = useRef(fn);
   useEffect(() => {
     fnRef.current = fn;
   }, [fn]);
 
+  const onlyOnceRef = useRef(onlyOnce);
   useEffect(() => {
-    if (firstTimeRef.current && condition) {
-      firstTimeRef.current = false;
+    onlyOnceRef.current = onlyOnce;
+  }, [onlyOnce]);
+
+  useEffect(() => {
+    if (!hasRunRef.current && condition) {
       fnRef.current();
+      hasRunRef.current = true;
     }
+
     return () => {
-      firstTimeRef.current = true;
+      if (!onlyOnceRef.current) {
+        hasRunRef.current = false;
+      }
     };
   }, [condition]);
 }


### PR DESCRIPTION
This allows a parameter to only run an action once, even if the condition keeps toggling between `true` and `false`.

More discussion can be found [here](https://github.com/AtB-AS/mittatb-app/pull/4727#discussion_r1793339837).