### PR TITLE
feat: Only stop places checked as default

### DIFF
--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -173,6 +173,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
                 label: t(AddEditFavoriteTexts.fields.location.label),
                 favoriteChipTypes: ['location', 'map'],
                 initialLocation: location,
+                onlyStopPlacesCheckboxInitialState: false,
               })
             }
             testID="locationSearchButton"

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/Root_LocationSearchByTextScreen.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/Root_LocationSearchByTextScreen.tsx
@@ -20,6 +20,7 @@ export const Root_LocationSearchByTextScreen = ({
       favoriteChipTypes,
       initialLocation,
       includeJourneyHistory = false,
+      onlyStopPlacesCheckboxInitialState,
     },
   },
 }: Props) => {
@@ -70,6 +71,7 @@ export const Root_LocationSearchByTextScreen = ({
             : undefined
         }
         includeJourneyHistory={includeJourneyHistory}
+        onlyStopPlacesCheckboxInitialState={onlyStopPlacesCheckboxInitialState}
         onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
       />
     </View>

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -80,6 +80,7 @@ export function LocationSearchContent({
   const [onlyStopPlaces, setOnlyStopPlaces] = usePersistedBoolState(
     storage,
     '@ATB_only_stop_places_checkbox',
+    true,
   );
 
   const {location: geolocation} = useGeolocationContext();

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -41,6 +41,7 @@ type LocationSearchContentProps = {
   onlyLocalTariffZoneAuthority?: boolean;
   includeHistory?: boolean;
   includeJourneyHistory?: boolean;
+  onlyStopPlacesCheckboxInitialState: boolean;
   onAddFavorite: () => void;
 };
 
@@ -56,6 +57,7 @@ export function LocationSearchContent({
   onlyLocalTariffZoneAuthority = false,
   includeHistory = true,
   includeJourneyHistory = false,
+  onlyStopPlacesCheckboxInitialState,
   onAddFavorite,
 }: LocationSearchContentProps) {
   const styles = useThemeStyles();
@@ -80,7 +82,7 @@ export function LocationSearchContent({
   const [onlyStopPlaces, setOnlyStopPlaces] = usePersistedBoolState(
     storage,
     '@ATB_only_stop_places_checkbox',
-    true,
+    onlyStopPlacesCheckboxInitialState,
   );
 
   const {location: geolocation} = useGeolocationContext();

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/navigation-types.ts
@@ -7,4 +7,5 @@ export type Root_LocationSearchByTextScreenParams = {
   favoriteChipTypes?: ChipTypeGroup[];
   initialLocation?: Location;
   includeJourneyHistory?: boolean;
+  onlyStopPlacesCheckboxInitialState: boolean;
 };

--- a/src/stacks-hierarchy/Root_SearchStopPlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_SearchStopPlaceScreen.tsx
@@ -36,6 +36,7 @@ export const Root_SearchStopPlaceScreen = ({
         placeholder={t(AddEditFavoriteTexts.fields.location.placeholder)}
         favoriteChipTypes={[]}
         onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
+        onlyStopPlacesCheckboxInitialState={true}
       />
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
@@ -32,6 +32,7 @@ export const Dashboard_NearbyStopPlacesScreen = ({
           callerRouteName: route.name,
           callerRouteParam: 'location',
           initialLocation: location,
+          onlyStopPlacesCheckboxInitialState: true,
         })
       }
       onSelectStopPlace={useCallback(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
@@ -124,6 +124,7 @@ export const Dashboard_RootScreen: React.FC<RootProps> = ({
       callerRouteParam,
       initialLocation,
       includeJourneyHistory: true,
+      onlyStopPlacesCheckboxInitialState: false,
     });
 
   const setCurrentLocationOrRequest = useCallback(async () => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -170,6 +170,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
       callerRouteParam,
       initialLocation,
       includeJourneyHistory: true,
+      onlyStopPlacesCheckboxInitialState: false,
     });
 
   const setCurrentLocationOrRequest = useCallback(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
@@ -31,6 +31,7 @@ export const Departures_NearbyStopPlacesScreen = ({
           callerRouteName: route.name,
           callerRouteParam: 'location',
           initialLocation: location,
+          onlyStopPlacesCheckboxInitialState: true,
         })
       }
       onSelectStopPlace={useCallback(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
@@ -30,6 +30,7 @@ export const Profile_NearbyStopPlacesScreen = ({navigation, route}: Props) => {
           callerRouteName: route.name,
           callerRouteParam: 'location',
           initialLocation: location,
+          onlyStopPlacesCheckboxInitialState: true,
         })
       }
       onSelectStopPlace={useCallback(

--- a/src/utils/__tests__/use-persisted-bool-state.test.ts
+++ b/src/utils/__tests__/use-persisted-bool-state.test.ts
@@ -11,9 +11,11 @@ const createStorage = (initialValue?: string) =>
   } as any as StorageService);
 
 describe('usePersistedBoolState', () => {
-  it('should be false if no value in storage', async () => {
+  it('should be false if initial state false and no value in storage', async () => {
     const storage = createStorage();
-    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+    const hook = renderHook(() =>
+      usePersistedBoolState(storage, STORAGE_KEY, false),
+    );
 
     expect(hook.result.current[0]).toBe(false);
     expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
@@ -25,9 +27,27 @@ describe('usePersistedBoolState', () => {
     expect(storage.set).toHaveBeenCalledTimes(0);
   });
 
+  it('should be true if initial state true and no value in storage', async () => {
+    const storage = createStorage();
+    const hook = renderHook(() =>
+      usePersistedBoolState(storage, STORAGE_KEY, true),
+    );
+
+    expect(hook.result.current[0]).toBe(true);
+    expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
+
+    await hook.waitFor(() => expect(storage.get).toHaveReturned());
+    expect(hook.result.current[0]).toBe(true);
+
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenCalledTimes(0);
+  });
+
   it('should be true after update from storage', async () => {
     const storage = createStorage('true');
-    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+    const hook = renderHook(() =>
+      usePersistedBoolState(storage, STORAGE_KEY, false),
+    );
 
     expect(hook.result.current[0]).toBe(false);
     expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
@@ -41,9 +61,11 @@ describe('usePersistedBoolState', () => {
 
   it('should be false after update from storage', async () => {
     const storage = createStorage('false');
-    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+    const hook = renderHook(() =>
+      usePersistedBoolState(storage, STORAGE_KEY, true),
+    );
 
-    expect(hook.result.current[0]).toBe(false);
+    expect(hook.result.current[0]).toBe(true);
     expect(storage.get).toHaveBeenCalledWith(STORAGE_KEY);
 
     await hook.waitFor(() => expect(storage.get).toHaveReturned());
@@ -55,7 +77,9 @@ describe('usePersistedBoolState', () => {
 
   it('setting true should give true as state and invoke storing the value', async () => {
     const storage = createStorage();
-    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+    const hook = renderHook(() =>
+      usePersistedBoolState(storage, STORAGE_KEY, false),
+    );
 
     const [_, setState] = hook.result.current;
     await act(async () => setState(true));
@@ -69,7 +93,9 @@ describe('usePersistedBoolState', () => {
 
   it('setting false should give false as state and invoke storing the value', async () => {
     const storage = createStorage('false');
-    const hook = renderHook(() => usePersistedBoolState(storage, STORAGE_KEY));
+    const hook = renderHook(() =>
+      usePersistedBoolState(storage, STORAGE_KEY, false),
+    );
 
     const [_, setState] = hook.result.current;
     await act(async () => setState(false));

--- a/src/utils/use-persisted-bool-state.ts
+++ b/src/utils/use-persisted-bool-state.ts
@@ -4,8 +4,9 @@ import {type StorageService} from '@atb/storage';
 export const usePersistedBoolState = (
   storage: StorageService,
   storageKey: string,
+  initialState: boolean,
 ): [boolean, (b: boolean) => void] => {
-  const [state, setState] = useState(false);
+  const [state, setState] = useState(initialState);
 
   useEffect(() => {
     storage.get(storageKey).then((v) => {


### PR DESCRIPTION
### Background
PO wanted to test having the only stop places initial state set to true to test how many people turns it off.

### Acceptance criteria
- [ ] The initial state for the checkbox is **on** when searching in context of nearby stop places screen, and add favourite departure flow. It is by default **off** in trip search context and add favourite place flow.
- [ ] If the checkbox has been interacted with, then the checked state should be preserved (as before)