### PR TITLE
feat: use secondary transport color for trip leg decorations

### DIFF
--- a/src/components/estimated-call/LineChip.tsx
+++ b/src/components/estimated-call/LineChip.tsx
@@ -2,7 +2,7 @@ import {Statuses, StyleSheet, useThemeContext} from '@atb/theme';
 import {ThemeIcon} from '../theme-icon';
 import {ThemeText} from '../text';
 import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {getTransportModeSvg} from '../icon-box';
 import {View} from 'react-native';
 import {useFontScale} from '@atb/utils/use-font-scale';
@@ -32,7 +32,7 @@ export function LineChip({
   const {transportMode, transportSubmode} = serviceJourney;
   const publicCode = serviceJourney.line?.publicCode;
 
-  const transportColor = useTransportationColor(
+  const transportColor = useTransportColor(
     transportMode,
     transportSubmode,
   ).primary;

--- a/src/components/estimated-call/LineChip.tsx
+++ b/src/components/estimated-call/LineChip.tsx
@@ -35,7 +35,7 @@ export function LineChip({
   const transportColor = useTransportationColor(
     transportMode,
     transportSubmode,
-  );
+  ).primary;
   const {svg} = getTransportModeSvg(transportMode, transportSubmode);
   const icon = messageType && messageTypeToIcon(messageType, true, themeName);
 

--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -4,7 +4,7 @@ import {StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
-import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
+import {useThemeColorForTransportMode} from '@atb/utils/use-transport-color';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemeText} from '@atb/components/text';
 import {getTransportModeSvg} from './utils';

--- a/src/components/map/components/mobility/Bicycles.tsx
+++ b/src/components/map/components/mobility/Bicycles.tsx
@@ -61,7 +61,7 @@ export const Bicycles = ({bicycles, onClusterClick}: Props) => {
           aboveLayerID="bicycleClusterCountCircle"
           style={{
             textField: ['get', 'point_count'],
-            textColor: bicycleColor.background,
+            textColor: bicycleColor.primary.background,
             textSize: 11,
             textTranslate: [13, -13],
             textAllowOverlap: true,

--- a/src/components/map/components/mobility/Bicycles.tsx
+++ b/src/components/map/components/mobility/Bicycles.tsx
@@ -2,7 +2,7 @@ import React, {RefObject, useRef} from 'react';
 import {FeatureCollection, GeoJSON} from 'geojson';
 import {VehicleBasicFragment} from '@atb/api/types/generated/fragments/vehicles';
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {hitboxCoveringIconOnly} from '@atb/components/map';
@@ -18,7 +18,7 @@ type Props = {
 export const Bicycles = ({bicycles, onClusterClick}: Props) => {
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
   const vehiclesSource = useRef<MapboxGL.ShapeSource>(null);
-  const bicycleColor = useTransportationColor(Mode.Bicycle);
+  const bicycleColor = useTransportColor(Mode.Bicycle);
 
   return (
     <>

--- a/src/components/map/components/mobility/BikeStations.tsx
+++ b/src/components/map/components/mobility/BikeStations.tsx
@@ -15,19 +15,12 @@ type Props = {
 };
 
 export const BikeStations = ({stations, onClusterClick}: Props) => {
-  const stationBackgroundColor = useTransportationColor(
-    Mode.Bicycle,
-  ).background;
-  const stationTextColor = useTransportationColor(
-    Mode.Bicycle,
-    undefined,
-    false,
-  ).foreground.primary;
+  const bicycleColor = useTransportationColor(Mode.Bicycle).primary;
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
   const symbolStyling = {
     textAnchor: 'center',
     textOffset: [0.75, 0],
-    textColor: stationBackgroundColor,
+    textColor: bicycleColor.background,
     textSize: 12,
     iconImage: 'BikeChip',
     iconAllowOverlap: true,
@@ -81,8 +74,8 @@ export const BikeStations = ({stations, onClusterClick}: Props) => {
           maxZoomLevel={13}
           minZoomLevel={12}
           style={{
-            circleColor: stationBackgroundColor,
-            circleStrokeColor: stationTextColor,
+            circleColor: bicycleColor.background,
+            circleStrokeColor: bicycleColor.foreground.primary,
             circleOpacity: 0.7,
             circleStrokeOpacity: 0.7,
             circleRadius: 4,

--- a/src/components/map/components/mobility/BikeStations.tsx
+++ b/src/components/map/components/mobility/BikeStations.tsx
@@ -1,5 +1,5 @@
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import React, {RefObject, useRef} from 'react';
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export const BikeStations = ({stations, onClusterClick}: Props) => {
-  const bicycleColor = useTransportationColor(Mode.Bicycle).primary;
+  const bicycleColor = useTransportColor(Mode.Bicycle).primary;
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
   const symbolStyling = {
     textAnchor: 'center',

--- a/src/components/map/components/mobility/CarStations.tsx
+++ b/src/components/map/components/mobility/CarStations.tsx
@@ -1,5 +1,5 @@
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import React, {RefObject, useRef} from 'react';
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export const CarStations = ({stations, onClusterClick}: Props) => {
-  const carColor = useTransportationColor(Mode.Car);
+  const carColor = useTransportColor(Mode.Car);
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
 
   const symbolStyling = {

--- a/src/components/map/components/mobility/CarStations.tsx
+++ b/src/components/map/components/mobility/CarStations.tsx
@@ -15,15 +15,13 @@ type Props = {
 };
 
 export const CarStations = ({stations, onClusterClick}: Props) => {
-  const stationBackgroundColor = useTransportationColor(Mode.Car).background;
-  const stationTextColor = useTransportationColor(Mode.Car, undefined, false)
-    .foreground.primary;
+  const carColor = useTransportationColor(Mode.Car);
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
 
   const symbolStyling = {
     textAnchor: 'center',
     textOffset: [0.75, 0],
-    textColor: stationBackgroundColor,
+    textColor: carColor.primary.background,
     textSize: 12,
     textAllowOverlap: true,
     iconImage: 'CarChip',
@@ -78,8 +76,8 @@ export const CarStations = ({stations, onClusterClick}: Props) => {
           maxZoomLevel={12}
           minZoomLevel={11}
           style={{
-            circleColor: stationBackgroundColor,
-            circleStrokeColor: stationTextColor,
+            circleColor: carColor.primary.background,
+            circleStrokeColor: carColor.primary.foreground.primary,
             circleOpacity: 0.7,
             circleStrokeOpacity: 0.7,
             circleRadius: 4,

--- a/src/components/map/components/mobility/Scooters.tsx
+++ b/src/components/map/components/mobility/Scooters.tsx
@@ -2,7 +2,7 @@ import React, {RefObject, useRef} from 'react';
 import {FeatureCollection, GeoJSON} from 'geojson';
 import {VehicleBasicFragment} from '@atb/api/types/generated/fragments/vehicles';
 import MapboxGL, {ShapeSource} from '@rnmapbox/maps';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {
@@ -23,7 +23,7 @@ type Props = {
 export const Scooters = ({scooters, onClusterClick}: Props) => {
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
   const vehiclesSource = useRef<MapboxGL.ShapeSource>(null);
-  const scooterColor = useTransportationColor(Mode.Scooter).primary.background;
+  const scooterColor = useTransportColor(Mode.Scooter).primary.background;
 
   return (
     <>

--- a/src/components/map/components/mobility/Scooters.tsx
+++ b/src/components/map/components/mobility/Scooters.tsx
@@ -23,7 +23,7 @@ type Props = {
 export const Scooters = ({scooters, onClusterClick}: Props) => {
   const clustersSource = useRef<MapboxGL.ShapeSource>(null);
   const vehiclesSource = useRef<MapboxGL.ShapeSource>(null);
-  const scooterColor = useTransportationColor(Mode.Scooter).background;
+  const scooterColor = useTransportationColor(Mode.Scooter).primary.background;
 
   return (
     <>

--- a/src/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/fare-contracts/components/InspectionSymbol.tsx
@@ -11,7 +11,7 @@ import {
   useFirestoreConfigurationContext,
 } from '@atb/configuration';
 import {Moon, Youth} from '@atb/assets/svg/mono-icons/ticketing';
-import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
+import {useThemeColorForTransportMode} from '@atb/utils/use-transport-color';
 import {ContrastColor} from '@atb/theme/colors';
 import {useMobileTokenContext} from '@atb/mobile-token';
 import {getTransportModeSvg} from '@atb/components/icon-box';

--- a/src/fare-contracts/use-validity-line-colors.ts
+++ b/src/fare-contracts/use-validity-line-colors.ts
@@ -1,6 +1,6 @@
 import {useFirestoreConfigurationContext} from '@atb/configuration';
 import {useThemeContext} from '@atb/theme';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 
 export function useValidityLineColors(fareProductType?: string) {
   const {theme} = useThemeContext();
@@ -13,7 +13,7 @@ export function useValidityLineColors(fareProductType?: string) {
   const {mode, subMode} = fareProductTypeConfig?.transportModes?.[0] || {};
 
   const lineColor = theme.color.background.neutral[2].background;
-  const backgroundColor = useTransportationColor(mode, subMode);
+  const backgroundColor = useTransportColor(mode, subMode);
 
   return {
     lineColor,

--- a/src/fare-contracts/use-validity-line-colors.ts
+++ b/src/fare-contracts/use-validity-line-colors.ts
@@ -17,6 +17,8 @@ export function useValidityLineColors(fareProductType?: string) {
 
   return {
     lineColor,
-    backgroundColor: mode ? backgroundColor : theme.color.status.valid.primary,
+    backgroundColor: mode
+      ? backgroundColor.primary
+      : theme.color.status.valid.primary,
   };
 }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -23,7 +23,7 @@ export const TicketingTile = ({
   onPress: () => void;
   testID: string;
   illustrationName: string;
-  transportColor: TransportColor['city'];
+  transportColor: TransportColor;
   title?: string;
   description?: string;
   accessibilityLabel?: string;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
@@ -6,7 +6,7 @@ import {
 } from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 
-import {useThemeColorForTransportMode} from '@atb/utils/use-transportation-color';
+import {useThemeColorForTransportMode} from '@atb/utils/use-transport-color';
 import {TicketingTile} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile';
 import {useThemeContext} from '@atb/theme';
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -18,8 +18,10 @@ export type {
   ContrastColor,
   TextNames,
   InteractiveColor,
-  TransportColors as TransportColor,
-  StatusColors as StatusColor,
+  TransportColors,
+  TransportColor,
+  StatusColors,
+  StatusColor,
 } from '@atb-as/theme';
 
 export {textNames} from '@atb-as/theme';

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -24,7 +24,7 @@ import {MapTexts, useTranslation} from '@atb/translations';
 import {Coordinates} from '@atb/utils/coordinates';
 import {secondsBetween} from '@atb/utils/date';
 import {useInterval} from '@atb/utils/use-interval';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
 import {Feature, Point, Position} from 'geojson';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
@@ -254,7 +254,7 @@ const LiveVehicleMarker = ({
   isError,
 }: VehicleIconProps) => {
   const {theme} = useThemeContext();
-  const fillColor = useTransportationColor(mode, subMode).primary.background;
+  const fillColor = useTransportColor(mode, subMode).primary.background;
   const {live_vehicle_stale_threshold} = useRemoteConfigContext();
 
   const [isStale, setIsStale] = useState(false);
@@ -360,8 +360,7 @@ const LiveVehicleIcon = ({
   isError,
 }: LiveVehicleIconProps): JSX.Element => {
   const {theme} = useThemeContext();
-  const fillColor = useTransportationColor(mode, subMode).primary.foreground
-    .primary;
+  const fillColor = useTransportColor(mode, subMode).primary.foreground.primary;
   const {svg} = getTransportModeSvg(mode, subMode);
 
   if (isError)

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -254,7 +254,7 @@ const LiveVehicleMarker = ({
   isError,
 }: VehicleIconProps) => {
   const {theme} = useThemeContext();
-  const fillColor = useTransportationColor(mode, subMode, false).background;
+  const fillColor = useTransportationColor(mode, subMode).primary.background;
   const {live_vehicle_stale_threshold} = useRemoteConfigContext();
 
   const [isStale, setIsStale] = useState(false);
@@ -273,9 +273,7 @@ const LiveVehicleMarker = ({
     true,
   );
 
-  const circleColor = useTransportationColor(mode, subMode).background;
-
-  let circleBackgroundColor = circleColor;
+  let circleBackgroundColor = fillColor;
   let circleBorderColor = 'transparent';
   if (isError) {
     circleBackgroundColor =
@@ -362,7 +360,8 @@ const LiveVehicleIcon = ({
   isError,
 }: LiveVehicleIconProps): JSX.Element => {
   const {theme} = useThemeContext();
-  const fillColor = useTransportationColor(mode, subMode).foreground.primary;
+  const fillColor = useTransportationColor(mode, subMode).primary.foreground
+    .primary;
   const {svg} = getTransportModeSvg(mode, subMode);
 
   if (isError)

--- a/src/travel-details-map-screen/components/MapRoute.tsx
+++ b/src/travel-details-map-screen/components/MapRoute.tsx
@@ -31,8 +31,7 @@ function MapLineItem({line, index}: MapLineItemProps) {
     line?.faded ? undefined : line?.travelType,
     line?.subMode,
     line.isFlexible,
-    'secondary',
-  ).background;
+  ).secondary.background;
 
   const lineColor = line?.faded
     ? hexToRgba(lineColorInput, 0.5)

--- a/src/travel-details-map-screen/components/MapRoute.tsx
+++ b/src/travel-details-map-screen/components/MapRoute.tsx
@@ -1,4 +1,4 @@
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import MapboxGL from '@rnmapbox/maps';
 import {Point} from 'geojson';
 import hexToRgba from 'hex-to-rgba';
@@ -27,7 +27,7 @@ type MapLineItemProps = {
   index: number;
 };
 function MapLineItem({line, index}: MapLineItemProps) {
-  const lineColorInput = useTransportationColor(
+  const lineColorInput = useTransportColor(
     line?.faded ? undefined : line?.travelType,
     line?.subMode,
     line.isFlexible,

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -529,9 +529,7 @@ function EstimatedCallRow({
   const tripLegDecorationColor = useTransportationColor(
     group === 'trip' ? mode : undefined,
     subMode,
-    false,
-    'secondary',
-  ).background;
+  ).secondary.background;
 
   const {flex_booking_number_of_days_available} = useRemoteConfigContext();
   const bookingStatus = getBookingStatus(

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -33,7 +33,7 @@ import {
   getQuayName,
   getTranslatedModeName,
 } from '@atb/utils/transportation-names';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import React, {useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {Time} from './components/Time';
@@ -526,7 +526,7 @@ function EstimatedCallRow({
   const isStartOfTripGroup = group === 'trip' && isStartOfGroup;
 
   const isBetween = !isStartOfGroup && !isEndOfGroup;
-  const tripLegDecorationColor = useTransportationColor(
+  const tripLegDecorationColor = useTransportColor(
     group === 'trip' ? mode : undefined,
     subMode,
   ).secondary.background;

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -526,9 +526,11 @@ function EstimatedCallRow({
   const isStartOfTripGroup = group === 'trip' && isStartOfGroup;
 
   const isBetween = !isStartOfGroup && !isEndOfGroup;
-  const iconColor = useTransportationColor(
+  const tripLegDecorationColor = useTransportationColor(
     group === 'trip' ? mode : undefined,
     subMode,
+    false,
+    'secondary',
   ).background;
 
   const {flex_booking_number_of_days_available} = useRemoteConfigContext();
@@ -545,7 +547,7 @@ function EstimatedCallRow({
         hasStart={isStartOfGroup}
         hasCenter={isBetween}
         hasEnd={isEndOfGroup}
-        color={iconColor}
+        color={tripLegDecorationColor}
       />
       <TripRow
         rowLabel={

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -105,8 +105,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
     leg.mode,
     leg.line?.transportSubmode,
     isFlexible,
-    'secondary',
-  ).background;
+  ).secondary.background;
 
   const showFrom = !isWalkSection || !!(isFirst && isWalkSection);
   const showTo = !isWalkSection || !!(isLast && isWalkSection);
@@ -537,12 +536,7 @@ function InterchangeSection({
 }: InterchangeSectionProps) {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
-  const secondaryColor = useTransportationColor(
-    undefined,
-    undefined,
-    false,
-    'secondary',
-  );
+  const legColor = useTransportationColor().secondary;
 
   let text = '';
   if (publicCode && staySeated) {
@@ -585,7 +579,7 @@ function InterchangeSection({
   return (
     <View style={style.interchangeSection}>
       <TripLegDecoration
-        color={secondaryColor.background}
+        color={legColor.background}
         hasStart={false}
         hasEnd={false}
       />

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -105,8 +105,8 @@ export const TripSection: React.FC<TripSectionProps> = ({
     leg.mode,
     leg.line?.transportSubmode,
     isFlexible,
+    'secondary',
   ).background;
-  const iconColor = useTransportationColor().background;
 
   const showFrom = !isWalkSection || !!(isFirst && isWalkSection);
   const showTo = !isWalkSection || !!(isLast && isWalkSection);
@@ -350,7 +350,6 @@ export const TripSection: React.FC<TripSectionProps> = ({
       </View>
       {showInterchangeSection && (
         <InterchangeSection
-          iconColor={iconColor}
           publicCode={publicCode}
           interchangeDetails={interchangeDetails}
           maximumWaitTime={leg.interchangeTo?.maximumWaitTime}
@@ -524,7 +523,6 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
 };
 
 type InterchangeSectionProps = {
-  iconColor: string;
   publicCode: string;
   interchangeDetails: InterchangeDetails;
   maximumWaitTime?: number;
@@ -532,7 +530,6 @@ type InterchangeSectionProps = {
 };
 
 function InterchangeSection({
-  iconColor,
   publicCode,
   interchangeDetails,
   maximumWaitTime,
@@ -540,6 +537,12 @@ function InterchangeSection({
 }: InterchangeSectionProps) {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
+  const secondaryColor = useTransportationColor(
+    undefined,
+    undefined,
+    false,
+    'secondary',
+  );
 
   let text = '';
   if (publicCode && staySeated) {
@@ -581,7 +584,11 @@ function InterchangeSection({
 
   return (
     <View style={style.interchangeSection}>
-      <TripLegDecoration color={iconColor} hasStart={false} hasEnd={false} />
+      <TripLegDecoration
+        color={secondaryColor.background}
+        hasStart={false}
+        hasEnd={false}
+      />
       <TripRow>
         <MessageInfoBox type="info" message={text} />
       </TripRow>

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -21,7 +21,7 @@ import {
   getQuayName,
   getTranslatedModeName,
 } from '@atb/utils/transportation-names';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import React from 'react';
 import {Linking, View} from 'react-native';
@@ -101,7 +101,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const isBikeSection = leg.mode === Mode.Bicycle;
   const isFlexible = isLineFlexibleTransport(leg.line);
   const timesAreApproximations = isFlexible;
-  const legColor = useTransportationColor(
+  const legColor = useTransportColor(
     leg.mode,
     leg.line?.transportSubmode,
     isFlexible,
@@ -536,7 +536,7 @@ function InterchangeSection({
 }: InterchangeSectionProps) {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
-  const legColor = useTransportationColor().secondary;
+  const legColor = useTransportColor().secondary;
 
   let text = '';
   if (publicCode && staySeated) {

--- a/src/travel-details-screens/components/WaitSection.tsx
+++ b/src/travel-details-screens/components/WaitSection.tsx
@@ -22,7 +22,12 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
   const {t, language} = useTranslation();
   const waitTime = secondsToDuration(wait.waitTimeInSeconds, language);
   const shortWait = timeIsShort(wait.waitTimeInSeconds);
-  const iconColor = useTransportationColor().background;
+  const iconColor = useTransportationColor(
+    undefined,
+    undefined,
+    false,
+    'secondary',
+  ).background;
 
   return (
     <View style={style.section}>

--- a/src/travel-details-screens/components/WaitSection.tsx
+++ b/src/travel-details-screens/components/WaitSection.tsx
@@ -4,7 +4,7 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {StyleSheet} from '@atb/theme';
 import {TripDetailsTexts, useTranslation} from '@atb/translations';
 import {secondsToDuration} from '@atb/utils/date';
-import {useTransportationColor} from '@atb/utils/use-transportation-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import React from 'react';
 import {View} from 'react-native';
 import {timeIsShort} from '../utils';
@@ -22,7 +22,7 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
   const {t, language} = useTranslation();
   const waitTime = secondsToDuration(wait.waitTimeInSeconds, language);
   const shortWait = timeIsShort(wait.waitTimeInSeconds);
-  const legColor = useTransportationColor();
+  const legColor = useTransportColor();
 
   return (
     <View style={style.section}>

--- a/src/travel-details-screens/components/WaitSection.tsx
+++ b/src/travel-details-screens/components/WaitSection.tsx
@@ -22,16 +22,15 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
   const {t, language} = useTranslation();
   const waitTime = secondsToDuration(wait.waitTimeInSeconds, language);
   const shortWait = timeIsShort(wait.waitTimeInSeconds);
-  const iconColor = useTransportationColor(
-    undefined,
-    undefined,
-    false,
-    'secondary',
-  ).background;
+  const legColor = useTransportationColor();
 
   return (
     <View style={style.section}>
-      <TripLegDecoration color={iconColor} hasStart={false} hasEnd={false} />
+      <TripLegDecoration
+        color={legColor.secondary.background}
+        hasStart={false}
+        hasEnd={false}
+      />
       {shortWait && (
         <TripRow>
           <MessageInfoBox
@@ -40,7 +39,7 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
           />
         </TripRow>
       )}
-      <TripRow rowLabel={<ThemeIcon svg={Time} color={iconColor} />}>
+      <TripRow rowLabel={<ThemeIcon svg={Time} color={legColor.secondary} />}>
         <ThemeText typography="body__secondary" color="secondary">
           {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
         </ThemeText>

--- a/src/utils/use-transport-color.ts
+++ b/src/utils/use-transport-color.ts
@@ -6,7 +6,7 @@ import {
   TransportColors,
 } from '@atb/theme/colors';
 
-export function useTransportationColor(
+export function useTransportColor(
   mode?: AnyMode,
   subMode?: AnySubMode,
   isFlexible?: boolean,

--- a/src/utils/use-transportation-color.ts
+++ b/src/utils/use-transportation-color.ts
@@ -1,16 +1,19 @@
 import {useThemeContext} from '@atb/theme';
 import {AnyMode, AnySubMode} from '@atb/components/icon-box';
-import {ContrastColor, TransportColors} from '@atb/theme/colors';
+import {
+  ContrastColor,
+  TransportColor,
+  TransportColors,
+} from '@atb/theme/colors';
 
 export function useTransportationColor(
   mode?: AnyMode,
   subMode?: AnySubMode,
   isFlexible?: boolean,
-  colorMode: keyof TransportColors[keyof TransportColors] = 'primary',
-): ContrastColor {
+): TransportColor<ContrastColor> {
   const themeColor = useThemeColorForTransportMode(mode, subMode, isFlexible);
   const {theme} = useThemeContext();
-  return theme.color.transport[themeColor][colorMode];
+  return theme.color.transport[themeColor];
 }
 
 export const useThemeColorForTransportMode = (

--- a/src/utils/use-transportation-color.ts
+++ b/src/utils/use-transportation-color.ts
@@ -1,12 +1,12 @@
 import {useThemeContext} from '@atb/theme';
 import {AnyMode, AnySubMode} from '@atb/components/icon-box';
-import {ContrastColor, TransportColor} from '@atb/theme/colors';
+import {ContrastColor, TransportColors} from '@atb/theme/colors';
 
 export function useTransportationColor(
   mode?: AnyMode,
   subMode?: AnySubMode,
   isFlexible?: boolean,
-  colorMode: keyof TransportColor[keyof TransportColor] = 'primary',
+  colorMode: keyof TransportColors[keyof TransportColors] = 'primary',
 ): ContrastColor {
   const themeColor = useThemeColorForTransportMode(mode, subMode, isFlexible);
   const {theme} = useThemeContext();
@@ -17,7 +17,7 @@ export const useThemeColorForTransportMode = (
   mode?: AnyMode,
   subMode?: AnySubMode,
   isFlexible?: boolean,
-): keyof TransportColor => {
+): keyof TransportColors => {
   if (isFlexible) return 'flexible';
   switch (mode) {
     case 'bus':


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/19401

In preparation for adding a VM specific transport colors, we need to use secondary transport colors for trip leg decorations in order to have enough contrast against the background in dark mode. See ad037ad90812c75553e4bb31459069632135983a for this change.

Since this made the secondary variant of transport colors more used in the app, I thought it made sense to return `TransportColor` (with both primary and secondary) from the useTransportColor hook instead of passing a `colorMode` parameter and returning ContrastColor. Because of this, the PR contains some refactorings related to usage of the hook as well.

<img width="300px" src="https://github.com/user-attachments/assets/93d52779-bbee-4e09-8c46-7a18c3c3894e">
<img width="300px" src="https://github.com/user-attachments/assets/cb5a25d7-e507-433c-80be-14329bb6df1d">

## Acceptance criteria

- [ ] Leg decorations (the vertical line) in trip and departure details uses secondary transport colors (slightly darker than primary)
- [ ] Transport colors elsewhere in the app look like before:
	- [ ] Fare contracts
	- [ ] Live bus in map
	- [ ] Statons and scooters in the map
	- [ ] Departures
	- [ ] Trip search