### PR TITLE
feat: add feature flag for onboarding login

### DIFF
--- a/src/RemoteConfigContext.tsx
+++ b/src/RemoteConfigContext.tsx
@@ -21,6 +21,7 @@ const RETRY_INTERVAL_MS_MAX = 30000;
 
 export type RemoteConfigContextState = RemoteConfig & {
   refresh: () => void;
+  isLoaded: boolean;
   feedback_questions: FeedbackConfiguration[];
 };
 
@@ -61,6 +62,7 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
   const [config, setConfig] = useState<RemoteConfig>(defaultRemoteConfig);
   const [fetchError, setFetchError] = useState(false);
   const [retryInterval, incrementRetryInterval] = useRetryIntervalWithBackoff();
+  const [isLoaded, setIsLoaded] = useState(false);
 
   const fetchConfig = useCallback(async () => {
     try {
@@ -68,6 +70,7 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
       const currentConfig = await getConfig();
       setConfig(currentConfig);
       setFetchError(false);
+      setIsLoaded(true);
     } catch (e) {
       setFetchError(true);
       if (isRemoteConfigError(e) && isUserInfo(e.userInfo)) {
@@ -116,6 +119,7 @@ export const RemoteConfigContextProvider: React.FC = ({children}) => {
         ...config,
         feedback_questions: parseJson(config.feedback_questions, []),
         refresh,
+        isLoaded,
       }}
     >
       {children}

--- a/src/fare-contracts/__tests__/sort-fc-reservation-by-validity-creation.test.ts
+++ b/src/fare-contracts/__tests__/sort-fc-reservation-by-validity-creation.test.ts
@@ -12,6 +12,7 @@ const DEFAULT_MOCK_STATE: LoadingParams = {
   isLoadingAppState: false,
   authStatus: 'authenticated',
   firestoreConfigStatus: 'success',
+  remoteConfigIsLoaded: true,
 };
 
 jest.mock('@atb/auth/AuthContext', () => {});

--- a/src/feature-toggles/toggle-specifications.ts
+++ b/src/feature-toggles/toggle-specifications.ts
@@ -74,6 +74,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_on_behalf_of',
   },
   {
+    name: 'isOnboardingLoginEnabled',
+    remoteConfigKey: 'enable_onboarding_login',
+  },
+  {
     name: 'isOnlyStopPlacesCheckboxEnabled',
     remoteConfigKey: 'enable_only_stop_places_checkbox',
   },

--- a/src/loading-screen/__tests__/use-loading-state.test.ts
+++ b/src/loading-screen/__tests__/use-loading-state.test.ts
@@ -7,6 +7,7 @@ const DEFAULT_MOCK_STATE: LoadingParams = {
   authStatus: 'loading',
   firestoreConfigStatus: 'loading',
   userId: 'user1',
+  remoteConfigIsLoaded: false,
 };
 
 let mockState = DEFAULT_MOCK_STATE;
@@ -35,6 +36,12 @@ jest.mock('@atb/loading-screen', () => ({
   useIsLoadingAppState: () => mockState.isLoadingAppState,
 }));
 
+jest.mock('@atb/RemoteConfigContext', () => ({
+  useRemoteConfig: () => ({
+    isLoaded: mockState.remoteConfigIsLoaded,
+  }),
+}));
+
 describe('useLoadingState', () => {
   beforeAll(() => jest.useFakeTimers());
   beforeEach(() => {
@@ -56,6 +63,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');
@@ -65,6 +73,17 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
+    };
+    hook.rerender();
+    expect(hook.result.current.status).toBe('loading');
+
+    mockState = {
+      isLoadingAppState: false,
+      authStatus: 'authenticated',
+      firestoreConfigStatus: 'success',
+      userId: 'user1',
+      remoteConfigIsLoaded: false,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');
@@ -90,6 +109,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     expect(hook.result.current.status).toBe('success');
@@ -105,6 +125,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('success');
@@ -119,6 +140,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('success');
@@ -130,6 +152,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     expect(hook.result.current.status).toBe('success');
@@ -138,6 +161,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');
@@ -149,6 +173,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -158,6 +183,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('timeout');
@@ -169,6 +195,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(80));
@@ -178,6 +205,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('success');
@@ -192,6 +220,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -206,6 +235,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -215,6 +245,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     act(() => hook.result.current.retry());
     expect(hook.result.current.status).toBe('success');
@@ -226,6 +257,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'loading',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -234,6 +266,7 @@ describe('useLoadingState', () => {
       isLoadingAppState: false,
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     };
     act(() => hook.result.current.retry());
     expect(hook.result.current.status).toBe('success');
@@ -245,6 +278,7 @@ describe('useLoadingState', () => {
       authStatus: 'fetching-id-token',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => hook.result.current.retry());
@@ -257,6 +291,7 @@ describe('useLoadingState', () => {
       authStatus: 'fetching-id-token',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -271,6 +306,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'loading',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -285,6 +321,7 @@ describe('useLoadingState', () => {
       authStatus: 'authenticated',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -298,6 +335,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -311,6 +349,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user1',
+      remoteConfigIsLoaded: true,
     };
     const hook = renderHook(() => useLoadingState(100));
     act(() => jest.advanceTimersByTime(120));
@@ -321,6 +360,7 @@ describe('useLoadingState', () => {
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
       userId: 'user2',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(hook.result.current.status).toBe('loading');

--- a/src/loading-screen/__tests__/use-notify-bugsnag-on-timeout-status.test.ts
+++ b/src/loading-screen/__tests__/use-notify-bugsnag-on-timeout-status.test.ts
@@ -30,6 +30,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     renderHook(() => useNotifyBugsnagOnTimeoutStatus('timeout', ref));
     expect(mockBugsnagNotification).toEqual([
@@ -40,6 +41,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
           isLoadingAppState: true,
           authStatus: 'loading',
           firestoreConfigStatus: 'success',
+          remoteConfigIsLoaded: true,
         },
       }),
     ]);
@@ -50,6 +52,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     renderHook(() => useNotifyBugsnagOnTimeoutStatus('loading', ref));
     expect(mockBugsnagNotification).toEqual(undefined);
@@ -60,6 +63,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     renderHook(() => useNotifyBugsnagOnTimeoutStatus('success', ref));
     expect(mockBugsnagNotification).toEqual(undefined);
@@ -70,6 +74,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     const hook = renderHook(
       ({status}) => useNotifyBugsnagOnTimeoutStatus(status, ref),
@@ -87,6 +92,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
           isLoadingAppState: true,
           authStatus: 'loading',
           firestoreConfigStatus: 'success',
+          remoteConfigIsLoaded: true,
         },
       }),
     ]);
@@ -97,6 +103,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     const hook = renderHook(() =>
       useNotifyBugsnagOnTimeoutStatus('timeout', ref),
@@ -109,6 +116,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
           isLoadingAppState: true,
           authStatus: 'loading',
           firestoreConfigStatus: 'success',
+          remoteConfigIsLoaded: true,
         },
       }),
     ]);
@@ -122,6 +130,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     const hook = renderHook(
       ({status}) => useNotifyBugsnagOnTimeoutStatus(status, ref),
@@ -134,6 +143,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'fetching-id-token',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender({status: 'timeout'});
     expect(mockBugsnagNotification).toEqual([
@@ -144,6 +154,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
           isLoadingAppState: true,
           authStatus: 'fetching-id-token',
           firestoreConfigStatus: 'success',
+          remoteConfigIsLoaded: true,
         },
       }),
     ]);
