### PR TITLE
fix: remove redundant section around filter RadioSegments

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchPreference.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchPreference.tsx
@@ -2,7 +2,6 @@ import {RadioSegments} from '@atb/components/radio';
 import React from 'react';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {TravelSearchPreferenceWithSelectionType} from '@atb/travel-search-filters/types';
-import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -29,20 +28,16 @@ export const TravelSearchPreference = ({
       <ThemeText style={styles.heading} typography="body__primary--bold">
         {getTextForLanguage(preference.title, language)}
       </ThemeText>
-      <Section>
-        <GenericSectionItem>
-          <RadioSegments
-            activeIndex={selectedIndex}
-            color={theme.color.interactive[2]}
-            options={preference.options.map((option) => ({
-              text: getTextForLanguage(option.text, language) ?? '',
-              onPress: () => {
-                onPreferenceChange({...preference, selectedOption: option.id});
-              },
-            }))}
-          />
-        </GenericSectionItem>
-      </Section>
+      <RadioSegments
+        activeIndex={selectedIndex}
+        color={theme.color.interactive[2]}
+        options={preference.options.map((option) => ({
+          text: getTextForLanguage(option.text, language) ?? '',
+          onPress: () => {
+            onPreferenceChange({...preference, selectedOption: option.id});
+          },
+        }))}
+      />
     </View>
   );
 };


### PR DESCRIPTION
@Mariblaas requested that we remove some padding around RadioSegments in travel search filters:

### Before and after

<div>
<img width="300px" src="https://github.com/user-attachments/assets/db2e9d56-569e-4335-bd63-f7ad9f50c422">
<img width="300px" src="https://github.com/user-attachments/assets/465b9d39-0f7a-4b14-8842-ceca6819ad72">
</div>

## Acceptance criteria

- [ ] Filters works as before
- [ ] Screen readers are still able to update filters