### PR TITLE
style: reduce size of Aztek

### DIFF
--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -257,9 +257,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     aspectRatio: 1,
     padding: theme.spacing.large,
     backgroundColor: '#FFFFFF',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    maxWidth: 200,
+    maxHeight: 275,
   },
   staticBottomContainer: {
     flex: 1,

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -257,6 +257,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     aspectRatio: 1,
     padding: theme.spacing.large,
     backgroundColor: '#FFFFFF',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    maxWidth: 200,
   },
   staticBottomContainer: {
     flex: 1,

--- a/src/fare-contracts/details/Barcode.tsx
+++ b/src/fare-contracts/details/Barcode.tsx
@@ -106,15 +106,13 @@ const MobileTokenAztec = ({fc}: {fc: FareContract}) => {
   }
 
   return (
-    <View style={{alignItems: 'center'}}>
-      <View
-        style={styles.aztecCode}
-        accessible={true}
-        accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
-        testID="mobileTokenBarcode"
-      >
-        <SvgXml xml={aztecXml} width="100%" height="100%" />
-      </View>
+    <View
+      style={styles.aztecCode}
+      accessible={true}
+      accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
+      testID="mobileTokenBarcode"
+    >
+      <SvgXml xml={aztecXml} width="100%" height="100%" />
     </View>
   );
 };


### PR DESCRIPTION
Now that FRAM will be going from using static QR code to using Aztek, the testers have experienced that the Aztek is too large for FLV+, and that FLV+ sometimes has trouble reading. By reducing it to a maximum width of 200 (up for discussion), it will be easier for the FLV+ to read the code.


Co-authored-by: Morten Nordseth <morten@nordseth.net>
Co-authored-by: Mathias Oterhals Myklebust <mom@variant.no>
