### PR TITLE
refactor: Rename historic to historical

### DIFF
--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -31,7 +31,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   reservations,
   now,
   showTokenInfo,
-  mode = 'historic',
+  mode = 'historical',
   emptyStateTitleText,
   emptyStateDetailsText,
 }) => {
@@ -92,7 +92,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
 
 const emptyStateImage = (emptyStateMode: TicketHistoryMode) => {
   switch (emptyStateMode) {
-    case 'historic':
+    case 'historical':
       return <TicketTilted height={84} />;
     case 'sent':
       return <HoldingHands height={84} />;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistorySelectionScreen.tsx
@@ -29,14 +29,14 @@ export const Profile_TicketHistorySelectionScreen = ({navigation}: Props) => {
     >
       <Section style={styles.content}>
         <LinkSectionItem
-          text={t(TicketHistoryModeTexts.historic.title)}
+          text={t(TicketHistoryModeTexts.historical.title)}
           accessibility={{
-            accessibilityHint: t(TicketHistoryModeTexts.historic.titleA11y),
+            accessibilityHint: t(TicketHistoryModeTexts.historical.titleA11y),
           }}
           testID="historicTicketsButton"
           onPress={() =>
             navigation.navigate('Profile_TicketHistoryScreen', {
-              mode: 'historic',
+              mode: 'historical',
             })
           }
         />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -29,8 +29,8 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
     fareContracts: availableFareContracts,
     refetch: refetchAvailableFareContracts,
   } = useFareContracts({availability: 'available'}, serverNow);
-  const {fareContracts: historicFareContracts} = useFareContracts(
-    {availability: 'historic'},
+  const {fareContracts: historicalFareContracts} = useFareContracts(
+    {availability: 'historical'},
     serverNow,
   );
 
@@ -38,7 +38,7 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
   const {t} = useTranslation();
   const {addPopOver} = usePopOverContext();
 
-  const hasHistoricFareContracts = historicFareContracts.length > 0;
+  const hasHistoricalFareContracts = historicalFareContracts.length > 0;
 
   const hasSentFareContracts = sentFareContracts.length > 0;
 
@@ -114,16 +114,18 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           )}
         />
         <Section>
-          {hasHistoricFareContracts && (
+          {hasHistoricalFareContracts && (
             <LinkSectionItem
-              text={t(TicketHistoryModeTexts.historic.title)}
+              text={t(TicketHistoryModeTexts.historical.title)}
               accessibility={{
-                accessibilityHint: t(TicketHistoryModeTexts.historic.titleA11y),
+                accessibilityHint: t(
+                  TicketHistoryModeTexts.historical.titleA11y,
+                ),
               }}
               testID="historicTicketsButton"
               onPress={() =>
                 navigation.navigate('Ticketing_TicketHistoryScreen', {
-                  mode: 'historic',
+                  mode: 'historical',
                 })
               }
             />

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -29,9 +29,9 @@ export const TicketHistoryScreenComponent = ({
   } = useTicketingContext();
   const {serverNow} = useTimeContext();
   const {
-    fareContracts: historicFareContracts,
-    refetch: refetchHistoricFareContracts,
-  } = useFareContracts({availability: 'historic'}, serverNow);
+    fareContracts: historicalFareContracts,
+    refetch: refetchHistoricalFareContracts,
+  } = useFareContracts({availability: 'historical'}, serverNow);
 
   const {abtCustomerId: customerAccountId} = useAuthContext();
 
@@ -53,14 +53,14 @@ export const TicketHistoryScreenComponent = ({
       refreshControl={
         <RefreshControl
           refreshing={isRefreshingFareContracts}
-          onRefresh={refetchHistoricFareContracts}
+          onRefresh={refetchHistoricalFareContracts}
         />
       }
     >
       <View style={styles.container}>
         <FareContractAndReservationsList
           fareContracts={
-            mode === 'sent' ? sentFareContracts : historicFareContracts
+            mode === 'sent' ? sentFareContracts : historicalFareContracts
           }
           reservations={displayReservations(
             mode,
@@ -85,7 +85,7 @@ const displayReservations = (
   customerAccountId?: string,
 ) => {
   switch (mode) {
-    case 'historic':
+    case 'historical':
       return rejectedReservations.filter(
         (reservation) => reservation.customerAccountId === customerAccountId,
       );

--- a/src/ticket-history/types.ts
+++ b/src/ticket-history/types.ts
@@ -1,4 +1,4 @@
-export type TicketHistoryMode = 'historic' | 'sent';
+export type TicketHistoryMode = 'historical' | 'sent';
 
 export type TicketHistoryScreenParams = {
   mode: TicketHistoryMode;

--- a/src/ticketing/__tests__/get-availability-status.test.ts
+++ b/src/ticketing/__tests__/get-availability-status.test.ts
@@ -73,7 +73,7 @@ describe('getAvailabilityStatus', () => {
       new Date().getTime(),
     );
 
-    expect(availabilityStatus.availability).toEqual('historic');
+    expect(availabilityStatus.availability).toEqual('historical');
     expect(availabilityStatus.status).toEqual('refunded');
   });
 
@@ -83,7 +83,7 @@ describe('getAvailabilityStatus', () => {
       new Date().getTime(),
     );
 
-    expect(availabilityStatus.availability).toEqual('historic');
+    expect(availabilityStatus.availability).toEqual('historical');
     expect(availabilityStatus.status).toEqual('cancelled');
   });
 
@@ -124,7 +124,7 @@ describe('getAvailabilityStatus', () => {
       new Date().getTime(),
     );
 
-    expect(availabilityStatus.availability).toEqual('historic');
+    expect(availabilityStatus.availability).toEqual('historical');
     expect(availabilityStatus.status).toEqual('expired');
   });
 
@@ -261,7 +261,7 @@ describe('getAvailabilityStatus', () => {
       new Date().getTime(),
     );
 
-    expect(availabilityStatus.availability).toEqual('historic');
+    expect(availabilityStatus.availability).toEqual('historical');
     expect(availabilityStatus.status).toEqual('empty');
   });
 
@@ -279,7 +279,7 @@ describe('getAvailabilityStatus', () => {
       new Date().getTime(),
     );
 
-    expect(availabilityStatus.availability).toEqual('historic');
+    expect(availabilityStatus.availability).toEqual('historical');
     expect(availabilityStatus.status).toEqual('expired');
   });
 

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -18,6 +18,7 @@ import {
 } from './types';
 import {PreassignedFareProduct} from '@atb/configuration';
 import {convertIsoStringFieldsToDate} from '@atb/utils/date';
+import capitalize from 'lodash/capitalize';
 
 export async function listRecentFareContracts(): Promise<
   RecentFareContractBackend[]
@@ -194,9 +195,9 @@ export async function getFareProducts(): Promise<PreassignedFareProduct[]> {
 }
 
 export async function getFareContracts(
-  availability: 'Available' | 'Historical',
+  availability: 'available' | 'historical',
 ): Promise<FareContract[]> {
-  const url = `ticket/v4/list?availability=${availability}`;
+  const url = `ticket/v4/list?availability=${capitalize(availability)}`;
   const response = await client.get(url, {
     authWithIdToken: true,
   });

--- a/src/ticketing/get-availability-status.ts
+++ b/src/ticketing/get-availability-status.ts
@@ -19,11 +19,11 @@ export const getAvailabilityStatus = (
   now: number,
 ): AvailabilityStatus => {
   if (fc.state === FareContractState.Refunded) {
-    return {availability: 'historic', status: 'refunded'};
+    return {availability: 'historical', status: 'refunded'};
   }
 
   if (fc.state === FareContractState.Cancelled) {
-    return {availability: 'historic', status: 'cancelled'};
+    return {availability: 'historical', status: 'cancelled'};
   }
 
   if (fc.state === FareContractState.Unspecified) {
@@ -42,15 +42,15 @@ export const getAvailabilityStatus = (
     if (usedAccesses.some(isValid(now))) {
       return {availability: 'available', status: 'valid'};
     } else if (numberOfUsedAccesses >= maximumNumberOfAccesses) {
-      return {availability: 'historic', status: 'empty'};
+      return {availability: 'historical', status: 'empty'};
     } else if (travelRights.every(isExpired(now))) {
-      return {availability: 'historic', status: 'expired'};
+      return {availability: 'historical', status: 'expired'};
     } else {
       return {availability: 'available', status: 'upcoming'};
     }
   } else {
     if (travelRights.every(isExpired(now))) {
-      return {availability: 'historic', status: 'expired'};
+      return {availability: 'historical', status: 'expired'};
     } else if (travelRights.some(isValid(now))) {
       return {availability: 'available', status: 'valid'};
     } else {

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -272,7 +272,7 @@ export type AddPaymentMethodResponse = {
 export type AvailabilityStatus =
   | {availability: 'available'; status: 'upcoming' | 'valid'}
   | {
-      availability: 'historic';
+      availability: 'historical';
       status: 'expired' | 'empty' | 'refunded' | 'cancelled';
     }
   | {availability: 'invalid'; status: 'unspecified' | 'invalid'};

--- a/src/ticketing/use-fare-contracts.ts
+++ b/src/ticketing/use-fare-contracts.ts
@@ -62,19 +62,8 @@ const useGetFareContractsQuery = (
   const {userId} = useAuthContext();
   return useQuery({
     queryKey: ['FETCH_FARE_CONTRACTS', availability, userId],
-    queryFn: () => getFareContracts(mapAvailability(availability)),
+    queryFn: () => getFareContracts(availability),
     enabled: false,
     retry: 0,
   });
-};
-
-const mapAvailability = (
-  availability: AvailabilityStatusInput['availability'],
-) => {
-  switch (availability) {
-    case 'available':
-      return 'Available';
-    case 'historic':
-      return 'Historical';
-  }
 };

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -12,7 +12,7 @@ type TicketHistoryModeText = {
 export const TicketHistoryModeTexts: {
   [key in TicketHistoryMode]: TicketHistoryModeText;
 } = {
-  historic: {
+  historical: {
     title: _('Utløpte billetter', 'Expired tickets', 'Utgåtte billettar'),
     titleA11y: _(
       'Aktiver for å vise dine utløpte billetter',


### PR DESCRIPTION
It is a more fitting term to use historical fare contracts than
historic fare contracts.
