### PR TITLE
refactor: Decouple navigation object on fare contract lists

### DIFF
--- a/src/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/fare-contracts/FareContractAndReservationsList.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import {RootStackParamList} from '@atb/stacks-hierarchy';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
 import {FareContract, Reservation} from '@atb/ticketing';
-import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAnalyticsContext} from '@atb/analytics';
 import {EmptyState} from '@atb/components/empty-state';
 import {useSortFcOrReservationByValidityAndCreation} from './utils';
@@ -11,12 +9,11 @@ import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
 import type {EmptyStateProps} from '@atb/components/empty-state';
 
-type RootNavigationProp = NavigationProp<RootStackParamList>;
-
 type Props = {
   reservations: Reservation[];
   fareContracts: FareContract[];
   now: number;
+  onPressFareContract: (orderId: string) => void;
   emptyStateConfig: Pick<
     EmptyStateProps,
     'title' | 'details' | 'illustrationComponent'
@@ -27,10 +24,10 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   fareContracts,
   reservations,
   now,
+  onPressFareContract,
   emptyStateConfig,
 }) => {
   const styles = useStyles();
-  const navigation = useNavigation<RootNavigationProp>();
   const analytics = useAnalyticsContext();
 
   const fcOrReservations = [...fareContracts, ...reservations];
@@ -54,12 +51,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
           now={now}
           onPressFareContract={() => {
             analytics.logEvent('Ticketing', 'Ticket details clicked');
-            navigation.navigate({
-              name: 'Root_FareContractDetailsScreen',
-              params: {
-                orderId: fcOrReservation.orderId,
-              },
-            });
+            onPressFareContract(fcOrReservation.orderId);
           }}
           key={fcOrReservation.orderId}
           fcOrReservation={fcOrReservation}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistoryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TicketHistoryScreen.tsx
@@ -4,6 +4,13 @@ import {TicketHistoryScreenComponent} from '@atb/ticket-history';
 
 type Props = ProfileScreenProps<'Profile_TicketHistoryScreen'>;
 
-export const Profile_TicketHistoryScreen = ({route}: Props) => {
-  return <TicketHistoryScreenComponent mode={route.params.mode} />;
+export const Profile_TicketHistoryScreen = ({route, navigation}: Props) => {
+  return (
+    <TicketHistoryScreenComponent
+      mode={route.params.mode}
+      onPressFareContract={(orderId) =>
+        navigation.navigate('Root_FareContractDetailsScreen', {orderId})
+      }
+    />
+  );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketHistoryScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketHistoryScreen.tsx
@@ -4,6 +4,13 @@ import {TicketingScreenProps} from './navigation-types';
 
 type Props = TicketingScreenProps<'Ticketing_TicketHistoryScreen'>;
 
-export const Ticketing_TicketHistoryScreen = ({route}: Props) => {
-  return <TicketHistoryScreenComponent mode={route.params.mode} />;
+export const Ticketing_TicketHistoryScreen = ({route, navigation}: Props) => {
+  return (
+    <TicketHistoryScreenComponent
+      mode={route.params.mode}
+      onPressFareContract={(orderId) =>
+        navigation.navigate('Root_FareContractDetailsScreen', {orderId})
+      }
+    />
+  );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -106,6 +106,9 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           reservations={reservations}
           fareContracts={availableFareContracts}
           now={serverNow}
+          onPressFareContract={(orderId) =>
+            navigation.navigate('Root_FareContractDetailsScreen', {orderId})
+          }
           emptyStateConfig={{
             title: t(
               TicketingTexts.availableFareProductsAndReservationsTab

--- a/src/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/ticket-history/TicketHistoryScreenComponent.tsx
@@ -24,16 +24,18 @@ import {useAnalyticsContext} from '@atb/analytics';
 import {FlatList} from 'react-native-gesture-handler';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
 import {EmptyState} from '@atb/components/empty-state';
-import {NavigationProp, useNavigation} from '@react-navigation/native';
-import {RootStackParamList} from '@atb/stacks-hierarchy';
+
+type Props = TicketHistoryScreenParams & {
+  onPressFareContract: (orderId: string) => void;
+};
 
 export const TicketHistoryScreenComponent = ({
   mode,
-}: TicketHistoryScreenParams) => {
+  onPressFareContract,
+}: Props) => {
   const {sentFareContracts, reservations, rejectedReservations} =
     useTicketingContext();
   const {serverNow} = useTimeContext();
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const analytics = useAnalyticsContext();
   const {fareContracts: historicalFareContracts} = useFareContracts(
     {availability: 'historical'},
@@ -74,12 +76,7 @@ export const TicketHistoryScreenComponent = ({
             now={serverNow}
             onPressFareContract={() => {
               analytics.logEvent('Ticketing', 'Ticket details clicked');
-              navigation.navigate({
-                name: 'Root_FareContractDetailsScreen',
-                params: {
-                  orderId: item.orderId,
-                },
-              });
+              onPressFareContract(item.orderId);
             }}
             fcOrReservation={item}
             index={index}


### PR DESCRIPTION
This is to adhere to the [coding guidelines](https://github.com/AtB-AS/docs-private/blob/main/kundevendt-development-guidelines.md#screen-reuse) that the screens are the
ones that should use the navigation object, so that child
components doesn't need to.

### Acceptance criteria
- [ ] Should be able to navigate to ticket details from front page
- [ ] Should be able to navigate to ticket details from my tickets tab
- [ ] Should be able to navigate to ticket details from expired ticket history
- [ ] Should be able to navigate to ticket details from sent ticket history