### PR TITLE
feat: Store only stop places checkbox state on device

### DIFF
--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -21,6 +21,7 @@ import {animateNextChange} from '@atb/utils/animation';
 import {CheckboxWithLabel} from '@atb/components/checkbox';
 import {useAnalytics} from '@atb/analytics';
 import {useFeatureToggles} from '@atb/feature-toggles';
+import {storage} from '@atb/storage';
 
 type LocationSearchContentProps = {
   label: string;
@@ -65,7 +66,7 @@ export function LocationSearchContent({
   );
 
   const {isOnlyStopPlacesCheckboxEnabled} = useFeatureToggles();
-  const [onlyStopPlaces, setOnlyStopPlaces] = useState(false);
+  const [onlyStopPlaces, setOnlyStopPlaces] = useOnlyStopPlacesState();
 
   const {location: geolocation} = useGeolocationState();
 
@@ -223,6 +224,24 @@ export function LocationSearchContent({
     </>
   );
 }
+
+const useOnlyStopPlacesState = (): [boolean, (b: boolean) => void] => {
+  const [onlyStopPlacesState, setOnlyStopPlacesState] = useState(false);
+
+  useEffect(() => {
+    storage.get('@ATB_only_stop_places_checkbox').then((v) => {
+      setOnlyStopPlacesState(v === 'true');
+    });
+  }, []);
+
+  return [
+    onlyStopPlacesState,
+    (b: boolean) => {
+      setOnlyStopPlacesState(b);
+      storage.set('@ATB_only_stop_places_checkbox', String(b));
+    },
+  ];
+};
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   header: {

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -22,6 +22,7 @@ import {CheckboxWithLabel} from '@atb/components/checkbox';
 import {useAnalytics} from '@atb/analytics';
 import {useFeatureToggles} from '@atb/feature-toggles';
 import {storage} from '@atb/storage';
+import {usePersistedBoolState} from '@atb/utils/use-persisted-bool-state';
 
 type LocationSearchContentProps = {
   label: string;
@@ -66,7 +67,10 @@ export function LocationSearchContent({
   );
 
   const {isOnlyStopPlacesCheckboxEnabled} = useFeatureToggles();
-  const [onlyStopPlaces, setOnlyStopPlaces] = useOnlyStopPlacesState();
+  const [onlyStopPlaces, setOnlyStopPlaces] = usePersistedBoolState(
+    storage,
+    '@ATB_only_stop_places_checkbox',
+  );
 
   const {location: geolocation} = useGeolocationState();
 
@@ -224,24 +228,6 @@ export function LocationSearchContent({
     </>
   );
 }
-
-const useOnlyStopPlacesState = (): [boolean, (b: boolean) => void] => {
-  const [onlyStopPlacesState, setOnlyStopPlacesState] = useState(false);
-
-  useEffect(() => {
-    storage.get('@ATB_only_stop_places_checkbox').then((v) => {
-      setOnlyStopPlacesState(v === 'true');
-    });
-  }, []);
-
-  return [
-    onlyStopPlacesState,
-    (b: boolean) => {
-      setOnlyStopPlacesState(b);
-      storage.set('@ATB_only_stop_places_checkbox', String(b));
-    },
-  ];
-};
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   header: {

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -24,6 +24,7 @@ export type StorageModel = {
   '@ATB_user_preferences': string;
   '@ATB_user_travel_search_filters': string;
   '@ATB_user_travel_search_filters_v2': string;
+  '@ATB_only_stop_places_checkbox': string;
 };
 
 export type StorageModelTypes = keyof StorageModel | StorageModelKeysTypes;

--- a/src/utils/__tests__/use-persisted-bool-state.test.ts
+++ b/src/utils/__tests__/use-persisted-bool-state.test.ts
@@ -1,0 +1,83 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import {usePersistedBoolState} from '@atb/utils/use-persisted-bool-state';
+import type {StorageService} from '@atb/storage';
+
+const STORAGE_KEY = 'key1';
+
+const createStorage = (initialValue?: string) =>
+  ({
+    get: jest.fn(() => Promise.resolve(initialValue || null)),
+    set: jest.fn(() => Promise.resolve()),
+  } as any as StorageService);
+
+describe('usePersistedBoolState', () => {
+  it('should be false if no value in storage', async () => {
+    const storage = createStorage();
+    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+
+    expect(hook.result.current[0]).toBe(false);
+    expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
+
+    await hook.waitFor(() => expect(storage.get).toHaveReturned());
+    expect(hook.result.current[0]).toBe(false);
+
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenCalledTimes(0);
+  });
+
+  it('should be true after update from storage', async () => {
+    const storage = createStorage('true');
+    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+
+    expect(hook.result.current[0]).toBe(false);
+    expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
+
+    await hook.waitForNextUpdate();
+    expect(hook.result.current[0]).toBe(true);
+
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenCalledTimes(0);
+  });
+
+  it('should be false after update from storage', async () => {
+    const storage = createStorage('false');
+    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+
+    expect(hook.result.current[0]).toBe(false);
+    expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
+
+    await hook.waitFor(() => expect(storage.get).toHaveReturned());
+    expect(hook.result.current[0]).toBe(false);
+
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenCalledTimes(0);
+  });
+
+  it('setting true should give true as state and invoke storing the value', async () => {
+    const storage = createStorage();
+    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+
+    const [_, setState] = hook.result.current;
+    await act(async () => setState(true));
+
+    expect(hook.result.current[0]).toBe(true);
+    expect(storage.set).toHaveBeenCalledWith(STORAGE_KEY, 'true');
+
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('setting false should give false as state and invoke storing the value', async () => {
+    const storage = createStorage('false');
+    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+
+    const [_, setState] = hook.result.current;
+    await act(async () => setState(false));
+
+    expect(hook.result.current[0]).toBe(false);
+    expect(storage.set).toHaveBeenCalledWith(STORAGE_KEY, 'false');
+
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/use-persisted-bool-state.ts
+++ b/src/utils/use-persisted-bool-state.ts
@@ -1,0 +1,25 @@
+import {useEffect, useState} from 'react';
+import {type StorageService} from '@atb/storage';
+
+export const usePersistedBoolState = (
+  storage: StorageService,
+  storageKey: string,
+): [boolean, (b: boolean) => void] => {
+  const [state, setState] = useState(false);
+
+  useEffect(() => {
+    storage.get(storageKey).then((v) => {
+      if (v) {
+        setState(v === 'true');
+      }
+    });
+  }, [storage, storageKey]);
+
+  return [
+    state,
+    (b: boolean) => {
+      setState(b);
+      storage.set(storageKey, String(b));
+    },
+  ];
+};


### PR DESCRIPTION
This is decided to be in place for next round of testing of the
only stop places checkbox. In last round of testing the usage of
the checkbox was quite high at the start, but then dropped of. The
theory is that users don't use the extra click to check off the
checkbox for every search.

### Acceptance criteria
- [ ] Only stop places checkbox state persists when opening and closing location search screen
- [ ] Only stop places checkbox state persists when restarting app
- [ ] Only stop places checkbox state is shared between all places one can do location search in app
