### PR TITLE
feat: Remove button compact param

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -60,7 +60,6 @@ export type ButtonProps = {
   leftIcon?: ButtonIconProps;
   rightIcon?: ButtonIconProps;
   active?: boolean;
-  compact?: boolean;
   expanded: boolean;
   loading?: boolean;
   style?: StyleProp<ViewStyle>;
@@ -82,7 +81,6 @@ export const Button = React.forwardRef<any, ButtonProps>(
       disabled,
       active,
       loading = false,
-      compact = false,
       expanded,
       hasShadow = false,
       style,
@@ -116,7 +114,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
       }).start();
     }, [disabled, fadeAnim]);
 
-    const spacing = compact ? theme.spacing.small : theme.spacing.medium;
+    const spacing = theme.spacing.medium;
     const {background: buttonColor} =
       interactiveColor[active ? 'active' : 'default'];
 

--- a/src/components/empty-state/EmptyState.tsx
+++ b/src/components/empty-state/EmptyState.tsx
@@ -54,7 +54,6 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
           text={buttonProps.text}
           mode="primary"
           onPress={buttonProps.onPress}
-          compact={true}
           type="small"
         />
       )}

--- a/src/components/map/components/BackArrow.tsx
+++ b/src/components/map/components/BackArrow.tsx
@@ -14,7 +14,6 @@ export const BackArrow: React.FC<{onBack(): void} & AccessibilityProps> = ({
   return (
     <Button
       expanded={false}
-      compact={true}
       interactiveColor={interactiveColor}
       onPress={onBack}
       hitSlop={insets.symmetric(12, 20)}

--- a/src/components/map/components/PositionArrow.tsx
+++ b/src/components/map/components/PositionArrow.tsx
@@ -16,7 +16,6 @@ export const PositionArrow: React.FC<
   return (
     <Button
       expanded={false}
-      compact={true}
       interactiveColor={interactiveColor}
       onPress={onPress}
       hitSlop={insets.symmetric(12, 20)}

--- a/src/components/map/components/ScanButton.tsx
+++ b/src/components/map/components/ScanButton.tsx
@@ -23,7 +23,7 @@ export const ScanButton = () => {
     <Button
       expanded={false}
       style={{...styles.scanButton, bottom: mapButtonsContainer.bottom}}
-      compact={true}
+      type="small"
       interactiveColor={interactiveColor}
       accessibilityRole="button"
       onPress={() => {

--- a/src/components/map/components/bonus-program/BonusProgramMapButton.tsx
+++ b/src/components/map/components/bonus-program/BonusProgramMapButton.tsx
@@ -21,7 +21,6 @@ export const BonusProgramMapButton = ({
     <Button
       expanded={false}
       style={style.bonusProgramButton}
-      compact={true}
       interactiveColor={interactiveColor}
       accessibilityRole="button"
       onPress={() => {

--- a/src/components/map/components/external-realtime-map/ExternalRealtimeMapButton.tsx
+++ b/src/components/map/components/external-realtime-map/ExternalRealtimeMapButton.tsx
@@ -32,7 +32,7 @@ export const ExternalRealtimeMapButton = ({
     <Button
       expanded={false}
       style={style.button}
-      compact={true}
+      type="small"
       interactiveColor={interactiveColor}
       accessibilityRole="button"
       onPress={() =>

--- a/src/components/map/components/filter/MapFilter.tsx
+++ b/src/components/map/components/filter/MapFilter.tsx
@@ -18,7 +18,6 @@ export const MapFilter = ({onPress, isLoading}: MapFilterProps) => {
     <Button
       expanded={false}
       style={style.filterButton}
-      compact={true}
       interactiveColor={interactiveColor}
       accessibilityRole="button"
       onPress={() => {

--- a/src/components/map/components/mobility/ShmoTesting.tsx
+++ b/src/components/map/components/mobility/ShmoTesting.tsx
@@ -140,7 +140,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
       <Button
         expanded={false}
         style={styles.filterButton}
-        compact={true}
+        type="small"
         interactiveColor={
           initShmoOneStopBookingIsError ? destructiveColor : interactiveColor
         }
@@ -157,7 +157,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
       <Button
         expanded={false}
         style={styles.filterButton}
-        compact={true}
+        type="small"
         interactiveColor={
           sendShmoBookingEventIsError ? destructiveColor : interactiveColor
         }
@@ -174,7 +174,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
       <Button
         expanded={false}
         style={styles.filterButton}
-        compact={true}
+        type="small"
         interactiveColor={
           sendShmoBookingEventIsError ? destructiveColor : interactiveColor
         }
@@ -191,7 +191,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
       <Button
         expanded={false}
         style={styles.filterButton}
-        compact={true}
+        type="small"
         interactiveColor={
           getIdsFromQrCodeIsError ? destructiveColor : interactiveColor
         }
@@ -208,7 +208,7 @@ export const ShmoTesting = ({selectedVehicleId}: ShmoTestingProps) => {
       <Button
         expanded={false}
         style={styles.filterButton}
-        compact={true}
+        type="small"
         interactiveColor={interactiveColor}
         accessibilityRole="button"
         onPress={() => {

--- a/src/favorites/FavoriteChips.tsx
+++ b/src/favorites/FavoriteChips.tsx
@@ -119,7 +119,7 @@ export const FavoriteChips: React.FC<Props> = ({
 };
 
 const FavoriteChip: React.FC<ButtonProps> = (props) => {
-  return <Button {...props} compact={true} />;
+  return <Button {...props} type="small" />;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/place-screen/components/DateSelection.tsx
+++ b/src/place-screen/components/DateSelection.tsx
@@ -97,7 +97,7 @@ export const DateSelection = ({
             : undefined
         }
         mode="tertiary"
-        compact={true}
+        type="small"
         leftIcon={{svg: ArrowLeft}}
         disabled={disablePreviousDayNavigation}
         accessibilityHint={
@@ -117,7 +117,7 @@ export const DateSelection = ({
           ),
         )}
         accessibilityHint={t(DeparturesTexts.dateNavigation.a11yChangeDateHint)}
-        compact={true}
+        type="small"
         mode="tertiary"
         rightIcon={{svg: DateIcon}}
         testID="setDateButton"
@@ -133,7 +133,7 @@ export const DateSelection = ({
             ? t(DeparturesTexts.dateNavigation.nextDay)
             : undefined
         }
-        compact={true}
+        type="small"
         mode="tertiary"
         rightIcon={{svg: ArrowRight}}
         accessibilityHint={t(DeparturesTexts.dateNavigation.a11yNextDayHint)}

--- a/src/place-screen/components/StopPlaceAndQuaySelection.tsx
+++ b/src/place-screen/components/StopPlaceAndQuaySelection.tsx
@@ -24,7 +24,7 @@ const StopPlaceAndQuaySelection = ({
   const styles = useStyles();
   const {t} = useTranslation();
   const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[1];
+  const interactiveColor = theme.color.interactive[2];
 
   const isMissingQuays = place.quays === undefined;
 

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SendToOtherButton.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SendToOtherButton.tsx
@@ -22,7 +22,7 @@ export const SendToOtherButton = ({
       text={t(OnBehalfOfTexts.sendToOtherButton)}
       onPress={onPress}
       mode="secondary"
-      compact={true}
+      type="small"
       backgroundColor={themeColor}
       leftIcon={{svg: Add}}
     />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -351,7 +351,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 )}
                 mode="primary"
                 interactiveColor={interactiveColor}
-                compact={true}
+                type="small"
                 style={styles.searchTimeButton}
                 onPress={onSearchTimePress}
                 testID="dashboardDateTimePicker"
@@ -374,7 +374,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                     accessibilityHint={t(TripSearchTexts.filterButton.a11yHint)}
                     mode="primary"
                     interactiveColor={interactiveColor}
-                    compact={true}
+                    type="small"
                     onPress={filtersState.openBottomSheet}
                     testID="filterButton"
                     ref={filterButtonRef}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
@@ -110,7 +110,6 @@ const CityZoneBox = ({
                 expanded={false}
                 key={actionButton.id}
                 type="small"
-                compact={true}
                 interactiveColor={actionButton.interactiveColor}
                 text={actionButton.text}
                 onPress={actionButton.onPress}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -487,14 +487,6 @@ export const Profile_DesignSystemScreen = ({
                     disabled={true}
                     interactiveColor={theme.color.interactive[0]}
                   />
-                  <Button
-                    expanded={true}
-                    text="Compact"
-                    onPress={presser}
-                    mode="primary"
-                    compact={true}
-                    interactiveColor={theme.color.interactive[0]}
-                  />
                 </View>
 
                 <ThemeText
@@ -525,14 +517,6 @@ export const Profile_DesignSystemScreen = ({
                     onPress={presser}
                     mode="primary"
                     disabled={true}
-                    interactiveColor={theme.color.interactive[1]}
-                  />
-                  <Button
-                    expanded={true}
-                    text="Compact"
-                    onPress={presser}
-                    mode="primary"
-                    compact={true}
                     interactiveColor={theme.color.interactive[1]}
                   />
                 </View>
@@ -567,14 +551,6 @@ export const Profile_DesignSystemScreen = ({
                     disabled={true}
                     interactiveColor={theme.color.interactive[2]}
                   />
-                  <Button
-                    expanded={true}
-                    text="Compact"
-                    onPress={presser}
-                    mode="primary"
-                    compact={true}
-                    interactiveColor={theme.color.interactive[2]}
-                  />
                 </View>
 
                 <ThemeText
@@ -607,14 +583,6 @@ export const Profile_DesignSystemScreen = ({
                     disabled={true}
                     interactiveColor={theme.color.interactive.destructive}
                   />
-                  <Button
-                    expanded={true}
-                    text="Compact"
-                    onPress={presser}
-                    mode="primary"
-                    compact={true}
-                    interactiveColor={theme.color.interactive.destructive}
-                  />
                 </View>
 
                 <ThemeText
@@ -644,13 +612,6 @@ export const Profile_DesignSystemScreen = ({
                     mode="secondary"
                     disabled={true}
                   />
-                  <Button
-                    expanded={true}
-                    text="Compact"
-                    onPress={presser}
-                    mode="secondary"
-                    compact={true}
-                  />
                 </View>
 
                 <ThemeText
@@ -679,13 +640,6 @@ export const Profile_DesignSystemScreen = ({
                     onPress={presser}
                     mode="tertiary"
                     disabled={true}
-                  />
-                  <Button
-                    expanded={true}
-                    text="Compact"
-                    onPress={presser}
-                    mode="tertiary"
-                    compact={true}
                   />
                 </View>
 
@@ -724,15 +678,6 @@ export const Profile_DesignSystemScreen = ({
                   />
                   <Button
                     expanded={false}
-                    text="Primary - compact"
-                    onPress={presser}
-                    mode="primary"
-                    compact={true}
-                    interactiveColor={theme.color.interactive[0]}
-                    style={{margin: 4}}
-                  />
-                  <Button
-                    expanded={false}
                     text="Secondary"
                     onPress={presser}
                     mode="secondary"
@@ -744,14 +689,6 @@ export const Profile_DesignSystemScreen = ({
                     onPress={presser}
                     mode="secondary"
                     active={true}
-                    style={{margin: 4}}
-                  />
-                  <Button
-                    expanded={false}
-                    text="Secondary - compact"
-                    onPress={presser}
-                    mode="secondary"
-                    compact={true}
                     style={{margin: 4}}
                   />
                   <Button
@@ -809,16 +746,6 @@ export const Profile_DesignSystemScreen = ({
                   />
                   <Button
                     expanded={false}
-                    text="Primary - compact"
-                    onPress={presser}
-                    mode="primary"
-                    type="small"
-                    compact={true}
-                    interactiveColor={theme.color.interactive[0]}
-                    style={{margin: 4}}
-                  />
-                  <Button
-                    expanded={false}
                     text="Secondary"
                     onPress={presser}
                     mode="secondary"
@@ -832,15 +759,6 @@ export const Profile_DesignSystemScreen = ({
                     mode="secondary"
                     type="small"
                     active={true}
-                    style={{margin: 4}}
-                  />
-                  <Button
-                    expanded={false}
-                    text="Secondary - compact"
-                    onPress={presser}
-                    mode="secondary"
-                    type="small"
-                    compact={true}
                     style={{margin: 4}}
                   />
                   <Button
@@ -976,15 +894,6 @@ export const Profile_DesignSystemScreen = ({
                   <Button
                     expanded={false}
                     onPress={presser}
-                    mode="primary"
-                    compact={true}
-                    interactiveColor={theme.color.interactive[0]}
-                    rightIcon={{svg: Delete}}
-                    style={{margin: 4}}
-                  />
-                  <Button
-                    expanded={false}
-                    onPress={presser}
                     mode="secondary"
                     rightIcon={{svg: Delete}}
                     style={{margin: 4}}
@@ -1012,7 +921,6 @@ export const Profile_DesignSystemScreen = ({
                     mode="secondary"
                     type="small"
                     expanded={false}
-                    compact={true}
                     rightIcon={{svg: Delete}}
                     style={{margin: 4}}
                   />

--- a/src/storybook/stories/Button.stories.tsx
+++ b/src/storybook/stories/Button.stories.tsx
@@ -22,7 +22,6 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
   argTypes: {
     expanded: {control: 'boolean'},
     active: {control: 'boolean'},
-    compact: {control: 'boolean'},
     disabled: {control: 'boolean'},
     loading: {control: 'boolean'},
     hasShadow: {control: 'boolean'},

--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -305,7 +305,7 @@ export const DepartureDetailsScreenComponent = ({
           style={styles.scrollView__content}
           testID="departureDetailsContentView"
         >
-          {screenReaderEnabled ? ( // Let users navigate other departures if screen reader is enabled
+          {true ? ( // Let users navigate other departures if screen reader is enabled
             activeItem ? (
               <PaginatedDetailsHeader
                 page={activeItemIndexState + 1}

--- a/src/travel-details-screens/components/PaginatedDetailsHeader.tsx
+++ b/src/travel-details-screens/components/PaginatedDetailsHeader.tsx
@@ -36,7 +36,7 @@ export const PaginatedDetailsHeader: React.FC<PaginatedDetailsHeader> = ({
           <View style={styles.buttonLeft}>
             <Button
               expanded={false}
-              compact={true}
+              type="small"
               mode="tertiary"
               disabled={!hasPrevious}
               leftIcon={{svg: ArrowLeft}}
@@ -59,7 +59,7 @@ export const PaginatedDetailsHeader: React.FC<PaginatedDetailsHeader> = ({
           <View style={styles.buttonRight}>
             <Button
               expanded={false}
-              compact={true}
+              type="small"
               mode="tertiary"
               disabled={!hasNext}
               rightIcon={{svg: ArrowRight}}
@@ -95,7 +95,8 @@ const usePaginateStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'center',
-    padding: theme.spacing.medium,
+    padding: theme.spacing.xSmall,
+    paddingBottom: theme.spacing.medium,
   },
   wrapper: {
     borderBottomWidth: theme.border.width.slim,


### PR DESCRIPTION
### Background
Design has decided to remove the compact mode for buttons. As this change is quick and pretty risk free (as there are no functional changes), it is being done as a "quick issue".

This issue fixes point 4 described here:
https://github.com/AtB-AS/kundevendt/issues/19773

### Solution
Remove the `compact` param on buttons. Buttons that previously was compact should now be small.

Some before/after pictures from the app:
<div>
<img width=350 src="https://github.com/user-attachments/assets/2c11756b-6469-40c5-b8e7-078ee4ba97b1"/>
<img width=350 src="https://github.com/user-attachments/assets/19e7e57c-9e91-457e-9865-c7f45acf2dc0"/>
</div>
<div>
<img width=350 src="https://github.com/user-attachments/assets/1bbfdc4c-936f-465c-9ccf-75b2270aabf5"/>
<img width=350 src="https://github.com/user-attachments/assets/27ae8a02-8461-44e9-8dbe-3ddefbd9534c"/>
</div>

### Acceptance criteria
- [ ] Buttons that previously was small are now rounded. If wanting to check them one-by-one, then use the changelog of this PR to see affected files. Or just look through the app and see that nothing seems weird or out of place.