### PR TITLE
refactor: Add generated types including service journey authority

### DIFF
--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -4,14 +4,14 @@ import {StreetMode} from '@atb/api/types/generated/journey_planner_v3_types';
 export type TripsQueryVariables = Types.Exact<{
   from: Types.Location;
   to: Types.Location;
-  arriveBy: Types.Scalars['Boolean'];
-  when?: Types.Maybe<Types.Scalars['DateTime']>;
-  cursor?: Types.Maybe<Types.Scalars['String']>;
-  transferSlack?: Types.Maybe<Types.Scalars['Int']>;
-  transferPenalty?: Types.Maybe<Types.Scalars['Int']>;
-  waitReluctance?: Types.Maybe<Types.Scalars['Float']>;
-  walkReluctance?: Types.Maybe<Types.Scalars['Float']>;
-  walkSpeed?: Types.Maybe<Types.Scalars['Float']>;
+  arriveBy: Types.Scalars['Boolean']['input'];
+  when?: Types.Maybe<Types.Scalars['DateTime']['input']>;
+  cursor?: Types.Maybe<Types.Scalars['String']['input']>;
+  transferSlack?: Types.Maybe<Types.Scalars['Int']['input']>;
+  transferPenalty?: Types.Maybe<Types.Scalars['Int']['input']>;
+  waitReluctance?: Types.Maybe<Types.Scalars['Float']['input']>;
+  walkReluctance?: Types.Maybe<Types.Scalars['Float']['input']>;
+  walkSpeed?: Types.Maybe<Types.Scalars['Float']['input']>;
   modes?: Types.Modes;
 }>;
 

