### PR TITLE
fix: build android staging without cache

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -6,7 +6,7 @@ on:
         description: 'Forces a new build and ignores the cache'
         required: false
         type: choice
-        default: false
+        default: true
         options:
           - true
           - false


### PR DESCRIPTION
Until issue https://github.com/AtB-AS/kundevendt/issues/19990 is fixed, we need to run Android builds in Staging without cache. Will revert this when that issue is done.