### PR TITLE
fix: update widget to use new favorite type

### DIFF
--- a/ios/departureWidget/Structs.swift
+++ b/ios/departureWidget/Structs.swift
@@ -336,9 +336,8 @@ struct FavouriteDeparture: Codable {
     let quayName: String
     let quayPublicCode: String?
     let quayId: String
-    let stopId: String
 
-    init(id: String, lineId: String, lineName: String?, lineLineNumber: String, lineTransportationMode: TransportMode?, lineTransportationSubMode: TransportSubMode?, quayName: String, quayPublicCode: String, quayId: String, stopId: String) {
+    init(id: String, lineId: String, lineName: String?, lineLineNumber: String, lineTransportationMode: TransportMode?, lineTransportationSubMode: TransportSubMode?, quayName: String, quayPublicCode: String, quayId: String) {
         self.id = id
         self.lineId = lineId
         self.lineName = lineName
@@ -348,7 +347,6 @@ struct FavouriteDeparture: Codable {
         self.quayName = quayName
         self.quayPublicCode = quayPublicCode
         self.quayId = quayId
-        self.stopId = stopId
     }
 
     init(from decoder: Decoder) throws {
@@ -362,7 +360,6 @@ struct FavouriteDeparture: Codable {
         quayName = try container.decode(String.self, forKey: .quayName)
         quayPublicCode = try container.decodeIfPresent(String.self, forKey: .quayPublicCode)
         quayId = try container.decode(String.self, forKey: .quayId)
-        stopId = try container.decode(String.self, forKey: .stopId)
     }
 }
 
@@ -378,8 +375,7 @@ extension FavouriteDeparture {
         lineTransportationSubMode: TransportSubMode.undefined,
         quayName: "Prinsens gate",
         quayPublicCode: "P1",
-        quayId: "NSR:Quay:71184",
-        stopId: "NSR:StopPlace:41613"
+        quayId: "NSR:Quay:71184"
     )
 }
 

--- a/ios/departureWidget/Structs.swift
+++ b/ios/departureWidget/Structs.swift
@@ -265,6 +265,7 @@ struct DepartureTime: Codable {
     let situations: [SituationElement]
     let serviceJourneyId: String
     let serviceDate: String
+    let stopPositionInPattern: Int
 }
 
 struct SituationElement: Codable {
@@ -427,7 +428,8 @@ extension DepartureGroup {
             realtime: false,
             situations: [],
             serviceJourneyId: "",
-            serviceDate: ""
+            serviceDate: "",
+            stopPositionInPattern: 0
         )
     }
   )

--- a/ios/departureWidget/WidgetViewModel.swift
+++ b/ios/departureWidget/WidgetViewModel.swift
@@ -68,7 +68,9 @@ struct WidgetViewModel {
             link.append("details")
             queryItems.append(contentsOf: [
                 URLQueryItem(name: "serviceJourneyId", value: departure.serviceJourneyId),
+                URLQueryItem(name: "date", value: toISOString(departure.aimedTime)),
                 URLQueryItem(name: "serviceDate", value: departure.serviceDate),
+                URLQueryItem(name: "fromStopPosition", value: String(departure.stopPositionInPattern)),
             ])
         }
 
@@ -139,5 +141,11 @@ struct WidgetViewModel {
         let dateformat = DateFormatter()
         dateformat.dateFormat = "HH:mm"
         return dateformat.string(from: date)
+    }
+  
+    private func toISOString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
     }
 }

--- a/src/favorites/types.ts
+++ b/src/favorites/types.ts
@@ -44,6 +44,8 @@ export type ChipTypeGroup = 'location' | 'map' | 'favorites' | 'add-favorite';
 export type StoredLocationFavorite = StoredType<LocationFavorite>;
 export type UserFavorites = StoredLocationFavorite[];
 
