### PR TITLE
refactor: Not store stop place id on favorites

### DIFF
--- a/src/api/departures/index.ts
+++ b/src/api/departures/index.ts
@@ -70,7 +70,6 @@ export async function getFavouriteDepartures(
     lineId: f.lineId,
     quayId: f.quayId,
     quayName: f.quayName,
-    stopId: f.stopId,
     lineLineNumber: f.lineLineNumber,
     destinationDisplay: f.destinationDisplay,
     lineTransportationMode: f.lineTransportationMode,

--- a/src/favorites/FavoritesContext.tsx
+++ b/src/favorites/FavoritesContext.tsx
@@ -164,7 +164,6 @@ export const FavoritesContextProvider: React.FC = ({children}) => {
               favorite.destinationDisplay,
               potential.destinationDisplay,
             )) &&
-          favorite.stopId == potential.stopId &&
           favorite.quayId == potential.quayId
         );
       });

--- a/src/favorites/types.ts
+++ b/src/favorites/types.ts
@@ -45,7 +45,6 @@ export type StoredLocationFavorite = StoredType<LocationFavorite>;
 export type UserFavorites = StoredLocationFavorite[];
 
 type FavoriteDepartureBaseIds = {
-  stopId: string;
   lineId: string;
   quayId: string;
 };

--- a/src/favorites/use-on-mark-favourite-departures.tsx
+++ b/src/favorites/use-on-mark-favourite-departures.tsx
@@ -1,7 +1,7 @@
 import {useFavoritesContext, StoredFavoriteDeparture} from '@atb/favorites';
 import {AccessibilityInfo, Alert} from 'react-native';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
-import {Quay, StopPlace} from '@atb/api/types/departures';
+import {Quay} from '@atb/api/types/departures';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
 import React, {RefObject} from 'react';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
