### PR TITLE
fix: Allow update certs to rebundle the app with cache on

### DIFF
--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "The ruby version to use"
     default: "2.7.6"
     required: false
+  keychain-name:
+    description: "The keychain name where the keys are going to be stored"
+    default: "CI"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -56,3 +60,4 @@ runs:
           APPCONNECT_API_KEY_PATH: app-store-connect-api-key.json
           FASTLANE_MATCH_TYPE: ${{ inputs.app-environment }}
           MATCH_DEPLOY_KEY: ${{ inputs.match-deploy-key }}
+          KEYCHAIN_NAME: ${{ inputs.keychain_name }}

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Remove use of beacons
         if: ${{ env.KETTLE_API_KEY == '' }}
         run: bundle exec fastlane ios remove_use_of_beacons
+      - name: Run fastlane cert match
+        if: inputs.force-build == 'false'
+        run: bundle exec fastlane ios get_certs
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       - name: Run fastlane build
         if: inputs.force-build == 'true' || steps.ipa-cache.outputs.cache-hit != 'true'
         run: bundle exec fastlane ios build
@@ -87,10 +92,6 @@ jobs:
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 1
           EXPORT_METHOD: 'ad-hoc'
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-      - name: Run fastlane cert match
-        run: bundle exec fastlane ios get_certs
-        env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       - name: Replace ipa bundle
         if: inputs.force-build == 'false' || steps.ipa-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -25,6 +25,8 @@ jobs:
     environment: ${{ matrix.org }}
     timeout-minutes: 360
     runs-on: macOS-13
+    env:
+      KEYCHAIN_NAME: "CI"
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
@@ -82,6 +84,7 @@ jobs:
         run: bundle exec fastlane ios get_certs
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          KEYCHAIN_NAME: ${{ env.KEYCHAIN_NAME }}
       - name: Run fastlane build
         if: inputs.force-build == 'true' || steps.ipa-cache.outputs.cache-hit != 'true'
         run: bundle exec fastlane ios build
@@ -93,12 +96,15 @@ jobs:
           EXPORT_METHOD: 'ad-hoc'
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          KEYCHAIN_NAME: ${{ env.KEYCHAIN_NAME }}
       - name: Replace ipa bundle
         if: inputs.force-build == 'false' || steps.ipa-cache.outputs.cache-hit == 'true'
         run: sh ./scripts/ios/replace-bundle.sh
         env:
           IPA_FILE_NAME: 'AtB.ipa'
           APP_NAME: 'AtB.app'
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          KEYCHAIN_NAME: ${{ env.KEYCHAIN_NAME }}
       - name: Distribute to Firebase App Distribution
         if: matrix.org != 'atb'
         run: |

--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -89,7 +89,6 @@ jobs:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       - name: Run fastlane cert match
-        if: inputs.force-build == 'false' || steps.ipa-cache.outputs.cache-hit == 'true'
         run: bundle exec fastlane ios get_certs
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -187,9 +187,6 @@ platform :ios do
       keychain_path = lane_context[SharedValues::KEYCHAIN_PATH]
       keychain_file_path = "#{keychain_path}-db"
 
-      # Update Apple WWDR Certificate using the keychain path
-      download_and_install_wwdr_cert(keychain: keychain_file_path, keychain_name: keychain_name)
-
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],
         app_identifier: identifiers,
@@ -200,6 +197,8 @@ platform :ios do
         keychain_password: ENV["MATCH_PASSWORD"],
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )
+
+      verify_installed_certificates(keychain: keychain_file_path)
     else
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],
@@ -222,42 +221,12 @@ platform :ios do
     )
   end
 
