### PR TITLE
feat: remove feedback component from departures and trip details

### DIFF
--- a/src/place-screen/components/StopPlacesView.tsx
+++ b/src/place-screen/components/StopPlacesView.tsx
@@ -1,5 +1,4 @@
 import {Quay, StopPlace} from '@atb/api/types/departures';
-import {Feedback} from '@atb/components/feedback';
 import {useFavorites, UserFavoriteDepartures} from '@atb/favorites';
 import {SearchTime, StopPlaceAndQuay} from '../types';
 import {StyleSheet} from '@atb/theme';
@@ -116,8 +115,6 @@ export const StopPlacesView = (props: Props) => {
     if (!placeHasFavorites) setShowOnlyFavorites(false);
   }, [placeHasFavorites, setShowOnlyFavorites]);
 
-  const lastIndex = quays?.length ? quays.length - 1 : 0;
-
   return (
     <SectionList
       ListHeaderComponent={
@@ -219,30 +216,21 @@ export const StopPlacesView = (props: Props) => {
       testID={testID}
       keyExtractor={(item) => item.quay.id}
       renderItem={({item, index}) => (
-        <>
-          <QuaySection
-            quay={item.quay}
-            isLoading={state.isLoading}
-            departuresPerQuay={NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW}
-            data={state.data}
-            didLoadingDataFail={didLoadingDataFail}
-            navigateToDetails={navigateToDetails}
-            navigateToQuay={(quay) => navigateToQuay(item.stopPlace, quay)}
-            testID={'quaySection' + index}
-            stopPlace={item.stopPlace}
-            showOnlyFavorites={showOnlyFavorites}
-            addedFavoritesVisibleOnDashboard={addedFavoritesVisibleOnDashboard}
-            searchDate={searchStartTime}
-            mode={mode}
-          />
-          {mode === 'Departure' && index === lastIndex && (
-            <Feedback
-              viewContext="departures"
-              metadata={quayListData}
-              avoidResetOnMetadataUpdate
-            />
-          )}
-        </>
+        <QuaySection
+          quay={item.quay}
+          isLoading={state.isLoading}
+          departuresPerQuay={NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW}
+          data={state.data}
+          didLoadingDataFail={didLoadingDataFail}
+          navigateToDetails={navigateToDetails}
+          navigateToQuay={(quay) => navigateToQuay(item.stopPlace, quay)}
+          testID={'quaySection' + index}
+          stopPlace={item.stopPlace}
+          showOnlyFavorites={showOnlyFavorites}
+          addedFavoritesVisibleOnDashboard={addedFavoritesVisibleOnDashboard}
+          searchDate={searchStartTime}
+          mode={mode}
+        />
       )}
     />
   );

--- a/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -64,7 +64,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
   }
 
   return (
-    <>
+    <View>
       <View style={styles.mapContainer}>
         <MapboxGL.MapView
           style={styles.map}
@@ -104,7 +104,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
         </ThemeText>
         <ThemeIcon svg={ArrowRight} />
       </PressableOpacity>
-    </>
+    </View>
   );
 };
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -387,7 +387,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   heading: {marginBottom: theme.spacing.medium},
   parallaxContent: {marginHorizontal: theme.spacing.medium},
   paddedContainer: {
-    paddingHorizontal: theme.spacing.medium,
+    padding: theme.spacing.medium,
   },
   purchaseButton: {
     position: 'absolute',

--- a/src/travel-details-screens/components/Trip.tsx
+++ b/src/travel-details-screens/components/Trip.tsx
@@ -114,17 +114,18 @@ export const Trip: React.FC<TripProps> = ({
     <View style={styles.container}>
       {shouldShowDate && (
         <>
-          <View style={styles.date}>
-            <ThemeText typography="body__secondary" color="secondary">
-              {formatToVerboseFullDate(tripPattern.expectedStartTime, language)}
-            </ThemeText>
-          </View>
-          <Divider style={styles.divider} />
+          <ThemeText
+            typography="body__secondary"
+            color="secondary"
+            style={styles.date}
+          >
+            {formatToVerboseFullDate(tripPattern.expectedStartTime, language)}
+          </ThemeText>
+          <Divider />
         </>
       )}
       {shortWaitTime && (
         <MessageInfoBox
-          style={styles.messageBox}
           type="info"
           message={[
             t(TripDetailsTexts.messages.shortTime),
@@ -136,7 +137,6 @@ export const Trip: React.FC<TripProps> = ({
       )}
       <GlobalMessage
         globalMessageContext={GlobalMessageContextEnum.appTripDetails}
-        style={styles.messageBox}
         textColor={theme.color.background.neutral[0]}
         ruleVariables={{
           ticketingEnabled: enable_ticketing,
@@ -151,11 +151,7 @@ export const Trip: React.FC<TripProps> = ({
       {error && (
         <>
           <ScreenReaderAnnouncement message={translatedError(error, t)} />
-          <MessageInfoBox
-            style={styles.messageBox}
-            type="warning"
-            message={translatedError(error, t)}
-          />
+          <MessageInfoBox type="warning" message={translatedError(error, t)} />
         </>
       )}
       <View style={styles.trip}>
@@ -198,7 +194,7 @@ export const Trip: React.FC<TripProps> = ({
             );
           })}
       </View>
-      <Divider style={styles.divider} />
+      <Divider />
       {tripPatternLegs && (
         <CompactTravelDetailsMap
           mapLegs={tripPatternLegs}
@@ -237,22 +233,13 @@ function legWaitDetails(index: number, legs: Leg[]): WaitDetails | undefined {
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   container: {
-    marginTop: theme.spacing.medium,
-    marginBottom: theme.spacing.medium,
+    rowGap: theme.spacing.medium,
   },
   date: {
-    alignItems: 'center',
-    marginBottom: theme.spacing.medium,
-  },
-  divider: {
-    marginBottom: theme.spacing.medium,
-  },
-  messageBox: {
-    marginBottom: theme.spacing.medium,
+    textAlign: 'center',
   },
   trip: {
     marginTop: theme.spacing.medium,
-    marginBottom: theme.spacing.xSmall,
   },
 }));
 

--- a/src/travel-details-screens/components/Trip.tsx
+++ b/src/travel-details-screens/components/Trip.tsx
@@ -1,5 +1,4 @@
 import {Leg, TripPattern} from '@atb/api/types/trips';
-import {Feedback} from '@atb/components/feedback';
 import {StyleSheet, useTheme} from '@atb/theme';
 import {
   formatToVerboseFullDate,
@@ -217,7 +216,6 @@ export const Trip: React.FC<TripProps> = ({
         />
       )}
       <TripSummary {...tripPattern} />
-      <Feedback metadata={tripPattern} viewContext="assistant" />
     </View>
   );
 };

--- a/src/travel-details-screens/components/TripSummary.tsx
+++ b/src/travel-details-screens/components/TripSummary.tsx
@@ -1,6 +1,5 @@
 import {TripPattern} from '@atb/api/types/trips';
 import {Walk, Bicycle} from '@atb/assets/svg/mono-icons/transportation-entur';
-import {StyleSheet} from '@atb/theme';
 import {TripDetailsTexts, useTranslation} from '@atb/translations';
 import {secondsToDuration} from '@atb/utils/date';
 import React from 'react';
@@ -11,7 +10,6 @@ import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {SummaryDetail} from '@atb/travel-details-screens/components/SummaryDetail';
 
 export const TripSummary: React.FC<TripPattern> = ({legs, duration}) => {
-  const styles = useStyle();
   const {t, language} = useTranslation();
   const time = secondsToDuration(duration, language);
   const walkDistance = getDistance(legs, Mode.Foot);
@@ -20,7 +18,7 @@ export const TripSummary: React.FC<TripPattern> = ({legs, duration}) => {
   const readableBikeDistance = useHumanizeDistance(bikeDistance);
 
   return (
-    <View style={styles.tripSummary}>
+    <View>
       <SummaryDetail
         icon={Duration}
         accessibilityLabel={t(
@@ -63,12 +61,6 @@ export const TripSummary: React.FC<TripPattern> = ({legs, duration}) => {
     </View>
   );
 };
-
-const useStyle = StyleSheet.createThemeHook((theme) => ({
-  tripSummary: {
-    paddingVertical: theme.spacing.medium,
-  },
-}));
 
 function getDistance<T extends {mode: Mode; distance: number}>(
   legs: Array<T>,


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/19645

Since there was some padding after I removed the feedback component from trip details, I updated the styling to use rowGap instead. This should be better in line with how it's made in Figma, but no significant visual changes.