### PR TITLE
refactor: extract estimated call components

### DIFF
--- a/src/components/estimated-call/DepartureTime.tsx
+++ b/src/components/estimated-call/DepartureTime.tsx
@@ -1,0 +1,72 @@
+import {EstimatedCall} from '@atb/api/types/departures';
+import {dictionary, useTranslation} from '@atb/translations';
+import {View} from 'react-native';
+import {ThemeIcon} from '../theme-icon';
+import {ThemeText} from '../text';
+import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
+import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {
+  formatLocaleTime,
+  formatToClockOrRelativeMinutes,
+  secondsBetween,
+} from '@atb/utils/date';
+
+type DepartureTimeProps = {
+  departure: EstimatedCall;
+};
+export const DepartureTime = ({departure}: DepartureTimeProps) => {
+  const {t, language} = useTranslation();
+  const styles = useStyles();
+  const {themeName} = useTheme();
+
+  return (
+    <View>
+      <View style={{flexDirection: 'row', alignItems: 'center'}}>
+        {departure.realtime && !departure.cancellation && (
+          <ThemeIcon
+            style={styles.realtimeIcon}
+            svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
+            size="xSmall"
+          />
+        )}
+        <ThemeText
+          type={
+            departure.cancellation
+              ? 'body__primary--strike'
+              : 'body__primary--bold'
+          }
+          color={departure.cancellation ? 'secondary' : 'primary'}
+        >
+          {formatToClockOrRelativeMinutes(
+            departure.expectedDepartureTime,
+            language,
+            t(dictionary.date.units.now),
+          )}
+        </ThemeText>
+      </View>
+      {isMoreThanOneMinuteDelayed(departure) && (
+        <ThemeText
+          type="body__tertiary--strike"
+          color="secondary"
+          style={styles.aimedTime}
+        >
+          {formatLocaleTime(departure.aimedDepartureTime, language)}
+        </ThemeText>
+      )}
+    </View>
+  );
+};
+
+const isMoreThanOneMinuteDelayed = (departure: EstimatedCall) =>
+  secondsBetween(
+    departure.aimedDepartureTime,
+    departure.expectedDepartureTime,
+  ) >= 60;
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  realtimeIcon: {
+    marginRight: theme.spacings.xSmall,
+  },
+  aimedTime: {textAlign: 'right'},
+}));

--- a/src/components/estimated-call/EstimatedCallInfo.tsx
+++ b/src/components/estimated-call/EstimatedCallInfo.tsx
@@ -1,0 +1,67 @@
+import {EstimatedCall} from '@atb/api/types/departures';
+import {StyleSheet} from '@atb/theme';
+import {useTranslation} from '@atb/translations';
+import {View} from 'react-native';
+import {formatDestinationDisplay} from '@atb/travel-details-screens/utils';
+import {usePreferences} from '@atb/preferences';
+import {LineChip} from './LineChip';
+import {ThemeIcon} from '../theme-icon';
+import {PinInvalid} from '@atb/assets/svg/mono-icons/map';
+import {ThemeText} from '@atb/components/text';
+
+type EstimatedCallProps = {
+  departure: EstimatedCall;
+  ignoreSituationsAndCancellations?: boolean;
+  testID?: string;
+};
+export function EstimatedCallInfo({
+  departure,
+  ignoreSituationsAndCancellations = false,
+  testID = 'estimatedCallItem',
+}: EstimatedCallProps) {
+  const styles = useStyles();
+  const {t} = useTranslation();
+  const {
+    preferences: {debugPredictionInaccurate},
+  } = usePreferences();
+
+  const lineName = formatDestinationDisplay(t, departure.destinationDisplay);
+  const showAsCancelled =
+    departure.cancellation && !ignoreSituationsAndCancellations;
+
+  return (
+    <View style={styles.transportInfo}>
+      <LineChip
+        departure={departure}
+        ignoreSituationsAndCancellations={ignoreSituationsAndCancellations}
+        testID={testID}
+      />
+      {debugPredictionInaccurate && departure.predictionInaccurate && (
+        <ThemeIcon svg={PinInvalid} colorType="warning" />
+      )}
+      <ThemeText
+        type={showAsCancelled ? 'body__primary--strike' : 'body__primary'}
+        color={showAsCancelled ? 'secondary' : 'primary'}
+        style={styles.lineName}
+        testID={`${testID}LineName`}
+      >
+        {lineName}
+      </ThemeText>
+    </View>
+  );
+}
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  transportInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 1,
+    flexWrap: 'wrap',
+  },
+  lineName: {
+    flexGrow: 1,
+    flexShrink: 1,
+    marginRight: theme.spacings.medium,
+    minWidth: '30%',
+  },
+}));

