### PR TITLE
fix: Some date tests failing after new year

### DIFF
--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -86,16 +86,35 @@ describe.each<TimeZone>([
   });
 
   describe('formatToLongDateTime', () => {
-    test('for norwegian (bokmål) format', () => {
+    const currentYear = new Date().getFullYear();
+    test('for norwegian (bokmål) format, current year', () => {
       expect(
-        formatToLongDateTime('2024-09-01T12:00:00Z', Language.Norwegian),
+        formatToLongDateTime(
+          `${currentYear}-09-01T12:00:00Z`,
+          Language.Norwegian,
+        ),
       ).toBe('01. sep. 14:00');
     });
 
-    test('for english format', () => {
+    test('for english format, current year', () => {
       expect(
-        formatToLongDateTime('2024-09-01T12:00:00Z', Language.English),
+        formatToLongDateTime(
+          `${currentYear}-09-01T12:00:00Z`,
+          Language.English,
+        ),
       ).toBe('01. Sep 14:00');
+    });
+
+    test('for norwegian (bokmål) format, not current year', () => {
+      expect(
+        formatToLongDateTime(`2020-09-01T12:00:00Z`, Language.Norwegian),
+      ).toBe('01. sep. 2020, 14:00');
+    });
+
+    test('for english format, not current year', () => {
+      expect(
+        formatToLongDateTime(`2020-09-01T12:00:00Z`, Language.English),
+      ).toBe('01. Sep 2020, 14:00');
     });
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -344,7 +344,7 @@ export function formatToShortDateTimeWithRelativeDayNames(
 
 export function fullDateTime(isoDate: string | Date, language: Language) {
   const parsed = parseIfNeeded(isoDate);
-  return format(parsed, 'PP, p', {
+  return format(parsed, 'dd. MMM yyyy, HH:mm', {
     locale: languageToLocale(language),
   });
 }


### PR DESCRIPTION
The tests need to have current year provided programatically to not
need manual fixing every new year.

In addition when adding some more tests it came to light that the
formatting of the day and month differed based on whether it was
the current year or not. The full date formatting was changed to
give the same day/month format no matter if current year or not.

### Acceptance criteria
- [ ] Full dates presented correctly both for current and previous year, in english and norwegian. (Can be viewed in sent fare contract header)