### PR TITLE
refactor: Allow change theme text to allow a type color definition

### DIFF
--- a/src/anonymous-purchase-consequences-screen/AnonymousPurchaseConsequencesScreenComponent.tsx
+++ b/src/anonymous-purchase-consequences-screen/AnonymousPurchaseConsequencesScreenComponent.tsx
@@ -63,7 +63,7 @@ export const AnonymousPurchaseConsequencesScreenComponent = ({
       secondaryTestID={onPressLogin ? 'acceptLimitations' : ''}
     >
       <View ref={focusRef} accessible>
-        <ThemeText type="heading--big" color={themeColor} style={styles.header}>
+        <ThemeText typography="heading--big" color={themeColor} style={styles.header}>
           {t(AnonymousPurchasesTexts.consequences.title)}
         </ThemeText>
       </View>

--- a/src/anonymous-purchase-consequences-screen/AnonymousPurchaseConsequencesScreenComponent.tsx
+++ b/src/anonymous-purchase-consequences-screen/AnonymousPurchaseConsequencesScreenComponent.tsx
@@ -63,7 +63,11 @@ export const AnonymousPurchaseConsequencesScreenComponent = ({
       secondaryTestID={onPressLogin ? 'acceptLimitations' : ''}
     >
       <View ref={focusRef} accessible>
-        <ThemeText typography="heading--big" color={themeColor} style={styles.header}>
+        <ThemeText
+          typography="heading--big"
+          color={themeColor}
+          style={styles.header}
+        >
           {t(AnonymousPurchasesTexts.consequences.title)}
         </ThemeText>
       </View>

--- a/src/components/bordered-info-box/BorderedInfoBox.tsx
+++ b/src/components/bordered-info-box/BorderedInfoBox.tsx
@@ -32,7 +32,7 @@ export const BorderedInfoBox = ({
     <View style={[styles.container, style]}>
       {'text' in props ? (
         <ThemeText
-          type="body__tertiary"
+          typography="body__tertiary"
           color={backgroundColor}
           testID={testID}
         >

--- a/src/components/bottom-sheet/BottomSheetHeader.tsx
+++ b/src/components/bottom-sheet/BottomSheetHeader.tsx
@@ -52,7 +52,7 @@ export const BottomSheetHeader = ({
         style={styles.headerTitle}
         ref={focusTitleOnLoad ? onOpenFocusRef : undefined}
       >
-        <ThemeText accessible={false} type="body__primary--bold">
+        <ThemeText accessible={false} typography="body__primary--bold">
           {title}
         </ThemeText>
       </View>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -207,7 +207,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
           {text && (
             <View style={textContainer}>
               <ThemeText
-                type={getTextType(mode, type)}
+                typography={getTextType(mode, type)}
                 style={styleText}
                 testID="buttonText"
               >

--- a/src/components/empty-state/EmptyState.tsx
+++ b/src/components/empty-state/EmptyState.tsx
@@ -34,14 +34,14 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
     >
       {illustrationComponent}
       <ThemeText
-        type="body__primary--bold"
+        typography="body__primary--bold"
         color="secondary"
         style={styles.emptyStateTitle}
       >
         {title}
       </ThemeText>
       <ThemeText
-        type="body__secondary"
+        typography="body__secondary"
         color="secondary"
         style={styles.emptyStateDetails}
       >

--- a/src/components/estimated-call/DepartureTime.tsx
+++ b/src/components/estimated-call/DepartureTime.tsx
@@ -11,11 +11,13 @@ import {
   formatToClockOrRelativeMinutes,
   secondsBetween,
 } from '@atb/utils/date';
+import {ContrastColor} from '@atb-as/theme';
 
 type DepartureTimeProps = {
+  color?: ContrastColor;
   departure: EstimatedCall;
 };
-export const DepartureTime = ({departure}: DepartureTimeProps) => {
+export const DepartureTime = ({departure, color}: DepartureTimeProps) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {themeName} = useTheme();
@@ -31,12 +33,13 @@ export const DepartureTime = ({departure}: DepartureTimeProps) => {
           />
         )}
         <ThemeText
-          type={
+          typography={
             departure.cancellation
               ? 'body__primary--strike'
               : 'body__primary--bold'
           }
-          color={departure.cancellation ? 'secondary' : 'primary'}
+          color={color}
+          type={departure.cancellation ? 'secondary' : 'primary'}
         >
           {formatToClockOrRelativeMinutes(
             departure.expectedDepartureTime,
@@ -47,8 +50,9 @@ export const DepartureTime = ({departure}: DepartureTimeProps) => {
       </View>
       {isMoreThanOneMinuteDelayed(departure) && (
         <ThemeText
-          type="body__tertiary--strike"
-          color="secondary"
+          typography="body__tertiary--strike"
+          color={color}
+          type="secondary"
           style={styles.aimedTime}
         >
           {formatLocaleTime(departure.aimedDepartureTime, language)}

--- a/src/components/estimated-call/EstimatedCallInfo.tsx
+++ b/src/components/estimated-call/EstimatedCallInfo.tsx
@@ -50,7 +50,7 @@ export function EstimatedCallInfo({
         <ThemeIcon svg={PinInvalid} color="warning" />
       )}
       <ThemeText
-        type={showAsCancelled ? 'body__primary--strike' : 'body__primary'}
+        typography={showAsCancelled ? 'body__primary--strike' : 'body__primary'}
         color={showAsCancelled ? 'secondary' : 'primary'}
         style={styles.lineName}
         testID={`${testID}LineName`}

--- a/src/components/estimated-call/LineChip.tsx
+++ b/src/components/estimated-call/LineChip.tsx
@@ -59,7 +59,7 @@ export function LineChip({
               minWidth: fontScale * 20,
             },
           ]}
-          type="body__primary--bold"
+          typography="body__primary--bold"
           testID={`${testID}PublicCode`}
         >
           {publicCode}

--- a/src/components/feedback/GoodOrBadButton.tsx
+++ b/src/components/feedback/GoodOrBadButton.tsx
@@ -50,7 +50,7 @@ export const GoodOrBadButton = ({
         >
           <ThemeText
             color={getThemeColor(theme)}
-            type={checked ? 'body__primary--bold' : 'body__primary'}
+            typography={checked ? 'body__primary--bold' : 'body__primary'}
           >
             {opinion === Opinions.Good && t(FeedbackTexts.goodOrBadTexts.good)}
             {opinion === Opinions.Bad && t(FeedbackTexts.goodOrBadTexts.bad)}
@@ -58,10 +58,10 @@ export const GoodOrBadButton = ({
 
           <View style={styles.emoji}>
             {opinion === Opinions.Good && (
-              <ThemeText type="body__primary--jumbo">🙌</ThemeText>
+              <ThemeText typography="body__primary--jumbo">🙌</ThemeText>
             )}
             {opinion === Opinions.Bad && (
-              <ThemeText type="body__primary--jumbo">👎</ThemeText>
+              <ThemeText typography="body__primary--jumbo">👎</ThemeText>
             )}
           </View>
         </View>

--- a/src/components/feedback/GoodOrBadQuestion.tsx
+++ b/src/components/feedback/GoodOrBadQuestion.tsx
@@ -31,7 +31,7 @@ export const GoodOrBadQuestion = ({
 
   return (
     <>
-      <ThemeText type="heading__component" style={styles.questionText}>
+      <ThemeText typography="heading__component" style={styles.questionText}>
         {category.introText[language]}
       </ThemeText>
 

--- a/src/components/feedback/RenderQuestions.tsx
+++ b/src/components/feedback/RenderQuestions.tsx
@@ -41,7 +41,7 @@ export const RenderQuestion = ({
   return (
     <View>
       <View style={styles.questionTitleView}>
-        <ThemeText type="body__primary--bold">
+        <ThemeText typography="body__primary--bold">
           {question.questionText[language]}
         </ThemeText>
       </View>
@@ -97,7 +97,7 @@ function AlternativeItem({
             : [topContainer, styles.alternativeBox]
         }
       >
-        <ThemeText type="body__primary">
+        <ThemeText typography="body__primary">
           {alternative.alternativeText[language]}
         </ThemeText>
       </View>

--- a/src/components/feedback/SubmittedComponent.tsx
+++ b/src/components/feedback/SubmittedComponent.tsx
@@ -56,7 +56,7 @@ export const SubmittedComponent = ({
     <View style={styles.container}>
       <View accessible={true} accessibilityRole="header" ref={focusRef}>
         <ThemeText
-          type="body__primary--bold"
+          typography="body__primary--bold"
           style={[styles.questionText, styles.centerText]}
         >
           {t(FeedbackTexts.submittedText.thanks)}

--- a/src/components/heading/ContentHeading.tsx
+++ b/src/components/heading/ContentHeading.tsx
@@ -22,7 +22,7 @@ export function ContentHeading({
   return (
     <View style={[styles.container, style]}>
       <ThemeText
-        type="body__secondary"
+        typography="body__secondary"
         color={color}
         accessibilityLabel={accessibilityLabel}
       >

--- a/src/components/heading/ScreenHeading.tsx
+++ b/src/components/heading/ScreenHeading.tsx
@@ -19,7 +19,7 @@ export const ScreenHeading = forwardRef<any, ScreenHeadingProps>(
     return (
       <View style={styles.container} ref={ref} accessible role="heading">
         <ThemeText
-          type="heading--medium"
+          typography="heading--medium"
           color={color}
           accessibilityLabel={accessibilityLabel}
         >

--- a/src/components/icon-box/CounterIconBox.tsx
+++ b/src/components/icon-box/CounterIconBox.tsx
@@ -41,7 +41,7 @@ export const CounterIconBox = ({
     >
       <ThemeText
         color={getTransportColor(theme).secondary}
-        type={textType}
+        typography={textType}
         testID="tripLegMore"
         style={{
           height: lineHeight * fontScale,

--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -45,7 +45,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
 
   const lineNumberElement = lineNumber ? (
     <ThemeText
-      type="body__primary--bold"
+      typography="body__primary--bold"
       color={transportationColor}
       style={styles.lineNumberText}
       testID="lineNumber"

--- a/src/components/label-info/LabelInfo.tsx
+++ b/src/components/label-info/LabelInfo.tsx
@@ -22,7 +22,10 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
   return (
     <View style={linkSectionItemStyle.flag}>
-      <ThemeText color={theme.color.status.info.primary} typography="body__tertiary">
+      <ThemeText
+        color={theme.color.status.info.primary}
+        typography="body__tertiary"
+      >
         {flagTranslated}
       </ThemeText>
     </View>

--- a/src/components/label-info/LabelInfo.tsx
+++ b/src/components/label-info/LabelInfo.tsx
@@ -22,7 +22,7 @@ export const LabelInfo = ({label}: LabelInfoProps) => {
 
   return (
     <View style={linkSectionItemStyle.flag}>
-      <ThemeText color={theme.color.status.info.primary} type="body__tertiary">
+      <ThemeText color={theme.color.status.info.primary} typography="body__tertiary">
         {flagTranslated}
       </ThemeText>
     </View>

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -18,7 +18,7 @@ export const Loading: React.FC<{text?: string}> = ({text}) => {
         color={themeColor.foreground.primary}
       />
       {text ? (
-        <ThemeText type="body__primary--bold" style={styles.text}>
+        <ThemeText typography="body__primary--bold" style={styles.text}>
           {text}
         </ThemeText>
       ) : null}

--- a/src/components/map/components/LocationBar.tsx
+++ b/src/components/map/components/LocationBar.tsx
@@ -115,8 +115,8 @@ const LocationText: React.FC<{
   const {title, subtitle} = getLocationText(t, location, error);
   return (
     <>
-      <ThemeText type="body__secondary">{title}</ThemeText>
-      {subtitle && <ThemeText type="body__tertiary">{subtitle}</ThemeText>}
+      <ThemeText typography="body__secondary">{title}</ThemeText>
+      {subtitle && <ThemeText typography="body__tertiary">{subtitle}</ThemeText>}
     </>
   );
 };

--- a/src/components/map/components/LocationBar.tsx
+++ b/src/components/map/components/LocationBar.tsx
@@ -116,7 +116,9 @@ const LocationText: React.FC<{
   return (
     <>
       <ThemeText typography="body__secondary">{title}</ThemeText>
-      {subtitle && <ThemeText typography="body__tertiary">{subtitle}</ThemeText>}
+      {subtitle && (
+        <ThemeText typography="body__tertiary">{subtitle}</ThemeText>
+      )}
     </>
   );
 };

--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -110,7 +110,7 @@ export const MessageInfoBox = ({
       >
         {title && (
           <ThemeText
-            type="body__primary--bold"
+            typography="body__primary--bold"
             color={textColor}
             style={styles.title}
             testID={testID ? `${testID}Title` : 'title'}
@@ -120,7 +120,7 @@ export const MessageInfoBox = ({
         )}
         <ThemeText
           color={textColor}
-          type="body__primary"
+          typography="body__primary"
           isMarkdown={isMarkdown}
         >
           {message}
@@ -129,7 +129,7 @@ export const MessageInfoBox = ({
           <ThemeText
             color={textColor}
             style={styles.linkText}
-            type="body__primary--underline"
+            typography="body__primary--underline"
           >
             {onPressConfig.text}
           </ThemeText>

--- a/src/components/message-info-text/MessageInfoText.tsx
+++ b/src/components/message-info-text/MessageInfoText.tsx
@@ -47,7 +47,7 @@ export const MessageInfoText = ({
       <ThemeText
         color={textColor}
         isMarkdown={isMarkdown}
-        type="body__secondary"
+        typography="body__secondary"
         style={styles.text}
       >
         {message}

--- a/src/components/popover/PopOver.tsx
+++ b/src/components/popover/PopOver.tsx
@@ -51,7 +51,7 @@ export const PopOver = ({
       backgroundStyle={style.backdrop}
     >
       <View style={style.heading}>
-        <ThemeText type="body__primary--bold">{heading}</ThemeText>
+        <ThemeText typography="body__primary--bold">{heading}</ThemeText>
         <TouchableOpacity onPress={handleClose} testID="closePopover">
           <ThemeIcon style={style.closeIcon} svg={Close} />
         </TouchableOpacity>

--- a/src/components/radio/RadioBox.tsx
+++ b/src/components/radio/RadioBox.tsx
@@ -70,7 +70,7 @@ export function RadioBox({
       testID={testID}
     >
       <ThemeText
-        type="heading__title"
+        typography="heading__title"
         color={themeColor}
         style={{...styles.title, marginBottom: spacing}}
       >
@@ -78,7 +78,7 @@ export function RadioBox({
       </ThemeText>
       <View style={{...styles.icon, marginBottom: spacing}}>{icon}</View>
       <ThemeText
-        type="body__secondary"
+        typography="body__secondary"
         color={themeColor}
         style={{...styles.description, marginBottom: spacing}}
         accessible={false}

--- a/src/components/radio/RadioSegments.tsx
+++ b/src/components/radio/RadioSegments.tsx
@@ -78,14 +78,14 @@ export function RadioSegments({
             ]}
           >
             <ThemeText
-              type={selected ? 'body__secondary--bold' : 'body__secondary'}
+              typography={selected ? 'body__secondary--bold' : 'body__secondary'}
               style={[styles.optionText, {color: textColor}]}
             >
               {option.text}
             </ThemeText>
             {option.subtext && (
               <ThemeText
-                type="body__secondary"
+                typography="body__secondary"
                 style={[styles.optionText, {color: textColor}]}
               >
                 {option.subtext}

--- a/src/components/radio/RadioSegments.tsx
+++ b/src/components/radio/RadioSegments.tsx
@@ -78,7 +78,9 @@ export function RadioSegments({
             ]}
           >
             <ThemeText
-              typography={selected ? 'body__secondary--bold' : 'body__secondary'}
+              typography={
+                selected ? 'body__secondary--bold' : 'body__secondary'
+              }
               style={[styles.optionText, {color: textColor}]}
             >
               {option.text}

--- a/src/components/screen-header/AnimatedScreenHeader.tsx
+++ b/src/components/screen-header/AnimatedScreenHeader.tsx
@@ -80,7 +80,7 @@ export const AnimatedScreenHeader: React.FC<ScreenHeaderProps> = ({
           ]}
         >
           <View accessible={true} accessibilityRole="header" ref={focusRef}>
-            <ThemeText color={themeColor} type="body__primary--bold">
+            <ThemeText color={themeColor} typography="body__primary--bold">
               {title}
             </ThemeText>
           </View>

--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -100,7 +100,7 @@ export const ScreenHeader: React.FC<ScreenHeaderProps> = ({
           <ThemeText
             accessible={false}
             onLayout={setLayoutFor('title')}
-            type="body__primary--bold"
+            typography="body__primary--bold"
             color={themeColor}
           >
             {title && textOpacity > 0 ? title : '\u00a0'}

--- a/src/components/sections/items/ButtonSectionItem.tsx
+++ b/src/components/sections/items/ButtonSectionItem.tsx
@@ -75,7 +75,9 @@ export function ButtonSectionItem({
     isStringText(value) || !value ? (
       <ThemeText
         numberOfLines={1}
-        typography={value && highlighted ? 'body__primary--bold' : 'body__primary'}
+        typography={
+          value && highlighted ? 'body__primary--bold' : 'body__primary'
+        }
         style={!value && styles.faded}
       >
         {value ?? placeholder}

--- a/src/components/sections/items/ButtonSectionItem.tsx
+++ b/src/components/sections/items/ButtonSectionItem.tsx
@@ -75,7 +75,7 @@ export function ButtonSectionItem({
     isStringText(value) || !value ? (
       <ThemeText
         numberOfLines={1}
-        type={value && highlighted ? 'body__primary--bold' : 'body__primary'}
+        typography={value && highlighted ? 'body__primary--bold' : 'body__primary'}
         style={!value && styles.faded}
       >
         {value ?? placeholder}
@@ -95,7 +95,7 @@ export function ButtonSectionItem({
         {...props}
       >
         <View style={sectionStyles.spaceBetween}>
-          <ThemeText type="body__secondary" style={styles.label}>
+          <ThemeText typography="body__secondary" style={styles.label}>
             {label}
           </ThemeText>
           {inlineValue && (

--- a/src/components/sections/items/CounterSectionItem.tsx
+++ b/src/components/sections/items/CounterSectionItem.tsx
@@ -59,7 +59,7 @@ export function CounterSectionItem({
         <ThemeText>{text}</ThemeText>
         {subtext && !hideSubtext && (
           <ThemeText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={counterStyles.infoSubtext}
           >
@@ -112,7 +112,7 @@ export function CounterSectionItem({
               counterStyles.countText,
               activeColor && {color: activeColor.foreground.primary},
             ]}
-            type="body__primary--bold"
+            typography="body__primary--bold"
             testID={testID + '_count'}
           >
             {count}

--- a/src/components/sections/items/ExpandableSectionItem.tsx
+++ b/src/components/sections/items/ExpandableSectionItem.tsx
@@ -91,7 +91,7 @@ export function ExpandableSectionItem({
         testID={testID}
         {...accessibility}
       >
-        <ThemeText style={contentContainer} type={textType}>
+        <ThemeText style={contentContainer} typography={textType}>
           {text}
         </ThemeText>
         {label && <LabelInfo label={label} />}
@@ -123,7 +123,7 @@ function ExpandIcon({
   return (
     <View style={styles.expandIcon}>
       {text && (
-        <ThemeText style={styles.expandIcon__text} type="body__secondary">
+        <ThemeText style={styles.expandIcon__text} typography="body__secondary">
           {text}
         </ThemeText>
       )}

--- a/src/components/sections/items/FavoriteDepartureSectionItem.tsx
+++ b/src/components/sections/items/FavoriteDepartureSectionItem.tsx
@@ -79,7 +79,7 @@ function FavoriteItemContent({favorite, icon, ...props}: BaseProps) {
           {formatDestinationDisplay(t, favorite.destinationDisplay) ??
             t(SectionTexts.favoriteDeparture.allVariations)}
         </ThemeText>
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {t(SectionTexts.favoriteDeparture.from)} {favorite.quayName}{' '}
           {favorite.quayPublicCode ?? ''}
         </ThemeText>

--- a/src/components/sections/items/HeaderSectionItem.tsx
+++ b/src/components/sections/items/HeaderSectionItem.tsx
@@ -23,7 +23,7 @@ export function HeaderSectionItem({
     <View style={topContainer}>
       <ThemeText
         style={contentContainer}
-        type={mode === 'heading' ? 'body__primary--bold' : 'body__secondary'}
+        typography={mode === 'heading' ? 'body__primary--bold' : 'body__secondary'}
       >
         {text}
       </ThemeText>
@@ -31,7 +31,7 @@ export function HeaderSectionItem({
         <ThemeText
           style={[styles.subtitle, contentContainer]}
           color="secondary"
-          type={mode === 'heading' ? 'body__secondary' : 'body__tertiary'}
+          typography={mode === 'heading' ? 'body__secondary' : 'body__tertiary'}
         >
           {subtitle}
         </ThemeText>

--- a/src/components/sections/items/HeaderSectionItem.tsx
+++ b/src/components/sections/items/HeaderSectionItem.tsx
@@ -10,6 +10,7 @@ type Props = SectionItemProps<{
   subtitle?: string;
   mode?: 'heading' | 'subheading';
 }>;
+
 export function HeaderSectionItem({
   text,
   subtitle,
@@ -23,7 +24,9 @@ export function HeaderSectionItem({
     <View style={topContainer}>
       <ThemeText
         style={contentContainer}
-        typography={mode === 'heading' ? 'body__primary--bold' : 'body__secondary'}
+        typography={
+          mode === 'heading' ? 'body__primary--bold' : 'body__secondary'
+        }
       >
         {text}
       </ThemeText>

--- a/src/components/sections/items/InternalLabeledSectionItem.tsx
+++ b/src/components/sections/items/InternalLabeledSectionItem.tsx
@@ -34,12 +34,12 @@ export function InternalLabeledSectionItem({
     <View style={[style.spaceBetween, topContainer, wrapperStyle]}>
       {leftIcon && <ThemeIcon svg={leftIcon} style={itemStyle.icon} />}
       <View accessible={accessibleLabel} style={itemStyle.label}>
-        <ThemeText accessible={accessibleLabel} type="body__primary">
+        <ThemeText accessible={accessibleLabel} typography="body__primary">
           {label}
         </ThemeText>
         {subtext && (
           <ThemeText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={itemStyle.label}
             accessible={accessibleLabel}

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -87,7 +87,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
         <View style={[style.spaceBetween, disabledStyle]}>
           <ThemeText
             style={[contentContainer, {color: themeColor.foreground.primary}]}
-            type={textType}
+            typography={textType}
           >
             {text}
           </ThemeText>
@@ -96,7 +96,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
         </View>
         {subtitle && (
           <View style={disabledStyle}>
-            <ThemeText color="secondary" type="body__secondary">
+            <ThemeText color="secondary" typography="body__secondary">
               {subtitle}
             </ThemeText>
           </View>

--- a/src/components/sections/items/MessageSectionItem.tsx
+++ b/src/components/sections/items/MessageSectionItem.tsx
@@ -64,7 +64,7 @@ export function MessageSectionItem({
       <View style={styles.textContent}>
         {title && (
           <ThemeText
-            type="body__primary--bold"
+            typography="body__primary--bold"
             style={styles.title}
             color={messageType}
             testID="title"
@@ -77,7 +77,7 @@ export function MessageSectionItem({
           <ThemeText
             color={messageType}
             style={styles.linkText}
-            type="body__primary--underline"
+            typography="body__primary--underline"
           >
             {onPressConfig.text}
           </ThemeText>

--- a/src/components/sections/items/PhoneInputSectionItem.tsx
+++ b/src/components/sections/items/PhoneInputSectionItem.tsx
@@ -162,7 +162,7 @@ export const PhoneInputSectionItem = forwardRef<InternalTextInput, Props>(
           onAccessibilityEscape={accessibilityEscapeKeyboard}
         >
           {label && (
-            <ThemeText type="body__secondary" style={styles.label}>
+            <ThemeText typography="body__secondary" style={styles.label}>
               {label}
             </ThemeText>
           )}

--- a/src/components/sections/items/RadioSectionItem.tsx
+++ b/src/components/sections/items/RadioSectionItem.tsx
@@ -88,14 +88,14 @@ export function RadioSectionItem({
         {leftIcon && <ThemeIcon svg={leftIcon} style={styles.leftIcon} />}
         <View style={styles.textContainer}>
           <ThemeText
-            type="body__primary"
+            typography="body__primary"
             style={[contentContainer, {color: textColor}]}
           >
             {text}
           </ThemeText>
           {subtext && !hideSubtext && (
             <ThemeText
-              type="body__secondary"
+              typography="body__secondary"
               color="secondary"
               style={{marginTop: theme.spacing.small}}
             >

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -122,7 +122,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         ]}
         onAccessibilityEscape={accessibilityEscapeKeyboard}
       >
-        <ThemeText type="body__secondary" style={styles.label}>
+        <ThemeText typography="body__secondary" style={styles.label}>
           {label}
         </ThemeText>
         <View style={inlineLabel ? contentContainer : undefined}>

--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -80,7 +80,7 @@ export function ToggleSectionItem({
         <View style={{flexDirection: 'column', flex: 1}}>
           <View style={sectionStyle.spaceBetween}>
             <View style={styles.textContainer}>
-              <ThemeText type={textType}>{text}</ThemeText>
+              <ThemeText typography={textType}>{text}</ThemeText>
             </View>
             {label && <LabelInfo label={label} />}
             <Toggle
@@ -95,7 +95,7 @@ export function ToggleSectionItem({
           </View>
           {subtext && (
             <ThemeText
-              type="body__secondary"
+              typography="body__secondary"
               color="secondary"
               style={styles.subtext}
               isMarkdown={isSubtextMarkdown}

--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -104,7 +104,7 @@ const SnackbarInstance = ({
           <View style={styles.snackbarTexts} ref={focusRef} accessible={true}>
             {activeTextContent?.title && (
               <ThemeText
-                type="body__primary--bold"
+                typography="body__primary--bold"
                 color="primary"
                 numberOfLines={4} // max limit, should normally not come into play
               >
@@ -113,7 +113,7 @@ const SnackbarInstance = ({
             )}
             {activeTextContent?.description && (
               <ThemeText
-                type="body__primary"
+                typography="body__primary"
                 color={activeTextContent?.title ? 'secondary' : 'primary'}
                 numberOfLines={7} // max limit, should normally not come into play
               >

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -88,7 +88,10 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   return <Text {...textProps}>{content}</Text>;
 };
 
-function useColor(color: ContrastColor | TextColor | Statuses | ColorValue | undefined, type: keyof ContrastColor['foreground']) {
+function useColor(
+  color: ContrastColor | TextColor | Statuses | ColorValue | undefined,
+  type: keyof ContrastColor['foreground'],
+) {
   const {theme} = useTheme();
   if (typeof color === 'object') {
     return color.foreground[type];

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -20,13 +20,15 @@ import {
 } from '@atb/theme/colors';
 
 export type ThemeTextProps = TextProps & {
-  type?: TextNames;
+  typography?: TextNames;
+  type?: keyof ContrastColor['foreground'];
   color?: ContrastColor | Statuses | TextColor | ColorValue;
   isMarkdown?: boolean;
 };
 
 export const ThemeText: React.FC<ThemeTextProps> = ({
-  type: fontType = 'body__primary',
+  typography: fontType = 'body__primary',
+  type = 'primary',
   color,
   isMarkdown = false,
   style,
@@ -34,7 +36,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   ...props
 }) => {
   const {theme, useAndroidSystemFont} = useTheme();
-  const textColor = useColor(color);
+  const textColor = useColor(color, type);
 
   const typeStyle = {
     ...theme.typography[fontType],
@@ -86,12 +88,12 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   return <Text {...textProps}>{content}</Text>;
 };
 
-function useColor(color?: ContrastColor | TextColor | Statuses | ColorValue) {
+function useColor(color: ContrastColor | TextColor | Statuses | ColorValue | undefined, type: keyof ContrastColor['foreground']) {
   const {theme} = useTheme();
   if (typeof color === 'object') {
-    return color.foreground.primary;
+    return color.foreground[type];
   } else if (isStatusColor(color, theme)) {
-    return theme.color.status[color].secondary.foreground.primary;
+    return theme.color.status[color].secondary.foreground[type];
   } else if (isTextColor(color, theme) || color === undefined) {
     return theme.color.foreground.dynamic[color ?? 'primary'];
   } else {

--- a/src/components/tile/TileWithButton.tsx
+++ b/src/components/tile/TileWithButton.tsx
@@ -63,7 +63,7 @@ export function TileWithButton({
       >
         <ThemeText
           style={styles.buttonText}
-          type={mode === 'spacious' ? 'body__primary' : 'body__tertiary'}
+          typography={mode === 'spacious' ? 'body__primary' : 'body__tertiary'}
         >
           {buttonText}
         </ThemeText>

--- a/src/components/transportation-modes/TransportModes.tsx
+++ b/src/components/transportation-modes/TransportModes.tsx
@@ -85,7 +85,7 @@ export const TransportModes = ({
         iconSize={iconSize}
         disabled={disabled}
       />
-      <ThemeText type={textType ?? 'label__uppercase'} color={textColor}>
+      <ThemeText typography={textType ?? 'label__uppercase'} color={textColor}>
         {customTransportModeText ?? description}
       </ThemeText>
     </View>

--- a/src/components/vipps-login-button/VippsLoginButton.tsx
+++ b/src/components/vipps-login-button/VippsLoginButton.tsx
@@ -33,7 +33,7 @@ export const VippsLoginButton = ({
         style={[styles.container, disabled && styles.disabledOpacity, style]}
       >
         <ThemeText
-          type="body__primary--bold"
+          typography="body__primary--bold"
           style={styles.label}
           color={interactiveColor}
         >

--- a/src/components/walking-distance/WalkingDistance.tsx
+++ b/src/components/walking-distance/WalkingDistance.tsx
@@ -20,7 +20,7 @@ export const WalkingDistance = ({style, distance}: Props) => {
   return (
     <View style={[style, sheetStyles.distanceLabel]}>
       <ThemeIcon svg={Walk} color="secondary" style={sheetStyles.icon} />
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {humanizedDistance}
       </ThemeText>
     </View>

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -254,7 +254,7 @@ function DepartureTimeItem({
       {leftIcon && <ThemeIcon svg={leftIcon} size="xSmall" />}
 
       <ThemeText
-        type="body__primary--bold"
+        typography="body__primary--bold"
         style={[
           styles.departureText,
           departure.cancellation && styles.strikethrough,

--- a/src/departure-list/section-items/quay-header.tsx
+++ b/src/departure-list/section-items/quay-header.tsx
@@ -68,7 +68,7 @@ export function QuayHeaderItem({
         accessibilityLabel={`${accessibilityLabel} ${label} ${screenReaderPause}`}
         accessibilityRole="header"
       >
-        <ThemeText type="body__primary--bold" testID={testID + 'Title'}>
+        <ThemeText typography="body__primary--bold" testID={testID + 'Title'}>
           {title}
         </ThemeText>
         <Distance distance={humanized} />

--- a/src/error-boundary/FullScreenErrorView.tsx
+++ b/src/error-boundary/FullScreenErrorView.tsx
@@ -25,7 +25,7 @@ export function FullScreenErrorView({onRestartApp, errorCode}: ErrorProps) {
       </View>
       <View style={styles.container}>
         <View>
-          <ThemeText type="body__primary--bold" style={styles.title}>
+          <ThemeText typography="body__primary--bold" style={styles.title}>
             Appen krasja - håper du lander mykt!
           </ThemeText>
           <ThemeText style={styles.message}>

--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -80,21 +80,21 @@ const CompactFareContractInfoTexts = (
 
   return (
     <View style={styles.textsContainer}>
-      <ThemeText type="body__primary--bold" style={styles.expireTime}>
+      <ThemeText typography="body__primary--bold" style={styles.expireTime}>
         {timeUntilExpire}
       </ThemeText>
       {userProfilesWithCount.map((u) => (
-        <ThemeText key={u.id} type="body__secondary" color="secondary">
+        <ThemeText key={u.id} typography="body__secondary" color="secondary">
           {userProfileCountAndName(u, language)}
         </ThemeText>
       ))}
       {productName && (
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {productName}
         </ThemeText>
       )}
       {tariffZoneSummary && (
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {tariffZoneSummary}
         </ThemeText>
       )}

--- a/src/fare-contracts/FareContractInfo.tsx
+++ b/src/fare-contracts/FareContractInfo.tsx
@@ -105,7 +105,7 @@ export const FareContractInfoHeader = ({
     <View style={styles.header}>
       {productName && (
         <ThemeText
-          type="body__primary--bold"
+          typography="body__primary--bold"
           accessibilityLabel={productName + screenReaderPause}
           testID={testID + 'Product'}
         >
@@ -114,7 +114,7 @@ export const FareContractInfoHeader = ({
       )}
       {productDescription && (
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           accessibilityLabel={productDescription + screenReaderPause}
           testID={testID + 'ProductDescription'}
         >

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -29,6 +29,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
       Bugsnag.notify(err);
     }
   }
+
   const getStatus = () => {
     const paymentStatus = reservation.paymentStatus;
     switch (paymentStatus) {
@@ -65,7 +66,10 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
             ) : (
               <FareContractStatusSymbol status={status} />
             )}
-            <ThemeText typography="body__secondary" style={styles.reservationStatus}>
+            <ThemeText
+              typography="body__secondary"
+              style={styles.reservationStatus}
+            >
               {t(TicketingTexts.reservation[status])}
             </ThemeText>
           </View>

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -65,7 +65,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
             ) : (
               <FareContractStatusSymbol status={status} />
             )}
-            <ThemeText type="body__secondary" style={styles.reservationStatus}>
+            <ThemeText typography="body__secondary" style={styles.reservationStatus}>
               {t(TicketingTexts.reservation[status])}
             </ThemeText>
           </View>
@@ -73,7 +73,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
         <VerifyingValidityLine status={status} />
         <View style={styles.infoContainer} accessible={true}>
           {status == 'rejected' && (
-            <ThemeText type="body__secondary" color="secondary">
+            <ThemeText typography="body__secondary" color="secondary">
               {t(
                 TicketingTexts.reservation.orderDate(
                   formatToLongDateTime(
@@ -85,7 +85,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
             </ThemeText>
           )}
           <ThemeText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={styles.detail}
           >

--- a/src/fare-contracts/ValidityHeader.tsx
+++ b/src/fare-contracts/ValidityHeader.tsx
@@ -59,7 +59,7 @@ export const ValidityHeader: React.FC<{
         )}
         <ThemeText
           style={styles.label}
-          type="body__secondary"
+          typography="body__secondary"
           accessibilityLabel={
             !isInspectable
               ? label +

--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -33,7 +33,7 @@ export const CarnetFooter: React.FC<Props> = ({
       )}
     >
       <View>
-        <ThemeText type="body__secondary">
+        <ThemeText typography="body__secondary">
           {t(
             FareContractTexts.carnet.numberOfUsedAccessesRemaining(
               accessesRemaining,
@@ -75,7 +75,7 @@ function MultiCarnet({count}: {count: number}) {
         <View style={styles.triangle} />
       </View>
       <View style={styles.count}>
-        <ThemeText type="body__tertiary">{count}</ThemeText>
+        <ThemeText typography="body__tertiary">{count}</ThemeText>
       </View>
     </View>
   );

--- a/src/fare-contracts/components/FareContractDetail.tsx
+++ b/src/fare-contracts/components/FareContractDetail.tsx
@@ -20,7 +20,7 @@ export function FareContractDetail({
 
   return (
     <View style={styles.container}>
-      <ThemeText type="body__secondary" color={textColor}>
+      <ThemeText typography="body__secondary" color={textColor}>
         {header}
       </ThemeText>
       {content.map((c) => (

--- a/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
+++ b/src/fare-contracts/components/FareContractHarborStopPlaces.tsx
@@ -82,7 +82,7 @@ export function FareContractHarborStopPlaces({
           borderLeftWidth: decorationLineWidth,
         }}
       >
-        <ThemeText type="body__secondary" color="primary">
+        <ThemeText typography="body__secondary" color="primary">
           {fromName}
         </ThemeText>
 
@@ -110,7 +110,7 @@ export function FareContractHarborStopPlaces({
           )}
         </View>
 
-        <ThemeText type="body__secondary" color="primary">
+        <ThemeText typography="body__secondary" color="primary">
           {toName}
         </ThemeText>
       </View>

--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -115,7 +115,7 @@ const NotInspectableContent = () => {
   return (
     <View style={styles.symbolContent}>
       <ThemeText
-        type="body__tertiary"
+        typography="body__tertiary"
         style={{
           textAlign: 'center',
         }}

--- a/src/fare-contracts/details/OrderDetails.tsx
+++ b/src/fare-contracts/details/OrderDetails.tsx
@@ -26,7 +26,7 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
 
   return (
     <View accessible={true}>
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {t(
           FareContractTexts.details.purchaseTime(
             fullDateTime(
@@ -39,7 +39,7 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
       {isNormalTravelRight(firstTravelRight) && (
         <>
           <ThemeText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={style.marginTop}
           >
@@ -50,7 +50,7 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
             )}
           </ThemeText>
           <ThemeText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={style.marginTop}
           >
@@ -64,7 +64,7 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
       )}
       {fareContract.state !== FareContractState.Refunded && priceString && (
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           color="secondary"
           style={style.marginTop}
         >
@@ -73,7 +73,7 @@ export const OrderDetails = ({fareContract}: {fareContract: FareContract}) => {
       )}
       {fareContract.state !== FareContractState.Refunded && (
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           color="secondary"
           style={style.marginTop}
         >

--- a/src/fare-contracts/details/UsedAccessesSectionItem.tsx
+++ b/src/fare-contracts/details/UsedAccessesSectionItem.tsx
@@ -23,7 +23,11 @@ export const UsedAccessesSectionItem = ({usedAccesses}: Props) => {
         {t(FareContractTexts.details.usedAccesses)}
       </ThemeText>
       {dateStrings.map((dateString) => (
-        <ThemeText key={dateString} typography="body__secondary" color="secondary">
+        <ThemeText
+          key={dateString}
+          typography="body__secondary"
+          color="secondary"
+        >
           {dateString}
         </ThemeText>
       ))}

--- a/src/fare-contracts/details/UsedAccessesSectionItem.tsx
+++ b/src/fare-contracts/details/UsedAccessesSectionItem.tsx
@@ -19,11 +19,11 @@ export const UsedAccessesSectionItem = ({usedAccesses}: Props) => {
 
   return (
     <View style={topContainer} accessible={true}>
-      <ThemeText type="body__secondary">
+      <ThemeText typography="body__secondary">
         {t(FareContractTexts.details.usedAccesses)}
       </ThemeText>
       {dateStrings.map((dateString) => (
-        <ThemeText key={dateString} type="body__secondary" color="secondary">
+        <ThemeText key={dateString} typography="body__secondary" color="secondary">
           {dateString}
         </ThemeText>
       ))}

--- a/src/force-update-screen/ForceUpdateScreen.tsx
+++ b/src/force-update-screen/ForceUpdateScreen.tsx
@@ -38,7 +38,7 @@ export const ForceUpdateScreen = () => {
             />
           </View>
           <ThemeText
-            type="body__primary--big--bold"
+            typography="body__primary--big--bold"
             style={styles.title}
             color={themeColor}
           >

--- a/src/information-screen/InformationScreenComponent.tsx
+++ b/src/information-screen/InformationScreenComponent.tsx
@@ -79,7 +79,7 @@ export const InformationScreenComponent: React.FC<InformationProps> = ({
 const Header = ({text}: {text: string}) => {
   const styles = useStyles();
   return (
-    <ThemeText style={styles.paragraphHeading} type="heading__paragraph">
+    <ThemeText style={styles.paragraphHeading} typography="heading__paragraph">
       {text}
     </ThemeText>
   );
@@ -94,7 +94,7 @@ const Link = ({link}: {link: InformationLink}) => {
       onPress={() => Linking.openURL(link.link ?? '')}
       accessibilityRole="link"
     >
-      <ThemeText type="body__primary--underline">{link.text}</ThemeText>
+      <ThemeText typography="body__primary--underline">{link.text}</ThemeText>
     </PressableOpacity>
   );
 };

--- a/src/loading-screen/LoadingErrorScreen.tsx
+++ b/src/loading-screen/LoadingErrorScreen.tsx
@@ -34,7 +34,7 @@ export const LoadingErrorScreen = React.memo(({retry}: {retry: () => void}) => {
         <View>
           <View ref={focusRef} accessible={true}>
             <ThemeText
-              type="heading--jumbo"
+              typography="heading--jumbo"
               style={styles.header}
               color={themeColor}
             >
@@ -47,7 +47,7 @@ export const LoadingErrorScreen = React.memo(({retry}: {retry: () => void}) => {
           {localConfig && (
             <ThemeText
               color={themeColor}
-              type="body__secondary"
+              typography="body__secondary"
               accessibilityLabel={t(
                 LoadingScreenTexts.error.installId(
                   spellOut(localConfig.installId),

--- a/src/loading-screen/LoadingScreen.tsx
+++ b/src/loading-screen/LoadingScreen.tsx
@@ -25,7 +25,7 @@ export const LoadingScreen = React.memo(() => {
       />
       <ThemeText
         style={styles.loadingText}
-        type="body__primary"
+        typography="body__primary"
         color={themeColor}
         testID="loadingScreenText"
       >

--- a/src/mobility/components/BenefitTiles.tsx
+++ b/src/mobility/components/BenefitTiles.tsx
@@ -83,7 +83,10 @@ export const BenefitTile = ({
             style: styles.image,
           }}
         />
-        <ThemeText typography="body__tertiary--bold" color={interactiveColor.default}>
+        <ThemeText
+          typography="body__tertiary--bold"
+          color={interactiveColor.default}
+        >
           {title}
         </ThemeText>
         <ThemeText

--- a/src/mobility/components/BenefitTiles.tsx
+++ b/src/mobility/components/BenefitTiles.tsx
@@ -83,11 +83,11 @@ export const BenefitTile = ({
             style: styles.image,
           }}
         />
-        <ThemeText type="body__tertiary--bold" color={interactiveColor.default}>
+        <ThemeText typography="body__tertiary--bold" color={interactiveColor.default}>
           {title}
         </ThemeText>
         <ThemeText
-          type="body__tertiary"
+          typography="body__tertiary"
           color="secondary"
           style={styles.description}
         >

--- a/src/mobility/components/BikeStationBottomSheet.tsx
+++ b/src/mobility/components/BikeStationBottomSheet.tsx
@@ -88,7 +88,7 @@ export const BikeStationBottomSheet = ({
                     style={styles.operatorNameAndLogo}
                   />
                   <View style={styles.stationText}>
-                    <ThemeText type="body__secondary" color="secondary">
+                    <ThemeText typography="body__secondary" color="secondary">
                       {stationName}
                     </ThemeText>
                     <WalkingDistance distance={distance} />

--- a/src/mobility/components/CarName.tsx
+++ b/src/mobility/components/CarName.tsx
@@ -9,14 +9,14 @@ export const CarName = ({vehicleType}: Props) => {
 
   if (vehicleType.make && vehicleType.model) {
     return (
-      <ThemeText type="body__primary--bold">
+      <ThemeText typography="body__primary--bold">
         {vehicleType.make} {vehicleType.model}
       </ThemeText>
     );
   }
 
   return (
-    <ThemeText type="body__primary--bold">
+    <ThemeText typography="body__primary--bold">
       {vehicleType.name &&
         getTextForLanguage(vehicleType.name.translation, language)}
     </ThemeText>

--- a/src/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/mobility/components/CarSharingStationBottomSheet.tsx
@@ -88,7 +88,7 @@ export const CarSharingStationBottomSheet = ({
                     style={styles.operatorNameAndLogo}
                   />
                   <View style={styles.stationText}>
-                    <ThemeText type="body__secondary" color="secondary">
+                    <ThemeText typography="body__secondary" color="secondary">
                       {stationName}
                     </ThemeText>
                     <WalkingDistance distance={distance} />

--- a/src/mobility/components/IconText.tsx
+++ b/src/mobility/components/IconText.tsx
@@ -19,7 +19,7 @@ export const IconText = ({svg, text}: Props) => {
           svg={svg}
         />
       )}
-      <ThemeText type="body__primary--bold">{text}</ThemeText>
+      <ThemeText typography="body__primary--bold">{text}</ThemeText>
     </View>
   );
 };

--- a/src/mobility/components/MobilityBenefitsActionSectionItem.tsx
+++ b/src/mobility/components/MobilityBenefitsActionSectionItem.tsx
@@ -26,7 +26,7 @@ export const MobilityBenefitsActionSectionItem = ({
 
   return (
     <View style={[topContainer, styles.benefitSection]}>
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {t(FareContractTexts.label.includedBenefits)}
       </ThemeText>
       <BenefitTiles

--- a/src/mobility/components/MobilityBenefitsInfoSectionItem.tsx
+++ b/src/mobility/components/MobilityBenefitsInfoSectionItem.tsx
@@ -44,7 +44,7 @@ export const MobilityBenefitsInfoSectionItem = ({
       accessible={true}
       accessibilityLabel={accessibilityLabel}
     >
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {t(MobilityTexts.includedWithTheTicket)}
       </ThemeText>
       <BorderedInfoBox
@@ -82,7 +82,7 @@ const BenefitInfo = ({
           ))}
         </View>
       )}
-      <ThemeText type="body__tertiary" style={styles.benefitText}>
+      <ThemeText typography="body__tertiary" style={styles.benefitText}>
         {getTextForLanguage(ticketDescription, language)}
       </ThemeText>
     </View>

--- a/src/mobility/components/MobilitySingleBenefitInfoSectionItem.tsx
+++ b/src/mobility/components/MobilitySingleBenefitInfoSectionItem.tsx
@@ -25,7 +25,10 @@ export const MobilitySingleBenefitInfoSectionItem = ({
         {benefit.formFactors.map((ff) => (
           <BenefitImageAsset formFactor={toFormFactorEnum(ff)} key={ff} />
         ))}
-        <ThemeText typography="body__secondary" style={styles.mobilityBenefitText}>
+        <ThemeText
+          typography="body__secondary"
+          style={styles.mobilityBenefitText}
+        >
           {getTextForLanguage(benefit.ticketDescription, language)}
         </ThemeText>
       </View>

--- a/src/mobility/components/MobilitySingleBenefitInfoSectionItem.tsx
+++ b/src/mobility/components/MobilitySingleBenefitInfoSectionItem.tsx
@@ -25,7 +25,7 @@ export const MobilitySingleBenefitInfoSectionItem = ({
         {benefit.formFactors.map((ff) => (
           <BenefitImageAsset formFactor={toFormFactorEnum(ff)} key={ff} />
         ))}
-        <ThemeText type="body__secondary" style={styles.mobilityBenefitText}>
+        <ThemeText typography="body__secondary" style={styles.mobilityBenefitText}>
           {getTextForLanguage(benefit.ticketDescription, language)}
         </ThemeText>
       </View>

--- a/src/mobility/components/MobilityStat.tsx
+++ b/src/mobility/components/MobilityStat.tsx
@@ -26,7 +26,7 @@ export const MobilityStat = ({
       <StatWithIcon svg={svg} text={String(primaryStat)} />
       {secondaryStat && (
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           style={secondaryStatStyle}
           color="secondary"
         >
@@ -47,7 +47,7 @@ export const StatWithIcon = ({svg, text}: StatWithIconProps) => {
   return (
     <View style={styles.statWithIcon}>
       {svg && <ThemeIcon svg={svg} color="secondary" style={styles.statIcon} />}
-      <ThemeText type="body__secondary--bold" color="secondary">
+      <ThemeText typography="body__secondary--bold" color="secondary">
         {text}
       </ThemeText>
     </View>

--- a/src/mobility/components/OperatorBenefit.tsx
+++ b/src/mobility/components/OperatorBenefit.tsx
@@ -49,7 +49,9 @@ export const OperatorBenefit = ({benefit, formFactor, style}: Props) => {
             />
             <View style={styles.benefitContent}>
               {heading && (
-                <ThemeText typography="body__primary--bold">{heading}</ThemeText>
+                <ThemeText typography="body__primary--bold">
+                  {heading}
+                </ThemeText>
               )}
               <ThemeText typography="body__secondary" color="secondary">
                 {text}

--- a/src/mobility/components/OperatorBenefit.tsx
+++ b/src/mobility/components/OperatorBenefit.tsx
@@ -49,9 +49,9 @@ export const OperatorBenefit = ({benefit, formFactor, style}: Props) => {
             />
             <View style={styles.benefitContent}>
               {heading && (
-                <ThemeText type="body__primary--bold">{heading}</ThemeText>
+                <ThemeText typography="body__primary--bold">{heading}</ThemeText>
               )}
-              <ThemeText type="body__secondary" color="secondary">
+              <ThemeText typography="body__secondary" color="secondary">
                 {text}
               </ThemeText>
             </View>

--- a/src/mobility/components/OperatorNameAndLogo.tsx
+++ b/src/mobility/components/OperatorNameAndLogo.tsx
@@ -52,7 +52,7 @@ export const OperatorNameAndLogo = ({
           />
         )
       ) : null}
-      <ThemeText type="body__primary--bold">{operatorName}</ThemeText>
+      <ThemeText typography="body__primary--bold">{operatorName}</ThemeText>
     </View>
   );
 };

--- a/src/mobility/components/ParkAndRideBottomSheet.tsx
+++ b/src/mobility/components/ParkAndRideBottomSheet.tsx
@@ -84,7 +84,7 @@ export const ParkAndRideBottomSheet = ({
           <Section>
             <GenericSectionItem>
               <View style={styles.parkingName}>
-                <ThemeText type="body__secondary" color="secondary">
+                <ThemeText typography="body__secondary" color="secondary">
                   {heading}
                 </ThemeText>
                 <WalkingDistance distance={distance} />

--- a/src/nearby-stop-places/components/StopPlaceItem.tsx
+++ b/src/nearby-stop-places/components/StopPlaceItem.tsx
@@ -74,7 +74,10 @@ export const StopPlaceItem = ({
             <ThemeText typography="heading__component" testID={testID + 'Name'}>
               {place.name}
             </ThemeText>
-            <ThemeText typography="body__secondary" style={styles.stopDescription}>
+            <ThemeText
+              typography="body__secondary"
+              style={styles.stopDescription}
+            >
               {description}
             </ThemeText>
             {humanizedDistance && (

--- a/src/nearby-stop-places/components/StopPlaceItem.tsx
+++ b/src/nearby-stop-places/components/StopPlaceItem.tsx
@@ -71,14 +71,14 @@ export const StopPlaceItem = ({
       >
         <View style={styles.stopPlaceContainer} testID={testID}>
           <View style={styles.stopPlaceInfo}>
-            <ThemeText type="heading__component" testID={testID + 'Name'}>
+            <ThemeText typography="heading__component" testID={testID + 'Name'}>
               {place.name}
             </ThemeText>
-            <ThemeText type="body__secondary" style={styles.stopDescription}>
+            <ThemeText typography="body__secondary" style={styles.stopDescription}>
               {description}
             </ThemeText>
             {humanizedDistance && (
-              <ThemeText type="body__secondary" color="secondary">
+              <ThemeText typography="body__secondary" color="secondary">
                 {humanizedDistance}
               </ThemeText>
             )}

--- a/src/onboarding/OnboardingFullScreenView.tsx
+++ b/src/onboarding/OnboardingFullScreenView.tsx
@@ -44,7 +44,7 @@ export const OnboardingFullScreenView = ({
           {footerDescription && (
             <ScrollView style={styles.footerScrollView}>
               <ThemeText
-                type="body__tertiary"
+                typography="body__tertiary"
                 color={themeColor}
                 style={styles.footerDescription}
               >

--- a/src/onboarding/OnboardingScreenComponent.tsx
+++ b/src/onboarding/OnboardingScreenComponent.tsx
@@ -54,7 +54,7 @@ export const OnboardingScreenComponent = ({
       <View style={styles.header}>{illustration}</View>
       <View ref={focusRef} accessible collapsable={false}>
         <ThemeText
-          type="body__primary--big--bold"
+          typography="body__primary--big--bold"
           color={themeColor}
           style={styles.title}
           accessibilityRole="header"
@@ -63,7 +63,7 @@ export const OnboardingScreenComponent = ({
         </ThemeText>
       </View>
       <ThemeText
-        type="body__primary"
+        typography="body__primary"
         color={themeColor}
         style={styles.description}
       >
@@ -76,7 +76,7 @@ export const OnboardingScreenComponent = ({
           accessibilityHint={descriptionLink.a11yHint}
         >
           <ThemeText
-            type="body__primary--underline"
+            typography="body__primary--underline"
             color={themeColor}
             style={styles.descriptionLink}
           >

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -109,7 +109,7 @@ export const EstimatedCallItem = memo(
               messageType={msgType}
               testID={testID}
             />
-            {mode !== 'Favourite' && <DepartureTime departure={departure} />}
+            {mode !== 'Favourite' && <DepartureTime departure={departure}  />}
           </View>
 
           {mode !== 'Map' && (

--- a/src/place-screen/components/EstimatedCallItem.tsx
+++ b/src/place-screen/components/EstimatedCallItem.tsx
@@ -109,7 +109,7 @@ export const EstimatedCallItem = memo(
               messageType={msgType}
               testID={testID}
             />
-            {mode !== 'Favourite' && <DepartureTime departure={departure}  />}
+            {mode !== 'Favourite' && <DepartureTime departure={departure} />}
           </View>
 
           {mode !== 'Map' && (

--- a/src/place-screen/components/EstimatedCallList.tsx
+++ b/src/place-screen/components/EstimatedCallList.tsx
@@ -135,7 +135,7 @@ export const EstimatedCallList = ({
             >
               <ThemeText
                 color="secondary"
-                type="body__secondary"
+                typography="body__secondary"
                 style={{textAlign: 'center', width: '100%'}}
               >
                 {showOnlyFavorites

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -107,7 +107,7 @@ export function QuaySection({
           <View style={styles.stopPlaceHeader} testID={testID + 'HideAction'}>
             <View style={styles.stopPlaceHeaderText}>
               <ThemeText
-                type="body__secondary--bold"
+                typography="body__secondary--bold"
                 color="secondary"
                 style={styles.rightMargin}
                 testID={testID + 'Name'}
@@ -119,7 +119,7 @@ export function QuaySection({
               {!!quay.description && (
                 <ThemeText
                   style={styles.rightMargin}
-                  type="body__secondary"
+                  typography="body__secondary"
                   color="secondary"
                   testID={testID + 'Description'}
                 >
@@ -154,7 +154,7 @@ export function QuaySection({
         {!isMinimized && didLoadingDataFail && !isLoading && (
           <GenericSectionItem>
             <View style={styles.messageBox}>
-              <ThemeText type="body__secondary" color="secondary">
+              <ThemeText typography="body__secondary" color="secondary">
                 {t(DeparturesTexts.message.noData)}
               </ThemeText>
             </View>

--- a/src/place-screen/components/StopPlacesView.tsx
+++ b/src/place-screen/components/StopPlacesView.tsx
@@ -180,7 +180,7 @@ export const StopPlacesView = (props: Props) => {
                 </View>
               </View>
               <ThemeText
-                type="body__secondary"
+                typography="body__secondary"
                 color="secondary"
                 style={styles.title}
               >

--- a/src/situations/SituationBottomSheet.tsx
+++ b/src/situations/SituationBottomSheet.tsx
@@ -66,7 +66,10 @@ export const SituationBottomSheet = forwardRef<View, Props>(
                       situation={situation}
                       style={styles.summaryIcon}
                     />
-                    <ThemeText typography="heading__title" style={styles.summaryText}>
+                    <ThemeText
+                      typography="heading__title"
+                      style={styles.summaryText}
+                    >
                       {summary || description}
                     </ThemeText>
                   </View>

--- a/src/situations/SituationBottomSheet.tsx
+++ b/src/situations/SituationBottomSheet.tsx
@@ -66,7 +66,7 @@ export const SituationBottomSheet = forwardRef<View, Props>(
                       situation={situation}
                       style={styles.summaryIcon}
                     />
-                    <ThemeText type="heading__title" style={styles.summaryText}>
+                    <ThemeText typography="heading__title" style={styles.summaryText}>
                       {summary || description}
                     </ThemeText>
                   </View>
@@ -94,7 +94,7 @@ export const SituationBottomSheet = forwardRef<View, Props>(
                       style={styles.validityIcon}
                     />
                     <ThemeText
-                      type="body__secondary"
+                      typography="body__secondary"
                       color="secondary"
                       style={styles.validityText}
                     >
@@ -175,7 +175,7 @@ const InfoLink = ({infoLink}: {infoLink: InfoLinkFragment}) => {
       accessibilityRole="link"
       style={styles.infoLink}
     >
-      <ThemeText type="body__primary--underline" color="secondary">
+      <ThemeText typography="body__primary--underline" color="secondary">
         {infoLink.label || t(dictionary.readMore)}
       </ThemeText>
     </PressableOpacity>

--- a/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_ActiveTokenOnPhoneRequiredForFareProductScreen.tsx
@@ -75,14 +75,14 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
         >
           <View style={styles.textSpacing}>
             <ThemeText
-              type="body__primary--big"
+              typography="body__primary--big"
               color={themeColor}
               style={styles.text}
             >
               {t(ActiveTokenRequiredTexts.ticketNotAvailable)}
             </ThemeText>
             <ThemeText
-              type="body__primary--big--bold"
+              typography="body__primary--big--bold"
               color={themeColor}
               style={styles.text}
             >
@@ -92,7 +92,7 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
         </View>
 
         <ThemeText
-          type="body__primary"
+          typography="body__primary"
           color={themeColor}
           style={[styles.text, styles.textSpacing]}
         >
@@ -130,7 +130,7 @@ export const Root_ActiveTokenOnPhoneRequiredForFareProductScreen = ({
         )}
 
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           color={themeColor}
           style={[styles.text, styles.textSpacing]}
         >

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -203,7 +203,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
               !emoji ? (
                 <ThemeIcon svg={Pin} />
               ) : (
-                <ThemeText type="body__primary">{emoji}</ThemeText>
+                <ThemeText typography="body__primary">{emoji}</ThemeText>
               )
             }
             testID="iconButton"

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/PhoneAndNameInputSection.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/PhoneAndNameInputSection.tsx
@@ -33,7 +33,7 @@ export const PhoneAndNameInputSection = ({
     <>
       {settingName && (
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           color={themeColor}
           style={styles.newRecipientLabel}
         >

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/TitleAndDescription.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/TitleAndDescription.tsx
@@ -13,7 +13,7 @@ export const TitleAndDescription = forwardRef<any, {themeColor: ContrastColor}>(
       <>
         <View accessible={true} accessibilityRole="header" ref={focusRef}>
           <ThemeText
-            type="heading--big"
+            typography="heading--big"
             color={themeColor}
             style={styles.title}
           >
@@ -22,7 +22,7 @@ export const TitleAndDescription = forwardRef<any, {themeColor: ContrastColor}>(
         </View>
         <View accessible={true}>
           <ThemeText
-            type="body__primary"
+            typography="body__primary"
             color={themeColor}
             style={styles.description}
           >

--- a/src/stacks-hierarchy/Root_ConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_ConfirmationScreen.tsx
@@ -36,7 +36,7 @@ export const Root_ConfirmationScreen = ({
   return (
     <View style={styles.container}>
       <ThemeText
-        type="heading--jumbo"
+        typography="heading--jumbo"
         color={themeColor}
         style={styles.message}
       >

--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
@@ -60,7 +60,11 @@ export const Root_ConsiderTravelTokenChangeScreen = () => {
       }}
     >
       <View ref={focusRef} accessible>
-        <ThemeText typography="heading--big" color={themeColor} style={styles.header}>
+        <ThemeText
+          typography="heading--big"
+          color={themeColor}
+          style={styles.header}
+        >
           {t(ConsiderTravelTokenChangeTexts.title)}
         </ThemeText>
       </View>

--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
@@ -60,12 +60,12 @@ export const Root_ConsiderTravelTokenChangeScreen = () => {
       }}
     >
       <View ref={focusRef} accessible>
-        <ThemeText type="heading--big" color={themeColor} style={styles.header}>
+        <ThemeText typography="heading--big" color={themeColor} style={styles.header}>
           {t(ConsiderTravelTokenChangeTexts.title)}
         </ThemeText>
       </View>
       <ThemeText
-        type="body__primary"
+        typography="body__primary"
         color={themeColor}
         style={styles.description}
       >

--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/components/NoTravelTokenInfo.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/components/NoTravelTokenInfo.tsx
@@ -31,7 +31,7 @@ export function NoTravelTokenInfo({
         text: t(MobileTokenOnboardingTexts.ok),
       }}
     >
-      <ThemeText type="heading--big" style={styles.header} color={themeColor}>
+      <ThemeText typography="heading--big" style={styles.header} color={themeColor}>
         {t(MobileTokenOnboardingTexts.error.heading)}
       </ThemeText>
       <ThemeText style={styles.description} color={themeColor}>

--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/components/NoTravelTokenInfo.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/components/NoTravelTokenInfo.tsx
@@ -31,7 +31,11 @@ export function NoTravelTokenInfo({
         text: t(MobileTokenOnboardingTexts.ok),
       }}
     >
-      <ThemeText typography="heading--big" style={styles.header} color={themeColor}>
+      <ThemeText
+        typography="heading--big"
+        style={styles.header}
+        color={themeColor}
+      >
         {t(MobileTokenOnboardingTexts.error.heading)}
       </ThemeText>
       <ThemeText style={styles.description} color={themeColor}>

--- a/src/stacks-hierarchy/Root_ExtendedOnboardingStack/ExtendedOnboarding_AlsoGoodToKnowScreen.tsx
+++ b/src/stacks-hierarchy/Root_ExtendedOnboardingStack/ExtendedOnboarding_AlsoGoodToKnowScreen.tsx
@@ -26,7 +26,7 @@ export const ExtendedOnboarding_AlsoGoodToKnowScreen = () => {
     >
       <View style={styles.mainView}>
         <ThemeText
-          type="body__primary--jumbo--bold"
+          typography="body__primary--jumbo--bold"
           color={themeColor}
           style={styles.header}
         >

--- a/src/stacks-hierarchy/Root_ExtendedOnboardingStack/ExtendedOnboarding_GoodToKnowScreen.tsx
+++ b/src/stacks-hierarchy/Root_ExtendedOnboardingStack/ExtendedOnboarding_GoodToKnowScreen.tsx
@@ -29,7 +29,7 @@ export const ExtendedOnboarding_GoodToKnowScreen = ({
     >
       <View style={styles.mainView}>
         <ThemeText
-          type="body__primary--jumbo--bold"
+          typography="body__primary--jumbo--bold"
           color={themeColor}
           style={styles.header}
         >

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/JourneyHistory.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/JourneyHistory.tsx
@@ -59,7 +59,7 @@ export function JourneyHistory({searchText, onSelect}: JourneyHistoryProps) {
               testID={'journeyHistoryItem' + idx}
             >
               <GenericSectionItem transparent>
-                <ThemeText type="body__primary--bold">
+                <ThemeText typography="body__primary--bold">
                   {searchResult.text}
                 </ThemeText>
               </GenericSectionItem>

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationResults.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationResults.tsx
@@ -35,7 +35,7 @@ export const LocationResults: React.FC<Props> = ({
     <>
       {title && (
         <View accessibilityRole="header" style={styles.subHeader}>
-          <ThemeText type="body__secondary">{title}</ThemeText>
+          <ThemeText typography="body__secondary">{title}</ThemeText>
         </View>
       )}
       <View>

--- a/src/stacks-hierarchy/Root_LoginActiveFareContractWarningScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginActiveFareContractWarningScreen.tsx
@@ -61,7 +61,7 @@ export const Root_LoginActiveFareContractWarningScreen = ({
       <ScrollView centerContent={true} contentContainerStyle={styles.mainView}>
         <View accessible={true} accessibilityRole="header" ref={focusRef}>
           <ThemeText
-            type="body__primary--big--bold"
+            typography="body__primary--big--bold"
             style={styles.title}
             color={themeColor}
           >

--- a/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginConfirmCodeScreen.tsx
@@ -91,7 +91,7 @@ export const Root_LoginConfirmCodeScreen = ({route}: Props) => {
         >
           <View accessible={true} accessibilityRole="header" ref={focusRef}>
             <ThemeText
-              type="body__primary--jumbo--bold"
+              typography="body__primary--jumbo--bold"
               style={styles.title}
               color={themeColor}
             >
@@ -153,7 +153,7 @@ export const Root_LoginConfirmCodeScreen = ({route}: Props) => {
                 >
                   <ThemeText
                     style={styles.resendButtonText}
-                    type="body__primary--underline"
+                    typography="body__primary--underline"
                     color={themeColor}
                   >
                     {t(LoginTexts.confirmCode.resendButton)}

--- a/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
@@ -163,7 +163,7 @@ export const Root_LoginOptionsScreen = ({
       <ScrollView contentContainerStyle={styles.scrollView} bounces={false}>
         <View accessible={true} accessibilityRole="header">
           <ThemeText
-            type="body__primary--jumbo--bold"
+            typography="body__primary--jumbo--bold"
             style={styles.title}
             color={themeColor}
           >

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -106,7 +106,7 @@ export const Root_LoginPhoneInputScreen = ({
         >
           <View accessible={true} accessibilityRole="header" ref={focusRef}>
             <ThemeText
-              type="body__primary--jumbo--bold"
+              typography="body__primary--jumbo--bold"
               style={styles.title}
               color={themeColor}
             >

--- a/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
@@ -66,7 +66,7 @@ export const Root_LoginRequiredForFareProductScreen = ({
       <ScrollView centerContent={true} contentContainerStyle={styles.mainView}>
         <View accessible={true} accessibilityRole="header" ref={focusRef}>
           <ThemeText
-            type="body__primary--jumbo--bold"
+            typography="body__primary--jumbo--bold"
             style={styles.title}
             color={themeColor}
           >
@@ -100,7 +100,7 @@ export const Root_LoginRequiredForFareProductScreen = ({
         >
           <ThemeText
             style={styles.laterButtonText}
-            type="body__primary"
+            typography="body__primary"
             color={themeColor}
           >
             {t(LoginTexts.onboarding.laterButton)}
@@ -110,12 +110,12 @@ export const Root_LoginRequiredForFareProductScreen = ({
           <Psst />
           <ThemeText
             style={styles.carrotTitle}
-            type="body__primary--bold"
+            typography="body__primary--bold"
             color={themeColor}
           >
             {t(LoginTexts.onboarding.carrotTitle)}
           </ThemeText>
-          <ThemeText type="body__primary" color={themeColor}>
+          <ThemeText typography="body__primary" color={themeColor}>
             {t(LoginTexts.onboarding.carrotBody)}
           </ThemeText>
         </View>

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/Root_ParkingViolationsConfirmationScreen.tsx
@@ -33,7 +33,7 @@ export const Root_ParkingViolationsConfirmationScreen = ({
       rightHeaderButton={{type: 'close', onPress: closeReporting}}
     >
       <View style={styles.confirmation}>
-        <ThemeText color={themeColor} type="heading--big">
+        <ThemeText color={themeColor} typography="heading--big">
           {t(ParkingViolationTexts.confirmation.title)}
         </ThemeText>
         <ThemeText style={styles.description} color={themeColor}>

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ProviderLogo.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ProviderLogo.tsx
@@ -48,7 +48,7 @@ const UnknownProvider = ({height, width}: {height: number; width: number}) => {
         justifyContent: 'center',
       }}
     >
-      <ThemeText type="body__primary--big--bold" color={themeColor}>
+      <ThemeText typography="body__primary--big--bold" color={themeColor}>
         ?
       </ThemeText>
     </View>

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ScreenContainer.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ScreenContainer.tsx
@@ -61,7 +61,7 @@ const ContentBody = ({title, secondaryText, buttons, children}: Props) => {
       <View style={style.content}>
         <View style={style.header}>
           <View ref={focusRef} accessible>
-            <ThemeText color={themeColor} type="heading--medium">
+            <ThemeText color={themeColor} typography="heading--medium">
               {title}
             </ThemeText>
           </View>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -356,7 +356,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
                   ref={onCloseFocusRef}
                 >
                   <View style={styles.flexRowCenter}>
-                    <ThemeText type="body__primary--bold">
+                    <ThemeText typography="body__primary--bold">
                       {t(PurchaseConfirmationTexts.changePaymentMethod.text)}
                     </ThemeText>
                   </View>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -66,7 +66,7 @@ export const PreassignedFareContractSummary = ({
     return (
       <ThemeText
         style={styles.smallTopMargin}
-        type="body__secondary"
+        typography="body__secondary"
         color="secondary"
         testID="summaryText"
       >
@@ -117,7 +117,7 @@ export const PreassignedFareContractSummary = ({
           </ThemeText>
           {recipient && (
             <ThemeText
-              type="body__secondary"
+              typography="body__secondary"
               color="secondary"
               style={styles.sendingToText}
               testID="onBehalfOfText"

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PriceSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PriceSummary.tsx
@@ -53,10 +53,10 @@ export const PriceSummary = ({
       <GenericSectionItem>
         <View style={styles.totalPaymentContainer} accessible={true}>
           <View style={styles.totalContainerHeadings}>
-            <ThemeText type="body__primary">
+            <ThemeText typography="body__primary">
               {t(PurchaseConfirmationTexts.totalCost.title)}
             </ThemeText>
-            <ThemeText type="body__tertiary" color="secondary">
+            <ThemeText typography="body__tertiary" color="secondary">
               {t(
                 PurchaseConfirmationTexts.totalCost.label(
                   vatPercentString,
@@ -67,7 +67,7 @@ export const PriceSummary = ({
           </View>
 
           {!isSearchingOffer ? (
-            <ThemeText type="body__primary--jumbo" testID="totalPrice">
+            <ThemeText typography="body__primary--jumbo" testID="totalPrice">
               {totalPriceString} kr
             </ThemeText>
           ) : (
@@ -126,7 +126,7 @@ const PricePerUserProfile = ({
       <ThemeText
         style={styles.userProfileCountAndName}
         color="secondary"
-        type="body__secondary"
+        typography="body__secondary"
         testID="userProfileCountAndName"
       >
         {count} {userProfileName}
@@ -134,14 +134,14 @@ const PricePerUserProfile = ({
       <View style={styles.userProfilePrice}>
         {hasFlexDiscount && (
           <ThemeText
-            type="body__tertiary"
+            typography="body__tertiary"
             color="secondary"
             style={styles.userProfileOriginalPriceAmount}
           >
             {originalPriceString} kr
           </ThemeText>
         )}
-        <ThemeText color="secondary" type="body__secondary">
+        <ThemeText color="secondary" typography="body__secondary">
           {priceString} kr
         </ThemeText>
       </View>

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/HarborResults.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/HarborResults.tsx
@@ -56,7 +56,7 @@ export const HarborResults: React.FC<Props> = ({
             message={t(HarborSearchTexts.messages.emptyResult)}
           />
         ) : (
-          <ThemeText type="body__secondary" color="secondary">
+          <ThemeText typography="body__secondary" color="secondary">
             {getHeading(t, searchText, fromHarborName, currentLocation)}
           </ThemeText>
         )}
@@ -80,7 +80,7 @@ export const HarborResults: React.FC<Props> = ({
               >
                 <ThemeIcon svg={Boat} />
                 <View style={styles.nameContainer}>
-                  <ThemeText type="body__primary--bold">
+                  <ThemeText typography="body__primary--bold">
                     {harbor.name}
                   </ThemeText>
                 </View>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader.tsx
@@ -54,7 +54,7 @@ export const FareProductHeader = forwardRef<View, Props>(
             iconSize="normal"
           />
           <ThemeText
-            type="heading--medium"
+            typography="heading--medium"
             color={themeColor}
             style={styles.headerText}
           >
@@ -64,7 +64,7 @@ export const FareProductHeader = forwardRef<View, Props>(
         {isTicketInformationEnabled && (
           <View style={styles.headerSubSection}>
             <ThemeText
-              type="body__secondary"
+              typography="body__secondary"
               color={themeColor}
               style={styles.ticketDescription}
               numberOfLines={1}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -54,7 +54,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
         />
         {expanded && (
           <GenericSectionItem accessibility={{accessible: true}}>
-            <ThemeText type="body__secondary" color="secondary">
+            <ThemeText typography="body__secondary" color="secondary">
               {description}
             </ThemeText>
           </GenericSectionItem>
@@ -92,7 +92,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                 key={u.id}
               >
                 <View style={styles.userProfileDiscountInfo}>
-                  <ThemeText type="body__secondary" color="secondary">
+                  <ThemeText typography="body__secondary" color="secondary">
                     {t(
                       PurchaseOverviewTexts.flexDiscount.per(
                         userProfileName.toLowerCase(),
@@ -110,7 +110,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                     )}
                     <ThemeText
                       style={styles.priceInfo}
-                      type="body__tertiary"
+                      typography="body__tertiary"
                       color="primary"
                     >
                       {priceText}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -118,7 +118,7 @@ const HarborSelectionItem = forwardRef<
       <View style={styles.sectionContent}>
         <ThemeText
           color={disabled ? 'disabled' : 'secondary'}
-          type="body__secondary"
+          typography="body__secondary"
           style={styles.toFromLabel}
         >
           {t(PurchaseOverviewTexts.fromToLabel[fromOrTo])}
@@ -139,7 +139,7 @@ const HarborLabel = ({
   const harborName = harbor?.name;
   const {t} = useTranslation();
   return harborName ? (
-    <ThemeText type="body__primary--bold">{harborName}</ThemeText>
+    <ThemeText typography="body__primary--bold">{harborName}</ThemeText>
   ) : (
     <ThemeText
       style={{flexShrink: 1}}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip.tsx
@@ -42,7 +42,7 @@ export const ProductAliasChip = ({color, text, selected, onPress}: Props) => {
     >
       <ThemeText
         color={currentColor}
-        type={selected ? 'body__secondary--bold' : 'body__secondary'}
+        typography={selected ? 'body__secondary--bold' : 'body__secondary'}
       >
         {text}
       </ThemeText>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle.tsx
@@ -17,14 +17,14 @@ export function ProductDescriptionToggle({title}: {title: string}) {
   return (
     <View style={styles.container}>
       <View style={{flexShrink: 1}}>
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {title}
         </ThemeText>
       </View>
 
       <View style={styles.switchAndLabel}>
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           accessible={false}
           importantForAccessibility="no"
           style={styles.label}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
@@ -53,7 +53,7 @@ export function Summary({
         <ActivityIndicator size="large" />
       ) : (
         <ThemeText
-          type="body__primary--bold"
+          typography="body__primary--bold"
           style={styles.price}
           testID="offerTotalPriceText"
         >
@@ -62,7 +62,7 @@ export function Summary({
       )}
       {!isLoading && originalPrice !== price && (
         <ThemeText
-          type="body__tertiary--strike"
+          typography="body__tertiary--strike"
           style={styles.originalPrice}
           testID="offerTotalPriceText"
           accessibilityLabel={t(

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -160,7 +160,7 @@ export function TravellerSelection({
   const content = (
     <View style={styles.sectionContentContainer}>
       <View style={{flex: 1}}>
-        <ThemeText type="body__primary--bold" testID="selectedTravellers">
+        <ThemeText typography="body__primary--bold" testID="selectedTravellers">
           {multipleTravellerCategoriesSelectedFrom
             ? t(
                 PurchaseOverviewTexts.travellerSelection.travellers_title(
@@ -170,19 +170,19 @@ export function TravellerSelection({
             : travellersDetailsText}
         </ThemeText>
         {!canSelectUserProfile && (
-          <ThemeText type="body__secondary" color="secondary">
+          <ThemeText typography="body__secondary" color="secondary">
             {travellerInfo}
           </ThemeText>
         )}
         {isOnBehalfOfToggle && canSelectUserProfile && (
-          <ThemeText type="body__secondary" color="secondary">
+          <ThemeText typography="body__secondary" color="secondary">
             {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
           </ThemeText>
         )}
 
         {multipleTravellerCategoriesSelectedFrom && (
           <ThemeText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={styles.multipleTravellersDetails}
             testID="selectedTravellers"

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -94,7 +94,7 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
               <View style={styles.fromZone}>
                 <ThemeText
                   color="secondary"
-                  type="body__secondary"
+                  typography="body__secondary"
                   style={styles.toFromLabel}
                 >
                   {t(PurchaseOverviewTexts.fromToLabel.from)}
@@ -104,7 +104,7 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
               <View style={styles.toZone}>
                 <ThemeText
                   color="secondary"
-                  type="body__secondary"
+                  typography="body__secondary"
                   style={styles.toFromLabel}
                 >
                   {t(PurchaseOverviewTexts.fromToLabel.to)}
@@ -164,13 +164,13 @@ const ZoneLabel = ({tariffZone}: {tariffZone: TariffZoneWithMetadata}) => {
 
   return tariffZone.venueName ? (
     <ThemeText style={{flexShrink: 1}} testID="selectedStationAndZone">
-      <ThemeText type="body__primary--bold" testID="selectedStation">
+      <ThemeText typography="body__primary--bold" testID="selectedStation">
         {tariffZone.venueName + ' '}
       </ThemeText>
       ({zoneLabel})
     </ThemeText>
   ) : (
-    <ThemeText type="body__primary--bold" testID="selectedZone">
+    <ThemeText typography="body__primary--bold" testID="selectedZone">
       {zoneLabel}
     </ThemeText>
   );

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByTextScreen/VenueResults.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByTextScreen/VenueResults.tsx
@@ -29,7 +29,7 @@ export const VenueResults: React.FC<Props> = ({
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {t(TariffZoneSearchTexts.results.heading)}
         </ThemeText>
       </View>
@@ -64,10 +64,10 @@ export const VenueResults: React.FC<Props> = ({
                   />
                 </View>
                 <View style={styles.nameContainer}>
-                  <ThemeText type="body__primary--bold">
+                  <ThemeText typography="body__primary--bold">
                     {location.name}
                   </ThemeText>
-                  <ThemeText type="body__secondary">
+                  <ThemeText typography="body__secondary">
                     {t(
                       TariffZoneSearchTexts.results.item.zoneLabel(
                         getReferenceDataName(tariffZone, language),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -158,7 +158,7 @@ function tabSettings(
   return {
     tabBarLabel: ({color}) => (
       <ThemeText
-        type="body__secondary"
+        typography="body__secondary"
         style={{color, textAlign: 'center', lineHeight}}
         accessibilityLabel={tabBarA11yLabel}
         testID={testID}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -69,7 +69,7 @@ export const Announcement = ({announcement, style}: Props) => {
             <View style={styles.summaryTitle}>
               <ThemeText
                 style={styles.summaryTitleText}
-                type="body__primary--bold"
+                typography="body__primary--bold"
               >
                 {summaryTitle}
               </ThemeText>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -86,7 +86,7 @@ export const DeparturesWidget = ({
               <ThemedNoFavouriteDepartureImage />
               <View style={styles.noFavouritesTextContainer}>
                 <ThemeText
-                  type="body__secondary"
+                  typography="body__secondary"
                   color="secondary"
                   style={styles.noFavouritesText}
                   testID="noFavoriteWidget"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SectionHeading.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SectionHeading.tsx
@@ -11,7 +11,7 @@ export const SectionHeading = ({accessibilityLabel, children}: Props) => {
   const themeColor = theme.color.background.accent[0];
   return (
     <ThemeText
-      type="body__secondary"
+      typography="body__secondary"
       color={themeColor}
       style={style.heading}
       accessibilityLabel={accessibilityLabel}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet.tsx
@@ -123,7 +123,10 @@ export const SelectFavouritesBottomSheet = ({
       <ScrollView style={styles.flatListArea}>
         {favoriteDepartures.length > 0 && (
           <>
-            <ThemeText style={styles.questionText} typography="heading__component">
+            <ThemeText
+              style={styles.questionText}
+              typography="heading__component"
+            >
               {t(SelectFavouriteDeparturesText.title.text)}
             </ThemeText>
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet.tsx
@@ -65,11 +65,11 @@ const SelectableFavouriteDeparture = ({
         subMode={favorite.lineTransportationSubMode}
       />
       <View style={styles.selectableDepartureTextView}>
-        <ThemeText type="body__primary" style={styles.lineIdentifierText}>
+        <ThemeText typography="body__primary" style={styles.lineIdentifierText}>
           {lineIdentifier} {lineName}
         </ThemeText>
 
-        <ThemeText type="body__secondary" style={styles.secondaryText}>
+        <ThemeText typography="body__secondary" style={styles.secondaryText}>
           {t(SelectFavouriteDeparturesText.departures.from)} {favorite.quayName}
           {departureQuay && ' ' + departureQuay}
         </ThemeText>
@@ -123,7 +123,7 @@ export const SelectFavouritesBottomSheet = ({
       <ScrollView style={styles.flatListArea}>
         {favoriteDepartures.length > 0 && (
           <>
-            <ThemeText style={styles.questionText} type="heading__component">
+            <ThemeText style={styles.questionText} typography="heading__component">
               {t(SelectFavouriteDeparturesText.title.text)}
             </ThemeText>
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/DayLabel.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/DayLabel.tsx
@@ -41,7 +41,7 @@ export function DayLabel({
 
   if (isFirst || !isSameDay(prevDate, departureDate)) {
     return (
-      <ThemeText type="body__secondary" style={style.title}>
+      <ThemeText typography="body__secondary" style={style.title}>
         {dateLabel}
       </ThemeText>
     );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -91,7 +91,7 @@ const ResultItemHeader: React.FC<{
     <View style={styles.resultHeader}>
       <ThemeText
         style={styles.fromPlaceText}
-        type="body__secondary--bold"
+        typography="body__secondary--bold"
         testID="resultDeparturePlace"
       >
         {startName
@@ -111,7 +111,7 @@ const ResultItemHeader: React.FC<{
       </ThemeText>
       <View style={styles.durationContainer}>
         <AccessibleText
-          type="body__secondary"
+          typography="body__secondary"
           color="secondary"
           testID="resultDuration"
           prefix={t(TripSearchTexts.results.resultItem.header.totalDuration)}
@@ -274,7 +274,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                       <View style={styles.departureTimes}>
                         {staySeated(i) ? null : (
                           <ThemeText
-                            type="body__tertiary"
+                            typography="body__tertiary"
                             color="primary"
                             testID={'schTime' + i}
                           >
@@ -291,7 +291,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                         {isSignificantDifference(leg) && (
                           <ThemeText
                             style={styles.scheduledTime}
-                            type="body__tertiary--strike"
+                            typography="body__tertiary--strike"
                             color="secondary"
                             testID={'aimTime' + i}
                           >
@@ -333,7 +333,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
           <View>
             <DestinationIcon style={styles.iconContainer} />
             <View style={styles.departureTimes}>
-              <ThemeText type="body__tertiary" color="primary" testID="endTime">
+              <ThemeText typography="body__tertiary" color="primary" testID="endTime">
                 {(lastLegIsFlexible
                   ? t(dictionary.missingRealTimePrefix)
                   : '') +
@@ -374,7 +374,7 @@ const ResultItemFooter: React.FC<{
         )}
       </View>
       <View style={styles.detailsTextWrapper}>
-        <ThemeText type="body__secondary">
+        <ThemeText typography="body__secondary">
           {t(TripSearchTexts.results.resultItem.footer.detailsLabel)}
         </ThemeText>
         <ThemeIcon svg={ArrowRight} style={styles.detailsIcon} />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -333,7 +333,11 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
           <View>
             <DestinationIcon style={styles.iconContainer} />
             <View style={styles.departureTimes}>
-              <ThemeText typography="body__tertiary" color="primary" testID="endTime">
+              <ThemeText
+                typography="body__tertiary"
+                color="primary"
+                testID="endTime"
+              >
                 {(lastLegIsFlexible
                   ? t(dictionary.missingRealTimePrefix)
                   : '') +

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
@@ -209,7 +209,7 @@ export const TravelSearchFiltersBottomSheet = forwardRef<
                 }}
                 testID="saveFilter"
               />
-              <ThemeText type="body__secondary" color="secondary">
+              <ThemeText typography="body__secondary" color="secondary">
                 {t(TripSearchTexts.filters.bottomSheet.saveFilters.text)}
               </ThemeText>
             </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchPreference.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchPreference.tsx
@@ -26,7 +26,7 @@ export const TravelSearchPreference = ({
 
   return (
     <View style={containerStyle}>
-      <ThemeText style={styles.heading} type="body__primary--bold">
+      <ThemeText style={styles.heading} typography="body__primary--bold">
         {getTextForLanguage(preference.title, language)}
       </ThemeText>
       <Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/components/MapDisabledForScreenReader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/components/MapDisabledForScreenReader.tsx
@@ -28,7 +28,7 @@ export const MapDisabledForScreenReader = () => {
           t(MapTexts.disabledForScreenReader.description)
         }
       >
-        <ThemeText type="body__primary--bold" style={styles.header}>
+        <ThemeText typography="body__primary--bold" style={styles.header}>
           {t(MapTexts.disabledForScreenReader.title)}
         </ThemeText>
         <ThemeText style={styles.description}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -385,7 +385,7 @@ export const Profile_DebugInfoScreen = () => {
             expandContent={
               preferences && (
                 <View>
-                  <ThemeText type="body__secondary">
+                  <ThemeText typography="body__secondary">
                     Press a line to reset to undefined {'\n'}
                   </ThemeText>
                   {Object.keys(preferences).map((key) => (
@@ -608,7 +608,7 @@ function MapEntry({title, value}: {title: string; value: any}) {
           style={{flexDirection: 'row'}}
           onPress={() => setIsExpanded(!isExpanded)}
         >
-          <ThemeText type="heading__title" color="secondary">
+          <ThemeText typography="heading__title" color="secondary">
             {title}
           </ThemeText>
           <ThemeIcon svg={isExpanded ? ExpandLess : ExpandMore} />
@@ -628,11 +628,11 @@ function MapEntry({title, value}: {title: string; value: any}) {
             style={{flexDirection: 'row'}}
             onPress={() => setIsExpanded(!isExpanded)}
           >
-            <ThemeText type="body__primary--bold">{title}: </ThemeText>
+            <ThemeText typography="body__primary--bold">{title}: </ThemeText>
             <ThemeIcon svg={isExpanded ? ExpandLess : ExpandMore} />
           </PressableOpacity>
         ) : (
-          <ThemeText type="body__primary--bold">{title}: </ThemeText>
+          <ThemeText typography="body__primary--bold">{title}: </ThemeText>
         )}
         {isExpanded && <MapValue value={value} />}
       </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -77,7 +77,7 @@ export const Profile_DeleteProfileScreen = () => {
           ref={focusRef}
         >
           <ThemeText
-            type="heading--medium"
+            typography="heading--medium"
             color={themeColor}
             style={{flexShrink: 1}}
           >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -458,7 +458,7 @@ export const Profile_DesignSystemScreen = ({
               <View>
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Primary - block - interactive/0
                 </ThemeText>
@@ -494,7 +494,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Primary - block - interactive/1
                 </ThemeText>
@@ -530,7 +530,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Primary - block - interactive/2
                 </ThemeText>
@@ -566,7 +566,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Primary - block - interactive/destructive
                 </ThemeText>
@@ -602,7 +602,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Secondary - block
                 </ThemeText>
@@ -630,7 +630,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   tertiary - block
                 </ThemeText>
@@ -658,7 +658,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Medium button examples (interactive_0)
                 </ThemeText>
@@ -740,7 +740,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   Pill button examples (interactive_0)
                 </ThemeText>
@@ -822,7 +822,7 @@ export const Profile_DesignSystemScreen = ({
 
                 <ThemeText
                   style={{marginTop: 24, marginBottom: 12}}
-                  type="heading__paragraph"
+                  typography="heading__paragraph"
                 >
                   With icons examples (interactive_0)
                 </ThemeText>
@@ -1106,7 +1106,7 @@ export const Profile_DesignSystemScreen = ({
           <GenericSectionItem>
             {textNames.map(function (t: TextNames) {
               return (
-                <ThemeText type={t} key={t}>
+                <ThemeText typography={t} key={t}>
                   {t}
                 </ThemeText>
               );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -97,7 +97,7 @@ export const Profile_EditProfileScreen = ({
       parallaxContent={(focusRef) => (
         <View style={styles.parallaxContent} ref={focusRef} accessible={true}>
           <ThemeText
-            type="heading--medium"
+            typography="heading--medium"
             color={themeColor}
             style={{flexShrink: 1}}
           >
@@ -169,7 +169,7 @@ export const Profile_EditProfileScreen = ({
                   <ThemeText>
                     {t(EditProfileTexts.personalDetails.email.label)}
                   </ThemeText>
-                  <ThemeText type="body__secondary" color="secondary">
+                  <ThemeText typography="body__secondary" color="secondary">
                     {t(
                       EditProfileTexts.personalDetails.email
                         .disabledWithRemoteConfig,
@@ -203,7 +203,7 @@ export const Profile_EditProfileScreen = ({
                   <ThemeText>
                     {t(EditProfileTexts.personalDetails.phone.header)}
                   </ThemeText>
-                  <ThemeText type="body__secondary" color="secondary">
+                  <ThemeText typography="body__secondary" color="secondary">
                     {t(
                       EditProfileTexts.personalDetails.phone.loggedIn(
                         phoneNumber,
@@ -248,7 +248,7 @@ export const Profile_EditProfileScreen = ({
             </ThemeText>
             {phoneNumber && (
               <ThemeText
-                type="body__secondary"
+                typography="body__secondary"
                 color="secondary"
                 style={styles.profileItem}
               >
@@ -261,7 +261,7 @@ export const Profile_EditProfileScreen = ({
                   {t(EditProfileTexts.profileInfo.customerNumber)}
                 </ThemeText>
                 <ThemeText
-                  type="body__secondary"
+                  typography="body__secondary"
                   color="secondary"
                   accessibilityLabel={numberToAccessibilityString(
                     customerNumber,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -192,14 +192,14 @@ export const Profile_FareContractsScreen = () => {
     <View style={styles.container}>
       <FullScreenHeader title="Fare Contracts" leftButton={{type: 'back'}} />
       <ScrollView style={styles.content}>
-        <ThemeText type="heading--jumbo">Reservation</ThemeText>
+        <ThemeText typography="heading--jumbo">Reservation</ThemeText>
         <FareContractOrReservation
           index={0}
           onPressFareContract={() => {}}
           fcOrReservation={RESERVATION}
           now={Date.now()}
         />
-        <ThemeText type="heading--jumbo">Fare Contracts</ThemeText>
+        <ThemeText typography="heading--jumbo">Fare Contracts</ThemeText>
         {fareContracts.map((fc, i) => (
           <FareContractOrReservation
             key={i}
@@ -209,7 +209,7 @@ export const Profile_FareContractsScreen = () => {
             onPressFareContract={() => {}}
           />
         ))}
-        <ThemeText type="heading--jumbo">Fare contract details</ThemeText>
+        <ThemeText typography="heading--jumbo">Fare contract details</ThemeText>
         {fareContracts.map((fc, i) => (
           <DetailsContent
             key={i}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NotificationsScreen.tsx
@@ -93,7 +93,7 @@ export const Profile_NotificationsScreen = ({
       }}
       parallaxContent={(focusRef) => (
         <View style={style.parallaxContent} ref={focusRef} accessible={true}>
-          <ThemeText color={themeColor} type="heading--medium">
+          <ThemeText color={themeColor} typography="heading--medium">
             {t(
               ProfileTexts.sections.settings.linkSectionItems.notifications
                 .heading,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -200,7 +200,7 @@ const Card = (props: {
         </View>
       </View>
 
-      <ThemeText color="secondary" type="body__secondary">
+      <ThemeText color="secondary" typography="body__secondary">
         {getExpireDate(card.expires_at)}
       </ThemeText>
     </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -112,7 +112,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   {t(ProfileTexts.sections.account.infoItems.phoneNumber)}
                 </ThemeText>
                 {phoneNumber && (
-                  <ThemeText type="body__secondary" color="secondary">
+                  <ThemeText typography="body__secondary" color="secondary">
                     {phoneNumber}
                   </ThemeText>
                 )}
@@ -124,7 +124,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   {t(ProfileTexts.sections.account.infoItems.customerNumber)}
                 </ThemeText>
                 <ThemeText
-                  type="body__secondary"
+                  typography="body__secondary"
                   color="secondary"
                   accessibilityLabel={numberToAccessibilityString(
                     customerNumber,
@@ -521,7 +521,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             </>
           )}
           <View style={style.debugInfoContainer}>
-            <ThemeText type="body__secondary" color="secondary">
+            <ThemeText typography="body__secondary" color="secondary">
               v{version} ({buildNumber})
             </ThemeText>
             {config?.installId && (
@@ -531,7 +531,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                     <ScreenReaderAnnouncement
                       message={t(ProfileTexts.installId.wasCopiedAlert)}
                     />
-                    <ThemeText type="body__secondary" color="secondary">
+                    <ThemeText typography="body__secondary" color="secondary">
                       ✅ {t(ProfileTexts.installId.wasCopiedAlert)}
                     </ThemeText>
                   </>
@@ -542,13 +542,13 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
                 accessibilityHint={t(ProfileTexts.installId.a11yHint)}
               >
-                <ThemeText type="body__secondary" color="secondary">
+                <ThemeText typography="body__secondary" color="secondary">
                   {t(ProfileTexts.installId.label(config.installId))}
                 </ThemeText>
               </ClickableCopy>
             )}
             <ThemeText
-              type="body__secondary"
+              typography="body__secondary"
               color="secondary"
               accessibilityLabel={t(
                 ProfileTexts.orgNumberA11yLabel(APP_ORG_NUMBER),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SortFavoritesScreen/SortableList.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SortFavoritesScreen/SortableList.tsx
@@ -86,7 +86,7 @@ function Item(props: ItemProps) {
       <View importantForAccessibility="no-hide-descendants">
         <FavoriteIcon favorite={item} />
       </View>
-      <ThemeText type="body__primary" style={contentContainer}>
+      <ThemeText typography="body__primary" style={contentContainer}>
         {name(item)}
       </ThemeText>
       <MoveIcon direction="up" {...props} />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -55,7 +55,7 @@ export const TicketingTile = ({
       <View style={styles.spreadContent} testID={testID}>
         <View style={styles.contentContainer}>
           <ThemeText
-            type="body__secondary--bold"
+            typography="body__secondary--bold"
             style={styles.title}
             accessibilityLabel={title}
             color={themeColor}
@@ -64,7 +64,7 @@ export const TicketingTile = ({
             {title}
           </ThemeText>
           <ThemeText
-            type="body__tertiary"
+            typography="body__tertiary"
             style={styles.description}
             color="secondary"
           >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_NotEnabledScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_NotEnabledScreen.tsx
@@ -30,7 +30,7 @@ export const Ticketing_NotEnabledScreen = () => {
         <View style={styles.contentContainer}>
           <View style={styles.textContent}>
             <ThemeText
-              type="body__primary--jumbo--bold"
+              typography="body__primary--jumbo--bold"
               color={bgColor}
               style={styles.text}
             >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContractComponent.tsx
@@ -155,7 +155,7 @@ export const RecentFareContractComponent = ({
 
       <View style={styles.productName} testID={testID + 'Title'}>
         <ThemeText
-          type="body__secondary--bold"
+          typography="body__secondary--bold"
           color={interactiveColor.default}
         >
           {getReferenceDataName(preassignedFareProduct, language)}
@@ -175,7 +175,7 @@ export const RecentFareContractComponent = ({
 
       <View style={styles.horizontalFlex}>
         <View style={styles.detailContainer}>
-          <ThemeText type="label__uppercase" color="secondary">
+          <ThemeText typography="label__uppercase" color="secondary">
             {t(RecentFareContractsTexts.titles.travellers)}
           </ThemeText>
           {userProfilesWithCount.length <= 2 &&
@@ -205,7 +205,7 @@ export const RecentFareContractComponent = ({
                 />
               ))}
               <ThemeText
-                type="body__tertiary"
+                typography="body__tertiary"
                 testID={`${testID}TravellersOthers`}
                 color={interactiveColor.default}
                 style={styles.additionalCategories}
@@ -220,7 +220,7 @@ export const RecentFareContractComponent = ({
           fromZoneName &&
           toZoneName && (
             <View style={styles.detailContainer}>
-              <ThemeText type="label__uppercase" color="secondary">
+              <ThemeText typography="label__uppercase" color="secondary">
                 {t(RecentFareContractsTexts.titles.zone)}
               </ThemeText>
               {fromZoneName === toZoneName ? (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
@@ -60,7 +60,7 @@ export const RecentFareContracts = ({
           accessibilityLabel={t(RecentFareContractsTexts.titles.loading)}
         >
           <ThemeText
-            type="body__primary"
+            typography="body__primary"
             style={{textAlign: 'center', marginBottom: theme.spacing.large}}
           >
             {t(TicketingTexts.recentFareContracts.loading)}
@@ -73,7 +73,7 @@ export const RecentFareContracts = ({
 
       {!loading && !!memoizedRecentFareContracts.length && (
         <>
-          <ThemeText type="body__secondary" style={styles.header}>
+          <ThemeText typography="body__secondary" style={styles.header}>
             {t(RecentFareContractsTexts.repeatPurchase.label)}
           </ThemeText>
           <ScrollView

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/Ticketing_TicketTabNavStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/Ticketing_TicketTabNavStack.tsx
@@ -120,7 +120,7 @@ const TabBar: React.FC<MaterialTopTabBarProps> = ({
             ]}
           >
             <ThemeText
-              type={isFocused ? 'body__primary--bold' : 'body__primary'}
+              typography={isFocused ? 'body__primary--bold' : 'body__primary'}
               color={tabColor}
               testID={options.tabBarTestID}
             >

--- a/src/stacks-hierarchy/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen.tsx
@@ -67,12 +67,12 @@ export const Root_TicketInformationScreen = (props: Props) => {
                       iconSize="xSmall"
                       modes={fareProductTypeConfig?.transportModes}
                     />
-                    <ThemeText type="body__primary--bold">
+                    <ThemeText typography="body__primary--bold">
                       {getTextForLanguage(fareProductTypeConfig.name, language)}
                     </ThemeText>
                   </View>
                 )}
-                <ThemeText type="body__secondary" isMarkdown={true}>
+                <ThemeText typography="body__secondary" isMarkdown={true}>
                   {getTextForLanguage(
                     preassignedFareProduct.productDescription,
                     language,

--- a/src/storybook/stories/BorderedInfoBox.stories.tsx
+++ b/src/storybook/stories/BorderedInfoBox.stories.tsx
@@ -68,7 +68,7 @@ const BorderedInfoBoxMeta: Meta<BorderedInfoBoxMetaProps> = {
                     color={storyContrastColor}
                   />
                   <ThemeText
-                    type="body__tertiary"
+                    typography="body__tertiary"
                     color={storyContrastColor}
                     style={{flex: 1}}
                   >

--- a/src/storybook/stories/ThemeText.stories.tsx
+++ b/src/storybook/stories/ThemeText.stories.tsx
@@ -16,14 +16,14 @@ const ThemeTextMeta: Meta<ThemeTextMetaProps> = {
   title: 'ThemeText',
   component: ThemeText,
   argTypes: {
-    type: {
+    typography: {
       control: 'select',
       options: textNames,
     },
     ...themedStoryControls,
   },
   args: {
-    type: 'body__primary',
+    typography: 'body__primary',
     isMarkdown: false,
     children: 'Hello world',
     ...themedStoryDefaultArgs,

--- a/src/storybook/stories/ThemeText.stories.tsx
+++ b/src/storybook/stories/ThemeText.stories.tsx
@@ -20,11 +20,16 @@ const ThemeTextMeta: Meta<ThemeTextMetaProps> = {
       control: 'select',
       options: textNames,
     },
+    type: {
+      control: 'select',
+      options: ['primary', 'secondary', 'disabled'],
+    },
     ...themedStoryControls,
   },
   args: {
     typography: 'body__primary',
     isMarkdown: false,
+    type: 'primary',
     children: 'Hello world',
     ...themedStoryDefaultArgs,
   },

--- a/src/tariff-zones-selector/TariffZoneResults.tsx
+++ b/src/tariff-zones-selector/TariffZoneResults.tsx
@@ -28,7 +28,7 @@ export const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {t(TariffZoneSearchTexts.zones.heading)}
         </ThemeText>
       </View>
@@ -56,11 +56,11 @@ export const TariffZoneResults: React.FC<Props> = ({tariffZones, onSelect}) => {
                   <ThemeIcon svg={Pin} width={20} />
                 </View>
                 <View style={styles.nameContainer}>
-                  <ThemeText type="body__primary--bold">
+                  <ThemeText typography="body__primary--bold">
                     {getReferenceDataName(tariffZone, language)}
                   </ThemeText>
                   {tariffZone.description && (
-                    <ThemeText type="body__secondary">
+                    <ThemeText typography="body__secondary">
                       {getTextForLanguage(tariffZone.description, language)}
                     </ThemeText>
                   )}

--- a/src/tips-and-information/TipsAndInformation.tsx
+++ b/src/tips-and-information/TipsAndInformation.tsx
@@ -47,7 +47,7 @@ export const TipsAndInformation = () => {
             }}
             expandContent={
               <ThemeText
-                type="body__secondary"
+                typography="body__secondary"
                 color="secondary"
                 isMarkdown={true}
               >

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -310,7 +310,9 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
                 svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
                 size="xSmall"
               />
-              <ThemeText typography="heading__title">{relativeRealtime}</ThemeText>
+              <ThemeText typography="heading__title">
+                {relativeRealtime}
+              </ThemeText>
             </View>
           </LiveRegionWrapper>
           <LiveRegionWrapper
@@ -337,7 +339,9 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
               svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
               size="xSmall"
             />
-            <ThemeText typography="heading__title">{relativeRealtime}</ThemeText>
+            <ThemeText typography="heading__title">
+              {relativeRealtime}
+            </ThemeText>
           </View>
         </LiveRegionWrapper>
       );

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -247,10 +247,10 @@ const TravelAidSection = ({
                 getStopHeader(status, t) + screenReaderPause + quayName
               }
             >
-              <ThemeText type="body__tertiary--bold">
+              <ThemeText typography="body__tertiary--bold">
                 {getStopHeader(status, t)}
               </ThemeText>
-              <ThemeText type="heading__title">{quayName}</ThemeText>
+              <ThemeText typography="heading__title">{quayName}</ThemeText>
             </LiveRegionWrapper>
             <TimeInfo state={{status, focusedEstimatedCall}} />
           </View>
@@ -292,7 +292,7 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
         <LiveRegionWrapper
           accessibilityLabel={t(TravelAidTexts.scheduledTime(scheduledClock))}
         >
-          <ThemeText type="body__secondary--bold">
+          <ThemeText typography="body__secondary--bold">
             {t(TravelAidTexts.scheduledTime(scheduledClock))}
           </ThemeText>
         </LiveRegionWrapper>
@@ -310,7 +310,7 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
                 svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
                 size="xSmall"
               />
-              <ThemeText type="heading__title">{relativeRealtime}</ThemeText>
+              <ThemeText typography="heading__title">{relativeRealtime}</ThemeText>
             </View>
           </LiveRegionWrapper>
           <LiveRegionWrapper
@@ -318,7 +318,7 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
               TravelAidTexts.scheduledTimeA11yLabel(scheduledClock),
             )}`}
           >
-            <ThemeText type="body__secondary--bold">
+            <ThemeText typography="body__secondary--bold">
               {t(TravelAidTexts.scheduledTime(scheduledClock))}
             </ThemeText>
           </LiveRegionWrapper>
@@ -337,7 +337,7 @@ const TimeInfo = ({state}: {state: FocusedEstimatedCallState}) => {
               svg={themeName === 'light' ? RealtimeLight : RealtimeDark}
               size="xSmall"
             />
-            <ThemeText type="heading__title">{relativeRealtime}</ThemeText>
+            <ThemeText typography="heading__title">{relativeRealtime}</ThemeText>
           </View>
         </LiveRegionWrapper>
       );

--- a/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -99,7 +99,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
         </MapboxGL.MapView>
       </View>
       <PressableOpacity style={styles.button} onPress={onExpand}>
-        <ThemeText type="body__secondary--bold" color="primary">
+        <ThemeText typography="body__secondary--bold" color="primary">
           {buttonText}
         </ThemeText>
         <ThemeIcon svg={ArrowRight} />

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -187,7 +187,7 @@ export const DepartureDetailsScreenComponent = ({
                 />
               )}
               <ThemeText
-                type="heading--medium"
+                typography="heading--medium"
                 color={themeColor}
                 style={{flexShrink: 1}}
               >
@@ -278,7 +278,7 @@ export const DepartureDetailsScreenComponent = ({
           ) : !isWithinSameDate(new Date(), activeItem.date) ? (
             <>
               <View style={styles.date}>
-                <ThemeText type="body__primary" color="secondary">
+                <ThemeText typography="body__primary" color="secondary">
                   {formatToVerboseFullDate(activeItem.date, language)}
                 </ThemeText>
               </View>
@@ -373,7 +373,7 @@ function LastPassedStop({realtimeText}: {realtimeText: string}) {
         style={styles.passedSectionRealtimeIcon}
       />
       <ThemeText
-        type="body__secondary"
+        typography="body__secondary"
         color={themeColor}
         style={styles.passedText}
       >
@@ -543,7 +543,7 @@ function EstimatedCallRow({
         <ThemeText testID="quayName">{getQuayName(call.quay)}</ThemeText>
         {!call.forAlighting && !call.metadata.isStartOfServiceJourney && (
           <AccessibleText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={styles.boardingInfo}
             pause="before"
@@ -553,7 +553,7 @@ function EstimatedCallRow({
         )}
         {!call.forBoarding && !call.metadata.isEndOfServiceJourney && (
           <AccessibleText
-            type="body__secondary"
+            typography="body__secondary"
             color="secondary"
             style={styles.boardingInfo}
             pause="before"

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -485,6 +485,7 @@ type TripItemProps = {
   situations: SituationFragment[];
   onPressQuay: Props['onPressQuay'];
 };
+
 function EstimatedCallRow({
   call,
   mode,
@@ -607,6 +608,7 @@ type CollapseButtonRowProps = {
   setCollapsed(collapsed: boolean): void;
   testID?: string;
 };
+
 function CollapseButtonRow({
   label,
   collapsed,
@@ -641,6 +643,7 @@ function CollapseButtonRow({
     </PressableOpacity>
   );
 }
+
 const useCollapseButtonStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
     flexDirection: 'row',

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -75,7 +75,7 @@ export const TripDetailsScreenComponent = ({
             <View accessible={true} ref={focusRef}>
               <ThemeText
                 color={themeColor}
-                type="heading--medium"
+                typography="heading--medium"
                 style={styles.heading}
                 accessibilityLabel={
                   fromToNames
@@ -99,7 +99,7 @@ export const TripDetailsScreenComponent = ({
                 color={themeColor}
               />
               <ThemeText
-                type="body__secondary"
+                typography="body__secondary"
                 color={themeColor}
                 accessibilityLabel={t(
                   TripDetailsTexts.header.startEndTimeA11yLabel(startEndTime),

--- a/src/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
+++ b/src/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
@@ -99,7 +99,9 @@ export const FlexibleTransportBookingDetailsSheet: React.FC<
                     accessibilityLabel={stepNumberText + stepInstructionText}
                     accessibilityRole="text"
                   >
-                    <ThemeText typography="body__primary">{stepNumberText}</ThemeText>
+                    <ThemeText typography="body__primary">
+                      {stepNumberText}
+                    </ThemeText>
                     <ThemeText typography="body__primary">
                       {stepInstructionText}
                     </ThemeText>

--- a/src/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
+++ b/src/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
@@ -82,7 +82,7 @@ export const FlexibleTransportBookingDetailsSheet: React.FC<
             </View>
           )}
 
-          <ThemeText type="heading__title" style={style.title}>
+          <ThemeText typography="heading__title" style={style.title}>
             {t(TripDetailsTexts.flexibleTransport.contentTitle(publicCode))}
           </ThemeText>
           <View style={style.steps} accessibilityRole="list">
@@ -99,8 +99,8 @@ export const FlexibleTransportBookingDetailsSheet: React.FC<
                     accessibilityLabel={stepNumberText + stepInstructionText}
                     accessibilityRole="text"
                   >
-                    <ThemeText type="body__primary">{stepNumberText}</ThemeText>
-                    <ThemeText type="body__primary">
+                    <ThemeText typography="body__primary">{stepNumberText}</ThemeText>
+                    <ThemeText typography="body__primary">
                       {stepInstructionText}
                     </ThemeText>
                   </View>
@@ -128,7 +128,7 @@ export const FlexibleTransportBookingDetailsSheet: React.FC<
             <ThemeText
               color="secondary"
               style={style.linkText}
-              type="body__primary--underline"
+              typography="body__primary--underline"
             >
               {t(TripDetailsTexts.flexibleTransport.readMoreAbout(publicCode))}
             </ThemeText>

--- a/src/travel-details-screens/components/Time.tsx
+++ b/src/travel-details-screens/components/Time.tsx
@@ -46,7 +46,7 @@ export const Time: React.FC<{
             </AccessibleText>
           </View>
           <AccessibleText
-            type="body__tertiary"
+            typography="body__tertiary"
             color="secondary"
             prefix={t(dictionary.travel.time.aimedPrefix)}
             style={{textDecorationLine: 'line-through'}}

--- a/src/travel-details-screens/components/Trip.tsx
+++ b/src/travel-details-screens/components/Trip.tsx
@@ -116,7 +116,7 @@ export const Trip: React.FC<TripProps> = ({
       {shouldShowDate && (
         <>
           <View style={styles.date}>
-            <ThemeText type="body__secondary" color="secondary">
+            <ThemeText typography="body__secondary" color="secondary">
               {formatToVerboseFullDate(tripPattern.expectedStartTime, language)}
             </ThemeText>
           </View>

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -139,6 +139,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
     isLineFlexibleTransport(leg.line) && leg.authority?.id === atbAuthorityId;
 
   const {open: openBottomSheet} = useBottomSheet();
+
   function openBookingDetails() {
     openBottomSheet(
       () => <FlexibleTransportBookingDetailsSheet leg={leg} />,
@@ -498,7 +499,11 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   return (
     <TripRow accessible={false}>
       <View style={style.authoritySection}>
-        <ThemeText typography="body__secondary" color="secondary" accessible={false}>
+        <ThemeText
+          typography="body__secondary"
+          color="secondary"
+          accessible={false}
+        >
           {t(TripDetailsTexts.trip.leg.buyTicketFrom)}
         </ThemeText>
         <Button
@@ -525,6 +530,7 @@ type InterchangeSectionProps = {
   maximumWaitTime?: number;
   staySeated?: boolean;
 };
+
 function InterchangeSection({
   iconColor,
   publicCode,
@@ -587,6 +593,7 @@ export function getPlaceName(place: Place): string {
   const fallback = place.name ?? '';
   return place.quay ? getQuayName(place.quay) ?? fallback : fallback;
 }
+
 export function mapLegToTimeValues(leg: Leg) {
   const legIsMissingRealTime = !leg.realtime;
   return {
@@ -602,6 +609,7 @@ export function mapLegToTimeValues(leg: Leg) {
     },
   };
 }
+
 function getStopRowA11yTranslated(
   key: 'start' | 'end',
   placeName: string,

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -229,7 +229,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
             {isFlexible && (
               <ThemeText
                 color="secondary"
-                type="body__secondary"
+                typography="body__secondary"
                 style={style.onDemandTransportLabel}
               >
                 {t(TripDetailsTexts.flexibleTransport.onDemandTransportLabel)}
@@ -309,7 +309,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
               />
               <ThemeText
                 style={style.realtimeText}
-                type="body__secondary"
+                typography="body__secondary"
                 color="secondary"
               >
                 {realtimeText}
@@ -416,7 +416,7 @@ const IntermediateInfo = ({
         TripDetailsTexts.trip.leg.intermediateStops.a11yHint,
       )}
     >
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {t(
           TripDetailsTexts.trip.leg.intermediateStops.label(
             numberOfIntermediateCalls,
@@ -441,7 +441,7 @@ const WalkSection = (leg: Leg) => {
       }
       testID="footLeg"
     >
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {isWalkTimeOfSignificance
           ? t(
               TripDetailsTexts.trip.leg.walk.label(
@@ -466,7 +466,7 @@ const BikeSection = (leg: Leg) => {
       }
       testID="bikeLeg"
     >
-      <ThemeText type="body__secondary" color="secondary">
+      <ThemeText typography="body__secondary" color="secondary">
         {t(
           TripDetailsTexts.trip.leg.bicycle.label(
             secondsToDuration(leg.duration ?? 0, language),
@@ -488,7 +488,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
     return (
       <TripRow>
         <View style={style.authoritySection}>
-          <ThemeText type="body__secondary" color="secondary">
+          <ThemeText typography="body__secondary" color="secondary">
             {t(TripDetailsTexts.trip.leg.buyTicketFrom) + ' ' + name}
           </ThemeText>
         </View>
@@ -498,7 +498,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   return (
     <TripRow accessible={false}>
       <View style={style.authoritySection}>
-        <ThemeText type="body__secondary" color="secondary" accessible={false}>
+        <ThemeText typography="body__secondary" color="secondary" accessible={false}>
           {t(TripDetailsTexts.trip.leg.buyTicketFrom)}
         </ThemeText>
         <Button

--- a/src/travel-details-screens/components/WaitSection.tsx
+++ b/src/travel-details-screens/components/WaitSection.tsx
@@ -36,7 +36,7 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
         </TripRow>
       )}
       <TripRow rowLabel={<ThemeIcon svg={Time} color={iconColor} />}>
-        <ThemeText type="body__secondary" color="secondary">
+        <ThemeText typography="body__secondary" color="secondary">
           {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
         </ThemeText>
       </TripRow>

--- a/src/travel-token-box/TravelTokenBox.tsx
+++ b/src/travel-token-box/TravelTokenBox.tsx
@@ -92,7 +92,7 @@ export function TravelTokenBox({
         )}
         <View style={styles.activeTravelTokenInfo}>
           <ThemeText
-            type="body__primary--bold"
+            typography="body__primary--bold"
             color={themeTextColor.default}
             style={styles.travelTokenBoxTitle}
           >

--- a/src/travel-token-box/TravelTokenDeviceTitle.tsx
+++ b/src/travel-token-box/TravelTokenDeviceTitle.tsx
@@ -29,21 +29,21 @@ export const TravelTokenDeviceTitle = ({
         accessibilityLabel={a11yLabel}
       >
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           color={themeTextColor}
           style={styles.transparent}
         >
           {prefixX}
         </ThemeText>
         <ThemeText
-          type="body__secondary--bold"
+          typography="body__secondary--bold"
           color={themeTextColor}
           testID="travelCardNumber"
         >
           {travelCardIdOuttake}
         </ThemeText>
         <ThemeText
-          type="body__secondary"
+          typography="body__secondary"
           color={themeTextColor}
           style={styles.transparent}
         >
@@ -54,7 +54,7 @@ export const TravelTokenDeviceTitle = ({
   } else {
     return (
       <ThemeText
-        type="body__secondary"
+        typography="body__secondary"
         color={themeTextColor}
         style={styles.tokenName}
         testID="mobileTokenName"


### PR DESCRIPTION
Part of https://github.com/AtB-AS/kundevendt/issues/17880

This tries to allow ThemeText to be more flexible about the colour to choose, here is a discussion https://github.com/AtB-AS/mittatb-app/pull/4860#discussion_r1873260173 where they did not match the header well because the secondary colour did not match when light mode.

Refer to the link for more details.