### PR TITLE
fix: sort out issues with splash screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,8 +38,7 @@
             android:screenOrientation="portrait"
             android:launchMode="singleTask"
             android:windowSoftInputMode="adjustPan"
-            android:exported="true"
-            android:theme="@style/BootTheme">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,10 @@
         android:theme="@style/AppTheme">
         <activity
             android:exported="true"
-            android:name=".LaunchActivity">
+            android:name=".LaunchActivity"
+            android:screenOrientation="portrait"
+            android:label="@string/app_name"
+            android:theme="@style/BootTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/java/no/mittatb/LaunchActivity.kt
+++ b/android/app/src/main/java/no/mittatb/LaunchActivity.kt
@@ -3,11 +3,13 @@ package no.mittatb
 import com.facebook.react.ReactActivity
 import android.content.Intent
 import android.os.Bundle
+import com.zoontek.rnbootsplash.RNBootSplash
 
 class LaunchActivity : ReactActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        RNBootSplash.init(this, R.style.AppTheme);
         super.onCreate(savedInstanceState)
-        val intent: Intent = Intent(this, MainActivity::class.java)
+        val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)
         finish()
     }

--- a/android/app/src/main/java/no/mittatb/MainActivity.kt
+++ b/android/app/src/main/java/no/mittatb/MainActivity.kt
@@ -5,7 +5,6 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
-import com.zoontek.rnbootsplash.RNBootSplash
 
 class MainActivity : ReactActivity() {
 
@@ -16,7 +15,6 @@ class MainActivity : ReactActivity() {
   override fun getMainComponentName(): String = "atb"
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    RNBootSplash.init(this, R.style.AppTheme);
     super.onCreate(null)
   }
 


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/19454
related to https://github.com/AtB-AS/mittatb-app/pull/4763

This fix is a hotfix that should be already released on version 1.58.1-rc2.

It seems that the issue occurring on 1.58 was caused by the wrong splash screen placement. In 1.58, the `LaunchActivity` doesn't have any theme or splash screen on it, so when it launches the `MainActivity`, it will then show the splash screen stuffs. While this shouldn't block anything, on some Android devices, the splash screen blocks the user from interacting with the UI.

The fix here is to move all splash screen related functionality to the `LaunchActivity` instead, so when it launches `MainActivity`, it should directly shows the app, since the splash screen is shown on the `LaunchActivity`.