### PR TITLE
fix: provide correct props to InspectionSymbol in FareContract details

### DIFF
--- a/src/fare-contracts/sections/FareContractInfoDetailsSectionItem.tsx
+++ b/src/fare-contracts/sections/FareContractInfoDetailsSectionItem.tsx
@@ -101,7 +101,10 @@ export const FareContractInfoDetailsSectionItem = ({
           )}
         </View>
         {isValidOrSentFareContract && (
-          <InspectionSymbol {...props} sentTicket={isStatusSent} />
+          <InspectionSymbol
+            preassignedFareProduct={preassignedFareProduct}
+            sentTicket={isStatusSent}
+          />
         )}
       </View>
     </View>


### PR DESCRIPTION
After https://github.com/AtB-AS/mittatb-app/pull/4991, the `{...props}` given to InspectionSymbol in fare contact details were no longer correct, resulting in an UFO inspection symbol 🛸👽

<img width="300px" src="https://github.com/user-attachments/assets/6db17d71-1755-4469-8c2e-c37a0b1357a3">

Fixed by passing `preassignedFareProduct` directly.
