### PR TITLE
refactor: use stopPositionInPattern as estimatedCall key

### DIFF
--- a/src/place-screen/components/EstimatedCallList.tsx
+++ b/src/place-screen/components/EstimatedCallList.tsx
@@ -109,10 +109,10 @@ export const EstimatedCallList = ({
 
   const keyExtractor = useCallback(
     ({departure}: EstimatedCallItemProps) =>
-      // ServiceJourney ID is not a unique key if a ServiceJourney
-      // passes by the same stop several times, (e.g. Ringen in Oslo)
-      // which is why it is used in combination with aimedDepartureTime.
-      departure.serviceJourney.id + departure.aimedDepartureTime,
+      // ServiceJourney ID is not a unique key if a ServiceJourney passes by the
+      // same stop several times, (e.g. Ringen in Oslo) which is why it is used
+      // in combination with stopPositionInPattern.
+      departure.serviceJourney.id + departure.stopPositionInPattern,
     [],
   );
 

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -473,10 +473,7 @@ function EstimatedCallRows({
     <View style={styles.estimatedCallRows}>
       {estimatedCallsToShow.map((call) => (
         <EstimatedCallRow
-          // Quay ID is not a unique key if a ServiceJourney passes by the
-          // same stop several times, (e.g. Ringen in Oslo) which is why it
-          // is used in combination with aimedDepartureTime.
-          key={`${call.quay?.id}-${call.aimedDepartureTime}`}
+          key={call.stopPositionInPattern}
           call={call}
           mode={mode}
           subMode={subMode}


### PR DESCRIPTION
Follow up to https://github.com/AtB-AS/mittatb-app/pull/4926. 

`stopPositionInPattern` is a cleaner way to differentiate estimated calls than `aimedDepartureTime`, so this refactors two places where this is applicable.

### Acceptance criteria

No functional changes

- [ ] The list of estimated calls on departures works as before
- [ ] The list of estimated calls on stop places in the map works as before
- [ ] The list of estimated calls in the adding favorites flow works as before
- [ ] The departure details screen works as before