### PR TITLE
fix: disable fetching of vehicles when out of focus

### DIFF
--- a/src/travel-details-screens/use-get-service-journey-vehicles.ts
+++ b/src/travel-details-screens/use-get-service-journey-vehicles.ts
@@ -1,12 +1,14 @@
 import {getServiceJourneyVehicles} from '@atb/api/vehicles';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {useQuery} from '@tanstack/react-query';
 
 export const useGetServiceJourneyVehiclesQuery = (
   serviceJourneyIds: string[],
   enabled: boolean = true,
 ) => {
+  const isFocusedAndActive = useIsFocusedAndActive();
   return useQuery({
-    enabled,
+    enabled: enabled && isFocusedAndActive,
     queryKey: ['serviceJourneyVehicles', ...serviceJourneyIds],
     queryFn: () => getServiceJourneyVehicles(serviceJourneyIds),
     refetchInterval: 20000,


### PR DESCRIPTION
We're still seeing a lot of requests towards vehicles in 1.60.1, and it seems it might be caused by requests that are active without focus. E.g. if the user navigates from trip details to departure details or switches tab, the trip query is still active and fetching updates every 20s. And if several screens with vehicles queries are open, several requests are sent every 20s.

follow up to https://github.com/AtB-AS/mittatb-app/pull/4885