### PR TITLE
bugfix: able to use map area between buttons

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -308,7 +308,7 @@ export const Map = (props: MapProps) => {
         <View
           style={[
             controlStyles.mapButtonsContainer,
-            controlStyles['mapButtonsContainer--left'],
+            controlStyles.mapButtonsContainerLeft,
           ]}
         >
           {isBonusProgramEnabled &&
@@ -322,7 +322,7 @@ export const Map = (props: MapProps) => {
         <View
           style={[
             controlStyles.mapButtonsContainer,
-            controlStyles['mapButtonsContainer--right'],
+            controlStyles.mapButtonsContainerRight,
           ]}
         >
           <ExternalRealtimeMapButton onMapClick={onMapClick} />

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -305,40 +305,48 @@ export const Map = (props: MapProps) => {
             />
           )}
         </MapboxGL.MapView>
-        <View style={controlStyles.controlsContainer}>
-          <View>
-            {isBonusProgramEnabled &&
-              props.selectionMode === 'ExploreEntities' && (
-                <BonusProgramMapButton
-                  onPress={() => onMapClick({source: 'bonus-program-button'})}
-                />
-              )}
-          </View>
-
-          <View>
-            <ExternalRealtimeMapButton onMapClick={onMapClick} />
-
-            {(props.vehicles || props.stations) && (
-              <MapFilter
-                onPress={() => onMapClick({source: 'filters-button'})}
-                isLoading={
-                  (props.vehicles?.isLoading || props.stations?.isLoading) ??
-                  false
-                }
+        <View
+          style={[
+            controlStyles.mapButtonsContainer,
+            controlStyles['mapButtonsContainer--left'],
+          ]}
+        >
+          {isBonusProgramEnabled &&
+            props.selectionMode === 'ExploreEntities' && (
+              <BonusProgramMapButton
+                onPress={() => onMapClick({source: 'bonus-program-button'})}
               />
             )}
-            <PositionArrow
-              onPress={async () => {
-                const coordinates = await getCurrentCoordinates(true);
-                if (coordinates) {
-                  onMapClick({
-                    source: 'my-position',
-                    coords: coordinates,
-                  });
-                }
-              }}
+        </View>
+
+        <View
+          style={[
+            controlStyles.mapButtonsContainer,
+            controlStyles['mapButtonsContainer--right'],
+          ]}
+        >
+          <ExternalRealtimeMapButton onMapClick={onMapClick} />
+
+          {(props.vehicles || props.stations) && (
+            <MapFilter
+              onPress={() => onMapClick({source: 'filters-button'})}
+              isLoading={
+                (props.vehicles?.isLoading || props.stations?.isLoading) ??
+                false
+              }
             />
-          </View>
+          )}
+          <PositionArrow
+            onPress={async () => {
+              const coordinates = await getCurrentCoordinates(true);
+              if (coordinates) {
+                onMapClick({
+                  source: 'my-position',
+                  coords: coordinates,
+                });
+              }
+            }}
+          />
         </View>
         {isShmoDeepIntegrationEnabled && (
           <ShmoTesting selectedVehicleId={selectedFeature?.properties?.id} />

--- a/src/components/map/hooks/use-control-styles.ts
+++ b/src/components/map/hooks/use-control-styles.ts
@@ -36,11 +36,11 @@ export function useControlPositionsStyle(extraPaddingBottom = false) {
           theme.spacing.medium,
       },
 
-      'mapButtonsContainer--left': {
+      mapButtonsContainerLeft: {
         left: theme.spacing.medium,
       },
 
-      'mapButtonsContainer--right': {
+      mapButtonsContainerRight: {
         right: theme.spacing.medium,
       },
       locationContainer: {

--- a/src/components/map/hooks/use-control-styles.ts
+++ b/src/components/map/hooks/use-control-styles.ts
@@ -27,17 +27,21 @@ export function useControlPositionsStyle(extraPaddingBottom = false) {
         top: top + theme.spacing.medium,
         right: theme.spacing.medium,
       },
-      controlsContainer: {
+
+      mapButtonsContainer: {
         position: 'absolute',
-        width: '100%',
         bottom:
           (extraPaddingBottom ? bottom : 0) +
           bottomPaddingIfBottomSheetIsOpen +
           theme.spacing.medium,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'flex-end',
-        paddingHorizontal: theme.spacing.medium,
+      },
+
+      'mapButtonsContainer--left': {
+        left: theme.spacing.medium,
+      },
+
+      'mapButtonsContainer--right': {
+        right: theme.spacing.medium,
       },
       locationContainer: {
         position: 'absolute',


### PR DESCRIPTION
In the map tab:

The bug is that users are not able to use area at the bottom of the screen between the buttons (area marked with red on the screenshot).
The user can not press buttons (for example bus stops) in the area or use the area to move the map.

This is now fixed.

![image](https://github.com/user-attachments/assets/7776698a-c25c-4d7e-9e83-47bb4e7f2962)

### Acceptance Criteria

<!-- Acceptance criteria to test it and verify that the issue is solved. -->

- [ ] user can click on button (bus stop or bike stand) at the bottom of the map
- [ ] user can start moving the map at the bottom of the map
- [ ] Buttons over map (star, location, filter) are present and function as before
  - [ ] Star in bottom left when isBonusProgramEnabled is true (this button does nothing)
  - [ ] Filter and location in bottom right, with filter above location

### Test input

<!-- Things that should be tested due to code refactors or changes in the code not covered by acceptance criteria -->

- [ ] 200% Zoom
- [ ] Light and Dark mode
- [ ] Language 