-  private_lane :download_and_install_wwdr_cert do |options|
-    require 'open-uri'
-
-    keychain_path = options[:keychain] || "/Library/Keychains/System.keychain"
-    keychain_name = options[:keychain_name] || "CI"
-    wwdr_cert_url = "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer"
-    cert_file_path = File.join(Dir.tmpdir, "AppleWWDRCAG3.cer")
-
-    unlock_keychain(
-      path: keychain_path,
-      password: ENV['MATCH_PASSWORD']
-    )
-
-    UI.message("Downloading the latest Apple WWDR Certificate...")
-    File.write(cert_file_path, URI.open(wwdr_cert_url).read)
-
-    UI.message("Installing the Apple WWDR Certificate into #{keychain_path}...")
-    import_certificate(
-      certificate_path: cert_file_path,
-      keychain_name: keychain_name,
-      keychain_password: ENV['MATCH_PASSWORD'],
-      log_output: true
-    )
-
-    UI.message("Cleaning up temporary files...")
-    File.delete(cert_file_path)
-
-    verify_installed_certificates(keychain: keychain_path)
-  end
-
   lane :verify_installed_certificates do |options|
     keychain_path = options[:keychain] || File.expand_path("/Library/Keychains/System.keychain")
-  
+
     UI.message("Listing installed certificates in #{keychain_path}...")
     installed_certs = `security find-certificate -c "Apple Worldwide Developer Relations Certification Authority" -a -Z #{keychain_path}`
-    
+
     if installed_certs.empty?
       UI.user_error!("WWDR Certificate is missing in #{keychain_path}.")
     else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,11 +185,12 @@ platform :ios do
 
       # Retrieve the keychain path from lane_context
       keychain_path = lane_context[SharedValues::KEYCHAIN_PATH]
+      keychain_file_path = "#{keychain_path}-db"
         
-      sh "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{ENV['MATCH_PASSWORD']} #{keychain_path}"
+      sh "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{ENV['MATCH_PASSWORD']} #{keychain_file_path}"
 
       # Update Apple WWDR Certificate using the keychain path
-      download_and_install_wwdr_cert(keychain: keychain_path, keychain_name: keychain_name)
+      download_and_install_wwdr_cert(keychain: keychain_file_path, keychain_name: keychain_name)
 
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],
@@ -202,7 +203,7 @@ platform :ios do
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )
 
-      sh "security find-identity -v -p codesigning #{keychain_path}"
+      sh "security find-identity -v -p codesigning #{keychain_file_path}"
     else
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -172,8 +172,10 @@ platform :ios do
     )
     identifiers = [ENV['IOS_BUNDLE_IDENTIFIER'], ENV['IOS_APP_WIDGET_IDENTIFIER'], ENV['IOS_APP_INTENT_IDENTIFIER']]
     if is_ci
+      keychain_name = "CI"
+
       create_keychain(
-        name: "CI",
+        name: keychain_name,
         password: ENV["MATCH_PASSWORD"],
         default_keychain: true,
         unlock: true,
@@ -185,7 +187,7 @@ platform :ios do
       keychain_path = lane_context[SharedValues::KEYCHAIN_PATH]
 
       # Update Apple WWDR Certificate using the keychain path
-      download_and_install_wwdr_cert(keychain: keychain_path)
+      download_and_install_wwdr_cert(keychain: keychain_path, keychain_name: keychain_name)
 
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],
@@ -223,6 +225,7 @@ platform :ios do
     require 'open-uri'
 
     keychain_path = options[:keychain] || "/Library/Keychains/System.keychain"
+    keychain_name = options[:keychain_name] || "CI"
     wwdr_cert_url = "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer"
     cert_file_path = File.join(Dir.tmpdir, "AppleWWDRCAG3.cer")
 
@@ -237,8 +240,9 @@ platform :ios do
     UI.message("Installing the Apple WWDR Certificate into #{keychain_path}...")
     import_certificate(
       certificate_path: cert_file_path,
-      keychain_name: keychain_path,
-      keychain_password: ENV['MATCH_PASSWORD']
+      keychain_name: keychain_name,
+      keychain_password: ENV['MATCH_PASSWORD'],
+      log_output: true
     )
 
     UI.message("Cleaning up temporary files...")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,6 +185,8 @@ platform :ios do
 
       # Retrieve the keychain path from lane_context
       keychain_path = lane_context[SharedValues::KEYCHAIN_PATH]
+        
+      sh "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{ENV['MATCH_PASSWORD']} #{keychain_path}"
 
       # Update Apple WWDR Certificate using the keychain path
       download_and_install_wwdr_cert(keychain: keychain_path, keychain_name: keychain_name)
