### PR TITLE
test: e2e test change for departure details header

### DIFF
--- a/e2e/test/pageobjects/departure.details.page.ts
+++ b/e2e/test/pageobjects/departure.details.page.ts
@@ -20,6 +20,22 @@ class DepartureDetailPage {
   }
 
   /**
+   * Return the public code
+   */
+  async getPublicCode() {
+    const publicCodeId = `//*[@resource-id="PublicCode"]`;
+    return $(publicCodeId).getText();
+  }
+
+  /**
+   * Return the line name
+   */
+  async getLineName() {
+    const lineNameId = `//*[@resource-id="lineName"]`;
+    return $(lineNameId).getText();
+  }
+
+  /**
    * Return the quay name
    * @param legType 'passed' or 'trip'
    * @param legIndex index of the leg

--- a/e2e/test/specs/departure.e2e.ts
+++ b/e2e/test/specs/departure.e2e.ts
@@ -108,7 +108,10 @@ describe('Departure', () => {
       const lineName = await DepartureOverviewPage.getLineName();
       await DepartureOverviewPage.openDeparture();
       await ElementHelper.waitForElement('id', 'departureDetailsContentView');
-      await ElementHelper.expectText(`${linePublicCode} ${lineName}`);
+      expect(await DepartureDetailsPage.getPublicCode()).toHaveText(
+        linePublicCode,
+      );
+      expect(await DepartureDetailsPage.getLineName()).toHaveText(lineName);
 
       // Show intermediate stops
       const noPassed = await DepartureDetailsPage.passedLegs.length;
@@ -123,7 +126,10 @@ describe('Departure', () => {
 
       await NavigationHelper.back();
       await ElementHelper.waitForElement('id', 'departureDetailsContentView');
-      await ElementHelper.expectText(`${linePublicCode} ${lineName}`);
+      expect(await DepartureDetailsPage.getPublicCode()).toHaveText(
+        linePublicCode,
+      );
+      expect(await DepartureDetailsPage.getLineName()).toHaveText(lineName);
     } catch (errMsg) {
       await AppHelper.screenshot(
         'error_departure_should_show_intermediate_stops',

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -208,6 +208,7 @@ export const DepartureDetailsScreenComponent = ({
                 typography="heading__title"
                 color={themeColor}
                 style={styles.headerTitle}
+                testID="lineName"
               >
                 {title ?? t(DepartureDetailsTexts.header.notFound)}
               </ThemeText>


### PR DESCRIPTION
- Added a test-id to the departure details header for line name
- Changed the tests accordingly