### PR TITLE
fix: prevent markdown overflow in global messages

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -82,7 +82,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   // If markdown is enabled, we need to wrap the content in a <View></View> to properly align the <Text></Text> elements,
   // by doing this we also avoid to wrap the list elements inside the markdown render in a Text component, which is not allowed.
   if (isMarkdown) {
-    return <View style={{flex: 1}}>{content}</View>;
+    return <View>{content}</View>;
   }
 
   return <Text {...textProps}>{content}</Text>;

--- a/src/stacks-hierarchy/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen.tsx
@@ -61,7 +61,7 @@ export const Root_TicketInformationScreen = (props: Props) => {
             />
             <Section>
               <GenericSectionItem>
-                <View style={{flex: 1}}>
+                <View style={styles.descriptionContainer}>
                   {fareProductTypeConfig && (
                     <View style={styles.descriptionHeading}>
                       <TransportationIconBoxList
@@ -114,6 +114,9 @@ const useStyle = StyleSheet.createThemeHook((theme) => {
       marginHorizontal: theme.spacing.medium,
       marginBottom: Math.max(bottom, theme.spacing.medium),
       rowGap: theme.spacing.small,
+    },
+    descriptionContainer: {
+      flex: 1,
     },
     descriptionHeading: {
       flexDirection: 'row',

--- a/src/stacks-hierarchy/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen.tsx
@@ -61,23 +61,28 @@ export const Root_TicketInformationScreen = (props: Props) => {
             />
             <Section>
               <GenericSectionItem>
-                {fareProductTypeConfig && (
-                  <View style={styles.descriptionHeading}>
-                    <TransportationIconBoxList
-                      iconSize="xSmall"
-                      modes={fareProductTypeConfig?.transportModes}
-                    />
-                    <ThemeText typography="body__primary--bold">
-                      {getTextForLanguage(fareProductTypeConfig.name, language)}
-                    </ThemeText>
-                  </View>
-                )}
-                <ThemeText typography="body__secondary" isMarkdown={true}>
-                  {getTextForLanguage(
-                    preassignedFareProduct.productDescription,
-                    language,
+                <View style={{flex: 1}}>
+                  {fareProductTypeConfig && (
+                    <View style={styles.descriptionHeading}>
+                      <TransportationIconBoxList
+                        iconSize="xSmall"
+                        modes={fareProductTypeConfig?.transportModes}
+                      />
+                      <ThemeText typography="body__primary--bold">
+                        {getTextForLanguage(
+                          fareProductTypeConfig.name,
+                          language,
+                        )}
+                      </ThemeText>
+                    </View>
                   )}
-                </ThemeText>
+                  <ThemeText typography="body__secondary" isMarkdown={true}>
+                    {getTextForLanguage(
+                      preassignedFareProduct.productDescription,
+                      language,
+                    )}
+                  </ThemeText>
+                </View>
               </GenericSectionItem>
               {benefits?.map((b) => (
                 <MobilitySingleBenefitInfoSectionItem benefit={b} key={b.id} />


### PR DESCRIPTION
Fixes an issue with markdown overflowing introduced by https://github.com/AtB-AS/mittatb-app/pull/4953

<img width="300px" src="https://github.com/user-attachments/assets/2995b44b-0ca9-4cf7-9eb3-bd007775295d">

fixes https://mittatb.slack.com/archives/CR75QKX6G/p1739112362530579?thread_ts=1739111540.478569&cid=CR75QKX6G
