### PR TITLE
feat: add first iteration of journey aid screen

### DIFF
--- a/src/api/serviceJourney.ts
+++ b/src/api/serviceJourney.ts
@@ -1,4 +1,3 @@
-import {formatISO} from 'date-fns';
 import {client} from './client';
 import qs from 'query-string';
 import {stringifyUrl} from './utils';
@@ -7,11 +6,10 @@ import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragm
 
 export async function getServiceJourneyWithEstimatedCalls(
   id: string,
-  date: Date,
+  isoDate: string,
 ): Promise<ServiceJourneyWithEstCallsFragment> {
   const encodedId = encodeURIComponent(id);
-  const formattedDate = formatISO(date, {representation: 'date'});
-  const url = `bff/v2/servicejourney/${encodedId}/calls?date=${formattedDate}`;
+  const url = `bff/v2/servicejourney/${encodedId}/calls?date=${isoDate}`;
   const response = await client.get<{
     value: ServiceJourneyWithEstCallsFragment;
   }>(url);

--- a/src/api/serviceJourney.ts
+++ b/src/api/serviceJourney.ts
@@ -4,12 +4,16 @@ import {stringifyUrl} from './utils';
 import {ServiceJourneyMapInfoData_v3} from '@atb/api/types/serviceJourney';
 import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 
+/**
+ * @param id Service Journey ID
+ * @param serviceDate Service Journey date on the format "YYYY-MM-DD"
+ */
 export async function getServiceJourneyWithEstimatedCalls(
   id: string,
-  isoDate: string,
+  serviceDate: string,
 ): Promise<ServiceJourneyWithEstCallsFragment> {
   const encodedId = encodeURIComponent(id);
-  const url = `bff/v2/servicejourney/${encodedId}/calls?date=${isoDate}`;
+  const url = `bff/v2/servicejourney/${encodedId}/calls?date=${serviceDate}`;
   const response = await client.get<{
     value: ServiceJourneyWithEstCallsFragment;
   }>(url);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_DepartureDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_DepartureDetailsScreen.tsx
@@ -23,6 +23,11 @@ export const Dashboard_DepartureDetailsScreen = ({
           mode: 'Departure',
         })
       }
+      onPressTravelAid={(serviceJourney) => {
+        navigation.push('Dashboard_TravelAidScreen', {
+          serviceJourney,
+        });
+      }}
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_DepartureDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_DepartureDetailsScreen.tsx
@@ -23,9 +23,9 @@ export const Dashboard_DepartureDetailsScreen = ({
           mode: 'Departure',
         })
       }
