### PR TITLE
refactor: Selection as field on purchase components

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -80,12 +80,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const analytics = useAnalyticsContext();
 
-  const {
-    timeSelectionMode,
-    travellerSelectionMode,
-    zoneSelectionMode,
-    requiresTokenOnMobile,
-  } = selection.fareProductTypeConfig.configuration;
+  const {travellerSelectionMode, zoneSelectionMode, requiresTokenOnMobile} =
+    selection.fareProductTypeConfig.configuration;
 
   const fareProductOnBehalfOfEnabled =
     selection.fareProductTypeConfig.configuration.onBehalfOfEnabled;
@@ -223,8 +219,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             ))}
 
           <ProductSelection
-            preassignedFareProduct={selection.preassignedFareProduct}
-            fareProductTypeConfig={selection.fareProductTypeConfig}
+            selection={selection}
             setSelectedProduct={onSelectPreassignedFareProduct}
             style={styles.selectionComponent}
           />
@@ -240,10 +235,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           />
 
           <FromToSelection
-            fareProductTypeConfig={selection.fareProductTypeConfig}
-            fromPlace={selection.zones?.from || selection.stopPlaces?.from}
-            toPlace={selection.zones?.to || selection.stopPlaces?.to}
-            preassignedFareProduct={selection.preassignedFareProduct}
+            selection={selection}
             style={styles.selectionComponent}
             onSelect={(params) => {
               navigation.setParams({onFocusElement: undefined});
@@ -258,11 +250,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           />
 
           <StartTimeSelection
-            selectionMode={timeSelectionMode}
+            selection={selection}
             color={theme.color.interactive[2]}
-            travelDate={selection.travelDate}
             setTravelDate={(travelDate) => navigation.setParams({travelDate})}
-            validFromTime={selection.travelDate}
             style={styles.selectionComponent}
           />
 
@@ -317,12 +307,12 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           )}
 
           <Summary
+            selection={selection}
             isLoading={isSearchingOffer}
             isFree={isFree}
             isError={!!error || !hasSelection}
             originalPrice={originalPrice}
             price={totalPrice}
