### PR TITLE
feat: Support for better list views in markdown

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -70,7 +70,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
     isMarkdown && typeof children === 'string'
       ? renderMarkdown(children, {
           textProps,
-          spacingBetweenListElements: theme.spacings.small,
+          spacingBetweenListElements: theme.spacings.xSmall,
         })
       : children;
 

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useTheme} from '@atb/theme';
-import {Platform, Text, TextProps, TextStyle} from 'react-native';
+import {Platform, Text, TextProps, TextStyle, View} from 'react-native';
 import {renderMarkdown} from './markdown-renderer';
 import {MAX_FONT_SCALE} from './utils';
 import {
@@ -60,20 +60,29 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
     };
   }
 
+  const textProps = {
+    style: [textStyle, style],
+    maxFontSizeMultiplier: MAX_FONT_SCALE,
+    ...props,
+  };
+
   const content =
     isMarkdown && typeof children === 'string'
-      ? renderMarkdown(children)
+      ? renderMarkdown(children, {
+          textProps,
+          spacingBetweenListElements: theme.spacings.small,
+        })
       : children;
 
-  return (
-    <Text
-      style={[textStyle, style]}
-      maxFontSizeMultiplier={MAX_FONT_SCALE}
-      {...props}
-    >
-      {content}
-    </Text>
-  );
+  // If markdown is enabled, we need to wrap the content in a <View></View> to properly align the <Text></Text> elements,
+  // by doing this we also avoid to wrap the list elements inside the markdown render in a Text component, which is not allowed.
+  if (isMarkdown) {
+    return (
+      <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>{content}</View>
+    );
+  }
+
+  return <Text {...textProps}>{content}</Text>;
 };
 
 const useColor = (color: ColorType): string => {
@@ -83,7 +92,7 @@ const useColor = (color: ColorType): string => {
     return color.text;
   } else if (isStatusColor(color)) {
     return theme.status[color].secondary.text;
-  } 
+  }
   return isStaticColor(color)
     ? getStaticColor(themeName, color).text
     : theme.text.colors[color];

