### PR TITLE
fix: Fix double offer search

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -127,15 +127,12 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       (p) => p.id === userProfilesWithCountAndOffer[0]?.offer.fare_product,
     ) ?? preassignedFareProductAlternatives[0];
 
-  useEffect(() => {
-    if (selection.preassignedFareProduct.id !== preassignedFareProduct.id) {
-      navigation.setParams({preassignedFareProduct});
-    }
-  }, [navigation, selection, preassignedFareProduct]);
-
   const rootPurchaseConfirmationScreenParams: Root_PurchaseConfirmationScreenParams =
     {
-      selection,
+      selection: {
+        ...selection,
+        preassignedFareProduct,
+      },
       mode: params.mode,
     };
 
@@ -165,7 +162,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const handleTicketInfoButtonPress = () => {
     const parameters = {
       fareProductTypeConfigType: params.fareProductTypeConfig.type,
-      preassignedFareProductId: selection.preassignedFareProduct?.id,
+      preassignedFareProductId: preassignedFareProduct.id,
     };
     analytics.logEvent(
       'Ticketing',
@@ -206,7 +203,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           ref={params.onFocusElement ? undefined : focusRef}
           style={styles.header}
           fareProductTypeConfig={params.fareProductTypeConfig}
-          preassignedFareProduct={selection.preassignedFareProduct}
+          preassignedFareProduct={preassignedFareProduct}
           onTicketInfoButtonPress={handleTicketInfoButtonPress}
         />
       )}
@@ -225,7 +222,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 type="info"
                 message={t(
                   PurchaseOverviewTexts.errorMessageBox.productUnavailable(
-                    getReferenceDataName(selection.preassignedFareProduct, language),
+                    getReferenceDataName(preassignedFareProduct, language),
                   ),
                 )}
                 style={styles.selectionComponent}


### PR DESCRIPTION
The ProductSelectionType has one product, but the offer search may
return another product with the same product alias id. This is what
happens for carnet Trondheim-Vanvikan.

The double offer search was because of the ProductSelection was
updated after the offer search results came in. This shouldn't be
done, the selection should still be the same even if the product in
the offer response changes.

Also made som changes to ensure that texts shown in the app is the
texts for offer search result product.