@@ -24,7 +24,6 @@ type FavouriteDepartureLine = {
 
 export function useOnMarkFavouriteDepartures(
   quay: Quay,
-  stopPlace: StopPlace,
   addedFavoritesVisibleOnDashboard?: boolean,
 ) {
   const {addFavoriteDeparture, removeFavoriteDeparture, getFavoriteDeparture} =
@@ -46,7 +45,6 @@ export function useOnMarkFavouriteDepartures(
       quayName: quay.name,
       quayPublicCode: quay.publicCode,
       quayId: quay.id,
-      stopId: stopPlace.id,
       visibleOnDashboard: addedFavoritesVisibleOnDashboard,
     });
     AccessibilityInfo.announceForAccessibility(
@@ -58,7 +56,6 @@ export function useOnMarkFavouriteDepartures(
     getFavoriteDeparture({
       destinationDisplay: line.destinationDisplay,
       lineId: line.id,
-      stopId: stopPlace.id,
       quayId: quay.id,
     });
 
@@ -70,7 +67,7 @@ export function useOnMarkFavouriteDepartures(
             `${line.lineNumber} ${
               formatDestinationDisplay(t, existing.destinationDisplay) ?? ''
             }`,
-            stopPlace.name,
+            quay.name,
           ),
         )
       : t(
@@ -79,7 +76,7 @@ export function useOnMarkFavouriteDepartures(
               t,
               line.destinationDisplay,
             )}`,
-            stopPlace.name,
+            quay.name,
           ),
         );
   };

--- a/src/place-screen/components/EstimatedCallList.tsx
+++ b/src/place-screen/components/EstimatedCallList.tsx
@@ -23,7 +23,6 @@ type EstimatedCallRenderItem = {
 type Props = Pick<
   QuaySectionProps,
   | 'quay'
-  | 'stopPlace'
   | 'addedFavoritesVisibleOnDashboard'
   | 'navigateToDetails'
   | 'mode'
@@ -35,7 +34,6 @@ type Props = Pick<
 };
 export const EstimatedCallList = ({
   quay,
-  stopPlace,
   departures,
   addedFavoritesVisibleOnDashboard,
   navigateToDetails,
@@ -47,7 +45,6 @@ export const EstimatedCallList = ({
   const {t} = useTranslation();
   const {onMarkFavourite, getExistingFavorite} = useOnMarkFavouriteDepartures(
     quay,
-    stopPlace,
     addedFavoritesVisibleOnDashboard,
   );
 

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -1,4 +1,4 @@
-import {EstimatedCall, Quay, StopPlace} from '@atb/api/types/departures';
+import {EstimatedCall, Quay} from '@atb/api/types/departures';
 import {ExpandLess, ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
 import {
   GenericClickableSectionItem,
@@ -37,7 +37,6 @@ export type QuaySectionProps = {
     fromQuayId?: string,
     isCancelled?: boolean,
   ) => void;
-  stopPlace: StopPlace;
   showOnlyFavorites: boolean;
   searchDate?: string | Date;
   addedFavoritesVisibleOnDashboard?: boolean;
@@ -53,7 +52,6 @@ export function QuaySection({
   testID,
   navigateToQuay,
   navigateToDetails,
-  stopPlace,
   showOnlyFavorites,
   addedFavoritesVisibleOnDashboard,
   searchDate,
@@ -141,7 +139,6 @@ export function QuaySection({
         {!isMinimized && (
           <EstimatedCallList
             quay={quay}
-            stopPlace={stopPlace}
             departures={departuresToDisplay.slice(0, departuresPerQuay)}
             mode={mode}
             addedFavoritesVisibleOnDashboard={addedFavoritesVisibleOnDashboard}

--- a/src/place-screen/components/QuayView.tsx
+++ b/src/place-screen/components/QuayView.tsx
@@ -67,7 +67,6 @@ export function QuayView({
 
   const placeHasFavorites = hasFavorites(
     favoriteDepartures,
-    stopPlace.id,
     stopPlace.quays?.map((q) => q.id),
   );
 
@@ -132,7 +131,6 @@ export function QuayView({
           didLoadingDataFail={didLoadingDataFail}
           navigateToDetails={navigateToDetails}
           testID="quaySection"
-          stopPlace={stopPlace}
           showOnlyFavorites={showOnlyFavorites}
           addedFavoritesVisibleOnDashboard={addedFavoritesVisibleOnDashboard}
           searchDate={searchStartTime}

--- a/src/place-screen/components/StopPlacesView.tsx
+++ b/src/place-screen/components/StopPlacesView.tsx
@@ -104,7 +104,6 @@ export const StopPlacesView = (props: Props) => {
   const placeHasFavorites = stopPlaces.some((sp) =>
     hasFavorites(
       favoriteDepartures,
-      sp.id,
       sp.quays?.map((q) => q.id),
     ),
   );
@@ -225,7 +224,6 @@ export const StopPlacesView = (props: Props) => {
           navigateToDetails={navigateToDetails}
           navigateToQuay={(quay) => navigateToQuay(item.stopPlace, quay)}
           testID={'quaySection' + index}
-          stopPlace={item.stopPlace}
           showOnlyFavorites={showOnlyFavorites}
           addedFavoritesVisibleOnDashboard={addedFavoritesVisibleOnDashboard}
           searchDate={searchStartTime}
@@ -238,13 +236,10 @@ export const StopPlacesView = (props: Props) => {
 
 export function hasFavorites(
   favorites: UserFavoriteDepartures,
-  stopPlaceId?: string,
   quayIds?: string[],
 ) {
-  return favorites.some(
-    (favorite) =>
-      stopPlaceId === favorite.stopId ||
-      quayIds?.find((quayId) => favorite.quayId === quayId),
+  return favorites.some((favorite) =>
+    quayIds?.find((quayId) => favorite.quayId === quayId),
   );
 }
 

--- a/src/storybook/stories/Section.stories.tsx
+++ b/src/storybook/stories/Section.stories.tsx
@@ -93,7 +93,6 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
                 <FavoriteDepartureSectionItem
                   favorite={{
                     id: '1',
-                    stopId: '2',
                     lineId: '3',
                     quayId: '4',
                     quayName: 'FavoriteDepartureSectionItem',


### PR DESCRIPTION
When thinking about it I think it is no reason to store the stop
place id on favorites, as the quay id is uniquely identifiable.

### Acceptance criteria
- [ ] Existing favorites work as expected
- [ ] Storing new favorites work as expected
