### PR TITLE
feat: add screen reader labels to travel aid

### DIFF
--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren} from 'react';
+import React, {PropsWithChildren, Ref} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {ContainerSizingType} from './types';
@@ -8,6 +8,7 @@ export type SectionProps = PropsWithChildren<{
   type?: ContainerSizingType;
   style?: StyleProp<ViewStyle>;
   testID?: string;
+  ref?: Ref<View>;
 }> &
   AccessibilityProps;
 

--- a/src/components/sections/Section.tsx
+++ b/src/components/sections/Section.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, Ref} from 'react';
+import React, {PropsWithChildren, forwardRef} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {ContainerSizingType} from './types';
@@ -8,45 +8,41 @@ export type SectionProps = PropsWithChildren<{
   type?: ContainerSizingType;
   style?: StyleProp<ViewStyle>;
   testID?: string;
-  ref?: Ref<View>;
 }> &
   AccessibilityProps;
 
-export function Section({
-  children,
-  type = 'block',
-  style,
-  ...props
-}: SectionProps) {
-  const styles = useStyles();
-  const validChildren: boolean[] =
-    React.Children.map(children, React.isValidElement) ?? [];
-  const firstIndex = validChildren.indexOf(true);
-  const lastIndex = validChildren.lastIndexOf(true);
+export const Section = forwardRef<View, SectionProps>(
+  ({children, type = 'block', style, ...props}: SectionProps, focusRef) => {
+    const styles = useStyles();
+    const validChildren: boolean[] =
+      React.Children.map(children, React.isValidElement) ?? [];
+    const firstIndex = validChildren.indexOf(true);
+    const lastIndex = validChildren.lastIndexOf(true);
 
-  return (
-    <View style={style} {...props}>
-      {React.Children.map(children, (child, index) => {
-        if (!React.isValidElement(child)) return child;
-        if (child == null) return child;
+    return (
+      <View style={style} ref={focusRef} {...props}>
+        {React.Children.map(children, (child, index) => {
+          if (!React.isValidElement(child)) return child;
+          if (child == null) return child;
 
-        const additionalProps: Partial<BaseSectionItemProps> = {
-          radius: toRadius(index, lastIndex, firstIndex),
-          radiusSize: 'regular',
-          type,
-          ...child.props,
-        };
+          const additionalProps: Partial<BaseSectionItemProps> = {
+            radius: toRadius(index, lastIndex, firstIndex),
+            radiusSize: 'regular',
+            type,
+            ...child.props,
+          };
 
-        return (
-          <>
-            {React.cloneElement(child, additionalProps)}
-            {index !== lastIndex && <View style={styles.separator} />}
-          </>
-        );
-      })}
-    </View>
-  );
-}
+          return (
+            <>
+              {React.cloneElement(child, additionalProps)}
+              {index !== lastIndex && <View style={styles.separator} />}
+            </>
+          );
+        })}
+      </View>
+    );
+  },
+);
 
 function toRadius(index: number, lastIndex: number, firstIndex: number) {
   const isFirst = index === firstIndex;

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -6,10 +6,10 @@ import {
 } from '@atb/favorites';
 import {StyleSheet} from '@atb/theme';
 import {
-  formatDestinationDisplay,
   getNoticesForEstimatedCall,
   bookingStatusToMsgType,
   getBookingStatus,
+  getLineA11yLabel,
 } from '@atb/travel-details-screens/utils';
 import {destinationDisplaysAreEqual} from '@atb/utils/destination-displays-are-equal';
 import {
@@ -74,7 +74,11 @@ export const EstimatedCallItem = memo(
 
     const a11yLabel =
       mode === 'Favourite'
-        ? getLineA11yLabel(departure, t)
+        ? getLineA11yLabel(
+            departure.destinationDisplay,
+            departure.serviceJourney.line.publicCode,
+            t,
+          )
         : getLineAndTimeA11yLabel(departure, t, language);
 
     const a11yHint =
@@ -162,7 +166,11 @@ export function getLineAndTimeA11yLabel(
   const msgType = getMsgTypeForEstimatedCall(departure);
   return [
     departure.cancellation ? t(CancelledDepartureTexts.message) : undefined,
-    getLineA11yLabel(departure, t),
+    getLineA11yLabel(
+      departure.destinationDisplay,
+      departure.serviceJourney.line.publicCode,
+      t,
+    ),
     msgType && t(SituationsTexts.a11yLabel[msgType]),
     departure.realtime
       ? t(dictionary.a11yRealTimePrefix)
@@ -180,19 +188,6 @@ export function getLineAndTimeA11yLabel(
   ]
     .filter(isDefined)
     .join(screenReaderPause);
-}
-
-export function getLineA11yLabel(
-  departure: EstimatedCall,
-  t: TranslateFunction,
-) {
-  const line = departure.serviceJourney?.line;
-  const a11yLine = line?.publicCode
-    ? `${t(DeparturesTexts.line)} ${line?.publicCode},`
-    : '';
-  const lineName = formatDestinationDisplay(t, departure.destinationDisplay);
-  const a11yLineName = lineName ? `${lineName}.` : '';
-  return `${a11yLine} ${a11yLineName}`;
 }
 
 const isMoreThanOneMinuteDelayed = (departure: EstimatedCall) =>

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -40,20 +40,7 @@ const dictionary = {
         `Ukjent transportmiddel`,
       ),
     },
-    quay: {
-      defaultName: _(
-        'Ukjent stoppestedsnavn',
-        'Unknown name of stop place',
-        `Ukjent namn på stoppestad`,
-      ),
-    },
-    line: {
-      defaultName: _(
-        'Ukjent linjenavn',
-        'Unknown line name',
-        `Ukjent namn på linje`,
-      ),
-    },
+    line: _('Linje', 'Line', 'Linje'),
     time: {
       aimedPrefix: _('Rutetid', 'Route time', `Rutetid`),
       expectedPrefix: _('Sanntid', 'Realtime', `Sanntid`),

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -97,7 +97,6 @@ const DeparturesTexts = {
       'Sjå fleire avgangar',
     ),
   },
-  line: _('Linje', 'Line', 'Linje'),
   a11yViewDepartureDetailsHint: _(
     'Aktiver for å se detaljer',
     'Activate to view details',

--- a/src/translations/screens/subscreens/TravelAid.ts
+++ b/src/translations/screens/subscreens/TravelAid.ts
@@ -9,6 +9,12 @@ export const TravelAidTexts = {
   },
   scheduledTime: (time: string) =>
     _(`Rutetid kl. ${time}`, `Scheduled at ${time}`, `Rutetid kl. ${time}`),
+  scheduledTimeA11yLabel: (time: string) =>
+    _(
+      `Rutetid klokken. ${time}`,
+      `Scheduled at ${time}`,
+      `Rutetid klokken. ${time}`,
+    ),
   clock: (time: string) => _(`kl. ${time}`, `${time}`, `kl. ${time}`),
   error: {
     message: _(

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -30,6 +30,7 @@ import {
   getFocusedEstimatedCall,
 } from './get-focused-estimated-call';
 import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
 export type TravelAidScreenParams = {
   serviceJourneyDeparture: ServiceJourneyDeparture;
@@ -44,6 +45,7 @@ export const TravelAidScreenComponent = ({
   const styles = useStyles();
   const {t} = useTranslation();
   const {themeName} = useTheme();
+  const focusRef = useFocusOnLoad();
 
   const {
     data: serviceJourney,
@@ -79,6 +81,7 @@ export const TravelAidScreenComponent = ({
           <TravelAidSection
             serviceJourney={serviceJourney}
             fromQuayId={serviceJourneyDeparture.fromQuayId}
+            focusRef={focusRef}
           />
         )}
       </ScrollView>
@@ -89,9 +92,11 @@ export const TravelAidScreenComponent = ({
 const TravelAidSection = ({
   serviceJourney,
   fromQuayId,
+  focusRef,
 }: {
   serviceJourney: ServiceJourneyWithEstCallsFragment;
   fromQuayId?: string;
+  focusRef: Ref<any>;
 }) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
@@ -104,7 +109,7 @@ const TravelAidSection = ({
   );
 
   return (
-    <Section>
+    <Section ref={focusRef}>
       <GenericSectionItem
         style={styles.sectionContainer}
         accessibility={{

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -31,6 +31,7 @@ import {
 } from './get-focused-estimated-call';
 import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {getQuayName} from '@atb/utils/transportation-names.ts';
 
 export type TravelAidScreenParams = {
   serviceJourneyDeparture: ServiceJourneyDeparture;
@@ -108,6 +109,8 @@ const TravelAidSection = ({
     fromQuayId,
   );
 
+  const quayName = getQuayName(focusedEstimatedCall.quay) ?? '';
+
   return (
     <Section ref={focusRef}>
       <GenericSectionItem
@@ -137,8 +140,7 @@ const TravelAidSection = ({
           accessibilityLabel:
             getStopHeader(status, t) +
             ' ' +
-            focusedEstimatedCall.quay.stopPlace?.name +
-            focusedEstimatedCall.quay.publicCode +
+            quayName +
             '. ' +
             getTimeInfoA11yLabel({status, focusedEstimatedCall}, t, language),
         }}
@@ -155,10 +157,7 @@ const TravelAidSection = ({
             <ThemeText type="body__tertiary--bold">
               {getStopHeader(status, t)}
             </ThemeText>
-            <ThemeText type="heading__title">
-              {focusedEstimatedCall.quay.stopPlace?.name}{' '}
-              {focusedEstimatedCall.quay.publicCode}
-            </ThemeText>
+            <ThemeText type="heading__title">{quayName}</ThemeText>
           </View>
           <TimeInfo state={{status, focusedEstimatedCall}} />
         </View>

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -147,6 +147,19 @@ export function getLineName(t: TranslateFunction, leg: Leg) {
     : name;
 }
 
+export function getLineA11yLabel(
+  destinationDisplay: DestinationDisplay | undefined,
+  publicCode: string | undefined,
+  t: TranslateFunction,
+) {
+  const a11yLine = publicCode
+    ? `${t(dictionary.travel.line)} ${publicCode},`
+    : '';
+  const lineName = formatDestinationDisplay(t, destinationDisplay);
+  const a11yLineName = lineName ? `${lineName}.` : '';
+  return `${a11yLine} ${a11yLineName}`;
+}
+
 export function hasShortWaitTime(legs: Leg[]) {
   return iterateWithNext(legs)
     .map((pair) => {


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/19125

This adds a11y lables to the travel aid screen, with the focus areas described in [figma](https://www.figma.com/design/Ftpf9FC06MLGFVWI5vHLLu/Bl%C3%A5-knapp-(iterasjon)?node-id=1351-44780&node-type=frame&t=wNWuKJTY4tx0TtlG-0).

Still missing the "announcement" -parts, that will read out changes as they happen.

_Tip: Might be easier to review this PR one commit at a time_