### PR TITLE
test: add test-ids for the map

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -248,6 +248,7 @@ export const Map = (props: MapProps) => {
           onDidFinishLoadingMap={onDidFinishLoadingMap}
           onMapIdle={onMapIdle}
           onPress={onFeatureClick}
+          testID="mapView"
           {...MapViewConfig}
         >
           <MapboxGL.Camera

--- a/src/components/map/components/filter/MapFilter.tsx
+++ b/src/components/map/components/filter/MapFilter.tsx
@@ -11,7 +11,7 @@ type MapFilterProps = {
 export const MapFilter = ({onPress, isLoading}: MapFilterProps) => {
   const style = useStyle();
   const {theme} = useTheme();
-  const interactiveColor = theme.color.interactive[2]
+  const interactiveColor = theme.color.interactive[2];
   const analytics = useAnalytics();
 
   return (
@@ -28,6 +28,7 @@ export const MapFilter = ({onPress, isLoading}: MapFilterProps) => {
       loading={isLoading}
       rightIcon={{svg: Filter}}
       hasShadow={true}
+      testID="mapFilter"
     />
   );
 };

--- a/src/components/map/components/filter/MapFilterSheet.tsx
+++ b/src/components/map/components/filter/MapFilterSheet.tsx
@@ -73,6 +73,7 @@ export const MapFilterSheet = ({
             closeBottomSheet();
           }}
           rightIcon={{svg: Confirm}}
+          testID="confirmFilters"
         />
       </FullScreenFooter>
     </BottomSheetContainer>

--- a/src/mobility/components/filter/FormFactorFilter.tsx
+++ b/src/mobility/components/filter/FormFactorFilter.tsx
@@ -45,6 +45,7 @@ export const FormFactorFilter = ({
             text={t(MobilityTexts.filter.selectAll)}
             value={showAll()}
             onValueChange={onAllToggle}
+            testID={`${formFactor.toLowerCase()}ToggleAll`}
           />
         )}
         {operators.map((operator) => (
@@ -54,6 +55,7 @@ export const FormFactorFilter = ({
             leftImage={<ThemeIcon svg={icon} />}
             value={isChecked(operator.id)}
             onValueChange={onOperatorToggle(operator.id)}
+            testID={`${operator.name.toLowerCase().replace(' ', '')}Toggle`}
           />
         ))}
       </Section>


### PR DESCRIPTION
In order to interact with the map (on a superficial kind of way), I need som extra test-ids for the map. I cannot interact with the map elements like el-scooter, but having e.g. `mapView` gives the possibility to drag and zoom. Along with toggling the filters, test scenarios testing the performance can be created.