### PR TITLE
feat: add hugeicons and update to new theme colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^5.2.0",
-    "@atb-as/generate-assets": "^13.6.0",
-    "@atb-as/theme": "^13.0.0",
+    "@atb-as/generate-assets": "^14.0.0",
+    "@atb-as/theme": "^13.1.0",
     "@bugsnag/react-native": "^7.25.0",
     "@bugsnag/source-maps": "^2.3.3",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.6",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^5.2.0",
-    "@atb-as/generate-assets": "^14.0.0",
-    "@atb-as/theme": "^13.1.0",
+    "@atb-as/generate-assets": "^14.0.1",
+    "@atb-as/theme": "^13.1.1",
     "@bugsnag/react-native": "^7.25.0",
     "@bugsnag/source-maps": "^2.3.3",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^5.2.0",
     "@atb-as/generate-assets": "^13.6.0",
-    "@atb-as/theme": "^12.0.0",
+    "@atb-as/theme": "^12.0.7",
     "@bugsnag/react-native": "^7.25.0",
     "@bugsnag/source-maps": "^2.3.3",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^5.2.0",
     "@atb-as/generate-assets": "^13.6.0",
-    "@atb-as/theme": "^12.0.7",
+    "@atb-as/theme": "^13.0.0",
     "@bugsnag/react-native": "^7.25.0",
     "@bugsnag/source-maps": "^2.3.3",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.6",

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -47,7 +47,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     width: '100%',
     position: 'absolute',
     bottom: 0,
-    borderTopLeftRadius: theme.border.radius.circle,
-    borderTopRightRadius: theme.border.radius.circle,
+    borderTopLeftRadius: theme.border.radius.large,
+    borderTopRightRadius: theme.border.radius.large,
   },
 }));

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -142,7 +142,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
         paddingVertical: type === 'small' ? theme.spacing.xSmall : spacing,
         borderRadius:
           type === 'small'
-            ? theme.border.radius.circle
+            ? theme.border.radius.large
             : theme.border.radius.regular,
         ...(expanded && type === 'small'
           ? {

--- a/src/components/icon-box/utils.ts
+++ b/src/components/icon-box/utils.ts
@@ -10,11 +10,11 @@ import {
   Unknown,
 } from '@atb/assets/svg/mono-icons/transportation';
 import {
-  Bicycle,
   Plane,
   Scooter,
   Subway,
 } from '@atb/assets/svg/mono-icons/transportation-entur';
+import {Bicycle} from '@atb/assets/svg/mono-icons/vehicles';
 
 const TRANSPORT_SUB_MODES_BOAT: AnySubMode[] = [
   TransportSubmode.HighSpeedPassengerService,

--- a/src/components/label-info/LabelInfo.tsx
+++ b/src/components/label-info/LabelInfo.tsx
@@ -38,6 +38,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginRight: theme.spacing.medium,
     paddingHorizontal: theme.spacing.small,
     paddingVertical: theme.spacing.xSmall,
-    borderRadius: theme.border.radius.circle,
+    borderRadius: theme.border.radius.large,
   },
 }));

