### PR TITLE
feat: add submode rule variable on trip and departure details

### DIFF
--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -337,6 +337,7 @@ export const DepartureDetailsScreenComponent = ({
               ticketingEnabled: enable_ticketing,
               canSellTicketsForDeparture: canSellTicketsForDeparture,
               mode: mode || null,
+              subMode: subMode || null,
               fromZones:
                 fromQuay?.quay?.tariffZones.map((zone) => zone.id) || null,
               toZones: toQuay?.quay?.tariffZones.map((zone) => zone.id) || null,

--- a/src/travel-details-screens/components/Trip.tsx
+++ b/src/travel-details-screens/components/Trip.tsx
@@ -143,6 +143,9 @@ export const Trip: React.FC<TripProps> = ({
           ticketingEnabled: enable_ticketing,
           hasLegsWeCantSellTicketsFor: tripHasLegsWeCantSellTicketsFor,
           modes: tripPattern.legs.map((l) => l.mode),
+          subModes: tripPattern.legs
+            .map((l) => l.transportSubmode)
+            .filter(isDefined),
           withinZoneIds: containingZones,
         }}
       />


### PR DESCRIPTION
Identified as something that could be useful for VM, where global messages on submode `shuttleBus` could be used.

### Acceptance criteria

- [ ] A rule variable like "subMode" "equalTo" "localBus" works on context `app-departure-details`
- [ ] A rule variable like "subModes" "contains" "localBus" works on context `app-trip-details`
