### PR TITLE
feat: add travel aid screen reader announcements

### DIFF
--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -144,12 +144,11 @@ const TravelAidSection = ({
       <GenericSectionItem
         accessibility={{
           accessible: true,
-          accessibilityLabel:
-            getStopHeader(status, t) +
-            ' ' +
-            quayName +
-            '. ' +
-            getTimeInfoA11yLabel({status, focusedEstimatedCall}, t, language),
+          accessibilityLabel: getFocussedStateA11yLabel(
+            {status, focusedEstimatedCall},
+            t,
+            language,
+          ),
         }}
       >
         <View style={styles.sectionContainer}>
@@ -176,14 +175,7 @@ const TravelAidSection = ({
 const useTravelAidAnnouncements = (state: FocusedEstimatedCallState) => {
   const {language, t} = useTranslation();
   const isFirstRender = useRef(true);
-
-  const quayName = getQuayName(state.focusedEstimatedCall.quay) ?? '';
-  const message =
-    getStopHeader(state.status, t) +
-    ' ' +
-    quayName +
-    '. ' +
-    getTimeInfoA11yLabel(state, t, language);
+  const message = getFocussedStateA11yLabel(state, t, language);
 
   useEffect(() => {
     if (isFirstRender.current) {
@@ -240,6 +232,22 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
         </View>
       );
   }
+};
+
+const getFocussedStateA11yLabel = (
+  state: FocusedEstimatedCallState,
+  t: TranslateFunction,
+  language: Language,
+) => {
+  const quayName = getQuayName(state.focusedEstimatedCall.quay) ?? '';
+
+  return (
+    getStopHeader(state.status, t) +
+    ' ' +
+    quayName +
+    '. ' +
+    getTimeInfoA11yLabel(state, t, language)
+  );
 };
 
 const getTimeInfoA11yLabel = (

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -14,6 +14,16 @@ export type Flattened<T> = T extends object
   : T;
 
 /**
+ * Make values in T required.
+ *
+ * @example
+ * type A = { a: number, b?: string, c: boolean | undefined};
+ * type B = RequireValue<A, 'b' | 'c'>;
+ * // B is { a: number, b: string, c: boolean }
+ */
+export type RequireValue<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+/**
  * Flatten an object, non-recursively
  *
  * E.g.


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/19125

Adds a useEffect to the travel aid screen that reads out updates every time the a11y label changes.

Since hooks can't be run conditionally and I needed to check if `serviceJourney.estimatedCalls` was undefined before rendering TravelAidSection, I had to move the undefined check, and do some type-trickery to make things work. Added a type to utils to make it easier to discover this method in the future. ~Found one spot where it was used before.~