### PR TITLE
refactor: Use LaunchActivity on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,14 @@
         android:allowBackup="false"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
+            android:name=".LaunchActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
@@ -29,10 +37,6 @@
             android:windowSoftInputMode="adjustPan"
             android:exported="true"
             android:theme="@style/BootTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/android/app/src/main/java/no/mittatb/LaunchActivity.kt
+++ b/android/app/src/main/java/no/mittatb/LaunchActivity.kt
@@ -1,0 +1,14 @@
+package no.mittatb
+
+import com.facebook.react.ReactActivity
+import android.content.Intent
+import android.os.Bundle
+
+class LaunchActivity : ReactActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val intent: Intent = Intent(this, MainActivity::class.java)
+        startActivity(intent)
+        finish()
+    }
+}


### PR DESCRIPTION
### Background
Reopening the app through the app icon on Android closes an open in-app-browser. This is not good when the user needs to do secure customer authentication (SCA) in another app. This only happens when using the app icon, if following a deeplink back to the app or using the app switcher, then this doesn't happen.

Description of the problem:
https://github.com/proyecto26/react-native-inappbrowser/issues/213#issuecomment-878915862

### Solution
The solution with adding a `LaunchActivity` described here:
https://github.com/proyecto26/react-native-inappbrowser/issues/213#issuecomment-2165493514

**Before (with just `MainActivity`) / After (with `LaunchActivity`)**
<div>
<img src="https://github.com/user-attachments/assets/88f98486-db6d-459a-bed3-47d752dca1bd"/>
<img src="https://github.com/user-attachments/assets/eae7f380-8c0a-44ce-952f-ccefa4bfd66b"/>
</div>

### Acceptance criteria
It is hard to know if there are any unwanted side effects of adding this `LaunchActivity`. I have tried looking it up, but couldn't really find a problem with it outside of that many intents could make the app slower. Since this is a pretty small one I don't think that should be noticable.

- [ ] Reopening backgrounded app through app icon doesn't close in-app-browser
- [ ] When compared to app releases before this one, there should be no negative changes or noticeable performance degrade when opening the app through app icon (both fresh open and reopen), app-switching and deeplinking.
