### PR TITLE
fix: intecom update token metadata not working as intended

### DIFF
--- a/src/chat/use-intercom-metadata.ts
+++ b/src/chat/use-intercom-metadata.ts
@@ -4,6 +4,7 @@ import {PermissionStatus} from 'react-native-permissions';
 import pickBy from 'lodash.pickby';
 import {useRemoteConfigContext} from '@atb/RemoteConfigContext';
 import {useCallback} from 'react';
+import {IntercomTokenStatus} from '@atb/mobile-token/types';
 
 type Metadata = {
   'AtB-Firebase-Auth-Id': string;
@@ -17,7 +18,7 @@ type Metadata = {
   'AtB-OS-Font-Scale': number;
   'AtB-Screen-Size': string;
   'AtB-Mobile-Token-Id': string;
-  'AtB-Mobile-Token-Status': 'attested' | 'non-attested' | 'error';
+  'AtB-Mobile-Token-Status': IntercomTokenStatus;
   'AtB-Mobile-Token-Error-Correlation-Id': string;
   'AtB-Beta-TripSearch': string;
 };

--- a/src/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/mobile-token/hooks/use-load-native-token-query.tsx
@@ -17,7 +17,7 @@ export const LOAD_NATIVE_TOKEN_QUERY_KEY = 'loadNativeToken';
 export const useLoadNativeTokenQuery = (
   enabled: boolean,
   userId: string | undefined,
-  traceId: string
+  traceId: string,
 ) => {
   return useQuery({
     queryKey: [MOBILE_TOKEN_QUERY_KEY, LOAD_NATIVE_TOKEN_QUERY_KEY, userId],

--- a/src/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/mobile-token/hooks/use-load-native-token-query.tsx
@@ -4,13 +4,11 @@ import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
 import {mobileTokenClient} from '@atb/mobile-token/mobileTokenClient';
 import {tokenService} from '@atb/mobile-token/tokenService';
 import {TokenMustBeRenewedRemoteTokenStateError} from '@entur-private/abt-token-server-javascript-interface';
-import {v4 as uuid} from 'uuid';
 import {
   getSdkErrorHandlingStrategy,
   getSdkErrorTokenIds,
   MOBILE_TOKEN_QUERY_KEY,
 } from '../utils';
-import {useIntercomMetadata} from '@atb/chat/use-intercom-metadata';
 import {logToBugsnag} from '@atb/utils/bugsnag-utils';
 import {wipeToken} from '@atb/mobile-token/helpers';
 import Bugsnag from '@bugsnag/react-native';
@@ -19,29 +17,15 @@ export const LOAD_NATIVE_TOKEN_QUERY_KEY = 'loadNativeToken';
 export const useLoadNativeTokenQuery = (
   enabled: boolean,
   userId: string | undefined,
+  traceId: string
 ) => {
-  const {updateMetadata} = useIntercomMetadata();
-
   return useQuery({
     queryKey: [MOBILE_TOKEN_QUERY_KEY, LOAD_NATIVE_TOKEN_QUERY_KEY, userId],
     queryFn: async () => {
-      const traceId = uuid();
       try {
         const token = await loadNativeToken(userId!, traceId);
-        updateMetadata({
-          'AtB-Mobile-Token-Id': token.tokenId,
-          'AtB-Mobile-Token-Status': token.isAttested()
-            ? 'attested'
-            : 'non-attested',
-          'AtB-Mobile-Token-Error-Correlation-Id': undefined,
-        });
         return token;
       } catch (err: any) {
-        updateMetadata({
-          'AtB-Mobile-Token-Id': undefined,
-          'AtB-Mobile-Token-Status': 'error',
-          'AtB-Mobile-Token-Error-Correlation-Id': traceId,
-        });
         logError(err, traceId);
         throw err;
       }

--- a/src/mobile-token/types.ts
+++ b/src/mobile-token/types.ts
@@ -100,3 +100,8 @@ export type MobileTokenStatus =
   | 'staticQr'
   | 'error'
   | 'fallback';
+
+export type IntercomTokenStatus = 
+  | 'attested'
+  | 'non-attested'
+  | 'error'

--- a/src/mobile-token/types.ts
+++ b/src/mobile-token/types.ts
@@ -101,7 +101,4 @@ export type MobileTokenStatus =
   | 'error'
   | 'fallback';
 
-export type IntercomTokenStatus = 
-  | 'attested'
-  | 'non-attested'
-  | 'error'
+export type IntercomTokenStatus = 'attested' | 'non-attested' | 'error';


### PR DESCRIPTION
This fixes the issue with intercom update metadata logging, right now, the metadata for token is only updated when the user changes (login/logout), while what we want is to update it everytime the token status gets updated (renewal, error, creation, etc.).

In general:
- `updateMetadata()` is now a part of `MobileTokenContext`, with similar trigger to the ones in `GeolocationContext`.
- load native token query no longer calls the `updateMetadata()`.
- added a type for intercom token metadata (`attested | non-attested | error`).