### PR TITLE
fix: phone input overflow

### DIFF
--- a/src/components/sections/items/PhoneInputSectionItem.tsx
+++ b/src/components/sections/items/PhoneInputSectionItem.tsx
@@ -160,20 +160,20 @@ export const PhoneInputSectionItem = forwardRef<InternalTextInput, Props>(
           getBorderColor(),
         ]}
       >
-        <View style={styles.inputContainer}>
+        <View style={styles.inputWrapper}>
           <View
             onAccessibilityEscape={accessibilityEscapeKeyboard}
-            style={styles.inputContent}
+            style={styles.inputMainContent}
           >
             {label && (
               <ThemeText typography="body__secondary" style={styles.label}>
                 {label}
               </ThemeText>
             )}
-            <View style={styles.containerInline}>
+            <View style={styles.inputRow}>
               {prefix && (
                 <PressableOpacity
-                  style={styles.prefix}
+                  style={styles.inputPrefix}
                   onPress={onOpenPrefixSelection}
                   accessibilityRole="button"
                   accessibilityLabel={t(
@@ -190,12 +190,13 @@ export const PhoneInputSectionItem = forwardRef<InternalTextInput, Props>(
               )}
               <InternalTextInput
                 ref={combinedRef}
-                style={styles.input}
+                style={styles.inputPhoneNumber}
                 placeholderTextColor={theme.color.foreground.dynamic.secondary}
                 onFocus={onFocusEvent}
                 onBlur={onBlurEvent}
                 maxFontSizeMultiplier={MAX_FONT_SCALE}
                 testID={loginPhoneInputId}
+                keyboardType="number-pad"
                 {...props}
               />
             </View>
@@ -254,36 +255,36 @@ export const PhoneInputSectionItem = forwardRef<InternalTextInput, Props>(
 );
 
 const useInputStyle = StyleSheet.createTheme((theme) => ({
-  inputContainer: {
-    flexDirection: 'row',
-  },
-  inputContent: {
-    flex: 1,
-  },
-  input: {
-    color: theme.color.foreground.dynamic.primary,
-    fontSize: theme.typography.body__primary.fontSize,
-    flex: 1,
-  },
   container: {
     backgroundColor: theme.color.background.neutral[0].background,
     borderWidth: theme.border.width.slim,
     borderColor: theme.color.background.neutral[0].background,
   },
-  containerInline: {
-    alignItems: 'center',
-    flexDirection: 'row',
-  },
   containerMultiline: {
     paddingTop: theme.spacing.small,
     rowGap: theme.spacing.small,
+  },
+  inputWrapper: {
+    flexDirection: 'row',
+  },
+  inputMainContent: {
+    flex: 1,
+  },
+  inputRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
   },
   label: {
     minWidth: 60 - theme.spacing.medium,
     paddingRight: theme.spacing.xSmall,
   },
-  prefix: {
+  inputPrefix: {
     flexDirection: 'row',
+  },
+  inputPhoneNumber: {
+    color: theme.color.foreground.dynamic.primary,
+    fontSize: theme.typography.body__primary.fontSize,
+    flex: 1,
   },
   expandIcon: {
     marginLeft: theme.spacing.xSmall,

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/PhoneAndNameInputSection.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/PhoneAndNameInputSection.tsx
@@ -48,7 +48,6 @@ export const PhoneAndNameInputSection = ({
           prefix={prefix}
           onChangePrefix={onChangePrefix}
           showClear={true}
-          keyboardType="number-pad"
           placeholder={t(PhoneInputTexts.input.placeholder.sendTicket)}
           autoFocus={true}
           textContentType="telephoneNumber"

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -129,7 +129,6 @@ export const Root_LoginPhoneInputScreen = ({
               prefix={prefix}
               onChangePrefix={setPrefix}
               showClear={true}
-              keyboardType="number-pad"
               placeholder={t(PhoneInputTexts.input.placeholder.login)}
               autoFocus={true}
               textContentType="telephoneNumber"

--- a/src/stacks-hierarchy/Root_ScooterHelp/Root_ContactScooterOperatorScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/Root_ContactScooterOperatorScreen.tsx
@@ -190,7 +190,6 @@ export const Root_ContactScooterOperatorScreen = ({
                   ContactScooterOperatorTexts.contactInfo.phone.placeholder,
                 )}
                 showClear
-                keyboardType="number-pad"
                 textContentType="telephoneNumber"
                 errorText={
                   !isPhoneNumberValid && showError


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20017

Solution: 
* Fixes so that phone number input inside PhoneInputSectionItem has correct width
  * Now functions the same as all other inputs when content is too long (size scales down for placeholder, ... at the end for placeholder and input)
* _number-pad_ is now default keyboard type for PhoneInputSectionItem

 Screenshots: 

<img width=200 src="https://github.com/user-attachments/assets/14bb057e-a6b5-49af-8539-4e3cb4bda1a7">
<img width=200 src="https://github.com/user-attachments/assets/ca8b3c75-c79f-4c10-81db-850acdf4778b">
<img width=200 src="https://github.com/user-attachments/assets/9e7efa7b-9cdb-43a4-9646-389bef8fab18">