@@ -154,6 +165,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'loading',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     });
     const hook = renderHook(() =>
       useNotifyBugsnagOnTimeoutStatus('timeout', ref),
@@ -166,6 +178,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
           isLoadingAppState: true,
           authStatus: 'loading',
           firestoreConfigStatus: 'success',
+          remoteConfigIsLoaded: true,
         },
       }),
     ]);
@@ -174,6 +187,7 @@ describe('useNotifyBugsnagOnTimeoutStatus', () => {
       isLoadingAppState: true,
       authStatus: 'fetching-id-token',
       firestoreConfigStatus: 'success',
+      remoteConfigIsLoaded: true,
     };
     hook.rerender();
     expect(mockBugsnagNotification).toEqual(undefined);

--- a/src/loading-screen/types.ts
+++ b/src/loading-screen/types.ts
@@ -9,6 +9,7 @@ export type LoadingParams = {
   isLoadingAppState: boolean;
   authStatus: AuthStatus;
   firestoreConfigStatus: FirestoreConfigStatus;
+  remoteConfigIsLoaded: boolean;
 };
 
 export type LoadingState = {

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -1,6 +1,6 @@
 import {useAuthState} from '@atb/auth';
 import {useCallback, useEffect, useRef, useState} from 'react';
-import {LoadingState} from '@atb/loading-screen/types';
+import {LoadingParams, LoadingState} from '@atb/loading-screen/types';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {useIsLoadingAppState} from '@atb/loading-screen';
 import {useRemoteConfig} from '@atb/RemoteConfigContext';
@@ -12,7 +12,7 @@ export const useLoadingState = (timeoutMs: number): LoadingState => {
   const {resubscribeFirestoreConfig, firestoreConfigStatus} =
     useFirestoreConfiguration();
   const {isLoaded: remoteConfigIsLoaded} = useRemoteConfig();
-  const paramsRef = useRef({
+  const paramsRef = useRef<LoadingParams>({
     userId,
     isLoadingAppState,
     authStatus,

--- a/src/loading-screen/use-loading-state.ts
+++ b/src/loading-screen/use-loading-state.ts
@@ -3,6 +3,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import {LoadingState} from '@atb/loading-screen/types';
 import {useFirestoreConfiguration} from '@atb/configuration';
 import {useIsLoadingAppState} from '@atb/loading-screen';
+import {useRemoteConfig} from '@atb/RemoteConfigContext';
 
 export const useLoadingState = (timeoutMs: number): LoadingState => {
   const isLoadingAppState = useIsLoadingAppState();
@@ -10,17 +11,20 @@ export const useLoadingState = (timeoutMs: number): LoadingState => {
   const [isTimeout, setIsTimeout] = useState(false);
   const {resubscribeFirestoreConfig, firestoreConfigStatus} =
     useFirestoreConfiguration();
+  const {isLoaded: remoteConfigIsLoaded} = useRemoteConfig();
   const paramsRef = useRef({
     userId,
     isLoadingAppState,
     authStatus,
     firestoreConfigStatus,
+    remoteConfigIsLoaded,
   });
 
   const loadSuccessful =
     !isLoadingAppState &&
     authStatus === 'authenticated' &&
-    firestoreConfigStatus === 'success';
+    firestoreConfigStatus === 'success' &&
+    remoteConfigIsLoaded;
 
   const status = loadSuccessful ? 'success' : isTimeout ? 'timeout' : 'loading';
 
@@ -32,8 +36,15 @@ export const useLoadingState = (timeoutMs: number): LoadingState => {
       isLoadingAppState,
       authStatus,
       firestoreConfigStatus,
+      remoteConfigIsLoaded,
     };
-  }, [userId, isLoadingAppState, authStatus, firestoreConfigStatus]);
+  }, [
+    userId,
+    isLoadingAppState,
+    authStatus,
+    firestoreConfigStatus,
+    remoteConfigIsLoaded,
+  ]);
 
   useEffect(() => {
     if (status === 'success') {

--- a/src/onboarding/OnboardingContext.tsx
+++ b/src/onboarding/OnboardingContext.tsx
@@ -282,7 +282,8 @@ const useShouldShowArgs = (
   const hasFareContractWithActivatedNotification =
     useHasFareContractWithActivatedNotification();
 
-  const {isPushNotificationsEnabled} = useFeatureToggles();
+  const {isPushNotificationsEnabled, isOnboardingLoginEnabled} =
+    useFeatureToggles();
   const {permissionStatus: pushNotificationPermissionStatus} =
     useNotifications();
 
@@ -292,7 +293,6 @@ const useShouldShowArgs = (
   const {
     enable_extended_onboarding: extendedOnboardingEnabled,
     disable_travelcard: travelCardDisabled,
-    enable_onboarding_login: onboardingLoginEnabled,
   } = useRemoteConfig();
 
   const shouldShowShareTravelHabitsScreen =
@@ -309,6 +309,7 @@ const useShouldShowArgs = (
     () => ({
       hasFareContractWithActivatedNotification,
       pushNotificationPermissionStatus,
+      isOnboardingLoginEnabled,
       isPushNotificationsEnabled,
       locationPermissionStatus,
       authenticationType,
@@ -317,11 +318,11 @@ const useShouldShowArgs = (
       travelCardDisabled,
       userCreationIsOnboarded,
       mobileTokenStatus,
-      onboardingLoginEnabled,
     }),
     [
       hasFareContractWithActivatedNotification,
       pushNotificationPermissionStatus,
+      isOnboardingLoginEnabled,
       isPushNotificationsEnabled,
       locationPermissionStatus,
       authenticationType,
@@ -330,7 +331,6 @@ const useShouldShowArgs = (
       travelCardDisabled,
       userCreationIsOnboarded,
       mobileTokenStatus,
-      onboardingLoginEnabled,
     ],
   );
 };

--- a/src/onboarding/OnboardingContext.tsx
+++ b/src/onboarding/OnboardingContext.tsx
@@ -292,6 +292,7 @@ const useShouldShowArgs = (
   const {
     enable_extended_onboarding: extendedOnboardingEnabled,
     disable_travelcard: travelCardDisabled,
+    enable_onboarding_login: onboardingLoginEnabled,
   } = useRemoteConfig();
 
   const shouldShowShareTravelHabitsScreen =
@@ -316,6 +317,7 @@ const useShouldShowArgs = (
       travelCardDisabled,
       userCreationIsOnboarded,
       mobileTokenStatus,
+      onboardingLoginEnabled,
     }),
     [
       hasFareContractWithActivatedNotification,
@@ -328,6 +330,7 @@ const useShouldShowArgs = (
       travelCardDisabled,
       userCreationIsOnboarded,
       mobileTokenStatus,
+      onboardingLoginEnabled,
     ],
   );
 };

--- a/src/onboarding/onboarding-config.ts
+++ b/src/onboarding/onboarding-config.ts
@@ -22,8 +22,8 @@ export const onboardingSectionsInPrioritizedOrder: OnboardingSectionConfig[] = [
       params: {},
     },
     shouldShowBeforeUserCreated: true,
-    shouldShowPredicate: ({authenticationType}) =>
-      authenticationType === 'anonymous',
+    shouldShowPredicate: ({onboardingLoginEnabled, authenticationType}) =>
+      onboardingLoginEnabled && authenticationType === 'anonymous',
   },
   {
     isOnboardedStoreKey: '@ATB_location_when_in_use_permission_onboarded',

--- a/src/onboarding/onboarding-config.ts
+++ b/src/onboarding/onboarding-config.ts
@@ -22,8 +22,8 @@ export const onboardingSectionsInPrioritizedOrder: OnboardingSectionConfig[] = [
       params: {},
     },
     shouldShowBeforeUserCreated: true,
-    shouldShowPredicate: ({onboardingLoginEnabled, authenticationType}) =>
-      onboardingLoginEnabled && authenticationType === 'anonymous',
+    shouldShowPredicate: ({isOnboardingLoginEnabled, authenticationType}) =>
+      isOnboardingLoginEnabled && authenticationType === 'anonymous',
   },
   {
     isOnboardedStoreKey: '@ATB_location_when_in_use_permission_onboarded',

--- a/src/onboarding/types.ts
+++ b/src/onboarding/types.ts
@@ -26,6 +26,7 @@ export type ShouldShowArgsType = {
   locationPermissionStatus: PermissionStatus | null;
   pushNotificationPermissionStatus: NotificationPermissionStatus;
   authenticationType: AuthenticationType;
+  isOnboardingLoginEnabled: boolean;
   isPushNotificationsEnabled: boolean;
   hasFareContractWithActivatedNotification: boolean;
   travelCardDisabled: boolean;
@@ -33,7 +34,6 @@ export type ShouldShowArgsType = {
   extendedOnboardingEnabled: boolean;
   userCreationIsOnboarded: boolean;
   shouldShowShareTravelHabitsScreen: boolean;
-  onboardingLoginEnabled: boolean;
 };
 
 export type OnboardingSectionConfig = {

--- a/src/onboarding/types.ts
+++ b/src/onboarding/types.ts
@@ -33,6 +33,7 @@ export type ShouldShowArgsType = {
   extendedOnboardingEnabled: boolean;
   userCreationIsOnboarded: boolean;
   shouldShowShareTravelHabitsScreen: boolean;
+  onboardingLoginEnabled: boolean;
 };
 
 export type OnboardingSectionConfig = {

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -30,6 +30,7 @@ export type RemoteConfig = {
   enable_non_transit_trip_search: boolean;
   enable_nynorsk: boolean;
   enable_on_behalf_of: boolean;
+  enable_onboarding_login: boolean;
   enable_parking_violations_reporting: boolean;
   enable_posthog: boolean;
   enable_push_notifications: boolean;
@@ -99,6 +100,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_non_transit_trip_search: true,
   enable_nynorsk: true,
   enable_on_behalf_of: false,
+  enable_onboarding_login: true,
   enable_parking_violations_reporting: false,
   enable_posthog: false,
   enable_push_notifications: false,
@@ -208,6 +210,9 @@ export function getConfig(): RemoteConfig {
   const enable_on_behalf_of =
     values['enable_on_behalf_of']?.asBoolean() ??
     defaultRemoteConfig.enable_on_behalf_of;
+  const enable_onboarding_login =
+    values['enable_onboarding_login']?.asBoolean() ??
+    defaultRemoteConfig.enable_onboarding_login;
   const enable_parking_violations_reporting =
     values['enable_parking_violations_reporting']?.asBoolean() ??
     defaultRemoteConfig.enable_parking_violations_reporting;
@@ -351,6 +356,7 @@ export function getConfig(): RemoteConfig {
     enable_non_transit_trip_search,
     enable_nynorsk,
     enable_on_behalf_of,
+    enable_onboarding_login,
     enable_parking_violations_reporting,
     enable_posthog,
     enable_push_notifications,


### PR DESCRIPTION
Disables the onboarding login if the `enable_onboarding_login` remote config flag is `false`.

Also adds remote config to the loading boundary, making the app wait for remote config to load before letting users into the app, since the `enable_onboarding_login` flag is needed before onboarding starts. If loading of remote config fails, the default value is true, meaning that the login will be shown after a loading boundary timeout.

Note: There's an issue with the extended onboarding (used by FRAM, and maybe other OMS partners), where if it's the only onboarding screen, it won't be able to navigate past the final extended onboarding page. (It ends up on `navigation.goBack()` in https://github.com/AtB-AS/mittatb-app/blob/master/src/onboarding/use-onboarding-navigation.ts#L42 )

closes https://github.com/AtB-AS/kundevendt/issues/19356
