### PR TITLE
feat: swap favorite and map button on departure details

### DIFF
--- a/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -271,6 +271,9 @@ export const DepartureDetailsScreenComponent = ({
             )}
             {shouldShowButtonsRow && (
               <View style={styles.actionButtons}>
+                {shouldShowFavoriteButton && (
+                  <FavoriteButton fromCall={fromCall} line={line} />
+                )}
                 {shouldShowMapButton && (
                   <View style={{flex: 1}}>
                     <Button
@@ -286,10 +289,6 @@ export const DepartureDetailsScreenComponent = ({
                       onPress={handleMapButtonPress}
                     />
                   </View>
-                )}
-
-                {shouldShowFavoriteButton && (
-                  <FavoriteButton fromCall={fromCall} line={line} />
                 )}
               </View>
             )}
@@ -802,7 +801,6 @@ const useStopsStyle = StyleSheet.createThemeHook((theme) => ({
   },
   actionButtons: {
     flexDirection: 'row',
-    justifyContent: 'flex-end',
     gap: theme.spacing.medium,
     marginTop: theme.spacing.medium,
   },


### PR DESCRIPTION
ref. https://mittatb.slack.com/archives/CS3JNRXEV/p1738936949715109?thread_ts=1738931606.382689&cid=CS3JNRXEV

<img width="300px" src="https://github.com/user-attachments/assets/f9bae718-70c0-4b41-b36c-f059f63c5eac">

## Acceptance criteria

- [ ] Favorite and map buttons on departure details has swapped places, but work like before.
- [ ] If the map button is hidden (e.g. if screen reader is enabled), the favorite button is aligned to the left side