--- a/src/api/types/generated/fragments/service-journeys.ts
+++ b/src/api/types/generated/fragments/service-journeys.ts
@@ -5,7 +5,11 @@ export type ServiceJourneyWithEstCallsFragment = {
   transportMode?: Types.TransportMode;
   transportSubmode?: Types.TransportSubmode;
   publicCode?: string;
-  line: {publicCode?: string; notices: Array<{id: string; text?: string}>};
+  line: {
+    publicCode?: string;
+    authority?: {id: string; name: string; url?: string};
+    notices: Array<{id: string; text?: string}>;
+  };
   journeyPattern?: {notices: Array<{id: string; text?: string}>};
   notices: Array<{id: string; text?: string}>;
   estimatedCalls?: Array<{
@@ -30,6 +34,7 @@ export type ServiceJourneyWithEstCallsFragment = {
         name: string;
         latitude?: number;
         longitude?: number;
+        transportMode?: Array<Types.TransportMode>;
       };
       tariffZones: Array<{id: string; name?: string}>;
     };

--- a/src/api/types/generated/journey_planner_v3_types.ts
+++ b/src/api/types/generated/journey_planner_v3_types.ts
@@ -13,23 +13,22 @@ export type MakeEmpty<T extends {[key: string]: unknown}, K extends keyof T> = {
 export type Incremental<T> =
   | T
   | {[P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never};
-
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  Coordinates: any;
-  Cost: any;
-  Date: any;
-  DateTime: any;
-  DoubleFunction: any;
-  Duration: any;
-  LocalTime: any;
-  Long: any;
-  Time: any;
+  ID: {input: string; output: string};
+  String: {input: string; output: string};
+  Boolean: {input: boolean; output: boolean};
+  Int: {input: number; output: number};
+  Float: {input: number; output: number};
+  Coordinates: {input: any; output: any};
+  Cost: {input: any; output: any};
+  Date: {input: any; output: any};
+  DateTime: {input: any; output: any};
+  DoubleFunction: {input: any; output: any};
+  Duration: {input: any; output: any};
+  LocalTime: {input: any; output: any};
+  Long: {input: any; output: any};
+  Time: {input: any; output: any};
 };
 
 export enum AbsoluteDirection {
@@ -49,7 +48,7 @@ export type AffectedLine = {
 
 export type AffectedServiceJourney = {
   datedServiceJourney?: Maybe<DatedServiceJourney>;
-  operatingDay?: Maybe<Scalars['Date']>;
+  operatingDay?: Maybe<Scalars['Date']['output']>;
   serviceJourney?: Maybe<ServiceJourney>;
 };
 
@@ -68,7 +67,7 @@ export type AffectedStopPlaceOnLine = {
 
 export type AffectedStopPlaceOnServiceJourney = {
   datedServiceJourney?: Maybe<DatedServiceJourney>;
-  operatingDay?: Maybe<Scalars['Date']>;
+  operatingDay?: Maybe<Scalars['Date']['output']>;
   quay?: Maybe<Quay>;
   serviceJourney?: Maybe<ServiceJourney>;
   stopConditions: Array<StopCondition>;
@@ -76,7 +75,7 @@ export type AffectedStopPlaceOnServiceJourney = {
 };
 
 export type AffectedUnknown = {
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
 };
 
 export type Affects =
@@ -107,16 +106,16 @@ export enum ArrivalDeparture {
 
 /** Authority involved in public transportation. An organisation under which the responsibility of organising the transport service in a certain area is placed. */
 export type Authority = {
-  fareUrl?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  lang?: Maybe<Scalars['String']>;
+  fareUrl?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  lang?: Maybe<Scalars['String']['output']>;
   lines: Array<Maybe<Line>>;
-  name: Scalars['String'];
-  phone?: Maybe<Scalars['String']>;
+  name: Scalars['String']['output'];
+  phone?: Maybe<Scalars['String']['output']>;
   /** Get all situations active for the authority. */
   situations: Array<PtSituationElement>;
-  timezone: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
+  timezone: Scalars['String']['output'];
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export enum BicycleOptimisationMethod {
@@ -128,24 +127,24 @@ export enum BicycleOptimisationMethod {
 }
 
 export type BikePark = PlaceInterface & {
-  id: Scalars['ID'];
-  latitude?: Maybe<Scalars['Float']>;
-  longitude?: Maybe<Scalars['Float']>;
-  name: Scalars['String'];
-  realtime?: Maybe<Scalars['Boolean']>;
-  spacesAvailable?: Maybe<Scalars['Int']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name: Scalars['String']['output'];
+  realtime?: Maybe<Scalars['Boolean']['output']>;
+  spacesAvailable?: Maybe<Scalars['Int']['output']>;
 };
 
 export type BikeRentalStation = PlaceInterface & {
-  allowDropoff?: Maybe<Scalars['Boolean']>;
-  bikesAvailable?: Maybe<Scalars['Int']>;
-  id: Scalars['ID'];
-  latitude?: Maybe<Scalars['Float']>;
-  longitude?: Maybe<Scalars['Float']>;
-  name: Scalars['String'];
-  networks: Array<Maybe<Scalars['String']>>;
-  realtimeOccupancyAvailable?: Maybe<Scalars['Boolean']>;
-  spacesAvailable?: Maybe<Scalars['Int']>;
+  allowDropoff?: Maybe<Scalars['Boolean']['output']>;
+  bikesAvailable?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name: Scalars['String']['output'];
+  networks: Array<Maybe<Scalars['String']['output']>>;
+  realtimeOccupancyAvailable?: Maybe<Scalars['Boolean']['output']>;
+  spacesAvailable?: Maybe<Scalars['Int']['output']>;
 };
 
 export enum BikesAllowed {
@@ -165,13 +164,13 @@ export type BookingArrangement = {
   /** How should service be booked? */
   bookingMethods?: Maybe<Array<Maybe<BookingMethod>>>;
   /** Textual description of booking arrangement for service */
-  bookingNote?: Maybe<Scalars['String']>;
+  bookingNote?: Maybe<Scalars['String']['output']>;
   /** How many days prior to the travel the service needs to be booked */
-  latestBookingDay?: Maybe<Scalars['Int']>;
+  latestBookingDay?: Maybe<Scalars['Int']['output']>;
   /** Latest time the service can be booked. ISO 8601 timestamp */
-  latestBookingTime?: Maybe<Scalars['LocalTime']>;
+  latestBookingTime?: Maybe<Scalars['LocalTime']['output']>;
   /** Minimum period in advance service can be booked as a ISO 8601 duration */
-  minimumBookingPeriod?: Maybe<Scalars['String']>;
+  minimumBookingPeriod?: Maybe<Scalars['String']['output']>;
 };
 
 export enum BookingMethod {
@@ -184,40 +183,40 @@ export enum BookingMethod {
 
 export type Branding = {
   /** Description of branding. */
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
+  description?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['ID']['output']>;
   /** URL to an image be used for branding */
-  image?: Maybe<Scalars['String']>;
+  image?: Maybe<Scalars['String']['output']>;
   /** Full name to be used for branding. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** Short name to be used for branding. */
-  shortName?: Maybe<Scalars['String']>;
+  shortName?: Maybe<Scalars['String']['output']>;
   /** URL to be used for branding */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export type Contact = {
   /** Name of person to contact */
-  contactPerson?: Maybe<Scalars['String']>;
+  contactPerson?: Maybe<Scalars['String']['output']>;
   /** Email adress for contact */
-  email?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']['output']>;
   /** Textual description of how to get in contact */
-  furtherDetails?: Maybe<Scalars['String']>;
+  furtherDetails?: Maybe<Scalars['String']['output']>;
   /** Phone number for contact */
-  phone?: Maybe<Scalars['String']>;
+  phone?: Maybe<Scalars['String']['output']>;
   /** Url for contact */
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** A planned journey on a specific day */
 export type DatedServiceJourney = {
   /** Returns scheduled passingTimes for this dated service journey, updated with real-time-updates (if available).  */
   estimatedCalls?: Maybe<Array<Maybe<EstimatedCall>>>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** JourneyPattern for the dated service journey. */
   journeyPattern?: Maybe<JourneyPattern>;
   /** The date this service runs. The date used is based on the service date as opposed to calendar date. */
-  operatingDay?: Maybe<Scalars['Date']>;
+  operatingDay?: Maybe<Scalars['Date']['output']>;
   /** Quays visited by the dated service journey. */
   quays: Array<Quay>;
   /** List of the dated service journeys this dated service journeys replaces */
@@ -230,16 +229,16 @@ export type DatedServiceJourney = {
 
 /** A planned journey on a specific day */
 export type DatedServiceJourneyQuaysArgs = {
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** An advertised destination of a specific journey pattern, usually displayed on a head sign or at other on-board locations. */
 export type DestinationDisplay = {
   /** Name of destination to show on front of vehicle. */
-  frontText?: Maybe<Scalars['String']>;
+  frontText?: Maybe<Scalars['String']['output']>;
   /** Intermediary destinations which the vehicle will pass before reaching its final destination. */
-  via?: Maybe<Array<Maybe<Scalars['String']>>>;
+  via?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
 };
 
 export enum DirectionType {
@@ -253,57 +252,57 @@ export enum DirectionType {
 /** Individual step of an elevation profile. */
 export type ElevationProfileStep = {
   /** The horizontal distance from the start of the step, in meters. */
-  distance?: Maybe<Scalars['Float']>;
+  distance?: Maybe<Scalars['Float']['output']>;
   /**
    * The elevation at this distance, in meters above sea level. It is negative if the
    * location is below sea level.
    *
    */
-  elevation?: Maybe<Scalars['Float']>;
+  elevation?: Maybe<Scalars['Float']['output']>;
 };
 
 /** List of visits to quays as part of vehicle journeys. Updated with real time information where available */
 export type EstimatedCall = {
   /** Actual time of arrival at quay. Updated from real time information if available. */
-  actualArrivalTime?: Maybe<Scalars['DateTime']>;
+  actualArrivalTime?: Maybe<Scalars['DateTime']['output']>;
   /** Actual time of departure from quay. Updated with real time information if available. */
-  actualDepartureTime?: Maybe<Scalars['DateTime']>;
+  actualDepartureTime?: Maybe<Scalars['DateTime']['output']>;
   /** Scheduled time of arrival at quay. Not affected by read time updated */
-  aimedArrivalTime: Scalars['DateTime'];
+  aimedArrivalTime: Scalars['DateTime']['output'];
   /** Scheduled time of departure from quay. Not affected by read time updated */
-  aimedDepartureTime: Scalars['DateTime'];
+  aimedDepartureTime: Scalars['DateTime']['output'];
   /** Booking arrangements for this EstimatedCall. */
   bookingArrangements?: Maybe<BookingArrangement>;
   /** Whether stop is cancelled. This means that either the ServiceJourney has a planned cancellation, the ServiceJourney has been cancelled by real-time data, or this particular StopPoint has been cancelled. This also means that both boarding and alighting has been cancelled. */
-  cancellation: Scalars['Boolean'];
+  cancellation: Scalars['Boolean']['output'];
   /** The date the estimated call is valid for. */
-  date: Scalars['Date'];
+  date: Scalars['Date']['output'];
   datedServiceJourney?: Maybe<DatedServiceJourney>;
   destinationDisplay?: Maybe<DestinationDisplay>;
   /** Expected time of arrival at quay. Updated with real time information if available. Will be null if an actualArrivalTime exists */
-  expectedArrivalTime: Scalars['DateTime'];
+  expectedArrivalTime: Scalars['DateTime']['output'];
   /** Expected time of departure from quay. Updated with real time information if available. Will be null if an actualDepartureTime exists */
-  expectedDepartureTime: Scalars['DateTime'];
+  expectedDepartureTime: Scalars['DateTime']['output'];
   /** Whether vehicle may be alighted at quay. */
-  forAlighting: Scalars['Boolean'];
+  forAlighting: Scalars['Boolean']['output'];
   /** Whether vehicle may be boarded at quay. */
-  forBoarding: Scalars['Boolean'];
+  forBoarding: Scalars['Boolean']['output'];
   notices: Array<Notice>;
   occupancyStatus: OccupancyStatus;
   /** Whether the updated estimates are expected to be inaccurate. */
-  predictionInaccurate: Scalars['Boolean'];
+  predictionInaccurate: Scalars['Boolean']['output'];
   quay: Quay;
   /** Whether this call has been updated with real time information. */
-  realtime: Scalars['Boolean'];
+  realtime: Scalars['Boolean']['output'];
   realtimeState: RealtimeState;
   /** Whether vehicle will only stop on request. */
-  requestStop: Scalars['Boolean'];
+  requestStop: Scalars['Boolean']['output'];
   serviceJourney: ServiceJourney;
   /** Get all relevant situations for this EstimatedCall. */
   situations: Array<PtSituationElement>;
-  stopPositionInPattern: Scalars['Int'];
+  stopPositionInPattern: Scalars['Int']['output'];
   /** Whether this is a timing point or not. Boarding and alighting is not allowed at timing points. */
-  timingPoint: Scalars['Boolean'];
+  timingPoint: Scalars['Boolean']['output'];
 };
 
 export enum FilterPlaceType {
@@ -322,40 +321,40 @@ export enum FilterPlaceType {
 /** Additional (optional) grouping of lines for particular purposes such as e.g. fare harmonisation or public presentation. */
 export type GroupOfLines = {
   /** Description of group of lines */
-  description?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
   /** All lines part of this group of lines */
   lines: Array<Line>;
   /** Full name for group of lines. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** For internal use by operator/authority. */
-  privateCode?: Maybe<Scalars['String']>;
+  privateCode?: Maybe<Scalars['String']['output']>;
   /** Short name for group of lines. */
-  shortName?: Maybe<Scalars['String']>;
+  shortName?: Maybe<Scalars['String']['output']>;
 };
 
 /** Filter trips by disallowing lines involving certain elements. If both lines and authorities are specified, only one must be valid for each line to be banned. If a line is both banned and whitelisted, it will be counted as banned. */
 export type InputBanned = {
   /** Set of ids for authorities that should not be used */
-  authorities?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorities?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Set of ids for lines that should not be used */
-  lines?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  lines?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** NOT IMPLEMENTED. Set of ids of quays that should not be allowed for boarding or alighting. Trip patterns that travel through the quay will still be permitted. */
-  quays?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  quays?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** NOT IMPLEMENTED. Set of ids of quays that should not be allowed for boarding, alighting or traveling thorugh. */
-  quaysHard?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  quaysHard?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Set of ids of rental networks that should not be allowed for renting vehicles. */
-  rentalNetworks?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  rentalNetworks?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Set of ids of service journeys that should not be used. */
-  serviceJourneys?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  serviceJourneys?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
 };
 
 /** Input type for coordinates in the WGS84 system */
 export type InputCoordinates = {
   /** The latitude of the place. */
-  latitude: Scalars['Float'];
+  latitude: Scalars['Float']['input'];
   /** The longitude of the place. */
-  longitude: Scalars['Float'];
+  longitude: Scalars['Float']['input'];
 };
 
 export enum InputField {
@@ -367,25 +366,27 @@ export enum InputField {
 
 export type InputPlaceIds = {
   /** Bike parks to include by id. */
-  bikeParks?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  bikeParks?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Bike rentals to include by id. */
-  bikeRentalStations?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  bikeRentalStations?: InputMaybe<
+    Array<InputMaybe<Scalars['String']['input']>>
+  >;
   /** Car parks to include by id. */
-  carParks?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  carParks?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Lines to include by id. */
-  lines?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  lines?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** Quays to include by id. */
-  quays?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  quays?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 /** Filter trips by only allowing lines involving certain elements. If both lines and authorities are specified, only one must be valid for each line to be used. If a line is both banned and whitelisted, it will be counted as banned. */
 export type InputWhiteListed = {
   /** Set of ids for authorities that should be used */
-  authorities?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  authorities?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Set of ids for lines that should be used */
-  lines?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  lines?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   /** Set of ids of rental networks that should be used for renting vehicles. */
-  rentalNetworks?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  rentalNetworks?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
 };
 
 export type Interchange = {
@@ -398,12 +399,12 @@ export type Interchange = {
   /** @deprecated Use toServiceJourney instead */
   ToServiceJourney?: Maybe<ServiceJourney>;
   fromServiceJourney?: Maybe<ServiceJourney>;
-  guaranteed?: Maybe<Scalars['Boolean']>;
+  guaranteed?: Maybe<Scalars['Boolean']['output']>;
   /** Maximum time after scheduled departure time the connecting transport is guaranteed to wait for the delayed trip. [NOT RESPECTED DURING ROUTING, JUST PASSED THROUGH] */
-  maximumWaitTime?: Maybe<Scalars['Int']>;
+  maximumWaitTime?: Maybe<Scalars['Int']['output']>;
   /** The transfer priority is used to decide where a transfer should happen, at the highest prioritized location. If the guaranteed flag is set it take precedence priority. A guaranteed ALLOWED transfer is preferred over a PREFERRED none-guaranteed transfer. */
   priority?: Maybe<InterchangePriority>;
-  staySeated?: Maybe<Scalars['Boolean']>;
+  staySeated?: Maybe<Scalars['Boolean']['output']>;
   toServiceJourney?: Maybe<ServiceJourney>;
 };
 
@@ -414,6 +415,7 @@ export enum InterchangePriority {
   Recommended = 'recommended',
 }
 
+/** Deprecated. Use STOP_INTERCHANGE_PRIORITY */
 export enum InterchangeWeighting {
   /** Third highest priority interchange. */
   InterchangeAllowed = 'interchangeAllowed',
@@ -457,20 +459,22 @@ export type ItineraryFilters = {
    */
   debug?: InputMaybe<ItineraryFilterDebugProfile>;
   /** Pick ONE itinerary from each group after putting itineraries that is 85% similar together. */
-  groupSimilarityKeepOne?: InputMaybe<Scalars['Float']>;
+  groupSimilarityKeepOne?: InputMaybe<Scalars['Float']['input']>;
   /** Reduce the number of itineraries in each group to to maximum 3 itineraries. The itineraries are grouped by similar legs (on board same journey). So, if  68% of the distance is traveled by similar legs, then two itineraries are in the same group. Default value is 68%, must be at least 50%. */
-  groupSimilarityKeepThree?: InputMaybe<Scalars['Float']>;
+  groupSimilarityKeepThree?: InputMaybe<Scalars['Float']['input']>;
   /** Of the itineraries grouped to maximum of three itineraries, how much worse can the non-grouped legs be compared to the lowest cost. 2.0 means that they can be double the cost, and any itineraries having a higher cost will be filtered. Default value is 2.0, use a value lower than 1.0 to turn off */
-  groupedOtherThanSameLegsMaxCostMultiplier?: InputMaybe<Scalars['Float']>;
+  groupedOtherThanSameLegsMaxCostMultiplier?: InputMaybe<
+    Scalars['Float']['input']
+  >;
   /** Set a relative limit for all transit itineraries. The limit is calculated based on the transit itinerary generalized-cost and the time between itineraries Itineraries without transit legs are excluded from this filter. Example: costLimitFunction(x) = 3600 + 2.0 x and intervalRelaxFactor = 0.5. If the lowest cost returned is 10 000, then the limit is set to: 3 600 + 2 * 10 000 = 26 600 plus half of the time between either departure or arrival times of the itinerary. Default: {"costLimitFunction": 15m + 1.50 t, "intervalRelaxFactor": 0.75} */
   transitGeneralizedCostLimit?: InputMaybe<TransitGeneralizedCostFilterParams>;
 };
 
 export type JourneyPattern = {
   directionType?: Maybe<DirectionType>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   line: Line;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   notices: Array<Notice>;
   pointsOnLink?: Maybe<PointsOnLink>;
   /** Quays visited by service journeys for this journey patterns */
@@ -485,27 +489,27 @@ export type JourneyPattern = {
 };
 
 export type JourneyPatternServiceJourneysForDateArgs = {
-  date?: InputMaybe<Scalars['Date']>;
+  date?: InputMaybe<Scalars['Date']['input']>;
 };
 
 /** Part of a trip pattern. Either a ride on a public transport vehicle or access or path link to/from/between places */
 export type Leg = {
   /** The aimed date and time this leg ends. */
-  aimedEndTime: Scalars['DateTime'];
+  aimedEndTime: Scalars['DateTime']['output'];
   /** The aimed date and time this leg starts. */
-  aimedStartTime: Scalars['DateTime'];
+  aimedStartTime: Scalars['DateTime']['output'];
   /** For ride legs, the service authority used for this legs. For non-ride legs, null. */
   authority?: Maybe<Authority>;
-  bikeRentalNetworks: Array<Maybe<Scalars['String']>>;
+  bikeRentalNetworks: Array<Maybe<Scalars['String']['output']>>;
   bookingArrangements?: Maybe<BookingArrangement>;
   /** The dated service journey used for this leg. */
   datedServiceJourney?: Maybe<DatedServiceJourney>;
   /** NOT IMPLEMENTED */
-  directDuration: Scalars['Long'];
+  directDuration: Scalars['Long']['output'];
   /** The distance traveled while traversing the leg in meters. */
-  distance: Scalars['Float'];
+  distance: Scalars['Float']['output'];
   /** The leg's duration in seconds */
-  duration: Scalars['Long'];
+  duration: Scalars['Long']['output'];
   /**
    * The leg's elevation profile. All elevation values, including the first one, are in meters
    * above sea level. The elevation is negative for places below sea level. The profile
@@ -514,17 +518,17 @@ export type Leg = {
    */
   elevationProfile: Array<Maybe<ElevationProfileStep>>;
   /** The expected, real-time adjusted date and time this leg ends. */
-  expectedEndTime: Scalars['DateTime'];
+  expectedEndTime: Scalars['DateTime']['output'];
   /** The expected, real-time adjusted date and time this leg starts. */
-  expectedStartTime: Scalars['DateTime'];
+  expectedStartTime: Scalars['DateTime']['output'];
   /** EstimatedCall for the quay where the leg originates. */
   fromEstimatedCall?: Maybe<EstimatedCall>;
   /** The Place where the leg originates. */
   fromPlace: Place;
   /** Generalized cost or weight of the leg. Used for debugging. */
-  generalizedCost?: Maybe<Scalars['Int']>;
-  /** An identifier for the leg, which can be used to re-fetch the information. */
-  id?: Maybe<Scalars['ID']>;
+  generalizedCost?: Maybe<Scalars['Int']['output']>;
+  /** An identifier for the leg, which can be used to re-fetch transit leg information. */
+  id?: Maybe<Scalars['ID']['output']>;
   interchangeFrom?: Maybe<Interchange>;
   interchangeTo?: Maybe<Interchange>;
   /** For ride legs, estimated calls for quays between the Place where the leg originates and the Place where the leg ends. For non-ride legs, empty list. */
@@ -544,13 +548,13 @@ export type Leg = {
   /** Fetch the previous legs, which can be used to replace this leg. The replacement legs do arrive/depart from/to the same stop places. It might be necessary to change other legs in an itinerary in order to be able to ride the returned legs. */
   previousLegs?: Maybe<Array<Leg>>;
   /** Whether there is real-time data about this leg */
-  realtime: Scalars['Boolean'];
+  realtime: Scalars['Boolean']['output'];
   /** Whether this leg is with a rented bike. */
-  rentedBike?: Maybe<Scalars['Boolean']>;
+  rentedBike?: Maybe<Scalars['Boolean']['output']>;
   /** Whether this leg is a ride leg or not. */
-  ride: Scalars['Boolean'];
+  ride: Scalars['Boolean']['output'];
   /** For transit legs, the service date of the trip. For non-transit legs, null. */
-  serviceDate?: Maybe<Scalars['Date']>;
+  serviceDate?: Maybe<Scalars['Date']['output']>;
   /** For ride legs, the service journey. For non-ride legs, null. */
   serviceJourney?: Maybe<ServiceJourney>;
   /** For ride legs, all estimated calls for the service journey. For non-ride legs, empty list. */
@@ -566,19 +570,19 @@ export type Leg = {
   /** The transport sub mode (e.g., localBus or expressBus) used when traversing this leg. Null if leg is not a ride */
   transportSubmode?: Maybe<TransportSubmode>;
   /** Whether this leg is walking with a bike. */
-  walkingBike?: Maybe<Scalars['Boolean']>;
+  walkingBike?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Part of a trip pattern. Either a ride on a public transport vehicle or access or path link to/from/between places */
 export type LegNextLegsArgs = {
   filter?: InputMaybe<AlternativeLegsFilter>;
-  next?: InputMaybe<Scalars['Int']>;
+  next?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Part of a trip pattern. Either a ride on a public transport vehicle or access or path link to/from/between places */
 export type LegPreviousLegsArgs = {
   filter?: InputMaybe<AlternativeLegsFilter>;
-  previous?: InputMaybe<Scalars['Int']>;
+  previous?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** A group of routes which is generally known to the public by a similar name or number */
@@ -591,26 +595,26 @@ export type Line = {
    */
   bookingArrangements?: Maybe<BookingArrangement>;
   branding?: Maybe<Branding>;
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** Type of flexible line, or null if line is not flexible. */
-  flexibleLineType?: Maybe<Scalars['String']>;
+  flexibleLineType?: Maybe<Scalars['String']['output']>;
   /** Groups of lines that line is a part of. */
   groupOfLines: Array<Maybe<GroupOfLines>>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   journeyPatterns?: Maybe<Array<Maybe<JourneyPattern>>>;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   notices: Array<Notice>;
   operator?: Maybe<Operator>;
   presentation?: Maybe<Presentation>;
   /** Publicly announced code for line, differentiating it from other lines for the same operator. */
-  publicCode?: Maybe<Scalars['String']>;
+  publicCode?: Maybe<Scalars['String']['output']>;
   quays: Array<Maybe<Quay>>;
   serviceJourneys: Array<Maybe<ServiceJourney>>;
   /** Get all situations active for the line. */
   situations: Array<PtSituationElement>;
   transportMode?: Maybe<TransportMode>;
   transportSubmode?: Maybe<TransportSubmode>;
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export enum Locale {
@@ -623,9 +627,9 @@ export type Location = {
   /** Coordinates for the location. This can be used alone or as fallback if the place id is not found. */
   coordinates?: InputMaybe<InputCoordinates>;
   /** The name of the location. This is pass-through informationand is not used in routing. */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The id of an element in the OTP model. Currently supports Quay, StopPlace, multimodal StopPlace, and GroupOfStopPlaces. */
-  place?: InputMaybe<Scalars['String']>;
+  place?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum Mode {
@@ -671,14 +675,14 @@ export enum MultiModalMode {
 
 /** Text with language */
 export type MultilingualString = {
-  language?: Maybe<Scalars['String']>;
-  value: Scalars['String'];
+  language?: Maybe<Scalars['String']['output']>;
+  value: Scalars['String']['output'];
 };
 
 export type Notice = {
-  id: Scalars['ID'];
-  publicCode?: Maybe<Scalars['String']>;
-  text?: Maybe<Scalars['String']>;
+  id: Scalars['ID']['output'];
+  publicCode?: Maybe<Scalars['String']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
 };
 
 /** OccupancyStatus to be exposed in the API. The values are based on GTFS-RT */
@@ -737,46 +741,46 @@ export enum OccupancyStatus {
 
 /** Organisation providing public transport services. */
 export type Operator = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   lines: Array<Maybe<Line>>;
-  name: Scalars['String'];
-  phone?: Maybe<Scalars['String']>;
+  name: Scalars['String']['output'];
+  phone?: Maybe<Scalars['String']['output']>;
   serviceJourney: Array<Maybe<ServiceJourney>>;
-  url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** Information about pagination in a connection. */
 export type PageInfo = {
   /** When paginating forwards, the cursor to continue. */
-  endCursor?: Maybe<Scalars['String']>;
+  endCursor?: Maybe<Scalars['String']['output']>;
   /** When paginating forwards, are there more items? */
-  hasNextPage: Scalars['Boolean'];
+  hasNextPage: Scalars['Boolean']['output'];
   /** When paginating backwards, are there more items? */
-  hasPreviousPage: Scalars['Boolean'];
+  hasPreviousPage: Scalars['Boolean']['output'];
   /** When paginating backwards, the cursor to continue. */
-  startCursor?: Maybe<Scalars['String']>;
+  startCursor?: Maybe<Scalars['String']['output']>;
 };
 
 /** Defines one point which the journey must pass through. */
 export type PassThroughPoint = {
   /** Optional name of the pass-through point for debugging and logging. It is not used in routing. */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /**
    * The list of *stop location ids* which define the pass-through point. At least one id is required.
    * Quay, StopPlace, multimodal StopPlace, and GroupOfStopPlaces are supported location types.
    * The journey must pass through at least one of these entities - not all of them.
    */
-  placeIds?: InputMaybe<Array<Scalars['String']>>;
+  placeIds?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** A series of turn by turn instructions used for walking, biking and driving. */
 export type PathGuidance = {
   /** This step is on an open area, such as a plaza or train platform, and thus the directions should say something like "cross" */
-  area?: Maybe<Scalars['Boolean']>;
+  area?: Maybe<Scalars['Boolean']['output']>;
   /** The name of this street was generated by the system, so we should only display it once, and generally just display right/left directions */
-  bogusName?: Maybe<Scalars['Boolean']>;
+  bogusName?: Maybe<Scalars['Boolean']['output']>;
   /** The distance in meters that this step takes. */
-  distance?: Maybe<Scalars['Float']>;
+  distance?: Maybe<Scalars['Float']['output']>;
   /**
    * The step's elevation profile. All elevation values, including the first one, are in meters
    * above sea level. The elevation is negative for places below sea level. The profile
@@ -785,19 +789,19 @@ export type PathGuidance = {
    */
   elevationProfile: Array<Maybe<ElevationProfileStep>>;
   /** When exiting a highway or traffic circle, the exit name/number. */
-  exit?: Maybe<Scalars['String']>;
+  exit?: Maybe<Scalars['String']['output']>;
   /** The absolute direction of this step. */
   heading?: Maybe<AbsoluteDirection>;
   /** The latitude of the step. */
-  latitude?: Maybe<Scalars['Float']>;
+  latitude?: Maybe<Scalars['Float']['output']>;
   /** The longitude of the step. */
-  longitude?: Maybe<Scalars['Float']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
   /** The relative direction of this step. */
   relativeDirection?: Maybe<RelativeDirection>;
   /** Indicates whether or not a street changes direction at an intersection. */
-  stayOn?: Maybe<Scalars['Boolean']>;
+  stayOn?: Maybe<Scalars['Boolean']['output']>;
   /** The name of the street. */
-  streetName?: Maybe<Scalars['String']>;
+  streetName?: Maybe<Scalars['String']['output']>;
 };
 
 /** A combination of street mode and penalty for time and cost. */
@@ -807,7 +811,7 @@ export type PenaltyForStreetMode = {
    *     The result is added to the generalized-cost.
    *
    */
-  costFactor?: InputMaybe<Scalars['Float']>;
+  costFactor?: InputMaybe<Scalars['Float']['input']>;
   /**
    * List of modes with the given penalty is applied to. A street-mode should not be listed
    * in more than one element. If empty or null the penalty is applied to all unlisted modes,
@@ -819,7 +823,7 @@ export type PenaltyForStreetMode = {
    * Penalty applied to the time for the given list of modes.
    *
    */
-  timePenalty: Scalars['DoubleFunction'];
+  timePenalty: Scalars['DoubleFunction']['input'];
 };
 
 /** Common super class for all places (stop places, quays, car parks, bike parks and bike rental stations ) */
@@ -827,13 +831,13 @@ export type Place = {
   /** The bike rental station related to the place */
   bikeRentalStation?: Maybe<BikeRentalStation>;
   /** The flexible area related to the place. */
-  flexibleArea?: Maybe<Scalars['Coordinates']>;
+  flexibleArea?: Maybe<Scalars['Coordinates']['output']>;
   /** The latitude of the place. */
-  latitude: Scalars['Float'];
+  latitude: Scalars['Float']['output'];
   /** The longitude of the place. */
-  longitude: Scalars['Float'];
+  longitude: Scalars['Float']['output'];
   /** For transit quays, the name of the quay. For points of interest, the name of the POI. */
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']['output']>;
   /** The quay related to the place. */
   quay?: Maybe<Quay>;
   /** The rental vehicle related to the place */
@@ -843,31 +847,31 @@ export type Place = {
 };
 
 export type PlaceAtDistance = {
-  distance?: Maybe<Scalars['Float']>;
+  distance?: Maybe<Scalars['Float']['output']>;
   /** @deprecated Id is not referable or meaningful and will be removed */
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   place?: Maybe<PlaceInterface>;
 };
 
 /** Interface for places, i.e. quays, stop places, parks */
 export type PlaceInterface = {
-  id: Scalars['ID'];
-  latitude?: Maybe<Scalars['Float']>;
-  longitude?: Maybe<Scalars['Float']>;
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
 };
 
 /** A list of coordinates encoded as a polyline string (see http://code.google.com/apis/maps/documentation/polylinealgorithm.html) */
 export type PointsOnLink = {
   /** The number of points in the string */
-  length?: Maybe<Scalars['Int']>;
+  length?: Maybe<Scalars['Int']['output']>;
   /** The encoded points of the polyline. Be aware that the string could contain escape characters that need to be accounted for. (https://www.freeformatter.com/javascript-escape.html) */
-  points?: Maybe<Scalars['String']>;
+  points?: Maybe<Scalars['String']['output']>;
 };
 
 /** Types describing common presentation properties */
 export type Presentation = {
-  colour?: Maybe<Scalars['String']>;
-  textColour?: Maybe<Scalars['String']>;
+  colour?: Maybe<Scalars['String']['output']>;
+  textColour?: Maybe<Scalars['String']['output']>;
 };
 
 /** Simple public transport situation element */
@@ -882,18 +886,18 @@ export type PtSituationElement = {
    */
   authority?: Maybe<Authority>;
   /** Timestamp for when the situation was created. */
-  creationTime?: Maybe<Scalars['DateTime']>;
+  creationTime?: Maybe<Scalars['DateTime']['output']>;
   /** Description of situation in all different translations available */
   description: Array<MultilingualString>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** Optional links to more information. */
   infoLinks?: Maybe<Array<InfoLink>>;
   /** @deprecated Use affects instead */
   lines: Array<Maybe<Line>>;
   /** Codespace of the data source. */
-  participant?: Maybe<Scalars['String']>;
+  participant?: Maybe<Scalars['String']['output']>;
   /** Priority of this situation  */
-  priority?: Maybe<Scalars['Int']>;
+  priority?: Maybe<Scalars['Int']['output']>;
   /** @deprecated Use affects instead */
   quays: Array<Quay>;
   /**
@@ -908,7 +912,7 @@ export type PtSituationElement = {
   /** Severity of this situation  */
   severity?: Maybe<Severity>;
   /** Operator's internal id for this situation */
-  situationNumber?: Maybe<Scalars['String']>;
+  situationNumber?: Maybe<Scalars['String']['output']>;
   /** @deprecated Use affects instead */
   stopPlaces: Array<StopPlace>;
   /** Summary of situation in all different translations available */
@@ -916,9 +920,9 @@ export type PtSituationElement = {
   /** Period this situation is in effect */
   validityPeriod?: Maybe<ValidityPeriod>;
   /** Operator's version number for the situation element. */
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars['Int']['output']>;
   /** Timestamp when the situation element was updated. */
-  versionedAtTime?: Maybe<Scalars['DateTime']>;
+  versionedAtTime?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export enum PurchaseWhen {
@@ -931,30 +935,30 @@ export enum PurchaseWhen {
 
 /** A place such as platform, stance, or quayside where passengers have access to PT vehicles. */
 export type Quay = PlaceInterface & {
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** List of visits to this quay as part of vehicle journeys. */
   estimatedCalls: Array<EstimatedCall>;
   /** Geometry for flexible area. */
-  flexibleArea?: Maybe<Scalars['Coordinates']>;
+  flexibleArea?: Maybe<Scalars['Coordinates']['output']>;
   /** the Quays part of a flexible group. */
   flexibleGroup?: Maybe<Array<Maybe<Quay>>>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** List of journey patterns servicing this quay */
   journeyPatterns: Array<Maybe<JourneyPattern>>;
-  latitude?: Maybe<Scalars['Float']>;
+  latitude?: Maybe<Scalars['Float']['output']>;
   /** List of lines servicing this quay */
   lines: Array<Line>;
-  longitude?: Maybe<Scalars['Float']>;
-  name: Scalars['String'];
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name: Scalars['String']['output'];
   /** Public code used to identify this quay within the stop place. For instance a platform code. */
-  publicCode?: Maybe<Scalars['String']>;
+  publicCode?: Maybe<Scalars['String']['output']>;
   /** Get all situations active for the quay. */
   situations: Array<PtSituationElement>;
   /** The stop place to which this quay belongs to. */
   stopPlace?: Maybe<StopPlace>;
-  stopType?: Maybe<Scalars['String']>;
+  stopType?: Maybe<Scalars['String']['output']>;
   tariffZones: Array<Maybe<TariffZone>>;
-  timeZone?: Maybe<Scalars['String']>;
+  timeZone?: Maybe<Scalars['String']['output']>;
   /** Whether this quay is suitable for wheelchair boarding. */
   wheelchairAccessible?: Maybe<WheelchairBoarding>;
 };
@@ -962,24 +966,26 @@ export type Quay = PlaceInterface & {
 /** A place such as platform, stance, or quayside where passengers have access to PT vehicles. */
 export type QuayEstimatedCallsArgs = {
   arrivalDeparture?: InputMaybe<ArrivalDeparture>;
-  includeCancelledTrips?: InputMaybe<Scalars['Boolean']>;
-  numberOfDepartures?: InputMaybe<Scalars['Int']>;
-  numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<Scalars['Int']>;
-  startTime?: InputMaybe<Scalars['DateTime']>;
-  timeRange?: InputMaybe<Scalars['Int']>;
+  includeCancelledTrips?: InputMaybe<Scalars['Boolean']['input']>;
+  numberOfDepartures?: InputMaybe<Scalars['Int']['input']>;
+  numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<
+    Scalars['Int']['input']
+  >;
+  startTime?: InputMaybe<Scalars['DateTime']['input']>;
+  timeRange?: InputMaybe<Scalars['Int']['input']>;
   whiteListed?: InputMaybe<InputWhiteListed>;
   whiteListedModes?: InputMaybe<Array<InputMaybe<TransportMode>>>;
 };
 
 /** A place such as platform, stance, or quayside where passengers have access to PT vehicles. */
 export type QuayNameArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type QuayAtDistance = {
   /** The distance in meters to the given quay. */
-  distance?: Maybe<Scalars['Float']>;
-  id: Scalars['ID'];
+  distance?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
   quay?: Maybe<Quay>;
 };
 
@@ -1006,7 +1012,7 @@ export type QueryType = {
   groupOfLines?: Maybe<GroupOfLines>;
   /** Get all groups of lines */
   groupsOfLines: Array<GroupOfLines>;
-  /** Refetch a single leg based on its id */
+  /** Refetch a single transit leg based on its id */
   leg?: Maybe<Leg>;
   /** Get a single line based on its id */
   line?: Maybe<Line>;
@@ -1028,7 +1034,7 @@ export type QueryType = {
   quaysByRadius?: Maybe<QuayAtDistanceConnection>;
   /** Get default routing parameters. */
   routingParameters?: Maybe<RoutingParameters>;
-  /** Get OTP server information */
+  /** Get OTP deployment information. This is only useful for developers of OTP itself not regular API users. */
   serverInfo: ServerInfo;
   /** Get a single service journey based on its id */
   serviceJourney?: Maybe<ServiceJourney>;
@@ -1046,209 +1052,214 @@ export type QueryType = {
   stopPlacesByBbox: Array<Maybe<StopPlace>>;
   /** Input type for executing a travel search for a trip between two locations. Returns trip patterns describing suggested alternatives for the trip. */
   trip: Trip;
-  /** Via trip search. Find trip patterns traveling via one or more intermediate (via) locations. */
+  /**
+   * Via trip search. Find trip patterns traveling via one or more intermediate (via) locations.
+   * @deprecated Use the regular trip query with via stop instead.
+   */
   viaTrip: ViaTrip;
 };
 
 export type QueryTypeAuthorityArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeBikeParkArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeBikeRentalStationArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeBikeRentalStationsArgs = {
-  ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type QueryTypeBikeRentalStationsByBboxArgs = {
-  maximumLatitude?: InputMaybe<Scalars['Float']>;
-  maximumLongitude?: InputMaybe<Scalars['Float']>;
-  minimumLatitude?: InputMaybe<Scalars['Float']>;
-  minimumLongitude?: InputMaybe<Scalars['Float']>;
+  maximumLatitude?: InputMaybe<Scalars['Float']['input']>;
+  maximumLongitude?: InputMaybe<Scalars['Float']['input']>;
+  minimumLatitude?: InputMaybe<Scalars['Float']['input']>;
+  minimumLongitude?: InputMaybe<Scalars['Float']['input']>;
 };
 
 export type QueryTypeDatedServiceJourneyArgs = {
-  id?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type QueryTypeDatedServiceJourneysArgs = {
   alterations?: InputMaybe<Array<ServiceAlteration>>;
-  authorities?: InputMaybe<Array<Scalars['String']>>;
-  lines?: InputMaybe<Array<Scalars['String']>>;
-  operatingDays: Array<Scalars['Date']>;
-  privateCodes?: InputMaybe<Array<Scalars['String']>>;
-  replacementFor?: InputMaybe<Array<Scalars['String']>>;
-  serviceJourneys?: InputMaybe<Array<Scalars['String']>>;
+  authorities?: InputMaybe<Array<Scalars['String']['input']>>;
+  lines?: InputMaybe<Array<Scalars['String']['input']>>;
+  operatingDays: Array<Scalars['Date']['input']>;
+  privateCodes?: InputMaybe<Array<Scalars['String']['input']>>;
+  replacementFor?: InputMaybe<Array<Scalars['String']['input']>>;
+  serviceJourneys?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type QueryTypeGroupOfLinesArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeLegArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 export type QueryTypeLineArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
 };
 
 export type QueryTypeLinesArgs = {
-  authorities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  flexibleOnly?: InputMaybe<Scalars['Boolean']>;
-  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  name?: InputMaybe<Scalars['String']>;
-  publicCode?: InputMaybe<Scalars['String']>;
-  publicCodes?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  authorities?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  flexibleOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  publicCode?: InputMaybe<Scalars['String']['input']>;
+  publicCodes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   transportModes?: InputMaybe<Array<InputMaybe<TransportMode>>>;
 };
 
 export type QueryTypeNearestArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
   filterByIds?: InputMaybe<InputPlaceIds>;
-  filterByInUse?: InputMaybe<Scalars['Boolean']>;
+  filterByInUse?: InputMaybe<Scalars['Boolean']['input']>;
   filterByModes?: InputMaybe<Array<InputMaybe<TransportMode>>>;
   filterByPlaceTypes?: InputMaybe<Array<InputMaybe<FilterPlaceType>>>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
-  maximumDistance?: Scalars['Float'];
-  maximumResults?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
+  maximumDistance?: Scalars['Float']['input'];
+  maximumResults?: InputMaybe<Scalars['Int']['input']>;
   multiModalMode?: InputMaybe<MultiModalMode>;
 };
 
 export type QueryTypeOperatorArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeQuayArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeQuaysArgs = {
-  ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  name?: InputMaybe<Scalars['String']>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type QueryTypeQuaysByBboxArgs = {
-  authority?: InputMaybe<Scalars['String']>;
-  filterByInUse?: InputMaybe<Scalars['Boolean']>;
-  maximumLatitude: Scalars['Float'];
-  maximumLongitude: Scalars['Float'];
-  minimumLatitude: Scalars['Float'];
-  minimumLongitude: Scalars['Float'];
+  authority?: InputMaybe<Scalars['String']['input']>;
+  filterByInUse?: InputMaybe<Scalars['Boolean']['input']>;
+  maximumLatitude: Scalars['Float']['input'];
+  maximumLongitude: Scalars['Float']['input'];
+  minimumLatitude: Scalars['Float']['input'];
+  minimumLongitude: Scalars['Float']['input'];
 };
 
 export type QueryTypeQuaysByRadiusArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  authority?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
-  radius: Scalars['Float'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  authority?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
+  radius: Scalars['Float']['input'];
 };
 
 export type QueryTypeServiceJourneyArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeServiceJourneysArgs = {
-  activeDates?: InputMaybe<Array<InputMaybe<Scalars['Date']>>>;
-  authorities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  lines?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  privateCodes?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  activeDates?: InputMaybe<Array<InputMaybe<Scalars['Date']['input']>>>;
+  authorities?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  lines?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  privateCodes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type QueryTypeSituationArgs = {
-  situationNumber: Scalars['String'];
+  situationNumber: Scalars['String']['input'];
 };
 
 export type QueryTypeSituationsArgs = {
-  codespaces?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  codespaces?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   severities?: InputMaybe<Array<InputMaybe<Severity>>>;
 };
 
 export type QueryTypeStopPlaceArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type QueryTypeStopPlacesArgs = {
-  ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type QueryTypeStopPlacesByBboxArgs = {
-  authority?: InputMaybe<Scalars['String']>;
-  filterByInUse?: InputMaybe<Scalars['Boolean']>;
-  maximumLatitude: Scalars['Float'];
-  maximumLongitude: Scalars['Float'];
-  minimumLatitude: Scalars['Float'];
-  minimumLongitude: Scalars['Float'];
+  authority?: InputMaybe<Scalars['String']['input']>;
+  filterByInUse?: InputMaybe<Scalars['Boolean']['input']>;
+  maximumLatitude: Scalars['Float']['input'];
+  maximumLongitude: Scalars['Float']['input'];
+  minimumLatitude: Scalars['Float']['input'];
+  minimumLongitude: Scalars['Float']['input'];
   multiModalMode?: InputMaybe<MultiModalMode>;
 };
 
 export type QueryTypeTripArgs = {
   accessEgressPenalty?: InputMaybe<Array<PenaltyForStreetMode>>;
-  alightSlackDefault?: InputMaybe<Scalars['Int']>;
+  alightSlackDefault?: InputMaybe<Scalars['Int']['input']>;
   alightSlackList?: InputMaybe<Array<InputMaybe<TransportModeSlack>>>;
-  arriveBy?: InputMaybe<Scalars['Boolean']>;
+  arriveBy?: InputMaybe<Scalars['Boolean']['input']>;
   banned?: InputMaybe<InputBanned>;
   bicycleOptimisationMethod?: InputMaybe<BicycleOptimisationMethod>;
-  bikeSpeed?: InputMaybe<Scalars['Float']>;
-  boardSlackDefault?: InputMaybe<Scalars['Int']>;
+  bikeSpeed?: InputMaybe<Scalars['Float']['input']>;
+  boardSlackDefault?: InputMaybe<Scalars['Int']['input']>;
   boardSlackList?: InputMaybe<Array<InputMaybe<TransportModeSlack>>>;
-  dateTime?: InputMaybe<Scalars['DateTime']>;
-  extraSearchCoachReluctance?: InputMaybe<Scalars['Float']>;
+  bookingTime?: InputMaybe<Scalars['DateTime']['input']>;
+  dateTime?: InputMaybe<Scalars['DateTime']['input']>;
   filters?: InputMaybe<Array<TripFilterInput>>;
   from: Location;
-  ignoreRealtimeUpdates?: InputMaybe<Scalars['Boolean']>;
-  includePlannedCancellations?: InputMaybe<Scalars['Boolean']>;
-  includeRealtimeCancellations?: InputMaybe<Scalars['Boolean']>;
+  ignoreRealtimeUpdates?: InputMaybe<Scalars['Boolean']['input']>;
+  includePlannedCancellations?: InputMaybe<Scalars['Boolean']['input']>;
+  includeRealtimeCancellations?: InputMaybe<Scalars['Boolean']['input']>;
   itineraryFilters?: InputMaybe<ItineraryFilters>;
   locale?: InputMaybe<Locale>;
   maxAccessEgressDurationForMode?: InputMaybe<Array<StreetModeDurationInput>>;
   maxDirectDurationForMode?: InputMaybe<Array<StreetModeDurationInput>>;
-  maximumAdditionalTransfers?: InputMaybe<Scalars['Int']>;
-  maximumTransfers?: InputMaybe<Scalars['Int']>;
+  maximumAdditionalTransfers?: InputMaybe<Scalars['Int']['input']>;
+  maximumTransfers?: InputMaybe<Scalars['Int']['input']>;
   modes?: InputMaybe<Modes>;
-  numTripPatterns?: InputMaybe<Scalars['Int']>;
-  pageCursor?: InputMaybe<Scalars['String']>;
-  passThroughPoints?: InputMaybe<Array<PassThroughPoint>>;
+  numTripPatterns?: InputMaybe<Scalars['Int']['input']>;
+  pageCursor?: InputMaybe<Scalars['String']['input']>;
   relaxTransitGroupPriority?: InputMaybe<RelaxCostInput>;
-  searchWindow?: InputMaybe<Scalars['Int']>;
-  timetableView?: InputMaybe<Scalars['Boolean']>;
+  searchWindow?: InputMaybe<Scalars['Int']['input']>;
+  timetableView?: InputMaybe<Scalars['Boolean']['input']>;
   to: Location;
-  transferPenalty?: InputMaybe<Scalars['Int']>;
-  transferSlack?: InputMaybe<Scalars['Int']>;
+  transferPenalty?: InputMaybe<Scalars['Int']['input']>;
+  transferSlack?: InputMaybe<Scalars['Int']['input']>;
   triangleFactors?: InputMaybe<TriangleFactors>;
-  useBikeRentalAvailabilityInformation?: InputMaybe<Scalars['Boolean']>;
-  waitReluctance?: InputMaybe<Scalars['Float']>;
-  walkReluctance?: InputMaybe<Scalars['Float']>;
-  walkSpeed?: InputMaybe<Scalars['Float']>;
-  wheelchairAccessible?: InputMaybe<Scalars['Boolean']>;
+  useBikeRentalAvailabilityInformation?: InputMaybe<
+    Scalars['Boolean']['input']
+  >;
+  via?: InputMaybe<Array<TripViaLocationInput>>;
+  waitReluctance?: InputMaybe<Scalars['Float']['input']>;
+  walkReluctance?: InputMaybe<Scalars['Float']['input']>;
+  walkSpeed?: InputMaybe<Scalars['Float']['input']>;
+  wheelchairAccessible?: InputMaybe<Scalars['Boolean']['input']>;
   whiteListed?: InputMaybe<InputWhiteListed>;
 };
 
 export type QueryTypeViaTripArgs = {
-  dateTime?: InputMaybe<Scalars['DateTime']>;
+  dateTime?: InputMaybe<Scalars['DateTime']['input']>;
   from: Location;
   locale?: InputMaybe<Locale>;
-  numTripPatterns?: InputMaybe<Scalars['Int']>;
-  pageCursor?: InputMaybe<Scalars['String']>;
-  searchWindow: Scalars['Duration'];
+  numTripPatterns?: InputMaybe<Scalars['Int']['input']>;
+  pageCursor?: InputMaybe<Scalars['String']['input']>;
+  searchWindow: Scalars['Duration']['input'];
   segments?: InputMaybe<Array<ViaSegmentInput>>;
   to: Location;
   via: Array<ViaLocationInput>;
-  wheelchairAccessible?: InputMaybe<Scalars['Boolean']>;
+  wheelchairAccessible?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum RealtimeState {
@@ -1292,26 +1303,26 @@ export enum RelativeDirection {
  */
 export type RelaxCostInput = {
   /** The constant value to add to the limit. Must be a positive number. The value is equivalent to transit-cost-seconds. Integers are treated as seconds, but you may use the duration format. Example: '3665 = 'DT1h1m5s' = '1h1m5s'. */
-  constant?: InputMaybe<Scalars['Cost']>;
+  constant?: InputMaybe<Scalars['Cost']['input']>;
   /** The factor to multiply with the 'other cost'. Minimum value is 1.0. */
-  ratio?: InputMaybe<Scalars['Float']>;
+  ratio?: InputMaybe<Scalars['Float']['input']>;
 };
 
 export type RentalVehicle = PlaceInterface & {
-  currentRangeMeters?: Maybe<Scalars['Float']>;
-  id: Scalars['ID'];
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
-  network: Scalars['String'];
+  currentRangeMeters?: Maybe<Scalars['Float']['output']>;
+  id: Scalars['ID']['output'];
+  latitude: Scalars['Float']['output'];
+  longitude: Scalars['Float']['output'];
+  network: Scalars['String']['output'];
   vehicleType: RentalVehicleType;
 };
 
 export type RentalVehicleType = {
-  formFactor: Scalars['String'];
-  maxRangeMeters?: Maybe<Scalars['Float']>;
-  name?: Maybe<Scalars['String']>;
-  propulsionType: Scalars['String'];
-  vehicleTypeId: Scalars['String'];
+  formFactor: Scalars['String']['output'];
+  maxRangeMeters?: Maybe<Scalars['Float']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  propulsionType: Scalars['String']['output'];
+  vehicleTypeId: Scalars['String']['output'];
 };
 
 export enum ReportType {
@@ -1326,7 +1337,7 @@ export type RoutingError = {
   /** An enum describing the reason */
   code: RoutingErrorCode;
   /** A textual description of why the search failed. The clients are expected to have their own translations based on the code, for user visible error messages. */
-  description: Scalars['String'];
+  description: Scalars['String']['output'];
   /** An enum describing the field which should be changed, in order for the search to succeed */
   inputField?: Maybe<InputField>;
 };
@@ -1351,131 +1362,144 @@ export enum RoutingErrorCode {
 /** The default parameters used in travel searches. */
 export type RoutingParameters = {
   /** The alightSlack is the minimum extra time after exiting a public transport vehicle. This is the default value used, if not overridden by the 'alightSlackList'. */
-  alightSlackDefault?: Maybe<Scalars['Int']>;
+  alightSlackDefault?: Maybe<Scalars['Int']['output']>;
   /** List of alightSlack for a given set of modes. */
   alightSlackList?: Maybe<Array<Maybe<TransportModeSlackType>>>;
   /** @deprecated Rental is specified by modes */
-  allowBikeRental?: Maybe<Scalars['Boolean']>;
+  allowBikeRental?: Maybe<Scalars['Boolean']['output']>;
   /** Separate cost for boarding a vehicle with a bicycle, which is more difficult than on foot. */
-  bikeBoardCost?: Maybe<Scalars['Int']>;
+  bikeBoardCost?: Maybe<Scalars['Int']['output']>;
   /** Cost to park a bike. */
-  bikeParkCost?: Maybe<Scalars['Int']>;
+  bikeParkCost?: Maybe<Scalars['Int']['output']>;
   /** Time to park a bike. */
-  bikeParkTime?: Maybe<Scalars['Int']>;
+  bikeParkTime?: Maybe<Scalars['Int']['output']>;
   /** Cost to drop-off a rented bike. */
-  bikeRentalDropOffCost?: Maybe<Scalars['Int']>;
+  bikeRentalDropOffCost?: Maybe<Scalars['Int']['output']>;
   /** Time to drop-off a rented bike. */
-  bikeRentalDropOffTime?: Maybe<Scalars['Int']>;
+  bikeRentalDropOffTime?: Maybe<Scalars['Int']['output']>;
   /** Cost to rent a bike. */
-  bikeRentalPickupCost?: Maybe<Scalars['Int']>;
+  bikeRentalPickupCost?: Maybe<Scalars['Int']['output']>;
   /** Time to rent a bike. */
-  bikeRentalPickupTime?: Maybe<Scalars['Int']>;
+  bikeRentalPickupTime?: Maybe<Scalars['Int']['output']>;
   /** Max bike speed along streets, in meters per second */
-  bikeSpeed?: Maybe<Scalars['Float']>;
-  /** The boardSlack is the minimum extra time to board a public transport vehicle. This is the same as the 'minimumTransferTime', except that this also apply to to the first transit leg in the trip. This is the default value used, if not overridden by the 'boardSlackList'. */
-  boardSlackDefault?: Maybe<Scalars['Int']>;
+  bikeSpeed?: Maybe<Scalars['Float']['output']>;
+  /** The boardSlack is the minimum extra time to board a public transport vehicle. This is the same as the 'minimumTransferTime', except that this also applies to to the first transit leg in the trip. This is the default value used, if not overridden by the 'boardSlackList'. */
+  boardSlackDefault?: Maybe<Scalars['Int']['output']>;
   /** List of boardSlack for a given set of modes. */
   boardSlackList?: Maybe<Array<Maybe<TransportModeSlackType>>>;
   /** The acceleration speed of an automobile, in meters per second per second. */
-  carAccelerationSpeed?: Maybe<Scalars['Float']>;
+  carAccelerationSpeed?: Maybe<Scalars['Float']['output']>;
   /** The deceleration speed of an automobile, in meters per second per second. */
-  carDecelerationSpeed?: Maybe<Scalars['Float']>;
+  carDecelerationSpeed?: Maybe<Scalars['Float']['output']>;
   /** Time to park a car in a park and ride, w/o taking into account driving and walking cost. */
-  carDropOffTime?: Maybe<Scalars['Int']>;
+  carDropOffTime?: Maybe<Scalars['Int']['output']>;
   /**
    * Max car speed along streets, in meters per second
    * @deprecated This parameter is no longer configurable.
    */
-  carSpeed?: Maybe<Scalars['Float']>;
+  carSpeed?: Maybe<Scalars['Float']['output']>;
   /** @deprecated NOT IN USE IN OTP2. */
-  compactLegsByReversedSearch?: Maybe<Scalars['Boolean']>;
+  compactLegsByReversedSearch?: Maybe<Scalars['Boolean']['output']>;
   /** @deprecated Use `itineraryFilter.debug` instead. */
-  debugItineraryFilter?: Maybe<Scalars['Boolean']>;
+  debugItineraryFilter?: Maybe<Scalars['Boolean']['output']>;
   /**
    * Option to disable the default filtering of GTFS-RT alerts by time.
    * @deprecated This is not supported!
    */
-  disableAlertFiltering?: Maybe<Scalars['Boolean']>;
+  disableAlertFiltering?: Maybe<Scalars['Boolean']['output']>;
   /** If true, the remaining weight heuristic is disabled. */
-  disableRemainingWeightHeuristic?: Maybe<Scalars['Boolean']>;
+  disableRemainingWeightHeuristic?: Maybe<Scalars['Boolean']['output']>;
   /** What is the cost of boarding a elevator? */
-  elevatorBoardCost?: Maybe<Scalars['Int']>;
+  elevatorBoardCost?: Maybe<Scalars['Int']['output']>;
   /** How long does it take to get on an elevator, on average. */
-  elevatorBoardTime?: Maybe<Scalars['Int']>;
+  elevatorBoardTime?: Maybe<Scalars['Int']['output']>;
   /** What is the cost of travelling one floor on an elevator? */
-  elevatorHopCost?: Maybe<Scalars['Int']>;
+  elevatorHopCost?: Maybe<Scalars['Int']['output']>;
   /** How long does it take to advance one floor on an elevator? */
-  elevatorHopTime?: Maybe<Scalars['Int']>;
+  elevatorHopTime?: Maybe<Scalars['Int']['output']>;
   /** Whether to apply the ellipsoid->geoid offset to all elevations in the response. */
-  geoIdElevation?: Maybe<Scalars['Boolean']>;
+  geoIdElevation?: Maybe<Scalars['Boolean']['output']>;
   /** When true, real-time updates are ignored during this search. */
-  ignoreRealTimeUpdates?: Maybe<Scalars['Boolean']>;
+  ignoreRealTimeUpdates?: Maybe<Scalars['Boolean']['output']>;
   /** When true, service journeys cancelled in scheduled route data will be included during this search. */
-  includedPlannedCancellations?: Maybe<Scalars['Boolean']>;
+  includedPlannedCancellations?: Maybe<Scalars['Boolean']['output']>;
   /** @deprecated Parking is specified by modes */
-  kissAndRide?: Maybe<Scalars['Boolean']>;
+  kissAndRide?: Maybe<Scalars['Boolean']['output']>;
   /** Maximum number of transfers allowed in addition to the result with least number of transfers */
-  maxAdditionalTransfers?: Maybe<Scalars['Int']>;
+  maxAdditionalTransfers?: Maybe<Scalars['Int']['output']>;
   /** This is the maximum duration in seconds for a direct street search. This is a performance limit and should therefore be set high. Use filters to limit what is presented to the client. */
-  maxDirectStreetDuration?: Maybe<Scalars['Int']>;
+  maxDirectStreetDuration?: Maybe<Scalars['Int']['output']>;
   /** The maximum slope of streets for wheelchair trips. */
-  maxSlope?: Maybe<Scalars['Float']>;
+  maxSlope?: Maybe<Scalars['Float']['output']>;
   /** Maximum number of transfers returned in a trip plan. */
-  maxTransfers?: Maybe<Scalars['Int']>;
+  maxTransfers?: Maybe<Scalars['Int']['output']>;
   /** The maximum number of itineraries to return. */
-  numItineraries?: Maybe<Scalars['Int']>;
+  numItineraries?: Maybe<Scalars['Int']['output']>;
   /**
    * Accept only paths that use transit (no street-only paths).
    * @deprecated This is replaced by modes input object
    */
-  onlyTransitTrips?: Maybe<Scalars['Boolean']>;
+  onlyTransitTrips?: Maybe<Scalars['Boolean']['output']>;
   /** Penalty added for using every route that is not preferred if user set any route as preferred. We return number of seconds that we are willing to wait for preferred route. */
-  otherThanPreferredRoutesPenalty?: Maybe<Scalars['Int']>;
+  otherThanPreferredRoutesPenalty?: Maybe<Scalars['Int']['output']>;
   /** @deprecated Parking is specified by modes */
-  parkAndRide?: Maybe<Scalars['Boolean']>;
+  parkAndRide?: Maybe<Scalars['Boolean']['output']>;
   /** @deprecated NOT IN USE IN OTP2. */
-  reverseOptimizeOnTheFly?: Maybe<Scalars['Boolean']>;
+  reverseOptimizeOnTheFly?: Maybe<Scalars['Boolean']['output']>;
   /**
    * Whether the planner should return intermediate stops lists for transit legs.
    * @deprecated This parameter is always enabled
    */
-  showIntermediateStops?: Maybe<Scalars['Boolean']>;
+  showIntermediateStops?: Maybe<Scalars['Boolean']['output']>;
   /** Used instead of walkReluctance for stairs. */
-  stairsReluctance?: Maybe<Scalars['Float']>;
+  stairsReluctance?: Maybe<Scalars['Float']['output']>;
   /** An extra penalty added on transfers (i.e. all boardings except the first one). */
-  transferPenalty?: Maybe<Scalars['Int']>;
+  transferPenalty?: Maybe<Scalars['Int']['output']>;
   /** A global minimum transfer time (in seconds) that specifies the minimum amount of time that must pass between exiting one transit vehicle and boarding another. */
-  transferSlack?: Maybe<Scalars['Int']>;
+  transferSlack?: Maybe<Scalars['Int']['output']>;
   /** Multiplicative factor on expected turning time. */
-  turnReluctance?: Maybe<Scalars['Float']>;
+  turnReluctance?: Maybe<Scalars['Float']['output']>;
   /** How much worse is waiting for a transit vehicle than being on a transit vehicle, as a multiplier. */
-  waitReluctance?: Maybe<Scalars['Float']>;
+  waitReluctance?: Maybe<Scalars['Float']['output']>;
   /** This prevents unnecessary transfers by adding a cost for boarding a vehicle. */
-  walkBoardCost?: Maybe<Scalars['Int']>;
+  walkBoardCost?: Maybe<Scalars['Int']['output']>;
   /** A multiplier for how bad walking is, compared to being in transit for equal lengths of time. */
-  walkReluctance?: Maybe<Scalars['Float']>;
+  walkReluctance?: Maybe<Scalars['Float']['output']>;
   /** Max walk speed along streets, in meters per second */
-  walkSpeed?: Maybe<Scalars['Float']>;
+  walkSpeed?: Maybe<Scalars['Float']['output']>;
   /** Whether the trip must be wheelchair accessible. */
-  wheelChairAccessible?: Maybe<Scalars['Boolean']>;
+  wheelChairAccessible?: Maybe<Scalars['Boolean']['output']>;
 };
 
+/**
+ * Information about the deployment. This is only useful to developers of OTP itself.
+ * It is not recommended for regular API consumers to use this type as it has no
+ * stability guarantees.
+ *
+ */
 export type ServerInfo = {
   /** The 'configVersion' of the build-config.json file. */
-  buildConfigVersion?: Maybe<Scalars['String']>;
+  buildConfigVersion?: Maybe<Scalars['String']['output']>;
   /** OTP Build timestamp */
-  buildTime?: Maybe<Scalars['String']>;
-  gitBranch?: Maybe<Scalars['String']>;
-  gitCommit?: Maybe<Scalars['String']>;
-  gitCommitTime?: Maybe<Scalars['String']>;
+  buildTime?: Maybe<Scalars['String']['output']>;
+  gitBranch?: Maybe<Scalars['String']['output']>;
+  gitCommit?: Maybe<Scalars['String']['output']>;
+  gitCommitTime?: Maybe<Scalars['String']['output']>;
+  /**
+   *   The internal time zone of the transit data.
+   *
+   *   Note: The input data can be in several time zones, but OTP internally operates on a single one.
+   *
+   */
+  internalTransitModelTimeZone?: Maybe<Scalars['String']['output']>;
   /** The 'configVersion' of the otp-config.json file. */
-  otpConfigVersion?: Maybe<Scalars['String']>;
+  otpConfigVersion?: Maybe<Scalars['String']['output']>;
   /** The otp-serialization-version-id used to check graphs for compatibility with current version of OTP. */
-  otpSerializationVersionId?: Maybe<Scalars['String']>;
+  otpSerializationVersionId?: Maybe<Scalars['String']['output']>;
   /** The 'configVersion' of the router-config.json file. */
-  routerConfigVersion?: Maybe<Scalars['String']>;
+  routerConfigVersion?: Maybe<Scalars['String']['output']>;
   /** Maven version */
-  version?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 export enum ServiceAlteration {
@@ -1487,7 +1511,7 @@ export enum ServiceAlteration {
 
 /** A planned vehicle journey with passengers. */
 export type ServiceJourney = {
-  activeDates: Array<Maybe<Scalars['Date']>>;
+  activeDates: Array<Maybe<Scalars['Date']['output']>>;
   /** Whether bikes are allowed on service journey. */
   bikesAllowed?: Maybe<BikesAllowed>;
   /**
@@ -1498,7 +1522,7 @@ export type ServiceJourney = {
   directionType?: Maybe<DirectionType>;
   /** Returns scheduled passingTimes for this ServiceJourney for a given date, updated with real-time-updates (if available). NB! This takes a date as argument (default=today) and returns estimatedCalls for that date and should only be used if the date is known when creating the request. For fetching estimatedCalls for a given trip.leg, use leg.serviceJourneyEstimatedCalls instead. */
   estimatedCalls?: Maybe<Array<Maybe<EstimatedCall>>>;
-  id: Scalars['ID'];
+  id: Scalars['ID']['output'];
   /** JourneyPattern for the service journey, according to scheduled data. If the ServiceJourney is not included in the scheduled data, null is returned. */
   journeyPattern?: Maybe<JourneyPattern>;
   line: Line;
@@ -1509,9 +1533,9 @@ export type ServiceJourney = {
   /** Detailed path travelled by service journey. Not available for flexible trips. */
   pointsOnLink?: Maybe<PointsOnLink>;
   /** For internal use by operators. */
-  privateCode?: Maybe<Scalars['String']>;
+  privateCode?: Maybe<Scalars['String']['output']>;
   /** Publicly announced code for service journey, differentiating it from other service journeys for the same line. */
-  publicCode?: Maybe<Scalars['String']>;
+  publicCode?: Maybe<Scalars['String']['output']>;
   /** Quays visited by service journey, according to scheduled data. If the ServiceJourney is not included in the scheduled data, an empty list is returned. */
   quays: Array<Quay>;
   /** @deprecated The service journey alteration will be moved out of SJ and grouped together with the SJ and date. In Netex this new type is called DatedServiceJourney. We will create artificial DSJs for the old SJs. */
@@ -1526,13 +1550,13 @@ export type ServiceJourney = {
 
 /** A planned vehicle journey with passengers. */
 export type ServiceJourneyEstimatedCallsArgs = {
-  date?: InputMaybe<Scalars['Date']>;
+  date?: InputMaybe<Scalars['Date']['input']>;
 };
 
 /** A planned vehicle journey with passengers. */
 export type ServiceJourneyQuaysArgs = {
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export enum Severity {
@@ -1567,51 +1591,69 @@ export enum StopCondition {
   StartPoint = 'startPoint',
 }
 
+export enum StopInterchangePriority {
+  /** Allow transfers from/to this stop. This is the default. NeTEx equivalent is INTERCHANGE_ALLOWED. */
+  Allowed = 'allowed',
+  /** Block transfers from/to this stop. In OTP this is not a definitive block, just a huge penalty is added to the cost function. NeTEx equivalent is NO_INTERCHANGE. */
+  Discouraged = 'discouraged',
+  /** Preferred place to transfer, strongly recommended. NeTEx equivalent is PREFERRED_INTERCHANGE. */
+  Preferred = 'preferred',
+  /** Recommended stop place. NeTEx equivalent is RECOMMENDED_INTERCHANGE. */
+  Recommended = 'recommended',
+}
+
 /** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
 export type StopPlace = PlaceInterface & {
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']['output']>;
   /** List of visits to this stop place as part of vehicle journeys. */
   estimatedCalls: Array<EstimatedCall>;
-  id: Scalars['ID'];
-  latitude?: Maybe<Scalars['Float']>;
-  longitude?: Maybe<Scalars['Float']>;
-  name: Scalars['String'];
+  id: Scalars['ID']['output'];
+  latitude?: Maybe<Scalars['Float']['output']>;
+  longitude?: Maybe<Scalars['Float']['output']>;
+  name: Scalars['String']['output'];
   /** Returns parent stop for this stop */
   parent?: Maybe<StopPlace>;
   /** Returns all quays that are children of this stop place */
   quays?: Maybe<Array<Maybe<Quay>>>;
   /** Get all situations active for the stop place. Situations affecting individual quays are not returned, and should be fetched directly from the quay. */
   situations: Array<PtSituationElement>;
+  /** Specify the priority of interchanges at this stop */
+  stopInterchangePriority?: Maybe<StopInterchangePriority>;
   tariffZones: Array<Maybe<TariffZone>>;
-  timeZone?: Maybe<Scalars['String']>;
+  timeZone?: Maybe<Scalars['String']['output']>;
   /** The transport modes of quays under this stop place. */
   transportMode?: Maybe<Array<Maybe<TransportMode>>>;
   /** The transport submode serviced by this stop place. */
   transportSubmode?: Maybe<Array<Maybe<TransportSubmode>>>;
-  /** Relative weighting of this stop with regards to interchanges. NOT IMPLEMENTED */
+  /**
+   * Relative weighting of this stop with regards to interchanges. NOT IMPLEMENTED
+   * @deprecated Not implemented. Use stopInterchangePriority
+   */
   weighting?: Maybe<InterchangeWeighting>;
 };
 
 /** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
 export type StopPlaceEstimatedCallsArgs = {
   arrivalDeparture?: InputMaybe<ArrivalDeparture>;
-  includeCancelledTrips?: InputMaybe<Scalars['Boolean']>;
-  numberOfDepartures?: InputMaybe<Scalars['Int']>;
-  numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<Scalars['Int']>;
-  startTime?: InputMaybe<Scalars['DateTime']>;
-  timeRange?: InputMaybe<Scalars['Int']>;
+  includeCancelledTrips?: InputMaybe<Scalars['Boolean']['input']>;
+  numberOfDepartures?: InputMaybe<Scalars['Int']['input']>;
+  numberOfDeparturesPerLineAndDestinationDisplay?: InputMaybe<
+    Scalars['Int']['input']
+  >;
+  startTime?: InputMaybe<Scalars['DateTime']['input']>;
+  timeRange?: InputMaybe<Scalars['Int']['input']>;
   whiteListed?: InputMaybe<InputWhiteListed>;
   whiteListedModes?: InputMaybe<Array<InputMaybe<TransportMode>>>;
 };
 
 /** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
 export type StopPlaceNameArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location. */
 export type StopPlaceQuaysArgs = {
-  filterByInUse?: InputMaybe<Scalars['Boolean']>;
+  filterByInUse?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** List of coordinates between two stops as a polyline */
@@ -1637,6 +1679,8 @@ export enum StreetMode {
   CarPark = 'car_park',
   /** Walk to a pickup point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include various taxi-services or kiss & ride. */
   CarPickup = 'car_pickup',
+  /** Walk to a car rental point along the road, drive to a drop-off point along the road, and walk the rest of the way. This can include car rentals at fixed locations or free-floating services. */
+  CarRental = 'car_rental',
   /** Walk to an eligible pickup area for flexible transportation, ride to an eligible drop-off area and then walk the rest of the way. */
   Flexible = 'flexible',
   /** Walk only */
@@ -1647,7 +1691,7 @@ export enum StreetMode {
 
 /** A combination of street mode and corresponding duration */
 export type StreetModeDurationInput = {
-  duration: Scalars['Duration'];
+  duration: Scalars['Duration']['input'];
   streetMode: StreetMode;
 };
 
@@ -1673,20 +1717,54 @@ export type StreetModes = {
  * client. The tags and usage may change without notice._
  */
 export type SystemNotice = {
-  tag?: Maybe<Scalars['String']>;
-  text?: Maybe<Scalars['String']>;
+  tag?: Maybe<Scalars['String']['output']>;
+  text?: Maybe<Scalars['String']['output']>;
 };
 
 export type TariffZone = {
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type TimeAndDayOffset = {
   /** Number of days offset from base line time */
-  dayOffset?: Maybe<Scalars['Int']>;
+  dayOffset?: Maybe<Scalars['Int']['output']>;
   /** Local time */
-  time?: Maybe<Scalars['Time']>;
+  time?: Maybe<Scalars['Time']['output']>;
+};
+
+/**
+ * The time-penalty is applied to either the access-legs and/or egress-legs. Both access and
+ * egress may contain more than one leg; Hence, the penalty is not a field on leg.
+ *
+ * Note! This is for debugging only. This type can change without notice.
+ *
+ */
+export type TimePenaltyWithCost = {
+  /**
+   * The time-penalty is applied to either the access-legs and/or egress-legs. Both access
+   * and egress may contain more than one leg; Hence, the penalty is not a field on leg. The
+   * `appliedTo` describe witch part of the itinerary that this instance applies to.
+   *
+   */
+  appliedTo?: Maybe<Scalars['String']['output']>;
+  /**
+   * The time-penalty does also propagate to the `generalizedCost`. As a result of the given
+   * time-penalty, the generalized-cost also increased by the given amount. This delta is
+   * included in the itinerary generalized-cost. In some cases the generalized-cost-delta is
+   * excluded when comparing itineraries - that happens if one of the itineraries is a
+   * "direct/street-only" itinerary. Time-penalty can not be set for direct searches, so it
+   * needs to be excluded from such comparison to be fair. The unit is transit-seconds.
+   *
+   */
+  generalizedCostDelta?: Maybe<Scalars['Int']['output']>;
+  /**
+   * The time-penalty added to the actual time/duration when comparing the itinerary with
+   * other itineraries. This is used to decide witch is the best option, but is not visible
+   * - the actual departure and arrival-times are not modified.
+   *
+   */
+  timePenalty?: Maybe<Scalars['String']['output']>;
 };
 
 /** Scheduled passing times. These are not affected by real time updates. */
@@ -1701,23 +1779,23 @@ export type TimetabledPassingTime = {
   /** Earliest possible departure time for a service journey with a service window. */
   earliestDepartureTime?: Maybe<TimeAndDayOffset>;
   /** Whether vehicle may be alighted at quay. */
-  forAlighting: Scalars['Boolean'];
+  forAlighting: Scalars['Boolean']['output'];
   /** Whether vehicle may be boarded at quay. */
-  forBoarding: Scalars['Boolean'];
+  forBoarding: Scalars['Boolean']['output'];
   /** Latest possible (planned) arrival time for a service journey with a service window. */
   latestArrivalTime?: Maybe<TimeAndDayOffset>;
   notices: Array<Notice>;
   quay: Quay;
   /** Whether vehicle will only stop on request. */
-  requestStop: Scalars['Boolean'];
+  requestStop: Scalars['Boolean']['output'];
   serviceJourney: ServiceJourney;
   /** Whether this is a timing point or not. Boarding and alighting is not allowed at timing points. */
-  timingPoint: Scalars['Boolean'];
+  timingPoint: Scalars['Boolean']['output'];
 };
 
 export type TransitGeneralizedCostFilterParams = {
-  costLimitFunction: Scalars['DoubleFunction'];
-  intervalRelaxFactor: Scalars['Float'];
+  costLimitFunction: Scalars['DoubleFunction']['input'];
+  intervalRelaxFactor: Scalars['Float']['input'];
 };
 
 export enum TransportMode {
@@ -1742,13 +1820,13 @@ export type TransportModeSlack = {
   /** List of modes for which the given slack apply. */
   modes: Array<TransportMode>;
   /** The slack used for all given modes. */
-  slack: Scalars['Int'];
+  slack: Scalars['Int']['input'];
 };
 
 /** Used to specify board and alight slack for a given modes. */
 export type TransportModeSlackType = {
   modes: Array<TransportMode>;
-  slack: Scalars['Int'];
+  slack: Scalars['Int']['output'];
 };
 
 export type TransportModes = {
@@ -1876,17 +1954,17 @@ export enum TransportSubmode {
 /** How much the factors safety, slope and distance are weighted relative to each other when routing bicycle legs. In total all three values need to add up to 1. */
 export type TriangleFactors = {
   /** How important is bicycle safety expressed as a fraction of 1. */
-  safety: Scalars['Float'];
+  safety: Scalars['Float']['input'];
   /** How important is slope/elevation expressed as a fraction of 1. */
-  slope: Scalars['Float'];
+  slope: Scalars['Float']['input'];
   /** How important is time expressed as a fraction of 1. Note that what this really optimises for is distance (even if that means going over terrible surfaces, so I might be slower than the safe route). */
-  time: Scalars['Float'];
+  time: Scalars['Float']['input'];
 };
 
 /** Description of a travel between two places. */
 export type Trip = {
   /** The time and date of travel */
-  dateTime?: Maybe<Scalars['DateTime']>;
+  dateTime?: Maybe<Scalars['DateTime']['output']>;
   /** Information about the timings for the trip generation */
   debugOutput: DebugOutput;
   /** The origin */
@@ -1895,24 +1973,24 @@ export type Trip = {
    * A list of possible error messages as enum
    * @deprecated Use routingErrors instead
    */
-  messageEnums: Array<Maybe<Scalars['String']>>;
+  messageEnums: Array<Maybe<Scalars['String']['output']>>;
   /**
    * A list of possible error messages in cleartext
    * @deprecated Use routingErrors instead
    */
-  messageStrings: Array<Maybe<Scalars['String']>>;
+  messageStrings: Array<Maybe<Scalars['String']['output']>>;
   /** The trip request metadata. */
   metadata?: Maybe<TripSearchData>;
   /**
    * Use the cursor to get the next page of results. Use this cursor for the pageCursor parameter in the trip query in order to get the next page.
    * The next page is a set of itineraries departing AFTER the last itinerary in this result.
    */
-  nextPageCursor?: Maybe<Scalars['String']>;
+  nextPageCursor?: Maybe<Scalars['String']['output']>;
   /**
    * Use the cursor to get the previous page of results. Use this cursor for the pageCursor parameter in the trip query in order to get the previous page.
    * The previous page is a set of itineraries departing BEFORE the first itinerary in this result.
    */
-  previousPageCursor?: Maybe<Scalars['String']>;
+  previousPageCursor?: Maybe<Scalars['String']['output']>;
   /** A list of routing errors, and fields which caused them */
   routingErrors: Array<RoutingError>;
   /** The destination */
@@ -1923,7 +2001,7 @@ export type Trip = {
 
 /** Description of a travel between two places. */
 export type TripMessageStringsArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** A collection of selectors for what lines/trips should be included in / excluded from search */
@@ -1937,63 +2015,89 @@ export type TripFilterInput = {
 /** A list of selectors for filter allow-list / exclude-list. An empty list means that everything is allowed. A trip/line will match with selectors if it matches with all non-empty lists. The `select` is always applied first, then `not`. If only `not` not is present, the exclude is applied to the existing set of lines.  */
 export type TripFilterSelectInput = {
   /** Set of ids for authorities that should be included in/excluded from search */
-  authorities?: InputMaybe<Array<Scalars['ID']>>;
+  authorities?: InputMaybe<Array<Scalars['ID']['input']>>;
   /** Set of ids for group of lines that should be included in/excluded from the search */
-  groupOfLines?: InputMaybe<Array<Scalars['ID']>>;
+  groupOfLines?: InputMaybe<Array<Scalars['ID']['input']>>;
   /** Set of ids for lines that should be included in/excluded from search */
-  lines?: InputMaybe<Array<Scalars['ID']>>;
+  lines?: InputMaybe<Array<Scalars['ID']['input']>>;
   /** Set of ids for service journeys that should be included in/excluded from search */
-  serviceJourneys?: InputMaybe<Array<Scalars['ID']>>;
+  serviceJourneys?: InputMaybe<Array<Scalars['ID']['input']>>;
   /** The allowed modes for the transit part of the trip. Use an empty list to disallow transit for this search. If the element is not present or null, it will default to all transport modes. */
   transportModes?: InputMaybe<Array<TransportModes>>;
+};
+
+/**
+ * One of the listed stop locations must be visited on-board a transit vehicle or the journey must
+ * alight or board at the location.
+ *
+ */
+export type TripPassThroughViaLocationInput = {
+  /** The label/name of the location. This is pass-through information and is not used in routing. */
+  label?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * A list of stop locations. A stop location can be a quay, a stop place, a multimodal
+   * stop place or a group of stop places. It is enough to visit ONE of the locations
+   * listed.
+   *
+   */
+  stopLocationIds: Array<Scalars['String']['input']>;
 };
 
 /** List of legs constituting a suggested sequence of rides and links for a specific trip. */
 export type TripPattern = {
   /** The aimed date and time the trip ends. */
-  aimedEndTime: Scalars['DateTime'];
+  aimedEndTime: Scalars['DateTime']['output'];
   /** The aimed date and time the trip starts. */
-  aimedStartTime: Scalars['DateTime'];
+  aimedStartTime: Scalars['DateTime']['output'];
   /** NOT IMPLEMENTED. */
-  directDuration?: Maybe<Scalars['Long']>;
+  directDuration?: Maybe<Scalars['Long']['output']>;
   /** Total distance for the trip, in meters. NOT IMPLEMENTED */
-  distance?: Maybe<Scalars['Float']>;
+  distance?: Maybe<Scalars['Float']['output']>;
   /** Duration of the trip, in seconds. */
-  duration?: Maybe<Scalars['Long']>;
+  duration?: Maybe<Scalars['Long']['output']>;
   /**
    * Time that the trip arrives.
    * @deprecated Replaced with expectedEndTime
    */
-  endTime?: Maybe<Scalars['DateTime']>;
+  endTime?: Maybe<Scalars['DateTime']['output']>;
   /** The expected, real-time adjusted date and time the trip ends. */
-  expectedEndTime: Scalars['DateTime'];
+  expectedEndTime: Scalars['DateTime']['output'];
   /** The expected, real-time adjusted date and time the trip starts. */
-  expectedStartTime: Scalars['DateTime'];
+  expectedStartTime: Scalars['DateTime']['output'];
   /** Generalized cost or weight of the itinerary. Used for debugging. */
-  generalizedCost?: Maybe<Scalars['Int']>;
+  generalizedCost?: Maybe<Scalars['Int']['output']>;
   /** A second cost or weight of the itinerary. Some use-cases like pass-through and transit-priority-groups use a second cost during routing. This is used for debugging. */
-  generalizedCost2?: Maybe<Scalars['Int']>;
+  generalizedCost2?: Maybe<Scalars['Int']['output']>;
   /** A list of legs. Each leg is either a walking (cycling, car) portion of the trip, or a ride leg on a particular vehicle. So a trip where the use walks to the Q train, transfers to the 6, then walks to their destination, has four legs. */
   legs: Array<Leg>;
   /**
    * Time that the trip departs.
    * @deprecated Replaced with expectedStartTime
    */
-  startTime?: Maybe<Scalars['DateTime']>;
+  startTime?: Maybe<Scalars['DateTime']['output']>;
   /** How far the user has to walk, bike and/or drive in meters. It includes all street(none transit) modes. */
-  streetDistance?: Maybe<Scalars['Float']>;
+  streetDistance?: Maybe<Scalars['Float']['output']>;
   /** Get all system notices. */
   systemNotices: Array<SystemNotice>;
+  /**
+   * A time and cost penalty applied to access and egress to favor regular scheduled
+   * transit over potentially faster options with FLEX, Car, bike and scooter.
+   *
+   * Note! This field is meant for debugging only. The field can be removed without notice
+   * in the future.
+   *
+   */
+  timePenalty: Array<TimePenaltyWithCost>;
   /** A cost calculated to favor transfer with higher priority. This field is meant for debugging only. */
-  transferPriorityCost?: Maybe<Scalars['Int']>;
+  transferPriorityCost?: Maybe<Scalars['Int']['output']>;
   /** A cost calculated to distribute wait-time and avoid very short transfers. This field is meant for debugging only. */
-  waitTimeOptimizedCost?: Maybe<Scalars['Int']>;
+  waitTimeOptimizedCost?: Maybe<Scalars['Int']['output']>;
   /** How much time is spent waiting for transit to arrive, in seconds. */
-  waitingTime?: Maybe<Scalars['Long']>;
+  waitingTime?: Maybe<Scalars['Long']['output']>;
   /** @deprecated Replaced by `streetDistance`. */
-  walkDistance?: Maybe<Scalars['Float']>;
+  walkDistance?: Maybe<Scalars['Float']['output']>;
   /** How much time is spent walking, in seconds. */
-  walkTime?: Maybe<Scalars['Long']>;
+  walkTime?: Maybe<Scalars['Long']['output']>;
 };
 
 /** Trips search metadata. */
@@ -2002,21 +2106,60 @@ export type TripSearchData = {
    * This is the suggested search time for the "next page" or time window. Insert it together with the 'searchWindowUsed' in the request to get a new set of trips following in the time-window AFTER the current search.
    * @deprecated Use pageCursor instead
    */
-  nextDateTime?: Maybe<Scalars['DateTime']>;
+  nextDateTime?: Maybe<Scalars['DateTime']['output']>;
   /**
    * This is the suggested search time for the "previous page" or time-window. Insert it together with the 'searchWindowUsed' in the request to get a new set of trips preceding in the time-window BEFORE the current search.
    * @deprecated Use pageCursor instead
    */
-  prevDateTime?: Maybe<Scalars['DateTime']>;
+  prevDateTime?: Maybe<Scalars['DateTime']['output']>;
   /** This is the time window used by the raptor search. The input searchWindow is an optional parameter and is dynamically assigned if not set. OTP might override the value if it is too small or too large. When paging OTP adjusts it to the appropriate size, depending on the number of itineraries found in the current search window. The scaling of the search window ensures faster paging and limits resource usage. The unit is seconds. */
-  searchWindowUsed: Scalars['Int'];
+  searchWindowUsed: Scalars['Int']['output'];
+};
+
+/**
+ * A via-location is used to specifying a location as an intermediate place the router must
+ * route through. The via-location is either a pass-through-location or a visit-via-location.
+ *
+ */
+export type TripViaLocationInput = {
+  /** Board, alight or pass-through(on-board) at the stop location. */
+  passThrough?: InputMaybe<TripPassThroughViaLocationInput>;
+  /** Board or alight at a stop location or visit a coordinate. */
+  visit?: InputMaybe<TripVisitViaLocationInput>;
+};
+
+/**
+ * A visit-via-location is a physical visit to one of the stop locations or coordinates listed. An
+ * on-board visit does not count, the traveler must alight or board at the given stop for it to to
+ * be accepted. To visit a coordinate, the traveler must walk(bike or drive) to the closest point
+ * in the street network from a stop and back to another stop to join the transit network.
+ *
+ * NOTE! Coordinates are NOT supported yet.
+ *
+ */
+export type TripVisitViaLocationInput = {
+  /** The label/name of the location. This is pass-through information and is not used in routing. */
+  label?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * The minimum wait time is used to force the trip to stay the given duration at the
+   * via-location before the trip is continued.
+   *
+   */
+  minimumWaitTime?: InputMaybe<Scalars['Duration']['input']>;
+  /**
+   * A list of stop locations. A stop location can be a quay, a stop place, a multimodal
+   * stop place or a group of stop places. It is enough to visit ONE of the locations
+   * listed.
+   *
+   */
+  stopLocationIds: Array<Scalars['String']['input']>;
 };
 
 export type ValidityPeriod = {
   /** End of validity period. Will return 'null' if validity is open-ended. */
-  endTime?: Maybe<Scalars['DateTime']>;
+  endTime?: Maybe<Scalars['DateTime']['output']>;
   /** Start of validity period */
-  startTime?: Maybe<Scalars['DateTime']>;
+  startTime?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export enum VertexType {
@@ -2029,9 +2172,9 @@ export enum VertexType {
 /** An acceptable combination of trip patterns between two segments of the via search */
 export type ViaConnection = {
   /** The index of the trip pattern in the segment before the via point */
-  from?: Maybe<Scalars['Int']>;
+  from?: Maybe<Scalars['Int']['output']>;
   /** The index of the trip pattern in the segment after the via point */
-  to?: Maybe<Scalars['Int']>;
+  to?: Maybe<Scalars['Int']['output']>;
 };
 
 /** Input format for specifying a location through either a place reference (id), coordinates or both. If both place and coordinates are provided the place ref will be used if found, coordinates will only be used if place is not known. The location also contain information about the minimum and maximum time the user is willing to stay at the via location. */
@@ -2039,13 +2182,13 @@ export type ViaLocationInput = {
   /** Coordinates for the location. This can be used alone or as fallback if the place id is not found. */
   coordinates?: InputMaybe<InputCoordinates>;
   /** The maximum time the user wants to stay in the via location before continuing his journey */
-  maxSlack?: InputMaybe<Scalars['Duration']>;
+  maxSlack?: InputMaybe<Scalars['Duration']['input']>;
   /** The minimum time the user wants to stay in the via location before continuing his journey */
-  minSlack?: InputMaybe<Scalars['Duration']>;
+  minSlack?: InputMaybe<Scalars['Duration']['input']>;
   /** The name of the location. This is pass-through information and is not used in routing. */
-  name?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   /** The id of an element in the OTP model. Currently supports Quay, StopPlace, multimodal StopPlace, and GroupOfStopPlaces. */
-  place?: InputMaybe<Scalars['String']>;
+  place?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ViaSegmentInput = {
@@ -2081,14 +2224,14 @@ export enum WheelchairBoarding {
 }
 
 export type DebugOutput = {
-  totalTime?: Maybe<Scalars['Long']>;
+  totalTime?: Maybe<Scalars['Long']['output']>;
 };
 
 export type InfoLink = {
   /** Label */
-  label?: Maybe<Scalars['String']>;
+  label?: Maybe<Scalars['String']['output']>;
   /** URI */
-  uri: Scalars['String'];
+  uri: Scalars['String']['output'];
 };
 
 /** A connection to a list of items. */
@@ -2102,7 +2245,7 @@ export type PlaceAtDistanceConnection = {
 /** An edge in a connection */
 export type PlaceAtDistanceEdge = {
   /** cursor marks a unique position or index into the connection */
-  cursor: Scalars['String'];
+  cursor: Scalars['String']['output'];
   /** The item at the end of the edge */
   node?: Maybe<PlaceAtDistance>;
 };
@@ -2118,7 +2261,7 @@ export type QuayAtDistanceConnection = {
 /** An edge in a connection */
 export type QuayAtDistanceEdge = {
   /** cursor marks a unique position or index into the connection */
-  cursor: Scalars['String'];
+  cursor: Scalars['String']['output'];
   /** The item at the end of the edge */
   node?: Maybe<QuayAtDistance>;
 };

--- a/src/api/types/serviceJourney.ts
+++ b/src/api/types/serviceJourney.ts
@@ -2,8 +2,8 @@ import * as Types_v3 from './generated/journey_planner_v3_types';
 
 export type ServiceJourneyMapInfoData_v3 = {
   mapLegs: MapLeg_v3[];
-  start?: Types_v3.Scalars['Coordinates'];
-  stop?: Types_v3.Scalars['Coordinates'];
+  start?: Types_v3.Scalars['Coordinates']['output'];
+  stop?: Types_v3.Scalars['Coordinates']['output'];
 };
 
 export type MapLeg_v3 = {


### PR DESCRIPTION
Changes to be in sync with the changes in BFF:
https://github.com/AtB-AS/atb-bff/pull/359

Also updated the `journey_planner_v3_types.ts` which hadn't been done in a while.