### PR TITLE
feat: Line styling for GeofencingZones

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^4.1.1",
     "@atb-as/generate-assets": "^13.2.1",
-    "@atb-as/theme": "^11.0.1",
+    "@atb-as/theme": "^11.0.1", // TODO: UPDATE TO VERSION WITH lineIsDashed support
     "@bugsnag/react-native": "^7.25.0",
     "@bugsnag/source-maps": "^2.3.3",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.6",

--- a/src/components/map/components/mobility/GeofencingZones.tsx
+++ b/src/components/map/components/mobility/GeofencingZones.tsx
@@ -52,18 +52,24 @@ type GeofencingZoneProps = {
 };
 const GeofencingZone = ({geofencingZone}: GeofencingZoneProps) => {
   const getGeofencingZoneCustomProps = ['get', 'geofencingZoneCustomProps'];
+
   const bgColor = [
     'get',
     'background',
     ['get', 'color', getGeofencingZoneCustomProps],
   ];
   const fillOpacity = ['get', 'fillOpacity', getGeofencingZoneCustomProps];
-  const lineOpacity = [
-    'get',
-    'background',
+  const lineOpacity = ['get', 'strokeOpacity', getGeofencingZoneCustomProps];
+  const lineIsDashed = ['get', 'lineIsDashed', getGeofencingZoneCustomProps];
 
-    ['get', 'strokeOpacity', getGeofencingZoneCustomProps],
-  ];
+  const lineStyle = {
+    lineWidth: ['interpolate', ['exponential', 1.5], ['zoom'], 12, 2, 18, 4],
+    lineColor: bgColor,
+    lineOpacity,
+    lineCap: 'round',
+    lineJoin: 'round',
+  };
+
   return (
     <MapboxGL.ShapeSource
       id={'geofencingZonesShapeSource_' + geofencingZone?.renderKey}
@@ -71,7 +77,7 @@ const GeofencingZone = ({geofencingZone}: GeofencingZoneProps) => {
       hitbox={hitboxCoveringIconOnly} // to not be able to hit multiple zones with one click
     >
       <MapboxGL.FillLayer
-        id="parkingFill"
+        id="geofencingZoneFill"
         style={{
           fillAntialias: true,
           fillColor: bgColor,
@@ -79,13 +85,22 @@ const GeofencingZone = ({geofencingZone}: GeofencingZoneProps) => {
         }}
         aboveLayerID="water-point-label"
       />
+
+      {/*
+        Unfortunately since there is a bug in mapbox not supporting
+        lineDasharray: ['get', 'lineDasharray'],
+        a hard coded style must be used for that style prop.
+      */}
       <MapboxGL.LineLayer
-        id="tariffZonesLine"
-        style={{
-          lineWidth: 3,
-          lineColor: bgColor,
-          lineOpacity,
-        }}
+        id="geofencingZoneLine"
+        filter={['!', lineIsDashed]}
+        style={lineStyle}
+        aboveLayerID="water-point-label"
+      />
+      <MapboxGL.LineLayer
+        id="geofencingZoneDashedLine"
+        filter={lineIsDashed}
+        style={{...lineStyle, lineDasharray: [2, 2]}}
         aboveLayerID="water-point-label"
       />
     </MapboxGL.ShapeSource>


### PR DESCRIPTION
_Draft PR until some other parts are ready_

Resolves https://github.com/AtB-AS/kundevendt/issues/18745

In this PR:
- GeofencingZones line thickness is set based on zoom.
- `lineIsDashed` in `GeofencingZoneStyle` is supported.

Ideally we could have `lineDasharray` directly in `GeofencingZoneStyle`, but Mapbox doesn't support `['get', 'someProp']` at all for this prop.

Example:
<img width="200" src="https://github.com/user-attachments/assets/3043f934-f4fc-4ce4-aa6c-06dc85869f02" />
