### PR TITLE
fix: Only enable get active booking when feature flag true

### DIFF
--- a/src/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/mobility/queries/use-active-shmo-booking-query.tsx
@@ -2,6 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 import {getActiveShmoBooking} from '@atb/api/mobility';
 import {ONE_MINUTE_MS} from '@atb/utils/durations.ts';
 import {useAcceptLanguage} from '@atb/api/use-accept-language';
+import {useFeatureToggles} from '@atb/feature-toggles';
 
 export const getActiveShmoBookingQueryKey = (acceptLanguage: string) => [
   'GET_ACTIVE_SHMO_BOOKING_QUERY_KEY',
@@ -10,7 +11,9 @@ export const getActiveShmoBookingQueryKey = (acceptLanguage: string) => [
 
 export const useActiveShmoBookingQuery = () => {
   const acceptLanguage = useAcceptLanguage();
+  const {isShmoDeepIntegrationEnabled} = useFeatureToggles();
   return useQuery({
+    enabled: isShmoDeepIntegrationEnabled,
     queryKey: getActiveShmoBookingQueryKey(acceptLanguage),
     queryFn: ({signal}) => getActiveShmoBooking(acceptLanguage, {signal}),
     staleTime: ONE_MINUTE_MS,


### PR DESCRIPTION
The call to get active shmo booking shouldn't be sent unless the feature flag is enabled.