### PR TITLE
refactor: ThemeIcon undefined svg safeguard

### DIFF
--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -15,6 +15,7 @@ import {
   NotificationIndicatorProps,
 } from './NotificationIndicator';
 import React from 'react';
+import {notifyBugsnag} from '@atb/utils/bugsnag-utils.ts';
 
 export type ThemeIconProps = {
   svg(props: SvgProps): JSX.Element;
@@ -33,12 +34,17 @@ export const ThemeIcon = ({
   style,
   allowFontScaling = true,
   ...props
-}: ThemeIconProps): JSX.Element => {
+}: ThemeIconProps): JSX.Element | null => {
   const {theme, themeName} = useTheme();
+  const fontScale = useFontScale();
+
+  if (!svg) {
+    notifyBugsnag('Undefined SVG provided to ThemeIcon');
+    return null;
+  }
 
   const fillToUse = fill || getFill(theme, themeName, colorType);
 
-  const fontScale = useFontScale();
   const iconSize = allowFontScaling
     ? theme.icon.size[size] * fontScale
     : theme.icon.size[size];


### PR DESCRIPTION
We got some reports in Bugsnag where the app has crashed because
of the svg prop sent to ThemeIcon was undefined. This should really
not happen, but it is a little extreme that the app crashes if it
does. This safeguard is added to prevent app crash, rather there
will be no rendered ThemeIcon.

### Acceptance criteria
Haven't been able to reproduce, we will rely on code review for this one.
