### PR TITLE
feat: add bonus points screen from profile

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -1,5 +1,5 @@
 import {GenericSectionItem, Section} from '@atb/components/sections';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {BonusProfileTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {View} from 'react-native';
@@ -10,7 +10,6 @@ import {ThemedCityBike} from '@atb/theme/ThemedAssets'; // TODO: update with ne 
 import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
 
 export const Profile_BonusScreen = () => {
-  useThemeContext();
   const {t} = useTranslation();
   const styles = useStyles();
 
@@ -52,8 +51,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   section: {
     marginHorizontal: theme.spacing.medium,
-    marginBottom: theme.spacing.small,
-    marginTop: theme.spacing.small,
+    marginVertical: theme.spacing.small,
   },
   currentPointsContainer: {
     flexDirection: 'row',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -1,0 +1,68 @@
+import {GenericSectionItem, Section} from '@atb/components/sections';
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import {BonusProfileTexts, useTranslation} from '@atb/translations';
+import React from 'react';
+import {View} from 'react-native';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ThemeText} from '@atb/components/text';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {ThemedCityBike} from '@atb/theme/ThemedAssets'; // TODO: update with ne illustration when available
+import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+
+export const Profile_BonusScreen = () => {
+  useThemeContext();
+  const {t} = useTranslation();
+  const styles = useStyles();
+
+  const currentPoints = 5; // TODO: get actual value when available
+
+  return (
+    <FullScreenView
+      headerProps={{
+        title: t(BonusProfileTexts.header.title),
+        leftButton: {type: 'back', withIcon: true},
+      }}
+    >
+      <View style={styles.container}>
+        <Section style={styles.section}>
+          <GenericSectionItem style={styles.currentPointsContainer}>
+            <View>
+              <View style={styles.currentPointsDisplay}>
+                <ThemeText typography="body__primary--jumbo--bold">
+                  {currentPoints}
+                </ThemeText>
+                <ThemeIcon svg={StarFill} size="large" />
+              </View>
+
+              <ThemeText typography="body__secondary">
+                {t(BonusProfileTexts.yourBonusPoints)}
+              </ThemeText>
+            </View>
+            <ThemedCityBike />
+          </GenericSectionItem>
+        </Section>
+      </View>
+    </FullScreenView>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    marginTop: theme.spacing.large,
+  },
+  section: {
+    marginHorizontal: theme.spacing.medium,
+    marginBottom: theme.spacing.small,
+    marginTop: theme.spacing.small,
+  },
+  currentPointsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  currentPointsDisplay: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -178,6 +178,13 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               }
               testID="ticketHistoryButton"
             />
+            <LinkSectionItem
+              text={t(
+                ProfileTexts.sections.account.linkSectionItems.bonus.label,
+              )}
+              onPress={() => navigation.navigate('Profile_BonusScreen')}
+              testID="BonusButton"
+            />
             {authenticationType !== 'phone' && (
               <LinkSectionItem
                 text={t(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -87,8 +87,11 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const [isLoading, setIsLoading] = useIsLoading(false);
 
   const phoneNumber = authPhoneNumber && formatPhoneNumber(authPhoneNumber);
-  const {isPushNotificationsEnabled, isTravelAidEnabled} =
-    useFeatureTogglesContext();
+  const {
+    isPushNotificationsEnabled,
+    isTravelAidEnabled,
+    isBonusProgramEnabled,
+  } = useFeatureTogglesContext();
 
   const {logEvent} = useAnalyticsContext();
 
@@ -178,13 +181,15 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               }
               testID="ticketHistoryButton"
             />
-            <LinkSectionItem
-              text={t(
-                ProfileTexts.sections.account.linkSectionItems.bonus.label,
-              )}
-              onPress={() => navigation.navigate('Profile_BonusScreen')}
-              testID="BonusButton"
-            />
+            {isBonusProgramEnabled && (
+              <LinkSectionItem
+                text={t(
+                  ProfileTexts.sections.account.linkSectionItems.bonus.label,
+                )}
+                onPress={() => navigation.navigate('Profile_BonusScreen')}
+                testID="BonusButton"
+              />
+            )}
             {authenticationType !== 'phone' && (
               <LinkSectionItem
                 text={t(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -26,6 +26,7 @@ import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
 import {Profile_TicketHistorySelectionScreen} from './Profile_TicketHistorySelectionScreen';
 import {Profile_TravelAidScreen} from './Profile_TravelAidScreen';
 import {Profile_TravelAidInformationScreen} from './Profile_TravelAidInformationScreen.tsx';
+import {Profile_BonusScreen} from './Profile_BonusScreen.tsx';
 
 const Stack = createStackNavigator<ProfileStackParams>();
 
@@ -45,6 +46,10 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_TicketHistorySelectionScreen"
         component={Profile_TicketHistorySelectionScreen}
+      />
+      <Stack.Screen
+        name="Profile_BonusScreen"
+        component={Profile_BonusScreen}
       />
       <Stack.Screen
         name="Profile_PaymentMethodsScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -13,6 +13,7 @@ export type ProfileStackParams = StackParams<{
   Profile_PaymentMethodsScreen: undefined;
   Profile_TicketHistoryScreen: TicketHistoryScreenParams;
   Profile_TicketHistorySelectionScreen: undefined;
+  Profile_BonusScreen: undefined;
   Profile_DeleteProfileScreen: undefined;
   Profile_EditProfileScreen: undefined;
   Profile_FavoriteListScreen: undefined;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -40,6 +40,7 @@ export {default as TripDetailsTexts} from './screens/subscreens/TripDetails';
 export {default as DepartureDetailsTexts} from './screens/subscreens/DepartureDetails';
 export {default as SelectStartScreenTexts} from './screens/subscreens/SelectStartScreen';
 export {default as AppearanceSettingsTexts} from './screens/subscreens/AppearanceSettings';
+export {default as BonusProfileTexts} from './screens/subscreens/BonusProfile';
 export {default as LanguageSettingsTexts} from './screens/subscreens/LanguageSettingsTexts';
 export {default as UserProfileSettingsTexts} from './screens/subscreens/UserProfileSettingsTexts';
 export {default as LoginTexts} from './screens/subscreens/Login';

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -33,6 +33,9 @@ const ProfileTexts = {
         ticketHistory: {
           label: _('Billetthistorikk', 'Ticket history', 'Billetthistorikk'),
         },
+        bonus: {
+          label: _('Bonus', 'Bonus', 'Bonus'),
+        },
         paymentMethods: {
           label: _('Betalingskort', 'Payment cards', 'Betalingskort'),
         },

--- a/src/translations/screens/subscreens/BonusProfile.ts
+++ b/src/translations/screens/subscreens/BonusProfile.ts
@@ -1,0 +1,12 @@
+import {translation as _} from '../../commons';
+const BonusProfileTexts = {
+  header: {
+    title: _('Bonus', 'Bonus', 'Bonus'),
+  },
+  yourBonusPoints: _(
+    'Dine bonuspoeng',
+    'Your bonus points',
+    'Bonuspoenga dine',
+  ),
+};
+export default BonusProfileTexts;

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,9 +34,9 @@
     zod-to-json-schema "^3.20.4"
 
 "@atb-as/generate-assets@^15.0.1":
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-15.0.1.tgz#a85c0c2233faa3ffaf072e09abfa79df46583e9f"
-  integrity sha512-iNhLbcfopxs+ADn+1tuWDKsAKJI5PxJQNfl7CpCx1pKd9WgMVQ+k1BGiplL6wrt/uDqqj76cnctborcgjW4psw==
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-15.1.0.tgz#45920af66a5679da7a1d8f2054d13a13671ec928"
+  integrity sha512-Izl9QXl1hyX8ev99SsJrz2oEVtxkPeOMad0f8LC0SiJFF9XtQW5zashC29NNd5grvZo8gw3ukCJQkZiosH440g==
   dependencies:
     "@atb-as/theme" "^13.1.3"
     commander "^9.4.0"
@@ -4561,7 +4561,14 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2, braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
+braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -6258,7 +6265,18 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
+fast-glob@^3.2.11:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
+fast-glob@^3.2.9, fast-glob@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
@@ -6292,9 +6310,9 @@ fast-xml-parser@^4.0.12, fast-xml-parser@^4.2.4:
     strnum "^1.0.5"
 
 fastq@^1.6.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
-  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.0.tgz#a82c6b7c2bb4e44766d865f07997785fecfdcb89"
+  integrity sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==
   dependencies:
     reusify "^1.0.4"
 
@@ -6326,10 +6344,10 @@ filelist@^1.0.4:
   dependencies:
     minimatch "^5.0.1"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.0.1, fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -8521,12 +8539,20 @@ metro@0.80.6, metro@^0.80.3:
     ws "^7.5.1"
     yargs "^17.6.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
     braces "^3.0.2"
+    picomatch "^2.3.1"
+
+micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/19827

Adds Bonus Screen as a page accessible from profile when bonus toggle is activated.

<img width="200" src="https://github.com/user-attachments/assets/5c564d68-9f06-427d-b593-79e3cbea24a2">
<img width="200" src="https://github.com/user-attachments/assets/4e96c2ea-9709-414a-8c34-1ea9feb9d13c">

[Figma](https://www.figma.com/design/8aTgkQtYXm7l0QvGYSCdR0/Bonusprogram?node-id=1624-29625&t=SFhRfpLnzkdmkJdG-0)

NB: The right illustration is not available (yet)