### PR TITLE
chore: bump theme to 13.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^5.2.0",
     "@atb-as/generate-assets": "^14.0.1",
-    "@atb-as/theme": "^13.1.1",
+    "@atb-as/theme": "^13.1.2",
     "@bugsnag/react-native": "^7.25.0",
     "@bugsnag/source-maps": "^2.3.3",
     "@entur-private/abt-mobile-barcode-javascript-lib": "2.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,15 @@
     hex-to-rgba "^2.0.1"
     ts-deepmerge "^4.0.0"
 
+"@atb-as/theme@^13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@atb-as/theme/-/theme-13.1.2.tgz#dd43e635fb894781c0b1d66762811f3a2aefad96"
+  integrity sha512-Id882xWREp7gZbaFeGhxCSonNdo3hsjEbUaMG9wLLQPSLI8nK54xG8Fe9jFsprlWNR4l+HYFSF//W4ZaF1dJFQ==
+  dependencies:
+    "@tfk-samf/figma-to-dtcg" "0.4.0"
+    hex-to-rgba "^2.0.1"
+    ts-deepmerge "^4.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"


### PR DESCRIPTION
Makes the VM shuttle bus color blue instead of white in dark mode:

<img width="300px" src="https://github.com/user-attachments/assets/0f56320f-014b-41a0-8870-254252ae5a8a">

closes https://github.com/AtB-AS/kundevendt/issues/19401