### PR TITLE
feat: Not available ticket text improvement

### DIFF
--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -23,7 +23,7 @@ const PurchaseOverviewTexts = {
         _(
           `${productName} er ikke gyldig på dette tidspunktet`,
           `${productName} is not valid at this time`,
-          `${productName}  er ikkje gyldig på dette tidspunktet`,
+          `${productName} er ikkje gyldig på dette tidspunktet`,
         ),
       message: _(
         `Du må velge en annen billett fra billettoversikten.`,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -21,9 +21,9 @@ const PurchaseOverviewTexts = {
     productUnavailable: {
       title: (productName: string) =>
         _(
-          `${productName} er ikke gyldig nå`,
-          `${productName} is not valid now`,
-          `${productName} er ikkje gyldig no`,
+          `${productName} er ikke gyldig på dette tidspunktet`,
+          `${productName} is not valid at this time`,
+          `${productName}  er ikkje gyldig på dette tidspunktet`,
         ),
       message: _(
         `Du må velge en annen billett fra billettoversikten.`,


### PR DESCRIPTION
Requested by Mr. PO himself!

### Acceptance criteria
- [ ] Text on not available message (for example when trying to purchase night ticket at day) is: "<product-navn> er ikke gyldig på dette tidspunktet".
- [ ] Figma is in sync with the text change