### PR TITLE
feat: Remove use of NFC

### DIFF
--- a/ios/atb.xcodeproj/project.pbxproj
+++ b/ios/atb.xcodeproj/project.pbxproj
@@ -39,8 +39,8 @@
 		5038614A28FD6EB900E16E13 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038614928FD6EB900E16E13 /* APIService.swift */; };
 		5038614C28FD750A00E16E13 /* LocationChangeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038614B28FD750A00E16E13 /* LocationChangeManager.swift */; };
 		5038614E28FD81B700E16E13 /* Structs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038614D28FD81B700E16E13 /* Structs.swift */; };
-		503D2E5A29674028002E0A6A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		503D2E5C2967436E002E0A6A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		503D2E5A29674028002E0A6A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		503D2E5C2967436E002E0A6A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		50488981293F4B660016DD7A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 50488983293F4B660016DD7A /* Localizable.strings */; };
 		505D9ECE291537E500AEFF94 /* DepartureTimesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505D9ECD291537E500AEFF94 /* DepartureTimesView.swift */; };
 		506538E028FEA57400A0DDCC /* WidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506538DF28FEA57400A0DDCC /* WidgetViewModel.swift */; };
@@ -77,7 +77,6 @@
 		FEBDDCD3293107D500C3755B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE55264828EC45ED0091F697 /* WidgetKit.framework */; };
 		FEBDDCDB29310DFE00C3755B /* WidgetUpdaterBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBDDCDA29310DFE00C3755B /* WidgetUpdaterBridge.m */; };
 		FEBDDCDE2934D49700C3755B /* ChangeNativeBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = FEBDDCDD2934D49600C3755B /* ChangeNativeBridge.m */; };
-		FED22489286F06AC0049ECE3 /* CoreNFC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FED22488286F06AC0049ECE3 /* CoreNFC.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		FED3D5DF2968501400B7DEC4 /* NoFavoriteViewSmall.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED3D5DD2968501400B7DEC4 /* NoFavoriteViewSmall.swift */; };
 		FED3D5E02968501400B7DEC4 /* NoFavoriteViewMedium.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED3D5DE2968501400B7DEC4 /* NoFavoriteViewMedium.swift */; };
 		FEE4FE192AE6F08600E1821B /* BeaconsPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE4FE182AE6F08600E1821B /* BeaconsPermissions.swift */; };
@@ -160,7 +159,7 @@
 		6DB88AD82A7A33EE0060CC31 /* PassPresentationBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PassPresentationBridge.h; sourceTree = "<group>"; };
 		6DB88AD92A7A35A10060CC31 /* PassPresentationBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PassPresentationBridge.m; sourceTree = "<group>"; };
 		6DB88ADB2A7A55570060CC31 /* PassPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassPresentation.swift; sourceTree = "<group>"; };
-		80CBD2ACDD97450583702DEF /* Colors.xcassets */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = folder.assetcatalog; name = Colors.xcassets; path = atb/Colors.xcassets; sourceTree = "<group>"; };
+		80CBD2ACDD97450583702DEF /* Colors.xcassets */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = folder.assetcatalog; name = Colors.xcassets; path = atb/Colors.xcassets; sourceTree = "<group>"; };
 		B59E90F341F04DB2B427E0EF /* Roboto-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Bold.ttf"; path = "../assets/fonts/Roboto-Bold.ttf"; sourceTree = "<group>"; };
 		BB1D1B473A9C41A79687569C /* Roboto-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Regular.ttf"; path = "../assets/fonts/Roboto-Regular.ttf"; sourceTree = "<group>"; };
 		E4189C266DDC08015840EBAA /* Pods_app.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_app.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -204,7 +203,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				6DAA1D0A2A77D3EC00CC8016 /* PassKit.framework in Frameworks */,
-				FED22489286F06AC0049ECE3 /* CoreNFC.framework in Frameworks */,
 				FEBDDCD3293107D500C3755B /* WidgetKit.framework in Frameworks */,
 				A1B2EBBAED425D9A597C8294 /* Pods_app.framework in Frameworks */,
 			);