-      onPressTravelAid={(serviceJourney) => {
+      onPressTravelAid={() => {
         navigation.push('Dashboard_TravelAidScreen', {
-          serviceJourney,
+          serviceJourneyDeparture: items[activeItemIndex],
         });
       }}
     />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TravelAidScreen.tsx
@@ -4,6 +4,10 @@ import {TravelAidScreenComponent} from '@atb/travel-aid/TravelAidScreenComponent
 type Props = DashboardScreenProps<'Dashboard_TravelAidScreen'>;
 
 export const Dashboard_TravelAidScreen = ({navigation, route}: Props) => {
-  const {serviceJourney} = route.params;
-  return <TravelAidScreenComponent serviceJourney={serviceJourney} />;
+  return (
+    <TravelAidScreenComponent
+      goBack={navigation.goBack}
+      serviceJourneyDeparture={route.params.serviceJourneyDeparture}
+    />
+  );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TravelAidScreen.tsx
@@ -1,0 +1,9 @@
+import {DashboardScreenProps} from './navigation-types';
+import {TravelAidScreenComponent} from '@atb/travel-aid/TravelAidScreenComponent';
+
+type Props = DashboardScreenProps<'Dashboard_TravelAidScreen'>;
+
+export const Dashboard_TravelAidScreen = ({navigation, route}: Props) => {
+  const {serviceJourney} = route.params;
+  return <TravelAidScreenComponent serviceJourney={serviceJourney} />;
+};

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/TabNav_DashboardStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/TabNav_DashboardStack.tsx
@@ -11,6 +11,7 @@ import {Dashboard_FavoriteDeparturesScreen} from '@atb/stacks-hierarchy/Root_Tab
 import {Dashboard_TripDetailsScreen} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripDetailsScreen';
 import {Dashboard_JourneyDatePickerScreen} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_JourneyDatePickerScreen';
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
+import {Dashboard_TravelAidScreen} from './Dashboard_TravelAidScreen';
 
 const Stack = createStackNavigator<DashboardStackParams>();
 
@@ -57,6 +58,10 @@ export const TabNav_DashboardStack = () => {
       <Stack.Screen
         name="Dashboard_FavoriteDeparturesScreen"
         component={Dashboard_FavoriteDeparturesScreen}
+      />
+      <Stack.Screen
+        name="Dashboard_TravelAidScreen"
+        component={Dashboard_TravelAidScreen}
       />
     </Stack.Navigator>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/navigation-types.ts
@@ -9,6 +9,7 @@ import {StackScreenProps} from '@react-navigation/stack';
 import {TripSearchScreenParams} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/types';
 import {NearbyStopPlacesScreenParams} from '@atb/nearby-stop-places/NearbyStopPlacesScreenComponent';
 import {StackParams} from '@atb/stacks-hierarchy/navigation-types';
+import {TravelAidScreenParams} from '@atb/travel-aid/TravelAidScreenComponent';
 
 export type DashboardRootScreenParams = {} & TripSearchScreenParams;
 
@@ -30,6 +31,7 @@ export type DashboardStackParams = StackParams<{
   Dashboard_JourneyDatePickerScreen: JourneyDatePickerScreenParams;
   Dashboard_FavoriteDeparturesScreen: undefined;
   Dashboard_NearbyStopPlacesScreen: Dashboard_NearbyStopPlacesScreenParams;
+  Dashboard_TravelAidScreen: TravelAidScreenParams;
 }>;
 
 export type RootDashboardScreenProps =

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_DepartureDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_DepartureDetailsScreen.tsx
@@ -23,6 +23,11 @@ export const Departures_DepartureDetailsScreen = ({
           mode: 'Departure',
         })
       }
+      onPressTravelAid={(serviceJourney) =>
+        navigation.push('Departures_TravelAidScreen', {
+          serviceJourney,
+        })
+      }
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_DepartureDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_DepartureDetailsScreen.tsx
@@ -8,6 +8,7 @@ export const Departures_DepartureDetailsScreen = ({
   route,
 }: Props) => {
   const {items, activeItemIndex} = route.params;
+  const activeItem = items[activeItemIndex];
 
   return (
     <DepartureDetailsScreenComponent
@@ -23,9 +24,9 @@ export const Departures_DepartureDetailsScreen = ({
           mode: 'Departure',
         })
       }
-      onPressTravelAid={(serviceJourney) =>
+      onPressTravelAid={() =>
         navigation.push('Departures_TravelAidScreen', {
-          serviceJourney,
+          serviceJourneyDeparture: activeItem,
         })
       }
     />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_TravelAidScreen.tsx
@@ -1,0 +1,9 @@
+import {DeparturesStackProps} from './navigation-types';
+import {TravelAidScreenComponent} from '@atb/travel-aid/TravelAidScreenComponent';
+
+type Props = DeparturesStackProps<'Departures_TravelAidScreen'>;
+
+export const Departures_TravelAidScreen = ({navigation, route}: Props) => {
+  const {serviceJourney} = route.params;
+  return <TravelAidScreenComponent serviceJourney={serviceJourney} />;
+};

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_TravelAidScreen.tsx
@@ -4,6 +4,10 @@ import {TravelAidScreenComponent} from '@atb/travel-aid/TravelAidScreenComponent
 type Props = DeparturesStackProps<'Departures_TravelAidScreen'>;
 
 export const Departures_TravelAidScreen = ({navigation, route}: Props) => {
-  const {serviceJourney} = route.params;
-  return <TravelAidScreenComponent serviceJourney={serviceJourney} />;
+  return (
+    <TravelAidScreenComponent
+      goBack={navigation.goBack}
+      serviceJourneyDeparture={route.params.serviceJourneyDeparture}
+    />
+  );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/TabNav_DeparturesStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/TabNav_DeparturesStack.tsx
@@ -9,6 +9,7 @@ import {Departures_DepartureDetailsScreen} from './Departures_DepartureDetailsSc
 import {Departures_TravelDetailsMapScreen} from './Departures_TravelDetailsMapScreen';
 import {Departures_PlaceScreen} from './Departures_PlaceScreen';
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
+import {Departures_TravelAidScreen} from './Departures_TravelAidScreen';
 
 const Stack = createStackNavigator<DeparturesStackParams>();
 
@@ -36,6 +37,10 @@ export const TabNav_DeparturesStack = ({}: RootDeparturesScreenProps) => {
       <Stack.Screen
         name="Departures_TravelDetailsMapScreen"
         component={Departures_TravelDetailsMapScreen}
+      />
+      <Stack.Screen
+        name="Departures_TravelAidScreen"
+        component={Departures_TravelAidScreen}
       />
     </Stack.Navigator>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/navigation-types.ts
@@ -5,13 +5,15 @@ import {PlaceScreenParams} from '@atb/place-screen/PlaceScreenComponent';
 import {DepartureDetailsScreenParams} from '@atb/travel-details-screens/DepartureDetailsScreenComponent';
 import {TravelDetailsMapScreenParams} from '@atb/travel-details-map-screen/TravelDetailsMapScreenComponent';
 import {NearbyStopPlacesScreenParams} from '@atb/nearby-stop-places/NearbyStopPlacesScreenComponent';
-import {StackParams} from "@atb/stacks-hierarchy/navigation-types";
+import {StackParams} from '@atb/stacks-hierarchy/navigation-types';
+import {TravelAidScreenParams} from '@atb/travel-aid/TravelAidScreenComponent';
 
 export type DeparturesStackParams = StackParams<{
   Departures_DepartureDetailsScreen: DepartureDetailsScreenParams;
   Departures_TravelDetailsMapScreen: TravelDetailsMapScreenParams;
   Departures_PlaceScreen: PlaceScreenParams;
   Departures_NearbyStopPlacesScreen: NearbyStopPlacesScreenParams;
+  Departures_TravelAidScreen: TravelAidScreenParams;
 }>;
 
 export type RootDeparturesScreenProps =

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_DepartureDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_DepartureDetailsScreen.tsx
@@ -5,6 +5,7 @@ type Props = MapScreenProps<'Map_DepartureDetailsScreen'>;
 
 export const Map_DepartureDetailsScreen = ({navigation, route}: Props) => {
   const {items, activeItemIndex} = route.params;
+  const activeItem = items[activeItemIndex];
 
   return (
     <DepartureDetailsScreenComponent
@@ -20,11 +21,11 @@ export const Map_DepartureDetailsScreen = ({navigation, route}: Props) => {
           mode: 'Departure',
         })
       }
-      onPressTravelAid={(serviceJourney) => {
+      onPressTravelAid={() =>
         navigation.push('Map_TravelAidScreen', {
-          serviceJourney,
-        });
-      }}
+          serviceJourneyDeparture: activeItem,
+        })
+      }
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_DepartureDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_DepartureDetailsScreen.tsx
@@ -20,6 +20,11 @@ export const Map_DepartureDetailsScreen = ({navigation, route}: Props) => {
           mode: 'Departure',
         })
       }
+      onPressTravelAid={(serviceJourney) => {
+        navigation.push('Map_TravelAidScreen', {
+          serviceJourney,
+        });
+      }}
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_TravelAidScreen.tsx
@@ -4,6 +4,10 @@ import {TravelAidScreenComponent} from '@atb/travel-aid/TravelAidScreenComponent
 type Props = MapScreenProps<'Map_TravelAidScreen'>;
 
 export const Map_TravelAidScreen = ({navigation, route}: Props) => {
-  const {serviceJourney} = route.params;
-  return <TravelAidScreenComponent serviceJourney={serviceJourney} />;
+  return (
+    <TravelAidScreenComponent
+      goBack={navigation.goBack}
+      serviceJourneyDeparture={route.params.serviceJourneyDeparture}
+    />
+  );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_TravelAidScreen.tsx
@@ -1,0 +1,9 @@
+import {MapScreenProps} from './navigation-types';
+import {TravelAidScreenComponent} from '@atb/travel-aid/TravelAidScreenComponent';
+
+type Props = MapScreenProps<'Map_TravelAidScreen'>;
+
+export const Map_TravelAidScreen = ({navigation, route}: Props) => {
+  const {serviceJourney} = route.params;
+  return <TravelAidScreenComponent serviceJourney={serviceJourney} />;
+};

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/TabNav_MapStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/TabNav_MapStack.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {TransitionPresets, createStackNavigator} from '@react-navigation/stack';
 import {Map_RootScreen} from './Map_RootScreen';
 import {Map_DepartureDetailsScreen} from './Map_DepartureDetailsScreen';
+import {Map_TravelAidScreen} from './Map_TravelAidScreen';
 import {Map_TravelDetailsMapScreen} from './Map_TravelDetailsMapScreen';
 import {Map_PlaceScreen} from './Map_PlaceScreen';
 import {MapStackParams} from './navigation-types';
@@ -26,6 +27,10 @@ export const TabNav_MapStack = () => {
       <Stack.Screen
         name="Map_TravelDetailsMapScreen"
         component={Map_TravelDetailsMapScreen}
+      />
+      <Stack.Screen
+        name="Map_TravelAidScreen"
+        component={Map_TravelAidScreen}
       />
     </Stack.Navigator>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/navigation-types.ts
@@ -7,12 +7,14 @@ import {StackScreenProps} from '@react-navigation/stack';
 import {DashboardScreenProps} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/navigation-types';
 import {StackParams} from '@atb/stacks-hierarchy/navigation-types';
 import {MapScreenParams} from './Map_RootScreen';
+import {TravelAidScreenParams} from '@atb/travel-aid/TravelAidScreenComponent';
 
 export type MapStackParams = StackParams<{
   Map_RootScreen: MapScreenParams;
   Map_PlaceScreen: PlaceScreenParams;
   Map_DepartureDetailsScreen: DepartureDetailsScreenParams;
   Map_TravelDetailsMapScreen: TravelDetailsMapScreenParams;
+  Map_TravelAidScreen: TravelAidScreenParams;
 }>;
 
 type RootMapScreenProps = TabNavigatorScreenProps<'TabNav_MapStack'>;

--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -6,6 +6,7 @@ const DepartureDetailsTexts = {
       _(departureName, departureName, departureName),
     alternateTitle: _('Reisedetaljer', 'Trip details', 'Reisedetaljar'),
     notFound: _('Detaljer', 'Details', 'Detaljar'),
+    journeyAid: _('Reisehjelp', 'Journey Aid', 'Reisehjelp'),
   },
   collapse: {
     label: (numberStops: number) =>

--- a/src/translations/screens/subscreens/TravelAid.ts
+++ b/src/translations/screens/subscreens/TravelAid.ts
@@ -1,9 +1,11 @@
 import {translation as _} from '../../commons';
 export const TravelAidTexts = {
   close: _('Lukk Reisehjelp', 'Close Journey Aid', 'Lukk Reisehjelp'),
-  arrivesAt: _('Kommer til:', 'Arrives at:', 'Kommer'),
-  from: _('Fra:', 'From:', 'Frå'),
-  nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste holdeplass'),
+  stopPlaceHeader: {
+    from: _('Fra:', 'From:', 'Frå'),
+    arrivesAt: _('Kommer til:', 'Arrives at:', 'Kommer'),
+    nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste holdeplass'),
+  },
   scheduledTime: (time: string) =>
     _(`Rutetid kl. ${time}`, `Scheduled at ${time}`, `Rutetid kl. ${time}`),
   noRealtimeError: {

--- a/src/translations/screens/subscreens/TravelAid.ts
+++ b/src/translations/screens/subscreens/TravelAid.ts
@@ -1,0 +1,21 @@
+import {translation as _} from '../../commons';
+export const TravelAidTexts = {
+  close: _('Lukk Reisehjelp', 'Close Journey Aid', 'Lukk Reisehjelp'),
+  arrivesAt: _('Kommer til:', 'Arrives at:', 'Kommer'),
+  from: _('Fra:', 'From:', 'Frå'),
+  nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste holdeplass'),
+  scheduledTime: (time: string) =>
+    _(`Rutetid kl. ${time}`, `Scheduled at ${time}`, `Rutetid kl. ${time}`),
+  noRealtimeError: {
+    title: _(
+      'Ingen kontakt med kjøretøy',
+      'No connection with vehicle',
+      'Ingen kontakt med køyretøy',
+    ),
+    message: _(
+      'Vi får ikke oppdatert kjøretøyets posisjon, og Reisehjelp er derfor utilgjengelig for denne avgangen. Vi jobber med å få kontakt.',
+      "We're not receiving updates on the vehicle's position, so Journey Aid is unavailable for this trip. We're working to establish a connection.",
+      'Vi får ikkje oppdatert køyretøyets posisjon, og Reisehjelp er difor utilgjengeleg for denne avgangen. Vi jobbar med å få kontakt.',
+    ),
+  },
+};

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -37,6 +37,7 @@ export const TravelAidScreenComponent = ({
   const {language, t} = useTranslation();
   const {themeName} = useTheme();
 
+  // TODO: Add error handling and loading state
   const {data: serviceJourney} = useTravelAidDataQuery(
     serviceJourneyDeparture.serviceJourneyId,
     formatToISODate(serviceJourneyDeparture.serviceDate),

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -58,9 +58,7 @@ export const TravelAidScreenComponent = ({
       <Button
         onPress={goBack}
         text={t(TravelAidTexts.close)}
-        leftIcon={{
-          svg: Close,
-        }}
+        leftIcon={{svg: Close}}
         mode="tertiary"
         type="medium"
       />

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -1,0 +1,27 @@
+import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ThemeText} from '@atb/components/text';
+import {StyleSheet} from '@atb/theme';
+import React from 'react';
+
+export type TravelAidScreenParams = {
+  serviceJourney: ServiceJourneyWithEstCallsFragment;
+};
+
+type Props = TravelAidScreenParams & {};
+
+export const TravelAidScreenComponent = ({serviceJourney}: Props) => {
+  const styles = useStyles();
+  return (
+    <FullScreenView
+      headerProps={{
+        leftButton: {type: 'back', withIcon: true},
+        title: 'Travel aid',
+      }}
+    >
+      <ThemeText>{serviceJourney.id}</ThemeText>
+    </FullScreenView>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({}));

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -1,27 +1,142 @@
-import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
-import {FullScreenView} from '@atb/components/screen-view';
-import {ThemeText} from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {Close} from '@atb/assets/svg/mono-icons/actions';
+import {Button} from '@atb/components/button';
+import {EstimatedCallInfo} from '@atb/components/estimated-call';
+import {StyleSheet, useTheme} from '@atb/theme';
+import {ServiceJourneyDeparture} from '@atb/travel-details-screens/types';
+import {addMetadataToEstimatedCalls} from '@atb/travel-details-screens/use-departure-data';
 import React from 'react';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {useTravelAidDataQuery} from './use-travel-aid-data';
+import {ScrollView} from 'react-native-gesture-handler';
+import {GenericSectionItem, Section} from '@atb/components/sections';
+import {View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import {formatToClock, formatToClockOrRelativeMinutes} from '@atb/utils/date';
+import {dictionary, useTranslation} from '@atb/translations';
+import {TravelAidTexts} from '@atb/translations/screens/subscreens/TravelAid';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
+import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
+import {StatusBarOnFocus} from '@atb/components/status-bar-on-focus';
 
 export type TravelAidScreenParams = {
-  serviceJourney: ServiceJourneyWithEstCallsFragment;
+  serviceJourneyDeparture: ServiceJourneyDeparture;
 };
 
-type Props = TravelAidScreenParams & {};
+type Props = TravelAidScreenParams & {
+  goBack: () => void;
+};
 
-export const TravelAidScreenComponent = ({serviceJourney}: Props) => {
+export const TravelAidScreenComponent = ({
+  serviceJourneyDeparture,
+  goBack,
+}: Props) => {
   const styles = useStyles();
+  const {language, t} = useTranslation();
+  const {themeName} = useTheme();
+
+  const {data: serviceJourney} = useTravelAidDataQuery(
+    serviceJourneyDeparture.serviceJourneyId,
+    new Date(serviceJourneyDeparture.serviceDate),
+  );
+  const estimatedCallsWithMetadata = addMetadataToEstimatedCalls(
+    serviceJourney?.estimatedCalls || [],
+    serviceJourneyDeparture.fromQuayId,
+    serviceJourneyDeparture.toQuayId,
+  );
+  const focusedEstimatedCall = estimatedCallsWithMetadata.find(
+    (e) => e.metadata.group === 'trip',
+  );
+
   return (
-    <FullScreenView
-      headerProps={{
-        leftButton: {type: 'back', withIcon: true},
-        title: 'Travel aid',
-      }}
-    >
-      <ThemeText>{serviceJourney.id}</ThemeText>
-    </FullScreenView>
+    <SafeAreaView style={{flex: 1}}>
+      <StatusBarOnFocus
+        barStyle={themeName === 'light' ? 'dark-content' : 'light-content'}
+      />
+      <Button
+        onPress={goBack}
+        text={t(TravelAidTexts.close)}
+        leftIcon={{
+          svg: Close,
+        }}
+        mode="tertiary"
+        type="medium"
+      />
+      <ScrollView contentContainerStyle={styles.container}>
+        {focusedEstimatedCall && (
+          <Section>
+            <GenericSectionItem style={styles.sectionContainer}>
+              <EstimatedCallInfo
+                departure={{
+                  cancellation: false,
+                  predictionInaccurate: false,
+                  serviceJourney: serviceJourney ?? {},
+                  destinationDisplay: focusedEstimatedCall?.destinationDisplay,
+                }}
+              />
+            </GenericSectionItem>
+            <GenericSectionItem style={styles.sectionContainer}>
+              <View style={styles.subContainer}>
+                <ThemeText type="body__tertiary--bold">
+                  {t(TravelAidTexts.arrivesAt)}
+                </ThemeText>
+                <ThemeText type="heading__title">
+                  {focusedEstimatedCall.quay.stopPlace?.name}{' '}
+                  {focusedEstimatedCall.quay.publicCode}
+                </ThemeText>
+              </View>
+              <View>
+                <View style={styles.realTime}>
+                  <ThemeIcon
+                    svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
+                    size="xSmall"
+                  />
+                  <ThemeText type="heading__title">
+                    {formatToClockOrRelativeMinutes(
+                      focusedEstimatedCall.expectedDepartureTime,
+                      language,
+                      t(dictionary.date.units.now),
+                    )}
+                  </ThemeText>
+                </View>
+                <ThemeText type="body__secondary--bold">
+                  {t(
+                    TravelAidTexts.scheduledTime(
+                      formatToClock(
+                        focusedEstimatedCall.aimedDepartureTime,
+                        language,
+                        'round',
+                      ),
+                    ),
+                  )}
+                </ThemeText>
+              </View>
+            </GenericSectionItem>
+          </Section>
+        )}
+      </ScrollView>
+    </SafeAreaView>
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({}));
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    paddingHorizontal: theme.spacings.medium,
+  },
+  sectionContainer: {
+    gap: theme.spacings.xLarge,
+  },
+  subContainer: {
+    gap: theme.spacings.small,
+  },
+  horizontalRule: {
+    borderBottomWidth: 1,
+    borderBottomColor: theme.static.background.background_0.text,
+    width: '100%',
+  },
+  realTime: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacings.xSmall,
+  },
+}));

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -10,11 +10,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
-import {
-  formatToClock,
-  formatToClockOrRelativeMinutes,
-  formatToISODate,
-} from '@atb/utils/date';
+import {formatToClock, formatToClockOrRelativeMinutes} from '@atb/utils/date';
 import {dictionary, useTranslation} from '@atb/translations';
 import {TravelAidTexts} from '@atb/translations/screens/subscreens/TravelAid';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -40,7 +36,7 @@ export const TravelAidScreenComponent = ({
   // TODO: Add error handling and loading state
   const {data: serviceJourney} = useTravelAidDataQuery(
     serviceJourneyDeparture.serviceJourneyId,
-    formatToISODate(serviceJourneyDeparture.serviceDate),
+    serviceJourneyDeparture.serviceDate,
   );
 
   // TODO: Change focused stop over time

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -10,7 +10,11 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
-import {formatToClock, formatToClockOrRelativeMinutes} from '@atb/utils/date';
+import {
+  formatToClock,
+  formatToClockOrRelativeMinutes,
+  formatToISODate,
+} from '@atb/utils/date';
 import {dictionary, useTranslation} from '@atb/translations';
 import {TravelAidTexts} from '@atb/translations/screens/subscreens/TravelAid';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -35,7 +39,7 @@ export const TravelAidScreenComponent = ({
 
   const {data: serviceJourney} = useTravelAidDataQuery(
     serviceJourneyDeparture.serviceJourneyId,
-    new Date(serviceJourneyDeparture.serviceDate),
+    formatToISODate(serviceJourneyDeparture.serviceDate),
   );
 
   // TODO: Change focused stop over time

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -135,6 +135,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacings.medium,
   },
   sectionContainer: {
+    flex: 1,
     gap: theme.spacings.xLarge,
   },
   subContainer: {

--- a/src/travel-aid/use-travel-aid-data.tsx
+++ b/src/travel-aid/use-travel-aid-data.tsx
@@ -1,9 +1,9 @@
 import {useQuery} from '@tanstack/react-query';
 import {getServiceJourneyWithEstimatedCalls} from '@atb/api/serviceJourney';
 
-export const useTravelAidDataQuery = (id: string, isoDate: string) =>
+export const useTravelAidDataQuery = (id: string, serviceDate: string) =>
   useQuery({
-    queryKey: ['travelAidData', id, isoDate],
-    queryFn: () => getServiceJourneyWithEstimatedCalls(id, isoDate),
+    queryKey: ['travelAidData', id, serviceDate],
+    queryFn: () => getServiceJourneyWithEstimatedCalls(id, serviceDate),
     refetchInterval: 10000,
   });

--- a/src/travel-aid/use-travel-aid-data.tsx
+++ b/src/travel-aid/use-travel-aid-data.tsx
@@ -1,0 +1,12 @@
+import {useQuery} from '@tanstack/react-query';
+import {ONE_HOUR_MS} from '@atb/utils/durations.ts';
+import {getServiceJourneyWithEstimatedCalls} from '@atb/api/serviceJourney';
+import {formatISO} from 'date-fns';
+
+export const useTravelAidDataQuery = (id: string, date: Date) =>
+  useQuery({
+    queryKey: ['travelAidData', id, formatISO(date, {representation: 'date'})],
+    queryFn: () => getServiceJourneyWithEstimatedCalls(id, date),
+    staleTime: ONE_HOUR_MS,
+    cacheTime: ONE_HOUR_MS,
+  });

--- a/src/travel-aid/use-travel-aid-data.tsx
+++ b/src/travel-aid/use-travel-aid-data.tsx
@@ -1,9 +1,9 @@
 import {useQuery} from '@tanstack/react-query';
 import {getServiceJourneyWithEstimatedCalls} from '@atb/api/serviceJourney';
 
-export const useTravelAidDataQuery = (id: string, date: Date) =>
+export const useTravelAidDataQuery = (id: string, isoDate: string) =>
   useQuery({
-    queryKey: ['travelAidData', id],
-    queryFn: () => getServiceJourneyWithEstimatedCalls(id, date),
+    queryKey: ['travelAidData', id, isoDate],
+    queryFn: () => getServiceJourneyWithEstimatedCalls(id, isoDate),
     refetchInterval: 10000,
   });

--- a/src/travel-aid/use-travel-aid-data.tsx
+++ b/src/travel-aid/use-travel-aid-data.tsx
@@ -1,12 +1,9 @@
 import {useQuery} from '@tanstack/react-query';
-import {ONE_HOUR_MS} from '@atb/utils/durations.ts';
 import {getServiceJourneyWithEstimatedCalls} from '@atb/api/serviceJourney';
-import {formatISO} from 'date-fns';
 
 export const useTravelAidDataQuery = (id: string, date: Date) =>
   useQuery({
-    queryKey: ['travelAidData', id, formatISO(date, {representation: 'date'})],
+    queryKey: ['travelAidData', id],
     queryFn: () => getServiceJourneyWithEstimatedCalls(id, date),
-    staleTime: ONE_HOUR_MS,
-    cacheTime: ONE_HOUR_MS,
+    refetchInterval: 10000,
   });

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -62,7 +62,6 @@ import {
 import {BookingOptions} from '@atb/travel-details-screens/components/BookingOptions';
 import {BookingInfoBox} from '@atb/travel-details-screens/components/BookingInfoBox';
 import {useIsTravelAidEnabled} from '@atb/travel-aid/use-is-travel-aid-enabled';
-import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 
 export type DepartureDetailsScreenParams = {
   items: ServiceJourneyDeparture[];
@@ -72,9 +71,7 @@ export type DepartureDetailsScreenParams = {
 type Props = DepartureDetailsScreenParams & {
   onPressDetailsMap: (params: TravelDetailsMapScreenParams) => void;
   onPressQuay: (stopPlace: StopPlaceFragment, selectedQuayId?: string) => void;
-  onPressTravelAid: (
-    serviceJourney: ServiceJourneyWithEstCallsFragment,
-  ) => void;
+  onPressTravelAid: () => void;
 };
 
 export const DepartureDetailsScreenComponent = ({

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -94,15 +94,7 @@ export const DepartureDetailsScreenComponent = ({
   const {t, language} = useTranslation();
 
   const [
-    {
-      estimatedCallsWithMetadata,
-      title,
-      mode,
-      subMode,
-      situations,
-      notices,
-      serviceJourney,
-    },
+    {estimatedCallsWithMetadata, title, mode, subMode, situations, notices},
     isLoading,
   ] = useDepartureData(activeItem, 20);
 
@@ -189,7 +181,7 @@ export const DepartureDetailsScreenComponent = ({
                 {title ?? t(DepartureDetailsTexts.header.notFound)}
               </ThemeText>
             </View>
-            {travelAidEnabled && serviceJourney && (
+            {travelAidEnabled && (
               <Button
                 style={styles.travelAidButton}
                 onPress={onPressTravelAid}

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -61,6 +61,8 @@ import {
 } from '@atb/travel-details-screens/utils';
 import {BookingOptions} from '@atb/travel-details-screens/components/BookingOptions';
 import {BookingInfoBox} from '@atb/travel-details-screens/components/BookingInfoBox';
+import {useIsTravelAidEnabled} from '@atb/travel-aid/use-is-travel-aid-enabled';
+import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 
 export type DepartureDetailsScreenParams = {
   items: ServiceJourneyDeparture[];
@@ -70,6 +72,9 @@ export type DepartureDetailsScreenParams = {
 type Props = DepartureDetailsScreenParams & {
   onPressDetailsMap: (params: TravelDetailsMapScreenParams) => void;
   onPressQuay: (stopPlace: StopPlaceFragment, selectedQuayId?: string) => void;
+  onPressTravelAid: (
+    serviceJourney: ServiceJourneyWithEstCallsFragment,
+  ) => void;
 };
 
 export const DepartureDetailsScreenComponent = ({
@@ -77,6 +82,7 @@ export const DepartureDetailsScreenComponent = ({
   activeItemIndex,
   onPressDetailsMap,
   onPressQuay,
+  onPressTravelAid,
 }: Props) => {
   const [activeItemIndexState, setActiveItem] = useState(activeItemIndex);
   const {theme} = useTheme();
@@ -91,7 +97,15 @@ export const DepartureDetailsScreenComponent = ({
   const {t, language} = useTranslation();
 
   const [
-    {estimatedCallsWithMetadata, title, mode, subMode, situations, notices},
+    {
+      estimatedCallsWithMetadata,
+      title,
+      mode,
+      subMode,
+      situations,
+      notices,
+      serviceJourney,
+    },
     isLoading,
   ] = useDepartureData(activeItem, 20);
 
@@ -103,6 +117,7 @@ export const DepartureDetailsScreenComponent = ({
 
   const realtimeMapEnabled = useRealtimeMapEnabled();
   const screenReaderEnabled = useIsScreenReaderEnabled();
+  const travelAidEnabled = useIsTravelAidEnabled();
 
   const shouldShowLive = getShouldShowLiveVehicle(
     estimatedCallsWithMetadata,
@@ -177,6 +192,14 @@ export const DepartureDetailsScreenComponent = ({
                 {title ?? t(DepartureDetailsTexts.header.notFound)}
               </ThemeText>
             </View>
+            {travelAidEnabled && serviceJourney && (
+              <Button
+                style={styles.travelAidButton}
+                onPress={onPressTravelAid}
+                text={t(DepartureDetailsTexts.header.journeyAid)}
+                interactiveColor="interactive_0"
+              />
+            )}
             {shouldShowMapButton || realtimeText ? (
               <View style={styles.headerSubSection}>
                 {realtimeText && !activeItem.isTripCancelled && (
@@ -663,6 +686,9 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   },
   liveButton: {
     marginLeft: theme.spacings.small,
+  },
+  travelAidButton: {
+    marginTop: theme.spacings.medium,
   },
   place: {
     marginBottom: -theme.tripLegDetail.decorationLineWidth,

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -14,6 +14,7 @@ import {
   getNoticesForServiceJourney,
 } from '@atb/travel-details-screens/utils';
 import {useTranslation} from '@atb/translations';
+import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 
 export type DepartureData = {
   estimatedCallsWithMetadata: EstimatedCallWithMetadata[];
@@ -22,6 +23,7 @@ export type DepartureData = {
   subMode?: TransportSubmode;
   situations: SituationFragment[];
   notices: NoticeFragment[];
+  serviceJourney?: ServiceJourneyWithEstCallsFragment;
 };
 
 type EstimatedCallMetadata = {
@@ -80,6 +82,7 @@ export function useDepartureData(
         estimatedCallsWithMetadata,
         situations,
         notices,
+        serviceJourney,
       };
     },
     [activeItem, t],

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -14,7 +14,6 @@ import {
   getNoticesForServiceJourney,
 } from '@atb/travel-details-screens/utils';
 import {useTranslation} from '@atb/translations';
-import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 
 export type DepartureData = {
   estimatedCallsWithMetadata: EstimatedCallWithMetadata[];
@@ -23,7 +22,6 @@ export type DepartureData = {
   subMode?: TransportSubmode;
   situations: SituationFragment[];
   notices: NoticeFragment[];
-  serviceJourney?: ServiceJourneyWithEstCallsFragment;
 };
 
 type EstimatedCallMetadata = {
@@ -82,7 +80,6 @@ export function useDepartureData(
         estimatedCallsWithMetadata,
         situations,
         notices,
-        serviceJourney,
       };
     },
     [activeItem, t],

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -100,7 +100,7 @@ export function useDepartureData(
   return [data, isLoading];
 }
 
-export function addMetadataToEstimatedCalls(
+function addMetadataToEstimatedCalls(
   estimatedCalls: EstimatedCallWithQuayFragment[],
   fromQuayId?: string,
   toQuayId?: string,

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -102,7 +102,7 @@ export function useDepartureData(
   return [data, isLoading];
 }
 
-function addMetadataToEstimatedCalls(
+export function addMetadataToEstimatedCalls(
   estimatedCalls: EstimatedCallWithQuayFragment[],
   fromQuayId?: string,
   toQuayId?: string,

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -14,6 +14,7 @@ import {
   getNoticesForServiceJourney,
 } from '@atb/travel-details-screens/utils';
 import {useTranslation} from '@atb/translations';
+import {formatToISODate} from '@atb/utils/date';
 
 export type DepartureData = {
   estimatedCallsWithMetadata: EstimatedCallWithMetadata[];
@@ -45,7 +46,7 @@ export function useDepartureData(
     async function (): Promise<DepartureData> {
       const serviceJourney = await getServiceJourneyWithEstimatedCalls(
         activeItem.serviceJourneyId,
-        new Date(activeItem.serviceDate),
+        formatToISODate(activeItem.serviceDate),
       );
       const estimatedCallsWithMetadata = addMetadataToEstimatedCalls(
         serviceJourney.estimatedCalls || [],

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -14,7 +14,6 @@ import {
   getNoticesForServiceJourney,
 } from '@atb/travel-details-screens/utils';
 import {useTranslation} from '@atb/translations';
-import {formatToISODate} from '@atb/utils/date';
 
 export type DepartureData = {
   estimatedCallsWithMetadata: EstimatedCallWithMetadata[];
@@ -46,7 +45,7 @@ export function useDepartureData(
     async function (): Promise<DepartureData> {
       const serviceJourney = await getServiceJourneyWithEstimatedCalls(
         activeItem.serviceJourneyId,
-        formatToISODate(activeItem.serviceDate),
+        activeItem.serviceDate,
       );
       const estimatedCallsWithMetadata = addMetadataToEstimatedCalls(
         serviceJourney.estimatedCalls || [],

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -10,6 +10,7 @@ import {
   format as fnsFormat,
   isAfter as fnsIsAfter,
   isBefore as fnsIsBefore,
+  formatISO,
   getHours,
   getMinutes,
   getSeconds,
@@ -351,6 +352,10 @@ export function formatToShortDate(date: Date | string, language: Language) {
   return format(parseIfNeeded(date), 'dd. MMM', {
     locale: languageToLocale(language),
   });
+}
+
+export function formatToISODate(date: Date | string) {
+  return formatISO(parseIfNeeded(date), {representation: 'date'});
 }
 
 export function formatToShortDateWithYear(

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -10,7 +10,6 @@ import {
   format as fnsFormat,
   isAfter as fnsIsAfter,
   isBefore as fnsIsBefore,
-  formatISO,
   getHours,
   getMinutes,
   getSeconds,
@@ -352,10 +351,6 @@ export function formatToShortDate(date: Date | string, language: Language) {
   return format(parseIfNeeded(date), 'dd. MMM', {
     locale: languageToLocale(language),
   });
-}
-
-export function formatToISODate(date: Date | string) {
-  return formatISO(parseIfNeeded(date), {representation: 'date'});
 }
 
 export function formatToShortDateWithYear(


### PR DESCRIPTION
First iteration of https://github.com/AtB-AS/kundevendt/issues/19125

Most of the features are missing at this point, this is just to have a screen with journey info visible, then we'll iterate from that.

<div>
<img width="300px" src="https://github.com/user-attachments/assets/f169f520-1a73-4a79-8bf1-438c4aa2b829">
<img width="300px" src="https://github.com/user-attachments/assets/e8896471-10fb-4356-8814-dac44e5b63e2">
</div>

Note: There's some inconsistency between the use of "travel aid" and "journey aid" in the app now. I'll make a separate PR to fix this.