### PR TITLE
feat: Secondary active button styling

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -5,6 +5,7 @@ import React, {useRef} from 'react';
 import {
   ActivityIndicator,
   Animated,
+  type ColorValue,
   Easing,
   PressableProps,
   StyleProp,
@@ -47,7 +48,7 @@ type ButtonIconProps = {
 };
 
 type ButtonModeAwareProps =
-  | {mode?: 'primary'; interactiveColor?: InteractiveColor}
+  | {mode?: 'primary'}
   | {
       mode: Exclude<ButtonMode, 'primary'>;
       backgroundColor?: ContrastColor;
@@ -59,6 +60,7 @@ export type ButtonProps = {
   type?: ButtonType;
   leftIcon?: ButtonIconProps;
   rightIcon?: ButtonIconProps;
+  interactiveColor?: InteractiveColor;
   active?: boolean;
   expanded: boolean;
   loading?: boolean;
@@ -92,10 +94,9 @@ export const Button = React.forwardRef<any, ButtonProps>(
     const styles = useButtonStyle();
     const {theme} = useThemeContext();
 
-    const interactiveColor =
-      'interactiveColor' in props && props.interactiveColor
-        ? props.interactiveColor
-        : theme.color.interactive[0];
+    const interactiveColor = props.interactiveColor
+      ? props.interactiveColor
+      : theme.color.interactive[0];
     const backgroundColor =
       'backgroundColor' in props && props.backgroundColor
         ? props.backgroundColor
@@ -125,16 +126,23 @@ export const Button = React.forwardRef<any, ButtonProps>(
         : interactiveColor[active ? 'active' : 'default'].foreground.primary;
 
     const borderColor =
-      active && mode === 'primary'
+      active && mode !== 'tertiary'
         ? interactiveColor.outline.background
         : modeData.visibleBorder
         ? textColor
         : 'transparent';
 
+    const backgroundColorValue: ColorValue =
+      active && mode !== 'tertiary'
+        ? buttonColor
+        : modeData.withBackground
+        ? buttonColor
+        : 'transparent';
+
     const styleContainer: ViewStyle[] = [
       styles.button,
       {
-        backgroundColor: modeData.withBackground ? buttonColor : 'transparent',
+        backgroundColor: backgroundColorValue,
         borderColor: borderColor,
         paddingHorizontal: spacing,
         paddingVertical: type === 'small' ? theme.spacing.xSmall : spacing,

--- a/src/storybook/stories/Button.stories.tsx
+++ b/src/storybook/stories/Button.stories.tsx
@@ -82,6 +82,7 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
             args={{
               ...args,
               mode: 'secondary',
+              interactiveColor: storyInteractiveColor,
               backgroundColor: storyContrastColor,
             }}
           />
@@ -90,6 +91,7 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
               ...args,
               mode: 'secondary',
               leftIcon: {svg: Add},
+              interactiveColor: storyInteractiveColor,
               backgroundColor: storyContrastColor,
             }}
           />
@@ -98,6 +100,7 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
               ...args,
               mode: 'secondary',
               rightIcon: {svg: Add},
+              interactiveColor: storyInteractiveColor,
               backgroundColor: storyContrastColor,
             }}
           />
@@ -105,6 +108,7 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
             args={{
               ...args,
               mode: 'tertiary',
+              interactiveColor: storyInteractiveColor,
               backgroundColor: storyContrastColor,
             }}
           />
@@ -113,6 +117,7 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
               ...args,
               mode: 'tertiary',
               leftIcon: {svg: Add},
+              interactiveColor: storyInteractiveColor,
               backgroundColor: storyContrastColor,
             }}
           />
@@ -121,6 +126,7 @@ const ButtonMeta: Meta<ButtonMetaProps> = {
               ...args,
               mode: 'tertiary',
               rightIcon: {svg: Add},
+              interactiveColor: storyInteractiveColor,
               backgroundColor: storyContrastColor,
             }}
           />


### PR DESCRIPTION
Active buttons with type secondary had no styling representing the
active state. This was not inline with Figma were active buttons
look the same both in primary and secondary mode.
