### PR TITLE
fix: announce travel aid cancellation messages

### DIFF
--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -202,7 +202,7 @@ const TravelAidSection = ({
             situationsForFocused.length > 0 ||
             noticesForFocused.length > 0) && (
             <View style={styles.subContainer}>
-              {isCancelled && <CancelledDepartureMessage />}
+              {isCancelled && <CancelledDepartureMessage a11yAnnounce={true} />}
 
               {situationsForFocused.map((situation) => (
                 <SituationMessageBox

--- a/src/travel-details-screens/components/CancelledDepartureMessage.tsx
+++ b/src/travel-details-screens/components/CancelledDepartureMessage.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import {StyleSheet} from '@atb/theme';
 import {CancelledDepartureTexts, useTranslation} from '@atb/translations';
 
-export const CancelledDepartureMessage = () => {
+export const CancelledDepartureMessage = ({
+  a11yAnnounce,
+}: {
+  a11yAnnounce?: boolean;
+}) => {
   const styles = useStopsStyle();
   const {t} = useTranslation();
 
@@ -12,6 +16,7 @@ export const CancelledDepartureMessage = () => {
       type="error"
       style={styles.cancellationContainer}
       message={t(CancelledDepartureTexts.message)}
+      a11yAnnounce={a11yAnnounce}
     />
   );
 };


### PR DESCRIPTION
Observation from @tormoseng: Cancellation messages were not announced.

closes https://github.com/AtB-AS/kundevendt/issues/19525