### PR TITLE
fix: make talkback ignore parent View on Profile RootScreen

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -99,7 +99,11 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
           rightButton: {type: 'chat'},
         }}
       >
-        <View testID="profileHomeScrollView" style={style.contentContainer}>
+        <View
+          testID="profileHomeScrollView"
+          importantForAccessibility="no"
+          style={style.contentContainer}
+        >
           <ContentHeading text={t(ProfileTexts.sections.account.heading)} />
           <Section>
             {authenticationType === 'phone' && (

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -353,11 +353,11 @@ const ProfileTexts = {
     ),
   },
   orgNumber: (orgNr: string) =>
-    _(`Org.nr: ${orgNr}`, `Org.nr: ${orgNr}`, `Org.nr: ${orgNr}`),
+    _(`Org.nr: ${orgNr}`, `Org.no: ${orgNr}`, `Org.nr: ${orgNr}`),
   orgNumberA11yLabel: (orgNr: string) =>
     _(
       `Organisasjonsnummer ${orgNr}`,
-      `Organization number ${orgNr}`,
+      `Organisation number ${orgNr}`,
       `Organisasjonsnummer ${orgNr}`,
     ),
 };


### PR DESCRIPTION
Today I learned that talkback treats Views with `testID`s as accessible, and in the case of the Profile RootScreen, makes the whole ScrollView one focus area. This can be prevented by setting `importantForAccessibility="no"`.

This PR fixes this for My Profile, and some translation feedback from https://github.com/AtB-AS/mittatb-app/pull/4845#discussion_r1858732624

closes https://github.com/AtB-AS/kundevendt/issues/19593