### PR TITLE
fix: Purchase builder products input from API

### DIFF
--- a/src/purchase-selection/use-purchase-selection-builder.ts
+++ b/src/purchase-selection/use-purchase-selection-builder.ts
@@ -5,6 +5,7 @@ import {getCurrentCoordinatesGlobal} from '@atb/GeolocationContext';
 import {usePreferences} from '@atb/preferences';
 import {useTicketingState} from '@atb/ticketing';
 import {APP_VERSION} from '@env';
+import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
 
 /**
  * Returns a purchase selection builder for creating or modifying a
@@ -19,16 +20,13 @@ import {APP_VERSION} from '@env';
  * should be invoked by user actions and not as a side effect of state change.
  */
 export const usePurchaseSelectionBuilder = () => {
-  const {
-    fareProductTypeConfigs,
-    userProfiles,
-    preassignedFareProducts,
-    tariffZones,
-  } = useFirestoreConfiguration();
+  const {fareProductTypeConfigs, userProfiles, tariffZones} =
+    useFirestoreConfiguration();
   const {
     preferences: {defaultUserTypeString},
   } = usePreferences();
   const {customerProfile} = useTicketingState();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
 
   const builderInput: PurchaseSelectionBuilderInput = {
     fareProductTypeConfigs,

--- a/src/ticketing/use-get-fare-products-query.tsx
+++ b/src/ticketing/use-get-fare-products-query.tsx
@@ -9,9 +9,11 @@ export const useGetFareProductsQuery = () => {
   const {userId, authStatus} = useAuthState();
   return useQuery({
     initialData: preassignedFareProducts,
+    initialDataUpdatedAt: 0,
     queryKey: ['getProducts', userId],
     queryFn: getFareProducts,
     cacheTime: ONE_HOUR_MS,
+    staleTime: ONE_HOUR_MS,
     enabled: authStatus === 'authenticated',
   });
 };


### PR DESCRIPTION
The fare products in the PurchaseSelectionBuilderInput needs to
come from the products API for HjemJobbHjem to work.

Added staleTime to not make the app query products API everytime
it tries to open the purchase flow. Also set initialDataUpdateAt: 0
so the products directly from Firestore is considered stale at
query mount.
