### PR TITLE
feat: Only reserving reservations gives login warning

### DIFF
--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -11,6 +11,7 @@ import {FareContractStatusSymbol} from './components/FareContractStatusSymbol';
 import {formatToLongDateTime} from '@atb/utils/date';
 import {fromUnixTime} from 'date-fns';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {getReservationStatus} from '@atb/fare-contracts/utils';
 
 type Props = {
   reservation: Reservation;
@@ -30,18 +31,6 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
     }
   }
 
-  const getStatus = () => {
-    const paymentStatus = reservation.paymentStatus;
-    switch (paymentStatus) {
-      case 'CAPTURE':
-        return 'approved';
-      case 'REJECT':
-        return 'rejected';
-      default:
-        return 'reserving';
-    }
-  };
-
   const isSubAccountReservation = customerProfile?.subAccounts?.some(
     (id) => id === reservation.customerAccountId,
   );
@@ -51,7 +40,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
     return null;
   }
 
-  const status = getStatus();
+  const status = getReservationStatus(reservation);
 
   const paymentType = PaymentType[reservation.paymentType];
   return (

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -319,3 +319,15 @@ export function getFareContractInfo(
     numberOfUsedAccesses,
   };
 }
+
+export const getReservationStatus = (reservation: Reservation) => {
+  const paymentStatus = reservation.paymentStatus;
+  switch (paymentStatus) {
+    case 'CAPTURE':
+      return 'approved';
+    case 'REJECT':
+      return 'rejected';
+    default:
+      return 'reserving';
+  }
+};

--- a/src/ticketing/use-has-reservation-or-active-fare-contract.ts
+++ b/src/ticketing/use-has-reservation-or-active-fare-contract.ts
@@ -1,6 +1,7 @@
 import {useTicketingState} from '@atb/ticketing/TicketingContext';
 import {useTimeContextState} from '@atb/time';
 import {filterActiveOrCanBeUsedFareContracts} from '@atb/ticketing/utils';
+import {getReservationStatus} from '@atb/fare-contracts/utils';
 
 export const useHasReservationOrActiveFareContract = () => {
   const {fareContracts, reservations} = useTicketingState();
@@ -10,7 +11,9 @@ export const useHasReservationOrActiveFareContract = () => {
     serverNow,
   );
   const hasActiveFareContracts = activeFareContracts.length > 0;
-  const hasReservations = reservations.length > 0;
+  const hasReservingReservations = reservations
+    .map(getReservationStatus)
+    .some((status) => status === 'reserving');
 
-  return hasActiveFareContracts || hasReservations;
+  return hasActiveFareContracts || hasReservingReservations;
 };


### PR DESCRIPTION
Reservations in rejected state made the user get the login
warning about active tickets. This should not be the case, so the
logic was changed so only reserving reservations gives login
warning.

<img width=400 src="https://github.com/user-attachments/assets/6408eb5c-2d57-4a77-b3c6-0417bcad5c9c" />

### Acceptance criteria
- [ ] Rejected reservations should not give login warning screen
- [ ] Reserving reservations should still give login warning screen
- [ ] Active tickets should still give login warning screen

