### PR TITLE
feat: use live regions to announce travel aid updates

### DIFF
--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -11,6 +11,8 @@ import {PressableOpacityOrView} from '@atb/components/touchable-opacity-or-view'
 import {insets} from '@atb/utils/insets';
 import {screenReaderPause} from '@atb/components/text';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {useLiveRegionAnnouncement} from '@atb/components/screen-reader-announcement';
+import {isDefined} from '@atb/utils/presence';
 
 /**
  * Configuration for how the onPress on the message box should work. The
@@ -35,6 +37,7 @@ export type MessageInfoBoxProps = {
   isMarkdown?: boolean;
   style?: StyleProp<ViewStyle>;
   onPressConfig?: OnPressConfig;
+  a11yAnnounce?: boolean;
   testID?: string;
 };
 export const MessageInfoBox = ({
@@ -46,6 +49,7 @@ export const MessageInfoBox = ({
   isMarkdown = false,
   onPressConfig,
   onDismiss,
+  a11yAnnounce,
   testID,
 }: MessageInfoBoxProps) => {
   const {theme, themeName} = useTheme();
@@ -62,8 +66,12 @@ export const MessageInfoBox = ({
 
   const a11yCriticalityPrefix = t(dictionary.messageTypes[type]);
   const a11yLabel = [a11yCriticalityPrefix, title, message, onPressConfig?.text]
-    .filter((s): s is string => !!s)
+    .filter(isDefined)
     .join(screenReaderPause);
+  const liveRegionA11yProps = useLiveRegionAnnouncement(
+    a11yLabel,
+    a11yAnnounce,
+  );
 
   return (
     <PressableOpacityOrView
@@ -81,17 +89,16 @@ export const MessageInfoBox = ({
       )}
       <View
         style={styles.content}
-        accessible={true}
         accessibilityRole={
           onPressConfig && ('action' in onPressConfig ? 'button' : 'link')
         }
-        accessibilityLabel={a11yLabel}
         accessibilityHint={
           onPressConfig &&
           ('action' in onPressConfig
             ? t(MessageBoxTexts.a11yHintActionPrefix)
             : t(MessageBoxTexts.a11yHintUrlPrefix)) + onPressConfig.text
         }
+        {...liveRegionA11yProps}
       >
         {title && (
           <ThemeText

--- a/src/components/screen-reader-announcement/LiveRegionWrapper.tsx
+++ b/src/components/screen-reader-announcement/LiveRegionWrapper.tsx
@@ -1,0 +1,18 @@
+import {View} from 'react-native';
+import {useLiveRegionAnnouncement} from './use-live-region-announcement';
+
+/**
+ * Wrapper for components that should be announced to screen readers on mount
+ * and when the a11yLabel changes. For interactive components, use
+ * `useLiveRegionAnnouncement` directly.
+ */
+export const LiveRegionWrapper = ({
+  accessibilityLabel,
+  children,
+}: {
+  accessibilityLabel: string;
+  children: React.ReactNode;
+}) => {
+  const a11yProps = useLiveRegionAnnouncement(accessibilityLabel, true);
+  return <View {...a11yProps}>{children}</View>;
+};

--- a/src/components/screen-reader-announcement/index.ts
+++ b/src/components/screen-reader-announcement/index.ts
@@ -1,2 +1,4 @@
 export {ScreenReaderAnnouncement} from './ScreenReaderAnnouncement';
 export {useScreenReaderAnnouncement} from './use-screen-reader-announcement';
+export {LiveRegionWrapper} from './LiveRegionWrapper';
+export {useLiveRegionAnnouncement} from './use-live-region-announcement';

