### PR TITLE
fix: width of markdown rendering + ToggleSectionItem

### DIFF
--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -77,7 +77,7 @@ export function ToggleSectionItem({
         {leftImage && (
           <View style={styles.leftImageContainer}>{leftImage}</View>
         )}
-        <View style={{flexDirection: 'column', flex: 1}}>
+        <View style={styles.contentContainer}>
           <View style={sectionStyle.spaceBetween}>
             <View style={styles.textContainer}>
               <ThemeText typography={textType}>{text}</ThemeText>
@@ -97,7 +97,6 @@ export function ToggleSectionItem({
             <ThemeText
               typography="body__secondary"
               color="secondary"
-              style={styles.subtext}
               isMarkdown={isSubtextMarkdown}
             >
               {subtext}
@@ -114,9 +113,10 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     marginRight: theme.spacing.small,
     justifyContent: 'center',
   },
-  textContainer: {flex: 1, marginRight: theme.spacing.small},
-  subtext: {
-    marginTop: theme.spacing.xSmall,
-    marginRight: theme.spacing.xSmall,
+  contentContainer: {
+    flexDirection: 'column',
+    flex: 1,
+    gap: theme.spacing.small,
   },
+  textContainer: {flex: 1, marginRight: theme.spacing.small},
 }));

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -82,7 +82,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   // If markdown is enabled, we need to wrap the content in a <View></View> to properly align the <Text></Text> elements,
   // by doing this we also avoid to wrap the list elements inside the markdown render in a Text component, which is not allowed.
   if (isMarkdown) {
-    return <View>{content}</View>;
+    return <View style={{flex: 1}}>{content}</View>;
   }
 
   return <Text {...textProps}>{content}</Text>;

--- a/src/storybook/stories/Section.stories.tsx
+++ b/src/storybook/stories/Section.stories.tsx
@@ -32,6 +32,8 @@ import {
   ThemedStoryProps,
 } from '@atb/storybook/ThemedStoryDecorator';
 import {ThemeText} from '@atb/components/text';
+import {Warning} from '@atb/assets/svg/mono-icons/status';
+import {ThemeIcon} from '@atb/components/theme-icon';
 
 type SectionMetaProps = ThemedStoryProps<SectionProps>;
 const containerSizingType: ContainerSizingType[] = ['block', 'spacious'];
@@ -139,6 +141,13 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
                 <TextInputSectionItem label="TextInputSectionItem" />
                 <ToggleSectionItem
                   text="ToggleSectionItem"
+                  onValueChange={() => {}}
+                />
+                <ToggleSectionItem
+                  leftImage={<ThemeIcon svg={Warning} />}
+                  text="ToggleSectionItem"
+                  isSubtextMarkdown={true}
+                  subtext={`1. This is a list \n 2. made with markdown`}
                   onValueChange={() => {}}
                 />
                 <DateInputSectionItem


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/19831
Fixes bug: https://github.com/AtB-AS/mittatb-app/pull/4938#issuecomment-2604148912

### Fixes so markdown ThemeText fills entire width

before: 
<img width="200" src="https://github.com/user-attachments/assets/979f0daa-7384-4c60-9c91-51a77f7e4498">

after:
<img width="200" src="https://github.com/user-attachments/assets/35eeb64d-5b21-4010-ab2c-61e67b1b266c">



### Also removes special margins on ToggleSectionItems
More accurate with design system, subtle change
before:
<img width="200" src="https://github.com/user-attachments/assets/818a062b-9e32-4cd1-9587-02627ae5dd34">

after:
<img width="200" src="https://github.com/user-attachments/assets/07f0a779-f437-4862-946a-3f0bc762ec21">
