### PR TITLE
fix: use correct selectable traveller count

### DIFF
--- a/src/purchase-selection/index.ts
+++ b/src/purchase-selection/index.ts
@@ -1,3 +1,3 @@
 export type {PurchaseSelectionType} from './types';
 export {usePurchaseSelectionBuilder} from './use-purchase-selection-builder';
-export {getSelectableUserProfiles} from './utils';
+export {useSelectableUserProfiles} from './use-selectable-user-profiles';

--- a/src/purchase-selection/use-selectable-user-profiles.ts
+++ b/src/purchase-selection/use-selectable-user-profiles.ts
@@ -1,0 +1,10 @@
+import {PreassignedFareProduct, UserProfile} from '@atb-as/config-specs';
+import {useFirestoreConfiguration} from '@atb/configuration';
+import {isSelectableProfile} from './utils';
+
+export function useSelectableUserProfiles(product: PreassignedFareProduct): UserProfile[] {
+  const {userProfiles} = useFirestoreConfiguration();
+  return userProfiles.filter((profile) =>
+    isSelectableProfile(product, profile),
+  );
+}

--- a/src/purchase-selection/use-selectable-user-profiles.ts
+++ b/src/purchase-selection/use-selectable-user-profiles.ts
@@ -2,7 +2,9 @@ import {PreassignedFareProduct, UserProfile} from '@atb-as/config-specs';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {isSelectableProfile} from './utils';
 
