### PR TITLE
refactor: remove some unused FareContract/TraveRight fields

### DIFF
--- a/src/fare-contracts/__tests__/sort-fc-reservation-by-validity-creation.test.ts
+++ b/src/fare-contracts/__tests__/sort-fc-reservation-by-validity-creation.test.ts
@@ -60,12 +60,10 @@ function mockupFareContract(
     orderId: '1',
     state: 0,
     totalAmount: '0',
-    minimumSecurityLevel: 1,
     travelRights: [{} as any as TravelRight],
     qrCode: '',
     validityStatus: validityStatus,
     paymentType: ['VISA'],
-    paymentTypeGroup: ['PAYMENTCARD'],
     totalTaxAmount: '0',
   };
 }

--- a/src/fare-contracts/details/DetailsContent.tsx
+++ b/src/fare-contracts/details/DetailsContent.tsx
@@ -114,7 +114,6 @@ export const DetailsContent: React.FC<Props> = ({
 
   const globalMessageRuleVariables = {
     fareProductType: preassignedFareProduct?.type ?? 'unknown',
-    firstTravelRightType: firstTravelRight.type,
     validityStatus: validityStatus,
     tariffZones: firstTravelRight.tariffZoneRefs ?? [],
     numberOfZones: firstTravelRight.tariffZoneRefs?.length ?? 0,

--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -27,7 +27,6 @@ import {
   isOfFareProductRef,
   useFirestoreConfigurationContext,
 } from '@atb/configuration';
-import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
 import {useTimeContext} from '@atb/time';
 import {getDeviceNameWithUnitInfo} from './utils';
 import {TokenToggleInfo} from '@atb/token-toggle-info';
@@ -72,9 +71,8 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
   );
 
   // Filter for unique travel rights config types
-  const availableFareContractsTypes = availableTravelRights
-    .filter(onlyUniquesBasedOnField('type'))
-    .map((travelRight) => {
+  const availableFareContractsTypes = availableTravelRights.map(
+    (travelRight) => {
       const preassignedFareProduct = findReferenceDataById(
         preassignedFareProducts,
         isOfFareProductRef(travelRight) ? travelRight.fareProductRef : '',
@@ -86,7 +84,8 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
           (c) => c.type === preassignedFareProduct.type,
         )
       );
-    });
+    },
+  );
 
   const fareProductConfigWhichRequiresTokenOnMobile =
     availableFareContractsTypes.find(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -41,10 +41,8 @@ export const Profile_FareContractsScreen = () => {
     customerAccountId: 'ATB:CustomerAccount:xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
     purchasedBy: 'ATB:CustomerAccount:xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
     id: 'ATB:FareContract:V3TZT6NE-xPWkGQzzmaRCdQ1JmERtk8eQtQA2',
-    minimumSecurityLevel: -200,
     orderId: 'V3TZT6NE',
     paymentType: ['VISA'],
-    paymentTypeGroup: ['PAYMENTCARD'],
     qrCode:
       'CioKKBImCiRmM2I4ZjQ1NC0wNGZiLTRlY2UtODc5ZC0wNDY2MzhiOWEzNjgSUwo+MDwCHDde9IPYTgNlJVADldKpl5GnkVowFiejaqbAcF0CHDqRdXIKEoOg0O67eH9sg8hNOuCYH35KJQ0oq2gaAU4qDAiXr++oBhDol5+uAjAB',
     state: 2,
@@ -70,7 +68,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'PeriodBoatTicket',
         fareProductRef: 'ATB:PreassignedFareProduct:5f61ee14',
         id: 'ATB:CustomerPurchasePackage:MMLMWZUV',
         direction: TravelRightDirection.Both,
@@ -85,7 +82,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'YouthTicket',
         fareProductRef: 'ATB:PreassignedFareProduct:47bb613e',
         id: 'ATB:CustomerPurchasePackage:Y1EGBK3C',
       },
@@ -97,7 +93,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'NightTicket',
         fareProductRef: 'ATB:PreassignedFareProduct:8f351521',
         id: 'ATB:CustomerPurchasePackage:Y1EGBK3C',
       },
@@ -108,7 +103,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'PreActivatedPeriodTicket',
         fareProductRef: 'ATB:PreassignedFareProduct:6dd9beab',
         id: 'ATB:CustomerPurchasePackage:83HMVOBI',
         tariffZoneRefs: [
@@ -125,7 +119,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'SingleBoatTicket',
         fareProductRef: 'ATB:PreassignedFareProduct:c4467e3a',
         id: 'ATB:CustomerPurchasePackage:83HMVOBI',
         direction: TravelRightDirection.Forwards,
@@ -140,7 +133,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'CarnetTicket',
         fareProductRef: 'ATB:AmountOfPriceUnitProduct:KlippekortBuss',
         id: 'ATB:CustomerPurchasePackage:4cb81f08-4499-44c4-8e23-507256f782a6-1',
         maximumNumberOfAccesses: 10,
@@ -155,7 +147,6 @@ export const Profile_FareContractsScreen = () => {
       },
       {
         ...BASE.travelRights[0],
-        type: 'CarnetTicket',
         fareProductRef: 'ATB:AmountOfPriceUnitProduct:KlippekortBuss',
         id: 'ATB:CustomerPurchasePackage:4cb81f08-4499-44c4-8e23-507256f782a6-2',
         maximumNumberOfAccesses: 10,
@@ -177,7 +168,6 @@ export const Profile_FareContractsScreen = () => {
     travelRights: [
       {
         ...BASE.travelRights[0],
-        type: 'CarnetTicket',
         fareProductRef: 'ATB:AmountOfPriceUnitProduct:KlippekortBuss',
         id: 'ATB:CustomerPurchasePackage:4cb81f08-4499-44c4-8e23-507256f782a6-1',
         maximumNumberOfAccesses: 50,

--- a/src/ticketing/__tests__/fixtures/carnet-farecontact.ts
+++ b/src/ticketing/__tests__/fixtures/carnet-farecontact.ts
@@ -9,11 +9,9 @@ export const carnetFareContract = {
   version: '1',
   qrCode:
     'ChYKFBISGhBioVl1qEVO/6iNfWGTutfhEkYKPzA9AhxHUC0xlHwngf3rC7SJnzaH1wme48tOIjRWjS8mAh0AxfqUUU6iO6eA8JnbSxKtZCD3nFJQSRuqJqMx1RoBTjAB',
-  minimumSecurityLevel: -200,
   customerAccountId: 'ATB:CustomerAccount:Qw3fhcJudvgCYR7yHScbFd1mPtP2',
   orderId: 'E69J9NJH',
   created: new Date(Date.now() - 1000 * 60 * 60 * 10), // 10 hours ago
   travelRights: [carnetTravelRight],
-  paymentTypeGroup: ['PAYMENTCARD'],
   totalTaxAmount: '46.07',
 };

--- a/src/ticketing/__tests__/fixtures/period-boat-farecontract.ts
+++ b/src/ticketing/__tests__/fixtures/period-boat-farecontract.ts
@@ -9,11 +9,9 @@ export const periodBoatFareContract = {
   version: '1',
   qrCode:
     'ChYKFBISGhANvqDoNVlNJqZxxTQcXpuiEkYKPzA9Ah0A1jaI46tFV5bNuVmhphKdGY+QestjJ9q52HG/4QIcT0/0ykhobiOB+zXaewI7Wf3sGHOxgcv2LZ3NIxoBTjAB',
-  minimumSecurityLevel: -200,
   customerAccountId: 'ATB:CustomerAccount:Qw3fhcJudvgCYR7yHScbFd1mPtP2',
   orderId: '8MTTWRI4',
   created: new Date(Date.now() - 1000 * 60 * 60 * 10), // 10 hours ago
   travelRights: [periodBoatTravelRight],
-  paymentTypeGroup: ['PAYMENTCARD'],
   totalTaxAmount: '895.82',
 };

--- a/src/ticketing/__tests__/fixtures/single-farecontract.ts
+++ b/src/ticketing/__tests__/fixtures/single-farecontract.ts
@@ -9,7 +9,6 @@ export const singleFareContract = {
   version: '1',
   qrCode:
     'ChYKFBISGhD21zmOb3NHrZqJ7Zp0kR/dEkUKPjA8Ahsup12ve5onG3q1++dKV8Ya/UJpDUNsOi3jsgoCHQCIDNWKPBObWQyrGgBr+yKIxPz94Au4rh++HtIMGgFOMAE=',
-  minimumSecurityLevel: -200,
   customerAccountId: 'ATB:CustomerAccount:Qw3fhcJudvgCYR7yHScbFd1mPtP2',
   orderId: '1MNPXN7A',
   created: new Date(Date.now() - 1000 * 60 * 60 * 10), // 10 hours ago
@@ -30,6 +29,5 @@ export const singleFareContract = {
       id: 'ATB:CustomerPurchasePackage:556ebc7d-6d55-4096-98fc-d5bf6243b36b',
     },
   ],
-  paymentTypeGroup: ['PAYMENTCARD'],
   totalTaxAmount: '9.11',
 };

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -23,8 +23,8 @@ export enum TravelRightDirection {
 }
 
 /**
- * For definition, see `elementAccess` type in eventhandler
- * https://github.com/AtB-AS/eventhandler/blob/main/customerstore/travel_right.go
+ * For definition, see `UsedAccess` struct in ticket service
+ * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/travel_right.rs
  */
 export const CarnetTravelRightUsedAccess = z.object({
   startDateTime: z.date(),
@@ -35,12 +35,11 @@ export type CarnetTravelRightUsedAccess = z.infer<
 >;
 
 /**
- * For definitions, see travel_right.go in eventhandler
- * https://github.com/AtB-AS/eventhandler/blob/main/customerstore/travel_right.go
+ * For definitions, see `TravelRight` struct in ticket service
+ * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/travel_right.rs
  */
 export const TravelRight = z.object({
   id: z.string(),
-  type: z.string(),
   customerAccountId: z.string().optional(),
   status: z.nativeEnum(TravelRightStatus),
   fareProductRef: z.string(),
@@ -68,17 +67,15 @@ export enum FareContractState {
   Refunded = 4,
 }
 /**
- * For definition, see `persistedFareContract` type in eventhandler
- * https://github.com/AtB-AS/eventhandler/blob/main/customerstore/fare_contract.go
+ * For definition, see `FareContract` struct in ticket service
+ * https://github.com/AtB-AS/ticket/blob/main/firestore-client/src/fare_contract.rs
  */
 export const FareContract = z.object({
   created: z.date(),
   id: z.string(),
   customerAccountId: z.string(),
-  minimumSecurityLevel: z.number(),
   orderId: z.string(),
   paymentType: z.array(z.string()),
-  paymentTypeGroup: z.array(z.string()),
   qrCode: z.string().optional(),
   state: z.nativeEnum(FareContractState),
   totalAmount: z.string(),


### PR DESCRIPTION
Some fields that are always present in Firestore, are not returned by the ticket service. After adding stricter Zod validation of fields, this caused tickets from the endpoint to fail validation. Since these fields were not used (in a significant way) in the app, I opted to treat them as deprecated and remove them from the app entirely.

At the same time, it shows that we should use the ticket service as source of truth for fare contract and travel right types in the app.

fixes comment https://github.com/AtB-AS/mittatb-app/pull/4971#issuecomment-2623942274