+// NOTE: The iOS departure widget is dependent on this type. When changing it,
+// make sure to update the widget as well.
 type FavoriteDepartureBaseIds = {
   lineId: string;
   quayId: string;
@@ -57,6 +59,8 @@ export type FavoriteDepartureId = FavoriteDepartureBaseIds & {
   destinationDisplay?: DestinationDisplay;
 };
 
+// NOTE: The iOS departure widget is dependent on this type. When changing it,
+// make sure to update the widget as well.
 type FavoriteDepartureWithoutId = {
   lineLineNumber?: string;
   lineTransportationMode?: TransportMode;

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -68,6 +68,7 @@ import {ForceUpdateScreen} from '@atb/force-update-screen';
 import {compareVersion} from '@atb/utils/compare-version';
 import {Root_ScooterHelpScreen} from './Root_ParkingViolationsReporting/Root_ScooterHelpScreen';
 import {Root_ScooterContactOperatorScreen} from './Root_ParkingViolationsReporting/Root_ScooterContactOperatorScreen';
+import {ServiceJourneyDeparture} from '@atb/travel-details-screens/types';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -127,21 +128,24 @@ export const RootStack = () => {
     ];
 
     if (path.includes('details')) {
+      const item: ServiceJourneyDeparture = {
+        serviceJourneyId: params.serviceJourneyId as string,
+        date: (params.date as string) || new Date().toISOString(),
+        serviceDate: params.serviceDate as string,
+        fromStopPosition:
+          typeof params.fromStopPosition === 'string'
+            ? parseInt(params.fromStopPosition)
+            : 0,
+        toStopPosition:
+          typeof params.toStopPosition === 'string'
+            ? parseInt(params.toStopPosition)
+            : undefined,
+      };
       destination.push({
         name: 'Departures_DepartureDetailsScreen',
         params: {
           activeItemIndex: 0,
-          items: [
-            {
-              serviceJourneyId: params.serviceJourneyId,
-              serviceDate: params.serviceDate,
-              date: (params.date as string) || new Date().toISOString(),
-              fromStopPosition:
-                typeof params.fromStopPosition === 'string'
-                  ? parseInt(params.fromStopPosition)
-                  : 0,
-            },
-          ],
+          items: [item],
         },
       });
     }

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -69,6 +69,7 @@ import {compareVersion} from '@atb/utils/compare-version';
 import {Root_ScooterHelpScreen} from './Root_ParkingViolationsReporting/Root_ScooterHelpScreen';
 import {Root_ScooterContactOperatorScreen} from './Root_ParkingViolationsReporting/Root_ScooterContactOperatorScreen';
 import {ServiceJourneyDeparture} from '@atb/travel-details-screens/types';
+import {parseParamAsInt} from './utils';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -132,14 +133,8 @@ export const RootStack = () => {
         serviceJourneyId: params.serviceJourneyId as string,
         date: (params.date as string) || new Date().toISOString(),
         serviceDate: params.serviceDate as string,
-        fromStopPosition:
-          typeof params.fromStopPosition === 'string'
-            ? parseInt(params.fromStopPosition)
-            : 0,
-        toStopPosition:
-          typeof params.toStopPosition === 'string'
-            ? parseInt(params.toStopPosition)
-            : undefined,
+        fromStopPosition: parseParamAsInt(params.fromStopPosition) || 0,
+        toStopPosition: parseParamAsInt(params.toStopPosition),
       };
       destination.push({
         name: 'Departures_DepartureDetailsScreen',

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -135,8 +135,11 @@ export const RootStack = () => {
             {
               serviceJourneyId: params.serviceJourneyId,
               serviceDate: params.serviceDate,
-              date: new Date(),
-              fromQuayId: params.quayId,
+              date: (params.date as string) || new Date().toISOString(),
+              fromStopPosition:
+                typeof params.fromStopPosition === 'string'
+                  ? parseInt(params.fromStopPosition)
+                  : 0,
             },
           ],
         },

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -77,3 +77,12 @@ export const useFilterTariffZone = (
     );
   }, [tariffZones, allowedTariffZoneRefs]);
 };
+
+/**
+ * Parses unknown param data as an integer, or falls back to undefined.
+ */
+export const parseParamAsInt = (data: any): number | undefined => {
+  if (typeof data === 'string') return parseInt(data) || undefined;
+  if (typeof data === 'number') return Math.round(data);
+  return undefined;
+};

--- a/src/travel-details-screens/types.ts
+++ b/src/travel-details-screens/types.ts
@@ -1,5 +1,7 @@
 import {TripPattern} from '@atb/api/types/trips';
 
+// NOTE: The iOS departure widget is dependent on this type. When changing it,
+// make sure to update the widget as well.
 export type ServiceJourneyDeparture = {
   serviceJourneyId: string;
   date: string;


### PR DESCRIPTION
With #4893 the `stopId` field was removed from the favorite departure type, which broke the iOS widget. Removing references to this field makes the widget function again.

fixes https://github.com/AtB-AS/kundevendt/issues/19834