### PR TITLE
fix: token issue fix and many more logging

### DIFF
--- a/src/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/mobile-token/hooks/use-load-native-token-query.tsx
@@ -1,13 +1,9 @@
 import {useQuery} from '@tanstack/react-query';
 import {storage} from '@atb/storage';
-import {
-  ActivatedToken,
-} from '@entur-private/abt-mobile-client-sdk';
+import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
 import {mobileTokenClient} from '@atb/mobile-token/mobileTokenClient';
 import {tokenService} from '@atb/mobile-token/tokenService';
-import {
-  TokenMustBeRenewedRemoteTokenStateError,
-} from '@entur-private/abt-token-server-javascript-interface';
+import {TokenMustBeRenewedRemoteTokenStateError} from '@entur-private/abt-token-server-javascript-interface';
 import {
   getMobileTokenErrorHandlingStrategy,
   getSdkErrorTokenIds,

--- a/src/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/mobile-token/hooks/use-load-native-token-query.tsx
@@ -8,7 +8,6 @@ import {mobileTokenClient} from '@atb/mobile-token/mobileTokenClient';
 import {tokenService} from '@atb/mobile-token/tokenService';
 import {
   TokenMustBeRenewedRemoteTokenStateError,
-  TokenMustBeReplacedRemoteTokenStateError,
 } from '@entur-private/abt-token-server-javascript-interface';
 import {
   getMobileTokenErrorHandlingStrategy,

--- a/src/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/mobile-token/hooks/use-load-native-token-query.tsx
@@ -2,7 +2,6 @@ import {useQuery} from '@tanstack/react-query';
 import {storage} from '@atb/storage';
 import {
   ActivatedToken,
-  TokenFactoryError,
 } from '@entur-private/abt-mobile-client-sdk';
 import {mobileTokenClient} from '@atb/mobile-token/mobileTokenClient';
 import {tokenService} from '@atb/mobile-token/tokenService';

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -54,7 +54,7 @@ export const wipeToken = async (tokensIds: string[], traceId: string) => {
             description: `Token already deleted in backoffice ${id}, start new`,
           },
         });
