### PR TITLE
fix: Align small tertiary button typography with Figma

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -283,7 +283,12 @@ const useButtonStyle = StyleSheet.createThemeHook(() => ({
 }));
 
 function getTextType(mode: string, type: string) {
-  if (mode === 'tertiary') return 'body__primary';
   if (type === 'small') return 'body__secondary';
-  return 'body__primary--bold';
+  switch (mode) {
+    case 'primary':
+    case 'secondary':
+      return 'body__primary--bold';
+    case 'tertiary':
+      return 'body__primary';
+  }
 }


### PR DESCRIPTION
All small buttons have body secondary as their font typography
in Figma. Before this change the small tertiary button had body
primary as their font typography in the app.

<img width="600" alt="Screenshot 2025-02-05 at 15 34 37" src="https://github.com/user-attachments/assets/eec830a6-c8de-4ec3-975a-136c93fedfbd" />

### Acceptance criteria
- [ ] Next day / Previous day on departures screen has body secondary typography.
