### PR TITLE
refactor: Make the sort fcs function not a hook

### DIFF
--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -5,11 +5,12 @@ import {FareContract, Reservation} from '@atb/ticketing';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAnalyticsContext} from '@atb/analytics';
 import {EmptyState} from '@atb/components/empty-state';
-import {useSortFcOrReservationByValidityAndCreation} from './utils';
+import {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation-by-validity-and-creation';
 import {getFareContractInfo} from './utils';
 import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
 import type {EmptyStateProps} from '@atb/components/empty-state';
+import {useAuthContext} from '@atb/auth';
 
 type RootNavigationProp = NavigationProp<RootStackParamList>;
 
@@ -32,11 +33,13 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   const styles = useStyles();
   const navigation = useNavigation<RootNavigationProp>();
   const analytics = useAnalyticsContext();
+  const {abtCustomerId} = useAuthContext();
 
   const fcOrReservations = [...fareContracts, ...reservations];
 
   const fareContractsAndReservationsSorted =
-    useSortFcOrReservationByValidityAndCreation(
+    sortFcOrReservationByValidityAndCreation(
+      abtCustomerId,
       now,
       fcOrReservations,
       (currentTime, fareContract, currentUserId) =>

--- a/src/fare-contracts/__tests__/sort-fc-or-reservation-by-validity-and-creation.test.ts
+++ b/src/fare-contracts/__tests__/sort-fc-or-reservation-by-validity-and-creation.test.ts
@@ -1,42 +1,8 @@
-import {
-  ValidityStatus,
-  useSortFcOrReservationByValidityAndCreation,
-} from '../utils';
+import type {ValidityStatus} from '../utils';
 import {FareContract, Reservation, TravelRight} from '@atb/ticketing/types';
 
-import {LoadingParams} from '@atb/loading-screen/types';
-import React from 'react';
 import {addMinutes} from 'date-fns';
-
-const DEFAULT_MOCK_STATE: LoadingParams = {
-  isLoadingAppState: false,
-  authStatus: 'authenticated',
-  firestoreConfigStatus: 'success',
-  remoteConfigIsLoaded: true,
-};
-
-jest.mock('@atb/auth/AuthContext', () => {});
-jest.mock('@atb/mobile-token', () => {});
-jest.mock('@atb/ticketing/TicketingContext', () => {});
-jest.mock('@atb/configuration/FirestoreConfigurationContext', () => {});
-jest.mock('@atb/api', () => {});
-jest.mock('@atb/time', () => {});
-jest.mock('@react-native-firebase/remote-config', () => {});
-jest.mock('@entur-private/abt-mobile-client-sdk', () => {});
-jest.mock('@bugsnag/react-native', () => {});
-jest.mock('@react-native-firebase/auth', () => {});
-jest.mock('@entur-private/abt-token-server-javascript-interface', () => {});
-jest.mock('react-native-device-info', () => {});
-jest.mock('react-native-inappbrowser-reborn', () => {});
-jest.mock('@atb/auth', () => ({
-  useAuthContext: () => ({
-    authStatus: DEFAULT_MOCK_STATE,
-    abtCustomerId: '1',
-    retryAuth: () => {},
-  }),
-}));
-jest.spyOn(React, 'useCallback').mockImplementation((f) => f);
-jest.spyOn(React, 'useMemo').mockImplementation((f) => f());
+import {sortFcOrReservationByValidityAndCreation} from '../sort-fc-or-reservation-by-validity-and-creation';
 
 type MockedFareContract = FareContract & {
   validityStatus: ValidityStatus;
@@ -94,7 +60,8 @@ describe('Sort by Validity', () => {
       mockupReservation('3', 'valid', 0),
     ];
 
-    const result = useSortFcOrReservationByValidityAndCreation(
+    const result = sortFcOrReservationByValidityAndCreation(
+      '',
       now,
       fcOrReservations,
       (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
@@ -118,7 +85,8 @@ describe('Sort by Validity', () => {
       mockupFareContract('2', 'valid', 0),
     ];
 
-    const result = useSortFcOrReservationByValidityAndCreation(
+    const result = sortFcOrReservationByValidityAndCreation(
+      '',
       now,
       fcOrReservations,
       (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
@@ -143,7 +111,8 @@ describe('Sort by Validity', () => {
       mockupFareContract('4', 'valid', 0.11),
     ];
 
-    const result = useSortFcOrReservationByValidityAndCreation(
+    const result = sortFcOrReservationByValidityAndCreation(
+      '',
       now,
       fcOrReservations,
       (_, fareContract) => (fareContract as MockedFareContract).validityStatus,

--- a/src/fare-contracts/sort-fc-or-reservation-by-validity-and-creation.ts
+++ b/src/fare-contracts/sort-fc-or-reservation-by-validity-and-creation.ts
@@ -1,0 +1,33 @@
+import {FareContract, Reservation} from '@atb/ticketing';
+import type {ValidityStatus} from '@atb/fare-contracts/utils';
+
+export const sortFcOrReservationByValidityAndCreation = (
+  userId: string | undefined,
+  now: number,
+  fcOrReservations: (Reservation | FareContract)[],
+  getFareContractStatus: (
+    now: number,
+    fc: FareContract,
+    currentUserId?: string,
+  ) => ValidityStatus | undefined,
+): (FareContract | Reservation)[] => {
+  const getFcOrReservationOrder = (
+    fcOrReservation: FareContract | Reservation,
+  ) => {
+    const isFareContract = 'travelRights' in fcOrReservation;
+    // Make reservations go first, then fare contracts
+    if (!isFareContract) return -1;
+
+    const validityStatus = getFareContractStatus(now, fcOrReservation, userId);
+    return validityStatus === 'valid' ? 0 : 1;
+  };
+
+  return fcOrReservations.sort((a, b) => {
+    const orderA = getFcOrReservationOrder(a);
+    const orderB = getFcOrReservationOrder(b);
+    // Negative return value for a - b means "place a before b"
+    if (orderA !== orderB) return orderA - orderB;
+    // Make sure most recent dates comes first
+    return b.created.getTime() - a.created.getTime();
+  });
+};

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -16,10 +16,8 @@ import {useAuthContext} from '@atb/auth';
 import {HoldingHands, TicketTilted} from '@atb/assets/svg/color/images';
 import React from 'react';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {
-  getFareContractInfo,
-  useSortFcOrReservationByValidityAndCreation,
-} from '@atb/fare-contracts/utils';
+import {getFareContractInfo} from '@atb/fare-contracts/utils';
+import {sortFcOrReservationByValidityAndCreation} from '@atb/fare-contracts/sort-fc-or-reservation-by-validity-and-creation';
 import {useAnalyticsContext} from '@atb/analytics';
 import {FlatList} from 'react-native-gesture-handler';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
@@ -53,7 +51,8 @@ export const TicketHistoryScreenComponent = ({
     customerAccountId,
   );
 
-  const sortedItems = useSortFcOrReservationByValidityAndCreation(
+  const sortedItems = sortFcOrReservationByValidityAndCreation(
+    customerAccountId,
     serverNow,
     [...fareContractsToShow, ...reservationsToShow],
     (currentTime, fareContract, currentUserId) =>


### PR DESCRIPTION
Some reasons:
- The useCallback and useMemo in the hook had no effect as the input
callback function was recreated on every render. Also the function
needs the now variable, which is updated every second, so the
memoisation would be limited even if it was working.
- Making it a utility function removed the need for lots of mocks in
the test class.
- The sorting is pretty quick. On simulator (which is pretty slow) it
was measured to be less than 0.1ms per fare contract.

### Acceptance criteria
- [x] The sort order of fare contracts (in "my tickets", "ticket history" and "frontpage") is the same as before.
- [x] Presenting a large ticket history feels just as fast as before.