@@ -195,10 +197,12 @@ platform :ios do
         storage_mode: 'git',
         git_url: ENV['FASTLANE_MATCH_GIT_SSH_URL'],
         readonly: true,
-        keychain_name: "CI",
+        keychain_name: keychain_name,
         keychain_password: ENV["MATCH_PASSWORD"],
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )
+
+      sh "security find-identity -v -p codesigning #{keychain_path}"
     else
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,7 @@ platform :ios do
         'FASTLANE_MATCH_TYPE',
         'MATCH_DEPLOY_KEY',
         'APPCONNECT_API_KEY_PATH',
+        'KEYCHAIN_NAME'
       ]
     )
     register_devices(
@@ -57,6 +58,7 @@ platform :ios do
       api_key_path: ENV['APPCONNECT_API_KEY_PATH'],
     )
     identifiers = [ENV['IOS_BUNDLE_IDENTIFIER'], ENV['IOS_APP_WIDGET_IDENTIFIER'], ENV['IOS_APP_INTENT_IDENTIFIER']]
+    keychain_name = ENV['KEYCHAIN_NAME']
     puts "Provisioning profiles for #{identifiers}"
     match(
       type: ENV["FASTLANE_MATCH_TYPE"],
@@ -66,6 +68,7 @@ platform :ios do
       app_identifier: identifiers,
       force_for_new_devices: true,
       force: true,
+      keychain_name: keychain_name,
       git_full_name: ENV['FASTLANE_MATCH_FULL_NAME'],
       git_user_email: ENV['FASTLANE_MATCH_EMAIL'],
       git_private_key: ENV['MATCH_DEPLOY_KEY'],
@@ -132,9 +135,18 @@ platform :ios do
   desc "Generate new certificates"
   lane :generate_new_certificates do
     ensure_env_vars(
-      env_vars: ['IOS_DEVELOPMENT_TEAM_ID', 'IOS_BUNDLE_IDENTIFIER', 'IOS_APP_WIDGET_IDENTIFIER', 'IOS_APP_INTENT_IDENTIFIER', 'FASTLANE_MATCH_GIT_URL', 'FASTLANE_MATCH_TYPE']
+      env_vars: [
+        'IOS_DEVELOPMENT_TEAM_ID',
+        'IOS_BUNDLE_IDENTIFIER',
+        'IOS_APP_WIDGET_IDENTIFIER',
+        'IOS_APP_INTENT_IDENTIFIER',
+        'FASTLANE_MATCH_GIT_URL',
+        'FASTLANE_MATCH_TYPE',
+        'KEYCHAIN_NAME'
+      ]
     )
     identifiers = [ENV['IOS_BUNDLE_IDENTIFIER'], ENV['IOS_APP_WIDGET_IDENTIFIER'], ENV['IOS_APP_INTENT_IDENTIFIER']]
+    keychain_name = ENV['KEYCHAIN_NAME']
     match_nuke(
       readonly: false,
       team_id: ENV['IOS_DEVELOPMENT_TEAM_ID'],
@@ -142,6 +154,7 @@ platform :ios do
       git_url:ENV['FASTLANE_MATCH_GIT_URL'],
       type:ENV['FASTLANE_MATCH_TYPE'],
       skip_confirmation: true,
+      keychain_name: keychain_name,
       include_all_certificates: true
     )
     get_certs
@@ -150,9 +163,19 @@ platform :ios do
   desc 'Generate new certificates without nuking old ones'
   lane :generate_new_certificates_without_nuke do
     ensure_env_vars(
-      env_vars: ['MATCH_PASSWORD', 'FASTLANE_MATCH_GIT_SSH_URL', 'FASTLANE_MATCH_TYPE', 'IOS_BUNDLE_IDENTIFIER', 'IOS_APP_WIDGET_IDENTIFIER', 'IOS_APP_INTENT_IDENTIFIER', 'IOS_DEVELOPMENT_TEAM_ID']
+      env_vars: [
+        'MATCH_PASSWORD',
+        'FASTLANE_MATCH_GIT_SSH_URL',
+        'FASTLANE_MATCH_TYPE',
+        'IOS_BUNDLE_IDENTIFIER',
+        'IOS_APP_WIDGET_IDENTIFIER',
+        'IOS_APP_INTENT_IDENTIFIER',
+        'IOS_DEVELOPMENT_TEAM_ID',
+        'KEYCHAIN_NAME'
+      ]
     )
     identifiers = [ENV['IOS_BUNDLE_IDENTIFIER'], ENV['IOS_APP_WIDGET_IDENTIFIER'], ENV['IOS_APP_INTENT_IDENTIFIER']]
+    keychain_name = ENV['KEYCHAIN_NAME']
     match(
       type: ENV["FASTLANE_MATCH_TYPE"],
       app_identifier: identifiers,
@@ -161,6 +184,7 @@ platform :ios do
       team_id: ENV['IOS_DEVELOPMENT_TEAM_ID'],
       readonly: false,
       force: true,
+      keychain_name: keychain_name,
       include_all_certificates: true
     )
   end
@@ -168,11 +192,20 @@ platform :ios do
   desc 'Match certificates'
   lane :get_certs do
     ensure_env_vars(
-      env_vars: ['MATCH_PASSWORD', 'FASTLANE_MATCH_GIT_SSH_URL', 'FASTLANE_MATCH_TYPE', 'IOS_BUNDLE_IDENTIFIER', 'IOS_APP_WIDGET_IDENTIFIER', 'IOS_APP_INTENT_IDENTIFIER', 'IOS_DEVELOPMENT_TEAM_ID']
+      env_vars: [
+        'MATCH_PASSWORD',
+        'FASTLANE_MATCH_GIT_SSH_URL',
+        'FASTLANE_MATCH_TYPE',
+        'IOS_BUNDLE_IDENTIFIER',
+        'IOS_APP_WIDGET_IDENTIFIER',
+        'IOS_APP_INTENT_IDENTIFIER',
+        'IOS_DEVELOPMENT_TEAM_ID',
+        'KEYCHAIN_NAME'
+      ]
     )
     identifiers = [ENV['IOS_BUNDLE_IDENTIFIER'], ENV['IOS_APP_WIDGET_IDENTIFIER'], ENV['IOS_APP_INTENT_IDENTIFIER']]
     if is_ci
-      keychain_name = "CI"
+      keychain_name = ENV['KEYCHAIN_NAME']
 
       create_keychain(
         name: keychain_name,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -200,10 +200,6 @@ platform :ios do
         keychain_password: ENV["MATCH_PASSWORD"],
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )
-
-      sh "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{ENV['MATCH_PASSWORD']} #{keychain_file_path}"
-
-      sh "security find-identity -v -p codesigning #{keychain_file_path}"
     else
       match(
         type: ENV["FASTLANE_MATCH_TYPE"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -186,8 +186,6 @@ platform :ios do
       # Retrieve the keychain path from lane_context
       keychain_path = lane_context[SharedValues::KEYCHAIN_PATH]
       keychain_file_path = "#{keychain_path}-db"
-        
-      sh "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{ENV['MATCH_PASSWORD']} #{keychain_file_path}"
 
       # Update Apple WWDR Certificate using the keychain path
       download_and_install_wwdr_cert(keychain: keychain_file_path, keychain_name: keychain_name)
@@ -202,6 +200,8 @@ platform :ios do
         keychain_password: ENV["MATCH_PASSWORD"],
         team_id: ENV['IOS_DEVELOPMENT_TEAM_ID']
       )
+
+      sh "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{ENV['MATCH_PASSWORD']} #{keychain_file_path}"
 
       sh "security find-identity -v -p codesigning #{keychain_file_path}"
     else

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -12,7 +12,7 @@ if [[
     || -z "${KEYCHAIN_NAME}"
    ]]; then
     echo "Argument error!"
-    echo "Expected four env variables: 
+    echo "Expected 6 env variables: 
   - BUILD_ID
   - IPA_FILE_NAME
   - APP_NAME

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -45,7 +45,7 @@ else
     security default-keychain -s "$KEYCHAIN_PATH"
 
     echo "Generated entitlements file from ipa content"
-    codesign -d --entitlements entitlements.plist Payload/$APP_NAME
+    codesign -d --entitlements :- "Payload/$APP_NAME" > entitlements.plist
 
     echo "Re-sign new Payload"
     codesign -vvvv -f -s "$IOS_CODE_SIGN_IDENTITY" --entitlements entitlements.plist Payload/$APP_NAME/

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -8,13 +8,17 @@ if [[
     || -z "${APP_NAME}"
     || -z "${IOS_CODE_SIGN_IDENTITY}"
     || -z "${BUILD_ID}"
+    || -z "${MATCH_PASSWORD}"
+    || -z "${KEYCHAIN_NAME}"
    ]]; then
     echo "Argument error!"
     echo "Expected four env variables: 
   - BUILD_ID
   - IPA_FILE_NAME
   - APP_NAME
-  - IOS_CODE_SIGN_IDENTITY"
+  - IOS_CODE_SIGN_IDENTITY
+  - MATCH_PASSWORD
+  - KEYCHAIN_NAME"
     exit 1
 else 
     mkdir -p bundle
@@ -33,6 +37,11 @@ else
 
     echo "Set CFBundleVersion to build id: $BUILD_ID"
     plutil -replace CFBundleVersion -string "${BUILD_ID}" "Payload/$APP_NAME/Info.plist"
+
+    echo "Set up the correct keychain"
+    KEYCHAIN_PATH=~/Library/Keychains/$KEYCHAIN_NAME-db
+    security list-keychains -s "$KEYCHAIN_PATH"
+    security unlock-keychain -p "$MATCH_PASSWORD" "$KEYCHAIN_PATH"
 
     echo "Generated entitlements file from ipa content"
     codesign -d --entitlements :- "Payload/$APP_NAME" > entitlements.plist

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -45,7 +45,7 @@ else
     security default-keychain -s "$KEYCHAIN_PATH"
 
     echo "Generated entitlements file from ipa content"
-    codesign -d --entitlements :- "Payload/$APP_NAME" > entitlements.plist
+    codesign -d --entitlements entitlements.plist Payload/$APP_NAME
 
     echo "Re-sign new Payload"
     codesign -vvvv -f -s "$IOS_CODE_SIGN_IDENTITY" --entitlements entitlements.plist Payload/$APP_NAME/

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -54,5 +54,5 @@ else
     zip -qr $IPA_FILE_NAME Payload/
 
     echo "Check integrity"
-    codesign -dvvvv Payload/$IPA_FILE_NAME
+    codesign -dvvvv $IPA_FILE_NAME
 fi

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -54,5 +54,5 @@ else
     zip -qr $IPA_FILE_NAME Payload/
 
     echo "Check integrity"
-    codesign -dvvvv $IPA_FILE_NAME
+    codesign -dvvvv Payload/$APP_NAME/
 fi

--- a/scripts/ios/replace-bundle.sh
+++ b/scripts/ios/replace-bundle.sh
@@ -42,13 +42,17 @@ else
     KEYCHAIN_PATH=~/Library/Keychains/$KEYCHAIN_NAME-db
     security list-keychains -s "$KEYCHAIN_PATH"
     security unlock-keychain -p "$MATCH_PASSWORD" "$KEYCHAIN_PATH"
+    security default-keychain -s "$KEYCHAIN_PATH"
 
     echo "Generated entitlements file from ipa content"
     codesign -d --entitlements :- "Payload/$APP_NAME" > entitlements.plist
 
     echo "Re-sign new Payload"
-    codesign -f -s "$IOS_CODE_SIGN_IDENTITY" --entitlements entitlements.plist Payload/$APP_NAME/
+    codesign -vvvv -f -s "$IOS_CODE_SIGN_IDENTITY" --entitlements entitlements.plist Payload/$APP_NAME/
 
     echo "Generate new ipa"
     zip -qr $IPA_FILE_NAME Payload/
+
+    echo "Check integrity"
+    codesign -dvvvv Payload/$IPA_FILE_NAME
 fi


### PR DESCRIPTION
It allows the certs always to be updated, this avoids always forcing a cache to update the certs, which means those are going to be up to date.