### PR TITLE
refactor: Slight refactor for TravelTokenBox usage

### DIFF
--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {RootStackParamList} from '@atb/stacks-hierarchy';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
 import {FareContract, Reservation, TravelCard} from '@atb/ticketing';
-import {TravelTokenBox} from '@atb/travel-token-box';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAnalyticsContext} from '@atb/analytics';
 import {HoldingHands, TicketTilted} from '@atb/assets/svg/color/images';
@@ -10,7 +9,7 @@ import {EmptyState} from '@atb/components/empty-state';
 import {TicketHistoryMode} from '@atb/ticket-history';
 import {useSortFcOrReservationByValidityAndCreation} from './utils';
 import {getFareContractInfo} from './utils';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
 
 type RootNavigationProp = NavigationProp<RootStackParamList>;
@@ -20,7 +19,6 @@ type Props = {
   fareContracts?: FareContract[];
   now: number;
   travelCard?: TravelCard;
-  showTokenInfo?: boolean;
   mode?: TicketHistoryMode;
   emptyStateTitleText: string;
   emptyStateDetailsText: string;
@@ -30,7 +28,6 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   fareContracts,
   reservations,
   now,
-  showTokenInfo,
   mode = 'historical',
   emptyStateTitleText,
   emptyStateDetailsText,
@@ -38,8 +35,6 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   const styles = useStyles();
   const navigation = useNavigation<RootNavigationProp>();
   const analytics = useAnalyticsContext();
-  const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[2];
 
   const fcOrReservations = [...(fareContracts || []), ...(reservations || [])];
 
@@ -54,13 +49,6 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
 
   return (
     <View style={styles.container}>
-      {showTokenInfo && (
-        <TravelTokenBox
-          showIfThisDevice={false}
-          alwaysShowErrors={false}
-          interactiveColor={interactiveColor}
-        />
-      )}
       {!fareContractsAndReservationsSorted.length && (
         <EmptyState
           title={emptyStateTitleText}

--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
@@ -24,7 +24,6 @@ export const Root_ConsiderTravelTokenChangeScreen = () => {
   const {t} = useTranslation();
   const {theme} = useThemeContext();
   const themeColor = theme.color.background.accent[0];
-  const interactiveColor = theme.color.interactive[2];
   const focusRef = useFocusOnLoad();
   const {disable_travelcard} = useRemoteConfigContext();
 
@@ -76,11 +75,7 @@ export const Root_ConsiderTravelTokenChangeScreen = () => {
       >
         {t(ConsiderTravelTokenChangeTexts.description)}
       </ThemeText>
-      <TravelTokenBox
-        showIfThisDevice={true}
-        alwaysShowErrors={true}
-        interactiveColor={interactiveColor}
-      />
+      <TravelTokenBox showIfThisDevice={true} alwaysShowErrors={true} />
     </OnboardingFullScreenView>
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/Profile_TravelTokenScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/Profile_TravelTokenScreen.tsx
@@ -1,5 +1,5 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
+import {StyleSheet, Theme} from '@atb/theme';
 import {TravelTokenTexts, useTranslation} from '@atb/translations';
 import {TravelTokenBox} from '@atb/travel-token-box';
 import React from 'react';
@@ -15,7 +15,6 @@ import {TokenToggleInfo} from '@atb/token-toggle-info';
 export const Profile_TravelTokenScreen = () => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {theme} = useThemeContext();
   const {disable_travelcard} = useRemoteConfigContext();
   const {data} = useTokenToggleDetailsQuery();
 
@@ -30,11 +29,7 @@ export const Profile_TravelTokenScreen = () => {
         leftButton={{type: 'back'}}
       />
       <ScrollView contentContainerStyle={styles.content}>
-        <TravelTokenBox
-          showIfThisDevice={true}
-          alwaysShowErrors={true}
-          interactiveColor={theme.color.interactive[2]}
-        />
+        <TravelTokenBox showIfThisDevice={true} alwaysShowErrors={true} />
         <Section>
           {data?.toggleLimit !== undefined && (
             <GenericSectionItem>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -13,6 +13,7 @@ import {RefreshControl, ScrollView} from 'react-native-gesture-handler';
 import {usePopOverContext} from '@atb/popover';
 import {useOneTimePopover} from '@atb/popover/use-one-time-popover';
 import {isElementFullyInsideScreen} from '@atb/utils/is-element-fully-inside-screen';
+import {TravelTokenBox} from '@atb/travel-token-box';
 
 type Props =
   TicketTabNavScreenProps<'TicketTabNav_AvailableFareContractsTabScreen'>;
@@ -99,11 +100,11 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           />
         }
       >
+        <TravelTokenBox showIfThisDevice={false} alwaysShowErrors={false} />
         <FareContractAndReservationsList
           reservations={reservations}
           fareContracts={availableFareContracts}
           now={serverNow}
-          showTokenInfo={true}
           emptyStateTitleText={t(
             TicketingTexts.availableFareProductsAndReservationsTab
               .noActiveTicketsTitle,

--- a/src/travel-token-box/TravelTokenBox.tsx
+++ b/src/travel-token-box/TravelTokenBox.tsx
@@ -9,25 +9,24 @@ import TravelTokenBoxTexts from '@atb/translations/components/TravelTokenBox';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {ThemedTokenPhone, ThemedTokenTravelCard} from '@atb/theme/ThemedAssets';
 import {Button} from '@atb/components/button'; // re-add when new onboarding ready
-import {InteractiveColor} from '@atb/theme/colors';
 import {TravelTokenDeviceTitle} from './TravelTokenDeviceTitle';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {MessageInfoText} from '@atb/components/message-info-text';
 
+const getInteractiveColor = (th: Theme) => th.color.interactive[2];
+
 export function TravelTokenBox({
   showIfThisDevice,
   alwaysShowErrors,
-  interactiveColor,
 }: {
   showIfThisDevice: boolean;
   alwaysShowErrors: boolean;
-  interactiveColor: InteractiveColor;
 }) {
   const {theme} = useThemeContext();
-  const themeTextColor = interactiveColor ?? theme.color.interactive[2];
+  const interactiveColor = getInteractiveColor(theme);
 
-  const styles = useStyles(themeTextColor)();
+  const styles = useStyles();
   const {t} = useTranslation();
   const {mobileTokenStatus, isInspectable, tokens, retry} =
     useMobileTokenContext();
@@ -79,7 +78,7 @@ export function TravelTokenBox({
           <View style={styles.activeTravelTokenInfo}>
             <ThemeText
               typography="body__primary--bold"
-              color={themeTextColor.default}
+              color={interactiveColor.default}
             >
               {t(TravelTokenBoxTexts.title) +
                 t(
@@ -93,7 +92,7 @@ export function TravelTokenBox({
 
             <TravelTokenDeviceTitle
               inspectableToken={inspectableToken}
-              themeTextColor={themeTextColor.default}
+              themeTextColor={interactiveColor.default}
             />
           </View>
         </View>
@@ -107,7 +106,7 @@ export function TravelTokenBox({
       <Button
         expanded={true}
         mode="secondary"
-        backgroundColor={themeTextColor.default}
+        backgroundColor={interactiveColor.default}
         onPress={onPressChangeButton}
         text={
           inspectableToken
@@ -120,21 +119,20 @@ export function TravelTokenBox({
   );
 }
 
-const useStyles = (interactiveColor: InteractiveColor) =>
-  StyleSheet.createThemeHook((theme: Theme) => ({
-    container: {
-      backgroundColor: interactiveColor.default.background,
-      padding: theme.spacing.xLarge,
-      rowGap: theme.spacing.medium,
-      borderRadius: theme.border.radius.regular,
-    },
-    content: {
-      display: 'flex',
-      flexDirection: 'row',
-      columnGap: theme.spacing.medium,
-    },
-    activeTravelTokenInfo: {
-      flex: 1,
-      rowGap: theme.spacing.xSmall,
-    },
-  }));
+const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    backgroundColor: getInteractiveColor(theme).default.background,
+    padding: theme.spacing.xLarge,
+    rowGap: theme.spacing.medium,
+    borderRadius: theme.border.radius.regular,
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'row',
+    columnGap: theme.spacing.medium,
+  },
+  activeTravelTokenInfo: {
+    flex: 1,
+    rowGap: theme.spacing.xSmall,
+  },
+}));


### PR DESCRIPTION
Moved the TravelTokenBox out of the FareContractAndReservationsList
component. This is to adhere to the single responsibility principle,
the component for listing fare contracts should not be responsible
for also showing token related info.

In addition removed the color parameter for the TravelTokenBox
since it was always themed to interactive color 2 and could just as
well be specified internally in the component.
