### PR TITLE
fix: Show product name on recent fare contract

### DIFF
--- a/src/recent-fare-contracts/RecentFareContract.tsx
+++ b/src/recent-fare-contracts/RecentFareContract.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ThemeText} from '@atb/components/text';
-import {getTextForLanguage, useTranslation} from '@atb/translations';
+import {useTranslation} from '@atb/translations';
 import RecentFareContractsTexts from '@atb/translations/screens/subscreens/RecentFareContractsTexts';
 import type {RecentFareContractType} from './types';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -60,12 +60,11 @@ export const RecentFareContract = ({
     transportModes: fareProductTypeConfig?.transportModes,
   });
 
+  const productName = getReferenceDataName(preassignedFareProduct, language);
+
   if (!fareProductTypeConfig) return null;
   const returnAccessibilityLabel = () => {
-    const modeInfo = `${getReferenceDataName(
-      preassignedFareProduct,
-      language,
-    )} ${t(
+    const modeInfo = `${productName} ${t(
       RecentFareContractsTexts.a11yPreLabels.transportModes,
     )}${getTransportModeText(fareProductTypeConfig.transportModes, t)}`;
 
@@ -147,7 +146,7 @@ export const RecentFareContract = ({
           typography="body__primary--bold"
           color={interactiveColor.default}
         >
-          {getTextForLanguage(fareProductTypeConfig.name, language) ?? ''}
+          {productName}
         </ThemeText>
       </View>
 
@@ -167,17 +166,21 @@ export const RecentFareContract = ({
         {userProfilesWithCount.length <= 2 &&
           userProfilesWithCount.map((u) => (
             <FareContractDetailItem
+              key={u.id}
               content={[`${u.count} ${getReferenceDataName(u, language)}`]}
             />
           ))}
 
         {userProfilesWithCount.length > 2 && (
           <>
-            {userProfilesWithCount.slice(0, 1).map((u) => (
-              <FareContractDetailItem
-                content={[`${u.count} ${getReferenceDataName(u, language)}`]}
-              />
-            ))}
+            <FareContractDetailItem
+              content={[
+                `${userProfilesWithCount[0].count} ${getReferenceDataName(
+                  userProfilesWithCount[0],
+                  language,
+                )}`,
+              ]}
+            />
             <ThemeText
               typography="body__tertiary"
               testID={`${testID}TravellersOthers`}


### PR DESCRIPTION
### Background
https://mittatb.slack.com/archives/C0116FMPX4Y/p1739353003234229?thread_ts=1739347072.253399&cid=C0116FMPX4Y

### Solution
Show product name instead of product type config name as recent fare contract heading.

Before/After:
<div>
<img src="https://github.com/user-attachments/assets/4639a614-bdbe-41e5-ab3f-211576df1148"/>
<img src="https://github.com/user-attachments/assets/58fd6de1-6c50-44e7-a0de-d0ad69b0c666"/>
</div>

Also fixed a couple duplicate key errors in console.

### Acceptance criteria
- [ ] Recent fare contracts show the preassigned product name.