--- a/src/components/screen-reader-announcement/use-live-region-announcement.ts
+++ b/src/components/screen-reader-announcement/use-live-region-announcement.ts
@@ -1,0 +1,31 @@
+import {useEffect} from 'react';
+import {AccessibilityInfo, AccessibilityProps, Platform} from 'react-native';
+
+/**
+ * When a11yLabel changes, announce it to screen readers without interrupting
+ * ongoing speach. Returns accessibility props that should be added to the
+ * relevant component. For non-interactive components, consider using
+ * `LiveRegionWrapper` instead.
+ *
+ * Docs: https://reactnative.dev/docs/accessibility#accessibilityliveregion-android
+ */
+export const useLiveRegionAnnouncement = (
+  a11yLabel?: string,
+  enabled?: boolean,
+): AccessibilityProps => {
+  // Since iOS does not support accessibilityLiveRegion, we trigger screen
+  // reader announcements when a11yLabel changes for a equivalent effect.
+  useEffect(() => {
+    if (enabled && a11yLabel && Platform.OS === 'ios') {
+      AccessibilityInfo.announceForAccessibilityWithOptions(a11yLabel, {
+        queue: true,
+      });
+    }
+  }, [a11yLabel, enabled]);
+
+  return {
+    accessible: true,
+    accessibilityLabel: a11yLabel,
+    accessibilityLiveRegion: enabled ? 'polite' : undefined,
+  };
+};

