### PR TITLE
feat: add spellOut util function

### DIFF
--- a/src/loading-screen/LoadingErrorScreen.tsx
+++ b/src/loading-screen/LoadingErrorScreen.tsx
@@ -14,6 +14,7 @@ import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useAnalytics} from '@atb/analytics';
+import {spellOut} from '@atb/utils/accessibility';
 
 const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
 
@@ -49,7 +50,7 @@ export const LoadingErrorScreen = React.memo(({retry}: {retry: () => void}) => {
               type="body__secondary"
               accessibilityLabel={t(
                 LoadingScreenTexts.error.installId(
-                  localConfig.installId.split('').join(' '),
+                  spellOut(localConfig.installId),
                 ),
               )}
             >

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/ExistingRecipientsList.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/ExistingRecipientsList.tsx
@@ -14,6 +14,7 @@ import {screenReaderPause} from '@atb/components/text';
 import {useFetchOnBehalfOfAccountsQuery} from '@atb/on-behalf-of/queries/use-fetch-on-behalf-of-accounts-query.ts';
 import {OnBehalfOfAccountType} from '@atb/on-behalf-of/types.ts';
 import {formatPhoneNumber} from '@atb/utils/phone-number-utils.ts';
+import {spellOut} from '@atb/utils/accessibility';
 
 export const ExistingRecipientsList = ({
   state: {recipient},
@@ -99,9 +100,7 @@ export const ExistingRecipientsList = ({
           itemToText={(i) => i.name}
           itemToSubtext={(i) => formatPhoneNumber(i.phoneNumber)}
           itemToA11yLabel={(i) =>
-            i.name +
-            screenReaderPause +
-            i.phoneNumber.split('').join(screenReaderPause)
+            i.name + screenReaderPause + spellOut(i.phoneNumber)
           }
           keyExtractor={(i) => i.accountId}
           selected={recipient}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -537,13 +537,13 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   </>
                 }
                 copyContent={config.installId}
+                accessibilityLabel={t(
+                  ProfileTexts.installId.a11yLabel(config.installId),
+                )}
+                accessibilityHint={t(ProfileTexts.installId.a11yHint)}
               >
-                <ThemeText
-                  accessibilityHint={t(ProfileTexts.installId.a11yHint)}
-                  type="body__secondary"
-                  color="secondary"
-                >
-                  {t(ProfileTexts.installId.label)}: {config.installId}
+                <ThemeText type="body__secondary" color="secondary">
+                  {t(ProfileTexts.installId.label(config.installId))}
                 </ThemeText>
               </ClickableCopy>
             )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/components/ClickableCopy.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/components/ClickableCopy.tsx
@@ -1,17 +1,20 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import React, {PropsWithChildren, useState} from 'react';
-import {TouchableOpacity} from 'react-native';
+import {AccessibilityProps, TouchableOpacity} from 'react-native';
 
-type ClickableCopyProps = PropsWithChildren<{
-  duration?: number;
-  copyContent: string;
-  successElement: React.ReactNode;
-}>;
+type ClickableCopyProps = PropsWithChildren<
+  {
+    duration?: number;
+    copyContent: string;
+    successElement: React.ReactNode;
+  } & AccessibilityProps
+>;
 export function ClickableCopy({
   duration = 5000,
   children,
   copyContent,
   successElement,
+  ...props
 }: ClickableCopyProps) {
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -23,7 +26,7 @@ export function ClickableCopy({
   }
 
   return (
-    <TouchableOpacity disabled={isAnimating} onPress={setClipboard}>
+    <TouchableOpacity disabled={isAnimating} onPress={setClipboard} {...props}>
       {isAnimating ? successElement : children}
     </TouchableOpacity>
   );

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -1,3 +1,4 @@
+import {spellOut} from '@atb/utils/accessibility';
 import {translation as _} from '../commons';
 import {orgSpecificTranslations} from '../orgSpecificTranslations';
 
@@ -340,7 +341,9 @@ const ProfileTexts = {
     },
   },
   installId: {
-    label: _('ID', 'ID', 'ID'),
+    label: (id: string) => _(`ID: ${id}`, `ID: ${id}`, `ID: ${id}`),
+    a11yLabel: (id: string) =>
+      _(`ID: ${spellOut(id)}`, `ID: ${spellOut(id)}`, `ID: ${spellOut(id)}`),
     wasCopiedAlert: _(
       'ID ble kopiert!',
       'ID was copied to clipboard!',

--- a/src/translations/screens/subscreens/DeleteProfile.ts
+++ b/src/translations/screens/subscreens/DeleteProfile.ts
@@ -1,3 +1,4 @@
+import {spellOut} from '@atb/utils/accessibility';
 import {translation as _} from '../../commons';
 import {orgSpecificTranslations} from '../../orgSpecificTranslations';
 
@@ -13,21 +14,15 @@ const DeleteProfileTexts = {
   buttonA11ytext: (customerNumber: string | undefined) =>
     _(
       `Aktiver for å slette kundeprofil ${
-        customerNumber
-          ? 'med kundenummer ' + customerNumber?.split('').join(', ')
-          : ''
+        customerNumber ? 'med kundenummer ' + spellOut(customerNumber) : ''
       }`,
 
       `Activate to delete customer profile ${
-        customerNumber
-          ? 'with customer number ' + customerNumber?.split('').join(', ')
-          : ''
+        customerNumber ? 'with customer number ' + spellOut(customerNumber) : ''
       }`,
 
       `Aktiver for å slette kundeprofil ${
-        customerNumber
-          ? 'med kundenummer ' + customerNumber?.split('').join(', ')
-          : ''
+        customerNumber ? 'med kundenummer ' + spellOut(customerNumber) : ''
       }`,
     ),
   unableToDeleteWithFareContracts: _(
@@ -81,21 +76,17 @@ export default orgSpecificTranslations(DeleteProfileTexts, {
     buttonA11ytext: (customerNumber: string | undefined) =>
       _(
         `Aktiver for å slette brukeren ${
-          customerNumber
-            ? 'med kundenummer ' + customerNumber?.split('').join(', ')
-            : ''
+          customerNumber ? 'med kundenummer ' + spellOut(customerNumber) : ''
         }`,
 
         `Activate to delete user ${
           customerNumber
-            ? 'with customer number ' + customerNumber?.split('').join(', ')
+            ? 'with customer number ' + spellOut(customerNumber)
             : ''
         }`,
 
         `Aktiver for å slette brukaren ${
-          customerNumber
-            ? 'med kundenummer ' + customerNumber?.split('').join(', ')
-            : ''
+          customerNumber ? 'med kundenummer ' + spellOut(customerNumber) : ''
         }`,
       ),
     deleteConfirmation: {

--- a/src/utils/accessibility.ts
+++ b/src/utils/accessibility.ts
@@ -16,3 +16,14 @@ export const screenReaderHidden: AccessibilityProps = {
 export function numberToAccessibilityString(number: number): string {
   return [...(number + '')].join(' ');
 }
+
+/**
+ * Split each letter of a string with spaces. This is useful for screen readers
+ * to spell out each digit instead of a big number with thousands or millions,
+ * or IDs as letters instead of a trying to pronounce it as a word.
+ *
+ * @example spellOut("+47 123 41 234") -> "+ 4 7 1 2 3 4 1 2 3 4"
+ */
+export function spellOut(s: string): string {
+  return s.replaceAll(' ', '').split('').join(' ');
+}


### PR DESCRIPTION
Adds a `spellOut` util to be used with strings like phone numbers and IDs, and puts it to use wherever I found functionality in the app. 

Also improves accessibility of the `ClickableCopy` component.

closes https://github.com/AtB-AS/kundevendt/issues/19593

### Acceptance criteria

Numbers/IDs are read out one digit/letter at a time in

- [ ] Phone number on existing recipients list (on behalf of)
- [ ] Install ID on My Profile
- [ ] Customer number on delete profile page