-export function useSelectableUserProfiles(product: PreassignedFareProduct): UserProfile[] {
+export function useSelectableUserProfiles(
+  product: PreassignedFareProduct,
+): UserProfile[] {
   const {userProfiles} = useFirestoreConfiguration();
   return userProfiles.filter((profile) =>
     isSelectableProfile(product, profile),

--- a/src/purchase-selection/utils.ts
+++ b/src/purchase-selection/utils.ts
@@ -88,21 +88,15 @@ export const getDefaultUserProfiles = (
   input: PurchaseSelectionBuilderInput,
   product: PreassignedFareProduct,
 ): UserProfileWithCount[] => {
-  const selectableProfiles = getSelectableUserProfiles(
-    input.userProfiles,
-    product,
-  );
-  const profile = selectableProfiles.reduce((selected, current) =>
-    current.userTypeString === input.defaultUserTypeString ? current : selected,
-  );
+  const profile = input.userProfiles
+    .filter((profile) => isSelectableProfile(product, profile))
+    .reduce((selected, current) =>
+      current.userTypeString === input.defaultUserTypeString
+        ? current
+        : selected,
+    );
   return [{...profile, count: 1}];
 };
-
-export const getSelectableUserProfiles = (
-  userProfiles: UserProfile[],
-  product: PreassignedFareProduct,
-): UserProfile[] =>
-  userProfiles.filter((profile) => isSelectableProfile(product, profile));
 
 export const isSelectableProduct = (
   input: PurchaseSelectionBuilderInput,
@@ -204,8 +198,8 @@ export const applyProductChange = (
   currentSelection: PurchaseSelectionType,
   product: PreassignedFareProduct,
 ): PurchaseSelectionType => {
-  const selectableProfiles = currentSelection.userProfilesWithCount.filter(
-    (up) => isSelectableProfile(product, up),
+  const userCount = currentSelection.userProfilesWithCount.filter((up) =>
+    isSelectableProfile(product, up),
   );
 
   const isFromZoneValid =
@@ -224,8 +218,8 @@ export const applyProductChange = (
   return {
     ...currentSelection,
     preassignedFareProduct: product,
-    userProfilesWithCount: selectableProfiles.length
-      ? selectableProfiles
+    userProfilesWithCount: userCount.length
+      ? userCount
       : getDefaultUserProfiles(input, product),
     zones: newZones ?? currentSelection.zones,
   };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -49,7 +49,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? 'isFree' in params.toPlace && !!params.toPlace.isFree
     : false;
 
-  const {selection, preassignedFareProductAlternatives} = useOfferDefaults(
+  const {selection, preassignedFareProductAlternatives, selectableUserProfiles} = useOfferDefaults(
     params.preassignedFareProduct,
     params.fareProductTypeConfig,
     params.userProfilesWithCount,
@@ -114,7 +114,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const canSelectUserProfile = isUserProfileSelectable(
     travellerSelectionMode,
-    selection.userProfilesWithCount,
+    selectableUserProfiles,
   );
 
   const isOnBehalfOfEnabled =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -33,6 +33,7 @@ import {isUserProfileSelectable} from './utils';
 import {useAuthState} from '@atb/auth';
 import {UserProfileWithCount} from '@atb/fare-contracts';
 import {useFeatureToggles} from '@atb/feature-toggles';
+import {useSelectableUserProfiles} from '@atb/purchase-selection';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -49,17 +50,17 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? 'isFree' in params.toPlace && !!params.toPlace.isFree
     : false;
 
-  const {
-    selection,
-    preassignedFareProductAlternatives,
-    selectableUserProfiles,
-  } = useOfferDefaults(
+  const {selection, preassignedFareProductAlternatives} = useOfferDefaults(
     params.preassignedFareProduct,
     params.fareProductTypeConfig,
     params.userProfilesWithCount,
     params.fromPlace,
     params.toPlace,
     params.travelDate,
+  );
+
+  const selectableUserProfiles = useSelectableUserProfiles(
+    selection.preassignedFareProduct,
   );
 
   const onSelectPreassignedFareProduct = (fp: PreassignedFareProduct) => {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -49,7 +49,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     ? 'isFree' in params.toPlace && !!params.toPlace.isFree
     : false;
 
-  const {selection, preassignedFareProductAlternatives, selectableUserProfiles} = useOfferDefaults(
+  const {
+    selection,
+    preassignedFareProductAlternatives,
+    selectableUserProfiles,
+  } = useOfferDefaults(
     params.preassignedFareProduct,
     params.fareProductTypeConfig,
     params.userProfilesWithCount,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -9,7 +9,6 @@ import {
   FareProductTypeConfig,
   getReferenceDataName,
   TravellerSelectionMode,
-  useFirestoreConfiguration,
 } from '@atb/configuration';
 import {
   GenericClickableSectionItem,
@@ -30,7 +29,7 @@ import {useFocusEffect} from '@react-navigation/native';
 import {isUserProfileSelectable} from '../utils';
 import {useAuthState} from '@atb/auth';
 import {useFeatureToggles} from '@atb/feature-toggles';
-import {getSelectableUserProfiles} from '@atb/purchase-selection';
+import {useSelectableUserProfiles} from '@atb/purchase-selection';
 import {PreassignedFareProduct} from '@atb-as/config-specs';
 
 type TravellerSelectionProps = {
@@ -59,7 +58,6 @@ export function TravellerSelection({
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {authenticationType} = useAuthState();
-  const {userProfiles} = useFirestoreConfiguration();
   const onCloseFocusRef = useRef<RefObject<any>>(null);
 
   const {open: openBottomSheet, close: closeBottomSheet} = useBottomSheet();
@@ -75,8 +73,7 @@ export function TravellerSelection({
   const {addPopOver} = usePopOver();
   const onBehalfOfIndicatorRef = useRef(null);
 
-  const selectableUserProfiles = getSelectableUserProfiles(
-    userProfiles,
+  const selectableUserProfiles = useSelectableUserProfiles(
     preassignedFareProduct,
   );
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -6,7 +6,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {useMemo} from 'react';
-import {FareProductTypeConfig} from '@atb-as/config-specs';
+import {FareProductTypeConfig, UserProfile} from '@atb-as/config-specs';
 import {
   PurchaseSelectionType,
   usePurchaseSelectionBuilder,
@@ -23,9 +23,10 @@ export function useOfferDefaults(
 ): {
   selection: PurchaseSelectionType;
   preassignedFareProductAlternatives: PreassignedFareProduct[];
+  selectableUserProfiles: UserProfile[];
 } {
   const selectionBuilder = usePurchaseSelectionBuilder();
-  const {preassignedFareProducts} = useFirestoreConfiguration();
+  const {preassignedFareProducts, userProfiles} = useFirestoreConfiguration();
 
   const selection = useMemo(
     () => {
@@ -59,6 +60,10 @@ export function useOfferDefaults(
     ],
   );
 
+  const selectableUserProfiles = userProfiles.filter((u) =>
+    selection.preassignedFareProduct.limitations.userProfileRefs.includes(u.id),
+  );
+
   const preassignedFareProductAlternatives = useMemo(() => {
     const productAliasId = selection.preassignedFareProduct?.productAliasId;
     return productAliasId
@@ -70,6 +75,7 @@ export function useOfferDefaults(
 
   return {
     selection,
+    selectableUserProfiles,
     preassignedFareProductAlternatives,
   };
 }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-defaults.ts
@@ -6,7 +6,7 @@ import {UserProfileWithCount} from '@atb/fare-contracts';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {useMemo} from 'react';
-import {FareProductTypeConfig, UserProfile} from '@atb-as/config-specs';
+import {FareProductTypeConfig} from '@atb-as/config-specs';
 import {
   PurchaseSelectionType,
   usePurchaseSelectionBuilder,
@@ -23,10 +23,9 @@ export function useOfferDefaults(
 ): {
   selection: PurchaseSelectionType;
   preassignedFareProductAlternatives: PreassignedFareProduct[];
-  selectableUserProfiles: UserProfile[];
 } {
   const selectionBuilder = usePurchaseSelectionBuilder();
-  const {preassignedFareProducts, userProfiles} = useFirestoreConfiguration();
+  const {preassignedFareProducts} = useFirestoreConfiguration();
 
   const selection = useMemo(
     () => {
@@ -60,10 +59,6 @@ export function useOfferDefaults(
     ],
   );
 
-  const selectableUserProfiles = userProfiles.filter((u) =>
-    selection.preassignedFareProduct.limitations.userProfileRefs.includes(u.id),
-  );
-
   const preassignedFareProductAlternatives = useMemo(() => {
     const productAliasId = selection.preassignedFareProduct?.productAliasId;
     return productAliasId
@@ -75,7 +70,6 @@ export function useOfferDefaults(
 
   return {
     selection,
-    selectableUserProfiles,
     preassignedFareProductAlternatives,
   };
 }


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/19640

The `userProfileWithCount` is not used to determine whether the user can select travellers or not, therefore I added `selectableUserProfiles` to help determine the number of travellers that can be selected, this will then affect the display of the on-behalf-of layout on the purchase overview screen.

I'm guessing we could also just use the `userProfileRefs` count from the `limitation` field inside the `referenceData`, but then we need to have `UserProfile[]` for the `isSelectableUserProfile` function to work.