### PR TITLE
fix: prevent serviceJourneyVehicles retries from useQuery

### DIFF
--- a/src/travel-details-screens/use-get-service-journey-vehicles.ts
+++ b/src/travel-details-screens/use-get-service-journey-vehicles.ts
@@ -11,5 +11,6 @@ export const useGetServiceJourneyVehiclesQuery = (
     queryFn: () => getServiceJourneyVehicles(serviceJourneyIds),
     refetchInterval: 20000,
     initialData: [],
+    retry: false,
   });
 };


### PR DESCRIPTION
Retries are already handled by axios, so this is a quick fix to prevent retries from happening on two levels in this case. We should look into a more permanent and global solution as well.

ref. https://mittatb.slack.com/archives/C0116FMPX4Y/p1734353027280489