### PR TITLE
fix: Update build-store-ios.yml to include KEYCHAIN_NAME

### DIFF
--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -13,6 +13,8 @@ jobs:
     environment: ${{ matrix.org }}
     timeout-minutes: 360
     runs-on: macOS-13
+    env:
+      KEYCHAIN_NAME: "CI"
     steps:
       - name: Check if release tag is org specific and exit for other orgs
         if: ${{ (contains(github.ref, 'atb') && matrix.org != 'atb') ||
@@ -75,6 +77,7 @@ jobs:
           EXPORT_METHOD: 'app-store'
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          KEYCHAIN_NAME: ${{ env.KEYCHAIN_NAME }}
       - name: Distribute to TestFlight
         run: |
           echo ${{ secrets.APP_STORE_CONNECT_API_KEY}} | base64 --decode > app-store-connect-api-key.json


### PR DESCRIPTION
Fix a building issue when the keychain name new parameter was missing for building for the App store.