### PR TITLE
fix: Device update issue, missing keychain name

### DIFF
--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -60,4 +60,4 @@ runs:
           APPCONNECT_API_KEY_PATH: app-store-connect-api-key.json
           FASTLANE_MATCH_TYPE: ${{ inputs.app-environment }}
           MATCH_DEPLOY_KEY: ${{ inputs.match-deploy-key }}
-          KEYCHAIN_NAME: ${{ inputs.keychain_name }}
+          KEYCHAIN_NAME: ${{ inputs.keychain-name }}

--- a/scripts/ios/get_ios_certs.sh
+++ b/scripts/ios/get_ios_certs.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export KEYCHAIN_NAME=atb
 bundle exec fastlane ios get_certs


### PR DESCRIPTION
It fixes issues while running update devices due to a missing parameter in the GA.