--- a/src/components/text/markdown-renderer.tsx
+++ b/src/components/text/markdown-renderer.tsx
@@ -38,8 +38,8 @@ function renderToken(
       return (
         <Text
           key={index}
-          style={{fontWeight: textTypeStyles['body__primary--bold'].fontWeight}}
           {...props.textProps}
+          style={{fontWeight: textTypeStyles['body__primary--bold'].fontWeight}}
         >
           {token.text}
         </Text>
@@ -56,9 +56,9 @@ function renderToken(
 
     case 'paragraph':
       return (
-        <React.Fragment key={index}>
+        <Text key={index} {...props.textProps}>
           {token.tokens.map((t, i) => renderToken(t, i, props))}
-        </React.Fragment>
+        </Text>
       );
 
     case 'br':
@@ -67,7 +67,7 @@ function renderToken(
 
     case 'em':
       return (
-        <Text key={index} style={{fontStyle: 'italic'}} {...props.textProps}>
+        <Text key={index} {...props.textProps} style={{fontStyle: 'italic'}}>
           {token.text}
         </Text>
       );
@@ -84,9 +84,9 @@ function renderToken(
       return (
         <Text
           key={index}
-          style={{textDecorationLine: 'underline'}}
           onPress={openLink}
           {...props.textProps}
+          style={{textDecorationLine: 'underline'}}
         >
           {token.text}
         </Text>

--- a/src/components/text/markdown-renderer.tsx
+++ b/src/components/text/markdown-renderer.tsx
@@ -1,18 +1,37 @@
 import React from 'react';
 import {marked} from 'marked';
-import {Linking, Text} from 'react-native';
+import {Linking, Text, View} from 'react-native';
 import {textTypeStyles} from '@atb/theme/colors';
 import Bugsnag from '@bugsnag/react-native';
+import {ThemeTextProps} from './ThemeText';
 
-export function renderMarkdown(markdown: string): React.ReactElement[] {
+type MarkdownRendererProps = {
+  // When rendering a list, this is the spacing between the list elements
+  spacingBetweenListElements?: number;
+  // The props to pass to the Text component
+  textProps?: ThemeTextProps;
+};
+
+export function renderMarkdown(
+  markdown: string,
+  props: MarkdownRendererProps,
+): React.ReactElement[] {
   const tree = marked.lexer(markdown, {smartypants: true});
-  return tree.map(renderToken);
+  return tree.map((token, index) => renderToken(token, index, props));
 }
 
-function renderToken(token: marked.Token, index: number): React.ReactElement {
+function renderToken(
+  token: marked.Token,
+  index: number,
+  props: MarkdownRendererProps,
+): React.ReactElement {
   switch (token.type) {
     case 'text':
-      return <Text key={index}>{token.text}</Text>;
+      return (
+        <Text key={index} {...props.textProps}>
+          {token.text}
+        </Text>
+      );
 
     case 'heading':
     case 'strong':
@@ -20,6 +39,7 @@ function renderToken(token: marked.Token, index: number): React.ReactElement {
         <Text
           key={index}
           style={{fontWeight: textTypeStyles['body__primary--bold'].fontWeight}}
+          {...props.textProps}
         >
           {token.text}
         </Text>
@@ -29,13 +49,15 @@ function renderToken(token: marked.Token, index: number): React.ReactElement {
       return token.raw === '<br>' ? (
         <Text key={index}>{'\n'}</Text>
       ) : (
-        <Text key={index}>{token.raw}</Text>
+        <Text key={index} {...props.textProps}>
+          {token.raw}
+        </Text>
       );
 
     case 'paragraph':
       return (
         <React.Fragment key={index}>
-          {token.tokens.map(renderToken)}
+          {token.tokens.map((t, i) => renderToken(t, i, props))}
         </React.Fragment>
       );
 
@@ -45,7 +67,7 @@ function renderToken(token: marked.Token, index: number): React.ReactElement {
 
     case 'em':
       return (
-        <Text key={index} style={{fontStyle: 'italic'}}>
+        <Text key={index} style={{fontStyle: 'italic'}} {...props.textProps}>
           {token.text}
         </Text>
       );
@@ -64,21 +86,37 @@ function renderToken(token: marked.Token, index: number): React.ReactElement {
           key={index}
           style={{textDecorationLine: 'underline'}}
           onPress={openLink}
+          {...props.textProps}
         >
           {token.text}
         </Text>
       );
     case 'list':
       return (
-        <Text key={index}>
-          {token.items.map((item) => `\u2022 ${item.text}\n`)}
-        </Text>
+        <React.Fragment key={index}>
+          {token.items.map((item, itemIndex) => (
+            <View
+              key={itemIndex}
+              style={{
+                flexDirection: 'row',
+                paddingTop: props.spacingBetweenListElements ?? 0,
+              }}
+            >
+              <Text {...props.textProps}>{'\u2022 '}</Text>
+              <Text {...props.textProps}>{item.text}</Text>
+            </View>
+          ))}
+        </React.Fragment>
       );
 
     default:
       console.warn(
         `We haven't defined a renderer for markdown type: "${token.type}", rendering raw: "${token.raw}"`,
       );
-      return <Text key={index}>{token.raw}</Text>;
+      return (
+        <Text key={index} {...props.textProps}>
+          {token.raw}
+        </Text>
+      );
   }
 }


### PR DESCRIPTION
Part of: 
https://github.com/AtB-AS/kundevendt/issues/17887

|Before|After|
|-|-|
|![Simulator Screenshot - iPhone 16 Pro - 2024-10-16 at 09 11 21](https://github.com/user-attachments/assets/480e39b2-9e6d-4959-880b-b3af864e1e26)|![Simulator Screenshot - iPhone 16 Pro - 2024-10-16 at 08 58 01](https://github.com/user-attachments/assets/a755dcfa-5cf7-4fe7-ad04-1e5014705315)|


Bullets points are aligned to the left and text to the right, there is a space between elements.

