### PR TITLE
fix: Only stop places checkbox label color

### DIFF
--- a/src/components/checkbox/CheckboxWithLabel.tsx
+++ b/src/components/checkbox/CheckboxWithLabel.tsx
@@ -1,13 +1,10 @@
-import {
-  screenReaderPause,
-  ThemeText,
-  ThemeTextProps,
-} from '@atb/components/text';
+import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {StyleProp, TouchableOpacity, ViewStyle} from 'react-native';
 import {dictionary, useTranslation} from '@atb/translations';
 import {Checkbox} from '.';
 import React from 'react';
 import {StyleSheet} from '@atb/theme';
+import type {ContrastColor} from '@atb-as/theme';
 
 export const CheckboxWithLabel = ({
   label,
@@ -19,7 +16,7 @@ export const CheckboxWithLabel = ({
   label: string;
   checked: boolean;
   onPress: (v: boolean) => void;
-  color?: ThemeTextProps['color'];
+  color: ContrastColor;
   style: StyleProp<ViewStyle>;
 }) => {
   const {t} = useTranslation();

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -15,7 +15,7 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {ScrollView} from 'react-native-gesture-handler';
 import {JourneyHistory} from './JourneyHistory';
 import {LocationResults} from './LocationResults';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, Theme, useTheme} from '@atb/theme';
 import {translateErrorType} from '@atb/stacks-hierarchy/utils';
 import {animateNextChange} from '@atb/utils/animation';
 import {CheckboxWithLabel} from '@atb/components/checkbox';
@@ -35,6 +35,8 @@ type LocationSearchContentProps = {
   onAddFavorite: () => void;
 };
 
+const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
+
 export function LocationSearchContent({
   label,
   placeholder,
@@ -52,6 +54,7 @@ export function LocationSearchContent({
   const {history, addSearchEntry} = useSearchHistory();
   const {t} = useTranslation();
   const analytics = useAnalytics();
+  const {theme} = useTheme();
 
   const [text, setText] = useState<string>(defaultText ?? '');
   const debouncedText = useDebounce(text, 200);
@@ -161,7 +164,7 @@ export function LocationSearchContent({
               );
               setOnlyStopPlaces(v);
             }}
-            color="background_accent_0"
+            color={getThemeColor(theme)}
             style={styles.onlyStopPlacesCheckbox}
           />
         )}
@@ -226,7 +229,7 @@ export function LocationSearchContent({
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   header: {
-    backgroundColor: theme.color.background.accent[0].background,
+    backgroundColor: getThemeColor(theme).background,
     paddingBottom: theme.spacing.medium,
   },
   withMargin: {


### PR DESCRIPTION
With the design system changes we need to send in contrast color
instead of the theme color name. The theme color name syntactic
sugar is no longer supported, so it ended up treated as a hex
color code.

Before / After:
<div>
<img width=350 src="https://github.com/user-attachments/assets/b391879b-9ec5-4019-b209-f484f904e7bf" />
<img width=350 src="https://github.com/user-attachments/assets/fd2b9c98-f4a8-4cba-9308-dbb5d54f3c0d" />
</div>

### Acceptance criteria
- [ ] Correct color on only stop places checkbox label in light and dark mode
