### PR TITLE
fix: Skip error logging for not available offer search

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -219,6 +219,7 @@ export function useOfferState(
             cancelToken,
             retry: true,
             authWithIdToken: true,
+            skipErrorLogging: isNotAvailableError,
           });
 
           cancelToken?.throwIfRequested();
@@ -234,10 +235,7 @@ export function useOfferState(
             });
           }
         } catch (err: any) {
-          const isNotAvailableError =
-            err.response?.status === 400 &&
-            err.response?.data === 'NotAvailable';
-          const errorType = isNotAvailableError
+          const errorType = isNotAvailableError(err)
             ? 'not-available'
             : getAxiosErrorType(err);
           if (errorType !== 'cancel') {
@@ -282,3 +280,6 @@ export function useOfferState(
 function isTariffZone(place: TariffZone | StopPlaceFragment) {
   return 'geometry' in place;
 }
+
+const isNotAvailableError = (err: any) =>
+    err.response?.status === 400 && err.response?.data === 'NotAvailable';


### PR DESCRIPTION
Not available response from offer search is a normal flow and not
really an error situation that needs to be logged.

### Acceptance criteria
- [ ] No error in Bugsnag regarding 400 NotAvailable from _ticket/v3/search/authority_.
