### PR TITLE
feat: Add PurchaseSelectionType

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -61,24 +61,16 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const paymentMethod = selectedPaymentMethod ?? previousPaymentMethod;
   const [vippsNotInstalledError, setVippsNotInstalledError] = useState(false);
 
-  const {
-    fareProductTypeConfig,
-    fromPlace,
-    toPlace,
-    preassignedFareProduct,
-    userProfilesWithCount,
-    travelDate,
-    recipient,
-  } = params;
+  const {selection, recipient} = params;
 
   const offerEndpoint = getOfferEndpoint(
-    fareProductTypeConfig.configuration.zoneSelectionMode,
+    selection.fareProductTypeConfig.configuration.zoneSelectionMode,
   );
   const isOnBehalfOf = !!recipient;
 
   const preassignedFareProductAlternatives = useMemo(
-    () => [preassignedFareProduct],
-    [preassignedFareProduct],
+    () => [selection.preassignedFareProduct],
+    [selection.preassignedFareProduct],
   );
 
   const {
@@ -90,13 +82,10 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     refreshOffer,
     userProfilesWithCountAndOffer,
   } = useOfferState(
+    selection,
     offerEndpoint,
     preassignedFareProductAlternatives,
-    fromPlace,
-    toPlace,
-    userProfilesWithCount,
     isOnBehalfOf,
-    travelDate,
   );
 
   const offers: ReserveOffer[] = userProfilesWithCountAndOffer.map(
@@ -265,17 +254,17 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           />
         )}
         <PreassignedFareContractSummary
-          fareProductTypeConfig={fareProductTypeConfig}
-          fromPlace={fromPlace}
-          toPlace={toPlace}
+          fareProductTypeConfig={selection.fareProductTypeConfig}
+          fromPlace={selection.fromPlace}
+          toPlace={selection.toPlace}
           isSearchingOffer={isSearchingOffer}
-          preassignedFareProduct={preassignedFareProduct}
+          preassignedFareProduct={selection.preassignedFareProduct}
           recipient={recipient}
-          travelDate={travelDate}
+          travelDate={selection.travelDate}
           validDurationSeconds={validDurationSeconds}
         />
         <PriceSummary
-          fareProductTypeConfig={fareProductTypeConfig}
+          fareProductTypeConfig={selection.fareProductTypeConfig}
           isSearchingOffer={isSearchingOffer}
           totalPrice={totalPrice}
           userProfilesWithCountAndOffer={userProfilesWithCountAndOffer}
