### PR TITLE
refactor: Better typing of places in purchase selection type

### DIFF
--- a/src/purchase-selection/__tests__/purchase-selection-builder-from-selection.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder-from-selection.test.ts
@@ -69,7 +69,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
     expect(selection.travelDate).toBeUndefined();
   });
 
-  it('Should create new selection with defaults when input selection to-place is invalid', () => {
+  it('Should create new selection with defaults when input selection to-zone is invalid', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection({
         ...TEST_SELECTION,

--- a/src/purchase-selection/__tests__/purchase-selection-builder-from-selection.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder-from-selection.test.ts
@@ -5,6 +5,7 @@ import {
   TEST_PRODUCT,
   TEST_ZONE,
   TEST_USER_PROFILE,
+  TEST_ZONE_WITH_MD,
 } from './test-utils';
 import type {PurchaseSelectionType} from '../types';
 
@@ -20,8 +21,10 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
   it('Should return same selection unaltered, with stop places', () => {
     const originalSelection: PurchaseSelectionType = {
       ...TEST_SELECTION,
-      fromPlace: {id: 'abc', name: 'Trondheim S'},
-      toPlace: {id: 'cba', name: 'Solsiden'},
+      stopPlaces: {
+        from: {id: 'abc', name: 'Trondheim S'},
+        to: {id: 'cba', name: 'Solsiden'},
+      },
     };
 
     const selection = createEmptyBuilder(TEST_INPUT)
@@ -44,7 +47,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
     expect(selection.travelDate).toBeUndefined();
   });
 
-  it('Should create new selection with defaults when input selection from-place is invalid', () => {
+  it('Should create new selection with defaults when input selection from-zone is invalid', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection({
         ...TEST_SELECTION,
@@ -53,13 +56,16 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
           id: 'P_X',
           limitations: {...TEST_PRODUCT.limitations, tariffZoneRefs: ['T1']},
         },
-        fromPlace: {...TEST_ZONE, id: 'T_X', resultType: 'zone'},
+        zones: {
+          from: {...TEST_ZONE_WITH_MD, id: 'T_X'},
+          to: TEST_ZONE_WITH_MD,
+        },
         travelDate: new Date().toISOString(),
       })
       .build();
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
-    expect(selection.fromPlace.id).toBe(TEST_ZONE.id);
+    expect(selection.zones?.from.id).toBe(TEST_ZONE.id);
     expect(selection.travelDate).toBeUndefined();
   });
 
@@ -72,13 +78,16 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
           id: 'P_X',
           limitations: {...TEST_PRODUCT.limitations, tariffZoneRefs: ['T1']},
         },
-        toPlace: {...TEST_ZONE, id: 'T_X', resultType: 'zone'},
+        zones: {
+          from: TEST_ZONE_WITH_MD,
+          to: {...TEST_ZONE_WITH_MD, id: 'T_X'},
+        },
         travelDate: new Date().toISOString(),
       })
       .build();
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
-    expect(selection.toPlace.id).toBe(TEST_ZONE.id);
+    expect(selection.zones?.to.id).toBe(TEST_ZONE.id);
     expect(selection.travelDate).toBeUndefined();
   });
 

