### PR TITLE
chore: Use PreassignedFareProduct id type directly

### DIFF
--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -3,8 +3,6 @@ export * from '@atb-as/config-specs/lib/mobility-operators';
 
 export type FirestoreConfigStatus = 'loading' | 'success';
 
-export type PreassignedFareProductId = string;
-
 export type PointToPointValidity = {
   fromPlace: string;
   toPlace: string;

--- a/src/mobility/api/api.ts
+++ b/src/mobility/api/api.ts
@@ -2,7 +2,7 @@ import {client} from '@atb/api';
 import {OperatorBenefitId} from '@atb-as/config-specs/lib/mobility-operators';
 import {getAxiosErrorMetadata} from '@atb/api/utils';
 import {z} from 'zod';
-import {PreassignedFareProductId} from '@atb/configuration/types';
+import {PreassignedFareProduct} from '@atb/configuration/types';
 
 const UserBenefits = z
   .object({
@@ -53,7 +53,7 @@ const FareProductBenefitMapping = z.object({
 type FareProductBenefitMappingType = z.infer<typeof FareProductBenefitMapping>;
 
 export const getFareProductBenefits = (
-  productId: PreassignedFareProductId,
+  productId: PreassignedFareProduct['id'],
 ): Promise<FareProductBenefitMappingType[]> => {
   return client
     .get(`/mobility/v1/benefits/${productId}`, {

--- a/src/mobility/queries/use-fare-product-benefits-query.tsx
+++ b/src/mobility/queries/use-fare-product-benefits-query.tsx
@@ -1,11 +1,11 @@
 import {useQuery} from '@tanstack/react-query';
-import {PreassignedFareProductId} from '@atb/configuration/types';
+import {PreassignedFareProduct} from '@atb/configuration/types';
 import {getFareProductBenefits} from '@atb/mobility/api/api';
 import {useAuthState} from '@atb/auth';
 import {ONE_HOUR_MS} from '@atb/utils/durations.ts';
 
 export const useFareProductBenefitsQuery = (
-  productId: PreassignedFareProductId | undefined,
+  productId: PreassignedFareProduct['id'] | undefined,
 ) => {
   const {userId, authStatus} = useAuthState();
   return useQuery({

--- a/src/mobility/use-operator-benefits-for-fare-product.tsx
+++ b/src/mobility/use-operator-benefits-for-fare-product.tsx
@@ -1,4 +1,4 @@
-import {PreassignedFareProductId} from '@atb/configuration/types';
+import {PreassignedFareProduct} from '@atb/configuration/types';
 import {useFareProductBenefitsQuery} from '@atb/mobility/queries/use-fare-product-benefits-query';
 import {useOperators} from '@atb/mobility/use-operators';
 import {OperatorBenefitType} from '@atb-as/config-specs/lib/mobility-operators';
@@ -17,7 +17,7 @@ export type FareProductBenefitType = {
 } & OperatorBenefitType;
 
 export const useOperatorBenefitsForFareProduct = (
-  productId: PreassignedFareProductId | undefined,
+  productId: PreassignedFareProduct['id'] | undefined,
 ): {
   status: UseQueryResult['status'];
   benefits?: FareProductBenefitType[];


### PR DESCRIPTION
I noticed that `export type PreassignedFareProductId = string;` was used instead of getting the type from source.
This is fixed in this PR.