### PR TITLE
feat: Slim border on small buttons

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -141,6 +141,10 @@ export const Button = React.forwardRef<any, ButtonProps>(
         paddingHorizontal: spacing,
         paddingVertical: type === 'small' ? theme.spacing.xSmall : spacing,
         borderRadius: theme.border.radius.circle,
+        borderWidth:
+          type === 'small'
+            ? theme.border.width.slim
+            : theme.border.width.medium,
         ...(expanded && type === 'small'
           ? {
               justifyContent: 'center',
@@ -265,11 +269,10 @@ const useTextMarginHorizontal = (
   return maxIconSize + theme.spacing.xSmall;
 };
 
-const useButtonStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+const useButtonStyle = StyleSheet.createThemeHook(() => ({
   button: {
     flexDirection: 'row',
     alignItems: 'center',
-    borderWidth: theme.border.width.medium,
   },
 }));
 


### PR DESCRIPTION
### Background
Design has decided to make border width on small buttons slim (1px). As this change is really quick and pretty risk free (as there are no functional changes), it is being done as a "quick issue".

This issue fixes point 3 described here:
https://github.com/AtB-AS/kundevendt/issues/19773

### Solution
Border width set to slim.

Before/After:
<div>
<img width=350 src="https://github.com/user-attachments/assets/bda82c3c-8502-4f5e-b319-13fdd19dfb3a" />
<img width=350 src="https://github.com/user-attachments/assets/f3254c04-46a3-4191-916a-99bd87b5c8f2" />
</div>

### Acceptance criteria
- [ ] Small buttons now have slim (1px) border. Check in Storybook.