### PR TITLE
fix: realtime text

### DIFF
--- a/src/translations/screens/subscreens/DepartureDetails.ts
+++ b/src/translations/screens/subscreens/DepartureDetails.ts
@@ -22,14 +22,7 @@ const DepartureDetailsTexts = {
       `Passed ${stopPlaceName} at ${time}`,
       `Passerte ${stopPlaceName} kl. ${time}`,
     ),
-  noPassedStop: (stopPlaceName: string, time: string) =>
-    _(
-      `Kjører fra ${stopPlaceName} kl. ${time}`,
-      `Departs from ${stopPlaceName} at ${time}`,
-      `Køyrer frå ${stopPlaceName} kl. ${time}`,
-    ),
-  onTime: _(`I rute`, `On time`, `I rute`),
-  notOnTime: _(`Etter rutetid`, `Behind scheduled time`, `Etter rutetid`),
+
   live: (transportMode: string) =>
     _(
       `Følg ${transportMode.toLowerCase()}`,

--- a/src/travel-details-screens/use-realtime-text.ts
+++ b/src/travel-details-screens/use-realtime-text.ts
@@ -1,7 +1,6 @@
 import {usePreferencesContext} from '@atb/preferences';
 import {DepartureDetailsTexts, useTranslation} from '@atb/translations';
-import {formatToClock, isInThePast} from '@atb/utils/date';
-import {getTimeRepresentationType} from '@atb/travel-details-screens/utils';
+import {formatToClock} from '@atb/utils/date';
 import {ServiceJourneyEstimatedCall} from '@atb/api/types/trips';
 
 export const useRealtimeText = (
@@ -29,36 +28,5 @@ export const useRealtimeText = (
     );
   }
 
-  const firstStop = estimatedCalls[0];
-
-  if (
-    firstStop?.quay?.name &&
-    firstStop.realtime &&
-    !isInThePast(firstStop.expectedDepartureTime)
-  ) {
-    return t(
-      DepartureDetailsTexts.noPassedStop(
-        firstStop.quay.name,
-        formatToClock(
-          firstStop.expectedDepartureTime,
-          language,
-          'floor',
-          debugShowSeconds,
-        ),
-      ),
-    );
-  }
-  const timeRepType = getTimeRepresentationType({
-    missingRealTime: !firstStop?.realtime,
-    aimedTime: firstStop?.aimedDepartureTime,
-    expectedTime: firstStop?.expectedDepartureTime,
-  });
-  switch (timeRepType) {
-    case 'no-significant-difference':
-      return t(DepartureDetailsTexts.onTime);
-    case 'significant-difference':
-      return t(DepartureDetailsTexts.notOnTime);
-    default:
-      return undefined;
-  }
+  return undefined;
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18182

Shows `Passerte ${stopPlaceName} kl. ${time}` if bus is on time
![Skjermbilde 2025-01-22 kl  10 32 41](https://github.com/user-attachments/assets/29f846a0-8122-4710-8ef7-2db2996e2b48)

Otherwise nothing is shown
![Skjermbilde 2025-01-22 kl  10 34 29](https://github.com/user-attachments/assets/924911ae-2774-46de-8276-f462f6690f34)
