### PR TITLE
fix: support carnets with multiple TravelRights in ValidTo

### DIFF
--- a/src/fare-contracts/components/ValidTo.tsx
+++ b/src/fare-contracts/components/ValidTo.tsx
@@ -1,5 +1,6 @@
 import {
   FareContract,
+  flattenCarnetTravelRightAccesses,
   getLastUsedAccess,
   isCarnetTravelRight,
   isNormalTravelRight,
@@ -20,20 +21,23 @@ export const ValidTo = ({fc}: Props) => {
   const {t, language} = useTranslation();
   const {theme} = useThemeContext();
   const {serverNow} = useTimeContext();
-  const travelRight = fc.travelRights[0];
-  if (!isNormalTravelRight(travelRight)) return null;
+  const firstTravelRight = fc.travelRights[0];
+  if (!isNormalTravelRight(firstTravelRight)) return null;
   if (!(getValidityStatus(serverNow, fc) === 'valid')) return null;
 
-  const endDateTime = (() => {
-    if (isCarnetTravelRight(travelRight)) {
-      const validTo = getLastUsedAccess(
-        serverNow,
-        travelRight.usedAccesses,
-      )?.validTo;
-      if (validTo) return new Date(validTo);
+  let endDateTime = firstTravelRight.endDateTime;
+  const {usedAccesses} = flattenCarnetTravelRightAccesses(
+    fc.travelRights.filter(isCarnetTravelRight),
+  );
+  if (usedAccesses.length) {
+    const {validTo: usedAccessValidTo} = getLastUsedAccess(
+      serverNow,
+      usedAccesses,
+    );
+    if (usedAccessValidTo) {
+      endDateTime = new Date(usedAccessValidTo);
     }
-    return travelRight.endDateTime;
-  })();
+  }
 
   return (
     <ThemeText

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -144,11 +144,26 @@ export const Profile_FareContractsScreen = () => {
         fareProductRef: 'ATB:AmountOfPriceUnitProduct:KlippekortBuss',
         id: 'ATB:CustomerPurchasePackage:4cb81f08-4499-44c4-8e23-507256f782a6-1',
         maximumNumberOfAccesses: 10,
-        numberOfUsedAccesses: 8,
+        numberOfUsedAccesses: 1,
         status: 5,
         usedAccesses: [
           {
-            startDateTime: daysFromNow(-1),
+            startDateTime: daysFromNow(-5),
+            endDateTime: daysFromNow(-4),
+          },
+        ],
+      },
+      {
+        ...BASE.travelRights[0],
+        type: 'CarnetTicket',
+        fareProductRef: 'ATB:AmountOfPriceUnitProduct:KlippekortBuss',
+        id: 'ATB:CustomerPurchasePackage:4cb81f08-4499-44c4-8e23-507256f782a6-2',
+        maximumNumberOfAccesses: 10,
+        numberOfUsedAccesses: 1,
+        status: 5,
+        usedAccesses: [
+          {
+            startDateTime: daysFromNow(-2),
             endDateTime: daysFromNow(1),
           },
         ],


### PR DESCRIPTION
Carnets will sometimes come with several travel rights, where accesses are added up. E.g. a carnet with 20 uses are really two travel rights with 10 accesses each. To account for this, we should use the `flattenCarnetTravelRightAccesses` util instead of reading from the first travel right.

Related to https://github.com/AtB-AS/kundevendt/issues/4220