### PR TITLE
feat: Remote Config flag for id token retry count

### DIFF
--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -67,7 +67,6 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
       await remoteConfig().fetchAndActivate();
       const currentConfig = await getConfig();
       console.log("CURRENT CONFIG", currentConfig)
-      setConfig(currentConfig);
       setFetchError(false);
     } catch (e) {
       setFetchError(true);

--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -66,6 +66,7 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
     try {
       await remoteConfig().fetchAndActivate();
       const currentConfig = await getConfig();
+      console.log("CURRENT CONFIG", currentConfig)
       setConfig(currentConfig);
       setFetchError(false);
     } catch (e) {

--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -66,7 +66,7 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
     try {
       await remoteConfig().fetchAndActivate();
       const currentConfig = await getConfig();
-      console.log("CURRENT CONFIG", currentConfig)
+      setConfig(currentConfig);
       setFetchError(false);
     } catch (e) {
       setFetchError(true);

--- a/src/auth/use-fetch-id-token-with-custom-claims.ts
+++ b/src/auth/use-fetch-id-token-with-custom-claims.ts
@@ -4,8 +4,7 @@ import {AuthReducerState} from '@atb/auth/AuthContext';
 import {useQuery} from '@tanstack/react-query';
 import {logToBugsnag, notifyBugsnag} from '@atb/utils/bugsnag-utils';
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
-
-const RETRY_COUNT = 3;
+import {useRemoteConfig} from '@atb/RemoteConfigContext.tsx';
 
 /**
  * Variable signalling whether the next fetch id token request should be force
@@ -29,6 +28,8 @@ export const useFetchIdTokenWithCustomClaims = (
   useEffect(() => {
     shouldForceRefresh = false;
   }, [state.user]);
+
+  const {fetch_id_token_retry_count: retryCount} = useRemoteConfig();
 
   const query = useQuery({
     queryKey: ['FETCH_ID_TOKEN'],
@@ -56,7 +57,7 @@ export const useFetchIdTokenWithCustomClaims = (
       return idToken;
     },
     enabled: !!state.user && state.authStatus === 'fetching-id-token',
-    retry: RETRY_COUNT,
+    retry: retryCount,
     retryDelay: (attempt) => (attempt + 1) * 2000,
   });
 
@@ -69,7 +70,9 @@ export const useFetchIdTokenWithCustomClaims = (
   useEffect(() => {
     if (query.error) {
       notifyBugsnag(
-        `No id token with custom claims received after ${RETRY_COUNT} retries`,
+        `No id token with custom claims received after ${
+          query.failureCount - 1
+        } retries`,
         {
           errorGroupHash: 'AuthError',
           metadata: errorToMetadata(query.error),
@@ -77,7 +80,7 @@ export const useFetchIdTokenWithCustomClaims = (
       );
       dispatch({type: 'SET_FETCH_ID_TOKEN_TIMEOUT'});
     }
-  }, [dispatch, query.error]);
+  }, [dispatch, query.error, query.failureCount]);
 };
 
 const errorToMetadata = (error: any) =>

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -68,6 +68,7 @@ export type RemoteConfig = {
   use_flexible_on_egressMode: boolean;
   use_trygg_overgang_qr_code: boolean;
   vehicles_poll_interval: number;
+  fetch_id_token_retry_count: number;
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
@@ -136,6 +137,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   use_flexible_on_egressMode: true,
   use_trygg_overgang_qr_code: false,
   vehicles_poll_interval: 20000,
+  fetch_id_token_retry_count: 3,
 };
 
 export type RemoteConfigKeys = keyof RemoteConfig;
@@ -318,6 +320,9 @@ export function getConfig(): RemoteConfig {
   const vehicles_poll_interval =
     values['vehicles_poll_interval']?.asNumber() ??
     defaultRemoteConfig.vehicles_poll_interval;
+  const fetch_id_token_retry_count =
+    values['fetch_id_token_retry_count']?.asNumber() ??
+    defaultRemoteConfig.fetch_id_token_retry_count;
 
   return {
     customer_feedback_url,
@@ -381,6 +386,7 @@ export function getConfig(): RemoteConfig {
     use_flexible_on_egressMode,
     use_trygg_overgang_qr_code,
     vehicles_poll_interval,
+    fetch_id_token_retry_count,
   };
 }
 


### PR DESCRIPTION
Added as an option so we can increase the retry count and see if it
affects how many end up in the missing-id-token state.
