### PR TITLE
test: run app tests on previous ubuntu

### DIFF
--- a/.github/workflows/test-e2e-android.yml
+++ b/.github/workflows/test-e2e-android.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   run_tests:
     name: E2E test Android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: atb
     timeout-minutes: 90
     steps:

--- a/.github/workflows/test-performance-android.yml
+++ b/.github/workflows/test-performance-android.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   run_tests:
     name: Performance measures for Android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       TESTED_VERSION: ${{ steps.get-appcenter-apk.outputs.TESTED_VERSION }}
     environment: atb


### PR DESCRIPTION
The emulator action `reactivecircus/android-emulator-runner@v2` doesn't support ubuntu 24 yet. Will thus have to use ubuntu 22.04 since ubuntu-latest now has become ubuntu 24.