### PR TITLE
feat: Get tileServerBaseUrl and mapboxSpriteUrl from Firestore

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^5.3.0",
+    "@atb-as/config-specs": "^5.7.0",
     "@atb-as/generate-assets": "^15.0.1",
     "@atb-as/theme": "^13.1.3",
     "@atb-as/utils": "^2.0.0",

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -563,6 +563,10 @@ function getConfigurableLinksFromSnapshot(
   const externalRealtimeMap = mapLanguageAndTextType(
     urls?.get('externalRealtimeMap'),
   );
+  const tileServerBaseUrl = mapLanguageAndTextType(
+    urls?.get('tileServerBaseUrl'),
+  );
+  const mapboxSpriteUrl = mapLanguageAndTextType(urls?.get('mapboxSpriteUrl'));
 
   return {
     ticketingInfo,
@@ -575,6 +579,8 @@ function getConfigurableLinksFromSnapshot(
     iosStoreListing,
     androidStoreListing,
     externalRealtimeMap,
+    tileServerBaseUrl,
+    mapboxSpriteUrl,
   };
 }
 

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -58,7 +58,6 @@ export type RemoteConfig = {
   flex_ticket_url: string;
   live_vehicle_stale_threshold: number;
   loading_screen_delay_ms: number;
-  mapbox_sprite_url: string;
   minimum_app_version: string;
   must_upgrade_ticketing: boolean;
   new_favourites_info_url: string;
@@ -131,7 +130,6 @@ export const defaultRemoteConfig: RemoteConfig = {
   flex_ticket_url: '',
   live_vehicle_stale_threshold: 15,
   loading_screen_delay_ms: 200,
-  mapbox_sprite_url: '',
   minimum_app_version: '',
   must_upgrade_ticketing: false,
   new_favourites_info_url: '',
@@ -298,9 +296,6 @@ export function getConfig(): RemoteConfig {
   const loading_screen_delay_ms =
     values['loading_screen_delay_ms']?.asNumber() ??
     defaultRemoteConfig.loading_screen_delay_ms;
-  const mapbox_sprite_url =
-    values['mapbox_sprite_url']?.asString() ??
-    defaultRemoteConfig.mapbox_sprite_url;
   const minimum_app_version =
     values['minimum_app_version']?.asString() ??
     defaultRemoteConfig.minimum_app_version;
@@ -395,7 +390,6 @@ export function getConfig(): RemoteConfig {
     flex_ticket_url,
     live_vehicle_stale_threshold,
     loading_screen_delay_ms,
-    mapbox_sprite_url,
     minimum_app_version,
     must_upgrade_ticketing,
     new_favourites_info_url,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,17 +20,17 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-5.3.0.tgz#04658cb1f317c9894af3c65a505bbb1101050018"
-  integrity sha512-dIpIZJvv6Uxqqij2NoqknwAeWlCYz70KQG5cy9QvNeJF8EBzB2Csw4IBZ6kc4GG/EntfNCNLoOEuMz5mh5F+Ew==
+"@atb-as/config-specs@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-5.7.0.tgz#3d6bf3a29fad8209205eb09c4b89ae687fa622aa"
+  integrity sha512-WSMPq9f12N8p1ZvnsqxAVAoFS4u6wUdyd/6iPhFcKI6cgd2pqqpOHKNwIGzv5eE9nq6oWxnHrw4UVNX7VJFUKw==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"
     glob "^9.3.2"
     js-yaml "^4.1.0"
     yargs "^17.7.1"
-    zod "^3.21.4"
+    zod "^3.24.1"
     zod-to-json-schema "^3.20.4"
 
 "@atb-as/generate-assets@^15.0.1":
@@ -11649,11 +11649,6 @@ zod-to-json-schema@^3.20.4:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz#de97c5b6d4a25e9d444618486cb55c0c7fb949fd"
   integrity sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==
-
-zod@^3.21.4:
-  version "3.22.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
-  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
 
 zod@^3.24.1:
   version "3.24.1"


### PR DESCRIPTION
Two things in this PR
- Get `tileServerBaseUrl` from Firestore
- Get `mapboxSpriteUrl` from Firestore instead of Remote Config where it was originally.

Resolves https://github.com/AtB-AS/kundevendt/issues/19555