### PR TITLE
feat: Border radius circle on buttons

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -140,10 +140,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
         borderColor: borderColor,
         paddingHorizontal: spacing,
         paddingVertical: type === 'small' ? theme.spacing.xSmall : spacing,
-        borderRadius:
-          type === 'small'
-            ? theme.border.radius.large
-            : theme.border.radius.regular,
+        borderRadius: theme.border.radius.circle,
         ...(expanded && type === 'small'
           ? {
               justifyContent: 'center',


### PR DESCRIPTION
### Background
Design has decided to make buttons in the app fully rounded. As this change is really quick and pretty risk free (as there are no functional changes), it is being done as a "quick issue".

This issue fixes point 1 and 2 described here:
https://github.com/AtB-AS/kundevendt/issues/19773

### Solution
Just set button border radius to circle.

Some pictures from the app after this change:
![Screenshot 2025-01-20 at 11 08 04](https://github.com/user-attachments/assets/0957a3eb-012d-4f2d-99ef-804096a7c094)
![Screenshot 2025-01-20 at 11 08 13](https://github.com/user-attachments/assets/8ea7fd71-09f1-499e-9864-a4de0240198d)
![Screenshot 2025-01-20 at 11 08 25](https://github.com/user-attachments/assets/37b82133-01d1-4504-aa4e-cffdd698e975)
![Screenshot 2025-01-20 at 11 08 31](https://github.com/user-attachments/assets/ddd2fd54-ed04-4847-a141-7ced194b006d)
![Screenshot 2025-01-20 at 11 08 42](https://github.com/user-attachments/assets/4cc12df4-c4bf-4723-a8ab-78b387c02a8b)


### Acceptance criteria
- [ ] Buttons around the app are rounded