### PR TITLE
fix: force true also on push for android

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -25,6 +25,8 @@ jobs:
     environment: ${{ matrix.org }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
+    env:
+      ENV_FORCE_BUILD: ${{ inputs.force-build || 'true' }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v1
@@ -52,14 +54,14 @@ jobs:
         with:
           node-version: 18
       - name: Get potential cached node_modules
-        if: inputs.force-build != 'true'
+        if: env.ENV_FORCE_BUILD != 'true'
         uses: actions/cache@v2
         id: modules-cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}
       - name: Install node_modules
-        if: inputs.force-build == 'true' || steps.modules-cache.outputs.cache-hit != 'true'
+        if: env.ENV_FORCE_BUILD == 'true' || steps.modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
@@ -84,17 +86,17 @@ jobs:
         env:
           KEYSTORE: ${{ secrets.KEYSTORE }}
       - name: Generate native assets
-        if: inputs.force-build == 'true' || steps.apk-cache.outputs.cache-hit != 'true'
+        if: env.ENV_FORCE_BUILD == 'true' || steps.apk-cache.outputs.cache-hit != 'true'
         run: yarn generate-native-assets
       - name: Run fastlane build
-        if: inputs.force-build == 'true' || steps.apk-cache.outputs.cache-hit != 'true'
+        if: env.ENV_FORCE_BUILD == 'true' || steps.apk-cache.outputs.cache-hit != 'true'
         run: bundle exec fastlane android build
         env:
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}
           KEY_PASS: ${{ secrets.KEYSTORE_KEY_PASS }}
           KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
       - name: Replace apk bundle
-        if: inputs.force-build == 'true' || steps.apk-cache.outputs.cache-hit == 'true'
+        if: env.ENV_FORCE_BUILD == 'true' || steps.apk-cache.outputs.cache-hit == 'true'
         run: bash ./scripts/android/replace-bundle.sh
         env:
           KEYSTORE_PASS: ${{ secrets.KEYSTORE_PASS }}


### PR DESCRIPTION
The tries to set force build as `true` in https://github.com/AtB-AS/mittatb-app/pull/5000 and https://github.com/AtB-AS/mittatb-app/pull/5001 didn't work (e.g. see https://github.com/AtB-AS/mittatb-app/actions/runs/13200613990/job/36851521623).

It seems that when running the yml from a schedule, the dispatch inputs are not picked up. See e.g. https://stackoverflow.com/questions/72539900/schedule-trigger-github-action-workflow-with-input-parameters.

In this suggestion, either the dispatch input is used, or a default value of `true` is used.