### PR TITLE
fix: Add refresh logic for id token

### DIFF
--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -31,6 +31,7 @@ import {useClearQueriesOnUserChange} from './use-clear-queries-on-user-change';
 import {useUpdateIntercomOnUserChange} from '@atb/auth/use-update-intercom-on-user-change';
 import {useIsBackendSmsAuthEnabled} from './use-is-backend-sms-auth-enabled';
 import {useLocaleContext} from '@atb/LocaleProvider';
+import {useRefreshIdTokenWhenNecessary} from "@atb/auth/use-refresh-id-token-when-necessary.ts";
 
 export type AuthReducerState = {
   authStatus: AuthStatus;
@@ -159,6 +160,7 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
   const {resubscribe} = useSubscribeToAuthUserChange(dispatch);
   useClearQueriesOnUserChange(state);
   useFetchIdTokenWithCustomClaims(state, dispatch);
+  useRefreshIdTokenWhenNecessary(state, dispatch);
 
   useUpdateAuthLanguageOnChange();
   useUpdateIntercomOnUserChange(state);

--- a/src/auth/use-fetch-id-token-with-custom-claims.ts
+++ b/src/auth/use-fetch-id-token-with-custom-claims.ts
@@ -2,7 +2,11 @@ import {Dispatch, useEffect} from 'react';
 import {AuthReducerAction} from './types';
 import {AuthReducerState} from '@atb/auth/AuthContext';
 import {useQuery} from '@tanstack/react-query';
-import {logToBugsnag, notifyBugsnag} from '@atb/utils/bugsnag-utils';
+import {
+  errorToMetadata,
+  logToBugsnag,
+  notifyBugsnag,
+} from '@atb/utils/bugsnag-utils';
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {useRemoteConfig} from '@atb/RemoteConfigContext.tsx';
 
@@ -82,6 +86,3 @@ export const useFetchIdTokenWithCustomClaims = (
     }
   }, [dispatch, query.error, query.failureCount]);
 };
-
-const errorToMetadata = (error: any) =>
-  'message' in error ? {errorMessage: error.message} : undefined;

--- a/src/auth/use-refresh-id-token-when-necessary.ts
+++ b/src/auth/use-refresh-id-token-when-necessary.ts
@@ -1,0 +1,40 @@
+import {Dispatch} from 'react';
+import {AuthReducerAction} from './types';
+import {AuthReducerState} from '@atb/auth/AuthContext';
+import {secondsToTokenExpiry} from '@atb/auth/utils.ts';
+import {useAppStateStatus} from '@atb/utils/use-app-state-status.ts';
+import {useInterval} from '@atb/utils/use-interval.ts';
+import {errorToMetadata, logToBugsnag} from '@atb/utils/bugsnag-utils.ts';
+import {ONE_SECOND_MS} from '@atb/utils/durations.ts';
+
+export const useRefreshIdTokenWhenNecessary = (
+  state: AuthReducerState,
+  dispatch: Dispatch<AuthReducerAction>,
+) => {
+  const appState = useAppStateStatus();
+  const disableInterval =
+    appState !== 'active' || state.authStatus !== 'authenticated';
+
+  useInterval(
+    async () => {
+      if (state.user && state.idTokenResult) {
+        const secondsToExpiry = secondsToTokenExpiry(state.idTokenResult);
+        if (secondsToExpiry < 300) {
+          try {
+            const idTokenResult = await state.user.getIdTokenResult(true);
+            dispatch({type: 'SET_ID_TOKEN', idTokenResult});
+          } catch (err) {
+            logToBugsnag(
+              'Error when refreshing id token',
+              errorToMetadata(err),
+            );
+          }
+        }
+      }
+    },
+    [dispatch, state.user, state.idTokenResult],
+    30 * ONE_SECOND_MS,
+    disableInterval,
+    true,
+  );
+};

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -1,5 +1,6 @@
 import {FirebaseAuthTypes} from '@react-native-firebase/auth';
 import {AuthenticationType} from './types';
+import {secondsBetween} from "@atb/utils/date.ts";
 
 export const mapAuthenticationType = (
   user: FirebaseAuthTypes.User | undefined,
@@ -8,3 +9,7 @@ export const mapAuthenticationType = (
   else if (user?.isAnonymous) return 'anonymous';
   else return 'none';
 };
+
+export const secondsToTokenExpiry = (
+  idTokenResult: FirebaseAuthTypes.IdTokenResult,
+) => secondsBetween(new Date(), new Date(idTokenResult.expirationTime));

--- a/src/utils/bugsnag-utils.ts
+++ b/src/utils/bugsnag-utils.ts
@@ -7,16 +7,16 @@ type MetaData = {[key: string]: any};
  * ensures that the correct grouping is provided,
  * and is easier to mock for testing Bugsnag notifications.
  *
- * Please see 
+ * Please see
  * {@link https://github.com/AtB-AS/docs-private/blob/main/bugsnag.md|bugsnag.md}
  *
  * @param error error object (@see {@link NotifiableError})
- * 
- * @param errorGroupHash error group hash, determines the grouping of issues 
+ *
+ * @param errorGroupHash error group hash, determines the grouping of issues
  * ({@link https://docs.bugsnag.com/product/error-grouping/#custom-grouping-hash|see official docs} for more info)
- * 
+ *
  * @param metadata metadata to send with the error report.
- * 
+ *
  * @returns
  */
 export const notifyBugsnag = (
@@ -35,3 +35,6 @@ export const notifyBugsnag = (
 
 export const logToBugsnag = (message: string, metadata?: MetaData) =>
   Bugsnag.leaveBreadcrumb(message, metadata);
+
+export const errorToMetadata = (error: any) =>
+    'message' in error ? {errorMessage: error.message} : undefined


### PR DESCRIPTION
There was no refresh logic for internal id token state in the
auth context. This wasn't really noticable before since the acios
client refetched the id tokens, so it didn't really matter that the
auth state was outdated. Now that we use id token from auth state
also for axios requests, then we need refresh logic in auth context.

### Acceptance criteria
- [ ] Id token refreshed from server when less than 5 minutes until expiry. Should happen only in authenticated state, and while the app is open. Id token is valid for 1 hour.
- [ ] Not invoke unnecessary fetch id token requests. (url `https://securetoken.googleapis.com/v1/token?…`)
