### PR TITLE
refactor: fix some departure favorite exhaustive deps warnings

### DIFF
--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -69,14 +69,16 @@ export function QuaySection({
     mode === 'Favourite'
       ? departures.sort((a, b) => compareByLineNameAndDesc(t, a, b))
       : departures;
+
+  const navigateToQuayEnabled = !!navigateToQuay;
+
+  // If the user has toggled "Show only favorites" and there are no favorites on
+  // this quay, we should minimize the quay section.
+  const hasFavorites = !!favoriteDepartures.find((f) => quay.id === f.quayId);
   useEffect(() => {
     if (!showOnlyFavorites) return setIsMinimized(false);
-    setIsMinimized(
-      !!navigateToQuay &&
-        !favoriteDepartures.find((favorite) => quay.id === favorite.quayId),
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showOnlyFavorites]);
+    setIsMinimized(navigateToQuayEnabled && !hasFavorites);
+  }, [showOnlyFavorites, navigateToQuayEnabled, hasFavorites]);
 
   const hasMoreItemsThanDisplayLimit =
     !!departuresPerQuay && departuresToDisplay.length > departuresPerQuay;

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -75,16 +75,17 @@ export function QuaySection({
   // If the user has toggled "Show only favorites" and there are no favorites on
   // this quay, we should minimize the quay section.
   const hasFavorites = !!favoriteDepartures.find((f) => quay.id === f.quayId);
+  const shouldBeMinimized =
+    navigateToQuayEnabled && !hasFavorites && showOnlyFavorites;
   useEffect(() => {
-    if (!showOnlyFavorites) return setIsMinimized(false);
-    setIsMinimized(navigateToQuayEnabled && !hasFavorites);
-  }, [showOnlyFavorites, navigateToQuayEnabled, hasFavorites]);
+    setIsMinimized(shouldBeMinimized);
+  }, [shouldBeMinimized]);
 
   const hasMoreItemsThanDisplayLimit =
     !!departuresPerQuay && departuresToDisplay.length > departuresPerQuay;
 
   const shouldShowMoreItemsLink =
-    !!navigateToQuay &&
+    navigateToQuayEnabled &&
     !isMinimized &&
     (mode === 'Departure' || mode === 'Map' || hasMoreItemsThanDisplayLimit);
 

--- a/src/place-screen/components/QuayView.tsx
+++ b/src/place-screen/components/QuayView.tsx
@@ -75,8 +75,7 @@ export function QuayView({
   // value to false
   useEffect(() => {
     if (!placeHasFavorites) setShowOnlyFavorites(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [favoriteDepartures]);
+  }, [placeHasFavorites, setShowOnlyFavorites]);
 
   return (
     <SectionList

--- a/src/place-screen/components/StopPlacesView.tsx
+++ b/src/place-screen/components/StopPlacesView.tsx
@@ -114,8 +114,7 @@ export const StopPlacesView = (props: Props) => {
   // value to false
   useEffect(() => {
     if (!placeHasFavorites) setShowOnlyFavorites(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [favoriteDepartures]);
+  }, [placeHasFavorites, setShowOnlyFavorites]);
 
   const lastIndex = quays?.length ? quays.length - 1 : 0;
 

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -190,7 +190,7 @@ const DeparturesTexts = {
           ),
         delete: {
           label: _(
-            'Fjerne faovrittavgang?',
+            'Fjerne favorittavgang?',
             'Delete favourite departure?',
             'Slette favorittavgang?',
           ),


### PR DESCRIPTION
Updated some logic related to departure favorites to have exhaustive deps. 

### Acceptance criteria

- [ ] When "Show only favorites" is enabled and all favorites for the stop/quay is removed, the filter is disabled and hidden.
- [ ] When "Show only favorites" is disabled, any minimized quay sections are expanded.


closes https://github.com/AtB-AS/kundevendt/issues/16267