### PR TITLE
fix: handle focus for travel aid error and loading states

### DIFF
--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -71,13 +71,17 @@ export const TravelAidScreenComponent = ({
         type="medium"
       />
       <ScrollView contentContainerStyle={styles.container}>
-        {status === 'loading' && <ActivityIndicator size="large" />}
+        {status === 'loading' && (
+          <ActivityIndicator size="large" ref={focusRef} />
+        )}
         {status === 'error' && (
-          <MessageInfoBox
-            type="error"
-            message={t(TravelAidTexts.error.message)}
-            onPressConfig={{action: refetch, text: t(dictionary.retry)}}
-          />
+          <View ref={focusRef}>
+            <MessageInfoBox
+              type="error"
+              message={t(TravelAidTexts.error.message)}
+              onPressConfig={{action: refetch, text: t(dictionary.retry)}}
+            />
+          </View>
         )}
         {status === 'success' && serviceJourney.estimatedCalls && (
           <TravelAidSection


### PR DESCRIPTION
Sets focusRef on the loading indicator and error message on the travel aid screen, fixing point 4 from comment https://github.com/AtB-AS/kundevendt/issues/19125#issuecomment-2446398675

closes https://github.com/AtB-AS/kundevendt/issues/19125