### PR TITLE
refactor: Only stop places not checked by default when adding favorite place

### DIFF
--- a/src/favorites/FavoriteChips.tsx
+++ b/src/favorites/FavoriteChips.tsx
@@ -24,7 +24,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   chipTypes?: ChipTypeGroup[];
   chipActionHint?: string;
-  onAddFavorite: () => void;
+  onAddFavoritePlace: () => void;
 };
 
 export const FavoriteChips: React.FC<Props> = ({
@@ -33,7 +33,7 @@ export const FavoriteChips: React.FC<Props> = ({
   onMapSelection = () => {},
   chipTypes = ['favorites', 'location', 'map'],
   chipActionHint,
-  onAddFavorite,
+  onAddFavoritePlace,
 }) => {
   const {favorites} = useFavoritesContext();
   const {t} = useTranslation();
@@ -109,7 +109,7 @@ export const FavoriteChips: React.FC<Props> = ({
             text={t(FavoriteTexts.chips.addFavorite)}
             accessibilityRole="button"
             leftIcon={{svg: Add}}
-            onPress={onAddFavorite}
+            onPress={onAddFavoritePlace}
             testID="addFavoriteButton"
           />
         )}

--- a/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -30,7 +30,7 @@ type Props = NearbyStopPlacesScreenParams & {
   onPressLocationSearch: (location?: Location) => void;
   onSelectStopPlace: (place: StopPlace) => void;
   onUpdateLocation: (location?: Location) => void;
-  onAddFavorite: () => void;
+  onAddFavoritePlace: () => void;
 };
 
 export const NearbyStopPlacesScreenComponent = ({
@@ -40,7 +40,7 @@ export const NearbyStopPlacesScreenComponent = ({
   onPressLocationSearch,
   onSelectStopPlace,
   onUpdateLocation,
-  onAddFavorite,
+  onAddFavoritePlace,
 }: Props) => {
   const {
     locationIsAvailable,
@@ -178,7 +178,7 @@ export const NearbyStopPlacesScreenComponent = ({
               : onUpdateLocation(location);
           }}
           mode={mode}
-          onAddFavorite={onAddFavorite}
+          onAddFavoritePlace={onAddFavoritePlace}
         />
       )}
     >
@@ -220,7 +220,7 @@ type HeaderProps = {
   setCurrentLocationOrRequest(): Promise<void>;
   setLocation: (location: Location) => void;
   mode: StopPlacesMode;
-  onAddFavorite: Props['onAddFavorite'];
+  onAddFavoritePlace: Props['onAddFavoritePlace'];
 };
 
 const Header = React.memo(function Header({
@@ -230,7 +230,7 @@ const Header = React.memo(function Header({
   setCurrentLocationOrRequest,
   setLocation,
   mode,
-  onAddFavorite,
+  onAddFavoritePlace,
 }: HeaderProps) {
   const {t} = useTranslation();
   const styles = useStyles();
@@ -262,7 +262,7 @@ const Header = React.memo(function Header({
           }}
           chipTypes={['favorites', 'add-favorite']}
           style={styles.favoriteChips}
-          onAddFavorite={onAddFavorite}
+          onAddFavoritePlace={onAddFavoritePlace}
         />
       )}
     </View>

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -24,7 +24,7 @@ import type {NavigationState, PartialState} from '@react-navigation/routers';
 import {Root_SelectTravelTokenScreen} from './Root_SelectTravelTokenScreen';
 import {Root_ConsiderTravelTokenChangeScreen} from '@atb/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen';
 import {Root_AddEditFavoritePlaceScreen} from './Root_AddEditFavoritePlaceScreen';
-import {Root_SearchStopPlaceScreen} from './Root_SearchStopPlaceScreen';
+import {Root_SearchFavoritePlaceScreen} from './Root_SearchFavoritePlaceScreen';
 import {Root_ShareTravelHabitsScreen} from './Root_ShareTravelHabitsScreen';
 import {Root_LocationSearchByMapScreen} from '@atb/stacks-hierarchy/Root_LocationSearchByMapScreen';
 import {Root_ScanQrCodeScreen} from '@atb/stacks-hierarchy/Root_ScanQrCodeScreen';
@@ -355,8 +355,8 @@ export const RootStack = () => {
                 component={Root_AddEditFavoritePlaceScreen}
               />
               <Stack.Screen
-                name="Root_SearchStopPlaceScreen"
-                component={Root_SearchStopPlaceScreen}
+                name="Root_SearchFavoritePlaceScreen"
+                component={Root_SearchFavoritePlaceScreen}
               />
               <Stack.Screen
                 name="Root_ShareTravelHabitsScreen"

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/Root_LocationSearchByTextScreen.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/Root_LocationSearchByTextScreen.tsx
@@ -72,7 +72,9 @@ export const Root_LocationSearchByTextScreen = ({
         }
         includeJourneyHistory={includeJourneyHistory}
         onlyStopPlacesCheckboxInitialState={onlyStopPlacesCheckboxInitialState}
-        onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
+        onAddFavoritePlace={() =>
+          navigation.navigate('Root_SearchFavoritePlaceScreen')
+        }
       />
     </View>
   );

--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/components/LocationSearchContent.tsx
@@ -42,7 +42,7 @@ type LocationSearchContentProps = {
   includeHistory?: boolean;
   includeJourneyHistory?: boolean;
   onlyStopPlacesCheckboxInitialState: boolean;
-  onAddFavorite: () => void;
+  onAddFavoritePlace: () => void;
 };
 
 const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
@@ -58,7 +58,7 @@ export function LocationSearchContent({
   includeHistory = true,
   includeJourneyHistory = false,
   onlyStopPlacesCheckboxInitialState,
-  onAddFavorite,
+  onAddFavoritePlace,
 }: LocationSearchContentProps) {
   const styles = useThemeStyles();
   const {favorites} = useFavoritesContext();
@@ -164,7 +164,7 @@ export function LocationSearchContent({
             onMapSelection={onMapSelection}
             chipTypes={favoriteChipTypes}
             style={styles.chipBox}
-            onAddFavorite={onAddFavorite}
+            onAddFavoritePlace={onAddFavoritePlace}
           />
         )}
         {isOnlyStopPlacesCheckboxEnabled && (

--- a/src/stacks-hierarchy/Root_SearchFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_SearchFavoritePlaceScreen.tsx
@@ -7,12 +7,9 @@ import React from 'react';
 import {Keyboard, View} from 'react-native';
 import {RootStackScreenProps} from './navigation-types';
 
-export type SearchStopPlaceProps =
-  RootStackScreenProps<'Root_SearchStopPlaceScreen'>;
+type Props = RootStackScreenProps<'Root_SearchFavoritePlaceScreen'>;
 
-export const Root_SearchStopPlaceScreen = ({
-  navigation,
-}: SearchStopPlaceProps) => {
+export const Root_SearchFavoritePlaceScreen = ({navigation}: Props) => {
   const {t} = useTranslation();
   const styles = useThemeStyles();
 
@@ -35,7 +32,9 @@ export const Root_SearchStopPlaceScreen = ({
         label={t(AddEditFavoriteTexts.fields.location.label)}
         placeholder={t(AddEditFavoriteTexts.fields.location.placeholder)}
         favoriteChipTypes={[]}
-        onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
+        onAddFavoritePlace={() =>
+          navigation.navigate('Root_SearchFavoritePlaceScreen')
+        }
         onlyStopPlacesCheckboxInitialState={false}
       />
     </View>

--- a/src/stacks-hierarchy/Root_SearchStopPlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_SearchStopPlaceScreen.tsx
@@ -36,7 +36,7 @@ export const Root_SearchStopPlaceScreen = ({
         placeholder={t(AddEditFavoriteTexts.fields.location.placeholder)}
         favoriteChipTypes={[]}
         onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
-        onlyStopPlacesCheckboxInitialState={true}
+        onlyStopPlacesCheckboxInitialState={false}
       />
     </View>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
@@ -46,7 +46,9 @@ export const Dashboard_NearbyStopPlacesScreen = ({
         [navigation, route.params.mode, route.params.onCloseRoute],
       )}
       onUpdateLocation={(location) => navigation.setParams({location})}
-      onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
+      onAddFavoritePlace={() =>
+        navigation.navigate('Root_SearchFavoritePlaceScreen')
+      }
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
@@ -243,8 +243,8 @@ export const Dashboard_RootScreen: React.FC<RootProps> = ({
               t(!!from ? dictionary.toPlace : dictionary.fromPlace) +
               screenReaderPause
             }
-            onAddFavorite={() =>
-              navigation.navigate('Root_SearchStopPlaceScreen')
+            onAddFavoritePlace={() =>
+              navigation.navigate('Root_SearchFavoritePlaceScreen')
             }
           />
         </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
@@ -44,7 +44,9 @@ export const Departures_NearbyStopPlacesScreen = ({
         [navigation, route.params.mode],
       )}
       onUpdateLocation={(location) => navigation.setParams({location})}
-      onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
+      onAddFavoritePlace={() =>
+        navigation.navigate('Root_SearchFavoritePlaceScreen')
+      }
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
@@ -29,7 +29,8 @@ export const Profile_FavoriteListScreen = ({navigation}: Props) => {
       editItem: item,
     });
   };
-  const onAddButtonClick = () => navigation.push('Root_SearchStopPlaceScreen');
+  const onAddButtonClick = () =>
+    navigation.push('Root_SearchFavoritePlaceScreen');
   const onSortClick = () => navigation.push('Profile_SortFavoritesScreen');
 
   return (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
@@ -43,7 +43,9 @@ export const Profile_NearbyStopPlacesScreen = ({navigation, route}: Props) => {
         [navigation, route.params.mode],
       )}
       onUpdateLocation={(location) => navigation.setParams({location})}
-      onAddFavorite={() => navigation.navigate('Root_SearchStopPlaceScreen')}
+      onAddFavoritePlace={() =>
+        navigation.navigate('Root_SearchFavoritePlaceScreen')
+      }
     />
   );
 };

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -112,7 +112,7 @@ export type RootStackParamList = StackParams<{
   Root_LocationSearchByMapScreen: Root_LocationSearchByMapScreenParams;
   Root_ScanQrCodeScreen: undefined;
   Root_AddEditFavoritePlaceScreen: Root_AddEditFavoritePlaceScreenParams;
-  Root_SearchStopPlaceScreen: undefined;
+  Root_SearchFavoritePlaceScreen: undefined;
   Root_ShareTravelHabitsScreen: undefined;
   Root_PurchaseOverviewScreen: Root_PurchaseOverviewScreenParams;
   Root_PurchaseConfirmationScreen: Root_PurchaseConfirmationScreenParams;


### PR DESCRIPTION
### Background
https://github.com/AtB-AS/mittatb-app/pull/5003#issuecomment-2650172885

The reason for the bug was a misunderstanding regarding what the functionality of the `Root_SearchStopPlaceScreen` was. It wasn't for searching stop places, but for searching for favorite places in context of add favorite place flow.

### Solution
- The first commit is the actual change that fixes the observed case.
- The second commit is renaming of a screen and some functions to be more clear that it belongs to the add favorite place flow.