### PR TITLE
fix: force build as strings

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -6,10 +6,10 @@ on:
         description: 'Forces a new build and ignores the cache'
         required: false
         type: choice
-        default: true
+        default: 'true'
         options:
-          - true
-          - false
+          - 'true'
+          - 'false'
   push:
     branches:
       - master


### PR DESCRIPTION
The change (`default: true`) in issue https://github.com/AtB-AS/mittatb-app/pull/5000 didn't help: https://github.com/AtB-AS/mittatb-app/actions/runs/13199924279

I think it's because the cache-step is checking the string value of "true".