### PR TITLE
feat: make journey aid focus on current or upcoming stop

### DIFF
--- a/src/translations/screens/subscreens/TravelAid.ts
+++ b/src/translations/screens/subscreens/TravelAid.ts
@@ -2,10 +2,10 @@ import {translation as _} from '../../commons';
 export const TravelAidTexts = {
   close: _('Lukk Reisehjelp', 'Close Journey Aid', 'Lukk Reisehjelp'),
   stopPlaceHeader: {
-    from: _('Fra:', 'From:', 'Frå'),
-    arrivesAt: _('Kommer til:', 'Arrives at:', 'Kommer'),
-    nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste haldeplass'),
-    endOfLine: _('Siste holdeplass', 'Last stop', 'Siste haldeplass'),
+    from: _('Fra:', 'From:', 'Frå:'),
+    arrivesAt: _('Kommer til:', 'Arrives at:', 'Kommer til:'),
+    nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste haldeplass:'),
+    endOfLine: _('Siste holdeplass:', 'Last stop:', 'Siste haldeplass:'),
   },
   scheduledTime: (time: string) =>
     _(`Rutetid kl. ${time}`, `Scheduled at ${time}`, `Rutetid kl. ${time}`),

--- a/src/translations/screens/subscreens/TravelAid.ts
+++ b/src/translations/screens/subscreens/TravelAid.ts
@@ -4,10 +4,12 @@ export const TravelAidTexts = {
   stopPlaceHeader: {
     from: _('Fra:', 'From:', 'Frå'),
     arrivesAt: _('Kommer til:', 'Arrives at:', 'Kommer'),
-    nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste holdeplass'),
+    nextStop: _('Neste holdeplass:', 'Next stop:', 'Neste haldeplass'),
+    endOfLine: _('Siste holdeplass', 'Last stop', 'Siste haldeplass'),
   },
   scheduledTime: (time: string) =>
     _(`Rutetid kl. ${time}`, `Scheduled at ${time}`, `Rutetid kl. ${time}`),
+  clock: (time: string) => _(`kl. ${time}`, `${time}`, `kl. ${time}`),
   noRealtimeError: {
     title: _(
       'Ingen kontakt med kjøretøy',

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -80,7 +80,7 @@ export const TravelAidScreenComponent = ({
             </GenericSectionItem>
             <GenericSectionItem>
               <View style={styles.sectionContainer}>
-                {state.status === 'no-realtime' && (
+                {state.status === TravelAidStatus.NoRealtime && (
                   <MessageInfoBox
                     type="error"
                     title={t(TravelAidTexts.noRealtimeError.title)}
@@ -118,50 +118,53 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
     'round',
   );
 
-  if (status === 'end-of-line') {
-    return null;
-  }
-
-  if (status === 'no-realtime' || status === 'not-getting-updates') {
-    return (
-      <ThemeText type="body__secondary--bold">
-        {t(TravelAidTexts.clock(clock))}
-      </ThemeText>
-    );
-  }
-
-  return (
-    <View>
-      <View style={styles.realTime}>
-        <ThemeIcon
-          svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
-          size="xSmall"
-        />
-        <ThemeText type="heading__title">
-          {formatToClockOrRelativeMinutes(
-            focusedEstimatedCall.expectedDepartureTime,
-            language,
-            t(dictionary.date.units.now),
-          )}
+  switch (status) {
+    case TravelAidStatus.EndOfLine:
+      return null;
+    case TravelAidStatus.NoRealtime:
+    case TravelAidStatus.NotGettingUpdates:
+      return (
+        <ThemeText type="body__secondary--bold">
+          {t(TravelAidTexts.clock(clock))}
         </ThemeText>
-      </View>
-      <ThemeText type="body__secondary--bold">
-        {t(TravelAidTexts.scheduledTime(clock))}
-      </ThemeText>
-    </View>
-  );
+      );
+    default:
+      return (
+        <View>
+          <View style={styles.realTime}>
+            <ThemeIcon
+              svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
+              size="xSmall"
+            />
+            <ThemeText type="heading__title">
+              {formatToClockOrRelativeMinutes(
+                focusedEstimatedCall.expectedDepartureTime,
+                language,
+                t(dictionary.date.units.now),
+              )}
+            </ThemeText>
+          </View>
+          <ThemeText type="body__secondary--bold">
+            {t(TravelAidTexts.scheduledTime(clock))}
+          </ThemeText>
+        </View>
+      );
+  }
 };
 
-const getStopHeader = (state: TravelAidStatus, t: TranslateFunction) => {
+const getStopHeader = (
+  state: TravelAidStatus,
+  t: TranslateFunction,
+): string => {
   switch (state) {
-    case 'not-yet-arrived':
-    case 'no-realtime':
-    case 'not-getting-updates':
+    case TravelAidStatus.NotYetArrived:
+    case TravelAidStatus.NoRealtime:
+    case TravelAidStatus.NotGettingUpdates:
       return t(TravelAidTexts.stopPlaceHeader.from);
-    case 'arrived':
-    case 'departed':
+    case TravelAidStatus.Arrived:
+    case TravelAidStatus.BetweenStops:
       return t(TravelAidTexts.stopPlaceHeader.nextStop);
-    case 'end-of-line':
+    case TravelAidStatus.EndOfLine:
       return t(TravelAidTexts.stopPlaceHeader.endOfLine);
   }
 };

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -128,7 +128,9 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
           {t(TravelAidTexts.clock(clock))}
         </ThemeText>
       );
-    default:
+    case TravelAidStatus.NotYetArrived:
+    case TravelAidStatus.Arrived:
+    case TravelAidStatus.BetweenStops:
       return (
         <View>
           <View style={styles.realTime}>

--- a/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
+++ b/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
@@ -1,0 +1,141 @@
+import {getFocusedEstimatedCall} from '../get-focused-estimated-call';
+
+const onGoingJourney: any[] = [
+  {
+    aimedDepartureTime: '2024-10-18T12:15:00+02:00',
+    actualArrivalTime: '2024-10-18T12:15:14+02:00',
+    actualDepartureTime: '2024-10-18T12:15:14+02:00',
+    realtime: true,
+    quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+  },
+  {
+    aimedDepartureTime: '2024-10-18T12:17:00+02:00',
+    actualArrivalTime: undefined,
+    actualDepartureTime: undefined,
+    realtime: true,
+    quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+  },
+];
+describe('getFocusedEstimatedCall for ongoing journey', () => {
+  it('next stop is Kattemsenteret', () => {
+    const focus = getFocusedEstimatedCall(onGoingJourney, 'NSR:Quay:102721');
+    expect(focus.status).toBe('departed');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
+  });
+  it('has not yet arrived at Kattemsenteret', () => {
+    const focus = getFocusedEstimatedCall(onGoingJourney, 'NSR:Quay:74027');
+    expect(focus.status).toBe('not-yet-arrived');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
+  });
+});
+
+const notStartedJourney: any[] = [
+  {
+    aimedDepartureTime: '2024-10-18T12:15:00+02:00',
+    actualArrivalTime: undefined,
+    actualDepartureTime: undefined,
+    realtime: true,
+    quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+  },
+  {
+    aimedDepartureTime: '2024-10-18T12:17:00+02:00',
+    actualArrivalTime: undefined,
+    actualDepartureTime: undefined,
+    realtime: true,
+    quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+  },
+];
+describe('getFocusedEstimatedCall for not started journey', () => {
+  it('state is not-yet-arrived', () => {
+    // Set current time to five minutes before first aimedDepartureTime
+    jest.useFakeTimers().setSystemTime(new Date('2024-10-18T12:10:00+02:00'));
+    const focus = getFocusedEstimatedCall(notStartedJourney, 'NSR:Quay:102721');
+
+    expect(focus.status).toBe('not-yet-arrived');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Østre Lund');
+  });
+
+  it('state is not-getting-updates', () => {
+    // Set current time to five minutes after first aimedDepartureTime
+    jest.useFakeTimers().setSystemTime(new Date('2024-10-18T12:20:00+02:00'));
+
+    const focus = getFocusedEstimatedCall(notStartedJourney, 'NSR:Quay:102721');
+    expect(focus.status).toBe('not-getting-updates');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Østre Lund');
+  });
+});
+
+const endedJourney: any[] = [
+  {
+    aimedDepartureTime: '2024-10-18T12:15:00+02:00',
+    actualArrivalTime: '2024-10-18T12:15:14+02:00',
+    actualDepartureTime: '2024-10-18T12:15:14+02:00',
+    realtime: true,
+    quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+  },
+  {
+    aimedDepartureTime: '2024-10-18T12:17:00+02:00',
+    actualArrivalTime: '2024-10-18T12:16:48+02:00',
+    actualDepartureTime: '2024-10-18T12:17:20+02:00',
+    realtime: true,
+    quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+  },
+];
+describe('getFocusedEstimatedCall for ended journey', () => {
+  it('end-of-line is Kattemsenteret', () => {
+    const focus = getFocusedEstimatedCall(endedJourney, 'NSR:Quay:102721');
+    expect(focus.status).toBe('end-of-line');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
+  });
+});
+
+const noRealtimeJourney: any[] = [
+  {
+    aimedDepartureTime: '2024-10-18T12:15:00+02:00',
+    actualArrivalTime: undefined,
+    actualDepartureTime: undefined,
+    realtime: false,
+    quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+  },
+  {
+    aimedDepartureTime: '2024-10-18T12:17:00+02:00',
+    actualArrivalTime: undefined,
+    actualDepartureTime: undefined,
+    realtime: false,
+    quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+  },
+];
+describe('getFocusedEstimatedCall for no realtime journey', () => {
+  it('no realtime for Østre Lund', () => {
+    const focus = getFocusedEstimatedCall(noRealtimeJourney, 'NSR:Quay:74027');
+    expect(focus.status).toBe('no-realtime');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
+  });
+});
+
+const arrivedButNotDepartedJourney: any[] = [
+  {
+    aimedDepartureTime: '2024-10-18T12:15:00+02:00',
+    actualArrivalTime: '2024-10-18T12:15:14+02:00',
+    actualDepartureTime: '2024-10-18T12:15:14+02:00',
+    realtime: true,
+    quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+  },
+  {
+    aimedDepartureTime: '2024-10-18T12:17:00+02:00',
+    actualArrivalTime: '2024-10-18T12:16:48+02:00',
+    actualDepartureTime: undefined,
+    realtime: true,
+    quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+  },
+];
+describe('getFocusedEstimatedCall for arrived but not departed journey', () => {
+  it('arrived at Kattemsenteret', () => {
+    const focus = getFocusedEstimatedCall(
+      arrivedButNotDepartedJourney,
+      'NSR:Quay:102721',
+    );
+    expect(focus.status).toBe('arrived');
+    expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
+  });
+});

--- a/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
+++ b/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
@@ -1,4 +1,7 @@
-import {getFocusedEstimatedCall} from '../get-focused-estimated-call';
+import {
+  TravelAidStatus,
+  getFocusedEstimatedCall,
+} from '../get-focused-estimated-call';
 
 const onGoingJourney: any[] = [
   {
@@ -19,12 +22,12 @@ const onGoingJourney: any[] = [
 describe('getFocusedEstimatedCall for ongoing journey', () => {
   it('next stop is Kattemsenteret', () => {
     const focus = getFocusedEstimatedCall(onGoingJourney, 'NSR:Quay:102721');
-    expect(focus.status).toBe('departed');
+    expect(focus.status).toBe(TravelAidStatus.BetweenStops);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
   it('has not yet arrived at Kattemsenteret', () => {
     const focus = getFocusedEstimatedCall(onGoingJourney, 'NSR:Quay:74027');
-    expect(focus.status).toBe('not-yet-arrived');
+    expect(focus.status).toBe(TravelAidStatus.NotYetArrived);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
 });
@@ -51,7 +54,7 @@ describe('getFocusedEstimatedCall for not started journey', () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-10-18T12:10:00+02:00'));
     const focus = getFocusedEstimatedCall(notStartedJourney, 'NSR:Quay:102721');
 
-    expect(focus.status).toBe('not-yet-arrived');
+    expect(focus.status).toBe(TravelAidStatus.NotYetArrived);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Østre Lund');
   });
 
@@ -60,7 +63,7 @@ describe('getFocusedEstimatedCall for not started journey', () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-10-18T12:20:00+02:00'));
 
     const focus = getFocusedEstimatedCall(notStartedJourney, 'NSR:Quay:102721');
-    expect(focus.status).toBe('not-getting-updates');
+    expect(focus.status).toBe(TravelAidStatus.NotGettingUpdates);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Østre Lund');
   });
 });
@@ -84,7 +87,7 @@ const endedJourney: any[] = [
 describe('getFocusedEstimatedCall for ended journey', () => {
   it('end-of-line is Kattemsenteret', () => {
     const focus = getFocusedEstimatedCall(endedJourney, 'NSR:Quay:102721');
-    expect(focus.status).toBe('end-of-line');
+    expect(focus.status).toBe(TravelAidStatus.EndOfLine);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
 });
@@ -108,7 +111,7 @@ const noRealtimeJourney: any[] = [
 describe('getFocusedEstimatedCall for no realtime journey', () => {
   it('no realtime for Østre Lund', () => {
     const focus = getFocusedEstimatedCall(noRealtimeJourney, 'NSR:Quay:74027');
-    expect(focus.status).toBe('no-realtime');
+    expect(focus.status).toBe(TravelAidStatus.NoRealtime);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
 });
@@ -135,7 +138,7 @@ describe('getFocusedEstimatedCall for arrived but not departed journey', () => {
       arrivedButNotDepartedJourney,
       'NSR:Quay:102721',
     );
-    expect(focus.status).toBe('arrived');
+    expect(focus.status).toBe(TravelAidStatus.Arrived);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
 });

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -1,5 +1,5 @@
 import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
-import {isInThePast} from '@atb/utils/date';
+import {minutesBetween} from '@atb/utils/date';
 
 export enum TravelAidStatus {
   /** Not yet arrived at the selected stop */
@@ -95,7 +95,7 @@ export const getFocusedEstimatedCall = (
   // No data on service journey progress
 
   // Has realtime, should have started, but no actual departure time
-  if (isInThePast(estimatedCalls[0].aimedDepartureTime)) {
+  if (minutesBetween(estimatedCalls[0].aimedDepartureTime, new Date()) > 2) {
     return {
       status: TravelAidStatus.NotGettingUpdates,
       focusedEstimatedCall: selectedCall,

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -25,69 +25,69 @@ export const getFocusedEstimatedCall = (
   estimatedCalls: EstimatedCallWithQuayFragment[],
   fromQuayId?: string,
 ): FocusedEstimatedCallState => {
-  const selectedStopIndex =
+  const selectedCallIndex =
     estimatedCalls.findIndex(
       // TODO: This can be wrong if there are multiple stops on the same quay
       (estimatedCall) => estimatedCall.quay?.id === fromQuayId,
     ) ?? 0;
-  const selectedStop: EstimatedCallWithQuayFragment =
-    estimatedCalls[selectedStopIndex];
+  const selectedCall: EstimatedCallWithQuayFragment =
+    estimatedCalls[selectedCallIndex];
 
-  let previousOrCurrentStopIndex = -1;
+  let previousOrCurrentCallIndex = -1;
   estimatedCalls.forEach((estimatedCall, index) => {
     if (estimatedCall.actualDepartureTime || estimatedCall.actualArrivalTime) {
-      previousOrCurrentStopIndex = index;
+      previousOrCurrentCallIndex = index;
     }
   });
-  const previousOrCurrentStop = estimatedCalls[previousOrCurrentStopIndex] as
+  const previousOrCurrentCall = estimatedCalls[previousOrCurrentCallIndex] as
     | EstimatedCallWithQuayFragment
     | undefined;
-  const nextStop = estimatedCalls[previousOrCurrentStopIndex + 1] as
+  const nextCall = estimatedCalls[previousOrCurrentCallIndex + 1] as
     | EstimatedCallWithQuayFragment
     | undefined;
 
   // No realtime data
-  if (!selectedStop.realtime) {
+  if (!selectedCall.realtime) {
     return {
       status: TravelAidStatus.NoRealtime,
-      focusedEstimatedCall: selectedStop,
+      focusedEstimatedCall: selectedCall,
     };
   }
 
   // Data on service journey progress
-  if (previousOrCurrentStop) {
+  if (previousOrCurrentCall) {
     // Has not yet arrived at the selected stop
-    if (selectedStopIndex > previousOrCurrentStopIndex) {
+    if (selectedCallIndex > previousOrCurrentCallIndex) {
       return {
         status: TravelAidStatus.NotYetArrived,
-        focusedEstimatedCall: selectedStop,
+        focusedEstimatedCall: selectedCall,
       };
     }
 
     // Has arrived, but not departed the stop
     if (
-      previousOrCurrentStop.actualArrivalTime &&
-      !previousOrCurrentStop.actualDepartureTime
+      previousOrCurrentCall.actualArrivalTime &&
+      !previousOrCurrentCall.actualDepartureTime
     ) {
       return {
         status: TravelAidStatus.Arrived,
-        focusedEstimatedCall: previousOrCurrentStop,
+        focusedEstimatedCall: previousOrCurrentCall,
       };
     }
 
     // Has passed the last stop
-    if (nextStop === undefined) {
+    if (nextCall === undefined) {
       return {
         status: TravelAidStatus.EndOfLine,
-        focusedEstimatedCall: previousOrCurrentStop,
+        focusedEstimatedCall: previousOrCurrentCall,
       };
     }
 
     // On its way to the next stop
-    if (previousOrCurrentStop.actualDepartureTime && nextStop) {
+    if (previousOrCurrentCall.actualDepartureTime && nextCall) {
       return {
         status: TravelAidStatus.BetweenStops,
-        focusedEstimatedCall: nextStop,
+        focusedEstimatedCall: nextCall,
       };
     }
   }
@@ -98,13 +98,13 @@ export const getFocusedEstimatedCall = (
   if (isInThePast(estimatedCalls[0].aimedDepartureTime)) {
     return {
       status: TravelAidStatus.NotGettingUpdates,
-      focusedEstimatedCall: selectedStop,
+      focusedEstimatedCall: selectedCall,
     };
   }
 
   // Has not yet started
   return {
     status: TravelAidStatus.NotYetArrived,
-    focusedEstimatedCall: selectedStop,
+    focusedEstimatedCall: selectedCall,
   };
 };

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -1,0 +1,106 @@
+import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
+import {isInThePast} from '@atb/utils/date';
+
+type EstimatedCall = Required<
+  Required<ServiceJourneyWithEstCallsFragment>['estimatedCalls']
+>[0];
+export type TravelAidStatus =
+  | 'not-yet-arrived'
+  | 'arrived'
+  | 'departed'
+  | 'end-of-line'
+  | 'no-realtime'
+  | 'not-getting-updates';
+export type FocusedEstimatedCallState = {
+  status: TravelAidStatus;
+  focusedEstimatedCall: EstimatedCall;
+};
+
+export const getFocusedEstimatedCall = (
+  estimatedCalls: EstimatedCall[],
+  fromQuayId?: string,
+): FocusedEstimatedCallState => {
+  const selectedStopIndex =
+    estimatedCalls.findIndex(
+      // TODO: This can be wrong if there are multiple stops on the same quay
+      (estimatedCall) => estimatedCall.quay?.id === fromQuayId,
+    ) ?? 0;
+  const selectedStop: EstimatedCall = estimatedCalls[selectedStopIndex];
+
+  let previousOrCurrentStopIndex = -1;
+  estimatedCalls.forEach((estimatedCall, index) => {
+    if (estimatedCall.actualDepartureTime || estimatedCall.actualArrivalTime) {
+      previousOrCurrentStopIndex = index;
+    }
+  });
+  const previousOrCurrentStop = estimatedCalls[previousOrCurrentStopIndex] as
+    | EstimatedCall
+    | undefined;
+  const nextStop = estimatedCalls[previousOrCurrentStopIndex + 1] as
+    | EstimatedCall
+    | undefined;
+
+  // No realtime data
+  if (!selectedStop.realtime) {
+    return {
+      status: 'no-realtime',
+      focusedEstimatedCall: selectedStop,
+    };
+  }
+
+  // Has data on service journey progress
+  if (previousOrCurrentStop) {
+    // Has not yet arrived at the selected stop
+    if (selectedStopIndex > previousOrCurrentStopIndex) {
+      return {
+        status: 'not-yet-arrived',
+        focusedEstimatedCall: selectedStop,
+      };
+    }
+
+    // Has arrived, but not departed the stop
+    if (
+      previousOrCurrentStop.actualArrivalTime &&
+      !previousOrCurrentStop.actualDepartureTime
+    ) {
+      return {
+        status: 'arrived',
+        focusedEstimatedCall: previousOrCurrentStop,
+      };
+    }
+
+    // Has passed the last stop
+    if (nextStop === undefined) {
+      return {
+        status: 'end-of-line',
+        focusedEstimatedCall: previousOrCurrentStop,
+      };
+    }
+
+    // On its way to the next stop
+    if (previousOrCurrentStop.actualDepartureTime && nextStop) {
+      return {
+        status: 'departed',
+        focusedEstimatedCall: nextStop,
+      };
+    }
+  }
+
+  // No data on service journey progress
+
+  // Has realtime, should have started, but no actual departure time
+  if (isInThePast(selectedStop.aimedDepartureTime)) {
+    // TODO: Should we check against aimed departure time from the first or selected stop?
+    // if (isInThePast(estimatedCalls[0].aimedDepartureTime)) {
+    return {
+      status: 'not-getting-updates',
+      focusedEstimatedCall: selectedStop,
+    };
+  }
+
+  // Has not yet started
+  return {
+    status: 'not-yet-arrived',
+    focusedEstimatedCall: selectedStop,
+  };
+};

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -39,12 +39,11 @@ export const getFocusedEstimatedCall = (
       previousOrCurrentCallIndex = index;
     }
   });
-  const previousOrCurrentCall = estimatedCalls[previousOrCurrentCallIndex] as
-    | EstimatedCallWithQuayFragment
-    | undefined;
-  const nextCall = estimatedCalls[previousOrCurrentCallIndex + 1] as
-    | EstimatedCallWithQuayFragment
-    | undefined;
+  const previousOrCurrentCall =
+    previousOrCurrentCallIndex >= 0
+      ? estimatedCalls.at(previousOrCurrentCallIndex)
+      : undefined;
+  const nextCall = estimatedCalls.at(previousOrCurrentCallIndex + 1);
 
   // No realtime data
   if (!selectedCall.realtime) {

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -1,4 +1,4 @@
-import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
+import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
 import {isInThePast} from '@atb/utils/date';
 
 export enum TravelAidStatus {
@@ -16,16 +16,13 @@ export enum TravelAidStatus {
   NotGettingUpdates,
 }
 
-type EstimatedCall = Required<
-  Required<ServiceJourneyWithEstCallsFragment>['estimatedCalls']
->[0];
 export type FocusedEstimatedCallState = {
   status: TravelAidStatus;
-  focusedEstimatedCall: EstimatedCall;
+  focusedEstimatedCall: EstimatedCallWithQuayFragment;
 };
 
 export const getFocusedEstimatedCall = (
-  estimatedCalls: EstimatedCall[],
+  estimatedCalls: EstimatedCallWithQuayFragment[],
   fromQuayId?: string,
 ): FocusedEstimatedCallState => {
   const selectedStopIndex =
@@ -33,7 +30,8 @@ export const getFocusedEstimatedCall = (
       // TODO: This can be wrong if there are multiple stops on the same quay
       (estimatedCall) => estimatedCall.quay?.id === fromQuayId,
     ) ?? 0;
-  const selectedStop: EstimatedCall = estimatedCalls[selectedStopIndex];
+  const selectedStop: EstimatedCallWithQuayFragment =
+    estimatedCalls[selectedStopIndex];
 
   let previousOrCurrentStopIndex = -1;
   estimatedCalls.forEach((estimatedCall, index) => {
@@ -42,10 +40,10 @@ export const getFocusedEstimatedCall = (
     }
   });
   const previousOrCurrentStop = estimatedCalls[previousOrCurrentStopIndex] as
-    | EstimatedCall
+    | EstimatedCallWithQuayFragment
     | undefined;
   const nextStop = estimatedCalls[previousOrCurrentStopIndex + 1] as
-    | EstimatedCall
+    | EstimatedCallWithQuayFragment
     | undefined;
 
   // No realtime data


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/19125

This adds logic for extracting the information that should be shown on the Journey Aid screen. At any time there the view has a "status" and a "focused" estimated call. 

- Status is documented in the `TravelAidStatus` enum
- Based on the status, `focusedEstimatedCall` can be the current stop, next stop or the stop the user selected start point.

We still need to decide what to show in the `NotGettingUpdates` state.

<div>
<img width="300px" src="https://github.com/user-attachments/assets/ec4a9821-7b62-4ac7-ba83-614a1f4030b5">
<img width="300px" src="https://github.com/user-attachments/assets/ad8823f1-e0f0-41a0-a2e9-18a7cb7f944e">
<img width="300px" src="https://github.com/user-attachments/assets/22f865a8-a139-4ce6-ac08-eea6abbd2a9a">
<img width="300px" src="https://github.com/user-attachments/assets/e409edd4-6fdd-4f60-9fb8-b198b4397c60">
</div>