### PR TITLE
fix: prevent MessageInfoText overflow

### DIFF
--- a/src/components/message-info-text/MessageInfoText.tsx
+++ b/src/components/message-info-text/MessageInfoText.tsx
@@ -44,14 +44,15 @@ export const MessageInfoText = ({
         />
       )}
 
-      <ThemeText
-        color={textColor}
-        isMarkdown={isMarkdown}
-        typography="body__secondary"
-        style={styles.text}
-      >
-        {message}
-      </ThemeText>
+      <View style={styles.text}>
+        <ThemeText
+          color={textColor}
+          isMarkdown={isMarkdown}
+          typography="body__secondary"
+        >
+          {message}
+        </ThemeText>
+      </View>
 
       {iconPosition === 'right' && (
         <ThemeIcon
@@ -69,6 +70,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     gap: theme.spacing.small,
   },
   text: {
-    flexShrink: 1,
+    flex: 1,
   },
 }));


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20021

<div>
<img width="300px" src="https://github.com/user-attachments/assets/f6ace0e4-a283-4400-ab13-6eee18c6edf3">
<img width="300px" src="https://github.com/user-attachments/assets/26e81fbe-eea1-47e6-867f-ddf7c12654d4">
</div>