@@ -295,7 +284,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           }
           textColor="primary"
           ruleVariables={{
-            preassignedFareProductType: preassignedFareProduct.type,
+            preassignedFareProductType: selection.preassignedFareProduct.type,
           }}
         />
         {reserveMutation.isError && (

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
@@ -1,16 +1,8 @@
-import {FareProductTypeConfig} from '@atb/configuration';
-import {PreassignedFareProduct, TariffZone} from '@atb/configuration';
-import {UserProfileWithCount} from '@atb/fare-contracts';
-import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {TicketRecipientType} from '@atb/ticketing';
+import {PurchaseSelectionType} from '@atb/stacks-hierarchy/types.ts';
 
 export type Root_PurchaseConfirmationScreenParams = {
-  fareProductTypeConfig: FareProductTypeConfig;
-  preassignedFareProduct: PreassignedFareProduct;
-  fromPlace: TariffZone | StopPlaceFragment;
-  toPlace: TariffZone | StopPlaceFragment;
-  userProfilesWithCount: UserProfileWithCount[];
-  travelDate?: string;
+  selection: PurchaseSelectionType;
   mode?: 'TravelSearch' | 'Ticket';
   recipient?: TicketRecipientType;
 };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -7,7 +7,7 @@ import {
   PurchaseOverviewTexts,
   useTranslation,
 } from '@atb/translations';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {ScrollView, View} from 'react-native';
 import {ProductSelection} from './components/ProductSelection';
 import {PurchaseMessages} from './components/PurchaseMessages';
@@ -33,6 +33,7 @@ import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from './utils';
 import {useOnBehalfOfEnabled} from '@atb/on-behalf-of';
 import {useAuthState} from '@atb/auth';
+import {UserProfileWithCount} from '@atb/fare-contracts';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -48,31 +49,27 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? 'isFree' in params.toPlace && !!params.toPlace.isFree
     : false;
 
-  const {
-    preassignedFareProductAlternatives,
-    selectableTravellers,
-    fromPlace,
-    toPlace,
-  } = useOfferDefaults(
+  const {selection, preassignedFareProductAlternatives} = useOfferDefaults(
     params.preassignedFareProduct,
-    params.fareProductTypeConfig.type,
+    params.fareProductTypeConfig,
     params.userProfilesWithCount,
     params.fromPlace,
     params.toPlace,
+    params.travelDate,
   );
 
   const onSelectPreassignedFareProduct = (fp: PreassignedFareProduct) => {
     navigation.setParams({
       preassignedFareProduct: fp,
     });
-    if (fp.limitations.latestActivationDate && travelDate) {
+    if (fp.limitations.latestActivationDate && selection.travelDate) {
       if (
         isAfter(
-          travelDate,
+          selection.travelDate,
           new Date(fp.limitations.latestActivationDate * 1000),
         )
       )
-        setTravelDate(undefined);
+        navigation.setParams({travelDate: undefined});
       else if (showActivationDateWarning) {
         setShowActivationDateWarning(false);
       }
@@ -80,14 +77,16 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       setShowActivationDateWarning(false);
     }
   };
-  const [travellerSelection, setTravellerSelection] =
-    useState(selectableTravellers);
+
+  const setUserProfilesWithCount = useCallback(
+    (userProfilesWithCount: UserProfileWithCount[]) => {
+      navigation.setParams({userProfilesWithCount});
+    },
+    [navigation],
+  );
 
   const [isOnBehalfOfToggle, setIsOnBehalfOfToggle] = useState<boolean>(false);
 
-  const [travelDate, setTravelDate] = useState<string | undefined>(
-    params.travelDate,
-  );
   const [showActivationDateWarning, setShowActivationDateWarning] =
     useState<boolean>(false);
   const analytics = useAnalytics();
@@ -97,10 +96,10 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     travellerSelectionMode,
     zoneSelectionMode,
     requiresTokenOnMobile,
-  } = params.fareProductTypeConfig.configuration;
+  } = selection.fareProductTypeConfig.configuration;
 
   const fareProductOnBehalfOfEnabled =
-    params.fareProductTypeConfig.configuration.onBehalfOfEnabled;
+    selection.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
   const offerEndpoint =
     zoneSelectionMode === 'none'
@@ -117,13 +116,10 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     refreshOffer,
     userProfilesWithCountAndOffer,
   } = useOfferState(
+    selection,
     offerEndpoint,
     preassignedFareProductAlternatives,
-    fromPlace,
-    toPlace,
-    travellerSelection,
     isOnBehalfOfToggle,
-    travelDate,
   );
 
   const preassignedFareProduct =
@@ -131,25 +127,26 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       (p) => p.id === userProfilesWithCountAndOffer[0]?.offer.fare_product,
     ) ?? preassignedFareProductAlternatives[0];
 
+  useEffect(() => {
+    if (selection.preassignedFareProduct.id !== preassignedFareProduct.id) {
+      navigation.setParams({preassignedFareProduct});
+    }
+  }, [navigation, selection, preassignedFareProduct]);
+
   const rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams =
     {
-      fareProductTypeConfig: params.fareProductTypeConfig,
-      fromPlace: fromPlace,
-      toPlace: toPlace,
-      userProfilesWithCount: travellerSelection,
-      preassignedFareProduct,
-      travelDate,
+      selection,
       mode: params.mode,
     };
 
-  const maximumDateObjectIfExisting = preassignedFareProduct.limitations
+  const maximumDateObjectIfExisting = selection.preassignedFareProduct.limitations
     ?.latestActivationDate
-    ? new Date(preassignedFareProduct.limitations.latestActivationDate * 1000)
+    ? new Date(selection.preassignedFareProduct.limitations.latestActivationDate * 1000)
     : undefined;
 
   const canSelectUserProfile = isUserProfileSelectable(
     travellerSelectionMode,
-    selectableTravellers,
+    selection.userProfilesWithCount,
   );
 
   const isOnBehalfOfEnabled =
@@ -160,7 +157,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const isOnBehalfOfAllowed = isOnBehalfOfEnabled && isLoggedIn;
 
   const hasSelection =