@@ -717,8 +715,8 @@
 				505D9ECE291537E500AEFF94 /* DepartureTimesView.swift in Sources */,
 				500752EC29855E4D00AC5A7F /* IntentHandler.swift in Sources */,
 				FE7DE4F5294A2EDC009BE6DB /* String.swift in Sources */,
-				503D2E5C2967436E002E0A6A /* BuildFile in Sources */,
-				503D2E5A29674028002E0A6A /* BuildFile in Sources */,
+				503D2E5C2967436E002E0A6A /* (null) in Sources */,
+				503D2E5A29674028002E0A6A /* (null) in Sources */,
 				5038614C28FD750A00E16E13 /* LocationChangeManager.swift in Sources */,
 				FE7E785F29433F3900C57A1F /* DefaultFonts.swift in Sources */,
 				FE55264E28EC45ED0091F697 /* DepartureWidget.swift in Sources */,

--- a/ios/atb/AtB.entitlements
+++ b/ios/atb/AtB.entitlements
@@ -6,10 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.nfc.readersession.formats</key>
-	<array>
-		<string>TAG</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_NAME)</string>

--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -65,8 +65,6 @@
 	<true/>
 	<key>MBXAccessToken</key>
 	<string>$(MAPBOX_PUBLIC_TOKEN)</string>
-	<key>NFCReaderUsageDescription</key>
-	<string>Vi må bruke NFC for sikkerhetsformål.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/ios/atb/atbDebug.entitlements
+++ b/ios/atb/atbDebug.entitlements
@@ -6,10 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.nfc.readersession.formats</key>
-	<array>
-		<string>TAG</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_NAME)</string>

--- a/patches/@entur-private+abt-token-state-react-native-lib+2.1.6.patch
+++ b/patches/@entur-private+abt-token-state-react-native-lib+2.1.6.patch
@@ -64,3 +64,34 @@ index a41752b..b558fda 100644
                          }
                          
                          if base64EncodedBarcode {
+diff --git a/node_modules/@entur-private/abt-token-state-react-native-lib/token-core-ios-lib/AbtTokenCoreSDK/device/NfcDeviceStatusEnricher.swift b/node_modules/@entur-private/abt-token-state-react-native-lib/token-core-ios-lib/AbtTokenCoreSDK/device/NfcDeviceStatusEnricher.swift
+index 45b327d..0fbf32c 100644
+--- a/node_modules/@entur-private/abt-token-state-react-native-lib/token-core-ios-lib/AbtTokenCoreSDK/device/NfcDeviceStatusEnricher.swift
++++ b/node_modules/@entur-private/abt-token-state-react-native-lib/token-core-ios-lib/AbtTokenCoreSDK/device/NfcDeviceStatusEnricher.swift
+@@ -1,6 +1,6 @@
+-#if canImport(CoreNFC)
+-    import CoreNFC
+-#endif
++// #if canImport(CoreNFC)
++//     import CoreNFC
++// #endif
+ 
+ import Foundation
+ import AbtProtobufTokenIosStubs
+@@ -11,10 +11,11 @@ public class NfcDeviceStatusEnricher: DeviceStatusEnricher {
+     }
+     
+     public func enrich(_ list: inout [AbtProtobufTokenIosStubs.No_Entur_Abt_Core_V1_DeviceStatus]) {
+-        #if canImport(CoreNFC)
+-            list.append(No_Entur_Abt_Core_V1_DeviceStatus.nfcNoPermission)
+-        #else
+-            list.append(No_Entur_Abt_Core_V1_DeviceStatus.nfcUnsupportedOnDevice)
+-        #endif
++        // #if canImport(CoreNFC)
++        //     list.append(No_Entur_Abt_Core_V1_DeviceStatus.nfcNoPermission)
++        // #else
++        //     list.append(No_Entur_Abt_Core_V1_DeviceStatus.nfcUnsupportedOnDevice)
++        // #endif
++        list.append(No_Entur_Abt_Core_V1_DeviceStatus.nfcDisabled)
+     }
+ }


### PR DESCRIPTION
After the message we got from Apple rejecting the app because use of NFC, this PR removes the usage of it on the code and creates a patch towards Entur MobileTokenSDK.