### PR TITLE
fix: Set BorderedInfoBox border color in same way as SectionItem separator color

### DIFF
--- a/src/components/bordered-info-box/BorderedInfoBox.tsx
+++ b/src/components/bordered-info-box/BorderedInfoBox.tsx
@@ -3,6 +3,7 @@ import {StyleProp, View, ViewStyle} from 'react-native';
 import React, {ReactNode} from 'react';
 import {StyleSheet} from '@atb/theme';
 import {ContrastColor} from '@atb/theme/colors';
+import {addOpacity} from '@atb/utils/add-opacity';
 
 export type BorderedInfoBoxProps =
   | {
@@ -26,7 +27,7 @@ export const BorderedInfoBox = ({
   testID,
   ...props
 }: BorderedInfoBoxProps) => {
-  const styles = useStyles(type);
+  const styles = useStyles(type, backgroundColor.foreground.primary);
   return (
     <View style={[styles.container, style]}>
       {'text' in props ? (
@@ -44,10 +45,10 @@ export const BorderedInfoBox = ({
   );
 };
 
-const useStyles = (type: BorderedInfoBoxProps['type']) => {
+const useStyles = (type: BorderedInfoBoxProps['type'], textColor: string) => {
   return StyleSheet.createThemeHook((theme) => ({
     container: {
-      borderColor: theme.color.background.neutral[2].background,
+      borderColor: addOpacity(textColor, 0.15),
       borderWidth: theme.border.width.slim,
       borderRadius: theme.border.radius.regular,
       paddingHorizontal:

--- a/src/components/bordered-info-box/BorderedInfoBox.tsx
+++ b/src/components/bordered-info-box/BorderedInfoBox.tsx
@@ -2,7 +2,6 @@ import {ThemeText} from '@atb/components/text';
 import {StyleProp, View, ViewStyle} from 'react-native';
 import React, {ReactNode} from 'react';
 import {StyleSheet} from '@atb/theme';
-import {addOpacity} from '@atb/utils/add-opacity';
 import {ContrastColor} from '@atb/theme/colors';
 
 export type BorderedInfoBoxProps =
@@ -27,7 +26,7 @@ export const BorderedInfoBox = ({
   testID,
   ...props
 }: BorderedInfoBoxProps) => {
-  const styles = useStyles(type, backgroundColor.foreground.primary);
+  const styles = useStyles(type);
   return (
     <View style={[styles.container, style]}>
       {'text' in props ? (
@@ -45,10 +44,10 @@ export const BorderedInfoBox = ({
   );
 };
 
-const useStyles = (type: BorderedInfoBoxProps['type'], textColor: string) =>
-  StyleSheet.createThemeHook((theme) => ({
+const useStyles = (type: BorderedInfoBoxProps['type']) => {
+  return StyleSheet.createThemeHook((theme) => ({
     container: {
-      borderColor: addOpacity(textColor, 0.1),
+      borderColor: theme.color.background.neutral[2].background,
       borderWidth: theme.border.width.slim,
       borderRadius: theme.border.radius.regular,
       paddingHorizontal:
@@ -59,3 +58,4 @@ const useStyles = (type: BorderedInfoBoxProps['type'], textColor: string) =>
       alignSelf: 'flex-start',
     },
   }))();
+};

--- a/src/components/bordered-info-box/BorderedInfoBox.tsx
+++ b/src/components/bordered-info-box/BorderedInfoBox.tsx
@@ -48,7 +48,7 @@ export const BorderedInfoBox = ({
 const useStyles = (type: BorderedInfoBoxProps['type'], textColor: string) => {
   return StyleSheet.createThemeHook((theme) => ({
     container: {
-      borderColor: addOpacity(textColor, 0.15),
+      borderColor: addOpacity(textColor, 0.2),
       borderWidth: theme.border.width.slim,
       borderRadius: theme.border.radius.regular,
       paddingHorizontal:


### PR DESCRIPTION
This was previously set using opacity, which obviously only works in light mode. 

**Before:** 
<div>
    <img src="https://github.com/user-attachments/assets/5c5a4c11-5f8a-4074-9fe5-e4ccf401a2f7" alt="drawing" width="300"/>
    <img src="https://github.com/user-attachments/assets/5c84ebd3-b41b-4374-8a63-995f690b57dd" alt="drawing" width="300"/>
</div>

**After:**
<div>
    <img src="https://github.com/user-attachments/assets/e0b7bf53-543c-4da1-b7b9-17c9fdb1ffbe" alt="drawing" width="300"/>
    <img src="https://github.com/user-attachments/assets/547d0fb3-7f5d-4b34-ba27-e2df74a020eb" alt="drawing" width="300"/>
</div>


