### PR TITLE
fix: upgrade `phone` to support 9 digit Bosnia and Herzegovina numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lodash.pickby": "^4.6.0",
     "lodash.sortby": "^4.7.0",
     "marked": "^4.2.12",
-    "phone": "^3.1.49",
+    "phone": "^3.1.58",
     "posthog-react-native": "^3.1.1",
     "prop-types": "^15.8.1",
     "qrcode": "1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9175,10 +9175,10 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-phone@^3.1.49:
-  version "3.1.49"
-  resolved "https://registry.yarnpkg.com/phone/-/phone-3.1.49.tgz#607672cbb2a7e6808b800ce597ab98640c6708f8"
-  integrity sha512-S+rHWXSQrllK5eQwz0sDbwfxQ2PzennWPgsP/jdpEPH3k7P5IBJZYjvYfU8e/RF5AwKCgOtzbTGTGJcBSLJVVw==
+phone@^3.1.58:
+  version "3.1.58"
+  resolved "https://registry.yarnpkg.com/phone/-/phone-3.1.58.tgz#af0523fc3d2d840e46d47fb4118845f0bc38babd"
+  integrity sha512-4R4qfXxNPpl08fxOH0qvTXTodQue0nCnAQP0OIu2i59TDq4QXM0dq/b7ODPNH93setqK5YdMSiMuce0RPsgu4w==
 
 picocolors@^1.0.0, picocolors@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/19919

After https://github.com/AfterShip/phone/pull/420, the issue with 9 digit phone numbers from Bosnia and Herzegovina is resolved by upgrading the phone package.