### PR TITLE
fix: Use stopPositionInPattern instead of quay id

### DIFF
--- a/src/api/departures/types.ts
+++ b/src/api/departures/types.ts
@@ -44,6 +44,7 @@ export type DepartureTime = {
   notices?: NoticeFragment[];
   cancellation?: boolean;
   bookingArrangements?: BookingArrangementFragment;
+  stopPositionInPattern: number;
 };
 
 export type DepartureGroup = {

--- a/src/api/types/generated/DeparturesQuery.ts
+++ b/src/api/types/generated/DeparturesQuery.ts
@@ -16,6 +16,7 @@ export type DeparturesQuery = {
       realtime: boolean;
       predictionInaccurate: boolean;
       cancellation: boolean;
+      stopPositionInPattern: number;
       quay: {id: string};
       destinationDisplay?: {frontText?: string; via?: Array<string>};
       serviceJourney: {

--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -50,10 +50,12 @@ export type TripFragment = {
       fromEstimatedCall?: {
         aimedDepartureTime: any;
         expectedDepartureTime: any;
+        stopPositionInPattern: number;
         destinationDisplay?: {frontText?: string; via?: Array<string>};
         quay: {publicCode?: string; name: string};
         notices: Array<{id: string; text?: string}>;
       };
+      toEstimatedCall?: {stopPositionInPattern: number};
       situations: Array<{
         id: string;
         situationNumber?: string;

--- a/src/api/types/generated/fragments/estimated-calls.ts
+++ b/src/api/types/generated/fragments/estimated-calls.ts
@@ -15,6 +15,7 @@ export type EstimatedCallWithQuayFragment = {
   forAlighting: boolean;
   forBoarding: boolean;
   realtime: boolean;
+  stopPositionInPattern: number;
   destinationDisplay?: {frontText?: string; via?: Array<string>};
   quay: QuayFragment;
   notices: Array<NoticeFragment>;

--- a/src/api/types/generated/fragments/trips.ts
+++ b/src/api/types/generated/fragments/trips.ts
@@ -39,10 +39,12 @@ export type TripPatternFragment = {
     fromEstimatedCall?: {
       aimedDepartureTime: any;
       expectedDepartureTime: any;
+      stopPositionInPattern: number;
       destinationDisplay?: {frontText?: string; via?: Array<string>};
       quay: {publicCode?: string; name: string};
       notices: Array<NoticeFragment>;
     };
+    toEstimatedCall?: {stopPositionInPattern: number};
     situations: Array<SituationFragment>;
     fromPlace: {
       name?: string;

--- a/src/api/types/generated/journey_planner_v3_types.ts
+++ b/src/api/types/generated/journey_planner_v3_types.ts
@@ -1038,7 +1038,7 @@ export type QueryType = {
   serverInfo: ServerInfo;
   /** Get a single service journey based on its id */
   serviceJourney?: Maybe<ServiceJourney>;
-  /** Get all service journeys */
+  /** Get all _service journeys_ */
   serviceJourneys: Array<Maybe<ServiceJourney>>;
   /** Get a single situation based on its situationNumber */
   situation?: Maybe<PtSituationElement>;
@@ -2112,7 +2112,7 @@ export type TripSearchData = {
    * @deprecated Use pageCursor instead
    */
   prevDateTime?: Maybe<Scalars['DateTime']['output']>;
-  /** This is the time window used by the raptor search. The input searchWindow is an optional parameter and is dynamically assigned if not set. OTP might override the value if it is too small or too large. When paging OTP adjusts it to the appropriate size, depending on the number of itineraries found in the current search window. The scaling of the search window ensures faster paging and limits resource usage. The unit is seconds. */
+  /** This is the time window used by the raptor search. The input searchWindow is an optional parameter and is dynamically assigned if not set. OTP might override the value if it is too small or too large. When paging OTP adjusts it to the appropriate size, depending on the number of itineraries found in the current search window. The scaling of the search window ensures faster paging and limits resource usage. The unit is minutes. */
   searchWindowUsed: Scalars['Int']['output'];
 };
 

--- a/src/components/map/components/DeparturesDialogSheet.tsx
+++ b/src/components/map/components/DeparturesDialogSheet.tsx
@@ -24,8 +24,8 @@ type DeparturesDialogSheetProps = {
   navigateToDetails: (
     serviceJourneyId: string,
     serviceDate: string,
-    date?: string,
-    fromQuayId?: string,
+    date: string | undefined,
+    stopPositionInPattern: number,
     isTripCancelled?: boolean,
   ) => void;
   navigateToTripSearch: NavigateToTripSearchCallback;

--- a/src/components/map/components/DeparturesDialogSheet.tsx
+++ b/src/components/map/components/DeparturesDialogSheet.tsx
@@ -25,7 +25,7 @@ type DeparturesDialogSheetProps = {
     serviceJourneyId: string,
     serviceDate: string,
     date: string | undefined,
-    stopPositionInPattern: number,
+    fromStopPosition: number,
     isTripCancelled?: boolean,
   ) => void;
   navigateToTripSearch: NavigateToTripSearchCallback;

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -85,8 +85,8 @@ export type NavigateToQuayCallback = (place: StopPlace, quay: Quay) => void;
 export type NavigateToDetailsCallback = (
   serviceJourneyId: string,
   serviceDate: string,
-  date?: string,
-  fromQuayId?: string,
+  date: string | undefined,
+  fromStopPosition: number,
   isTripCancelled?: boolean,
 ) => void;
 

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -75,7 +75,7 @@ export function LineItem({
   const items = group.departures.map<ServiceJourneyDeparture>((dep) => ({
     serviceJourneyId: dep.serviceJourneyId!,
     date: dep.aimedTime,
-    fromQuayId: group.lineInfo?.quayId,
+    fromStopPosition: dep.stopPositionInPattern,
     serviceDate: dep.serviceDate,
     isTripCancelled: dep.cancellation,
   }));

--- a/src/place-screen/PlaceScreenComponent.tsx
+++ b/src/place-screen/PlaceScreenComponent.tsx
@@ -90,8 +90,8 @@ export const PlaceScreenComponent = ({
   const navigateToDetails = (
     serviceJourneyId: string,
     serviceDate: string,
-    date?: string,
-    fromQuayId?: string,
+    date: string | undefined,
+    fromStopPosition: number,
     isTripCancelled?: boolean,
   ) => {
     if (!date) return;
@@ -101,7 +101,7 @@ export const PlaceScreenComponent = ({
           serviceJourneyId,
           serviceDate,
           date,
-          fromQuayId,
+          fromStopPosition,
           isTripCancelled,
         },
       ],

--- a/src/place-screen/components/EstimatedCallList.tsx
+++ b/src/place-screen/components/EstimatedCallList.tsx
@@ -73,7 +73,7 @@ export const EstimatedCallList = ({
       departure.serviceJourney.id,
       departure.date,
       departure.aimedDepartureTime,
-      departure.quay.id,
+      departure.stopPositionInPattern,
       departure.cancellation,
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/place-screen/components/QuaySection.tsx
+++ b/src/place-screen/components/QuaySection.tsx
@@ -33,8 +33,8 @@ export type QuaySectionProps = {
   navigateToDetails?: (
     serviceJourneyId: string,
     serviceDate: string,
-    date?: string,
-    fromQuayId?: string,
+    date: string | undefined,
+    fromStopPosition: number,
     isCancelled?: boolean,
   ) => void;
   showOnlyFavorites: boolean;

--- a/src/place-screen/components/QuayView.tsx
+++ b/src/place-screen/components/QuayView.tsx
@@ -21,8 +21,8 @@ export type QuayViewProps = {
   navigateToDetails?: (
     serviceJourneyId: string,
     serviceDate: string,
-    date?: string,
-    fromQuayId?: string,
+    date: string | undefined,
+    fromStopPosition: number,
   ) => void;
   searchTime: SearchTime;
   setSearchTime: (searchTime: SearchTime) => void;

--- a/src/place-screen/components/StopPlacesView.tsx
+++ b/src/place-screen/components/StopPlacesView.tsx
@@ -27,8 +27,8 @@ type Props = {
   navigateToDetails?: (
     serviceJourneyId: string,
     serviceDate: string,
-    date?: string,
-    fromQuayId?: string,
+    date: string | undefined,
+    fromStopPosition: number,
   ) => void;
   searchTime: SearchTime;
   setSearchTime: (searchTime: SearchTime) => void;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
@@ -36,8 +36,8 @@ export const Map_RootScreen = ({
   const navigateToDetails = (
     serviceJourneyId: string,
     serviceDate: string,
-    date?: string,
-    fromQuayId?: string,
+    date: string | undefined,
+    fromStopPosition: number,
     isTripCancelled?: boolean,
   ) => {
     if (!serviceJourneyId || !date) return;
@@ -47,7 +47,7 @@ export const Map_RootScreen = ({
           serviceJourneyId,
           serviceDate,
           date,
-          fromQuayId,
+          fromStopPosition,
           isTripCancelled,
         },
       ],

--- a/src/travel-aid/TravelAidScreenComponent.tsx
+++ b/src/travel-aid/TravelAidScreenComponent.tsx
@@ -135,7 +135,7 @@ export const TravelAidScreenComponent = ({
                 ...serviceJourney,
                 estimatedCalls,
               }}
-              fromQuayId={serviceJourneyDeparture.fromQuayId}
+              fromStopPosition={serviceJourneyDeparture.fromStopPosition}
               focusRef={focusRef}
               sendStopSignal={stopSignalMutation.mutate}
               sendStopSignalStatus={sendStopSignalStatus}
@@ -148,13 +148,13 @@ export const TravelAidScreenComponent = ({
 
 const TravelAidSection = ({
   serviceJourney,
-  fromQuayId,
+  fromStopPosition,
   focusRef,
   sendStopSignal,
   sendStopSignalStatus,
 }: {
   serviceJourney: ServiceJourneyWithGuaranteedCalls;
-  fromQuayId?: string;
+  fromStopPosition: number;
   focusRef: Ref<any>;
   sendStopSignal: (args: SendStopSignalRequestType) => void;
   sendStopSignalStatus: MutationStatus;
@@ -164,7 +164,7 @@ const TravelAidSection = ({
 
   const {status, focusedEstimatedCall} = getFocusedEstimatedCall(
     serviceJourney.estimatedCalls,
-    fromQuayId,
+    fromStopPosition,
   );
 
   const situationsForFocused =
@@ -174,7 +174,7 @@ const TravelAidSection = ({
   const noticesForFocused =
     getNoticesForServiceJourney(
       serviceJourney,
-      focusedEstimatedCall.quay.id,
+      focusedEstimatedCall.stopPositionInPattern,
     ).sort((n1, n2) => n1.id.localeCompare(n2.id)) ?? [];
 
   const isCancelled = focusedEstimatedCall.cancellation;
@@ -257,7 +257,7 @@ const TravelAidSection = ({
           </View>
           <StopSignalButton
             serviceJourney={serviceJourney}
-            fromQuayId={fromQuayId}
+            fromStopPosition={fromStopPosition}
             onPress={sendStopSignal}
             status={sendStopSignalStatus}
           />

--- a/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
+++ b/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
@@ -21,12 +21,12 @@ const onGoingJourney: any[] = [
 ];
 describe('getFocusedEstimatedCall for ongoing journey', () => {
   it('next stop is Kattemsenteret', () => {
-    const focus = getFocusedEstimatedCall(onGoingJourney, 'NSR:Quay:102721');
+    const focus = getFocusedEstimatedCall(onGoingJourney, 0);
     expect(focus.status).toBe(TravelAidStatus.BetweenStops);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
   it('has not yet arrived at Kattemsenteret', () => {
-    const focus = getFocusedEstimatedCall(onGoingJourney, 'NSR:Quay:74027');
+    const focus = getFocusedEstimatedCall(onGoingJourney, 1);
     expect(focus.status).toBe(TravelAidStatus.NotYetArrived);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
@@ -52,7 +52,7 @@ describe('getFocusedEstimatedCall for not started journey', () => {
   it('state is not-yet-arrived', () => {
     // Set current time to five minutes before first aimedDepartureTime
     jest.useFakeTimers().setSystemTime(new Date('2024-10-18T12:10:00+02:00'));
-    const focus = getFocusedEstimatedCall(notStartedJourney, 'NSR:Quay:102721');
+    const focus = getFocusedEstimatedCall(notStartedJourney, 0);
 
     expect(focus.status).toBe(TravelAidStatus.NotYetArrived);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Østre Lund');
@@ -62,7 +62,7 @@ describe('getFocusedEstimatedCall for not started journey', () => {
     // Set current time to five minutes after first aimedDepartureTime
     jest.useFakeTimers().setSystemTime(new Date('2024-10-18T12:20:00+02:00'));
 
-    const focus = getFocusedEstimatedCall(notStartedJourney, 'NSR:Quay:102721');
+    const focus = getFocusedEstimatedCall(notStartedJourney, 0);
     expect(focus.status).toBe(TravelAidStatus.NotGettingUpdates);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Østre Lund');
   });
@@ -86,7 +86,7 @@ const endedJourney: any[] = [
 ];
 describe('getFocusedEstimatedCall for ended journey', () => {
   it('end-of-line is Kattemsenteret', () => {
-    const focus = getFocusedEstimatedCall(endedJourney, 'NSR:Quay:102721');
+    const focus = getFocusedEstimatedCall(endedJourney, 0);
     expect(focus.status).toBe(TravelAidStatus.EndOfLine);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
@@ -110,7 +110,7 @@ const noRealtimeJourney: any[] = [
 ];
 describe('getFocusedEstimatedCall for no realtime journey', () => {
   it('no realtime for Østre Lund', () => {
-    const focus = getFocusedEstimatedCall(noRealtimeJourney, 'NSR:Quay:74027');
+    const focus = getFocusedEstimatedCall(noRealtimeJourney, 1);
     expect(focus.status).toBe(TravelAidStatus.NoRealtime);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });
@@ -134,10 +134,7 @@ const arrivedButNotDepartedJourney: any[] = [
 ];
 describe('getFocusedEstimatedCall for arrived but not departed journey', () => {
   it('arrived at Kattemsenteret', () => {
-    const focus = getFocusedEstimatedCall(
-      arrivedButNotDepartedJourney,
-      'NSR:Quay:102721',
-    );
+    const focus = getFocusedEstimatedCall(arrivedButNotDepartedJourney, 0);
     expect(focus.status).toBe(TravelAidStatus.Arrived);
     expect(focus.focusedEstimatedCall.quay.name).toBe('Kattemsenteret');
   });

--- a/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
+++ b/src/travel-aid/__tests__/get-focused-estimated-call.test.ts
@@ -10,6 +10,7 @@ const onGoingJourney: any[] = [
     actualDepartureTime: '2024-10-18T12:15:14+02:00',
     realtime: true,
     quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+    stopPositionInPattern: 0,
   },
   {
     aimedDepartureTime: '2024-10-18T12:17:00+02:00',
@@ -17,6 +18,7 @@ const onGoingJourney: any[] = [
     actualDepartureTime: undefined,
     realtime: true,
     quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+    stopPositionInPattern: 1,
   },
 ];
 describe('getFocusedEstimatedCall for ongoing journey', () => {
@@ -39,6 +41,7 @@ const notStartedJourney: any[] = [
     actualDepartureTime: undefined,
     realtime: true,
     quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+    stopPositionInPattern: 0,
   },
   {
     aimedDepartureTime: '2024-10-18T12:17:00+02:00',
@@ -46,6 +49,7 @@ const notStartedJourney: any[] = [
     actualDepartureTime: undefined,
     realtime: true,
     quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+    stopPositionInPattern: 1,
   },
 ];
 describe('getFocusedEstimatedCall for not started journey', () => {
@@ -75,6 +79,7 @@ const endedJourney: any[] = [
     actualDepartureTime: '2024-10-18T12:15:14+02:00',
     realtime: true,
     quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+    stopPositionInPattern: 0,
   },
   {
     aimedDepartureTime: '2024-10-18T12:17:00+02:00',
@@ -82,6 +87,7 @@ const endedJourney: any[] = [
     actualDepartureTime: '2024-10-18T12:17:20+02:00',
     realtime: true,
     quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+    stopPositionInPattern: 1,
   },
 ];
 describe('getFocusedEstimatedCall for ended journey', () => {
@@ -99,6 +105,7 @@ const noRealtimeJourney: any[] = [
     actualDepartureTime: undefined,
     realtime: false,
     quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+    stopPositionInPattern: 0,
   },
   {
     aimedDepartureTime: '2024-10-18T12:17:00+02:00',
@@ -106,6 +113,7 @@ const noRealtimeJourney: any[] = [
     actualDepartureTime: undefined,
     realtime: false,
     quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+    stopPositionInPattern: 1,
   },
 ];
 describe('getFocusedEstimatedCall for no realtime journey', () => {
@@ -123,6 +131,7 @@ const arrivedButNotDepartedJourney: any[] = [
     actualDepartureTime: '2024-10-18T12:15:14+02:00',
     realtime: true,
     quay: {id: 'NSR:Quay:102721', name: 'Østre Lund'},
+    stopPositionInPattern: 0,
   },
   {
     aimedDepartureTime: '2024-10-18T12:17:00+02:00',
@@ -130,6 +139,7 @@ const arrivedButNotDepartedJourney: any[] = [
     actualDepartureTime: undefined,
     realtime: true,
     quay: {id: 'NSR:Quay:74027', name: 'Kattemsenteret'},
+    stopPositionInPattern: 1,
   },
 ];
 describe('getFocusedEstimatedCall for arrived but not departed journey', () => {

--- a/src/travel-aid/__tests__/sent-stop-signals-cache.test.ts
+++ b/src/travel-aid/__tests__/sent-stop-signals-cache.test.ts
@@ -10,7 +10,7 @@ describe('sentStopSignalsCache', () => {
   it('hasSent is true if existing entry with all fields equal', () => {
     const testInput = {
       serviceJourneyId: 's1',
-      fromQuayId: 'q1',
+      fromStopPosition: 4,
       serviceDate: '2025-01-01',
     };
 
@@ -26,7 +26,7 @@ describe('sentStopSignalsCache', () => {
   it('hasSent is false if no existing entry with all fields equal', () => {
     const testInput = {
       serviceJourneyId: 's1',
-      fromQuayId: 'q1',
+      fromStopPosition: 4,
       serviceDate: '2025-01-01',
     };
 
@@ -38,9 +38,9 @@ describe('sentStopSignalsCache', () => {
       sentStopSignalsCache.hasSent({...testInput, serviceDate: 's2'}),
     ).toBe(false);
 
-    expect(sentStopSignalsCache.hasSent({...testInput, fromQuayId: 'q2'})).toBe(
-      false,
-    );
+    expect(
+      sentStopSignalsCache.hasSent({...testInput, fromStopPosition: 8}),
+    ).toBe(false);
 
     expect(
       sentStopSignalsCache.hasSent({...testInput, serviceDate: '2026-01-01'}),

--- a/src/travel-aid/components/StopSignalButton.tsx
+++ b/src/travel-aid/components/StopSignalButton.tsx
@@ -20,12 +20,12 @@ import {useAnalyticsContext} from '@atb/analytics';
 
 export const StopSignalButton = ({
   serviceJourney,
-  fromQuayId,
+  fromStopPosition,
   onPress,
   status,
 }: {
   serviceJourney: ServiceJourneyWithGuaranteedCalls;
-  fromQuayId?: string;
+  fromStopPosition: number;
   onPress: (args: SendStopSignalRequestType) => void;
   status: MutationStatus;
 }) => {
@@ -38,9 +38,7 @@ export const StopSignalButton = ({
 
   if (!isTravelAidStopButtonEnabled) return null;
 
-  const selectedCall = serviceJourney.estimatedCalls.reduce((selected, cur) =>
-    cur.quay.id === fromQuayId ? cur : selected,
-  );
+  const selectedCall = serviceJourney.estimatedCalls[fromStopPosition];
 
   const shouldShow = shouldShowStopButton(serviceJourney, selectedCall, config);
   if (!shouldShow) return null;

--- a/src/travel-aid/components/StopSignalButton.tsx
+++ b/src/travel-aid/components/StopSignalButton.tsx
@@ -17,6 +17,7 @@ import type {StopSignalButtonConfigType} from '@atb-as/config-specs';
 import {isApplicableTransportMode} from '@atb/travel-aid/utils';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useAnalyticsContext} from '@atb/analytics';
+import {getCallByStopPosition} from '@atb/travel-details-screens/utils';
 
 export const StopSignalButton = ({
   serviceJourney,
@@ -38,7 +39,10 @@ export const StopSignalButton = ({
 
   if (!isTravelAidStopButtonEnabled) return null;
 
-  const selectedCall = serviceJourney.estimatedCalls[fromStopPosition];
+  const selectedCall = getCallByStopPosition(
+    serviceJourney.estimatedCalls,
+    fromStopPosition,
+  );
 
   const shouldShow = shouldShowStopButton(serviceJourney, selectedCall, config);
   if (!shouldShow) return null;

--- a/src/travel-aid/components/StopSignalButton.tsx
+++ b/src/travel-aid/components/StopSignalButton.tsx
@@ -17,7 +17,6 @@ import type {StopSignalButtonConfigType} from '@atb-as/config-specs';
 import {isApplicableTransportMode} from '@atb/travel-aid/utils';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useAnalyticsContext} from '@atb/analytics';
-import {getCallByStopPosition} from '@atb/travel-details-screens/utils';
 
 export const StopSignalButton = ({
   serviceJourney,
@@ -39,10 +38,10 @@ export const StopSignalButton = ({
 
   if (!isTravelAidStopButtonEnabled) return null;
 
-  const selectedCall = getCallByStopPosition(
-    serviceJourney.estimatedCalls,
-    fromStopPosition,
-  );
+  const selectedCall =
+    serviceJourney.estimatedCalls.find(
+      (c) => c.stopPositionInPattern === fromStopPosition,
+    ) || serviceJourney.estimatedCalls[0];
 
   const shouldShow = shouldShowStopButton(serviceJourney, selectedCall, config);
   if (!shouldShow) return null;

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -1,5 +1,6 @@
 import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
 import {minutesBetween} from '@atb/utils/date';
+import {getCallByStopPosition} from '@atb/travel-details-screens/utils';
 
 export enum TravelAidStatus {
   /** Not yet arrived at the selected stop */
@@ -25,7 +26,7 @@ export const getFocusedEstimatedCall = (
   estimatedCalls: EstimatedCallWithQuayFragment[],
   fromStopPosition: number,
 ): FocusedEstimatedCallState => {
-  const selectedCall = estimatedCalls[fromStopPosition];
+  const selectedCall = getCallByStopPosition(estimatedCalls, fromStopPosition);
 
   let previousOrCurrentCallIndex = -1;
   estimatedCalls.forEach((estimatedCall, index) => {

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -23,15 +23,9 @@ export type FocusedEstimatedCallState = {
 
 export const getFocusedEstimatedCall = (
   estimatedCalls: EstimatedCallWithQuayFragment[],
-  fromQuayId?: string,
+  fromStopPosition: number,
 ): FocusedEstimatedCallState => {
-  const selectedCallIndex = estimatedCalls.findIndex(
-    // TODO: This can be wrong if there are multiple stops on the same quay
-    (estimatedCall) => estimatedCall.quay?.id === fromQuayId,
-  );
-
-  const selectedCall: EstimatedCallWithQuayFragment =
-    estimatedCalls[selectedCallIndex] ?? estimatedCalls[0];
+  const selectedCall = estimatedCalls[fromStopPosition];
 
   let previousOrCurrentCallIndex = -1;
   estimatedCalls.forEach((estimatedCall, index) => {
@@ -56,7 +50,7 @@ export const getFocusedEstimatedCall = (
   // Data on service journey progress
   if (previousOrCurrentCall) {
     // Has not yet arrived at the selected stop
-    if (selectedCallIndex > previousOrCurrentCallIndex) {
+    if (fromStopPosition > previousOrCurrentCall.stopPositionInPattern) {
       return {
         status: TravelAidStatus.NotYetArrived,
         focusedEstimatedCall: selectedCall,

--- a/src/travel-aid/get-focused-estimated-call.ts
+++ b/src/travel-aid/get-focused-estimated-call.ts
@@ -1,6 +1,5 @@
 import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
 import {minutesBetween} from '@atb/utils/date';
-import {getCallByStopPosition} from '@atb/travel-details-screens/utils';
 
 export enum TravelAidStatus {
   /** Not yet arrived at the selected stop */
@@ -26,7 +25,9 @@ export const getFocusedEstimatedCall = (
   estimatedCalls: EstimatedCallWithQuayFragment[],
   fromStopPosition: number,
 ): FocusedEstimatedCallState => {
-  const selectedCall = getCallByStopPosition(estimatedCalls, fromStopPosition);
+  const selectedCall =
+    estimatedCalls.find((c) => c.stopPositionInPattern === fromStopPosition) ||
+    estimatedCalls[0];
 
   let previousOrCurrentCallIndex = -1;
   estimatedCalls.forEach((estimatedCall, index) => {

--- a/src/travel-aid/sent-stop-signals-cache.ts
+++ b/src/travel-aid/sent-stop-signals-cache.ts
@@ -4,7 +4,7 @@ import type {ServiceJourneyDeparture} from '@atb/travel-details-screens/types';
 
 type ServiceJourneyDepartureRelevantFields = Pick<
   ServiceJourneyDeparture,
-  'serviceJourneyId' | 'fromQuayId' | 'serviceDate'
+  'serviceJourneyId' | 'fromStopPosition' | 'serviceDate'
 >;
 
 const addSentStopSignal =
@@ -19,7 +19,7 @@ const hasSentStopSignal =
     sentStopSignals.some((sc) => isEqual(sc, pickFields(departure)));
 
 const pickFields = (departure: ServiceJourneyDepartureRelevantFields) =>
-  pick(departure, 'serviceJourneyId', 'fromQuayId', 'serviceDate');
+  pick(departure, 'serviceJourneyId', 'fromStopPosition', 'serviceDate');
 
 /**
  * An in-memory cache of sent stop signals. The sent stop signals are only

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -59,7 +59,6 @@ import {useFirestoreConfigurationContext} from '@atb/configuration';
 import {canSellTicketsForSubMode} from '@atb/operator-config';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {
-  getCallByStopPosition,
   getBookingStatus,
   getLineAndTimeA11yLabel,
   getShouldShowLiveVehicle,
@@ -123,17 +122,12 @@ export const DepartureDetailsScreenComponent = ({
     isLoading,
   ] = useDepartureData(activeItem, 20);
 
-  const fromCall = getCallByStopPosition(
-    estimatedCallsWithMetadata,
-    activeItem.fromStopPosition,
+  const fromCall = estimatedCallsWithMetadata.find(
+    (c) => c.stopPositionInPattern === activeItem.fromStopPosition,
   );
-  const toCall =
-    activeItem.toStopPosition !== undefined
-      ? getCallByStopPosition(
-          estimatedCallsWithMetadata,
-          activeItem.toStopPosition,
-        )
-      : undefined;
+  const toCall = estimatedCallsWithMetadata.find(
+    (c) => c.stopPositionInPattern === activeItem.toStopPosition,
+  );
 
   const mapData = useMapData(
     activeItem.serviceJourneyId,

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -59,6 +59,7 @@ import {useFirestoreConfigurationContext} from '@atb/configuration';
 import {canSellTicketsForSubMode} from '@atb/operator-config';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {
+  getCallByStopPosition,
   getBookingStatus,
   getLineAndTimeA11yLabel,
   getShouldShowLiveVehicle,
@@ -122,10 +123,16 @@ export const DepartureDetailsScreenComponent = ({
     isLoading,
   ] = useDepartureData(activeItem, 20);
 
-  const fromCall = estimatedCallsWithMetadata.at(activeItem.fromStopPosition);
+  const fromCall = getCallByStopPosition(
+    estimatedCallsWithMetadata,
+    activeItem.fromStopPosition,
+  );
   const toCall =
     activeItem.toStopPosition !== undefined
-      ? estimatedCallsWithMetadata[activeItem.toStopPosition]
+      ? getCallByStopPosition(
+          estimatedCallsWithMetadata,
+          activeItem.toStopPosition,
+        )
       : undefined;
 
   const mapData = useMapData(

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -392,8 +392,8 @@ const IntermediateInfo = ({
         serviceJourneyId: leg.serviceJourney.id,
         date: leg.expectedStartTime,
         serviceDate: leg.intermediateEstimatedCalls[0].date,
-        fromQuayId: leg.fromPlace.quay?.id,
-        toQuayId: leg.toPlace.quay?.id,
+        fromStopPosition: leg.fromEstimatedCall?.stopPositionInPattern || 0,
+        toStopPosition: leg.toEstimatedCall?.stopPositionInPattern,
       };
       onPressDeparture([departureData], 0);
     }

--- a/src/travel-details-screens/types.ts
+++ b/src/travel-details-screens/types.ts
@@ -4,8 +4,8 @@ export type ServiceJourneyDeparture = {
   serviceJourneyId: string;
   date: string;
   serviceDate: string;
-  fromQuayId?: string;
-  toQuayId?: string;
+  fromStopPosition: number;
+  toStopPosition?: number;
   isTripCancelled?: boolean;
 };
 

--- a/src/travel-details-screens/use-departure-data.ts
+++ b/src/travel-details-screens/use-departure-data.ts
@@ -52,8 +52,8 @@ export function useDepartureData(
       );
       const estimatedCallsWithMetadata = addMetadataToEstimatedCalls(
         serviceJourney.estimatedCalls || [],
-        activeItem.fromQuayId,
-        activeItem.toQuayId,
+        activeItem.fromStopPosition,
+        activeItem.toStopPosition,
       );
 
       const focusedEstimatedCall = estimatedCallsWithMetadata.find(
@@ -68,7 +68,7 @@ export function useDepartureData(
       )}`;
       const notices = getNoticesForServiceJourney(
         serviceJourney,
-        activeItem.fromQuayId,
+        activeItem.fromStopPosition,
       );
 
       const situations = focusedEstimatedCall.situations.sort((n1, n2) =>
@@ -105,15 +105,15 @@ export function useDepartureData(
 
 function addMetadataToEstimatedCalls(
   estimatedCalls: EstimatedCallWithQuayFragment[],
-  fromQuayId?: string,
-  toQuayId?: string,
+  fromStopPosition: number,
+  toStopPosition?: number,
 ): EstimatedCallWithMetadata[] {
   let currentGroup: EstimatedCallMetadata['group'] = 'passed';
 
   return estimatedCalls.reduce<EstimatedCallWithMetadata[]>(
     (calls, currentCall, index) => {
       const previousCall = calls[calls.length - 1];
-      if (currentCall.quay?.id === fromQuayId) {
+      if (currentCall.stopPositionInPattern === fromStopPosition) {
         if (previousCall) previousCall.metadata.isEndOfGroup = true;
         currentGroup = 'trip';
       }
@@ -126,7 +126,7 @@ function addMetadataToEstimatedCalls(
         isEndOfGroup: index === estimatedCalls.length - 1,
       };
 
-      if (currentCall.quay?.id === toQuayId) {
+      if (currentCall.stopPositionInPattern === toStopPosition) {
         metadata.isEndOfGroup = true;
         currentGroup = 'after';
       }

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -56,6 +56,13 @@ export function getTimeRepresentationType({
     : 'significant-difference';
 }
 
+export const getCallByStopPosition = <
+  T extends Pick<EstimatedCall, 'stopPositionInPattern'>,
+>(
+  calls: T[],
+  stopPosition: number,
+): T => calls.find((c) => c.stopPositionInPattern === stopPosition) || calls[0];
+
 export const getNoticesForLeg = (leg: Leg) =>
   filterNotices([
     ...(leg.line?.notices || []),
@@ -69,7 +76,8 @@ export const getNoticesForServiceJourney = (
   fromStopPosition: number,
 ) => {
   const focusedEstimatedCall =
-    serviceJourney.estimatedCalls?.[fromStopPosition];
+    serviceJourney.estimatedCalls &&
+    getCallByStopPosition(serviceJourney.estimatedCalls, fromStopPosition);
 
   return filterNotices([
     ...serviceJourney.notices,

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -66,12 +66,10 @@ export const getNoticesForLeg = (leg: Leg) =>
 
 export const getNoticesForServiceJourney = (
   serviceJourney: ServiceJourneyWithEstCallsFragment,
-  fromQuayId?: string,
+  fromStopPosition: number,
 ) => {
   const focusedEstimatedCall =
-    serviceJourney.estimatedCalls?.find(
-      ({quay}) => quay?.id && quay.id === fromQuayId,
-    ) || serviceJourney.estimatedCalls?.[0];
+    serviceJourney.estimatedCalls?.[fromStopPosition];
 
   return filterNotices([
     ...serviceJourney.notices,

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -56,13 +56,6 @@ export function getTimeRepresentationType({
     : 'significant-difference';
 }
 
-export const getCallByStopPosition = <
-  T extends Pick<EstimatedCall, 'stopPositionInPattern'>,
->(
-  calls: T[],
-  stopPosition: number,
-): T => calls.find((c) => c.stopPositionInPattern === stopPosition) || calls[0];
-
 export const getNoticesForLeg = (leg: Leg) =>
   filterNotices([
     ...(leg.line?.notices || []),
@@ -75,9 +68,9 @@ export const getNoticesForServiceJourney = (
   serviceJourney: ServiceJourneyWithEstCallsFragment,
   fromStopPosition: number,
 ) => {
-  const focusedEstimatedCall =
-    serviceJourney.estimatedCalls &&
-    getCallByStopPosition(serviceJourney.estimatedCalls, fromStopPosition);
+  const focusedEstimatedCall = serviceJourney.estimatedCalls?.find(
+    (c) => c.stopPositionInPattern === fromStopPosition,
+  );
 
   return filterNotices([
     ...serviceJourney.notices,


### PR DESCRIPTION
Quay id doesn't uniquely identify a call in a service journey when
the service journeys visits the same quay twice. This change starts
using stopPositionInPattern to identify uniquely a call in a service
journey, as advices by Entur.
