### PR TITLE
fix: Bugs from FareContract inspection testing

### DIFF
--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -2,7 +2,6 @@ import React, {forwardRef, useEffect, useRef, useState} from 'react';
 import {
   AccessibilityInfo,
   NativeSyntheticEvent,
-  Platform,
   TextInput as InternalTextInput,
   TextInputFocusEventData,
   TextInputProps as InternalTextInputProps,
@@ -101,10 +100,10 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
     const padding = {
       // There are some oddities with handling padding
       // on Android and fonts: https://codeburst.io/react-native-quirks-2fb1ae0bbf80
-      paddingBottom:
-        theme.spacing.medium - Platform.select({android: 4, default: 0}),
-      paddingTop:
-        theme.spacing.medium - Platform.select({android: 5, default: 0}),
+      paddingBottom: 0,
+      //theme.spacing.medium - Platform.select({android: 4, default: 0}),
+      paddingTop: 0,
+      //theme.spacing.medium - Platform.select({android: 5, default: 0}),
     };
 
     // Remove padding from topContainerStyle
@@ -195,12 +194,14 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     paddingRight: theme.spacing.xSmall,
   },
   inputContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
     position: 'relative',
   },
   inputClear: {
     position: 'absolute',
     right: 0,
-    bottom: theme.spacing.medium,
+    //bottom: theme.spacing.medium,
   },
   clearButton: {
     alignSelf: 'center',

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -59,6 +59,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
     useEffect(() => {
       giveFocus(errorFocusRef);
     }, [errorText]);
+
     function accessibilityEscapeKeyboard() {
       setTimeout(
         () =>
@@ -179,6 +180,7 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
   },
   containerMultiline: {
     paddingTop: theme.spacing.small,
+    rowGap: theme.spacing.small,
   },
   label: {
     minWidth: 60 - theme.spacing.medium,

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -97,15 +97,6 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
       }
     };
 
-    const padding = {
-      // There are some oddities with handling padding
-      // on Android and fonts: https://codeburst.io/react-native-quirks-2fb1ae0bbf80
-      paddingBottom: 0,
-      //theme.spacing.medium - Platform.select({android: 4, default: 0}),
-      paddingTop: 0,
-      //theme.spacing.medium - Platform.select({android: 5, default: 0}),
-    };
-
     // Remove padding from topContainerStyle
     const {padding: _dropThis, ...topContainerStyle} = topContainer;
 
@@ -130,7 +121,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         <View style={inlineLabel ? contentContainer : undefined}>
           <InternalTextInput
             ref={combinedRef}
-            style={[styles.input, padding, style]}
+            style={[styles.input, style]}
             placeholderTextColor={theme.color.foreground.dynamic.secondary}
             onFocus={onFocusEvent}
             onBlur={onBlurEvent}

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -192,7 +192,6 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
   inputClear: {
     position: 'absolute',
     right: 0,
-    //bottom: theme.spacing.medium,
   },
   clearButton: {
     alignSelf: 'center',

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -84,7 +84,10 @@ export function LineItem({
   const nextValids = group.departures.filter(isValidDeparture);
 
   return (
-    <View style={[topContainer, {padding: 0}]} testID={testID}>
+    <View
+      style={[topContainer, {paddingVertical: 0, paddingHorizontal: 0}]}
+      testID={testID}
+    >
       <View style={[topContainer, sectionStyle.spaceBetween]}>
         <PressableOpacity
           style={[contentContainer, styles.lineHeader]}

--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -14,7 +14,7 @@ import {FareContractInfoDetailsProps} from './FareContractInfoDetails';
 import {useMobileTokenContext} from '@atb/mobile-token';
 import {InspectionSymbol} from '@atb/fare-contracts/components/InspectionSymbol';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
-import {secondsToDurationString} from '@atb/utils/date';
+import {secondsToDuration} from '@atb/utils/date';
 
 type CompactFareContractInfoProps = FareContractInfoDetailsProps & {
   style?: StyleProp<ViewStyle>;
@@ -148,7 +148,7 @@ export const useFareContractInfoTexts = (
 
   const secondsUntilValid = ((validTo || 0) - (now || 0)) / 1000;
   const conjunction = t(FareContractTexts.validityHeader.durationDelimiter);
-  const durationText = secondsToDurationString(secondsUntilValid, language, {
+  const durationText = secondsToDuration(secondsUntilValid, language, {
     conjunction,
     serialComma: false,
   });

--- a/src/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/fare-contracts/CompactFareContractInfo.tsx
@@ -5,6 +5,7 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
 import {
+  fareContractValidityUnits,
   isValidFareContract,
   useNonInspectableTokenWarning,
   userProfileCountAndName,
@@ -151,6 +152,7 @@ export const useFareContractInfoTexts = (
   const durationText = secondsToDuration(secondsUntilValid, language, {
     conjunction,
     serialComma: false,
+    units: fareContractValidityUnits(secondsUntilValid),
   });
 
   const tokenWarning = useNonInspectableTokenWarning();

--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -9,12 +9,10 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import {useAuthContext} from '@atb/auth';
 import {useMobileTokenContext} from '@atb/mobile-token';
 import {useOperatorBenefitsForFareProduct} from '@atb/mobility/use-operator-benefits-for-fare-product';
-import {CarnetFooter} from '@atb/fare-contracts/carnet/CarnetFooter';
 import {
   isCanBeConsumedNowFareContract,
   FareContract,
   isCanBeActivatedNowFareContract,
-  hasTravelRightAccesses,
 } from '@atb/ticketing';
 import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetSectionItem';
 import {StyleSheet} from '@atb/theme';
@@ -23,8 +21,8 @@ import {useFeatureTogglesContext} from '@atb/feature-toggles';
 import {ProductName} from '@atb/fare-contracts/components/ProductName';
 import {Description} from '@atb/fare-contracts/components/FareContractDescription';
 import {WithValidityLine} from '@atb/fare-contracts/components/WithValidityLine';
-import {ValidityHeader} from '@atb/fare-contracts/ValidityHeader';
 import {TravelInfoSectionItem} from '@atb/fare-contracts/modules/TravelInfoSectionItem';
+import {ValidityTime} from '@atb/fare-contracts/ValidityTime';
 
 type Props = {
   now: number;
@@ -48,12 +46,11 @@ export const FareContractView: React.FC<Props> = ({
   const {t} = useTranslation();
   const styles = useStyles();
 
-  const {
-    travelRights,
-    validityStatus,
-    maximumNumberOfAccesses,
-    numberOfUsedAccesses,
-  } = getFareContractInfo(now, fareContract, currentUserId);
+  const {travelRights, validityStatus} = getFareContractInfo(
+    now,
+    fareContract,
+    currentUserId,
+  );
 
   const firstTravelRight = travelRights[0];
 
@@ -69,20 +66,11 @@ export const FareContractView: React.FC<Props> = ({
       <GenericSectionItem style={styles.header}>
         <WithValidityLine fc={fareContract}>
           <ProductName fc={fareContract} />
-          <ValidityHeader fc={fareContract} />
+          <ValidityTime fc={fareContract} />
           <Description fc={fareContract} />
         </WithValidityLine>
       </GenericSectionItem>
       <TravelInfoSectionItem fc={fareContract} />
-      {hasTravelRightAccesses(fareContract.travelRights) && (
-        <GenericSectionItem>
-          <CarnetFooter
-            active={validityStatus === 'valid'}
-            maximumNumberOfAccesses={maximumNumberOfAccesses!}
-            numberOfUsedAccesses={numberOfUsedAccesses!}
-          />
-        </GenericSectionItem>
-      )}
       {shouldShowBundlingInfo && (
         <MobilityBenefitsInfoSectionItem benefits={benefits} />
       )}

--- a/src/fare-contracts/FareContractView.tsx
+++ b/src/fare-contracts/FareContractView.tsx
@@ -22,7 +22,7 @@ import {ProductName} from '@atb/fare-contracts/components/ProductName';
 import {Description} from '@atb/fare-contracts/components/FareContractDescription';
 import {WithValidityLine} from '@atb/fare-contracts/components/WithValidityLine';
 import {TravelInfoSectionItem} from '@atb/fare-contracts/modules/TravelInfoSectionItem';
-import {ValidityTime} from '@atb/fare-contracts/ValidityTime';
+import {ValidityTime} from '@atb/fare-contracts/components/ValidityTime';
 
 type Props = {
   now: number;

--- a/src/fare-contracts/PurchaseReservation.tsx
+++ b/src/fare-contracts/PurchaseReservation.tsx
@@ -1,17 +1,17 @@
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {Reservation, PaymentType, useTicketingContext} from '@atb/ticketing';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import Bugsnag from '@bugsnag/react-native';
 import React from 'react';
-import {ActivityIndicator, Linking, View} from 'react-native';
-import {ValidityLine} from './ValidityLine';
-import {FareContractStatusSymbol} from './components/FareContractStatusSymbol';
+import {Linking} from 'react-native';
 import {formatToLongDateTime} from '@atb/utils/date';
 import {fromUnixTime} from 'date-fns';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {WithValidityLine} from '@atb/fare-contracts/components/WithValidityLine';
 import {getReservationStatus} from '@atb/fare-contracts/utils';
+import {GenericSectionItem, Section} from '@atb/components/sections';
 
 type Props = {
   reservation: Reservation;
@@ -19,7 +19,6 @@ type Props = {
 
 export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
   const styles = useStyles();
-  const {theme} = useThemeContext();
   const {customerProfile} = useTicketingContext();
   const {t, language} = useTranslation();
 
@@ -45,26 +44,18 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
   const paymentType = PaymentType[reservation.paymentType];
   return (
     <PressableOpacity accessible={false} importantForAccessibility="no">
-      <View style={styles.container} testID="purchaseReservation">
-        <View style={styles.validityContainer}>
-          <View style={styles.validityHeader}>
-            {status === 'reserving' ? (
-              <ActivityIndicator
-                color={theme.color.foreground.dynamic.primary}
-              />
-            ) : (
-              <FareContractStatusSymbol status={status} />
-            )}
-            <ThemeText
-              typography="body__secondary"
-              style={styles.reservationStatus}
-            >
+      <Section>
+        <GenericSectionItem style={{paddingVertical: 0}}>
+          <WithValidityLine
+            reservation={reservation}
+            enabledLine={status !== 'rejected'}
+          >
+            <ThemeText typography="heading--medium">
               {t(TicketingTexts.reservation[status])}
             </ThemeText>
-          </View>
-        </View>
-        <VerifyingValidityLine status={status} />
-        <View style={styles.infoContainer} accessible={true}>
+          </WithValidityLine>
+        </GenericSectionItem>
+        <GenericSectionItem accessibility={{accessible: true}}>
           {status == 'rejected' && (
             <ThemeText typography="body__secondary" color="secondary">
               {t(
@@ -97,52 +88,14 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
                 mode="tertiary"
               />
             )}
-        </View>
-      </View>
+        </GenericSectionItem>
+      </Section>
     </PressableOpacity>
   );
 };
 
-const VerifyingValidityLine = ({status}: {status: any}) => {
-  const styles = useStyles();
-  return (
-    <View style={styles.validityDashContainer}>
-      <ValidityLine status={status} />
-    </View>
-  );
-};
-
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  validityHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'space-between',
-  },
   detail: {
     paddingVertical: theme.spacing.xSmall,
-  },
-  container: {
-    backgroundColor: theme.color.background.neutral[0].background,
-    borderRadius: theme.border.radius.regular,
-  },
-  extraText: {
-    paddingVertical: theme.spacing.xSmall,
-    color: theme.color.foreground.dynamic.disabled,
-  },
-  validityContainer: {
-    flexDirection: 'row',
-    padding: theme.spacing.small,
-  },
-  validityDashContainer: {
-    marginHorizontal: theme.spacing.medium,
-  },
-  infoContainer: {
-    padding: theme.spacing.medium,
-  },
-  reservationStatus: {
-    flex: 1,
-    textAlign: 'right',
-    marginLeft: theme.spacing.small,
   },
 }));

--- a/src/fare-contracts/ValidityLine.tsx
+++ b/src/fare-contracts/ValidityLine.tsx
@@ -13,9 +13,6 @@ const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
 type Props =
   | {
       status: 'valid';
-      now: number;
-      validFrom: number;
-      validTo: number;
       fareProductType?: string;
       animate?: boolean;
     }
@@ -25,6 +22,7 @@ export const ValidityLine = (props: Props): ReactElement => {
   const {status} = props;
 
   const {theme} = useThemeContext();
+
   const styles = useStyles();
   const {lineColor, backgroundColor} = useValidityLineColors(
     status === 'valid' ? props.fareProductType : undefined,
@@ -33,6 +31,12 @@ export const ValidityLine = (props: Props): ReactElement => {
 
   switch (status) {
     case 'reserving':
+      return (
+        <LineWithVerticalBars
+          backgroundColor={theme.color.foreground.dynamic.disabled}
+          lineColor={lineColor}
+        />
+      );
     case 'approved':
       return (
         <LineWithVerticalBars

--- a/src/fare-contracts/ValidityTime.tsx
+++ b/src/fare-contracts/ValidityTime.tsx
@@ -6,7 +6,7 @@ import {
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
-import {formatToLongDateTime, secondsToDurationString} from '@atb/utils/date';
+import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {toDate} from 'date-fns';
 import React from 'react';
 import {View} from 'react-native';
@@ -72,7 +72,7 @@ function validityTimeText(
 ): string {
   const conjunction = t(FareContractTexts.validityHeader.durationDelimiter);
   const toDurationText = (seconds: number) =>
-    secondsToDurationString(seconds, language, {
+    secondsToDuration(seconds, language, {
       conjunction,
       serialComma: false,
     });

--- a/src/fare-contracts/ValidityTime.tsx
+++ b/src/fare-contracts/ValidityTime.tsx
@@ -20,7 +20,7 @@ type Props = {
   fc: FareContract;
 };
 
-export const ValidityHeader = ({fc}: Props) => {
+export const ValidityTime = ({fc}: Props) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
   const {isInspectable} = useMobileTokenContext();
@@ -32,7 +32,6 @@ export const ValidityHeader = ({fc}: Props) => {
     fc,
     currentUserId,
   );
-
   const label: string = validityTimeText(
     validityStatus,
     serverNow,
@@ -115,6 +114,21 @@ function validityTimeText(
     default:
       return t(FareContractTexts.validityHeader.unknown);
   }
+}
+
+function createRepeatingTask(callback: () => void, delay: number) {
+  let timeoutId: NodeJS.Timeout;
+
+  const task = () => {
+    callback();
+    timeoutId = setTimeout(task, delay);
+  };
+
+  timeoutId = setTimeout(task, delay);
+
+  return {
+    cancel: () => clearTimeout(timeoutId),
+  };
 }
 
 const useStyles = StyleSheet.createThemeHook(() => ({

--- a/src/fare-contracts/ValidityTime.tsx
+++ b/src/fare-contracts/ValidityTime.tsx
@@ -116,21 +116,6 @@ function validityTimeText(
   }
 }
 
-function createRepeatingTask(callback: () => void, delay: number) {
-  let timeoutId: NodeJS.Timeout;
-
-  const task = () => {
-    callback();
-    timeoutId = setTimeout(task, delay);
-  };
-
-  timeoutId = setTimeout(task, delay);
-
-  return {
-    cancel: () => clearTimeout(timeoutId),
-  };
-}
-
 const useStyles = StyleSheet.createThemeHook(() => ({
   validityText: {
     textAlign: 'center',

--- a/src/fare-contracts/__tests__/fare-contract-validity-units.test.ts
+++ b/src/fare-contracts/__tests__/fare-contract-validity-units.test.ts
@@ -1,0 +1,142 @@
+import {fareContractValidityUnits} from '@atb/fare-contracts/utils';
+import {LoadingParams} from '@atb/loading-screen/types';
+import React from 'react';
+
+const DEFAULT_MOCK_STATE: LoadingParams = {
+  isLoadingAppState: false,
+  authStatus: 'authenticated',
+  firestoreConfigStatus: 'success',
+  remoteConfigIsLoaded: true,
+};
+
+jest.mock('@atb/auth/AuthContext', () => {});
+jest.mock('@atb/mobile-token', () => {});
+jest.mock('@atb/ticketing/TicketingContext', () => {});
+jest.mock('@atb/configuration/FirestoreConfigurationContext', () => {});
+jest.mock('@atb/api', () => {});
+jest.mock('@atb/time', () => {});
+jest.mock('@react-native-firebase/remote-config', () => {});
+jest.mock('@entur-private/abt-mobile-client-sdk', () => {});
+jest.mock('@bugsnag/react-native', () => {});
+jest.mock('@react-native-firebase/auth', () => {});
+jest.mock('@entur-private/abt-token-server-javascript-interface', () => {});
+jest.mock('react-native-device-info', () => {});
+jest.mock('react-native-inappbrowser-reborn', () => {});
+jest.mock('@atb/auth', () => ({
+  useAuthContext: () => ({
+    authStatus: DEFAULT_MOCK_STATE,
+    abtCustomerId: '1',
+    retryAuth: () => {},
+  }),
+}));
+jest.spyOn(React, 'useCallback').mockImplementation((f) => f);
+jest.spyOn(React, 'useMemo').mockImplementation((f) => f());
+
+describe('fareContractValidityUnits', () => {
+  // Constants for readability and maintainability
+  const SECONDS_IN_MINUTE = 60;
+  const SECONDS_IN_HOUR = SECONDS_IN_MINUTE * 60;
+  const SECONDS_IN_DAY = SECONDS_IN_HOUR * 24;
+  const SECONDS_IN_WEEK = SECONDS_IN_DAY * 7;
+
+  describe('seconds range (0 to 59 seconds)', () => {
+    it('should return seconds units for 0 seconds', () => {
+      expect(fareContractValidityUnits(0)).toEqual(['s']);
+    });
+
+    it('should return seconds units for 30 seconds', () => {
+      expect(fareContractValidityUnits(30)).toEqual(['s']);
+    });
+
+    it('should return seconds units for 59 seconds', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_MINUTE - 1)).toEqual(['s']);
+    });
+  });
+
+  describe('minutes range (60 seconds to 59 minutes, 59 seconds)', () => {
+    it('should return minutes and seconds units for 60 seconds', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_MINUTE)).toEqual(['m', 's']);
+    });
+
+    it('should return minutes and seconds units for 30 minutes', () => {
+      expect(fareContractValidityUnits(30 * SECONDS_IN_MINUTE)).toEqual([
+        'm',
+        's',
+      ]);
+    });
+
+    it('should return minutes and seconds units for 59 minutes, 59 seconds', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_HOUR - 1)).toEqual([
+        'm',
+        's',
+      ]);
+    });
+  });
+
+  describe('hours range (1 hour to 23 hours, 59 minutes)', () => {
+    it('should return hours and minutes units for 1 hour', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_HOUR)).toEqual(['h', 'm']);
+    });
+
+    it('should return hours and minutes units for 12 hours', () => {
+      expect(fareContractValidityUnits(12 * SECONDS_IN_HOUR)).toEqual([
+        'h',
+        'm',
+      ]);
+    });
+
+    it('should return hours and minutes units for 23 hours, 59 minutes', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_DAY - 1)).toEqual(['h', 'm']);
+    });
+  });
+
+  describe('days range (1 day to 6 days, 23 hours)', () => {
+    it('should return days and hours units for 1 day', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_DAY)).toEqual(['d', 'h']);
+    });
+
+    it('should return days and hours units for 3 days', () => {
+      expect(fareContractValidityUnits(3 * SECONDS_IN_DAY)).toEqual(['d', 'h']);
+    });
+
+    it('should return days and hours units for 6 days, 23 hours', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_WEEK - 1)).toEqual([
+        'd',
+        'h',
+      ]);
+    });
+  });
+
+  describe('week+ range (7 days or more)', () => {
+    it('should return days units for 7 days', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_WEEK)).toEqual(['d']);
+    });
+
+    it('should return days units for 14 days', () => {
+      expect(fareContractValidityUnits(2 * SECONDS_IN_WEEK)).toEqual(['d']);
+    });
+
+    it('should return days units for 30 days', () => {
+      expect(fareContractValidityUnits(30 * SECONDS_IN_DAY)).toEqual(['d']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return default units for negative values', () => {
+      expect(fareContractValidityUnits(-1)).toEqual(['s']);
+    });
+
+    it('should return days units for very large values', () => {
+      expect(fareContractValidityUnits(Number.MAX_SAFE_INTEGER)).toEqual(['d']);
+    });
+
+    it('should handle boundary transitions correctly', () => {
+      // Test exact boundaries
+      expect(fareContractValidityUnits(SECONDS_IN_MINUTE - 1)).toEqual(['s']);
+      expect(fareContractValidityUnits(SECONDS_IN_MINUTE)).toEqual(['m', 's']);
+      expect(fareContractValidityUnits(SECONDS_IN_HOUR)).toEqual(['h', 'm']);
+      expect(fareContractValidityUnits(SECONDS_IN_DAY)).toEqual(['d', 'h']);
+      expect(fareContractValidityUnits(SECONDS_IN_WEEK)).toEqual(['d']);
+    });
+  });
+});

--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {calculateCarnetData} from './calculate-carnet-data';
 
@@ -17,6 +17,7 @@ export const CarnetFooter: React.FC<Props> = ({
   numberOfUsedAccesses,
 }) => {
   const styles = useStyles();
+  const {theme} = useThemeContext();
   const {t} = useTranslation();
 
   const {accessesRemaining, multiCarnetArray, unusedArray, usedArray} =
@@ -24,7 +25,10 @@ export const CarnetFooter: React.FC<Props> = ({
 
   return (
     <View
-      style={{flexDirection: 'column', flex: 1}}
+      style={{
+        flexDirection: 'column',
+        flex: 1,
+      }}
       accessible={true}
       accessibilityLabel={t(
         FareContractTexts.carnet.numberOfUsedAccessesRemaining(

--- a/src/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/fare-contracts/carnet/CarnetFooter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {calculateCarnetData} from './calculate-carnet-data';
 
@@ -17,7 +17,6 @@ export const CarnetFooter: React.FC<Props> = ({
   numberOfUsedAccesses,
 }) => {
   const styles = useStyles();
-  const {theme} = useThemeContext();
   const {t} = useTranslation();
 
   const {accessesRemaining, multiCarnetArray, unusedArray, usedArray} =

--- a/src/fare-contracts/components/ValidityLine.tsx
+++ b/src/fare-contracts/components/ValidityLine.tsx
@@ -4,7 +4,7 @@ import {StyleSheet, useThemeContext} from '@atb/theme';
 import LinearGradient from 'react-native-linear-gradient';
 import {ValidityStatus} from '@atb/fare-contracts/utils';
 import {SectionSeparator} from '@atb/components/sections';
-import {useValidityLineColors} from './use-validity-line-colors';
+import {useValidityLineColors} from '../use-validity-line-colors';
 import {useMobileTokenContext} from '@atb/mobile-token';
 
 const SPACE_BETWEEN_VERTICAL_LINES = 72;

--- a/src/fare-contracts/components/ValidityTime.tsx
+++ b/src/fare-contracts/components/ValidityTime.tsx
@@ -10,7 +10,11 @@ import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {toDate} from 'date-fns';
 import React from 'react';
 import {View} from 'react-native';
-import {getFareContractInfo, ValidityStatus} from './utils';
+import {
+  fareContractValidityUnits,
+  getFareContractInfo,
+  ValidityStatus,
+} from '../utils';
 import {useMobileTokenContext} from '@atb/mobile-token';
 import {useTimeContext} from '@atb/time';
 import {useAuthContext} from '@atb/auth';
@@ -75,6 +79,7 @@ function validityTimeText(
     secondsToDuration(seconds, language, {
       conjunction,
       serialComma: false,
+      units: fareContractValidityUnits(seconds),
     });
 
   switch (status) {

--- a/src/fare-contracts/components/WithValidityLine.tsx
+++ b/src/fare-contracts/components/WithValidityLine.tsx
@@ -1,5 +1,5 @@
 import {StyleSheet} from '@atb/theme';
-import {ValidityLine} from '@atb/fare-contracts/ValidityLine';
+import {ValidityLine} from '@atb/fare-contracts/components/ValidityLine';
 import {View} from 'react-native';
 import React, {type PropsWithChildren} from 'react';
 import type {FareContract, Reservation} from '@atb/ticketing';

--- a/src/fare-contracts/components/WithValidityLine.tsx
+++ b/src/fare-contracts/components/WithValidityLine.tsx
@@ -45,7 +45,7 @@ export const WithValidityLine = (props: Props) => {
       preassignedFareProducts,
       firstTravelRight.fareProductRef,
     );
-    const {validityStatus, validFrom, validTo} = getFareContractInfo(
+    const {validityStatus} = getFareContractInfo(
       serverNow,
       props.fc,
       currentUserId,
@@ -54,9 +54,6 @@ export const WithValidityLine = (props: Props) => {
       <View style={styles.container}>
         <ValidityLine
           status={validityStatus}
-          now={serverNow}
-          validFrom={validFrom}
-          validTo={validTo}
           fareProductType={preassignedFareProduct?.type}
         />
         {!!props.children ? (

--- a/src/fare-contracts/components/WithValidityLine.tsx
+++ b/src/fare-contracts/components/WithValidityLine.tsx
@@ -2,8 +2,11 @@ import {StyleSheet} from '@atb/theme';
 import {ValidityLine} from '@atb/fare-contracts/ValidityLine';
 import {View} from 'react-native';
 import React, {type PropsWithChildren} from 'react';
-import type {FareContract} from '@atb/ticketing';
-import {getFareContractInfo} from '@atb/fare-contracts/utils';
+import type {FareContract, Reservation} from '@atb/ticketing';
+import {
+  getFareContractInfo,
+  getReservationStatus,
+} from '@atb/fare-contracts/utils';
 import {useTimeContext} from '@atb/time';
 import {useAuthContext} from '@atb/auth';
 import {
@@ -11,37 +14,58 @@ import {
   useFirestoreConfigurationContext,
 } from '@atb/configuration';
 
-type Props = PropsWithChildren<{
-  fc: FareContract;
-}>;
+type Props = PropsWithChildren<
+  | {
+      fc: FareContract;
+    }
+  | ({reservation: Reservation} & {enabledLine: boolean})
+>;
 
-export const WithValidityLine = ({fc, children}: Props) => {
+export const WithValidityLine = (props: Props) => {
   const styles = useStyles();
   const {serverNow} = useTimeContext();
   const {abtCustomerId: currentUserId} = useAuthContext();
-  const firstTravelRight = getFareContractInfo(serverNow, fc).travelRights?.[0];
   const {preassignedFareProducts} = useFirestoreConfigurationContext();
-  const preassignedFareProduct = findReferenceDataById(
-    preassignedFareProducts,
-    firstTravelRight.fareProductRef,
-  );
-  const {validityStatus, validFrom, validTo} = getFareContractInfo(
-    serverNow,
-    fc,
-    currentUserId,
-  );
-  return (
-    <View style={styles.container}>
-      <ValidityLine
-        status={validityStatus}
-        now={serverNow}
-        validFrom={validFrom}
-        validTo={validTo}
-        fareProductType={preassignedFareProduct?.type}
-      />
-      {!!children ? <View style={styles.content}>{children}</View> : null}
-    </View>
-  );
+
+  if ('reservation' in props) {
+    return (
+      <View style={styles.container}>
+        {!!props.enabledLine && (
+          <ValidityLine status={getReservationStatus(props.reservation)} />
+        )}
+        {!!props.children ? (
+          <View style={styles.content}>{props.children}</View>
+        ) : null}
+      </View>
+    );
+  } else if ('fc' in props) {
+    const firstTravelRight = getFareContractInfo(serverNow, props.fc)
+      .travelRights?.[0];
+    const preassignedFareProduct = findReferenceDataById(
+      preassignedFareProducts,
+      firstTravelRight.fareProductRef,
+    );
+    const {validityStatus, validFrom, validTo} = getFareContractInfo(
+      serverNow,
+      props.fc,
+      currentUserId,
+    );
+    return (
+      <View style={styles.container}>
+        <ValidityLine
+          status={validityStatus}
+          now={serverNow}
+          validFrom={validFrom}
+          validTo={validTo}
+          fareProductType={preassignedFareProduct?.type}
+        />
+        {!!props.children ? (
+          <View style={styles.content}>{props.children}</View>
+        ) : null}
+      </View>
+    );
+  }
+  return null;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -48,7 +48,7 @@ import {useFetchOnBehalfOfAccountsQuery} from '@atb/on-behalf-of/queries/use-fet
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {WithValidityLine} from '@atb/fare-contracts/components/WithValidityLine';
 import {ProductName} from '@atb/fare-contracts/components/ProductName';
-import {ValidityTime} from '@atb/fare-contracts/ValidityTime';
+import {ValidityTime} from '@atb/fare-contracts/components/ValidityTime';
 
 type Props = {
   fareContract: FareContract;

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -48,7 +48,7 @@ import {useFetchOnBehalfOfAccountsQuery} from '@atb/on-behalf-of/queries/use-fet
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {WithValidityLine} from '@atb/fare-contracts/components/WithValidityLine';
 import {ProductName} from '@atb/fare-contracts/components/ProductName';
-import {ValidityHeader} from '@atb/fare-contracts/ValidityHeader';
+import {ValidityTime} from '@atb/fare-contracts/ValidityTime';
 
 type Props = {
   fareContract: FareContract;
@@ -137,7 +137,7 @@ export const DetailsContent: React.FC<Props> = ({
       >
         <WithValidityLine fc={fc}>
           <ProductName fc={fc} />
-          <ValidityHeader fc={fc} />
+          <ValidityTime fc={fc} />
           <ValidTo fc={fc} />
           <Description fc={fc} />
         </WithValidityLine>

--- a/src/fare-contracts/modules/TravelInfoSectionItem.tsx
+++ b/src/fare-contracts/modules/TravelInfoSectionItem.tsx
@@ -47,13 +47,14 @@ export const TravelInfoSectionItem = ({fc}: Props) => {
     onBehalfOfAccounts?.find((a) => a.phoneNumber === phoneNumber)?.name;
   const {userProfiles, fareProductTypeConfigs, preassignedFareProducts} =
     useFirestoreConfigurationContext();
-  const fareProductTypeConfig = fareProductTypeConfigs.find(
-    (c) => c.type === preassignedFareProduct?.type,
-  );
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
     firstTravelRight.fareProductRef,
   );
+  const fareProductTypeConfig = fareProductTypeConfigs.find((c) => {
+    return c.type === preassignedFareProduct?.type;
+  });
+
   const userProfilesWithCount = mapToUserProfilesWithCount(
     travelRights.map((tr) => tr.userProfileRef),
     userProfiles,

--- a/src/fare-contracts/types.ts
+++ b/src/fare-contracts/types.ts
@@ -1,3 +1,6 @@
 import {UserProfile} from '@atb/configuration';
+import type {Unit} from 'humanize-duration';
 
 export type UserProfileWithCount = UserProfile & {count: number};
+export type Range = {low: number; high: number};
+export type UnitMapType = {range: Range; units: Unit[]}[];

--- a/src/fare-contracts/utils.ts
+++ b/src/fare-contracts/utils.ts
@@ -27,6 +27,8 @@ import {
 import {useMobileTokenContext} from '@atb/mobile-token';
 import {useCallback, useMemo} from 'react';
 import {useAuthContext} from '@atb/auth';
+import humanizeDuration from 'humanize-duration';
+import type {UnitMapType} from '@atb/fare-contracts/types';
 
 export type RelativeValidityStatus = 'upcoming' | 'valid' | 'expired';
 
@@ -319,3 +321,38 @@ export const getReservationStatus = (reservation: Reservation) => {
       return 'reserving';
   }
 };
+
+/**
+ * These are following the rules from AtB-AS/kundevendt#4220, which apply for validityDuration of FareContracts
+ * https://github.com/AtB-AS/kundevendt/issues/4220#issuecomment-2615206325
+ * @param seconds
+ */
+export function fareContractValidityUnits(
+  seconds: number,
+): humanizeDuration.Unit[] {
+  const oneMinuteInSeconds = 60;
+  const oneHourInSeconds = oneMinuteInSeconds * 60;
+  const oneDayInSeconds = oneHourInSeconds * 24;
+  const sevenDaysInSeconds = oneDayInSeconds * 7;
+  const unitMap: UnitMapType = [
+    {range: {low: -Infinity, high: oneMinuteInSeconds - 1}, units: ['s']},
+    {
+      range: {low: oneMinuteInSeconds, high: oneHourInSeconds - 1},
+      units: ['m', 's'],
+    },
+    {
+      range: {low: oneHourInSeconds, high: oneDayInSeconds - 1},
+      units: ['h', 'm'],
+    },
+    {
+      range: {low: oneDayInSeconds, high: sevenDaysInSeconds - 1},
+      units: ['d', 'h'],
+    },
+    {range: {low: sevenDaysInSeconds, high: Infinity}, units: ['d']},
+  ];
+
+  return (
+    unitMap.find(({range}) => seconds >= range.low && seconds <= range.high)
+      ?.units ?? ['d', 'h', 'm']
+  );
+}

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -16,7 +16,7 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {formatToLongDateTime, secondsToDurationString} from '@atb/utils/date';
+import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {formatPhoneNumber} from '@atb/utils/phone-number-utils';
 import React from 'react';
 import {View} from 'react-native';
@@ -144,7 +144,7 @@ export const PreassignedFareContractSummary = ({
             summary(
               t(
                 PurchaseConfirmationTexts.validityTexts.time(
-                  secondsToDurationString(validDurationSeconds, language),
+                  secondsToDuration(validDurationSeconds, language),
                 ),
               ),
             )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {ScrollView} from 'react-native';
 import {Button} from '@atb/components/button';
-import {secondsToDurationString, secondsToDurationShort} from '@atb/utils/date';
+import {secondsToDuration, secondsToDurationShort} from '@atb/utils/date';
 import {
   TranslateFunction,
   TripSearchTexts,
@@ -42,10 +42,7 @@ export const NonTransitResults = ({tripPatterns, onDetailsPressed}: Props) => {
           tripPattern.duration,
           language,
         );
-        const duration = secondsToDurationString(
-          tripPattern.duration,
-          language,
-        );
+        const duration = secondsToDuration(tripPattern.duration, language);
         const analyticsMetadata = {mode, duration: durationShort};
         return (
           <Button

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -22,7 +22,7 @@ import {
   formatToClock,
   isInThePast,
   secondsBetween,
-  secondsToDurationString,
+  secondsToDuration,
   secondsToDurationShort,
   secondsToMinutes,
 } from '@atb/utils/date';
@@ -552,8 +552,8 @@ const FootLeg = ({leg, nextLeg}: {leg: Leg; nextLeg?: Leg}) => {
   const waitTimeInSeconds = !nextLeg
     ? 0
     : secondsBetween(leg.expectedEndTime, nextLeg?.expectedStartTime);
-  const waitDuration = secondsToDurationString(waitTimeInSeconds, language);
-  const walkDuration = secondsToDurationString(leg.duration ?? 0, language);
+  const waitDuration = secondsToDuration(waitTimeInSeconds, language);
+  const walkDuration = secondsToDuration(leg.duration ?? 0, language);
 
   const mustWalk = significantWalkTime(leg.duration);
   const mustWait = showWaitTime && significantWaitTime(waitTimeInSeconds);
@@ -725,7 +725,7 @@ const tripSummary = (
     TripSearchTexts.results.resultItem.journeySummary.travelTimes(
       formatToClock(tripPattern.expectedStartTime, language, 'floor'),
       formatToClock(tripPattern.expectedEndTime, language, 'ceil'),
-      secondsToDurationString(tripPattern.duration, language),
+      secondsToDuration(tripPattern.duration, language),
       startTimeIsApproximation,
       endTimeIsApproximation,
     ),

--- a/src/time/TimeContext.tsx
+++ b/src/time/TimeContext.tsx
@@ -39,7 +39,7 @@ export const TimeContextProvider: React.FC = ({children}) => {
       }
     },
     [isServerTimeEnabled],
-    2500,
+    1000,
     false,
     true,
   );

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -15,11 +15,7 @@ const FareContractTexts = {
   },
   validityHeader: {
     valid: (duration: string) =>
-      _(
-        `Gyldig i ${duration}`,
-        `Valid through ${duration}`,
-        `Gyldig i ${duration}`,
-      ),
+      _(`${duration} igjen`, `${duration} left`, `${duration} igjen`),
     recentlyExpired: (duration: string) =>
       _(
         `Utløpt for ${duration} siden`,

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -170,9 +170,9 @@ const TicketingTexts = {
   },
   reservation: {
     reserving: _(
-      'Prosesseres... ikke gyldig enda',
-      'Processing... not yet valid',
-      'Prosesserer... ikkje gyldig enda',
+      'Venter på prosessering...',
+      'Waiting for processing...',
+      'Ventar på prosessering...',
     ),
     approved: _(
       'Betaling godkjent. Henter billett...',

--- a/src/travel-details-screens/components/TripSection.tsx
+++ b/src/travel-details-screens/components/TripSection.tsx
@@ -16,7 +16,7 @@ import {
   TripDetailsTexts,
   useTranslation,
 } from '@atb/translations';
-import {formatToClock, secondsToDurationString} from '@atb/utils/date';
+import {formatToClock, secondsToDuration} from '@atb/utils/date';
 import {
   getQuayName,
   getTranslatedModeName,
@@ -419,7 +419,7 @@ const IntermediateInfo = ({
         t(
           TripDetailsTexts.trip.leg.intermediateStops.a11yLabel(
             numberOfIntermediateCalls,
-            secondsToDurationString(leg.duration, language),
+            secondsToDuration(leg.duration, language),
           ),
         ) + screenReaderPause
       }
@@ -431,7 +431,7 @@ const IntermediateInfo = ({
         {t(
           TripDetailsTexts.trip.leg.intermediateStops.label(
             numberOfIntermediateCalls,
-            secondsToDurationString(leg.duration, language),
+            secondsToDuration(leg.duration, language),
           ),
         )}
       </ThemeText>
@@ -456,7 +456,7 @@ const WalkSection = (leg: Leg) => {
         {isWalkTimeOfSignificance
           ? t(
               TripDetailsTexts.trip.leg.walk.label(
-                secondsToDurationString(leg.duration ?? 0, language),
+                secondsToDuration(leg.duration ?? 0, language),
               ),
             )
           : t(TripDetailsTexts.trip.leg.shortWalk)}
@@ -480,7 +480,7 @@ const BikeSection = (leg: Leg) => {
       <ThemeText typography="body__secondary" color="secondary">
         {t(
           TripDetailsTexts.trip.leg.bicycle.label(
-            secondsToDurationString(leg.duration ?? 0, language),
+            secondsToDuration(leg.duration ?? 0, language),
           ),
         )}
       </ThemeText>
@@ -584,7 +584,7 @@ function InterchangeSection({
       ' ' +
       t(
         TripDetailsTexts.messages.interchangeMaxWait(
-          secondsToDurationString(maximumWaitTime, language),
+          secondsToDuration(maximumWaitTime, language),
         ),
       );
   }

--- a/src/travel-details-screens/components/TripSummary.tsx
+++ b/src/travel-details-screens/components/TripSummary.tsx
@@ -1,7 +1,7 @@
 import {TripPattern} from '@atb/api/types/trips';
 import {Walk, Bicycle} from '@atb/assets/svg/mono-icons/transportation-entur';
 import {TripDetailsTexts, useTranslation} from '@atb/translations';
-import {secondsToDurationString} from '@atb/utils/date';
+import {secondsToDuration} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
 import {Duration} from '@atb/assets/svg/mono-icons/time';
@@ -11,7 +11,7 @@ import {SummaryDetail} from '@atb/travel-details-screens/components/SummaryDetai
 
 export const TripSummary: React.FC<TripPattern> = ({legs, duration}) => {
   const {t, language} = useTranslation();
-  const time = secondsToDurationString(duration, language);
+  const time = secondsToDuration(duration, language);
   const walkDistance = getDistance(legs, Mode.Foot);
   const bikeDistance = getDistance(legs, Mode.Bicycle);
   const readableWalkDistance = useHumanizeDistance(walkDistance);

--- a/src/travel-details-screens/components/WaitSection.tsx
+++ b/src/travel-details-screens/components/WaitSection.tsx
@@ -3,7 +3,7 @@ import {ThemeText} from '@atb/components/text';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {StyleSheet} from '@atb/theme';
 import {TripDetailsTexts, useTranslation} from '@atb/translations';
-import {secondsToDurationString} from '@atb/utils/date';
+import {secondsToDuration} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
 import {timeIsShort} from '../utils';
@@ -20,7 +20,7 @@ export type WaitDetails = {
 export const WaitSection: React.FC<WaitDetails> = (wait) => {
   const style = useSectionStyles();
   const {t, language} = useTranslation();
-  const waitTime = secondsToDurationString(wait.waitTimeInSeconds, language);
+  const waitTime = secondsToDuration(wait.waitTimeInSeconds, language);
   const shortWait = timeIsShort(wait.waitTimeInSeconds);
   const legColor = useTransportColor();
 

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -256,12 +256,12 @@ describe('secondsToDuration', () => {
   describe('Basic conversions', () => {
     test('converts 500 seconds to duration string in English', () => {
       const result = secondsToDuration(500, Language.English);
-      expect(result).toBe('8 minutes, 20 seconds');
+      expect(result).toBe('8 minutes');
     });
 
     test('converts 500 seconds to duration string in Norwegian', () => {
       const result = secondsToDuration(500, Language.Norwegian);
-      expect(result).toBe('8 minutter, 20 sekunder');
+      expect(result).toBe('8 minutter');
     });
   });
 
@@ -269,7 +269,7 @@ describe('secondsToDuration', () => {
   describe('Edge case handling', () => {
     test('handles 59 seconds at low range', () => {
       const result = secondsToDuration(59, Language.English);
-      expect(result).toBe('59 seconds');
+      expect(result).toBe('1 minute');
     });
 
     test('handles 60 seconds (start of minutes range)', () => {
@@ -310,22 +310,17 @@ describe('secondsToDuration', () => {
   describe('Invalid or edge case inputs', () => {
     test('handles negative seconds gracefully', () => {
       const result = secondsToDuration(-500, Language.English);
-      expect(result).toBe('0 seconds');
+      expect(result).toBe('0 minutes');
     });
 
     test('handles exactly 0 seconds', () => {
       const result = secondsToDuration(0, Language.English);
-      expect(result).toBe('0 seconds');
+      expect(result).toBe('0 minutes');
     });
   });
 
   // Unit Map Logic
   describe('Unit map logic', () => {
-    test('uses seconds for durations under 60 seconds', () => {
-      const result = secondsToDuration(30, Language.English);
-      expect(result).toBe('30 seconds');
-    });
-
     test('uses minutes and seconds for durations under an hour', () => {
       const result = secondsToDuration(120, Language.English);
       expect(result).toBe('2 minutes');

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -8,7 +8,7 @@ import {
   dateWithReplacedTime,
   formatLocaleTime,
   formatToLongDateTime,
-  secondsToDurationString,
+  secondsToDuration,
 } from '../date'; // Adjust the path if needed
 
 type TimeZone =
@@ -251,16 +251,16 @@ describe('convertIsoStringFieldsToDate', () => {
   });
 });
 
-describe('secondsToDurationString', () => {
+describe('secondsToDuration', () => {
   // Basic Functionality
   describe('Basic conversions', () => {
     test('converts 500 seconds to duration string in English', () => {
-      const result = secondsToDurationString(500, Language.English);
+      const result = secondsToDuration(500, Language.English);
       expect(result).toBe('8 minutes, 20 seconds');
     });
 
     test('converts 500 seconds to duration string in Norwegian', () => {
-      const result = secondsToDurationString(500, Language.Norwegian);
+      const result = secondsToDuration(500, Language.Norwegian);
       expect(result).toBe('8 minutter, 20 sekunder');
     });
   });
@@ -268,22 +268,22 @@ describe('secondsToDurationString', () => {
   // Edge Cases
   describe('Edge case handling', () => {
     test('handles 59 seconds at low range', () => {
-      const result = secondsToDurationString(59, Language.English);
+      const result = secondsToDuration(59, Language.English);
       expect(result).toBe('59 seconds');
     });
 
     test('handles 60 seconds (start of minutes range)', () => {
-      const result = secondsToDurationString(60, Language.English);
+      const result = secondsToDuration(60, Language.English);
       expect(result).toBe('1 minute');
     });
 
     test('handles 3658 seconds (slightly above hours range)', () => {
-      const result = secondsToDurationString(3658, Language.English);
+      const result = secondsToDuration(3658, Language.English);
       expect(result).toBe('1 hour, 1 minute');
     });
 
     test('handles 3600 seconds (start of hours range)', () => {
-      const result = secondsToDurationString(3600, Language.English);
+      const result = secondsToDuration(3600, Language.English);
       expect(result).toBe('1 hour');
     });
   });
@@ -291,7 +291,7 @@ describe('secondsToDurationString', () => {
   // Large Durations
   describe('Large durations', () => {
     test('handles durations greater than a day', () => {
-      const result = secondsToDurationString(90000, Language.English);
+      const result = secondsToDuration(90000, Language.English);
       expect(result).toBe('1 day, 1 hour');
     });
   });
@@ -299,7 +299,7 @@ describe('secondsToDurationString', () => {
   // Custom Options
   describe('Custom options passed to humanizeDuration', () => {
     test('applies custom options (e.g., largest units) correctly', () => {
-      const result = secondsToDurationString(3661, Language.English, {
+      const result = secondsToDuration(3661, Language.English, {
         largest: 1,
       });
       expect(result).toBe('1 hour');
@@ -309,12 +309,12 @@ describe('secondsToDurationString', () => {
   // Invalid or Corner Case Inputs
   describe('Invalid or edge case inputs', () => {
     test('handles negative seconds gracefully', () => {
-      const result = secondsToDurationString(-500, Language.English);
+      const result = secondsToDuration(-500, Language.English);
       expect(result).toBe('0 seconds');
     });
 
     test('handles exactly 0 seconds', () => {
-      const result = secondsToDurationString(0, Language.English);
+      const result = secondsToDuration(0, Language.English);
       expect(result).toBe('0 seconds');
     });
   });
@@ -322,17 +322,17 @@ describe('secondsToDurationString', () => {
   // Unit Map Logic
   describe('Unit map logic', () => {
     test('uses seconds for durations under 60 seconds', () => {
-      const result = secondsToDurationString(30, Language.English);
+      const result = secondsToDuration(30, Language.English);
       expect(result).toBe('30 seconds');
     });
 
     test('uses minutes and seconds for durations under an hour', () => {
-      const result = secondsToDurationString(120, Language.English);
+      const result = secondsToDuration(120, Language.English);
       expect(result).toBe('2 minutes');
     });
 
     test('uses hours and minutes for durations under a day', () => {
-      const result = secondsToDurationString(7200, Language.English);
+      const result = secondsToDuration(7200, Language.English);
       expect(result).toBe('2 hours');
     });
   });

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -277,6 +277,11 @@ describe('secondsToDurationString', () => {
       expect(result).toBe('1 minute');
     });
 
+    test('handles 3658 seconds (slightly above hours range)', () => {
+      const result = secondsToDurationString(3658, Language.English);
+      expect(result).toBe('1 hour, 1 minute');
+    });
+
     test('handles 3600 seconds (start of hours range)', () => {
       const result = secondsToDurationString(3600, Language.English);
       expect(result).toBe('1 hour');

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -119,7 +119,7 @@ const unitMap: UnitMapType = [
   {range: {low: -Infinity, high: oneMinuteInSeconds - 1}, units: ['s']},
   {
     range: {low: oneMinuteInSeconds, high: oneHourInSeconds - 1},
-    units: ['m', 's'],
+    units: ['m'],
   },
   {
     range: {low: oneHourInSeconds, high: oneDayInSeconds - 1},

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -32,7 +32,7 @@ import {
   toZonedTime,
 } from 'date-fns-tz';
 import {enGB as en, nb} from 'date-fns/locale';
-import humanizeDuration, {type Unit} from 'humanize-duration';
+import humanizeDuration from 'humanize-duration';
 
 export {daysInWeek} from 'date-fns/constants';
 
@@ -40,9 +40,6 @@ import {
   parse as parseIso8601Duration,
   toSeconds as toSecondsIso8601Duration,
 } from 'iso8601-duration';
-
-type Range = {low: number; high: number};
-type UnitMapType = {range: Range; units: Unit[]}[];
 
 const CET = 'Europe/Oslo';
 /**
@@ -121,10 +118,9 @@ export function secondsToDuration(
 ): string {
   const currentLanguage = language === Language.English ? 'en' : 'no';
   const value = Math.max(seconds, 0);
-  const units = secondsToUnits(seconds);
 
   return humanizeDuration(value * 1000, {
-    units,
+    units: ['d', 'h', 'm'],
     round: true,
     language: currentLanguage,
     ...opts,
@@ -626,31 +622,3 @@ export const convertIsoStringFieldsToDate = (value: any): any => {
   }
   return value;
 };
-
-function secondsToUnits(seconds: number): humanizeDuration.Unit[] {
-  const oneMinuteInSeconds = 60;
-  const oneHourInSeconds = oneMinuteInSeconds * 60;
-  const oneDayInSeconds = oneHourInSeconds * 24;
-  const sevenDaysInSeconds = oneDayInSeconds * 7;
-  const unitMap: UnitMapType = [
-    {range: {low: -Infinity, high: oneMinuteInSeconds - 1}, units: ['s']},
-    {
-      range: {low: oneMinuteInSeconds, high: oneHourInSeconds - 1},
-      units: ['m', 's'],
-    },
-    {
-      range: {low: oneHourInSeconds, high: oneDayInSeconds - 1},
-      units: ['h', 'm'],
-    },
-    {
-      range: {low: oneDayInSeconds, high: sevenDaysInSeconds},
-      units: ['d', 'h'],
-    },
-    {range: {low: sevenDaysInSeconds, high: Infinity}, units: ['d']},
-  ];
-
-  return (
-    unitMap.find(({range}) => seconds >= range.low && seconds <= range.high)
-      ?.units ?? ['d', 'h', 'm']
-  );
-}


### PR DESCRIPTION
Fixes some bugs relating to AtB-AS/kundevendt#4220

The main issue was `TextInputSectionItem` and `LineItem` getting excessive padding due to the export from `use-section-item.ts`changing from `padding` to `paddingVertical` and `paddingHorizontal` ([see code here](https://github.com/AtB-AS/mittatb-app/commit/31f3280b3cfb4d52b54627daefa191c586219ec4#diff-704d1e9f5eb3e264a4abc336c07fe0913a48fb946a15c2f783a2f57396616344L30)). The underlying issue was setting a default value, which was not applicable in all cases and changing the generic component then lead to unintended consequences.
<div>
    <img width="350" src="https://github.com/user-attachments/assets/b0f72e48-0956-4ef2-9dab-c92c6b73bd13" />
   <img width="350" src="https://github.com/user-attachments/assets/2e53e612-658d-420d-9e39-c8150d3308c7" />
</div>

It now looks like this:
<div>
   <img width="350" src="https://github.com/user-attachments/assets/eb7d265f-c043-4905-b2ce-7584c97c57e4" />
   <img width="350" src="https://github.com/user-attachments/assets/d0da51bb-f2bc-46fa-a267-ca3380a53d68" />
</div>


This PR also implements the design for reservations with status `reserving` and `rejected` according to [Figma](https://www.figma.com/design/2QTjAdekdIPuLFovQhVrY3/Components?node-id=9314-86777&p=f&t=nGY94Q0EzbtvPqV2-0), which were missing from the previous PR. They now look like this: 
<img width="350" src="https://github.com/user-attachments/assets/ee208709-7228-46f8-998a-a12f534814af" />


There are also some small refactorings that I found, particularly to the secondsToDuration-dateutil.