### PR TITLE
feat: markdown renderer handles numbered lists

### DIFF
--- a/src/components/text/markdown-renderer.tsx
+++ b/src/components/text/markdown-renderer.tsx
@@ -102,8 +102,21 @@ function renderToken(
                 paddingTop: props.spacingBetweenListElements ?? 0,
               }}
             >
-              <Text {...props.textProps}>{'\u2022 '}</Text>
-              <Text {...props.textProps}>{item.text}</Text>
+              <Text {...props.textProps}>
+                {token.ordered ? `${itemIndex + 1}. ` : '\u2022 '}
+              </Text>
+              <Text
+                {...props.textProps}
+                style={[
+                  props.textProps?.style,
+                  {
+                    flex: 1,
+                    flexWrap: 'wrap',
+                  },
+                ]}
+              >
+                {item.text}
+              </Text>
             </View>
           ))}
         </React.Fragment>


### PR DESCRIPTION
markdown-renderer can now display numbered (ordered) lists.

Needed for https://github.com/AtB-AS/kundevendt/issues/19831
PR https://github.com/AtB-AS/mittatb-app/pull/4936 should be merged first to see it in use.

<img width="400" src="https://github.com/user-attachments/assets/f40d58c0-8ad0-4d2c-a5cc-736534aac059"/>