-        await mobileTokenClient.clear();
+        break; // No need to do anything, proceed to clear the local token
       } else {
         notifyBugsnag(err, {
           errorGroupHash: 'token',

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -60,7 +60,7 @@ export const wipeToken = async (tokensIds: string[], traceId: string) => {
           errorGroupHash: 'token',
           metadata: {
             traceId,
-            description: `Token already deleted in backoffice ${id}, start new`,
+            description: `Other error during wipe token, throw the error`,
           },
         });
         // if it is not entity deleted error

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -15,8 +15,7 @@ import Bugsnag from '@bugsnag/react-native';
 import {getAxiosErrorType} from '@atb/api/utils';
 import {tokenService} from './tokenService';
 import {mobileTokenClient} from './mobileTokenClient';
-import {logToBugsnag} from '@atb/utils/bugsnag-utils';
-import {isAxiosError} from 'axios';
+import {logToBugsnag, notifyBugsnag} from '@atb/utils/bugsnag-utils';
 
 export const MOBILE_TOKEN_QUERY_KEY = 'mobileToken';
 
@@ -48,7 +47,24 @@ export const wipeToken = async (tokensIds: string[], traceId: string) => {
        * already removed, in this case, just wipe the local token.
        */
       if (isEntityDeletedError(err)) {
+        notifyBugsnag(Error(`Token removed from backoffice ${id}`), {
+          errorGroupHash: 'token',
+          metadata: {
+            traceId,
+            description: `Token already deleted in backoffice ${id}, start new`,
+          },
+        });
         await mobileTokenClient.clear();
+      } else {
+        notifyBugsnag(err, {
+          errorGroupHash: 'token',
+          metadata: {
+            traceId,
+            description: `Token already deleted in backoffice ${id}, start new`,
+          },
+        });
+        // if it is not entity deleted error
+        throw err;
       }
     }
   }
@@ -78,17 +94,20 @@ export const getMobileTokenErrorHandlingStrategy = (
     errorResolution = err.resolution;
   } else if (err instanceof RemoteTokenStateError) {
     errorResolution = mapTokenErrorResolution(err);
-  } else if (isEntityDeletedError(err)) {
-    /**
-     * This handles the situation where local token is still stored, while
-     * the remote token is already deleted, should only happens with a very
-     * old account that got their account history truncated in backoffice.
-     */
-    return 'reset';
   } else {
     return 'unspecified';
   }
 
+  logToBugsnag(
+    `mobile token handle error ${err} with resolution ${errorResolution}`,
+  );
+
+  notifyBugsnag(err, {
+    errorGroupHash: 'token',
+    metadata: {
+      description: `Handling error ${err} with resolution of ${errorResolution}`,
+    },
+  });
   // handle the error resolution
   switch (errorResolution) {
     case TokenErrorResolution.RESET:
@@ -105,17 +124,12 @@ export const getMobileTokenErrorHandlingStrategy = (
 };
 
 /**
- * Checks if the error is an `Entity deleted` error
- * Should be only those with error code 500, and has message as follows:
- *
- * `5 NOT_FOUND: Entity deleted: Entity of type Token with id xxxx has been deleted`
- * `5 NOT_FOUND: Entity not found: Token not found for CustomerAccount: xxxx`
+ * Checks if the error calling the `/remove` endpoint has statusCode 500
+ * This usually happens when the token is removed from backoffice
+ * and they return error code 500.
  */
-const isEntityDeletedError = (err: any): boolean => {
-  return (
-    isAxiosError(err) && err.code === '500' && err.message.includes('NOT_FOUND')
-  );
-};
+const isEntityDeletedError = (err: any): boolean =>
+  'statusCode' in err && err.statusCode === 500;
 
 /**
  * Get the token ids that are encapsulated in some sdk errors.

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -54,16 +54,10 @@ export const wipeToken = async (tokensIds: string[], traceId: string) => {
             description: `Token already deleted in backoffice ${id}, start new`,
           },
         });
-        break; // No need to do anything, proceed to clear the local token
+        // No need to do anything, proceed to clear the local token
       } else {
-        notifyBugsnag(err, {
-          errorGroupHash: 'token',
-          metadata: {
-            traceId,
-            description: `Other error during wipe token, throw the error`,
-          },
-        });
-        // if it is not entity deleted error
+        logToBugsnag(`Other error found during wipe token, ${err}`);
+        // if it is not entity deleted error, throw it so it notifies bugsnag
         throw err;
       }
     }

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -42,24 +42,9 @@ export const wipeToken = async (tokensIds: string[], traceId: string) => {
     try {
       await tokenService.removeToken(id, traceId);
     } catch (err: any) {
-      /**
-       * There are cases where remove token fails due to the backoffice token
-       * already removed, in this case, just wipe the local token.
-       */
-      if (isEntityDeletedError(err)) {
-        notifyBugsnag(Error(`Token removed from backoffice ${id}`), {
-          errorGroupHash: 'token',
-          metadata: {
-            traceId,
-            description: `Token already deleted in backoffice ${id}, start new`,
-          },
-        });
-        // No need to do anything, proceed to clear the local token
-      } else {
-        logToBugsnag(`Other error found during wipe token, ${err}`);
-        // if it is not entity deleted error, throw it so it notifies bugsnag
-        throw err;
-      }
+      logToBugsnag(`Other error found during wipe token, ${err}`);
+      // if it is not entity deleted error, throw it so it notifies bugsnag
+      throw err;
     }
   }
   await mobileTokenClient.clear();
@@ -116,14 +101,6 @@ export const getMobileTokenErrorHandlingStrategy = (
       return 'unspecified';
   }
 };
-
-/**
- * Checks if the error calling the `/remove` endpoint has statusCode 500
- * This usually happens when the token is removed from backoffice
- * and they return error code 500.
- */
-const isEntityDeletedError = (err: any): boolean =>
-  'statusCode' in err && err.statusCode === 500;
 
 /**
  * Get the token ids that are encapsulated in some sdk errors.


### PR DESCRIPTION
Fix issue with mobile token where the token gets recreated whenever issues happened during fetching the local token.
Also adds many more loggings.

So, what happened on the issue in 1.61.4 is that I added a function to detect if a user needs to start fresh, there was an issue for old users when their data was truncated from backoffice and the token is already deleted, where their local device still has the old token. It means that the user should just remove that local token, and then init a new token, problem solved.

The problem was this code: 
```
export const wipeToken = async (tokensIds: string[], traceId: string) => {
  for (const id of tokensIds) {
    logToBugsnag('Wiping token with id ' + id);
    try {
      await tokenService.removeToken(id, traceId);
    } catch (err: any) {
      /**
       * There are cases where remove token fails due to the backoffice token
       * already removed, in this case, just wipe the local token.
       */
      if (isTokenDeletedError(err)) {
        await mobileTokenClient.clear();
      }
    }
  }
  await mobileTokenClient.clear();
};
```

In that `wipeToken` function, I added a catch block, and check if the token is deleted in backoffice, just clear the token. 

Unfortunately, I didn't realize that you need to actually **_throw_** the error for the error to propagate and stop the `clear()` function at the bottom from being called. Therefore, when an issue happens during fetching, the `wipeToken` gets called, then the local token is cleared, prompting an `/init` before calling `/remove`, causing the remote token to still be there, and a new token gets recreated everytime.

In this PR I tried fixing the issue by calling **_throw_** in the `catch` block, and added many more loggings.

Please point out if there's anything weird, or ask if you have any questions!