### PR TITLE
feat: make delay in LoadingScreenBoundary configurable

### DIFF
--- a/src/loading-screen/LoadingScreenBoundary.tsx
+++ b/src/loading-screen/LoadingScreenBoundary.tsx
@@ -18,8 +18,8 @@ export const LoadingScreenBoundary = ({
   const {status, retry, paramsRef} = useLoadingState(LOADING_TIMEOUT_MS);
   useNotifyBugsnagOnTimeoutStatus(status, paramsRef);
 
-  // Wait one second after load success to let the app "settle".
-  const waitFinished = useDelayGate(1000, status === 'success');
+  // Wait 200ms after load success to let the app "settle".
+  const waitFinished = useDelayGate(200, status === 'success');
 
   if (!isLoadingScreenEnabled) return children;
 

--- a/src/loading-screen/LoadingScreenBoundary.tsx
+++ b/src/loading-screen/LoadingScreenBoundary.tsx
@@ -5,6 +5,7 @@ import {useDelayGate} from '@atb/utils/use-delay-gate';
 import {useLoadingState} from '@atb/loading-screen/use-loading-state';
 import {useNotifyBugsnagOnTimeoutStatus} from '@atb/loading-screen/use-notify-bugsnag-on-timeout-status';
 import {useFeatureToggles} from '@atb/feature-toggles';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 const LOADING_TIMEOUT_MS = 10000;
 
@@ -15,11 +16,15 @@ export const LoadingScreenBoundary = ({
 }): JSX.Element => {
   const {isLoadingScreenEnabled, isLoadingErrorScreenEnabled} =
     useFeatureToggles();
+  const {loading_screen_delay_ms} = useRemoteConfig();
   const {status, retry, paramsRef} = useLoadingState(LOADING_TIMEOUT_MS);
   useNotifyBugsnagOnTimeoutStatus(status, paramsRef);
 
-  // Wait 200ms after load success to let the app "settle".
-  const waitFinished = useDelayGate(200, status === 'success');
+  // Wait after load success to let the app "settle".
+  const waitFinished = useDelayGate(
+    loading_screen_delay_ms,
+    status === 'success',
+  );
 
   if (!isLoadingScreenEnabled) return children;
 

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -55,6 +55,7 @@ export type RemoteConfig = {
   flex_booking_number_of_days_available: number;
   flex_ticket_url: string;
   live_vehicle_stale_threshold: number;
+  loading_screen_delay_ms: number;
   minimum_app_version: string;
   must_upgrade_ticketing: boolean;
   new_favourites_info_url: string;
@@ -125,6 +126,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   flex_booking_number_of_days_available: 7,
   flex_ticket_url: '',
   live_vehicle_stale_threshold: 15,
+  loading_screen_delay_ms: 200,
   minimum_app_version: '',
   must_upgrade_ticketing: false,
   new_favourites_info_url: '',
@@ -283,6 +285,9 @@ export function getConfig(): RemoteConfig {
   const live_vehicle_stale_threshold =
     values['live_vehicle_stale_threshold']?.asNumber() ??
     defaultRemoteConfig.live_vehicle_stale_threshold;
+  const loading_screen_delay_ms =
+    values['loading_screen_delay_ms']?.asNumber() ??
+    defaultRemoteConfig.loading_screen_delay_ms;
   const minimum_app_version =
     values['minimum_app_version']?.asString() ??
     defaultRemoteConfig.minimum_app_version;
@@ -377,6 +382,7 @@ export function getConfig(): RemoteConfig {
     flex_booking_number_of_days_available,
     flex_ticket_url,
     live_vehicle_stale_threshold,
+    loading_screen_delay_ms,
     minimum_app_version,
     must_upgrade_ticketing,
     new_favourites_info_url,


### PR DESCRIPTION
Requesting some feedback on a change I want to make, since it's been bugging me for a while 😄

The app currently has a 1s timeout on every cold start, _after_ the initial data is loaded (Firestore config, auth, etc.). This was done as an additional safety measure to prevent the "app freeze" a while back. At that point, the initial render of the app could be very demanding, since several contexts updated data globally, and caused several renders of the entire layout tree. It was probably due to some `setInterval` calls with a never ending update queue that caused the freeze to never stop, which was fixed by the addition of the `useInterval` hook.

But, as far as I know, we have no reason to believe that the 1s delay is necessary today, since no users with slow phones are complaining about the app being slow on boot.

The effect of this is (in my opinion) that the app feels heavy on launch, even on modern phones that usually have <100ms start times for apps. 1s boot is long enough that it feels like something is wrong / not loading correctly. If we reduce it to 200ms, we _might_ see some slowness on boot on the first render for very slow phones, but in return, we won't make app launch slow for everyone.

Maybe now isn't the right time to change it, and maybe 200ms isn't the correct value (maybe it could be less!), but it would be nice to discuss if there's any arguments to keep or change the current delay.

### Acceptance criteria

- [ ] The app loads much faster 🚀 
- [ ] The `loading_screen_delay_ms` remote config flags configures how long the loading screen (gray screen with spinner), stays after inital data is loaded.
- [ ] No app freeze on slow android phones 🥶 