### PR TITLE
feat: use form factor to decide AutoSelectableBottomSheetType

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -184,7 +184,7 @@ export const IdsFromQrCodeResponseSchema = z.object({
   operatorId: z.string(),
   vehicleId: z.string().nullable().optional(),
   stationId: z.string().nullable().optional(),
-  formFactor: FormFactorSchema,
+  formFactor: FormFactorSchema.optional(),
 });
 
 export type IdsFromQrCodeResponse = z.infer<typeof IdsFromQrCodeResponseSchema>;

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -184,7 +184,7 @@ export const IdsFromQrCodeResponseSchema = z.object({
   operatorId: z.string(),
   vehicleId: z.string().nullable().optional(),
   stationId: z.string().nullable().optional(),
-  formFactor: FormFactorSchema.optional(),
+  formFactor: FormFactorSchema.nullable().optional(),
 });
 
 export type IdsFromQrCodeResponse = z.infer<typeof IdsFromQrCodeResponseSchema>;

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -1,4 +1,5 @@
 import {z} from 'zod';
+import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 
 export type ViolationsReportingInitQuery = {
   lng: string;
@@ -175,10 +176,15 @@ type FinishEvent = {
 
 export type ShmoBookingEvent = StartFinishingEvent | FinishEvent;
 
+const FormFactorSchema = z.enum(
+  Object.values(FormFactor) as [FormFactor, ...FormFactor[]],
+);
+
 export const IdsFromQrCodeResponseSchema = z.object({
   operatorId: z.string(),
   vehicleId: z.string().nullable().optional(),
   stationId: z.string().nullable().optional(),
+  formFactor: FormFactorSchema,
 });
 
 export type IdsFromQrCodeResponse = z.infer<typeof IdsFromQrCodeResponseSchema>;

--- a/src/components/map/components/mobility/ShmoTesting.tsx
+++ b/src/components/map/components/mobility/ShmoTesting.tsx
@@ -62,7 +62,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
 
   const getVehicleIdFromQrCode = async () => {
     const idsFromQrCode = await getIdsFromQrCode({
-      qrCodeUrl: 'https://open.voi.com/scan/EN57',
+      qrCodeUrl: 'https://m.ryde.vip/scooter.html?n=168769',
       latitude: 0,
       longitude: 0,
     });

--- a/src/components/map/components/mobility/ShmoTesting.tsx
+++ b/src/components/map/components/mobility/ShmoTesting.tsx
@@ -62,7 +62,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
 
   const getVehicleIdFromQrCode = async () => {
     const idsFromQrCode = await getIdsFromQrCode({
-      qrCodeUrl: 'https://m.ryde.vip/scooter.html?n=168769',
+      qrCodeUrl: 'https://m.ryde.vip/scooter.html?n=154197',
       latitude: 0,
       longitude: 0,
     });


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19215
Completes https://github.com/AtB-AS/kundevendt/issues/19097

Now that Entur's endpoint supports `formFactor`, use that instead of the temporary solution to determine which type of bottom sheet to open after scanning a QR code in the map.