-    travellerSelection.some((u) => u.count) &&
+    selection.userProfilesWithCount.some((u) => u.count) &&
     userProfilesWithCountAndOffer.some((u) => u.count);
 
   const isEmptyOffer = error?.type === 'empty-offers';
@@ -168,7 +165,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const handleTicketInfoButtonPress = () => {
     const parameters = {
       fareProductTypeConfigType: params.fareProductTypeConfig.type,
-      preassignedFareProductId: preassignedFareProduct?.id,
+      preassignedFareProductId: selection.preassignedFareProduct?.id,
     };
     analytics.logEvent(
       'Ticketing',
@@ -209,7 +206,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           ref={params.onFocusElement ? undefined : focusRef}
           style={styles.header}
           fareProductTypeConfig={params.fareProductTypeConfig}
-          preassignedFareProduct={preassignedFareProduct}
+          preassignedFareProduct={selection.preassignedFareProduct}
           onTicketInfoButtonPress={handleTicketInfoButtonPress}
         />
       )}
@@ -228,7 +225,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 type="info"
                 message={t(
                   PurchaseOverviewTexts.errorMessageBox.productUnavailable(
-                    getReferenceDataName(preassignedFareProduct, language),
+                    getReferenceDataName(selection.preassignedFareProduct, language),
                   ),
                 )}
                 style={styles.selectionComponent}
@@ -247,26 +244,26 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             ))}
 
           <ProductSelection
-            preassignedFareProduct={preassignedFareProduct}
+            preassignedFareProduct={selection.preassignedFareProduct}
             fareProductTypeConfig={params.fareProductTypeConfig}
             setSelectedProduct={onSelectPreassignedFareProduct}
             style={styles.selectionComponent}
           />
 
           <TravellerSelection
-            setTravellerSelection={setTravellerSelection}
-            fareProductTypeConfig={params.fareProductTypeConfig}
+            setUserProfilesWithCount={setUserProfilesWithCount}
+            fareProductTypeConfig={selection.fareProductTypeConfig}
             selectionMode={travellerSelectionMode}
-            selectableUserProfiles={selectableTravellers}
+            userProfilesWithCount={selection.userProfilesWithCount}
             style={styles.selectionComponent}
             setIsOnBehalfOfToggle={setIsOnBehalfOfToggle}
             isOnBehalfOfToggle={isOnBehalfOfToggle}
           />
           <FromToSelection
             fareProductTypeConfig={params.fareProductTypeConfig}
