### PR TITLE
feat: Handle 400 NotAvailable error from offer search

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -158,8 +158,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     selection.userProfilesWithCount.some((u) => u.count) &&
     userProfilesWithCountAndOffer.some((u) => u.count);
 
-  const isEmptyOffer = error?.type === 'empty-offers';
-
   const handleTicketInfoButtonPress = () => {
     const parameters = {
       fareProductTypeConfigType: params.fareProductTypeConfig.type,
@@ -218,13 +216,17 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             />
           )}
           {error &&
-            (isEmptyOffer ? (
+            (error.type === 'not-available' ? (
               <MessageInfoBox
-                type="info"
-                message={t(
-                  PurchaseOverviewTexts.errorMessageBox.productUnavailable(
+                type="warning"
+                title={t(
+                  PurchaseOverviewTexts.errorMessageBox.productUnavailable.title(
                     getReferenceDataName(preassignedFareProduct, language),
                   ),
+                )}
+                message={t(
+                  PurchaseOverviewTexts.errorMessageBox.productUnavailable
+                    .message,
                 )}
                 style={styles.selectionComponent}
               />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -19,7 +19,7 @@ export type UserProfileWithCountAndOffer = UserProfileWithCount & {
 };
 
 export type OfferError = {
-  type: ErrorType | 'empty-offers';
+  type: ErrorType | 'empty-offers' | 'not-available';
 };
 
 type OfferState = {
@@ -233,8 +233,13 @@ export function useOfferState(
               },
             });
           }
-        } catch (err) {
-          const errorType = getAxiosErrorType(err);
+        } catch (err: any) {
+          const isNotAvailableError =
+            err.response?.status === 400 &&
+            err.response?.data === 'NotAvailable';
+          const errorType = isNotAvailableError
+            ? 'not-available'
+            : getAxiosErrorType(err);
           if (errorType !== 'cancel') {
             console.warn(err);
             dispatch({

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -23,7 +23,7 @@ const PurchaseOverviewTexts = {
         _(
           `${productName} er ikke gyldig nå`,
           `${productName} is not valid now`,
-          `${productName} er ikkje gyldig nå`,
+          `${productName} er ikkje gyldig no`,
         ),
       message: _(
         `Du må velge en annen billett fra billettoversikten.`,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -27,7 +27,7 @@ const PurchaseOverviewTexts = {
         ),
       message: _(
         `Du må velge en annen billett fra billettoversikten.`,
-        `You must choose another ticket from the ticket overview.`,
+        `You need to choose a different ticket from the ticket overview.`,
         `Du må velje ein annan billett frå billettoversikta.`,
       ),
     },

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -18,12 +18,19 @@ const PurchaseOverviewTexts = {
       'Whoops - we were unable to retrieve cost. Please try again 🤞',
       'Oops - vi klarte ikkje å finne prisinformasjonen. Prøv igjen 🤞',
     ),
-    productUnavailable: (productName: string) =>
-      _(
-        `${productName} er ikke tilgjengelig akkurat nå.`,
-        `${productName} is not available right now.`,
-        `${productName} er ikkje tilgjengeleg nett no.`,
+    productUnavailable: {
+      title: (productName: string) =>
+        _(
+          `${productName} er ikke gyldig nå`,
+          `${productName} is not valid now`,
+          `${productName} er ikkje gyldig nå`,
+        ),
+      message: _(
+        `Du må velge en annen billett fra billettoversikten.`,
+        `You must choose another ticket from the ticket overview.`,
+        `Du må velje ein annan billett frå billettoversikta.`,
       ),
+    },
   },
   travellers: {
     prefix: _('Nåværende valg: ', 'Current selection: ', 'Noverande val: '),


### PR DESCRIPTION
This error comes when the the travel date is outside of the
availability times configured for the product.

This is how the error looks:
<img width=350 src="https://github.com/user-attachments/assets/c6478f0d-abc9-4c60-a5af-c0f40bd4f3b2" />

With this change the empty offer response is just shown as a generic error:
<img width=350 src="https://github.com/user-attachments/assets/48e51803-8a6c-478e-91c4-4f28c507c003" />