### PR TITLE
fix: fix wrong type and allow intercom update to fire multiple times

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -114,20 +114,17 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
     data: nativeToken,
     status: nativeTokenStatus,
     error: nativeTokenError,
-    isFetched: isNativeTokenFetched,
   } = useLoadNativeTokenQuery(enabled, userId, traceId.current);
 
   useEffect(() => {
-    if (isNativeTokenFetched) {
-      updateMetadata({
-        'AtB-Mobile-Token-Id': nativeToken ? nativeToken.tokenId : 'undefined',
-        'AtB-Mobile-Token-Status': getAttestationStatus(nativeToken),
-        'AtB-Mobile-Token-Error-Correlation-Id': nativeToken
-          ? 'undefined'
-          : traceId.current,
-      });
-    }
-  }, [isNativeTokenFetched, nativeToken, updateMetadata]);
+    updateMetadata({
+      'AtB-Mobile-Token-Id': nativeToken ? nativeToken.tokenId : 'undefined',
+      'AtB-Mobile-Token-Status': getAttestationStatus(nativeToken),
+      'AtB-Mobile-Token-Error-Correlation-Id': nativeToken
+        ? 'undefined'
+        : traceId.current,
+    });
+  }, [nativeToken, updateMetadata]);
 
   const {
     data: remoteTokens,

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -47,7 +47,7 @@ export const wipeToken = async (tokensIds: string[], traceId: string) => {
        * There are cases where remove token fails due to the backoffice token
        * already removed, in this case, just wipe the local token.
        */
-      if (isTokenDeletedError(err)) {
+      if (isEntityDeletedError(err)) {
         await mobileTokenClient.clear();
       }
     }
@@ -76,9 +76,9 @@ export const getMobileTokenErrorHandlingStrategy = (
   // try to find the error resolution
   if (err instanceof TokenFactoryError) {
     errorResolution = err.resolution;
-  } else if (err instanceof isRemoteTokenStateError) {
+  } else if (err instanceof RemoteTokenStateError) {
     errorResolution = mapTokenErrorResolution(err);
-  } else if (isTokenDeletedError(err)) {
+  } else if (isEntityDeletedError(err)) {
     /**
      * This handles the situation where local token is still stored, while
      * the remote token is already deleted, should only happens with a very
@@ -105,13 +105,13 @@ export const getMobileTokenErrorHandlingStrategy = (
 };
 
 /**
- * Checks if the error is a token deleted error
+ * Checks if the error is an `Entity deleted` error
  * Should be only those with error code 500, and has message as follows:
  *
  * `5 NOT_FOUND: Entity deleted: Entity of type Token with id xxxx has been deleted`
- *
+ * `5 NOT_FOUND: Entity not found: Token not found for CustomerAccount: xxxx`
  */
-const isTokenDeletedError = (err: any): boolean => {
+const isEntityDeletedError = (err: any): boolean => {
   return (
     isAxiosError(err) && err.code === '500' && err.message.includes('NOT FOUND')
   );


### PR DESCRIPTION
fixes related to https://mittatb.slack.com/archives/C079LPXV1NF/p1737980690392759

- fix wrong `instanceof` checking, should be `RemoteTokenStateError` instead of `isRemoteTokenStateError`
- allow intercom state to be updated multiple times in one session, whenever the native token status is updated, to try to get more accurate statistics of the token.

Will be included in release 1.61.4