### PR TITLE
chore: Add imagemagick installation to build workflows

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -45,6 +45,8 @@ jobs:
         env:
           ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
+      - name: Install imagemagick
+        run: sudo apt-get update && sudo apt-get install imagemagick
       - name: install node v18
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -40,6 +40,8 @@ jobs:
         env:
           ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
+      - name: Install imagemagick
+        run: sudo apt-get update && sudo apt-get install imagemagick
       - name: install node v18
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Image magick dependency was missing. At least is not included in the latest image update from last week.

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md