### PR TITLE
fix: Active button border color mismatch

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -128,7 +128,7 @@ export const Button = React.forwardRef<any, ButtonProps>(
 
     const borderColor =
       active && mode === 'primary'
-        ? interactiveColor.default.background
+        ? interactiveColor.outline.background
         : modeData.visibleBorder
         ? textColor
         : 'transparent';


### PR DESCRIPTION
### Background
The border color on active buttons were not in sync between app and Figma. App used `interactiveColor.default` as border color, while Figma used `interactiveColor.outline`.
<img width="585" alt="Screenshot 2025-01-21 at 11 28 36" src="https://github.com/user-attachments/assets/83198855-f7ec-40fc-bb51-dcec22b09479" />

### Solution
Change border color on active buttons to `interactiveColor.outline`

Before/after:
<div>
<img width="350" src="https://github.com/user-attachments/assets/e7e885df-9c21-43ca-b6f8-6c55b3b0edfa"/>
<img width="350" src="https://github.com/user-attachments/assets/1858508b-cc91-4871-a111-ce9da67b2e2b"/>
</div>

### Acceptance criteria
- [ ] Active primary buttons now use border color from the outline contrast color in the interactive color scheme. Check by using Storybook.

