### PR TITLE
feat: add onCloseFocusRef param to bottom sheet open()

### DIFF
--- a/src/chat/use-chat-icon.tsx
+++ b/src/chat/use-chat-icon.tsx
@@ -1,7 +1,7 @@
 import {IconButtonProps} from '@atb/components/screen-header';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet, useTheme} from '@atb/theme';
-import React from 'react';
+import React, {RefObject, useRef} from 'react';
 import {View} from 'react-native';
 import {useChatUnreadCount} from './use-chat-unread-count';
 import {ContrastColor} from '@atb/theme/colors';
@@ -23,15 +23,19 @@ export const useChatIcon = (
   const {open: openBottomSheet} = useBottomSheet();
   const {t} = useTranslation();
   const navigation = useNavigation<RootNavigationProps>();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const openContactSheet = () => {
-    openBottomSheet(() => (
-      <ContactSheet
-        onReportParkingViolation={() =>
-          navigation.navigate('Root_ParkingViolationsSelectScreen')
-        }
-      />
-    ));
+    openBottomSheet(
+      () => (
+        <ContactSheet
+          onReportParkingViolation={() =>
+            navigation.navigate('Root_ParkingViolationsSelectScreen')
+          }
+        />
+      ),
+      onCloseFocusRef,
+    );
   };
 
   return {
@@ -53,6 +57,7 @@ export const useChatIcon = (
     ),
     accessibilityHint: t(ScreenHeaderTexts.headerButton.chat.a11yHint),
     onPress: () => openContactSheet(),
+    focusRef: onCloseFocusRef,
   };
 };
 

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -27,9 +27,9 @@ type BottomSheetContentFunction = () => ReactNode;
 type BottomSheetState = {
   open: (
     contentFunction: BottomSheetContentFunction,
-    useBackdrop?: boolean,
     /** Ref to component which should be focused on sheet close */
-    onCloseFocusRef?: RefObject<any>,
+    onCloseFocusRef: RefObject<any>,
+    useBackdrop?: boolean,
   ) => void;
   isOpen: () => boolean;
   close: () => void;
@@ -77,8 +77,8 @@ export const BottomSheetProvider: React.FC = ({children}) => {
 
   const open = (
     contentFunction: () => ReactNode,
+    onCloseFocusRef: RefObject<any>,
     useBackdrop: boolean = true,
-    onCloseFocusRef?: RefObject<any>,
   ) => {
     setContentFunction(() => contentFunction);
     setBackdropEnabled(useBackdrop);

--- a/src/components/camera/Camera.tsx
+++ b/src/components/camera/Camera.tsx
@@ -1,6 +1,6 @@
 import {StyleSheet, useTheme} from '@atb/theme';
 import {hasProp} from '@atb/utils/object';
-import {useRef} from 'react';
+import {RefObject, useRef} from 'react';
 import {Linking, StyleProp, View, ViewStyle} from 'react-native';
 import {Camera as CameraKitCamera, CameraType} from 'react-native-camera-kit';
 import {Processing} from '../loading';
@@ -23,9 +23,16 @@ type QrProps = {
 type Props = {
   style?: StyleProp<ViewStyle>;
   zoom?: number;
+  focusRef?: RefObject<any>;
 } & (PhotoProps | QrProps);
 
-export const Camera = ({style = {}, zoom = 1, mode, onCapture}: Props) => {
+export const Camera = ({
+  style = {},
+  zoom = 1,
+  mode,
+  onCapture,
+  focusRef,
+}: Props) => {
   const camera = useRef<CameraKitCamera>(null);
   const styles = useStyles();
   const {isAuthorized} = usePermissions();
@@ -85,6 +92,7 @@ export const Camera = ({style = {}, zoom = 1, mode, onCapture}: Props) => {
           <CaptureButton
             style={styles.captureButton}
             onCapture={handleCapture}
+            focusRef={focusRef}
           />
         )}
       </View>

--- a/src/components/camera/CaptureButton.tsx
+++ b/src/components/camera/CaptureButton.tsx
@@ -1,4 +1,5 @@
 import {StyleSheet} from '@atb/theme';
+import {RefObject} from 'react';
 import {StyleProp, TouchableOpacity, View, ViewStyle} from 'react-native';
 
 type Props = {
@@ -6,6 +7,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   size?: number;
   color?: string;
+  focusRef?: RefObject<any>;
 };
 
 export const CaptureButton = ({
@@ -13,11 +15,12 @@ export const CaptureButton = ({
   onCapture,
   size,
   color,
+  focusRef,
 }: Props) => {
   const style = useStyles({size, color})();
   return (
     <View style={containerStyle}>
-      <TouchableOpacity onPress={onCapture} style={style.button}>
+      <TouchableOpacity onPress={onCapture} style={style.button} ref={focusRef}>
         <View style={style.innerButton} />
       </TouchableOpacity>
     </View>

--- a/src/components/map/hooks/use-auto-select-map-item.tsx
+++ b/src/components/map/hooks/use-auto-select-map-item.tsx
@@ -2,7 +2,7 @@ import {VehicleExtendedFragment} from '@atb/api/types/generated/fragments/vehicl
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {AutoSelectableBottomSheetType, useMapState} from '@atb/MapContext';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
-import {useCallback, useEffect} from 'react';
+import {RefObject, useCallback, useEffect, useRef} from 'react';
 import {
   BikeStationBottomSheet,
   CarSharingStationBottomSheet,
@@ -33,6 +33,10 @@ export const useAutoSelectMapItem = (
   } = useMapState();
   const isFocused = useIsFocusedAndActive();
   const {open: openBottomSheet, close} = useBottomSheet();
+
+  // NOTE: This ref is not used for anything since the map doesn't support
+  // screen readers, but a ref is required when opening bottom sheets.
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const closeBottomSheet = useCallback(() => {
     close();
@@ -114,7 +118,7 @@ export const useAutoSelectMapItem = (
         }
 
         if (!!BottomSheetComponent) {
-          openBottomSheet(() => BottomSheetComponent, false);
+          openBottomSheet(() => BottomSheetComponent, onCloseFocusRef, false);
         }
         setBottomSheetCurrentlyAutoSelected(bottomSheetToAutoSelect);
         setBottomSheetToAutoSelect(undefined);

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -1,5 +1,11 @@
 import {MapFilterType, MapProps, MapSelectionActionType} from '../types';
-import React, {RefObject, useCallback, useEffect, useState} from 'react';
+import React, {
+  RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {useIsFocused, useNavigation} from '@react-navigation/native';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {DeparturesDialogSheet} from '../components/DeparturesDialogSheet';
@@ -43,6 +49,10 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
   const analytics = useMapSelectionAnalytics();
   const navigation = useNavigation<RootNavigationProps>();
 
+  // NOTE: This ref is not used for anything since the map doesn't support
+  // screen readers, but a ref is required when opening bottom sheets.
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
+
   const closeWithCallback = useCallback(() => {
     closeBottomSheet();
     closeCallback();
@@ -73,26 +83,32 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
       if (mapProps.selectionMode !== 'ExploreEntities') return;
 
       if (mapSelectionAction?.source === 'filters-button') {
-        openBottomSheet(() => (
-          <MapFilterSheet
-            onFilterChanged={(filter: MapFilterType) => {
-              analytics.logEvent('Map', 'Filter changed', {filter});
-              mapProps.vehicles?.onFilterChange(filter.mobility);
-              mapProps.stations?.onFilterChange(filter.mobility);
-            }}
-            onClose={closeCallback}
-          />
-        ));
+        openBottomSheet(
+          () => (
+            <MapFilterSheet
+              onFilterChanged={(filter: MapFilterType) => {
+                analytics.logEvent('Map', 'Filter changed', {filter});
+                mapProps.vehicles?.onFilterChange(filter.mobility);
+                mapProps.stations?.onFilterChange(filter.mobility);
+              }}
+              onClose={closeCallback}
+            />
+          ),
+          onCloseFocusRef,
+        );
         return;
       }
 
       if (mapSelectionAction?.source === 'external-map-button') {
-        openBottomSheet(() => (
-          <ExternalRealtimeMapSheet
-            onClose={closeCallback}
-            url={mapSelectionAction.url}
-          />
-        ));
+        openBottomSheet(
+          () => (
+            <ExternalRealtimeMapSheet
+              onClose={closeCallback}
+              url={mapSelectionAction.url}
+            />
+          ),
+          onCloseFocusRef,
+        );
         return;
       }
 
@@ -121,6 +137,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               }}
             />
           ),
+          onCloseFocusRef,
           false,
         );
       } else if (isBikeStation(selectedFeature)) {
@@ -132,6 +149,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               onClose={closeCallback}
             />
           ),
+          onCloseFocusRef,
           false,
         );
       } else if (isCarStation(selectedFeature)) {
@@ -143,44 +161,57 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
               onClose={closeCallback}
             />
           ),
+          onCloseFocusRef,
           false,
         );
       } else if (isScooter(selectedFeature)) {
-        openBottomSheet(() => {
-          return (
-            <ScooterSheet
-              vehicleId={selectedFeature.properties.id}
-              onClose={closeCallback}
-              onReportParkingViolation={onReportParkingViolation}
-            />
-          );
-        }, false);
+        openBottomSheet(
+          () => {
+            return (
+              <ScooterSheet
+                vehicleId={selectedFeature.properties.id}
+                onClose={closeCallback}
+                onReportParkingViolation={onReportParkingViolation}
+              />
+            );
+          },
+          onCloseFocusRef,
+          false,
+        );
       } else if (isBicycle(selectedFeature)) {
-        openBottomSheet(() => {
-          return (
-            <BicycleSheet
-              vehicleId={selectedFeature.properties.id}
-              onClose={closeCallback}
-            />
-          );
-        }, false);
+        openBottomSheet(
+          () => {
+            return (
+              <BicycleSheet
+                vehicleId={selectedFeature.properties.id}
+                onClose={closeCallback}
+              />
+            );
+          },
+          onCloseFocusRef,
+          false,
+        );
       } else if (isParkAndRide(selectedFeature)) {
-        openBottomSheet(() => {
-          return (
-            <ParkAndRideBottomSheet
-              name={selectedFeature.properties.name}
-              capacity={selectedFeature.properties.totalCapacity}
-              parkingFor={selectedFeature.properties.parkingVehicleTypes}
-              feature={selectedFeature}
-              distance={distance}
-              onClose={closeCallback}
-              navigateToTripSearch={(...params) => {
-                closeBottomSheet();
-                mapProps.navigateToTripSearch(...params);
-              }}
-            />
-          );
-        }, false);
+        openBottomSheet(
+          () => {
+            return (
+              <ParkAndRideBottomSheet
+                name={selectedFeature.properties.name}
+                capacity={selectedFeature.properties.totalCapacity}
+                parkingFor={selectedFeature.properties.parkingVehicleTypes}
+                feature={selectedFeature}
+                distance={distance}
+                onClose={closeCallback}
+                navigateToTripSearch={(...params) => {
+                  closeBottomSheet();
+                  mapProps.navigateToTripSearch(...params);
+                }}
+              />
+            );
+          },
+          onCloseFocusRef,
+          false,
+        );
       } else {
         closeBottomSheet();
       }

--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -41,6 +41,7 @@ export type MessageInfoBoxProps = {
   style?: StyleProp<ViewStyle>;
   onPressConfig?: OnPressConfig;
   a11yLiveRegion?: A11yLiveRegion;
+  focusRef?: React.Ref<any>;
   testID?: string;
 };
 export const MessageInfoBox = ({
@@ -53,6 +54,7 @@ export const MessageInfoBox = ({
   onPressConfig,
   onDismiss,
   a11yLiveRegion,
+  focusRef,
   testID,
 }: MessageInfoBoxProps) => {
   const {theme, themeName} = useTheme();
@@ -84,6 +86,7 @@ export const MessageInfoBox = ({
       style={[styles.container, style]}
       accessible={false}
       testID={testID}
+      focusRef={focusRef}
     >
       {!noStatusIcon && (
         <ThemeIcon

--- a/src/components/radio/RadioSegments.tsx
+++ b/src/components/radio/RadioSegments.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {RefObject} from 'react';
 import {InteractiveColor} from '@atb/theme/colors';
 import {View, ViewStyle, StyleProp} from 'react-native';
 import {StyleSheet, useTheme} from '@atb/theme';
@@ -12,6 +12,7 @@ export type SegmentOptions = {
   selected?: boolean;
   accessibilityHint?: string;
   accessibilityLabel?: string;
+  ref?: RefObject<any>;
 };
 
 type RadioSegmentsProps = {
@@ -63,6 +64,7 @@ export function RadioSegments({
             accessibilityState={{selected}}
             accessibilityLabel={getAccessibilityLabel(option)}
             accessibilityHint={option.accessibilityHint}
+            ref={option.ref}
             style={[
               styles.optionBox,
               {

--- a/src/components/screen-header/HeaderButton.tsx
+++ b/src/components/screen-header/HeaderButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {RefObject} from 'react';
 import {useChatIcon} from '@atb/chat/use-chat-icon';
 import {ScreenHeaderTexts, useTranslation} from '@atb/translations';
 import {insets} from '@atb/utils/insets';
@@ -36,6 +36,7 @@ export type HeaderButtonProps = {
    * pressed. If no context provided, then no analytics event will be logged.
    */
   analyticsEventContext?: AnalyticsEventContext;
+  focusRef?: RefObject<any>;
 } & AccessibilityProps;
 
 export type IconButtonProps = Omit<HeaderButtonProps, 'type' | 'withIcon'> & {
@@ -49,7 +50,7 @@ export const HeaderButton: React.FC<HeaderButtonProps> = (buttonProps) => {
     return null;
   }
 
-  const {onPress, children, ...accessibilityProps} = iconButton;
+  const {onPress, children, focusRef, ...accessibilityProps} = iconButton;
 
   const onPressWithLogEvent = () => {
     if (buttonProps.analyticsEventContext) {
@@ -66,6 +67,7 @@ export const HeaderButton: React.FC<HeaderButtonProps> = (buttonProps) => {
       onPress={onPressWithLogEvent}
       hitSlop={insets.all(12)}
       accessibilityRole="button"
+      ref={focusRef}
       {...accessibilityProps}
     >
       {children}

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -30,7 +30,7 @@ type Props = SectionItemProps<{
   interactiveColor?: InteractiveColor;
 }>;
 
-export const LinkSectionItem = forwardRef<View, Props>(
+export const LinkSectionItem = forwardRef<any, Props>(
   (
     {
       text,

--- a/src/components/sections/items/MessageSectionItem.tsx
+++ b/src/components/sections/items/MessageSectionItem.tsx
@@ -16,6 +16,7 @@ type Props = SectionItemProps<{
   title?: MessageInfoBoxProps['title'];
   message: MessageInfoBoxProps['message'];
   onPressConfig?: MessageInfoBoxProps['onPressConfig'];
+  focusRef?: React.Ref<any>;
 }>;
 
 export function MessageSectionItem({
@@ -23,6 +24,7 @@ export function MessageSectionItem({
   title,
   message,
   onPressConfig,
+  focusRef,
   ...props
 }: Props) {
   const {topContainer} = useSectionItem(props);
@@ -52,6 +54,7 @@ export function MessageSectionItem({
       accessibilityRole={accessibilityRole}
       accessibilityLabel={a11yLabel}
       style={[topContainer, styles.container]}
+      focusRef={focusRef}
     >
       <ThemeIcon
         style={styles.icon}

--- a/src/components/touchable-opacity-or-view/PressableOpacityOrView.tsx
+++ b/src/components/touchable-opacity-or-view/PressableOpacityOrView.tsx
@@ -7,24 +7,32 @@ export const PressableOpacityOrView = ({
   onClick,
   children,
   testID,
+  focusRef,
   ...a11yProps
 }: {
   style?: StyleProp<ViewStyle>;
   children: ReactNode;
   onClick?: () => void;
   testID?: string;
+  focusRef?: React.Ref<any>;
 } & AccessibilityProps) => {
   return onClick ? (
     <PressableOpacity
       onPress={onClick}
       style={style}
+      ref={focusRef}
       {...a11yProps}
       testID={testID ? testID : 'messageBox'}
     >
       {children}
     </PressableOpacity>
   ) : (
-    <View style={style} {...a11yProps} testID={testID ? testID : 'messageBox'}>
+    <View
+      style={style}
+      ref={focusRef}
+      {...a11yProps}
+      testID={testID ? testID : 'messageBox'}
+    >
       {children}
     </View>
   );

--- a/src/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -3,7 +3,7 @@ import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {FareContractTexts, useTranslation} from '@atb/translations';
-import React from 'react';
+import React, {RefObject, useRef} from 'react';
 import {ActivateNowBottomSheet} from './ActivateNowBottomSheet';
 
 type ActivateNowSectionItemProps = SectionItemProps<{
@@ -16,8 +16,13 @@ export function ActivateNowSectionItem({
 }: ActivateNowSectionItemProps): JSX.Element {
   const {t} = useTranslation();
   const {open} = useBottomSheet();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
+
   const onPress = () => {
-    open(() => <ActivateNowBottomSheet fareContractId={fareContractId} />);
+    open(
+      () => <ActivateNowBottomSheet fareContractId={fareContractId} />,
+      onCloseFocusRef,
+    );
   };
 
   return (
@@ -25,6 +30,7 @@ export function ActivateNowSectionItem({
       text={t(FareContractTexts.activateNow.startNow)}
       onPress={onPress}
       icon={<ThemeIcon svg={TicketValid} />}
+      ref={onCloseFocusRef}
       {...sectionProps}
     />
   );

--- a/src/fare-contracts/components/ConsumeCarnetSectionItem.tsx
+++ b/src/fare-contracts/components/ConsumeCarnetSectionItem.tsx
@@ -4,7 +4,7 @@ import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useTheme} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
-import React from 'react';
+import React, {RefObject, useRef} from 'react';
 import {ConsumeCarnetBottomSheet} from './ConsumeCarnetBottomSheet';
 
 type ConsumeCarnetSectionItemProps = SectionItemProps<{
@@ -18,10 +18,14 @@ export function ConsumeCarnetSectionItem({
   const {t} = useTranslation();
   const {theme} = useTheme();
   const interactiveColor = theme.color.interactive[0];
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const {open} = useBottomSheet();
   const onPress = () => {
-    open(() => <ConsumeCarnetBottomSheet fareContractId={fareContractId} />);
+    open(
+      () => <ConsumeCarnetBottomSheet fareContractId={fareContractId} />,
+      onCloseFocusRef,
+    );
   };
 
   return (
@@ -30,6 +34,7 @@ export function ConsumeCarnetSectionItem({
       onPress={onPress}
       icon={<ThemeIcon svg={TicketValid} color={interactiveColor.default} />}
       interactiveColor={interactiveColor}
+      ref={onCloseFocusRef}
       {...sectionProps}
     />
   );

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -13,7 +13,7 @@ import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import Bugsnag from '@bugsnag/react-native';
 import {renderAztec} from '@entur-private/abt-mobile-barcode-javascript-lib';
 import QRCode from 'qrcode';
-import React, {useEffect, useState} from 'react';
+import React, {RefObject, useEffect, useRef, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {SvgXml} from 'react-native-svg';
@@ -183,7 +183,11 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
   const styles = useStyles();
   const {t} = useTranslation();
   const [aztecXml, setAztecXml] = useState<string>();
-  const onOpenBarcodePress = useStaticBarcodeBottomSheet(aztecXml);
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
+  const onOpenBarcodePress = useStaticBarcodeBottomSheet(
+    aztecXml,
+    onCloseFocusRef,
+  );
 
   useEffect(() => {
     if (fc.qrCode) {
@@ -202,6 +206,7 @@ const StaticAztec = ({fc}: {fc: FareContract}) => {
           FareContractTexts.details.barcodeA11yLabelWithActivation,
         )}
         testID="staticBarcode"
+        ref={onCloseFocusRef}
       >
         <SvgXml xml={aztecXml} width="100%" height="100%" />
       </PressableOpacity>
@@ -213,7 +218,11 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
   const styles = useStyles();
   const {t} = useTranslation();
   const [qrCodeSvg, setQrCodeSvg] = useState<string>();
-  const onOpenBarcodePress = useStaticBarcodeBottomSheet(qrCodeSvg);
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
+  const onOpenBarcodePress = useStaticBarcodeBottomSheet(
+    qrCodeSvg,
+    onCloseFocusRef,
+  );
 
   useEffect(() => {
     if (fc.qrCode) {
@@ -234,6 +243,7 @@ const StaticQrCode = ({fc}: {fc: FareContract}) => {
           FareContractTexts.details.barcodeA11yLabelWithActivation,
         )}
         testID="staticQRCode"
+        ref={onCloseFocusRef}
       >
         <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
       </PressableOpacity>
@@ -263,7 +273,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-function useStaticBarcodeBottomSheet(qrCodeSvg: string | undefined) {
+function useStaticBarcodeBottomSheet(
+  qrCodeSvg: string | undefined,
+  onCloseFocusRef: RefObject<any>,
+) {
   const styles = useStyles();
   const {t} = useTranslation();
 
@@ -274,29 +287,32 @@ function useStaticBarcodeBottomSheet(qrCodeSvg: string | undefined) {
   } = useBottomSheet();
 
   const onOpenBarcodePress = () => {
-    openBottomSheet(() => (
-      <BottomSheetContainer
-        title={t(FareContractTexts.details.bottomSheetTitle)}
-        testID="barcodeBottomSheet"
-        fullHeight
-      >
-        <View style={styles.staticBottomContainer}>
-          <View style={[styles.aztecCode, styles.staticQrCode]}>
-            <PressableOpacity
-              ref={onOpenFocusRef}
-              onPress={closeBottomSheet}
-              accessible={true}
-              accessibilityLabel={t(
-                FareContractTexts.details.barcodeBottomSheetA11yLabel,
-              )}
-              testID="staticBigQRCode"
-            >
-              <SvgXml xml={qrCodeSvg ?? ''} width="100%" height="100%" />
-            </PressableOpacity>
+    openBottomSheet(
+      () => (
+        <BottomSheetContainer
+          title={t(FareContractTexts.details.bottomSheetTitle)}
+          testID="barcodeBottomSheet"
+          fullHeight
+        >
+          <View style={styles.staticBottomContainer}>
+            <View style={[styles.aztecCode, styles.staticQrCode]}>
+              <PressableOpacity
+                ref={onOpenFocusRef}
+                onPress={closeBottomSheet}
+                accessible={true}
+                accessibilityLabel={t(
+                  FareContractTexts.details.barcodeBottomSheetA11yLabel,
+                )}
+                testID="staticBigQRCode"
+              >
+                <SvgXml xml={qrCodeSvg ?? ''} width="100%" height="100%" />
+              </PressableOpacity>
+            </View>
           </View>
-        </View>
-      </BottomSheetContainer>
-    ));
+        </BottomSheetContainer>
+      ),
+      onCloseFocusRef,
+    );
   };
 
   return onOpenBarcodePress;

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -3,7 +3,7 @@ import {AccessibilityInfo, Alert} from 'react-native';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
-import React from 'react';
+import React, {RefObject} from 'react';
 import {useBottomSheet} from '@atb/components/bottom-sheet';
 import {
   TransportSubmode,
@@ -87,6 +87,7 @@ export function useOnMarkFavouriteDepartures(
   const onMarkFavourite = (
     line: FavouriteDepartureLine,
     existing: StoredFavoriteDeparture | undefined,
+    onCloseFocusRef: RefObject<any>,
   ) => {
     if (existing && line.lineNumber) {
       Alert.alert(
@@ -131,7 +132,7 @@ export function useOnMarkFavouriteDepartures(
         ) : (
           <></>
         );
-      });
+      }, onCloseFocusRef);
     }
   };
 

--- a/src/place-screen/components/DateSelection.tsx
+++ b/src/place-screen/components/DateSelection.tsx
@@ -14,7 +14,7 @@ import {
 } from '@atb/utils/date';
 import {useFontScale} from '@atb/utils/use-font-scale';
 import {addDays, isToday, parseISO} from 'date-fns';
-import React from 'react';
+import React, {RefObject, useRef} from 'react';
 import {View} from 'react-native';
 import {SearchTime} from '../types';
 import {DepartureTimeSheet} from './DepartureTimeSheet';
@@ -33,6 +33,7 @@ export const DateSelection = ({
   const disablePreviousDayNavigation = isToday(
     parseISOFromCET(searchTime.date),
   );
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const fontScale = useFontScale();
   const shouldShowNextPrevTexts = fontScale < 1.3;
@@ -70,14 +71,17 @@ export const DateSelection = ({
 
   const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
   const onLaterTimePress = () => {
-    openBottomSheet(() => (
-      <DepartureTimeSheet
-        ref={onOpenFocusRef}
-        initialTime={searchTime}
-        setSearchTime={onSetSearchTime}
-        allowTimeInPast={false}
-      />
-    ));
+    openBottomSheet(
+      () => (
+        <DepartureTimeSheet
+          ref={onOpenFocusRef}
+          initialTime={searchTime}
+          setSearchTime={onSetSearchTime}
+          allowTimeInPast={false}
+        />
+      ),
+      onCloseFocusRef,
+    );
   };
 
   return (
@@ -117,6 +121,7 @@ export const DateSelection = ({
         mode="tertiary"
         rightIcon={{svg: DateIcon}}
         testID="setDateButton"
+        ref={onCloseFocusRef}
       />
       <Button
         onPress={() => {

--- a/src/place-screen/components/EstimatedCallList.tsx
+++ b/src/place-screen/components/EstimatedCallList.tsx
@@ -2,7 +2,7 @@ import {GenericSectionItem, SectionSeparator} from '@atb/components/sections';
 import {EstimatedCall} from '@atb/api/types/departures';
 import {ThemeText} from '@atb/components/text';
 import {FlatList} from 'react-native-gesture-handler';
-import React, {useCallback} from 'react';
+import React, {RefObject, useCallback, useRef} from 'react';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import {
   EstimatedCallItem,
@@ -51,6 +51,11 @@ export const EstimatedCallList = ({
     addedFavoritesVisibleOnDashboard,
   );
 
+  // TODO: This ref isn't hooked up anywhere for now. Since the favorite feature
+  // is due to be moved out of EstimatedCallList, it should be fixed when that
+  // happens. (https://github.com/AtB-AS/kundevendt/issues/19124)
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
+
   const onPressFavorite = useCallback(
     (departure: EstimatedCall, existingFavorite?: StoredFavoriteDeparture) =>
       onMarkFavourite(
@@ -60,6 +65,7 @@ export const EstimatedCallList = ({
           destinationDisplay: departure.destinationDisplay,
         },
         existingFavorite,
+        onCloseFocusRef,
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],

--- a/src/service-disruptions/use-service-disruption-icon.tsx
+++ b/src/service-disruptions/use-service-disruption-icon.tsx
@@ -1,6 +1,6 @@
 import {IconButtonProps} from '@atb/components/screen-header';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import React from 'react';
+import React, {RefObject, useRef} from 'react';
 import {ScreenHeaderTexts, useTranslation} from '@atb/translations';
 import ServiceDisruption from '@atb/assets/svg/mono-icons/status/ServiceDisruption';
 import {
@@ -23,13 +23,14 @@ export const useServiceDisruptionIcon = (
   const {findGlobalMessages} = useGlobalMessagesState();
   const {open: openBottomSheet} = useBottomSheet();
   const now = useNow(2500);
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const globalMessages = findGlobalMessages(
     GlobalMessageContextEnum.appServiceDisruptions,
   ).filter((gm) => isWithinTimeRange(gm, now));
 
   const openServiceDisruptionSheet = () => {
-    openBottomSheet(() => <ServiceDisruptionSheet />);
+    openBottomSheet(() => <ServiceDisruptionSheet />, onCloseFocusRef);
   };
 
   return {
@@ -52,5 +53,6 @@ export const useServiceDisruptionIcon = (
     accessibilityHint: t(
       ScreenHeaderTexts.headerButton['status-disruption'].a11yHint,
     ),
+    focusRef: onCloseFocusRef,
   };
 };

--- a/src/situations/SituationMessageBox.tsx
+++ b/src/situations/SituationMessageBox.tsx
@@ -23,11 +23,12 @@ export const SituationMessageBox = ({
   a11yLiveRegion,
 }: Props) => {
   const {language} = useTranslation();
+  const onCloseFocusRef = React.useRef(null);
 
   const messageType = getMessageTypeForSituation(situation);
   const text = getSituationSummary(situation, language);
   const {t} = useTranslation();
-  const {openSituation} = useSituationBottomSheet();
+  const {openSituation} = useSituationBottomSheet({onCloseFocusRef});
 
   if (!text) return null;
 
@@ -42,6 +43,7 @@ export const SituationMessageBox = ({
         text: t(dictionary.readMore),
         action: () => openSituation(situation),
       }}
+      focusRef={onCloseFocusRef}
     />
   );
 };

--- a/src/situations/SituationSectionItem.tsx
+++ b/src/situations/SituationSectionItem.tsx
@@ -12,7 +12,8 @@ type Props = {
 export const SituationSectionItem = ({situation}: Props) => {
   const {t, language} = useTranslation();
   const situationText = getSituationSummary(situation, language);
-  const {openSituation} = useSituationBottomSheet();
+  const onCloseFocusRef = React.useRef(null);
+  const {openSituation} = useSituationBottomSheet({onCloseFocusRef});
 
   if (!situationText) return null;
 
@@ -24,6 +25,7 @@ export const SituationSectionItem = ({situation}: Props) => {
         text: t(dictionary.readMore),
         action: () => openSituation(situation),
       }}
+      focusRef={onCloseFocusRef}
     />
   );
 };

--- a/src/situations/use-situation-bottom-sheet.tsx
+++ b/src/situations/use-situation-bottom-sheet.tsx
@@ -13,7 +13,6 @@ export const useSituationBottomSheet = ({
   const openSituation = (situation: SituationType) => {
     openBottomSheet(
       () => <SituationBottomSheet situation={situation} ref={onOpenFocusRef} />,
-      undefined,
       onCloseFocusRef,
     );
   };

--- a/src/situations/use-situation-bottom-sheet.tsx
+++ b/src/situations/use-situation-bottom-sheet.tsx
@@ -1,15 +1,21 @@
 import {useBottomSheet} from '@atb/components/bottom-sheet';
-import React from 'react';
+import React, {RefObject} from 'react';
 import {SituationBottomSheet} from './SituationBottomSheet';
 import {SituationType} from './types';
 
-export const useSituationBottomSheet = () => {
+export const useSituationBottomSheet = ({
+  onCloseFocusRef,
+}: {
+  onCloseFocusRef: RefObject<any>;
+}) => {
   const {open: openBottomSheet, onOpenFocusRef} = useBottomSheet();
 
   const openSituation = (situation: SituationType) => {
-    openBottomSheet(() => (
-      <SituationBottomSheet situation={situation} ref={onOpenFocusRef} />
-    ));
+    openBottomSheet(
+      () => <SituationBottomSheet situation={situation} ref={onOpenFocusRef} />,
+      undefined,
+      onCloseFocusRef,
+    );
   };
 
   return {openSituation};

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -12,7 +12,7 @@ import {useFavorites} from '@atb/favorites';
 import {useOnlySingleLocation} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
 import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {AddEditFavoriteTexts, useTranslation} from '@atb/translations';
-import React, {useEffect, useState} from 'react';
+import React, {RefObject, useEffect, useRef, useState} from 'react';
 import {Alert, Keyboard, ScrollView, View} from 'react-native';
 import {EmojiSheet} from './EmojiSheet';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
@@ -49,6 +49,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
     'searchLocation',
     editItem?.location,
   );
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   useEffect(() => setEmoji(editItem?.emoji), [editItem?.emoji]);
 
@@ -107,29 +108,32 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
   const {open: openBottomSheet} = useBottomSheet();
 
   const openEmojiSheet = () => {
-    openBottomSheet(() => (
-      <EmojiSheet
-        localizedCategories={[
-          t(AddEditFavoriteTexts.emojiSheet.categories.smileys),
-          t(AddEditFavoriteTexts.emojiSheet.categories.people),
-          t(AddEditFavoriteTexts.emojiSheet.categories.animals),
-          t(AddEditFavoriteTexts.emojiSheet.categories.food),
-          t(AddEditFavoriteTexts.emojiSheet.categories.activities),
-          t(AddEditFavoriteTexts.emojiSheet.categories.travel),
-          t(AddEditFavoriteTexts.emojiSheet.categories.objects),
-          t(AddEditFavoriteTexts.emojiSheet.categories.symbols),
-        ]}
-        value={emoji ?? null}
-        closeOnSelect={true}
-        onEmojiSelected={(emoji) => {
-          if (emoji == null) {
-            setEmoji(undefined);
-          } else {
-            setEmoji(emoji);
-          }
-        }}
-      />
-    ));
+    openBottomSheet(
+      () => (
+        <EmojiSheet
+          localizedCategories={[
+            t(AddEditFavoriteTexts.emojiSheet.categories.smileys),
+            t(AddEditFavoriteTexts.emojiSheet.categories.people),
+            t(AddEditFavoriteTexts.emojiSheet.categories.animals),
+            t(AddEditFavoriteTexts.emojiSheet.categories.food),
+            t(AddEditFavoriteTexts.emojiSheet.categories.activities),
+            t(AddEditFavoriteTexts.emojiSheet.categories.travel),
+            t(AddEditFavoriteTexts.emojiSheet.categories.objects),
+            t(AddEditFavoriteTexts.emojiSheet.categories.symbols),
+          ]}
+          value={emoji ?? null}
+          closeOnSelect={true}
+          onEmojiSelected={(emoji) => {
+            if (emoji == null) {
+              setEmoji(undefined);
+            } else {
+              setEmoji(emoji);
+            }
+          }}
+        />
+      ),
+      onCloseFocusRef,
+    );
   };
 
   const openEmojiPopup = () => {
@@ -214,6 +218,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
             onPress={() => {
               setEmoji(undefined);
             }}
+            ref={onCloseFocusRef}
           />
         )}
       </ScrollView>

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsPhotoScreen.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsPhotoScreen.tsx
@@ -8,6 +8,7 @@ import {ScreenContainer} from './components/ScreenContainer';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {useParkingViolations} from '@atb/parking-violations-reporting';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import {RefObject, useRef} from 'react';
 
 export type PhotoScreenProps =
   RootStackScreenProps<'Root_ParkingViolationsPhotoScreen'>;
@@ -21,21 +22,25 @@ export const Root_ParkingViolationsPhotoScreen = ({
   const style = useStyles();
   const {coordinates, isLoading} = useParkingViolations();
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const handlePhotoCapture = (file: PhotoFile) => {
-    openBottomSheet(() => (
-      <ImageConfirmationBottomSheet
-        onConfirm={() => {
-          closeBottomSheet();
-          navigation.navigate('Root_ParkingViolationsQrScreen', {
-            ...params,
-            photo: file.path,
-          });
-        }}
-        coordinates={coordinates}
-        file={file}
-      />
-    ));
+    openBottomSheet(
+      () => (
+        <ImageConfirmationBottomSheet
+          onConfirm={() => {
+            closeBottomSheet();
+            navigation.navigate('Root_ParkingViolationsQrScreen', {
+              ...params,
+              photo: file.path,
+            });
+          }}
+          coordinates={coordinates}
+          file={file}
+        />
+      ),
+      onCloseFocusRef,
+    );
   };
 
   return (
@@ -50,6 +55,7 @@ export const Root_ParkingViolationsPhotoScreen = ({
           mode="photo"
           style={style.camera}
           onCapture={handlePhotoCapture}
+          focusRef={onCloseFocusRef}
         />
       )}
     </ScreenContainer>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -17,7 +17,14 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {addMinutes} from 'date-fns';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {useOfferState} from '../Root_PurchaseOverviewScreen/use-offer-state';
 import {
@@ -61,6 +68,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const [shouldSavePaymentMethod, setShouldSavePaymentMethod] = useState(false);
   const paymentMethod = selectedPaymentMethod ?? previousPaymentMethod;
   const [vippsNotInstalledError, setVippsNotInstalledError] = useState(false);
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const {selection, recipient} = params;
 
@@ -218,7 +226,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           }}
         />
       );
-    });
+    }, onCloseFocusRef);
   }
 
   return (
@@ -345,6 +353,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   accessibilityHint={t(
                     PurchaseConfirmationTexts.changePaymentMethod.a11yHint,
                   )}
+                  ref={onCloseFocusRef}
                 >
                   <View style={styles.flexRowCenter}>
                     <ThemeText type="body__primary--bold">
@@ -368,6 +377,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   selectPaymentMethod();
                 }}
                 testID="choosePaymentMethodButton"
+                ref={onCloseFocusRef}
               />
             )}
           </View>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {RefObject, useRef} from 'react';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {InteractiveColor} from '@atb/theme/colors';
 import {StyleProp, View, ViewStyle} from 'react-native';
@@ -31,11 +31,13 @@ export function StartTimeSelection({
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
   const {open: openBottomSheet} = useBottomSheet();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const openTravelDateSheet = () => {
-    openBottomSheet(() => (
-      <TravelDateSheet save={setTravelDate} travelDate={travelDate} />
-    ));
+    openBottomSheet(
+      () => <TravelDateSheet save={setTravelDate} travelDate={travelDate} />,
+      onCloseFocusRef,
+    );
   };
 
   const subtext = validFromTime
@@ -69,6 +71,7 @@ export function StartTimeSelection({
             onPress: openTravelDateSheet,
             accessibilityLabel,
             accessibilityHint: t(PurchaseOverviewTexts.startTime.a11yLaterHint),
+            ref: onCloseFocusRef,
           },
         ]}
       />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -61,11 +61,7 @@ export function TravellerSelection({
   const {authenticationType} = useAuthState();
   const {userProfiles} = useFirestoreConfiguration();
 
-  const {
-    open: openBottomSheet,
-    close: closeBottomSheet,
-    onCloseFocusRef,
-  } = useBottomSheet();
+  const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
 
   const isOnBehalfOfEnabled =
     useFeatureToggles().isOnBehalfOfEnabled &&
@@ -241,7 +237,7 @@ export function TravellerSelection({
         {canSelectUserProfile ? (
           <GenericClickableSectionItem
             onPress={travellerSelectionOnPress}
-            ref={onCloseFocusRef}
+            // ref={onCloseFocusRef}
             testID="selectTravellerButton"
           >
             {content}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef} from 'react';
+import React, {RefObject, useCallback, useRef} from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {
   getTextForLanguage,
@@ -60,6 +60,7 @@ export function TravellerSelection({
   const styles = useStyles();
   const {authenticationType} = useAuthState();
   const {userProfiles} = useFirestoreConfiguration();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
 
@@ -157,28 +158,31 @@ export function TravellerSelection({
   };
 
   const travellerSelectionOnPress = () => {
-    openBottomSheet(() => (
-      <TravellerSelectionSheet
-        selectionMode={selectionMode}
-        fareProductTypeConfig={fareProductTypeConfig}
-        selectableUserProfilesWithCountInit={userProfilesWithCountToShow}
-        isOnBehalfOfToggle={isOnBehalfOfToggle}
-        onConfirmSelection={(
-          chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
-          onBehalfOfToggle?: boolean,
-        ) => {
-          if (chosenSelectableUserProfilesWithCounts !== undefined) {
-            setUserProfilesWithCount(
-              chosenSelectableUserProfilesWithCounts.filter((u) => u.count),
-            );
-          }
-          if (onBehalfOfToggle !== undefined) {
-            setIsOnBehalfOfToggle(onBehalfOfToggle);
-          }
-          closeBottomSheet();
-        }}
-      />
-    ));
+    openBottomSheet(
+      () => (
+        <TravellerSelectionSheet
+          selectionMode={selectionMode}
+          fareProductTypeConfig={fareProductTypeConfig}
+          selectableUserProfilesWithCountInit={userProfilesWithCountToShow}
+          isOnBehalfOfToggle={isOnBehalfOfToggle}
+          onConfirmSelection={(
+            chosenSelectableUserProfilesWithCounts?: UserProfileWithCount[],
+            onBehalfOfToggle?: boolean,
+          ) => {
+            if (chosenSelectableUserProfilesWithCounts !== undefined) {
+              setUserProfilesWithCount(
+                chosenSelectableUserProfilesWithCounts.filter((u) => u.count),
+              );
+            }
+            if (onBehalfOfToggle !== undefined) {
+              setIsOnBehalfOfToggle(onBehalfOfToggle);
+            }
+            closeBottomSheet();
+          }}
+        />
+      ),
+      onCloseFocusRef,
+    );
   };
 
   const content = (
@@ -237,7 +241,7 @@ export function TravellerSelection({
         {canSelectUserProfile ? (
           <GenericClickableSectionItem
             onPress={travellerSelectionOnPress}
-            // ref={onCloseFocusRef}
+            ref={onCloseFocusRef}
             testID="selectTravellerButton"
           >
             {content}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -22,6 +22,7 @@ import {animateNextChange} from '@atb/utils/animation';
 import {useAnalytics} from '@atb/analytics';
 import {useAnnouncementsState} from '@atb/announcements';
 import Bugsnag from '@bugsnag/react-native';
+import {RefObject, useRef} from 'react';
 
 type Props = {
   announcement: AnnouncementType;
@@ -36,6 +37,7 @@ export const Announcement = ({announcement, style}: Props) => {
   const analytics = useAnalytics();
   const {dismissAnnouncement} = useAnnouncementsState();
   const {open: openBottomSheet} = useBottomSheet();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const handleDismiss = () => {
     animateNextChange();
@@ -117,6 +119,7 @@ export const Announcement = ({announcement, style}: Props) => {
                 ? 'button'
                 : 'link',
           }}
+          ref={onCloseFocusRef}
           onPress={async () => {
             analytics.logEvent('Dashboard', 'Announcement pressed', {
               id: announcement.id,
@@ -124,9 +127,10 @@ export const Announcement = ({announcement, style}: Props) => {
             if (
               announcement.actionButton.actionType === ActionType.bottom_sheet
             ) {
-              openBottomSheet(() => (
-                <AnnouncementSheet announcement={announcement} />
-              ));
+              openBottomSheet(
+                () => <AnnouncementSheet announcement={announcement} />,
+                onCloseFocusRef,
+              );
             } else {
               const actionButtonURL = announcement.actionButton.url;
               try {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -50,6 +50,7 @@ export const DeparturesWidget = ({
   const {favoriteDepartures} = useFavorites();
   const {location} = useGeolocationState();
   const {state, loadInitialDepartures, searchDate} = useFavoriteDepartureData();
+  const onCloseFocusRef = React.useRef(null);
 
   useEffect(() => loadInitialDepartures(), [loadInitialDepartures]);
 
@@ -62,7 +63,7 @@ export const DeparturesWidget = ({
           onEditFavouriteDeparture={onEditFavouriteDeparture}
         />
       );
-    });
+    }, onCloseFocusRef);
   }
 
   const sortedStopPlaceGroups = location
@@ -131,7 +132,7 @@ export const DeparturesWidget = ({
           onPress={openFrontpageFavouritesBottomSheet}
           text={t(DeparturesTexts.button.text)}
           rightIcon={{svg: Edit}}
-          // ref={onCloseFocusRef}
+          ref={onCloseFocusRef}
           testID="selectFavoriteDepartures"
         />
       )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -53,7 +53,7 @@ export const DeparturesWidget = ({
 
   useEffect(() => loadInitialDepartures(), [loadInitialDepartures]);
 
-  const {open: openBottomSheet, onCloseFocusRef} = useBottomSheet();
+  const {open: openBottomSheet} = useBottomSheet();
 
   async function openFrontpageFavouritesBottomSheet() {
     openBottomSheet(() => {
@@ -131,7 +131,7 @@ export const DeparturesWidget = ({
           onPress={openFrontpageFavouritesBottomSheet}
           text={t(DeparturesTexts.button.text)}
           rightIcon={{svg: Edit}}
-          ref={onCloseFocusRef}
+          // ref={onCloseFocusRef}
           testID="selectFavoriteDepartures"
         />
       )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -381,7 +381,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                           }
                         : undefined,
                     }}
-                    ref={filtersState.onCloseFocusRef}
                   />
                 </View>
               )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -90,7 +90,9 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
     date: new Date().toISOString(),
   });
 
-  const filtersState = useTravelSearchFiltersState();
+  const filtersState = useTravelSearchFiltersState({
+    onCloseFocusRef: filterButtonWrapperRef,
+  });
   const {isFlexibleTransportEnabled: isFlexibleTransportEnabledInRemoteConfig} =
     useFeatureToggles();
   const {tripPatterns, timeOfLastSearch, loadMore, searchState, error} =

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -1,5 +1,5 @@
 import {useBottomSheet} from '@atb/components/bottom-sheet';
-import React, {useState} from 'react';
+import React, {RefObject, useState} from 'react';
 import {TravelSearchFiltersBottomSheet} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet';
 import {useFirestoreConfiguration} from '@atb/configuration/FirestoreConfigurationContext';
 import {useFilters} from '@atb/travel-search-filters';
@@ -24,7 +24,11 @@ type TravelSearchFiltersState =
  * The travel search filters state, including whether it is enabled or not, the
  * selected filters, and a function for opening the bottom sheet.
  */
-export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
+export const useTravelSearchFiltersState = ({
+  onCloseFocusRef,
+}: {
+  onCloseFocusRef: RefObject<any>;
+}): TravelSearchFiltersState => {
   const {open, onOpenFocusRef} = useBottomSheet();
   const {travelSearchFilters} = useFirestoreConfiguration();
   const {filters, setFilters} = useFilters();
@@ -73,13 +77,16 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
   if (!travelSearchFilters?.transportModes) return {enabled: false};
 
   const openBottomSheet = () => {
-    open(() => (
-      <TravelSearchFiltersBottomSheet
-        ref={onOpenFocusRef}
-        filtersSelection={filtersSelection}
-        onSave={setFiltersSelection}
-      />
-    ));
+    open(
+      () => (
+        <TravelSearchFiltersBottomSheet
+          ref={onOpenFocusRef}
+          filtersSelection={filtersSelection}
+          onSave={setFiltersSelection}
+        />
+      ),
+      onCloseFocusRef,
+    );
   };
 
   return {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -17,7 +17,6 @@ type TravelSearchFiltersState =
       anyFiltersApplied: boolean;
       resetTransportModes: () => void;
       disableFlexibleTransport: () => void;
-      onCloseFocusRef: React.Ref<any>;
     }
   | {enabled: false; filtersSelection?: undefined};
 
@@ -26,7 +25,7 @@ type TravelSearchFiltersState =
  * selected filters, and a function for opening the bottom sheet.
  */
 export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
-  const {open, onOpenFocusRef, onCloseFocusRef} = useBottomSheet();
+  const {open, onOpenFocusRef} = useBottomSheet();
   const {travelSearchFilters} = useFirestoreConfiguration();
   const {filters, setFilters} = useFilters();
 
@@ -110,6 +109,5 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
       setFilters(filtersWithFlexibleTransportDisabled);
       setFiltersSelection(filtersWithFlexibleTransportDisabled);
     },
-    onCloseFocusRef,
   };
 };

--- a/src/travel-details-screens/components/BookingInfoBox.tsx
+++ b/src/travel-details-screens/components/BookingInfoBox.tsx
@@ -10,12 +10,14 @@ import {
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
 import {BookingArrangementFragment} from '@atb/api/types/generated/fragments/booking-arrangements';
 import {BookingArrangement} from '@atb/api/types/generated/journey_planner_v3_types';
+import {RefObject} from 'react';
 
 type Props = {
   bookingArrangements?: BookingArrangementFragment;
   aimedStartTime: string;
   now: number;
   onPressConfig?: OnPressConfig;
+  focusRef?: RefObject<any>;
 };
 
 export const BookingInfoBox = ({
@@ -23,6 +25,7 @@ export const BookingInfoBox = ({
   aimedStartTime,
   now,
   onPressConfig,
+  focusRef,
 }: Props) => {
   const bookingMessage = useBookingMessage(
     bookingArrangements,
@@ -43,6 +46,7 @@ export const BookingInfoBox = ({
       type={bookingStatus === 'late' ? 'error' : 'warning'}
       message={bookingMessage}
       onPressConfig={onPressConfig}
+      focusRef={focusRef}
     />
   );
 };

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -95,6 +95,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const {t, language} = useTranslation();
   const style = useSectionStyles();
   const {theme, themeName} = useTheme();
+  const onCloseFocusRef = React.useRef(null);
 
   const isWalkSection = leg.mode === Mode.Foot;
   const isBikeSection = leg.mode === Mode.Bicycle;
@@ -139,7 +140,10 @@ export const TripSection: React.FC<TripSectionProps> = ({
 
   const {open: openBottomSheet} = useBottomSheet();
   function openBookingDetails() {
-    openBottomSheet(() => <FlexibleTransportBookingDetailsSheet leg={leg} />);
+    openBottomSheet(
+      () => <FlexibleTransportBookingDetailsSheet leg={leg} />,
+      onCloseFocusRef,
+    );
   }
 
   const translatedModeName = getTranslatedModeName(leg.mode);
@@ -249,6 +253,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
               bookingArrangements={leg.bookingArrangements}
               aimedStartTime={leg.aimedStartTime}
               now={now}
+              focusRef={onCloseFocusRef}
               onPressConfig={
                 shouldShowButtonForOpeningFlexBottomSheet
                   ? {


### PR DESCRIPTION
Makes `onCloseFocusRef` a required parameter to every bottom sheet `open()` call. 

Previously the close ref was stored in the bottom sheet state globally, limiting the target element to just one per page. If there were several elements that could have focus after close (e.g. there were two situation messages, both with an `onClick` triggering a bottom sheet), there were no way for the bottom sheet to know which one to focus on close.

With the changes in this PR, the responsibility of providing a onCloseFocusRef is moved to the caller of `open()`, making every opened bottom sheet store the ref that should be focused on the next `close()`. The ref is still stored globally, so there might still be issues if at some point in the future several bottom sheets are opened at once. See the changes to `BottomSheetContext.tsx`.

The parameter is set as required, so that it's hard to forget setting a closeRef when adding the bottom sheet new places in the app.

closes https://github.com/AtB-AS/kundevendt/issues/16840