### PR TITLE
fix: GeofencingZone onPress

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -6,9 +6,8 @@ import {FOCUS_ORIGIN} from '@atb/api/geocoder';
 import {StyleSheet} from '@atb/theme';
 import {MapRoute} from '@atb/travel-details-map-screen/components/MapRoute';
 import MapboxGL, {LocationPuck, MapState} from '@rnmapbox/maps';
-import {Feature, Polygon, Position} from 'geojson';
+import {Feature, Position} from 'geojson';
 import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
-import {polygon} from '@turf/helpers';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import {MapCameraConfig, MapViewConfig} from './MapConfig';
@@ -351,13 +350,11 @@ function getFeatureWeight(feature: Feature, positionClicked: Position): number {
       ? 3
       : 1;
   } else if (isFeatureGeofencingZone(feature)) {
-    const coordinates = (feature.geometry as Polygon).coordinates;
-    const polygonGeometry = polygon(coordinates);
-    const positionClickedIsInsidePolygon = turfBooleanPointInPolygon(
+    const positionClickedIsInsideGeofencingZone = turfBooleanPointInPolygon(
       positionClicked,
-      polygonGeometry,
+      feature.geometry,
     );
-    return positionClickedIsInsidePolygon ? 2 : 0;
+    return positionClickedIsInsideGeofencingZone ? 2 : 0;
   } else {
     return 0;
   }

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -17,6 +17,7 @@ import {
   MapSelectionActionType,
   MapPadding,
   ParkingType,
+  GeofencingZoneCustomProps,
 } from './types';
 import distance from '@turf/distance';
 import {isStation} from '@atb/mobility/utils';
@@ -91,8 +92,12 @@ export const hasProperties = (f: Feature) =>
 export const hasGeofencingZoneCustomProps = (f: Feature) =>
   Object.keys(f.properties?.geofencingZoneCustomProps || {}).length > 0;
 
-export const isFeatureGeofencingZone = (f: Feature) =>
-  isFeaturePolylineEncodedMultiPolygon(f) && hasGeofencingZoneCustomProps(f);
+export const isFeatureGeofencingZone = (
+  f: Feature,
+): f is Feature<
+  MultiPolygon,
+  {geofencingZoneCustomProps: GeofencingZoneCustomProps}
+> => isFeaturePolylineEncodedMultiPolygon(f) && hasGeofencingZoneCustomProps(f);
 
 export const isClusterFeature = (
   feature: Feature,


### PR DESCRIPTION
Sometimes when clicking a geofencing zone, the snackbar didn't show.
This was because of incorrect input for `turfBooleanPointInPolygon`.

Acceptance Criteria:
- [ ] Clicking on a GeofencingZone should always result in a correct Snackbar behaviour.