### PR TITLE
feat: various travel aid tweaks

### DIFF
--- a/src/translations/screens/subscreens/TravelAid.ts
+++ b/src/translations/screens/subscreens/TravelAid.ts
@@ -25,14 +25,14 @@ export const TravelAidTexts = {
   },
   noRealtimeError: {
     title: _(
-      'Ingen kontakt med kjøretøy',
-      'No connection with vehicle',
-      'Ingen kontakt med køyretøy',
+      'Reisehjelp utilgjengelig for avgangen',
+      'Journey aid unavailable for this departure',
+      'Reisehjelp utilgjengeleg for denne avgangen',
     ),
     message: _(
-      'Vi får ikke oppdatert kjøretøyets posisjon, og Reisehjelp er derfor utilgjengelig for denne avgangen. Vi jobber med å få kontakt.',
-      "We're not receiving updates on the vehicle's position, so Journey Aid is unavailable for this trip. We're working to establish a connection.",
-      'Vi får ikkje oppdatert køyretøyets posisjon, og Reisehjelp er difor utilgjengeleg for denne avgangen. Vi jobbar med å få kontakt.',
+      'Vi har ingen kontakt med kjøretøyet. Prøv igjen senere eller velg en annen avgang.',
+      'We currently have no contact with the vehicle. Please try again later or choose a different departure.',
+      'Vi har ingen kontakt med køyretøyet. Prøv igjen seinare eller velg ein annan avgang.',
     ),
   },
 };

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -234,6 +234,7 @@ const useTravelAidAnnouncements = (
 ) => {
   const {language, t} = useTranslation();
   const isFirstRender = useRef(true);
+  const previousQuayId = useRef(state.focusedEstimatedCall.quay.id);
 
   const announcedSituationIds = situationsForFocusedStop
     .map((s) => s.id)
@@ -261,6 +262,7 @@ const useTravelAidAnnouncements = (
     getSituationA11yLabel(newSituations, language) +
     screenReaderPause +
     getNoticesA11yLabel(newNotices);
+  const timeInfoMessage = getTimeInfoA11yLabel(state, t, language);
 
   if (newSituations.length > 0) {
     setCurrentAnnouncedSituationIds((prev) => [
@@ -281,9 +283,14 @@ const useTravelAidAnnouncements = (
       isFirstRender.current = false;
       return;
     }
-
-    AccessibilityInfo.announceForAccessibility(message);
-  }, [message]);
+    if (previousQuayId.current === state.focusedEstimatedCall.quay.id) {
+      // Only announce the time if the focused estimated call hasn't changed
+      AccessibilityInfo.announceForAccessibility(timeInfoMessage);
+    } else {
+      AccessibilityInfo.announceForAccessibility(message);
+    }
+    previousQuayId.current = state.focusedEstimatedCall.quay.id;
+  }, [message, timeInfoMessage, state.focusedEstimatedCall.quay.id]);
 };
 
 const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -183,7 +183,7 @@ const TravelAidSection = ({
         <View style={styles.sectionContainer}>
           {status === TravelAidStatus.NoRealtime && (
             <MessageInfoBox
-              type="error"
+              type="warning"
               title={t(TravelAidTexts.noRealtimeError.title)}
               message={t(TravelAidTexts.noRealtimeError.message)}
             />

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -233,8 +233,7 @@ const useTravelAidAnnouncements = (
   cancelled: boolean,
 ) => {
   const {language, t} = useTranslation();
-  const isFirstRender = useRef(true);
-  const previousQuayId = useRef(state.focusedEstimatedCall.quay.id);
+  const previousQuayId = useRef<string | null>(null);
 
   const announcedSituationIds = situationsForFocusedStop
     .map((s) => s.id)
@@ -279,8 +278,10 @@ const useTravelAidAnnouncements = (
   }
 
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
+    if (!previousQuayId.current) {
+      // If previousQuayId is null, it is the first render, and we should not
+      // announce the time
+      previousQuayId.current = state.focusedEstimatedCall.quay.id;
       return;
     }
     if (previousQuayId.current === state.focusedEstimatedCall.quay.id) {

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -309,8 +309,6 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
         </ThemeText>
       );
     case TravelAidStatus.NotYetArrived:
-    case TravelAidStatus.Arrived:
-    case TravelAidStatus.BetweenStops:
       return (
         <View>
           <View style={styles.realTime}>
@@ -328,6 +326,23 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
           </View>
           <ThemeText type="body__secondary--bold">
             {t(TravelAidTexts.scheduledTime(clock))}
+          </ThemeText>
+        </View>
+      );
+    case TravelAidStatus.Arrived:
+    case TravelAidStatus.BetweenStops:
+      return (
+        <View style={styles.realTime}>
+          <ThemeIcon
+            svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
+            size="xSmall"
+          />
+          <ThemeText type="heading__title">
+            {formatToClockOrRelativeMinutes(
+              focusedEstimatedCall.expectedDepartureTime,
+              language,
+              t(dictionary.date.units.now),
+            )}
           </ThemeText>
         </View>
       );
@@ -388,9 +403,10 @@ const getTimeInfoA11yLabel = (
     case TravelAidStatus.NoRealtime:
     case TravelAidStatus.NotGettingUpdates:
       return t(TravelAidTexts.clock(scheduledClock));
-    case TravelAidStatus.NotYetArrived:
     case TravelAidStatus.Arrived:
     case TravelAidStatus.BetweenStops:
+      return `${t(dictionary.a11yRealTimePrefix)} ${relativeRealtime}`;
+    case TravelAidStatus.NotYetArrived:
       return `${t(dictionary.a11yRealTimePrefix)} ${relativeRealtime}, ${t(
         TravelAidTexts.scheduledTimeA11yLabel(scheduledClock),
       )}`;

--- a/src/travel-aid/use-travel-aid-data.tsx
+++ b/src/travel-aid/use-travel-aid-data.tsx
@@ -5,5 +5,5 @@ export const useTravelAidDataQuery = (id: string, serviceDate: string) =>
   useQuery({
     queryKey: ['travelAidData', id, serviceDate],
     queryFn: () => getServiceJourneyWithEstimatedCalls(id, serviceDate),
-    refetchInterval: 10000,
+    refetchInterval: 5000,
   });

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -115,8 +115,7 @@ export const DepartureDetailsScreenComponent = ({
   const {
     preferences: {journeyAidEnabled: travelAidPreferenceEnabled},
   } = usePreferences();
-  const shouldShowTravelAid =
-    travelAidPreferenceEnabled && isTravelAidEnabled;
+  const shouldShowTravelAid = travelAidPreferenceEnabled && isTravelAidEnabled;
 
   const shouldShowLive = getShouldShowLiveVehicle(
     estimatedCallsWithMetadata,
@@ -197,7 +196,6 @@ export const DepartureDetailsScreenComponent = ({
                 onPress={onPressTravelAid}
                 text={t(DepartureDetailsTexts.header.journeyAid)}
                 interactiveColor={ctaColor}
-                disabled={!fromQuay?.realtime}
               />
             )}
             {shouldShowMapButton || realtimeText ? (


### PR DESCRIPTION
## Changes / Acceptance criteria

- Announces the time only if the focused stop hasn't changed since the last announcement
- Enables the travel aid button even when realtime is false
- Updates the no realtime message box wording and type
- Only shows scheduled time on `NotYetArrived`
- Refresh interval is 5 seconds