### PR TITLE
refactor: PurchaseSelectionBuilder

### DIFF
--- a/src/purchase-selection/__tests__/purchase-selection-builder.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder.test.ts
@@ -10,7 +10,7 @@ describe('purchaseSelectionBuilder', () => {
   it('Selected zone is the first one if no zone specified as default', () => {
     const input = {
       ...DEFAULT_INPUT,
-      tariffZones: [{id: 'A'}, {id: 'B'}, {id: 'A'}],
+      tariffZones: [{id: 'A'}, {id: 'B'}, {id: 'C'}],
     } as PurchaseSelectionBuilderInput;
 
     const selection = createEmptyBuilder(input).forType('single').build();
@@ -21,7 +21,7 @@ describe('purchaseSelectionBuilder', () => {
   it('Selected zone is the zone specified as default', () => {
     const input = {
       ...DEFAULT_INPUT,
-      tariffZones: [{id: 'A'}, {id: 'B', isDefault: true}, {id: 'A'}],
+      tariffZones: [{id: 'A'}, {id: 'B', isDefault: true}, {id: 'C'}],
     } as PurchaseSelectionBuilderInput;
 
     const selection = createEmptyBuilder(input).forType('single').build();

--- a/src/purchase-selection/__tests__/purchase-selection-builder.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder.test.ts
@@ -1,0 +1,31 @@
+import {createEmptyBuilder} from '@atb/purchase-selection/purchase-selection-builder.ts';
+import {PurchaseSelectionBuilderInput} from '@atb/purchase-selection/types.ts';
+
+const DEFAULT_INPUT = {} as PurchaseSelectionBuilderInput;
+
+/*
+Really simplified example of how tests can look.
+ */
+describe('purchaseSelectionBuilder', () => {
+  it('Selected zone is the first one if no zone specified as default', () => {
+    const input = {
+      ...DEFAULT_INPUT,
+      tariffZones: [{id: 'A'}, {id: 'B'}, {id: 'A'}],
+    } as PurchaseSelectionBuilderInput;
+
+    const selection = createEmptyBuilder(input).forType('single').build();
+
+    expect(selection.fromPlace.id).toBe('A');
+  });
+
+  it('Selected zone is the zone specified as default', () => {
+    const input = {
+      ...DEFAULT_INPUT,
+      tariffZones: [{id: 'A'}, {id: 'B', isDefault: true}, {id: 'A'}],
+    } as PurchaseSelectionBuilderInput;
+
+    const selection = createEmptyBuilder(input).forType('single').build();
+
+    expect(selection.fromPlace.id).toBe('B');
+  });
+});

--- a/src/purchase-selection/index.ts
+++ b/src/purchase-selection/index.ts
@@ -1,0 +1,2 @@
+export type {PurchaseSelectionType} from './types';
+export {usePurchaseSelectionBuilder} from './use-purchase-selection-builder.ts';

--- a/src/purchase-selection/purchase-selection-builder.ts
+++ b/src/purchase-selection/purchase-selection-builder.ts
@@ -1,0 +1,39 @@
+import {
+  PurchaseSelectionType,
+  PurchaseSelectionBuilder,
+  PurchaseSelectionBuilderInput,
+  PurchaseSelectionEmptyBuilder,
+} from './types';
+
+export const createEmptyBuilder = (
+  input: PurchaseSelectionBuilderInput,
+): PurchaseSelectionEmptyBuilder => {
+  return {
+    forType: (t) => {
+      const selection = createSelectionForType(input, t);
+      return createBuilder(input, selection);
+    },
+  };
+};
+
+const createBuilder = (
+  _input: PurchaseSelectionBuilderInput,
+  _selection: PurchaseSelectionType,
+): PurchaseSelectionBuilder => {
+  return {
+    product: () => {},
+    from: () => {},
+    to: () => {},
+    userProfiles: () => {},
+    date: () => {},
+    build: () => {},
+  } as PurchaseSelectionBuilder;
+};
+
+const createSelectionForType = (
+  _input: PurchaseSelectionBuilderInput,
+  _configType: string,
+): PurchaseSelectionType => {
+  // Here we add defaults logic which previously was in use-offer-defaults
+  return {} as PurchaseSelectionType;
+};

--- a/src/purchase-selection/types.ts
+++ b/src/purchase-selection/types.ts
@@ -1,0 +1,41 @@
+import {
+  FareProductTypeConfig,
+  PreassignedFareProduct,
+  UserProfile,
+  TariffZone,
+} from '@atb/configuration';
+import {UserProfileWithCount} from '@atb/fare-contracts';
+import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
+import {StopPlaceFragmentWithIsFree} from '@atb/harbors/types.ts';
+
+export type PurchaseSelectionType = {
+  fareProductTypeConfig: FareProductTypeConfig;
+  preassignedFareProduct: PreassignedFareProduct;
+  userProfilesWithCount: UserProfileWithCount[];
+  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
+  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
+  travelDate?: string;
+};
+
+export type PurchaseSelectionBuilderInput = {
+  userProfiles: UserProfile[];
+  preassignedFareProducts: PreassignedFareProduct[];
+  tariffZones: TariffZone[];
+};
+
+export type PurchaseSelectionEmptyBuilder = {
+  forType: (t: string) => PurchaseSelectionBuilder;
+};
+
+export type PurchaseSelectionBuilder = {
+  product: (p?: PreassignedFareProduct) => PurchaseSelectionBuilder;
+  from: (
+    f?: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree,
+  ) => PurchaseSelectionBuilder;
+  to: (
+    t?: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree,
+  ) => PurchaseSelectionBuilder;
+  userProfiles: (u?: UserProfileWithCount[]) => PurchaseSelectionBuilder;
+  date: (d?: string) => PurchaseSelectionBuilder;
+  build: () => PurchaseSelectionType;
+};

--- a/src/purchase-selection/use-purchase-selection-builder.ts
+++ b/src/purchase-selection/use-purchase-selection-builder.ts
@@ -1,0 +1,14 @@
+import {useFirestoreConfiguration} from '@atb/configuration';
+import {createEmptyBuilder} from './purchase-selection-builder.ts';
+import {PurchaseSelectionBuilderInput} from './types.ts';
+
+export const usePurchaseSelectionBuilder = () => {
+  const {userProfiles, preassignedFareProducts, tariffZones} =
+    useFirestoreConfiguration();
+  const builderInput: PurchaseSelectionBuilderInput = {
+    userProfiles,
+    preassignedFareProducts,
+    tariffZones,
+  };
+  return createEmptyBuilder(builderInput);
+};

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
@@ -1,5 +1,5 @@
 import {TicketRecipientType} from '@atb/ticketing';
-import {PurchaseSelectionType} from '@atb/stacks-hierarchy/types.ts';
+import {PurchaseSelectionType} from "@atb/purchase-selection";
 
 export type Root_PurchaseConfirmationScreenParams = {
   selection: PurchaseSelectionType;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -161,7 +161,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const handleTicketInfoButtonPress = () => {
     const parameters = {
-      fareProductTypeConfigType: params.fareProductTypeConfig.type,
+      fareProductTypeConfigType: selection.fareProductTypeConfig.type,
       preassignedFareProductId: preassignedFareProduct.id,
     };
     analytics.logEvent(
@@ -190,7 +190,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   return (
     <FullScreenView
       headerProps={{
-        title: getTextForLanguage(params.fareProductTypeConfig.name, language),
+        title: getTextForLanguage(selection.fareProductTypeConfig.name, language),
         leftButton: {
           type: 'cancel',
           onPress: closeModal,
@@ -202,7 +202,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
         <FareProductHeader
           ref={params.onFocusElement ? undefined : focusRef}
           style={styles.header}
-          fareProductTypeConfig={params.fareProductTypeConfig}
+          fareProductTypeConfig={selection.fareProductTypeConfig}
           preassignedFareProduct={preassignedFareProduct}
           onTicketInfoButtonPress={handleTicketInfoButtonPress}
         />
@@ -242,7 +242,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
           <ProductSelection
             preassignedFareProduct={selection.preassignedFareProduct}
-            fareProductTypeConfig={params.fareProductTypeConfig}
+            fareProductTypeConfig={selection.fareProductTypeConfig}
             setSelectedProduct={onSelectPreassignedFareProduct}
             style={styles.selectionComponent}
           />
@@ -257,7 +257,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             isOnBehalfOfToggle={isOnBehalfOfToggle}
           />
           <FromToSelection
-            fareProductTypeConfig={params.fareProductTypeConfig}
+            fareProductTypeConfig={selection.fareProductTypeConfig}
             fromPlace={selection.fromPlace}
             toPlace={selection.toPlace}
             preassignedFareProduct={selection.preassignedFareProduct}
@@ -350,7 +350,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             }
             onPressBuy={() => {
               analytics.logEvent('Ticketing', 'Purchase summary clicked', {
-                fareProduct: params.fareProductTypeConfig.name,
+                fareProduct: selection.fareProductTypeConfig.name,
                 tariffZone: {
                   from: selection.fromPlace.id,
                   to: selection.toPlace.id,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -1,28 +1,16 @@
-import {usePreferences} from '@atb/preferences';
 import {
   PreassignedFareProduct,
-  UserProfile,
   useFirestoreConfiguration,
-  isProductSellableInApp,
 } from '@atb/configuration';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
-import {useTicketingState} from '@atb/ticketing';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {
-  useDefaultTariffZone,
-  useFilterTariffZone,
-} from '@atb/stacks-hierarchy/utils';
 import {useMemo} from 'react';
-import {useDefaultPreassignedFareProduct} from '@atb/fare-contracts/utils';
-import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
-import {PurchaseSelectionType} from '@atb/stacks-hierarchy/types.ts';
 import {FareProductTypeConfig} from '@atb-as/config-specs';
-
-type UserProfileTypeWithCount = {
-  userTypeString: string;
-  count: number;
-};
+import {
+  PurchaseSelectionType,
+  usePurchaseSelectionBuilder,
+} from '@atb/purchase-selection';
 
 export function useOfferDefaults(
   preassignedFareProduct: PreassignedFareProduct | undefined,
@@ -35,134 +23,46 @@ export function useOfferDefaults(
   selection: PurchaseSelectionType;
   preassignedFareProductAlternatives: PreassignedFareProduct[];
 } {
-  const {data: fareProducts} = useGetFareProductsQuery();
-  const {tariffZones, userProfiles, preassignedFareProducts} =
-    useFirestoreConfiguration();
-  const {customerProfile} = useTicketingState();
-
-  // Get default PreassignedFareProduct alternatives
-  const productType =
-    preassignedFareProduct?.type ?? fareProductTypeConfig.type;
-  const selectableProducts = fareProducts
-    .filter((product) => isProductSellableInApp(product, customerProfile))
-    .filter((product) => product.type === productType);
-  const defaultFareProduct =
-    useDefaultPreassignedFareProduct(selectableProducts);
-  const defaultPreassignedFareProduct =
-    preassignedFareProduct ?? defaultFareProduct;
-  const defaultPreassignedFareProductAlternatives = useMemo(() => {
-    const productAliasId = defaultPreassignedFareProduct.productAliasId;
-    return productAliasId
-      ? preassignedFareProducts.filter(
-          (fp) => fp.productAliasId === productAliasId,
-        )
-      : [defaultPreassignedFareProduct];
-  }, [defaultPreassignedFareProduct, preassignedFareProducts]);
-
-  // Check for whitelisted zones
-  const allowedTariffZoneRefs =
-    defaultPreassignedFareProduct.limitations.tariffZoneRefs ?? [];
-  const usableTariffZones = useFilterTariffZone(
-    tariffZones,
-    allowedTariffZoneRefs,
-  );
-
-  // Get default TariffZones
-  const defaultTariffZone = useDefaultTariffZone(usableTariffZones);
-  const defaultFromPlace = fromPlace ?? defaultTariffZone;
-  const defaultToPlace = toPlace ?? defaultTariffZone;
-
-  // Get default SelectableTravellers
-  const {
-    preferences: {defaultUserTypeString},
-  } = usePreferences();
-
-  const defaultSelection = useMemo(() => {
-    if (!userProfilesWithCount?.length) {
-      const defaultPreSelectedUser: UserProfileTypeWithCount = {
-        userTypeString: defaultUserTypeString ?? userProfiles[0].userTypeString,
-        count: 1,
-      };
-      return [defaultPreSelectedUser];
-    }
-
-    return userProfilesWithCount.map(
-      (up: UserProfileWithCount): UserProfileTypeWithCount => {
-        return {userTypeString: up.userTypeString, count: up.count};
-      },
-    );
-  }, [defaultUserTypeString, userProfiles, userProfilesWithCount]);
-
-  const defaultSelectableTravellers = useTravellersWithPreselectedCounts(
-    userProfiles,
-    defaultPreassignedFareProduct,
-    defaultSelection,
-  );
+  const selectionBuilder = usePurchaseSelectionBuilder();
+  const {preassignedFareProducts} = useFirestoreConfiguration();
 
   const selection = useMemo(
-    () => ({
-      fareProductTypeConfig,
-      preassignedFareProduct: defaultPreassignedFareProduct,
-      userProfilesWithCount: defaultSelectableTravellers,
-      fromPlace: defaultFromPlace,
-      toPlace: defaultToPlace,
-      travelDate,
-    }),
+    () =>
+      selectionBuilder
+        .forType(fareProductTypeConfig.type)
+        .product(preassignedFareProduct)
+        .userProfiles(userProfilesWithCount)
+        .from(fromPlace)
+        .to(toPlace)
+        .date(travelDate)
+        .build(),
+    /*
+     Ok to temporary disable this warning . We don't want to use the selection
+     builder in hooks like useEffect or useMemo, but it is temporarily done to
+     be able to introduce it step by step.
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       fareProductTypeConfig,
-      defaultPreassignedFareProduct,
-      defaultSelectableTravellers,
-      defaultFromPlace,
-      defaultToPlace,
+      preassignedFareProduct,
+      userProfilesWithCount,
+      fromPlace,
+      toPlace,
       travelDate,
     ],
   );
 
+  const preassignedFareProductAlternatives = useMemo(() => {
+    const productAliasId = selection.preassignedFareProduct?.productAliasId;
+    return productAliasId
+      ? preassignedFareProducts.filter(
+          (fp) => fp.productAliasId === productAliasId,
+        )
+      : [selection.preassignedFareProduct];
+  }, [selection.preassignedFareProduct, preassignedFareProducts]);
+
   return {
     selection,
-    preassignedFareProductAlternatives:
-      defaultPreassignedFareProductAlternatives,
+    preassignedFareProductAlternatives,
   };
 }
-
-const getCountIfUserIsIncluded = (
-  u: UserProfile,
-  selections: UserProfileTypeWithCount[],
-): number => {
-  const selectedUser = selections.filter(
-    (up: UserProfileTypeWithCount) => up.userTypeString === u.userTypeString,
-  );
-
-  if (selectedUser.length < 1) return 0;
-  return selectedUser[0].count;
-};
-
-/**
- * Get the default user profiles with count. If a default user profile has been
- * selected in the preferences that profile will have a count of one. If no
- * default user profile preference exists then the first user profile will have
- * a count of one.
- */
-const useTravellersWithPreselectedCounts = (
-  userProfiles: UserProfile[],
-  preassignedFareProduct: PreassignedFareProduct,
-  defaultSelections: UserProfileTypeWithCount[],
-) =>
-  useMemo(() => {
-    const mappedUserProfiles = userProfiles
-      .filter((u) =>
-        preassignedFareProduct.limitations.userProfileRefs.includes(u.id),
-      )
-      .map((u) => ({
-        ...u,
-        count: getCountIfUserIsIncluded(u, defaultSelections),
-      }));
-
-    if (
-      !mappedUserProfiles.some(({count}) => count) &&
-      mappedUserProfiles.length > 0 // how to handle if length 0?
-    ) {
-      mappedUserProfiles[0].count = 1;
-    }
-    return mappedUserProfiles;
-  }, [userProfiles, preassignedFareProduct, defaultSelections]);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -12,7 +12,7 @@ import {useCallback, useEffect, useReducer} from 'react';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {secondsBetween} from '@atb/utils/date';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {PurchaseSelectionType} from '@atb/stacks-hierarchy/types';
+import {PurchaseSelectionType} from "@atb/purchase-selection";
 
 export type UserProfileWithCountAndOffer = UserProfileWithCount & {
   offer: Offer;

--- a/src/stacks-hierarchy/types.ts
+++ b/src/stacks-hierarchy/types.ts
@@ -1,8 +1,4 @@
 import {PaymentType, RecurringPayment} from '@atb/ticketing';
-import {FareProductTypeConfig, PreassignedFareProduct} from "@atb/configuration";
-import {UserProfileWithCount} from "@atb/fare-contracts";
-import {TariffZoneWithMetadata} from "@atb/tariff-zones-selector";
-import {StopPlaceFragmentWithIsFree} from "@atb/harbors/types.ts";
 
 export enum SavedPaymentMethodType {
   /**
@@ -29,12 +25,3 @@ type VippsPaymentMethod = {
   recurringCard?: undefined;
 };
 export type PaymentMethod = CardPaymentMethod | VippsPaymentMethod;
-
-export type PurchaseSelectionType = {
-  fareProductTypeConfig: FareProductTypeConfig;
-  preassignedFareProduct: PreassignedFareProduct;
-  userProfilesWithCount: UserProfileWithCount[];
-  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
-  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
-  travelDate?: string;
-};


### PR DESCRIPTION
Just a proof of concept of how the purchase selection module can look. Here it exports a hook `usePurchaseSelectionBuilder` which should be used everywhere one want to create or modify a purchase selection. 

Take a look and let me know how the module "feels". The main point is that the outward-facing API to usages outside of the module feels nice, while the secondary point is how the internal implementation in the module looks.