-            fromPlace={fromPlace}
-            toPlace={toPlace}
-            preassignedFareProduct={preassignedFareProduct}
+            fromPlace={selection.fromPlace}
+            toPlace={selection.toPlace}
+            preassignedFareProduct={selection.preassignedFareProduct}
             style={styles.selectionComponent}
             onSelect={(params) => {
               navigation.setParams({onFocusElement: undefined});
@@ -283,9 +280,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           <StartTimeSelection
             selectionMode={timeSelectionMode}
             color="interactive_2"
-            travelDate={travelDate}
-            setTravelDate={setTravelDate}
-            validFromTime={travelDate}
+            travelDate={selection.travelDate}
+            setTravelDate={(travelDate) => navigation.setParams({travelDate})}
+            validFromTime={selection.travelDate}
             maximumDate={maximumDateObjectIfExisting}
             style={styles.selectionComponent}
             showActivationDateWarning={showActivationDateWarning}
@@ -334,8 +331,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 textColor="background_0"
                 ruleVariables={{
                   preassignedFareProductType: preassignedFareProduct.type,
-                  fromTariffZone: fromPlace.id,
-                  toTariffZone: toPlace.id,
+                  fromTariffZone: selection.fromPlace.id,
+                  toTariffZone: selection.toPlace.id,
                   userTypes: userTypeStrings,
                 }}
               />
@@ -348,7 +345,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             isError={!!error || !hasSelection}
             originalPrice={originalPrice}
             price={totalPrice}
-            userProfilesWithCount={travellerSelection}
+            userProfilesWithCount={selection.userProfilesWithCount}
             summaryButtonText={
               isOnBehalfOfToggle
                 ? t(PurchaseOverviewTexts.summary.button.sendToOthers)
@@ -357,16 +354,21 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             onPressBuy={() => {
               analytics.logEvent('Ticketing', 'Purchase summary clicked', {
                 fareProduct: params.fareProductTypeConfig.name,
-                tariffZone: {from: fromPlace.id, to: toPlace.id},
-                userProfilesWithCount: travellerSelection.map((t) => ({
-                  userType: t.userTypeString,
-                  count: t.count,
-                })),
-                preassignedFareProduct: {
-                  id: preassignedFareProduct.id,
-                  name: preassignedFareProduct.name.value,
+                tariffZone: {
+                  from: selection.fromPlace.id,
+                  to: selection.toPlace.id,
                 },
-                travelDate,
+                userProfilesWithCount: selection.userProfilesWithCount.map(
+                  (t) => ({
+                    userType: t.userTypeString,
+                    count: t.count,
+                  }),
+                ),
+                preassignedFareProduct: {
+                  id: selection.preassignedFareProduct.id,
+                  name: selection.preassignedFareProduct.name.value,
+                },
+                travelDate: selection.travelDate,
                 mode: params.mode,
               });
               isOnBehalfOfToggle

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {
   getTextForLanguage,
   PurchaseOverviewTexts,
@@ -47,8 +47,6 @@ export function ProductSelectionByProducts({
     .filter((product) => product.type === selectedProduct.type)
     .filter(onlyUniquesBasedOnField('productAliasId', true));
 
-  const [selected, setProduct] = useState(selectedProduct);
-
   const alias = (fareProduct: PreassignedFareProduct) =>
     fareProduct.productAlias &&
     getTextForLanguage(fareProduct.productAlias, language);
@@ -83,11 +81,8 @@ export function ProductSelectionByProducts({
             itemToText={(fp) => productDisplayName(fp)}
             hideSubtext={hideProductDescriptions}
             itemToSubtext={(fp) => subText(fp)}
-            selected={selected}
-            onSelect={(fp) => {
-              setProduct(fp);
-              setSelectedProduct(fp);
-            }}
+            selected={selectedProduct}
+            onSelect={setSelectedProduct}
             color="interactive_2"
             accessibilityHint={t(
               PurchaseOverviewTexts.productSelection.a11yTitle,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,13 +1,13 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useRef} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
-
 import {
-  PurchaseOverviewTexts,
   getTextForLanguage,
+  PurchaseOverviewTexts,
   useTranslation,
 } from '@atb/translations';
 import {
   FareProductTypeConfig,
+  getReferenceDataName,
   TravellerSelectionMode,
 } from '@atb/configuration';
 import {
@@ -16,10 +16,7 @@ import {
   Section,
 } from '@atb/components/sections';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-
 import {StyleSheet} from '@atb/theme';
-import {getReferenceDataName} from '@atb/configuration';
-
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {TravellerSelectionSheet} from './TravellerSelectionSheet';
 
@@ -34,8 +31,8 @@ import {isUserProfileSelectable} from '../utils';
 import {useAuthState} from '@atb/auth';
 
 type TravellerSelectionProps = {
-  selectableUserProfiles: UserProfileWithCount[];
-  setTravellerSelection: (
+  userProfilesWithCount: UserProfileWithCount[];
+  setUserProfilesWithCount: (
     userProfilesWithCount: UserProfileWithCount[],
   ) => void;
   style?: StyleProp<ViewStyle>;
@@ -46,9 +43,9 @@ type TravellerSelectionProps = {
 };
 
 export function TravellerSelection({
-  setTravellerSelection,
+  setUserProfilesWithCount,
   style,
-  selectableUserProfiles,
+  userProfilesWithCount,
   selectionMode,
   fareProductTypeConfig,
   setIsOnBehalfOfToggle,
@@ -75,35 +72,10 @@ export function TravellerSelection({
   const {addPopOver} = usePopOver();
   const onBehalfOfIndicatorRef = useRef(null);
 
-  const [userProfilesState, setUserProfilesState] = useState<
-    UserProfileWithCount[]
-  >(selectableUserProfiles);
-
   const canSelectUserProfile = isUserProfileSelectable(
     selectionMode,
-    selectableUserProfiles,
+    userProfilesWithCount,
   );
-
-  useEffect(() => {
-    setUserProfilesState((prevState) => {
-      const updatedState = selectableUserProfiles.map((u) => ({
-        ...u,
-        count: prevState.find((p) => u.id === p.id)?.count || 0,
-      }));
-
-      return updatedState.some(({count}) => count)
-        ? updatedState
-        : selectableUserProfiles;
-    });
-  }, [selectableUserProfiles]);
-
-  useEffect(() => {
-    const filteredSelection = userProfilesState.filter((u) =>
-      selectableUserProfiles.find((i) => i.id === u.id),
-    );
-    setTravellerSelection(filteredSelection);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectionMode, userProfilesState]);
 
   useFocusEffect(
     useCallback(() => {
@@ -120,7 +92,7 @@ export function TravellerSelection({
     return null;
   }
 
-  const selectedUserProfiles = userProfilesState.filter(({count}) => count);
+  const selectedUserProfiles = userProfilesWithCount.filter(({count}) => count);
   const totalTravellersCount = selectedUserProfiles.reduce(
     (acc, {count}) => acc + count,
     0,
@@ -140,7 +112,10 @@ export function TravellerSelection({
     : '';
 
   const travellerInfo = !canSelectUserProfile
-    ? getTextForLanguage(userProfilesState[0].alternativeDescriptions, language)
+    ? getTextForLanguage(
+        userProfilesWithCount[0].alternativeDescriptions,
+        language,
+      )
     : '';
 
   const accessibility: AccessibilityProps = {
@@ -172,14 +147,14 @@ export function TravellerSelection({
       <TravellerSelectionSheet
         selectionMode={selectionMode}
         fareProductTypeConfig={fareProductTypeConfig}
-        selectableUserProfilesWithCountInit={userProfilesState}
+        selectableUserProfilesWithCountInit={userProfilesWithCount}
         isOnBehalfOfToggle={isOnBehalfOfToggle}
         onConfirmSelection={(
           chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
           onBehalfOfToggle?: boolean,
         ) => {
           if (chosenSelectableUserProfilesWithCounts !== undefined) {
-            setUserProfilesState(chosenSelectableUserProfilesWithCounts);
+            setUserProfilesWithCount(chosenSelectableUserProfilesWithCounts);
           }
           if (onBehalfOfToggle !== undefined) {
             setIsOnBehalfOfToggle(onBehalfOfToggle);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -109,11 +109,11 @@ export function useOfferDefaults(
       travelDate,
     }),
     [
-      defaultFromPlace,
+      fareProductTypeConfig,
       defaultPreassignedFareProduct,
       defaultSelectableTravellers,
+      defaultFromPlace,
       defaultToPlace,
-      fareProductTypeConfig,
       travelDate,
     ],
   );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -12,7 +12,7 @@ import {useCallback, useEffect, useReducer} from 'react';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {secondsBetween} from '@atb/utils/date';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {PurchaseSelectionType} from '@atb/stacks-hierarchy/types.ts';
+import {PurchaseSelectionType} from '@atb/stacks-hierarchy/types';
 
 export type UserProfileWithCountAndOffer = UserProfileWithCount & {
   offer: Offer;

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_CategoryPickerScreen.tsx
@@ -37,14 +37,11 @@ export const TicketAssistant_CategoryPickerScreen = ({
 
   const {fareProductTypeConfigs} = useFirestoreConfiguration();
 
-  const offerDefaults = useOfferDefaults(
-    undefined,
-    fareProductTypeConfigs[0].type,
-  );
+  const offerDefaults = useOfferDefaults(undefined, fareProductTypeConfigs[0]);
   const {updateInputParams} = useTicketAssistantState();
 
-  const {selectableTravellers} = offerDefaults;
-  const defaultTravellerIndex = selectableTravellers.findIndex(
+  const {selection} = offerDefaults;
+  const defaultTravellerIndex = selection.userProfilesWithCount.findIndex(
     (a) => a.count > 0,
   );
   const [currentlyOpen, setCurrentlyOpen] = useState<number>(
@@ -60,7 +57,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('blur', () => {
-      const traveller = selectableTravellers[currentlyOpen];
+      const traveller = selection.userProfilesWithCount[currentlyOpen];
       updateCategory({
         id: traveller.userTypeString,
         userType: traveller.userTypeString,
@@ -70,7 +67,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
     return () => {
       unsubscribe();
     };
-  }, [navigation, selectableTravellers, currentlyOpen, updateCategory]);
+  }, [navigation, selection, currentlyOpen, updateCategory]);
 
   function getAdditionalTitleText(userTypeString: string) {
     switch (userTypeString) {
@@ -131,7 +128,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
 
         {!a11yContext.isScreenReaderEnabled ? (
           <Section style={styles.categoriesContainer}>
-            {selectableTravellers.map((u, index) => {
+            {selection.userProfilesWithCount.map((u, index) => {
               return (
                 <ExpandableSectionItem
                   key={index}
@@ -182,7 +179,7 @@ export const TicketAssistant_CategoryPickerScreen = ({
           </Section>
         ) : (
           <>
-            {selectableTravellers.map((u, index) => {
+            {selection.userProfilesWithCount.map((u, index) => {
               const title = getReferenceDataName(u, language);
               const description = getTextForLanguage(
                 u.alternativeDescriptions,

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
@@ -56,12 +56,15 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
     if (!recommendedTicketSummary) return;
     const purchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams =
       {
-        fareProductTypeConfig: recommendedTicketSummary.fareProductTypeConfig,
-        fromPlace: recommendedTicketSummary.tariffZones[0],
-        toPlace: recommendedTicketSummary.tariffZones[1],
-        userProfilesWithCount: recommendedTicketSummary.userProfileWithCount,
-        preassignedFareProduct: recommendedTicketSummary.preassignedFareProduct,
-        travelDate: undefined,
+        selection: {
+          fareProductTypeConfig: recommendedTicketSummary.fareProductTypeConfig,
+          fromPlace: recommendedTicketSummary.tariffZones[0],
+          toPlace: recommendedTicketSummary.tariffZones[1],
+          userProfilesWithCount: recommendedTicketSummary.userProfileWithCount,
+          preassignedFareProduct:
+            recommendedTicketSummary.preassignedFareProduct,
+          travelDate: undefined,
+        },
         mode: 'Ticket',
       };
     const {fareProductTypeConfig} = recommendedTicketSummary;

--- a/src/stacks-hierarchy/types.ts
+++ b/src/stacks-hierarchy/types.ts
@@ -1,4 +1,8 @@
 import {PaymentType, RecurringPayment} from '@atb/ticketing';
+import {FareProductTypeConfig, PreassignedFareProduct} from "@atb/configuration";
+import {UserProfileWithCount} from "@atb/fare-contracts";
+import {TariffZoneWithMetadata} from "@atb/tariff-zones-selector";
+import {StopPlaceFragmentWithIsFree} from "@atb/harbors/types.ts";
 
 export enum SavedPaymentMethodType {
   /**
@@ -25,3 +29,12 @@ type VippsPaymentMethod = {
   recurringCard?: undefined;
 };
 export type PaymentMethod = CardPaymentMethod | VippsPaymentMethod;
+
+export type PurchaseSelectionType = {
+  fareProductTypeConfig: FareProductTypeConfig;
+  preassignedFareProduct: PreassignedFareProduct;
+  userProfilesWithCount: UserProfileWithCount[];
+  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
+  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
+  travelDate?: string;
+};


### PR DESCRIPTION
### Background
The code in our purchase screens, especially `PurchaseOverviewScreen`, has just grown and grown and now feels a little out of control. There are multiple business rules applied in more or less random places, and they are more or less untestable as it is structured now.

### Solution
Establish a domain model for the purchase selection, with encapsulation and testing.

This PR is the first step towards the goal, where it is introduced a `PurchaseSelectionType` which works as a domain model for a purchase selection state. I have tried to do the least amount of changes possible to introduce such a type, to not let the PR grow out of hand.

The next steps will be:
- Encapsulate creation and modification of the `PurchaseSelectionType` in a module
- Let the `PurchaseSelectionType` be the main object sent around between screens and components in the purchase flow
- Enforce integrity of the `PurchaseSelectionType` in the module. A  `PurchaseSelectionType` object returned from the module should be valid with regards to the `FareProductTypeConfig` and other input.
- No business rules should be applied to the `PurchaseSelectionType` outside of the module
- The new module should be tested thoroughly

### Acceptance criteria
- [ ] Purchase flow for all products should work as before
- [ ] Offer searches should not be triggered unexpectedly