--- a/src/components/estimated-call/EstimatedCallInfo.tsx
+++ b/src/components/estimated-call/EstimatedCallInfo.tsx
@@ -1,22 +1,30 @@
-import {EstimatedCall} from '@atb/api/types/departures';
-import {StyleSheet} from '@atb/theme';
+import {Statuses, StyleSheet} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {View} from 'react-native';
 import {formatDestinationDisplay} from '@atb/travel-details-screens/utils';
 import {usePreferences} from '@atb/preferences';
-import {LineChip} from './LineChip';
+import {LineChip, LineChipServiceJourney} from './LineChip';
 import {ThemeIcon} from '../theme-icon';
 import {PinInvalid} from '@atb/assets/svg/mono-icons/map';
 import {ThemeText} from '@atb/components/text';
+import {DestinationDisplay} from '@atb/api/types/generated/journey_planner_v3_types';
 
+type EstimatedCallItemDeparture = {
+  destinationDisplay?: DestinationDisplay;
+  cancellation: boolean;
+  predictionInaccurate: boolean;
+  serviceJourney: LineChipServiceJourney;
+};
 type EstimatedCallProps = {
-  departure: EstimatedCall;
+  departure: EstimatedCallItemDeparture;
   ignoreSituationsAndCancellations?: boolean;
+  messageType?: Exclude<Statuses, 'valid'>;
   testID?: string;
 };
 export function EstimatedCallInfo({
   departure,
   ignoreSituationsAndCancellations = false,
+  messageType,
   testID = 'estimatedCallItem',
 }: EstimatedCallProps) {
   const styles = useStyles();
@@ -32,8 +40,10 @@ export function EstimatedCallInfo({
   return (
     <View style={styles.transportInfo}>
       <LineChip
-        departure={departure}
-        ignoreSituationsAndCancellations={ignoreSituationsAndCancellations}
+        serviceJourney={departure.serviceJourney}
+        messageType={
+          !ignoreSituationsAndCancellations ? messageType : undefined
+        }
         testID={testID}
       />
       {debugPredictionInaccurate && departure.predictionInaccurate && (

--- a/src/components/estimated-call/LineChip.tsx
+++ b/src/components/estimated-call/LineChip.tsx
@@ -1,0 +1,85 @@
+import {StyleSheet, useTheme} from '@atb/theme';
+import {ThemeIcon} from '../theme-icon';
+import {ThemeText} from '../text';
+import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
+import {getMsgTypeForEstimatedCall} from '@atb/place-screen/components/EstimatedCallItem';
+import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {getTransportModeSvg} from '../icon-box';
+import {View} from 'react-native';
+import {EstimatedCall} from '@atb/api/types/departures';
+import {useFontScale} from '@atb/utils/use-font-scale';
+
+type LineChipProps = {
+  departure: EstimatedCall;
+  ignoreSituationsAndCancellations?: boolean;
+  testID?: string;
+};
+export function LineChip({
+  departure,
+  ignoreSituationsAndCancellations = false,
+  testID = '',
+}: LineChipProps) {
+  const styles = useStyles();
+  const fontScale = useFontScale();
+  const {theme, themeName} = useTheme();
+  const publicCode = departure.serviceJourney.line.publicCode;
+  const {transportMode, transportSubmode} = departure.serviceJourney;
+  const {svg} = getTransportModeSvg(transportMode, transportSubmode);
+  const transportColor = useTransportationColor(
+    transportMode,
+    transportSubmode,
+  );
+  const transportTextColor = useTransportationColor(
+    transportMode,
+    transportSubmode,
+    false,
+    'text',
+  );
+
+  const msgType =
+    !ignoreSituationsAndCancellations && getMsgTypeForEstimatedCall(departure);
+  const icon = msgType && messageTypeToIcon(msgType, true, themeName);
+
+  if (!publicCode && !transportMode) return null;
+
+  return (
+    <View style={[styles.lineChip, {backgroundColor: transportColor}]}>
+      <ThemeIcon
+        fill={transportTextColor}
+        style={{marginRight: publicCode ? theme.spacings.small : 0}}
+        svg={svg}
+      />
+      {publicCode && (
+        <ThemeText
+          style={[
+            styles.lineChipText,
+            {color: transportTextColor, minWidth: fontScale * 20},
+          ]}
+          type="body__primary--bold"
+          testID={`${testID}PublicCode`}
+        >
+          {publicCode}
+        </ThemeText>
+      )}
+      {icon && <ThemeIcon svg={icon} style={styles.lineChipIcon} />}
+    </View>
+  );
+}
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  lineChip: {
+    padding: theme.spacings.small,
+    borderRadius: theme.border.radius.regular,
+    marginRight: theme.spacings.medium,
+    flexDirection: 'row',
+  },
+  lineChipIcon: {
+    position: 'absolute',
+    top: -theme.spacings.small,
+    left: -theme.spacings.small,
+  },
+  lineChipText: {
+    color: theme.static.background.background_accent_3.text,
+    textAlign: 'center',
+  },
+}));

--- a/src/components/estimated-call/LineChip.tsx
+++ b/src/components/estimated-call/LineChip.tsx
@@ -1,30 +1,37 @@
-import {StyleSheet, useTheme} from '@atb/theme';
+import {Statuses, StyleSheet, useTheme} from '@atb/theme';
 import {ThemeIcon} from '../theme-icon';
 import {ThemeText} from '../text';
 import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
-import {getMsgTypeForEstimatedCall} from '@atb/place-screen/components/EstimatedCallItem';
 import {useTransportationColor} from '@atb/utils/use-transportation-color';
 import {getTransportModeSvg} from '../icon-box';
 import {View} from 'react-native';
-import {EstimatedCall} from '@atb/api/types/departures';
 import {useFontScale} from '@atb/utils/use-font-scale';
+import {
+  TransportMode,
+  TransportSubmode,
+} from '@atb/api/types/generated/journey_planner_v3_types';
 
+export type LineChipServiceJourney = {
+  line?: {publicCode?: string | undefined};
+  transportMode?: TransportMode;
+  transportSubmode?: TransportSubmode;
+};
 type LineChipProps = {
-  departure: EstimatedCall;
-  ignoreSituationsAndCancellations?: boolean;
+  serviceJourney: LineChipServiceJourney;
+  messageType?: Exclude<Statuses, 'valid'>;
   testID?: string;
 };
 export function LineChip({
-  departure,
-  ignoreSituationsAndCancellations = false,
+  serviceJourney,
+  messageType,
   testID = '',
 }: LineChipProps) {
   const styles = useStyles();
   const fontScale = useFontScale();
   const {theme, themeName} = useTheme();
-  const publicCode = departure.serviceJourney.line.publicCode;
-  const {transportMode, transportSubmode} = departure.serviceJourney;
-  const {svg} = getTransportModeSvg(transportMode, transportSubmode);
+  const {transportMode, transportSubmode} = serviceJourney;
+  const publicCode = serviceJourney.line?.publicCode;
+
   const transportColor = useTransportationColor(
     transportMode,
     transportSubmode,
@@ -35,10 +42,8 @@ export function LineChip({
     false,
     'text',
   );
-
-  const msgType =
-    !ignoreSituationsAndCancellations && getMsgTypeForEstimatedCall(departure);
-  const icon = msgType && messageTypeToIcon(msgType, true, themeName);
+  const {svg} = getTransportModeSvg(transportMode, transportSubmode);
+  const icon = messageType && messageTypeToIcon(messageType, true, themeName);
 
   if (!publicCode && !transportMode) return null;
 

--- a/src/components/estimated-call/index.ts
+++ b/src/components/estimated-call/index.ts
@@ -1,3 +1,2 @@
 export {DepartureTime} from './DepartureTime';
 export {EstimatedCallInfo} from './EstimatedCallInfo';
-export {LineChip} from './LineChip';

--- a/src/components/estimated-call/index.ts
+++ b/src/components/estimated-call/index.ts
@@ -1,0 +1,3 @@
+export {DepartureTime} from './DepartureTime';
+export {EstimatedCallInfo} from './EstimatedCallInfo';
+export {LineChip} from './LineChip';

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -82,6 +82,8 @@ export const EstimatedCallItem = memo(
         ? t(DeparturesTexts.a11yMarkFavouriteHint)
         : t(DeparturesTexts.a11yViewDepartureDetailsHint);
 
+    const msgType = getMsgTypeForEstimatedCall(departure);
+
     return (
       <GenericClickableSectionItem
         radius={showBottomBorder ? 'bottom' : undefined}
@@ -100,6 +102,7 @@ export const EstimatedCallItem = memo(
             <EstimatedCallInfo
               departure={departure}
               ignoreSituationsAndCancellations={mode === 'Favourite'}
+              messageType={msgType}
               testID={`${testID}LineName`}
             />
             {mode !== 'Favourite' && <DepartureTime departure={departure} />}


### PR DESCRIPTION
In https://github.com/AtB-AS/kundevendt/issues/19125, some estimated call -related components are outside of the place-screen context, so I thought it made sense to extract them into `src/components/estimated-call. 

Replaces the `mode` param with `ignoreSituationsAndCancellations`, since I don't think a general component should handle the differences between screen specific modes  (map/favorites/departures). 