### PR TITLE
chore: Add eslint rules for not leaking values to jsx

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,9 @@ module.exports = {
   },
   parserOptions: {
     sourceType: 'module',
+    project: './tsconfig.json',
   },
+  ignorePatterns: ['.eslintrc.js'],
   root: true,
   extends: [
     // Add the recommended react-query eslint rules, with exhaustive deps for the query key
@@ -46,6 +48,7 @@ module.exports = {
     'rulesdir',
     'unused-imports',
     '@tanstack/query',
+    'jsx-no-leaked-values',
   ],
   rules: {
     // Warning on console.log
@@ -109,6 +112,9 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
+
+    // Avoid accidentally rendering 0 or NaN, which makes react-native crash if rendered not inside Text component
+    'jsx-no-leaked-values/jsx-no-leaked-values': 'error',
 
     // Warning on usage of texts from translations module without using the translation function
     'rulesdir/translations-warning': 'warn',

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "conventional-changelog-cli": "^5.0.0",
     "eslint": "8.47.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-jsx-no-leaked-values": "0.1.24",
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/components/screen-view/FullScreenView.tsx
+++ b/src/components/screen-view/FullScreenView.tsx
@@ -71,7 +71,7 @@ export function FullScreenView(props: Props) {
           contentColor={props.contentColor}
         />
       )}
-      {props.footer && (
+      {!!props.footer && (
         <FullScreenFooter footerColor={backgroundColor}>
           {props.footer}
         </FullScreenFooter>

--- a/src/mobility/components/MobilityStat.tsx
+++ b/src/mobility/components/MobilityStat.tsx
@@ -24,7 +24,7 @@ export const MobilityStat = ({
   return (
     <View style={[styles.container, externalStyle]}>
       <StatWithIcon svg={svg} text={String(primaryStat)} />
-      {secondaryStat && (
+      {!!secondaryStat && (
         <ThemeText
           typography="body__secondary"
           style={secondaryStatStyle}

--- a/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ScreenContainer.tsx
+++ b/src/stacks-hierarchy/Root_ParkingViolationsReporting/components/ScreenContainer.tsx
@@ -73,7 +73,7 @@ const ContentBody = ({title, secondaryText, buttons, children}: Props) => {
         </View>
         {children}
       </View>
-      {buttons && <View style={style.actionButtons}>{buttons}</View>}
+      {!!buttons && <View style={style.actionButtons}>{buttons}</View>}
     </>
   );
 };

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -139,7 +139,7 @@ export const PreassignedFareContractSummary = ({
             )}
           <SummaryText />
           {!isSearchingOffer &&
-            validDurationSeconds &&
+            !!validDurationSeconds &&
             isShowValidTimeInfoEnabled &&
             summary(
               t(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -255,7 +255,7 @@ export const Profile_EditProfileScreen = ({
                 {t(EditProfileTexts.profileInfo.otp(phoneNumber))}
               </ThemeText>
             )}
-            {customerNumber && (
+            {!!customerNumber && (
               <>
                 <ThemeText>
                   {t(EditProfileTexts.profileInfo.customerNumber)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -118,7 +118,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
               </GenericSectionItem>
             )}
-            {customerNumber && (
+            {!!customerNumber && (
               <GenericSectionItem>
                 <ThemeText style={style.customerNumberHeading}>
                   {t(ProfileTexts.sections.account.infoItems.customerNumber)}

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -155,7 +155,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const sectionOutput = (
     <>
       <View style={style.tripSection} testID={testID}>
-        {step && leg.mode && (
+        {!!step && leg.mode && (
           <AccessibleText
             style={style.a11yHelper}
             prefix={t(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,6 +3843,13 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
+"@typescript-eslint/experimental-utils@^5.36.1":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.62.0.tgz#14559bf73383a308026b427a4a6129bae2146741"
+  integrity sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==
+  dependencies:
+    "@typescript-eslint/utils" "5.62.0"
+
 "@typescript-eslint/parser@^5.30.5":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
@@ -5913,6 +5920,15 @@ eslint-plugin-jest@^26.5.3:
   integrity sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
+
+eslint-plugin-jsx-no-leaked-values@0.1.24:
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-no-leaked-values/-/eslint-plugin-jsx-no-leaked-values-0.1.24.tgz#5503c11c5f019d17c86ee65df926df2fc8f71109"
+  integrity sha512-gr81LxBZlWu+YsbdaoG6ruRN/wKPTLhuhZGrX95hgCNMoiyfPv4Xw/PFw8xR/sYOIIAGgrkuv38XFT0KrfSMWw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.36.1"
+    ts-pattern "^4.0.5"
+    tsutils "^3.21.0"
 
 eslint-plugin-prettier@5.0.0:
   version "5.0.0"
@@ -10843,6 +10859,11 @@ ts-jest@^29.2.4:
     make-error "1.x"
     semver "^7.5.3"
     yargs-parser "^21.0.1"
+
+ts-pattern@^4.0.5:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-4.3.0.tgz#7a995b39342f1b00d1507c2d2f3b90ea16e178a6"
+  integrity sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
In react-native the app crashes if trying to render text outside of
Text component. This has happened in our production app more than
once because of checks on length, and to be fair it will probably
happen more if we don't do anything about it.

This change adds an eslint rule that gives error when using in
combination with && inside jsx.

The eslint rule used is not that popular, but seems well created
and safe to use when reading through its code.

### Acceptance criteria
- [ ] Should be no changes for the app.