-            userProfilesWithCount={selection.userProfilesWithCount}
             summaryButtonText={
               isOnBehalfOfToggle
                 ? t(PurchaseOverviewTexts.summary.button.sendToOthers)

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection.tsx
@@ -1,20 +1,16 @@
 import React, {forwardRef} from 'react';
 import {ZonesSelection} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection';
 import {HarborSelection} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection';
-import {FareProductTypeConfig} from '@atb/configuration';
-import {PreassignedFareProduct} from '@atb/configuration';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {StyleProp, ViewStyle} from 'react-native';
 import {Root_PurchaseTariffZonesSearchByMapScreenParams} from '@atb/stacks-hierarchy/navigation-types';
 import {Root_PurchaseHarborSearchScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseHarborSearchScreen/navigation-types';
 import {FocusRefsType} from '@atb/utils/use-focus-refs';
 import {StopPlaceFragmentWithIsFree} from '@atb/harbors/types';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type SelectionProps = {
-  fareProductTypeConfig: FareProductTypeConfig;
-  fromPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree | undefined;
-  toPlace: TariffZoneWithMetadata | StopPlaceFragmentWithIsFree | undefined;
-  preassignedFareProduct: PreassignedFareProduct;
+  selection: PurchaseSelectionType;
   onSelect: (
     params:
       | Root_PurchaseHarborSearchScreenParams
@@ -24,18 +20,9 @@ type SelectionProps = {
 };
 
 export const FromToSelection = forwardRef<FocusRefsType, SelectionProps>(
-  (
-    {
-      fareProductTypeConfig,
-      fromPlace,
-      toPlace,
-      preassignedFareProduct,
-      onSelect,
-      style,
-    }: SelectionProps,
-    ref,
-  ) => {
-    let selectionMode = fareProductTypeConfig.configuration.zoneSelectionMode;
+  ({selection, onSelect, style}: SelectionProps, ref) => {
+    let selectionMode =
+      selection.fareProductTypeConfig.configuration.zoneSelectionMode;
     if (selectionMode === 'none') {
       return null;
     }
@@ -43,12 +30,7 @@ export const FromToSelection = forwardRef<FocusRefsType, SelectionProps>(
     if (selectionMode === 'multiple-stop-harbor') {
       return (
         <HarborSelection
-          fromHarbor={
-            fromPlace && isValidTariffZone(fromPlace) ? undefined : fromPlace
-          }
-          toHarbor={toPlace && isValidTariffZone(toPlace) ? undefined : toPlace}
-          fareProductTypeConfig={fareProductTypeConfig}
-          preassignedFareProduct={preassignedFareProduct}
+          selection={selection}
           onSelect={onSelect}
           style={style}
           ref={ref}
@@ -60,27 +42,20 @@ export const FromToSelection = forwardRef<FocusRefsType, SelectionProps>(
     if (selectionMode == 'multiple-stop' || selectionMode == 'multiple-zone') {
       selectionMode = 'multiple';
     } else if (
-      preassignedFareProduct.zoneSelectionMode?.includes('single') ||
       selectionMode == 'single-stop' ||
       selectionMode == 'single-zone'
     ) {
       selectionMode = 'single';
     }
-    return fromPlace &&
-      isValidTariffZone(fromPlace) &&
-      toPlace &&
-      isValidTariffZone(toPlace) ? (
+    return (
       <ZonesSelection
-        fromTariffZone={fromPlace}
-        toTariffZone={toPlace}
-        fareProductTypeConfig={fareProductTypeConfig}
-        preassignedFareProduct={preassignedFareProduct}
+        selection={selection}
         selectionMode={selectionMode}
         onSelect={onSelect}
         style={style}
         ref={ref}
       />
-    ) : null;
+    );
   },
 );
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -1,21 +1,17 @@
 import {ThemeText} from '@atb/components/text';
-import {FareProductTypeConfig} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 import {StyleProp, TouchableOpacity, View, ViewStyle} from 'react-native';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
-import {PreassignedFareProduct} from '@atb/configuration';
 import {Root_PurchaseHarborSearchScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseHarborSearchScreen/navigation-types';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {FocusRefsType} from '@atb/utils/use-focus-refs';
 import {ContentHeading} from '@atb/components/heading';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type StopPlaceSelectionProps = {
-  fareProductTypeConfig: FareProductTypeConfig;
-  fromHarbor?: StopPlaceFragment;
-  toHarbor?: StopPlaceFragment;
-  preassignedFareProduct: PreassignedFareProduct;
+  selection: PurchaseSelectionType;
   onSelect: (params: Root_PurchaseHarborSearchScreenParams) => void;
   style?: StyleProp<ViewStyle>;
 };
@@ -23,60 +19,52 @@ type StopPlaceSelectionProps = {
 export const HarborSelection = forwardRef<
   FocusRefsType,
   StopPlaceSelectionProps
->(
-  (
-    {
-      fareProductTypeConfig,
-      fromHarbor,
-      toHarbor,
-      preassignedFareProduct,
-      onSelect,
-      style,
-    }: StopPlaceSelectionProps,
-    ref,
-  ) => {
-    const {t} = useTranslation();
+>(({selection, onSelect, style}: StopPlaceSelectionProps, ref) => {
+  const {t} = useTranslation();
 
-    const fromHarborRef = useRef<TouchableOpacity>(null);
-    const toHarborRef = useRef<TouchableOpacity>(null);
-    useImperativeHandle(ref, () => ({fromHarborRef, toHarborRef}));
+  const fromHarborRef = useRef<TouchableOpacity>(null);
+  const toHarborRef = useRef<TouchableOpacity>(null);
+  useImperativeHandle(ref, () => ({fromHarborRef, toHarborRef}));
 
-    return (
-      <View style={style} accessible={false}>
-        <ContentHeading
-          text={t(PurchaseOverviewTexts.stopPlaces.harborSelection.select)}
+  if (!selection.stopPlaces) return null;
+  const fromHarbor = selection.stopPlaces.from;
+  const toHarbor = selection.stopPlaces.to;
+
+  return (
+    <View style={style} accessible={false}>
+      <ContentHeading
+        text={t(PurchaseOverviewTexts.stopPlaces.harborSelection.select)}
+      />
+      <Section accessible={false}>
+        <HarborSelectionItem
+          fromOrTo="from"
+          harbor={fromHarbor}
+          disabled={false}
+          onPress={() =>
+            onSelect({
+              fareProductTypeConfig: selection.fareProductTypeConfig,
+              preassignedFareProduct: selection.preassignedFareProduct,
+            })
+          }
+          ref={fromHarborRef}
         />
-        <Section accessible={false}>
-          <HarborSelectionItem
-            fromOrTo="from"
-            harbor={fromHarbor}
-            disabled={false}
-            onPress={() =>
-              onSelect({
-                fareProductTypeConfig,
-                preassignedFareProduct,
-              })
-            }
-            ref={fromHarborRef}
-          />
-          <HarborSelectionItem
-            fromOrTo="to"
-            harbor={toHarbor}
-            disabled={!fromHarbor}
-            onPress={() =>
-              onSelect({
-                fromHarbor,
-                fareProductTypeConfig,
-                preassignedFareProduct,
-              })
-            }
-            ref={toHarborRef}
-          />
-        </Section>
-      </View>
-    );
-  },
-);
+        <HarborSelectionItem
+          fromOrTo="to"
+          harbor={toHarbor}
+          disabled={!fromHarbor}
+          onPress={() =>
+            onSelect({
+              fromHarbor,
+              fareProductTypeConfig: selection.fareProductTypeConfig,
+              preassignedFareProduct: selection.preassignedFareProduct,
+            })
+          }
+          ref={toHarborRef}
+        />
+      </Section>
+    </View>
+  );
+});
 
 type HarborSelectionItemProps = {
   harbor?: StopPlaceFragment;

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelection.tsx
@@ -1,31 +1,28 @@
 import {PreassignedFareProduct} from '@atb/configuration';
-import {FareProductTypeConfig} from '@atb/configuration';
 import {ProductSelectionByAlias} from './ProductSelectionByAlias';
 import {ProductSelectionByProducts} from './ProductSelectionByProducts';
 import {StyleProp, ViewStyle} from 'react-native';
 import {useThemeContext} from '@atb/theme';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type ProductSelectionProps = {
-  preassignedFareProduct: PreassignedFareProduct;
-  fareProductTypeConfig: FareProductTypeConfig;
+  selection: PurchaseSelectionType;
   setSelectedProduct: (product: PreassignedFareProduct) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ProductSelection({
-  preassignedFareProduct,
-  fareProductTypeConfig,
+  selection,
   setSelectedProduct,
   style,
 }: ProductSelectionProps) {
   const {theme} = useThemeContext();
 
-  switch (fareProductTypeConfig.configuration.productSelectionMode) {
+  switch (selection.fareProductTypeConfig.configuration.productSelectionMode) {
     case 'product':
       return (
         <ProductSelectionByProducts
-          selectedProduct={preassignedFareProduct}
-          fareProductTypeConfig={fareProductTypeConfig}
+          selection={selection}
           setSelectedProduct={setSelectedProduct}
           style={style}
         />
@@ -35,8 +32,7 @@ export function ProductSelection({
       return (
         <ProductSelectionByAlias
           color={theme.color.interactive[2]}
-          selectedProduct={preassignedFareProduct}
-          fareProductTypeConfig={fareProductTypeConfig}
+          selection={selection}
           setSelectedProduct={setSelectedProduct}
           style={style}
         />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
@@ -8,29 +8,27 @@ import {InteractiveColor} from '@atb/theme/colors';
 import {ScrollView, StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {
-  useFirestoreConfigurationContext,
-  PreassignedFareProduct,
   isProductSellableInApp,
-  FareProductTypeConfig,
+  PreassignedFareProduct,
+  useFirestoreConfigurationContext,
 } from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 import {ProductAliasChip} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip';
 import {useTicketingContext} from '@atb/ticketing';
 import {ContentHeading} from '@atb/components/heading';
 import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type Props = {
   color: InteractiveColor;
-  selectedProduct: PreassignedFareProduct;
-  fareProductTypeConfig: FareProductTypeConfig;
+  selection: PurchaseSelectionType;
   setSelectedProduct: (product: PreassignedFareProduct) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ProductSelectionByAlias({
   color,
-  selectedProduct,
-  fareProductTypeConfig,
+  selection,
   setSelectedProduct,
   style,
 }: Props) {
@@ -41,11 +39,11 @@ export function ProductSelectionByAlias({
 
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
-    .filter((product) => product.type === selectedProduct.type)
+    .filter((product) => product.type === selection.preassignedFareProduct.type)
     .filter(onlyUniquesBasedOnField('productAliasId', true));
 
   const title = useTextForLanguage(
-    fareProductTypeConfig.configuration.productSelectionTitle,
+    selection.fareProductTypeConfig.configuration.productSelectionTitle,
   );
 
   return (
@@ -69,9 +67,10 @@ export function ProductSelectionByAlias({
               color={color}
               text={text}
               selected={
-                selectedProduct.productAliasId
-                  ? selectedProduct.productAliasId === fp.productAliasId
-                  : selectedProduct.id === fp.id
+                selection.preassignedFareProduct.productAliasId
+                  ? selection.preassignedFareProduct.productAliasId ===
+                    fp.productAliasId
+                  : selection.preassignedFareProduct.id === fp.id
               }
               onPress={() => setSelectedProduct(fp)}
               key={i}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -11,7 +11,6 @@ import {
   getReferenceDataName,
   isProductSellableInApp,
 } from '@atb/configuration';
-import {FareProductTypeConfig} from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 import {
   HeaderSectionItem,
@@ -24,17 +23,16 @@ import {usePreferencesContext} from '@atb/preferences';
 import {ContentHeading} from '@atb/components/heading';
 import {useThemeContext} from '@atb/theme';
 import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type ProductSelectionByProductsProps = {
-  selectedProduct: PreassignedFareProduct;
-  fareProductTypeConfig: FareProductTypeConfig;
+  selection: PurchaseSelectionType;
   setSelectedProduct: (product: PreassignedFareProduct) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ProductSelectionByProducts({
-  selectedProduct,
-  fareProductTypeConfig,
+  selection,
   setSelectedProduct,
   style,
 }: ProductSelectionByProductsProps) {
@@ -47,7 +45,7 @@ export function ProductSelectionByProducts({
 
   const selectableProducts = preassignedFareProducts
     .filter((product) => isProductSellableInApp(product, customerProfile))
-    .filter((product) => product.type === selectedProduct.type)
+    .filter((product) => product.type === selection.preassignedFareProduct.type)
     .filter(onlyUniquesBasedOnField('productAliasId', true));
 
   const alias = (fareProduct: PreassignedFareProduct) =>
@@ -61,7 +59,7 @@ export function ProductSelectionByProducts({
 
   const title =
     useTextForLanguage(
-      fareProductTypeConfig.configuration.productSelectionTitle,
+      selection.fareProductTypeConfig.configuration.productSelectionTitle,
     ) || t(PurchaseOverviewTexts.productSelection.title);
 
   const subText = (fp: PreassignedFareProduct) => {
@@ -84,7 +82,7 @@ export function ProductSelectionByProducts({
             itemToText={(fp) => productDisplayName(fp)}
             hideSubtext={hideProductDescriptions}
             itemToSubtext={(fp) => subText(fp)}
-            selected={selectedProduct}
+            selected={selection.preassignedFareProduct}
             color={interactiveColor}
             onSelect={setSelectedProduct}
             accessibilityHint={t(
@@ -97,8 +95,8 @@ export function ProductSelectionByProducts({
           <ContentHeading text={title} />
           <Section>
             <HeaderSectionItem
-              text={productDisplayName(selectedProduct)}
-              subtitle={subText(selectedProduct)}
+              text={productDisplayName(selection.preassignedFareProduct)}
+              subtitle={subText(selection.preassignedFareProduct)}
             />
           </Section>
         </>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -9,24 +9,20 @@ import {
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {TravelDateSheet} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet';
 import {RadioSegments} from '@atb/components/radio';
-import {TimeSelectionMode} from '@atb/configuration';
 import {ContentHeading} from '@atb/components/heading';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type StartTimeSelectionProps = {
+  selection: PurchaseSelectionType;
   color: InteractiveColor;
   setTravelDate: (date?: string) => void;
-  validFromTime?: string;
-  travelDate?: string;
-  selectionMode: TimeSelectionMode;
   style?: StyleProp<ViewStyle>;
 };
 
 export function StartTimeSelection({
+  selection,
   color,
   setTravelDate,
-  validFromTime,
-  travelDate,
-  selectionMode,
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
@@ -35,22 +31,24 @@ export function StartTimeSelection({
 
   const openTravelDateSheet = () => {
     openBottomSheet(
-      () => <TravelDateSheet save={setTravelDate} travelDate={travelDate} />,
+      () => <TravelDateSheet save={setTravelDate} selection={selection} />,
       onCloseFocusRef,
     );
   };
 
-  const subtext = validFromTime
-    ? formatToShortDateTimeWithoutYear(validFromTime, language)
+  const subtext = selection.travelDate
+    ? formatToShortDateTimeWithoutYear(selection.travelDate, language)
     : undefined;
-  const accessibilityLabel = validFromTime
+  const accessibilityLabel = selection.travelDate
     ? t(PurchaseOverviewTexts.startTime.later) +
       ', ' +
-      formatToVerboseDateTime(validFromTime, language)
+      formatToVerboseDateTime(selection.travelDate, language)
     : undefined;
 
-  if (selectionMode === 'none') {
-    return <></>;
+  if (
+    selection.fareProductTypeConfig.configuration.timeSelectionMode === 'none'
+  ) {
+    return null;
   }
 
   return (
@@ -58,7 +56,7 @@ export function StartTimeSelection({
       <ContentHeading text={t(PurchaseOverviewTexts.startTime.title)} />
       <RadioSegments
         color={color}
-        activeIndex={!!validFromTime ? 1 : 0}
+        activeIndex={!!selection.travelDate ? 1 : 0}
         options={[
           {
             text: t(PurchaseOverviewTexts.startTime.now),

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
@@ -1,32 +1,32 @@
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
-import {UserProfileWithCount} from '@atb/fare-contracts';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {formatDecimalNumber} from '@atb/utils/numbers';
 import React from 'react';
 import {ActivityIndicator, StyleProp, View, ViewStyle} from 'react-native';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type Props = {
+  selection: PurchaseSelectionType;
   price: number;
   originalPrice: number;
   isFree: boolean;
   isLoading: boolean;
   isError: boolean;
-  userProfilesWithCount: UserProfileWithCount[];
   summaryButtonText: string;
   onPressBuy: () => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function Summary({
+  selection,
   price,
   originalPrice,
   isFree,
   isLoading,
   isError,
-  userProfilesWithCount,
   summaryButtonText,
   onPressBuy,
   style,
@@ -41,7 +41,7 @@ export function Summary({
     language,
     2,
   );
-  const hasSelection = userProfilesWithCount.some((u) => u.count);
+  const hasSelection = selection.userProfilesWithCount.some((u) => u.count);
 
   const toPaymentFunction = () => {
     onPressBuy();

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravelDate/TravelDateSheet.tsx
@@ -16,18 +16,19 @@ import {
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {useKeyboardHeight} from '@atb/utils/use-keyboard-height';
 import SvgConfirm from '@atb/assets/svg/mono-icons/actions/Confirm';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type Props = {
-  travelDate?: string;
+  selection: PurchaseSelectionType;
   save: (dateString?: string) => void;
 };
 
-export const TravelDateSheet = ({travelDate, save}: Props) => {
+export const TravelDateSheet = ({selection, save}: Props) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {theme} = useThemeContext();
 
-  const defaultDate = travelDate ?? new Date().toISOString();
+  const defaultDate = selection.travelDate ?? new Date().toISOString();
   const [dateString, setDate] = useState(defaultDate);
 
   const [timeString, setTime] = useState(() =>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -1,5 +1,4 @@
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-import {FareProductTypeConfig} from '@atb/configuration';
 import {StyleSheet} from '@atb/theme';
 import {
   Language,
@@ -11,9 +10,9 @@ import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 import {
   AccessibilityProps,
   StyleProp,
+  TouchableOpacity,
   View,
   ViewStyle,
-  TouchableOpacity,
 } from 'react-native';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {
@@ -21,37 +20,24 @@ import {
   GenericSectionItem,
   Section,
 } from '@atb/components/sections';
-import {PreassignedFareProduct, getReferenceDataName} from '@atb/configuration';
+import {getReferenceDataName} from '@atb/configuration';
 
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Root_PurchaseTariffZonesSearchByMapScreenParams} from '@atb/stacks-hierarchy/navigation-types';
 import {FocusRefsType} from '@atb/utils/use-focus-refs';
 import {ContentHeading} from '@atb/components/heading';
+import type {PurchaseSelectionType} from '@atb/purchase-selection';
 
 type ZonesSelectionProps = {
-  fareProductTypeConfig: FareProductTypeConfig;
-  fromTariffZone: TariffZoneWithMetadata;
-  toTariffZone: TariffZoneWithMetadata;
-  preassignedFareProduct: PreassignedFareProduct;
+  selection: PurchaseSelectionType;
   selectionMode: 'single' | 'multiple';
   onSelect: (params: Root_PurchaseTariffZonesSearchByMapScreenParams) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
-  (
-    {
-      fareProductTypeConfig,
-      fromTariffZone,
-      toTariffZone,
-      preassignedFareProduct,
-      selectionMode,
-      onSelect,
-      style,
-    }: ZonesSelectionProps,
-    ref,
-  ) => {
+  ({selection, selectionMode, onSelect, style}: ZonesSelectionProps, ref) => {
     const styles = useStyles();
     const {t, language} = useTranslation();
 
@@ -60,9 +46,14 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
       zonesRef,
     }));
 
+    if (!selection.zones) return null;
+
+    const fromTariffZone = selection.zones.from;
+    const toTariffZone = selection.zones.to;
+
     // Can select zone if there is no whitelisted zones, or there is more than 1 whitelisted zone
     const canSelectZone =
-      preassignedFareProduct.limitations.tariffZoneRefs?.length !== 1;
+      selection.preassignedFareProduct.limitations.tariffZoneRefs?.length !== 1;
 
     const accessibility: AccessibilityProps = {
       accessible: true,
@@ -140,8 +131,8 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
                 onSelect({
                   fromTariffZone,
                   toTariffZone,
-                  fareProductTypeConfig,
-                  preassignedFareProduct,
+                  fareProductTypeConfig: selection.fareProductTypeConfig,
+                  preassignedFareProduct: selection.preassignedFareProduct,
                 })
               }
               testID="selectZonesButton"

--- a/src/ticketing/use-fare-contracts.ts
+++ b/src/ticketing/use-fare-contracts.ts
@@ -1,4 +1,4 @@
-import {useTicketingState} from '@atb/ticketing/TicketingContext';
+import {useTicketingContext} from '@atb/ticketing/TicketingContext';
 import type {AvailabilityStatus, FareContract} from '@atb/ticketing/types';
 import {getAvailabilityStatus} from '@atb/ticketing/get-availability-status';
 import type {PartialField} from '@atb/utils/object';
@@ -7,7 +7,7 @@ export const useFareContracts = (
   availabilityStatus: PartialField<AvailabilityStatus, 'status'>,
   now: number,
 ): FareContract[] => {
-  const {fareContracts} = useTicketingState();
+  const {fareContracts} = useTicketingContext();
   return fareContracts.filter((fc) => {
     const as = getAvailabilityStatus(fc, now);
     if (as.availability === availabilityStatus.availability) {


### PR DESCRIPTION
This is instead of passing multiple fields of the purchase selection
down individually, and gives a cleaner style overall. This is also
inline with the next step where the individual screen params of
the purchase overview screen will be replaced with the purchase
selection type.

### Acceptance criteria
- [ ] Purchase flow works as before