--- a/src/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
@@ -180,8 +180,10 @@ describe('purchaseSelectionBuilder - product', () => {
     const selection = createEmptyBuilder(input)
       .fromSelection({
         ...TEST_SELECTION,
-        fromPlace: {...TEST_ZONE, id: 'T3', resultType: 'zone'},
-        toPlace: {...TEST_ZONE, id: 'T1', resultType: 'zone'},
+        zones: {
+          from: {...TEST_ZONE, id: 'T3', resultType: 'zone'},
+          to: {...TEST_ZONE, id: 'T1', resultType: 'zone'},
+        },
       })
       .product({
         ...TEST_PRODUCT,
@@ -194,7 +196,7 @@ describe('purchaseSelectionBuilder - product', () => {
       .build();
 
     expect(selection.preassignedFareProduct.id).toBe('P2');
-    expect(selection.fromPlace.id).toBe('T2');
-    expect(selection.toPlace.id).toBe('T2');
+    expect(selection.zones?.from.id).toBe('T2');
+    expect(selection.zones?.to.id).toBe('T2');
   });
 });

--- a/src/purchase-selection/__tests__/purchase-selection-builder-stop-places.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder-stop-places.test.ts
@@ -40,7 +40,7 @@ describe('purchaseSelectionBuilder - stop places', () => {
     expect(selection.stopPlaces?.to?.id).toBe(undefined);
   });
 
-  it('Should not apply from to when no stop places object', () => {
+  it('Should not apply to stop when no stop places object', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .toStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})

--- a/src/purchase-selection/__tests__/purchase-selection-builder-stop-places.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder-stop-places.test.ts
@@ -1,0 +1,52 @@
+import {createEmptyBuilder} from '../purchase-selection-builder';
+import {TEST_INPUT, TEST_SELECTION} from './test-utils';
+
+describe('purchaseSelectionBuilder - stop places', () => {
+  it('Should apply a valid from stop', () => {
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection({
+        ...TEST_SELECTION,
+        zones: undefined,
+        stopPlaces: {from: undefined, to: undefined},
+      })
+      .fromStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
+      .build();
+
+    expect(selection.stopPlaces?.from?.id).toBe('a-stop-id');
+    expect(selection.stopPlaces?.to?.id).toBe(undefined);
+  });
+
+  it('Should apply a valid to stop', () => {
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection({
+        ...TEST_SELECTION,
+        zones: undefined,
+        stopPlaces: {from: undefined, to: undefined},
+      })
+      .toStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
+      .build();
+
+    expect(selection.stopPlaces?.from?.id).toBe(undefined);
+    expect(selection.stopPlaces?.to?.id).toBe('a-stop-id');
+  });
+
+  it('Should not apply from stop when no stop places object', () => {
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(TEST_SELECTION)
+      .fromStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
+      .build();
+
+    expect(selection.stopPlaces?.from?.id).toBe(undefined);
+    expect(selection.stopPlaces?.to?.id).toBe(undefined);
+  });
+
+  it('Should not apply from to when no stop places object', () => {
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(TEST_SELECTION)
+      .toStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
+      .build();
+
+      expect(selection.stopPlaces?.from?.id).toBe(undefined);
+      expect(selection.stopPlaces?.to?.id).toBe(undefined);
+  });
+});

--- a/src/purchase-selection/__tests__/purchase-selection-builder-zones.test.ts
+++ b/src/purchase-selection/__tests__/purchase-selection-builder-zones.test.ts
@@ -1,46 +1,46 @@
 import {createEmptyBuilder} from '../purchase-selection-builder';
-import {TEST_INPUT, TEST_PRODUCT, TEST_SELECTION} from './test-utils';
+import {TEST_INPUT, TEST_PRODUCT, TEST_SELECTION, TEST_ZONE_WITH_MD} from './test-utils';
 import type {PurchaseSelectionType} from '../types';
 
-describe('purchaseSelectionBuilder - places', () => {
+describe('purchaseSelectionBuilder - zones', () => {
   it('Should apply a valid from zone', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
-      .from({...TEST_SELECTION.fromPlace, id: 'T2'})
+      .fromZone({...TEST_ZONE_WITH_MD, id: 'T2'})
       .build();
 
-    expect(selection.fromPlace.id).toBe('T2');
-    expect(selection.toPlace.id).toBe(TEST_SELECTION.toPlace.id);
+    expect(selection.zones?.from.id).toBe('T2');
+    expect(selection.zones?.to.id).toBe(TEST_SELECTION.zones?.to.id);
   });
 
   it('Should apply a valid to zone', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
-      .to({...TEST_SELECTION.toPlace, id: 'T2'})
+      .toZone({...TEST_ZONE_WITH_MD, id: 'T2'})
       .build();
 
-    expect(selection.fromPlace.id).toBe(TEST_SELECTION.fromPlace.id);
-    expect(selection.toPlace.id).toBe('T2');
+    expect(selection.zones?.from.id).toBe(TEST_SELECTION.zones?.from.id);
+    expect(selection.zones?.to.id).toBe('T2');
   });
 
-  it('Should apply a valid from stop', () => {
+  it('Should not apply from zone when no zones object', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
-      .fromSelection(TEST_SELECTION)
-      .from({id: 'a-stop-id', name: 'Trondheim Kai'})
-      .build();
+        .fromSelection({...TEST_SELECTION, zones: undefined})
+        .fromZone({...TEST_ZONE_WITH_MD, id: 'T2'})
+        .build();
 
-    expect(selection.fromPlace.id).toBe('a-stop-id');
-    expect(selection.toPlace.id).toBe(TEST_SELECTION.toPlace.id);
+    expect(selection.zones?.from.id).toBe(undefined);
+    expect(selection.zones?.to.id).toBe(undefined);
   });
 
-  it('Should apply a valid to stop', () => {
+  it('Should not apply to zone when no zones object', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
-      .fromSelection(TEST_SELECTION)
-      .to({id: 'a-stop-id', name: 'Trondheim Kai'})
-      .build();
+        .fromSelection({...TEST_SELECTION, zones: undefined})
+        .toZone({...TEST_ZONE_WITH_MD, id: 'T2'})
+        .build();
 
-    expect(selection.fromPlace.id).toBe(TEST_SELECTION.toPlace.id);
-    expect(selection.toPlace.id).toBe('a-stop-id');
+    expect(selection.zones?.from.id).toBe(undefined);
+    expect(selection.zones?.to.id).toBe(undefined);
   });
 
   it('Should not apply a from zone which is not in product limitations', () => {
@@ -57,7 +57,7 @@ describe('purchaseSelectionBuilder - places', () => {
 
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(originalSelection)
-      .from({...TEST_SELECTION.fromPlace, id: 'T2'})
+      .fromZone({...TEST_ZONE_WITH_MD, id: 'T2'})
       .build();
 
     expect(selection).toBe(originalSelection);
@@ -77,7 +77,7 @@ describe('purchaseSelectionBuilder - places', () => {
 
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(originalSelection)
-      .to({...TEST_SELECTION.fromPlace, id: 'T2'})
+      .toZone({...TEST_ZONE_WITH_MD, id: 'T2'})
       .build();
 
     expect(selection).toBe(originalSelection);

--- a/src/purchase-selection/__tests__/test-utils.ts
+++ b/src/purchase-selection/__tests__/test-utils.ts
@@ -8,6 +8,7 @@ import type {
   PurchaseSelectionBuilderInput,
   PurchaseSelectionType,
 } from '../types';
+import type {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 
 export const TEST_TYPE_CONFIG: FareProductTypeConfig = {
   type: 'single',
@@ -53,6 +54,11 @@ export const TEST_ZONE: TariffZone = {
   },
 };
 
+export const TEST_ZONE_WITH_MD: TariffZoneWithMetadata = {
+  ...TEST_ZONE,
+  resultType: 'zone',
+};
+
 export const TEST_USER_PROFILE: UserProfile = {
   id: 'UP1',
   name: {lang: 'no', value: 'Passasjerprofil1'},
@@ -75,8 +81,11 @@ export const TEST_INPUT: PurchaseSelectionBuilderInput = {
 export const TEST_SELECTION: PurchaseSelectionType = {
   fareProductTypeConfig: TEST_TYPE_CONFIG,
   preassignedFareProduct: TEST_PRODUCT,
-  fromPlace: {...TEST_ZONE, resultType: 'zone'},
-  toPlace: {...TEST_ZONE, resultType: 'zone'},
+  zones: {
+    from: {...TEST_ZONE, resultType: 'zone'},
+    to: {...TEST_ZONE, resultType: 'zone'},
+  },
+  stopPlaces: undefined,
   userProfilesWithCount: [{...TEST_USER_PROFILE, count: 1}],
   travelDate: undefined,
 };

--- a/src/purchase-selection/__tests__/test-utils.ts
+++ b/src/purchase-selection/__tests__/test-utils.ts
@@ -82,8 +82,8 @@ export const TEST_SELECTION: PurchaseSelectionType = {
   fareProductTypeConfig: TEST_TYPE_CONFIG,
   preassignedFareProduct: TEST_PRODUCT,
   zones: {
-    from: {...TEST_ZONE, resultType: 'zone'},
-    to: {...TEST_ZONE, resultType: 'zone'},
+    from: TEST_ZONE_WITH_MD,
+    to: TEST_ZONE_WITH_MD,
   },
   stopPlaces: undefined,
   userProfilesWithCount: [{...TEST_USER_PROFILE, count: 1}],

--- a/src/purchase-selection/purchase-selection-builder.ts
+++ b/src/purchase-selection/purchase-selection-builder.ts
@@ -7,8 +7,9 @@ import type {
 import {
   applyProductChange,
   getDefaultProduct,
+  getDefaultStopPlaces,
   getDefaultUserProfiles,
-  getDefaultZone,
+  getDefaultZones,
   isSelectableProduct,
   isSelectableProfile,
   isSelectableZone,
@@ -55,27 +56,45 @@ const createBuilder = (
 
       return builder;
     },
-    from: (fromPlace) => {
-      const isZone = 'geometry' in fromPlace;
+    fromZone: (from) => {
       if (
-        isZone &&
-        isSelectableZone(currentSelection.preassignedFareProduct, fromPlace)
+        currentSelection.zones &&
+        isSelectableZone(currentSelection.preassignedFareProduct, from)
       ) {
-        currentSelection = {...currentSelection, fromPlace};
-      } else if (!isZone) {
-        currentSelection = {...currentSelection, fromPlace};
+        currentSelection = {
+          ...currentSelection,
+          zones: {...currentSelection.zones, from},
+        };
       }
       return builder;
     },
-    to: (toPlace) => {
-      const isZone = 'geometry' in toPlace;
+    toZone: (to) => {
       if (
-        isZone &&
-        isSelectableZone(currentSelection.preassignedFareProduct, toPlace)
+        currentSelection.zones &&
+        isSelectableZone(currentSelection.preassignedFareProduct, to)
       ) {
-        currentSelection = {...currentSelection, toPlace};
-      } else if (!isZone) {
-        currentSelection = {...currentSelection, toPlace};
+        currentSelection = {
+          ...currentSelection,
+          zones: {...currentSelection.zones, to},
+        };
+      }
+      return builder;
+    },
+    fromStopPlace: (from) => {
+      if (currentSelection.stopPlaces) {
+        currentSelection = {
+          ...currentSelection,
+          stopPlaces: {...currentSelection.stopPlaces, from},
+        };
+      }
+      return builder;
+    },
+    toStopPlace: (to) => {
+      if (currentSelection.stopPlaces) {
+        currentSelection = {
+          ...currentSelection,
+          stopPlaces: {...currentSelection.stopPlaces, to},
+        };
       }
       return builder;
     },
@@ -114,7 +133,12 @@ const createSelectionForType = (
     input,
     fareProductTypeConfig.type,
   );
-  const tariffZone = getDefaultZone(input, preassignedFareProduct);
+  const zones = getDefaultZones(
+    input,
+    fareProductTypeConfig,
+    preassignedFareProduct,
+  );
+  const stopPlaces = getDefaultStopPlaces(fareProductTypeConfig);
   const userProfilesWithCount = getDefaultUserProfiles(
     input,
     preassignedFareProduct,
@@ -123,8 +147,8 @@ const createSelectionForType = (
   return {
     fareProductTypeConfig,
     preassignedFareProduct,
-    fromPlace: tariffZone,
-    toPlace: tariffZone,
+    zones,
+    stopPlaces,
     userProfilesWithCount,
     travelDate: undefined,
   };

--- a/src/purchase-selection/types.ts
+++ b/src/purchase-selection/types.ts
@@ -14,8 +14,18 @@ export type PurchaseSelectionType = {
   fareProductTypeConfig: FareProductTypeConfig;
   preassignedFareProduct: PreassignedFareProduct;
   userProfilesWithCount: UserProfileWithCount[];
-  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
-  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
+  stopPlaces:
+    | {
+        from: StopPlaceFragmentWithIsFree | undefined;
+        to: StopPlaceFragmentWithIsFree | undefined;
+      }
+    | undefined;
+  zones:
+    | {
+        from: TariffZoneWithMetadata;
+        to: TariffZoneWithMetadata;
+      }
+    | undefined;
   travelDate: string | undefined;
 };
 
@@ -59,20 +69,28 @@ export type PurchaseSelectionBuilder = {
   product: (p: PreassignedFareProduct) => PurchaseSelectionBuilder;
 
   /**
-   * Apply the given from place to the purchase selection. If the given place is
+   * Apply the given from zone to the purchase selection. If the given zone is
    * not applicable the purchase selection will stay unmodified.
    */
-  from: (
-    f: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree,
-  ) => PurchaseSelectionBuilder;
+  fromZone: (f: TariffZoneWithMetadata) => PurchaseSelectionBuilder;
 
   /**
-   * Apply the given to place to the purchase selection. If the given place is
+   * Apply the given to zone to the purchase selection. If the given zone is
    * not applicable the purchase selection will stay unmodified.
    */
-  to: (
-    t: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree,
-  ) => PurchaseSelectionBuilder;
+  toZone: (t: TariffZoneWithMetadata) => PurchaseSelectionBuilder;
+
+  /**
+   * Apply the given from stop place to the purchase selection. If the given
+   * stop place is not applicable the purchase selection will stay unmodified.
+   */
+  fromStopPlace: (f?: StopPlaceFragmentWithIsFree) => PurchaseSelectionBuilder;
+
+  /**
+   * Apply the given to stop place to the purchase selection. If the given stop
+   * place is not applicable the purchase selection will stay unmodified.
+   */
+  toStopPlace: (t?: StopPlaceFragmentWithIsFree) => PurchaseSelectionBuilder;
 
   /**
    * Apply the given user profiles with count to the purchase selection. If one

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -27,7 +27,6 @@ import {
 import {PaymentMethod} from '../types';
 import {PreassignedFareContractSummary} from './components/PreassignedFareProductSummary';
 import {SelectPaymentMethodSheet} from './components/SelectPaymentMethodSheet';
-import {ZoneSelectionMode} from '@atb-as/config-specs';
 import {PriceSummary} from './components/PriceSummary';
 import {useReserveOfferMutation} from './use-reserve-offer-mutation';
 import {useCancelPaymentMutation} from './use-cancel-payment-mutation';
@@ -65,9 +64,6 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
 
   const {selection, recipient} = params;
 
-  const offerEndpoint = getOfferEndpoint(
-    selection.fareProductTypeConfig.configuration.zoneSelectionMode,
-  );
   const isOnBehalfOf = !!recipient;
 
   const preassignedFareProductAlternatives = useMemo(
@@ -85,7 +81,6 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     userProfilesWithCountAndOffer,
   } = useOfferState(
     selection,
-    offerEndpoint,
     preassignedFareProductAlternatives,
     isOnBehalfOf,
   );
@@ -257,8 +252,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
         )}
         <PreassignedFareContractSummary
           fareProductTypeConfig={selection.fareProductTypeConfig}
-          fromPlace={selection.fromPlace}
-          toPlace={selection.toPlace}
+          fromPlace={selection.zones?.from || selection.stopPlaces?.from}
+          toPlace={selection.zones?.to || selection.stopPlaces?.to}
           isSearchingOffer={isSearchingOffer}
           preassignedFareProduct={selection.preassignedFareProduct}
           recipient={recipient}
@@ -390,17 +385,6 @@ function getPaymentTypeSvg(paymentType: PaymentType) {
       return Vipps;
     case PaymentType.Visa:
       return Visa;
-  }
-}
-
-function getOfferEndpoint(zoneSelectionMode: ZoneSelectionMode) {
-  switch (zoneSelectionMode) {
-    case 'none':
-      return 'authority';
-    case 'multiple-stop-harbor':
-      return 'stop-places';
-    default:
-      return 'zones';
   }
 }
 

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -28,8 +28,8 @@ type Props = {
   fareProductTypeConfig: FareProductTypeConfig;
   recipient?: TicketRecipientType;
   isSearchingOffer: boolean;
-  fromPlace: TariffZone | StopPlaceFragment;
-  toPlace: TariffZone | StopPlaceFragment;
+  fromPlace: TariffZone | StopPlaceFragment | undefined;
+  toPlace: TariffZone | StopPlaceFragment | undefined;
   validDurationSeconds?: number;
   travelDate?: string;
 };
@@ -50,8 +50,8 @@ export const PreassignedFareContractSummary = ({
 
   const {zoneSelectionMode} = fareProductTypeConfig.configuration;
 
-  const fromPlaceName = getPlaceName(fromPlace, language);
-  const toPlaceName = getPlaceName(toPlace, language);
+  const fromPlaceName = fromPlace ? getPlaceName(fromPlace, language) : '';
+  const toPlaceName = toPlace ? getPlaceName(toPlace, language) : '';
 
   const travelDateText = travelDate
     ? t(
@@ -92,7 +92,7 @@ export const PreassignedFareContractSummary = ({
         );
       default:
         return summary(
-          fromPlace.id === toPlace.id
+          fromPlace?.id === toPlace?.id
             ? t(
                 PurchaseConfirmationTexts.validityTexts.zone.single(
                   fromPlaceName,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -85,13 +85,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const fareProductOnBehalfOfEnabled =
     selection.fareProductTypeConfig.configuration.onBehalfOfEnabled;
 
-  const offerEndpoint =
-    zoneSelectionMode === 'none'
-      ? 'authority'
-      : zoneSelectionMode === 'multiple-stop-harbor'
-      ? 'stop-places'
-      : 'zones';
-
   const {
     isSearchingOffer,
     error,
@@ -101,7 +94,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     userProfilesWithCountAndOffer,
   } = useOfferState(
     selection,
-    offerEndpoint,
     preassignedFareProductAlternatives,
     isOnBehalfOfToggle,
   );
@@ -243,8 +235,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           />
           <FromToSelection
             fareProductTypeConfig={selection.fareProductTypeConfig}
-            fromPlace={selection.fromPlace}
-            toPlace={selection.toPlace}
+            fromPlace={selection.zones?.from || selection.stopPlaces?.from}
+            toPlace={selection.zones?.to || selection.stopPlaces?.to}
             preassignedFareProduct={selection.preassignedFareProduct}
             style={styles.selectionComponent}
             onSelect={(params) => {
@@ -310,8 +302,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 textColor={theme.color.background.neutral[0]}
                 ruleVariables={{
                   preassignedFareProductType: preassignedFareProduct.type,
-                  fromTariffZone: selection.fromPlace.id,
-                  toTariffZone: selection.toPlace.id,
+                  fromTariffZone: selection.zones?.from.id || 'none',
+                  toTariffZone: selection.zones?.to.id || 'none',
                   userTypes: userTypeStrings,
                 }}
               />
@@ -334,8 +326,12 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
               analytics.logEvent('Ticketing', 'Purchase summary clicked', {
                 fareProduct: selection.fareProductTypeConfig.name,
                 tariffZone: {
-                  from: selection.fromPlace.id,
-                  to: selection.toPlace.id,
+                  from: selection.zones?.from.id,
+                  to: selection.zones?.to.id,
+                },
+                stopPlaces: {
+                  from: selection.stopPlaces?.from?.id,
+                  to: selection.stopPlaces?.to?.id,
                 },
                 userProfilesWithCount: selection.userProfilesWithCount.map(
                   (t) => ({

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection.tsx
@@ -12,8 +12,8 @@ import {StopPlaceFragmentWithIsFree} from '@atb/harbors/types';
 
 type SelectionProps = {
   fareProductTypeConfig: FareProductTypeConfig;
-  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
-  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree;
+  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree | undefined;
+  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree | undefined;
   preassignedFareProduct: PreassignedFareProduct;
   onSelect: (
     params:
@@ -43,8 +43,10 @@ export const FromToSelection = forwardRef<FocusRefsType, SelectionProps>(
     if (selectionMode === 'multiple-stop-harbor') {
       return (
         <HarborSelection
-          fromHarbor={isValidTariffZone(fromPlace) ? undefined : fromPlace}
-          toHarbor={isValidTariffZone(toPlace) ? undefined : toPlace}
+          fromHarbor={
+            fromPlace && isValidTariffZone(fromPlace) ? undefined : fromPlace
+          }
+          toHarbor={toPlace && isValidTariffZone(toPlace) ? undefined : toPlace}
           fareProductTypeConfig={fareProductTypeConfig}
           preassignedFareProduct={preassignedFareProduct}
           onSelect={onSelect}
@@ -64,7 +66,10 @@ export const FromToSelection = forwardRef<FocusRefsType, SelectionProps>(
     ) {
       selectionMode = 'single';
     }
-    return isValidTariffZone(fromPlace) && isValidTariffZone(toPlace) ? (
+    return fromPlace &&
+      isValidTariffZone(fromPlace) &&
+      toPlace &&
+      isValidTariffZone(toPlace) ? (
       <ZonesSelection
         fromTariffZone={fromPlace}
         toTariffZone={toPlace}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -11,6 +11,7 @@ import {
   PurchaseSelectionType,
   usePurchaseSelectionBuilder,
 } from '@atb/purchase-selection';
+import {isValidTariffZone} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection';
 
 export function useOfferDefaults(
   preassignedFareProduct: PreassignedFareProduct | undefined,
@@ -31,8 +32,12 @@ export function useOfferDefaults(
       const builder = selectionBuilder.forType(fareProductTypeConfig.type);
 
       if (preassignedFareProduct) builder.product(preassignedFareProduct);
-      if (fromPlace) builder.from(fromPlace);
-      if (toPlace) builder.to(toPlace);
+      if (fromPlace && isValidTariffZone(fromPlace))
+        builder.fromZone(fromPlace);
+      if (toPlace && isValidTariffZone(toPlace)) builder.toZone(toPlace);
+      if (fromPlace && !isValidTariffZone(fromPlace))
+        builder.fromStopPlace(fromPlace);
+      if (toPlace && !isValidTariffZone(toPlace)) builder.toStopPlace(toPlace);
       if (userProfilesWithCount) builder.userProfiles(userProfilesWithCount);
       if (travelDate) builder.date(travelDate);
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -1,6 +1,6 @@
 import {CancelToken as CancelTokenStatic} from '@atb/api';
 import {ErrorType, getAxiosErrorType} from '@atb/api/utils';
-import {PreassignedFareProduct, TariffZone} from '@atb/configuration';
+import {PreassignedFareProduct} from '@atb/configuration';
 import {
   FlexDiscountLadder,
   Offer,
@@ -11,8 +11,7 @@ import {CancelToken} from 'axios';
 import {useCallback, useEffect, useReducer} from 'react';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {secondsBetween} from '@atb/utils/date';
-import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {PurchaseSelectionType} from "@atb/purchase-selection";
+import {PurchaseSelectionType} from '@atb/purchase-selection';
 
 export type UserProfileWithCountAndOffer = UserProfileWithCount & {
   offer: Offer;
@@ -164,7 +163,6 @@ const initialState: OfferState = {
 
 export function useOfferState(
   selection: PurchaseSelectionType,
-  offerEndpoint: 'zones' | 'authority' | 'stop-places',
   preassignedFareProductAlternatives: PreassignedFareProduct[],
   isOnBehalfOf: boolean = false,
 ) {
@@ -173,7 +171,7 @@ export function useOfferState(
 
   const updateOffer = useCallback(
     async function (cancelToken?: CancelToken) {
-      if ('isFree' in selection.toPlace && selection.toPlace.isFree) {
+      if (selection.stopPlaces?.to?.isFree) {
         dispatch({type: 'CLEAR_OFFER'});
         return;
       }
@@ -186,35 +184,35 @@ export function useOfferState(
           count: t.count,
         }));
 
-      if (!offerTravellers.length) {
+      const isTravellersValid = offerTravellers.length > 0;
+      const isStopPlacesValid = selection.stopPlaces
+        ? selection.stopPlaces.from && selection.stopPlaces.to
+        : true;
+      const isSelectionValid = isTravellersValid && isStopPlacesValid;
+
+      if (!isSelectionValid) {
         dispatch({type: 'CLEAR_OFFER'});
       } else {
         try {
-          if (
-            offerEndpoint === 'stop-places' &&
-            (isTariffZone(selection.fromPlace) ||
-              isTariffZone(selection.toPlace))
-          ) {
-            dispatch({type: 'CLEAR_OFFER'});
-            return;
-          }
-
-          const zones = [
-            ...new Set([selection.fromPlace.id, selection.toPlace.id]),
-          ];
-
-          const placeParams =
-            offerEndpoint === 'stop-places'
-              ? {from: selection.fromPlace.id, to: selection.toPlace.id}
-              : {zones};
           const params = {
-            ...placeParams,
+            zones: selection.zones && [
+              ...new Set([selection.zones.from.id, selection.zones.to.id]),
+            ],
+            from: selection.stopPlaces?.from!.id,
+            to: selection.stopPlaces?.to!.id,
             is_on_behalf_of: isOnBehalfOf,
             travellers: offerTravellers,
             products: preassignedFareProductAlternatives.map((p) => p.id),
             travel_date: selection.travelDate,
           };
           dispatch({type: 'SEARCHING_OFFER'});
+
+          const offerEndpoint = selection.stopPlaces
+            ? 'stop-places'
+            : selection.zones
+            ? 'zones'
+            : 'authority';
+
           const response = await searchOffers(offerEndpoint, params, {
             cancelToken,
             retry: true,
@@ -252,12 +250,7 @@ export function useOfferState(
         }
       }
     },
-    [
-      selection,
-      preassignedFareProductAlternatives,
-      offerEndpoint,
-      isOnBehalfOf,
-    ],
+    [selection, preassignedFareProductAlternatives, isOnBehalfOf],
   );
 
   useEffect(() => {
@@ -277,8 +270,4 @@ export function useOfferState(
     ...state,
     refreshOffer,
   };
-}
-
-function isTariffZone(place: TariffZone | StopPlaceFragment) {
-  return 'geometry' in place;
 }

--- a/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketAssistantStack/TicketAssistant_SummaryScreen/TicketAssistant_SummaryScreen.tsx
@@ -61,8 +61,11 @@ export const TicketAssistant_SummaryScreen = ({navigation}: SummaryProps) => {
       {
         selection: {
           fareProductTypeConfig: recommendedTicketSummary.fareProductTypeConfig,
-          fromPlace: recommendedTicketSummary.tariffZones[0],
-          toPlace: recommendedTicketSummary.tariffZones[1],
+          zones: {
+            from: recommendedTicketSummary.tariffZones[0],
+            to: recommendedTicketSummary.tariffZones[1],
+          },
+          stopPlaces: undefined,
           userProfilesWithCount: recommendedTicketSummary.userProfileWithCount,
           preassignedFareProduct:
             recommendedTicketSummary.preassignedFareProduct,

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -24,24 +24,16 @@ export async function listRecentFareContracts(): Promise<
   return response.data;
 }
 
-export type OfferSearchParams = SearchParams &
-  (ZoneOfferSearchParams | StopPlaceOfferSearchParams);
-
-type SearchParams = {
+export type OfferSearchParams = {
   is_on_behalf_of: boolean;
   travellers: Traveller[];
   products: string[];
   travel_date?: string;
+  zones?: string[];
+  from?: string;
+  to?: string;
 };
 
-type ZoneOfferSearchParams = {
-  zones: string[];
-};
-
-type StopPlaceOfferSearchParams = {
-  from: string;
-  to: string;
-};
 type Traveller = {
   id: string;
   user_type: string;


### PR DESCRIPTION
The type for selecting a place in the purchase selection was not
optimal. This was observed already when creating the
PurchaseSelectionType, but not done anything with to not embrace
too much.

The place selection was typed to either a zone or a StopPlace, and
was mandatory. That ment that every time a stop place was not
selected, then a zone was selected. So for example during a boat
ticket purchase process, if the selected from harbor was undefined,
then in the data structure the from place was actually a tariff
zone.

This was improved by creating two different fields for zones and
stop places, and they can both be undefined if there is no
zoneSelectionMode on the type config.

### Acceptance criteria
- [ ] Purchase flow should work as before. Especially test zone selection variations (map, list, location search) and the harbor selection flow.