### PR TITLE
feat: move live bus button beside LastPassedStop text

### DIFF
--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -241,44 +241,45 @@ export const DepartureDetailsScreenComponent = ({
                 testID="journeyAidButton"
               />
             )}
-            {shouldShowMapButton ? (
-              <View style={styles.actionButtons}>
-                <Button
-                  type="small"
-                  leftIcon={{svg: Map}}
-                  text={t(
-                    vehiclePosition
-                      ? DepartureDetailsTexts.live(t(translatedModeName))
-                      : DepartureDetailsTexts.map,
-                  )}
-                  interactiveColor={interactiveColor}
-                  onPress={() => {
-                    vehiclePosition &&
-                      analytics.logEvent(
-                        'Departure details',
-                        'See live bus clicked',
-                        {
-                          fromPlace: mapData.start,
-                          toPlace: mapData?.stop,
-                          mode: mode,
-                          subMode: subMode,
-                        },
-                      );
-                    onPressDetailsMap({
-                      legs: mapData.mapLegs,
-                      fromPlace: mapData.start,
-                      toPlace: mapData.stop,
-                      vehicleWithPosition: vehiclePosition,
-                      mode: mode,
-                      subMode: subMode,
-                    });
-                  }}
-                />
-              </View>
-            ) : null}
-            {realtimeText && !activeItem.isTripCancelled && (
+            {((realtimeText && !activeItem.isTripCancelled) ||
+              shouldShowMapButton) && (
               <View style={styles.headerSubSection}>
-                <LastPassedStop realtimeText={realtimeText} />
+                {realtimeText && !activeItem.isTripCancelled && (
+                  <LastPassedStop realtimeText={realtimeText} />
+                )}
+                {shouldShowMapButton && (
+                  <Button
+                    type="small"
+                    leftIcon={{svg: Map}}
+                    text={t(
+                      vehiclePosition
+                        ? DepartureDetailsTexts.live(t(translatedModeName))
+                        : DepartureDetailsTexts.map,
+                    )}
+                    interactiveColor={interactiveColor}
+                    onPress={() => {
+                      vehiclePosition &&
+                        analytics.logEvent(
+                          'Departure details',
+                          'See live bus clicked',
+                          {
+                            fromPlace: mapData.start,
+                            toPlace: mapData?.stop,
+                            mode: mode,
+                            subMode: subMode,
+                          },
+                        );
+                      onPressDetailsMap({
+                        legs: mapData.mapLegs,
+                        fromPlace: mapData.start,
+                        toPlace: mapData.stop,
+                        vehicleWithPosition: vehiclePosition,
+                        mode: mode,
+                        subMode: subMode,
+                      });
+                    }}
+                  />
+                )}
               </View>
             )}
           </View>
@@ -709,6 +710,8 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     flexWrap: 'wrap',
+    alignItems: 'center',
+    columnGap: theme.spacing.small,
   },
   border: {
     borderColor: theme.color.background.neutral[3].background,
@@ -717,13 +720,10 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   passedSection: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
     minWidth: '50%',
     flex: 1,
   },
-  passedText: {
-    alignItems: 'center',
-  },
+  passedText: {},
   startPlace: {
     marginTop: theme.spacing.medium,
   },

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -397,11 +397,7 @@ function LastPassedStop({realtimeText}: {realtimeText: string}) {
 
   return (
     <View style={styles.passedSection}>
-      <ThemeText
-        typography="body__secondary"
-        color={themeColor}
-        style={styles.passedText}
-      >
+      <ThemeText typography="body__secondary" color={themeColor}>
         {realtimeText}
       </ThemeText>
     </View>
@@ -723,7 +719,6 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
     minWidth: '50%',
     flex: 1,
   },
-  passedText: {},
   startPlace: {
     marginTop: theme.spacing.medium,
   },


### PR DESCRIPTION
Since we don't want to merge https://github.com/AtB-AS/mittatb-app/pull/4907 to the release branch and spend time testing it right before the release, I'm making a temporary change to move the follow bus button back to beside the last passed stop text. Only for the release branch.

<img width="300px" src="https://github.com/user-attachments/assets/144fd40b-72e9-438c-8ae3-c80b34d40447">

## Acceptance criteria

- [ ] The button and last passed stop text still shows when it should
- [ ] Works for any screen/text size, and wraps on two lines for large text