--- a/src/situations/SituationMessageBox.tsx
+++ b/src/situations/SituationMessageBox.tsx
@@ -12,12 +12,14 @@ export type Props = {
   situation: SituationType;
   noStatusIcon?: MessageInfoBoxProps['noStatusIcon'];
   style?: MessageInfoBoxProps['style'];
+  a11yAnnounce?: boolean;
 };
 
 export const SituationMessageBox = ({
   situation,
   noStatusIcon,
   style,
+  a11yAnnounce,
 }: Props) => {
   const {language} = useTranslation();
 
@@ -34,6 +36,7 @@ export const SituationMessageBox = ({
       noStatusIcon={noStatusIcon}
       style={style}
       message={text}
+      a11yAnnounce={a11yAnnounce}
       onPressConfig={{
         text: t(dictionary.readMore),
         action: () => openSituation(situation),

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -3,21 +3,15 @@ import {Button} from '@atb/components/button';
 import {EstimatedCallInfo} from '@atb/components/estimated-call';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {ServiceJourneyDeparture} from '@atb/travel-details-screens/types';
-import React, {Ref, useEffect, useRef, useState} from 'react';
+import React, {Ref} from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useTravelAidDataQuery} from './use-travel-aid-data';
 import {ScrollView} from 'react-native-gesture-handler';
 import {GenericSectionItem, Section} from '@atb/components/sections';
-import {AccessibilityInfo, ActivityIndicator, View} from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {formatToClock, formatToClockOrRelativeMinutes} from '@atb/utils/date';
-import {
-  CancelledDepartureTexts,
-  Language,
-  TranslateFunction,
-  dictionary,
-  useTranslation,
-} from '@atb/translations';
+import {TranslateFunction, dictionary, useTranslation} from '@atb/translations';
 import {TravelAidTexts} from '@atb/translations/screens/subscreens/TravelAid';
 import {
   getLineA11yLabel,
@@ -35,12 +29,7 @@ import {
 } from './get-focused-estimated-call';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {getQuayName} from '@atb/utils/transportation-names.ts';
-import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import {SituationMessageBox} from '@atb/situations';
-import {getSituationSummary} from '@atb/situations/utils';
-import {SituationType} from '@atb/situations/types';
-import {isDefined} from '@atb/utils/presence';
-import {onlyUniques} from '@atb/utils/only-uniques';
 import {CancelledDepartureMessage} from '@atb/travel-details-screens/components/CancelledDepartureMessage';
 import {StopSignalButton} from '@atb/travel-aid/components/StopSignalButton';
 import type {ServiceJourneyWithGuaranteedCalls} from '@atb/travel-aid/types';
@@ -49,6 +38,7 @@ import {MutationStatus} from '@tanstack/react-query';
 import type {SendStopSignalRequestType} from '@atb/api/stop-signal';
 import type {ContrastColor} from '@atb/theme/colors';
 import {createSentStopSignalsCache} from '@atb/travel-aid/sent-stop-signals-cache';
+import {LiveRegionWrapper} from '@atb/components/screen-reader-announcement';
 
 export type TravelAidScreenParams = {
   serviceJourneyDeparture: ServiceJourneyDeparture;
@@ -154,7 +144,7 @@ const TravelAidSection = ({
   sendStopSignalStatus: MutationStatus;
 }) => {
   const styles = useStyles();
-  const {t, language} = useTranslation();
+  const {t} = useTranslation();
 
   const {status, focusedEstimatedCall} = getFocusedEstimatedCall(
     serviceJourney.estimatedCalls,
@@ -173,20 +163,7 @@ const TravelAidSection = ({
 
   const isCancelled = focusedEstimatedCall.cancellation;
 
-  useTravelAidAnnouncements(
-    {status, focusedEstimatedCall},
-    situationsForFocused,
-    noticesForFocused,
-    isCancelled,
-  );
-
   const quayName = getQuayName(focusedEstimatedCall.quay) ?? '';
-
-  const focussedStateA11yLabel = getFocussedStateA11yLabel(
-    {status, focusedEstimatedCall},
-    t,
-    language,
-  );
 
   return (
     <Section ref={focusRef}>
@@ -228,28 +205,36 @@ const TravelAidSection = ({
               {isCancelled && <CancelledDepartureMessage />}
 
               {situationsForFocused.map((situation) => (
-                <SituationMessageBox key={situation.id} situation={situation} />
+                <SituationMessageBox
+                  key={situation.id}
+                  situation={situation}
+                  a11yAnnounce={true}
+                />
               ))}
 
               {noticesForFocused.map(
                 (notice) =>
                   notice.text && (
-                    <MessageInfoBox type="info" message={notice.text} />
+                    <MessageInfoBox
+                      type="info"
+                      message={notice.text}
+                      a11yAnnounce={true}
+                    />
                   ),
               )}
             </View>
           )}
-          <View
-            accessible
-            accessibilityLabel={focussedStateA11yLabel}
-            style={styles.stopHeaderContainer}
-          >
-            <View>
+          <View accessible style={styles.stopHeaderContainer}>
+            <LiveRegionWrapper
+              accessibilityLabel={
+                getStopHeader(status, t) + screenReaderPause + quayName
+              }
+            >
               <ThemeText type="body__tertiary--bold">
                 {getStopHeader(status, t)}
               </ThemeText>
               <ThemeText type="heading__title">{quayName}</ThemeText>
-            </View>
+            </LiveRegionWrapper>
             <TimeInfo state={{status, focusedEstimatedCall}} />
           </View>
           <StopSignalButton
@@ -264,84 +249,21 @@ const TravelAidSection = ({
   );
 };
 
-const useTravelAidAnnouncements = (
-  state: FocusedEstimatedCallState,
-  situationsForFocusedStop: SituationType[],
-  noticesForFocusedStop: NoticeFragment[],
-  cancelled: boolean,
-) => {
-  const {language, t} = useTranslation();
-  const previousQuayId = useRef<string | null>(null);
-
-  const announcedSituationIds = situationsForFocusedStop
-    .map((s) => s.id)
-    .filter(onlyUniques);
-  const announcedNoticeIds = noticesForFocusedStop
-    .map((s) => s.id)
-    .filter(onlyUniques);
-
-  const [currentAnnouncedSituationIds, setCurrentAnnouncedSituationIds] =
-    useState<string[]>(announcedSituationIds);
-  const [currentAnnouncedNoticeIds, setCurrentAnnouncedNoticeIds] =
-    useState<string[]>(announcedNoticeIds);
-
-  const newSituations = situationsForFocusedStop.filter(
-    (s) => !currentAnnouncedSituationIds.includes(s.id),
-  );
-  const newNotices = noticesForFocusedStop.filter(
-    (s) => !currentAnnouncedNoticeIds.includes(s.id),
-  );
-
-  const message =
-    getFocussedStateA11yLabel(state, t, language) +
-    (cancelled ? screenReaderPause + t(CancelledDepartureTexts.message) : '') +
-    screenReaderPause +
-    getSituationA11yLabel(newSituations, language) +
-    screenReaderPause +
-    getNoticesA11yLabel(newNotices);
-  const timeInfoMessage = getTimeInfoA11yLabel(state, t, language);
-
-  if (newSituations.length > 0) {
-    setCurrentAnnouncedSituationIds((prev) => [
-      ...prev,
-      ...newSituations.map((s) => s.id),
-    ]);
-  }
-
-  if (newNotices.length > 0) {
-    setCurrentAnnouncedNoticeIds((prev) => [
-      ...prev,
-      ...newNotices.map((s) => s.id),
-    ]);
-  }
-
-  useEffect(() => {
-    if (!previousQuayId.current) {
-      // If previousQuayId is null, it is the first render, and we should not
-      // announce the time
-      previousQuayId.current = state.focusedEstimatedCall.quay.id;
-      return;
-    }
-    if (previousQuayId.current === state.focusedEstimatedCall.quay.id) {
-      // Only announce the time if the focused estimated call hasn't changed
-      AccessibilityInfo.announceForAccessibility(timeInfoMessage);
-    } else {
-      AccessibilityInfo.announceForAccessibility(message);
-    }
-    previousQuayId.current = state.focusedEstimatedCall.quay.id;
-  }, [message, timeInfoMessage, state.focusedEstimatedCall.quay.id]);
-};
-
 const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
   const {language, t} = useTranslation();
   const styles = useStyles();
   const {themeName} = useTheme();
   const {focusedEstimatedCall, status} = state;
 
-  const clock = formatToClock(
+  const scheduledClock = formatToClock(
     focusedEstimatedCall.aimedDepartureTime,
     language,
     'round',
+  );
+  const relativeRealtime = formatToClockOrRelativeMinutes(
+    focusedEstimatedCall.expectedDepartureTime,
+    language,
+    t(dictionary.date.units.now),
   );
 
   switch (status) {
@@ -350,112 +272,52 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
     case TravelAidStatus.NoRealtime:
     case TravelAidStatus.NotGettingUpdates:
       return (
-        <ThemeText type="body__secondary--bold">
-          {t(TravelAidTexts.scheduledTime(clock))}
-        </ThemeText>
+        <LiveRegionWrapper
+          accessibilityLabel={t(TravelAidTexts.scheduledTime(scheduledClock))}
+        >
+          <ThemeText type="body__secondary--bold">
+            {t(TravelAidTexts.scheduledTime(scheduledClock))}
+          </ThemeText>
+        </LiveRegionWrapper>
       );
     case TravelAidStatus.NotYetArrived:
       return (
-        <View>
+        <LiveRegionWrapper
+          accessibilityLabel={`${t(
+            dictionary.a11yRealTimePrefix,
+          )} ${relativeRealtime}, ${t(
+            TravelAidTexts.scheduledTimeA11yLabel(scheduledClock),
+          )}`}
+        >
           <View style={styles.realTime}>
             <ThemeIcon
               svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
               size="xSmall"
             />
-            <ThemeText type="heading__title">
-              {formatToClockOrRelativeMinutes(
-                focusedEstimatedCall.expectedDepartureTime,
-                language,
-                t(dictionary.date.units.now),
-              )}
-            </ThemeText>
+            <ThemeText type="heading__title">{relativeRealtime}</ThemeText>
           </View>
           <ThemeText type="body__secondary--bold">
-            {t(TravelAidTexts.scheduledTime(clock))}
+            {t(TravelAidTexts.scheduledTime(scheduledClock))}
           </ThemeText>
-        </View>
+        </LiveRegionWrapper>
       );
     case TravelAidStatus.Arrived:
     case TravelAidStatus.BetweenStops:
       return (
-        <View style={styles.realTime}>
-          <ThemeIcon
-            svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
-            size="xSmall"
-          />
-          <ThemeText type="heading__title">
-            {formatToClockOrRelativeMinutes(
-              focusedEstimatedCall.expectedDepartureTime,
-              language,
-              t(dictionary.date.units.now),
-            )}
-          </ThemeText>
-        </View>
+        <LiveRegionWrapper
+          accessibilityLabel={`${t(
+            dictionary.a11yRealTimePrefix,
+          )} ${relativeRealtime}`}
+        >
+          <View style={styles.realTime}>
+            <ThemeIcon
+              svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
+              size="xSmall"
+            />
+            <ThemeText type="heading__title">{relativeRealtime}</ThemeText>
+          </View>
+        </LiveRegionWrapper>
       );
-  }
-};
-
-const getFocussedStateA11yLabel = (
-  state: FocusedEstimatedCallState,
-  t: TranslateFunction,
-  language: Language,
-) => {
-  const quayName = getQuayName(state.focusedEstimatedCall.quay) ?? '';
-
-  return (
-    getStopHeader(state.status, t) +
-    ' ' +
-    quayName +
-    '. ' +
-    getTimeInfoA11yLabel(state, t, language)
-  );
-};
-
-const getSituationA11yLabel = (
-  situations: SituationType[],
-  language: Language,
-) => {
-  return situations
-    .map((s) => getSituationSummary(s, language))
-    .filter(isDefined)
-    .join(screenReaderPause);
-};
-
-const getNoticesA11yLabel = (notices: NoticeFragment[]) => {
-  return notices
-    .map((notice) => notice.text)
-    .filter(isDefined)
-    .join(screenReaderPause);
-};
-
-const getTimeInfoA11yLabel = (
-  state: FocusedEstimatedCallState,
-  t: TranslateFunction,
-  language: Language,
-) => {
-  const scheduledClock = formatToClock(
-    state.focusedEstimatedCall.aimedDepartureTime,
-    language,
-    'round',
-  );
-  const relativeRealtime = formatToClockOrRelativeMinutes(
-    state.focusedEstimatedCall.expectedDepartureTime,
-    language,
-    t(dictionary.date.units.now),
-  );
-  switch (state.status) {
-    case TravelAidStatus.EndOfLine:
-      return '';
-    case TravelAidStatus.NoRealtime:
-    case TravelAidStatus.NotGettingUpdates:
-      return t(TravelAidTexts.scheduledTime(scheduledClock));
-    case TravelAidStatus.Arrived:
-    case TravelAidStatus.BetweenStops:
-      return `${t(dictionary.a11yRealTimePrefix)} ${relativeRealtime}`;
-    case TravelAidStatus.NotYetArrived:
-      return `${t(dictionary.a11yRealTimePrefix)} ${relativeRealtime}, ${t(
-        TravelAidTexts.scheduledTimeA11yLabel(scheduledClock),
-      )}`;
   }
 };
 


### PR DESCRIPTION
Refactors travel aid to use [live regions](https://reactnative.dev/docs/accessibility#accessibilityliveregion-android) to announce changes on the page. Since iOS doesn't support live regions, the `useLiveRegionAnnouncement` hook is added, that triggers screen reader announcements on iOS when a11yLabel changes. There's also a wrapper component `LiveRegionWrapper` that can be used for non-interactive components in JSX.

### Example usage of live regions

There are two main ways to implement live regions

```tsx
const a11yProps = useLiveRegionAnnouncement(a11yLabelThatChangesOverTime, true);
return (
	<InteractiveComponentWithAnnoucements
		accessibilityRole="button"
		onPress={() => {}}
		{...a11yProps}
	/>
)
```

or

```tsx
return (
	<LiveRegionWrapper accessibilityLabel={a11yLabelThatChangesOverTime}>
		<NonInteractiveComponent />
	</LiveRegionWrapper>
)
```

closes https://github.com/AtB-AS/kundevendt/issues/19525