--- a/src/components/map/components/BackArrow.tsx
+++ b/src/components/map/components/BackArrow.tsx
@@ -9,7 +9,7 @@ export const BackArrow: React.FC<{onBack(): void} & AccessibilityProps> = ({
   onBack,
 }) => {
   const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[0];
+  const interactiveColor = theme.color.interactive[2];
 
   return (
     <Button

--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -68,7 +68,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     position: 'absolute',
     right: 0,
     top: 0,
-    borderRadius: theme.border.radius.circle,
+    borderRadius: theme.border.radius.large,
     zIndex: 10,
     overflow: 'hidden',
   },

--- a/src/components/vipps-login-button/VippsLoginButton.tsx
+++ b/src/components/vipps-login-button/VippsLoginButton.tsx
@@ -2,11 +2,12 @@ import {LoginTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {ThemeText} from '@atb/components/text';
 import {View, ViewStyle} from 'react-native';
-import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
+import {StyleSheet, Theme} from '@atb/theme';
 import VippsLogo from '@atb/assets/svg/color/icons/ticketing/VippsLogo';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 
 const VIPPS_BACKGROUND_COLOR = '#FF5B24';
+const VIPPS_TEXT_COLOR = '#FFFFFF';
 
 export const VippsLoginButton = ({
   onPress,
@@ -18,9 +19,6 @@ export const VippsLoginButton = ({
   style?: ViewStyle;
 }) => {
   const {t} = useTranslation();
-  const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[0].default;
-
   const styles = useStyles();
 
   return (
@@ -35,7 +33,7 @@ export const VippsLoginButton = ({
         <ThemeText
           typography="body__primary--bold"
           style={styles.label}
-          color={interactiveColor}
+          color={VIPPS_TEXT_COLOR}
         >
           {t(LoginTexts.logInOptions.options.vipps.label)}
         </ThemeText>

--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -112,15 +112,15 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.color.background.neutral[1].background,
   },
   dot: {
-    backgroundColor: theme.color.background.accent[1].background,
+    backgroundColor: theme.color.foreground.dynamic.secondary,
     borderRadius: 20,
-    borderColor: theme.color.background.accent[1].background,
+    borderColor: theme.color.foreground.dynamic.secondary,
     borderWidth: 2,
     width: 16,
     height: 16,
   },
   dot__unused: {
-    backgroundColor: theme.color.background.neutral[0].background,
+    backgroundColor: 'transparent',
   },
   dotFill__activeViewBox: {
     height: '100%',

--- a/src/stacks-hierarchy/Root_ExtendedOnboardingStack/Root_ExtendedOnboardingStack.tsx
+++ b/src/stacks-hierarchy/Root_ExtendedOnboardingStack/Root_ExtendedOnboardingStack.tsx
@@ -1,11 +1,10 @@
 import {PageIndicator} from '@atb/components/page-indicator';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {
   createMaterialTopTabNavigator,
   MaterialTopTabBarProps,
 } from '@react-navigation/material-top-tabs';
 import React from 'react';
-import {StatusBar} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ExtendedOnboardingStackParams} from './navigation-types';
 import {ExtendedOnboarding_GoodToKnowScreen} from './ExtendedOnboarding_GoodToKnowScreen';
@@ -17,10 +16,8 @@ const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
 
 export const Root_ExtendedOnboardingStack = () => {
   const styles = useStyles();
-  const {theme} = useThemeContext();
   return (
     <>
-      <StatusBar backgroundColor={getThemeColor(theme).background} />
       <SafeAreaView style={styles.container}>
         <Tab.Navigator
           tabBar={(props: MaterialTopTabBarProps) => {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader.tsx
@@ -97,7 +97,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   headerSubSection: {
     marginTop: theme.spacing.medium,
     borderTopWidth: theme.border.width.slim,
-    borderTopColor: theme.color.background.accent[1].background,
+    borderTopColor: theme.color.background.neutral[0].background,
     paddingTop: theme.spacing.medium,
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip.tsx
@@ -52,7 +52,7 @@ export const ProductAliasChip = ({color, text, selected, onPress}: Props) => {
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    borderRadius: theme.border.radius.circle * 2,
+    borderRadius: theme.border.radius.large * 2,
     marginRight: theme.spacing.small,
     justifyContent: 'center',
   },

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -77,7 +77,7 @@ type AppThemeExtension = {
 export const themes = createExtendedThemes<AppThemeExtension>(mainThemes, {
   light: {
     tripLegDetail,
-    statusBarStyle: 'light-content',
+    statusBarStyle: 'dark-content',
 
     typography: textTypeStyles,
   },

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -780,7 +780,7 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   headerSubSection: {
     marginTop: theme.spacing.medium,
     borderTopWidth: theme.border.width.slim,
-    borderTopColor: theme.color.background.accent[1].background,
+    borderTopColor: theme.color.background.neutral[0].background,
     paddingTop: theme.spacing.medium,
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/travel-details-screens/components/WaitSection.tsx
+++ b/src/travel-details-screens/components/WaitSection.tsx
@@ -39,7 +39,11 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
           />
         </TripRow>
       )}
-      <TripRow rowLabel={<ThemeIcon svg={Time} color={legColor.secondary} />}>
+      <TripRow
+        rowLabel={
+          <ThemeIcon svg={Time} color={legColor.secondary.background} />
+        }
+      >
         <ThemeText typography="body__secondary" color="secondary">
           {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
         </ThemeText>

--- a/src/utils/use-transport-color.ts
+++ b/src/utils/use-transport-color.ts
@@ -27,6 +27,7 @@ export const useThemeColorForTransportMode = (
     case 'coach':
       if (subMode === 'localBus') return 'city';
       if (subMode === 'airportLinkBus') return 'airportExpress';
+      if (subMode === 'shuttleBus') return 'shuttle';
       return 'region';
     case 'bicycle':
       return 'bike';

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,9 +34,9 @@
     zod-to-json-schema "^3.20.4"
 
 "@atb-as/generate-assets@^13.6.0":
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-13.6.0.tgz#d6b018a6e6ec4a6ed3f992427e8e2f43aa661269"
-  integrity sha512-BLvn6weTzVsaBakRIUsFP5UIJA5C6iP6D2zgjYRQemBMUFzahQMOgRxIxut4ufB0qso0q0eCH9Fa9v2sToUbXw==
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-13.7.0.tgz#574db8c75f7ea6fc330f061a4f71c1619a544a70"
+  integrity sha512-GmiCEoXEayntPRF+zSx/JLJeWFsIKPb2cWPNkhpCszZWCS2NOPAuMvd3lmXvHwEvpYyPJ9I9z1TNigsCEja4qA==
   dependencies:
     "@atb-as/theme" "^12.0.7"
     commander "^9.4.0"
@@ -44,15 +44,6 @@
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
-
-"@atb-as/theme@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-12.0.0.tgz#27bb8bc4db0574af5ec8b9d15b71de70014f51ad"
-  integrity sha512-OI6U3HgiIOBec1usPZ+2v7OF8nyw07mk3IanbZx/dtfux5Xre3usTLshZbybajFti1NOCp15V6FOsffLCawc5Q==
-  dependencies:
-    "@tfk-samf/figma-to-dtcg" "0.4.0"
-    hex-to-rgba "^2.0.1"
-    ts-deepmerge "^4.0.0"
 
 "@atb-as/theme@^12.0.7":
   version "12.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,31 +33,22 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^13.6.0":
-  version "13.7.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-13.7.0.tgz#574db8c75f7ea6fc330f061a4f71c1619a544a70"
-  integrity sha512-GmiCEoXEayntPRF+zSx/JLJeWFsIKPb2cWPNkhpCszZWCS2NOPAuMvd3lmXvHwEvpYyPJ9I9z1TNigsCEja4qA==
+"@atb-as/generate-assets@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-14.0.0.tgz#2f2fd64332c77eb5f0debfb99d7f213df6198368"
+  integrity sha512-vJFFGo97IVJF0j/V59KmcwB3EbdpKGfk2wt6Vr6vCcx2ykeRPJ35aOJym5B29sg7E+y2PykyoME5kCo8ToUlNw==
   dependencies:
-    "@atb-as/theme" "^12.0.7"
+    "@atb-as/theme" "^13.1.0"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^12.0.7":
-  version "12.0.7"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-12.0.7.tgz#dd750d9060091138923e9d07a61c59fef07b7ab6"
-  integrity sha512-iFmNve1NC34Sy+sp5W7wAMOI+E1HGtllT+ZcJTPGtbEj8nWFEZ/1jBcN/T8S08ucTGmlT22V6jliyyMyjrDzPA==
-  dependencies:
-    "@tfk-samf/figma-to-dtcg" "0.4.0"
-    hex-to-rgba "^2.0.1"
-    ts-deepmerge "^4.0.0"
-
-"@atb-as/theme@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-13.0.0.tgz#b33ce598bb08c478b349e800b4cca9f2dbc281c2"
-  integrity sha512-2jRa7tIsgi/r1TEXI9kVBT8XV6bWrU5LS0WrfCXgzh93zQOfFPkoD0b0Pp9nIN05dYTTFzD6vp+Ccvu0959Vxg==
+"@atb-as/theme@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-13.1.0.tgz#76b2e824a1163641310d34d10803d34210ad4a4a"
+  integrity sha512-pougAtL0fZ0qa7aPppLK4jsk7/7Jl3Md3X1rxpXPGEWw6F9+AkSceEPI0/9ppadHkUJ7jrTMPyGh/jDDvAMGeg==
   dependencies:
     "@tfk-samf/figma-to-dtcg" "0.4.0"
     hex-to-rgba "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,15 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
+"@atb-as/theme@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-13.0.0.tgz#b33ce598bb08c478b349e800b4cca9f2dbc281c2"
+  integrity sha512-2jRa7tIsgi/r1TEXI9kVBT8XV6bWrU5LS0WrfCXgzh93zQOfFPkoD0b0Pp9nIN05dYTTFzD6vp+Ccvu0959Vxg==
+  dependencies:
+    "@tfk-samf/figma-to-dtcg" "0.4.0"
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,22 +33,22 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.20.4"
 
-"@atb-as/generate-assets@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-14.0.0.tgz#2f2fd64332c77eb5f0debfb99d7f213df6198368"
-  integrity sha512-vJFFGo97IVJF0j/V59KmcwB3EbdpKGfk2wt6Vr6vCcx2ykeRPJ35aOJym5B29sg7E+y2PykyoME5kCo8ToUlNw==
+"@atb-as/generate-assets@^14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-14.0.1.tgz#c098f06e8180f1ebebf0ac1c6a5072ec0a227cfb"
+  integrity sha512-acr7eyKPRn/9wA85ZOc+pqSfXtmteeJbvlRT0tphZAK0tktqYAerKKWErFTz8ml3CdUwpzKzScj4aAvkJ4q0Xw==
   dependencies:
-    "@atb-as/theme" "^13.1.0"
+    "@atb-as/theme" "^13.1.1"
     commander "^9.4.0"
     fast-glob "^3.2.11"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     stream-editor "^1.11.0"
 
-"@atb-as/theme@^13.1.0":
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-13.1.0.tgz#76b2e824a1163641310d34d10803d34210ad4a4a"
-  integrity sha512-pougAtL0fZ0qa7aPppLK4jsk7/7Jl3Md3X1rxpXPGEWw6F9+AkSceEPI0/9ppadHkUJ7jrTMPyGh/jDDvAMGeg==
+"@atb-as/theme@^13.1.1":
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-13.1.1.tgz#60996e7cc7239bf27349df3a823c3732eec2f2f3"
+  integrity sha512-HkqPpy2rbjY7/rrMb3+fq6WN/Bv4Lh9AXJHzulMJcTUoJwGKZOjPvl5g/eFKxALRWJTLIrKHMVNSYpLDeaS4jA==
   dependencies:
     "@tfk-samf/figma-to-dtcg" "0.4.0"
     hex-to-rgba "^2.0.1"


### PR DESCRIPTION
A small step ~for man~ in terms of code changes, but a huge~icon~ leap for ~mankind~ the OMS ✨

- Uses new tokens from the design systems, with a new color set
- Uses new assets, with icons from hugeicons
- Implements the `transport.shuttle` color for `transportSubMode: "shuttleBus"` (VM colors for AtB)

<img width="300px" src="https://github.com/user-attachments/assets/5542bbd6-f9f1-47bd-a46a-72aa64de1a64">
<img width="300px" src="https://github.com/user-attachments/assets/4c417482-54b8-45d0-81e1-dcc05b3473f0">

closes https://github.com/AtB-AS/kundevendt/issues/19401
closes https://github.com/AtB-AS/kundevendt/issues/19098
closes https://github.com/AtB-AS/kundevendt/issues/19586