### PR TITLE
refactor: Cleaner configuration of empty state in fare contract list

### DIFF
--- a/src/components/empty-state/index.tsx
+++ b/src/components/empty-state/index.tsx
@@ -1,1 +1,1 @@
-export {EmptyState} from './EmptyState';
+export {EmptyState, type EmptyStateProps} from './EmptyState';

--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {RootStackParamList} from '@atb/stacks-hierarchy';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
-import {FareContract, Reservation, TravelCard} from '@atb/ticketing';
+import {FareContract, Reservation} from '@atb/ticketing';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAnalyticsContext} from '@atb/analytics';
 import {EmptyState} from '@atb/components/empty-state';
@@ -14,10 +14,9 @@ import type {EmptyStateProps} from '@atb/components/empty-state';
 type RootNavigationProp = NavigationProp<RootStackParamList>;
 
 type Props = {
-  reservations?: Reservation[];
-  fareContracts?: FareContract[];
+  reservations: Reservation[];
+  fareContracts: FareContract[];
   now: number;
-  travelCard?: TravelCard;
   emptyStateConfig: Pick<
     EmptyStateProps,
     'title' | 'details' | 'illustrationComponent'
@@ -34,7 +33,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   const navigation = useNavigation<RootNavigationProp>();
   const analytics = useAnalyticsContext();
 
-  const fcOrReservations = [...(fareContracts || []), ...(reservations || [])];
+  const fcOrReservations = [...fareContracts, ...reservations];
 
   const fareContractsAndReservationsSorted =
     useSortFcOrReservationByValidityAndCreation(

--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -4,13 +4,12 @@ import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReser
 import {FareContract, Reservation, TravelCard} from '@atb/ticketing';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAnalyticsContext} from '@atb/analytics';
-import {HoldingHands, TicketTilted} from '@atb/assets/svg/color/images';
 import {EmptyState} from '@atb/components/empty-state';
-import {TicketHistoryMode} from '@atb/ticket-history';
 import {useSortFcOrReservationByValidityAndCreation} from './utils';
 import {getFareContractInfo} from './utils';
 import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
+import type {EmptyStateProps} from '@atb/components/empty-state';
 
 type RootNavigationProp = NavigationProp<RootStackParamList>;
 
@@ -19,18 +18,17 @@ type Props = {
   fareContracts?: FareContract[];
   now: number;
   travelCard?: TravelCard;
-  mode?: TicketHistoryMode;
-  emptyStateTitleText: string;
-  emptyStateDetailsText: string;
+  emptyStateConfig: Pick<
+    EmptyStateProps,
+    'title' | 'details' | 'illustrationComponent'
+  >;
 };
 
 export const FareContractAndReservationsList: React.FC<Props> = ({
   fareContracts,
   reservations,
   now,
-  mode = 'historical',
-  emptyStateTitleText,
-  emptyStateDetailsText,
+  emptyStateConfig,
 }) => {
   const styles = useStyles();
   const navigation = useNavigation<RootNavigationProp>();
@@ -50,12 +48,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   return (
     <View style={styles.container}>
       {!fareContractsAndReservationsSorted.length && (
-        <EmptyState
-          title={emptyStateTitleText}
-          details={emptyStateDetailsText}
-          illustrationComponent={emptyStateImage(mode)}
-          testID="fareContracts"
-        />
+        <EmptyState {...emptyStateConfig} testID="fareContracts" />
       )}
       {fareContractsAndReservationsSorted?.map((fcOrReservation, index) => (
         <FareContractOrReservation
@@ -76,15 +69,6 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
       ))}
     </View>
   );
-};
-
-const emptyStateImage = (emptyStateMode: TicketHistoryMode) => {
-  switch (emptyStateMode) {
-    case 'historical':
-      return <TicketTilted height={84} />;
-    case 'sent':
-      return <HoldingHands height={84} />;
-  }
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -14,6 +14,7 @@ import {usePopOverContext} from '@atb/popover';
 import {useOneTimePopover} from '@atb/popover/use-one-time-popover';
 import {isElementFullyInsideScreen} from '@atb/utils/is-element-fully-inside-screen';
 import {TravelTokenBox} from '@atb/travel-token-box';
+import {TicketTilted} from '@atb/assets/svg/color/images';
 
 type Props =
   TicketTabNavScreenProps<'TicketTabNav_AvailableFareContractsTabScreen'>;
@@ -105,14 +106,17 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           reservations={reservations}
           fareContracts={availableFareContracts}
           now={serverNow}
-          emptyStateTitleText={t(
-            TicketingTexts.availableFareProductsAndReservationsTab
-              .noActiveTicketsTitle,
-          )}
-          emptyStateDetailsText={t(
-            TicketingTexts.availableFareProductsAndReservationsTab
-              .noActiveTicketsDetails,
-          )}
+          emptyStateConfig={{
+            title: t(
+              TicketingTexts.availableFareProductsAndReservationsTab
+                .noActiveTicketsTitle,
+            ),
+            details: t(
+              TicketingTexts.availableFareProductsAndReservationsTab
+                .noActiveTicketsDetails,
+            ),
+            illustrationComponent: <TicketTilted height={84} />,
+          }}
         />
         <Section>
           {hasHistoricalFareContracts && (

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -17,6 +17,8 @@ import {
 } from '@atb/ticket-history';
 import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 import {useAuthContext} from '@atb/auth';
+import {HoldingHands, TicketTilted} from '@atb/assets/svg/color/images';
+import React from 'react';
 
 export const TicketHistoryScreenComponent = ({
   mode,
@@ -69,9 +71,11 @@ export const TicketHistoryScreenComponent = ({
             customerAccountId,
           )}
           now={serverNow}
-          mode={mode}
-          emptyStateTitleText={t(TicketingTexts.ticketHistory.emptyState)}
-          emptyStateDetailsText={t(TicketHistoryModeTexts[mode].emptyDetail)}
+          emptyStateConfig={{
+            title: t(TicketingTexts.ticketHistory.emptyState),
+            details: t(TicketHistoryModeTexts[mode].emptyDetail),
+            illustrationComponent: emptyStateImage(mode),
+          }}
         />
       </View>
     </FullScreenView>
@@ -93,6 +97,15 @@ const displayReservations = (
       return reservations.filter(
         (reservation) => reservation.customerAccountId !== customerAccountId,
       );
+  }
+};
+
+const emptyStateImage = (emptyStateMode: TicketHistoryMode) => {
+  switch (emptyStateMode) {
+    case 'historical':
+      return <TicketTilted height={84} />;
+    case 'sent':
+      return <HoldingHands height={84} />;
   }
 };
 


### PR DESCRIPTION
This refactor started when I wanted to make the 'mode' parameter
non-optional, since it wasn't intuitive what the default value was.
But then making it required made it obvious that the possible
modes (historic and sent) was not enough as in the my tickets tab
neither historic or sent was fitting.

All in all I decided to remove the mode parameter and make all of the
empty state config parametrised from the outside. This also removed
the circular dependency where ticket history screen used fare contract
list, and the fare contract list used the TicketHistoryMode type from
the ticket history screen.

Also cleaned up some props that either could be made required or
removed.
