### PR TITLE
fix: use frontText instead of lineName in departures widget

### DIFF
--- a/ios/AtbAppIntent/IntentHandler.swift
+++ b/ios/AtbAppIntent/IntentHandler.swift
@@ -27,7 +27,7 @@ class IntentHandler: INExtension, UseLocationIntentHandling {
 
                     let favoriteDeparture = FavoriteDeparture(
                         identifier: departure.id,
-                        display: "\(departure.lineLineNumber) \(departure.lineName ?? NSLocalizedString("all_variations", comment: ""))"
+                        display: "\(departure.lineLineNumber) \(NSLocalizedString("all_variations", comment: ""))"
                     )
 
                     return favoriteDeparture

--- a/ios/AtbAppIntent/IntentHandler.swift
+++ b/ios/AtbAppIntent/IntentHandler.swift
@@ -27,7 +27,7 @@ class IntentHandler: INExtension, UseLocationIntentHandling {
 
                     let favoriteDeparture = FavoriteDeparture(
                         identifier: departure.id,
-                        display: "\(departure.lineLineNumber) \(NSLocalizedString("all_variations", comment: ""))"
+                        display: "\(departure.lineLineNumber) \(departure.destinationDisplay?.frontText ?? NSLocalizedString("all_variations", comment: ""))"
                     )
 
                     return favoriteDeparture

--- a/ios/departureWidget/Provider.swift
+++ b/ios/departureWidget/Provider.swift
@@ -69,12 +69,12 @@ struct Provider: IntentTimelineProvider {
                 }
                 var departures: [DepartureTime] = []
 
-                if departure.lineName == nil {
+                if departure.destinationDisplay?.frontText == nil {
                     quayGroup.group.forEach { line in
                         departures.append(contentsOf: line.departures)
                     }
                 } else {
-                    guard let lineDepartures = quayGroup.group.first(where: { $0.lineInfo.lineName == departure.lineName })?.departures else {
+                    guard let lineDepartures = quayGroup.group.first(where: { $0.lineInfo.destinationDisplay?.frontText == departure.destinationDisplay?.frontText })?.departures else {
                         return completion(noDeparturesTimeline)
                     }
                     departures = lineDepartures

--- a/ios/departureWidget/Structs.swift
+++ b/ios/departureWidget/Structs.swift
@@ -231,15 +231,13 @@ struct DepartureGroup: Codable {
 
 struct DepartureLineInfo: Codable {
     let lineId: String
-    let lineName: String?
     let lineNumber: String
     let transportMode: TransportMode?
     let transportSubmode: TransportSubMode?
     let quayId: String
 
-    init(lineId: String, lineName: String?, lineNumber: String, transportMode: TransportMode?, transportSubmode: TransportSubMode?, quayId: String) {
+    init(lineId: String, lineNumber: String, transportMode: TransportMode?, transportSubmode: TransportSubMode?, quayId: String) {
         self.lineId = lineId
-        self.lineName = lineName
         self.lineNumber = lineNumber
         self.transportMode = transportMode
         self.transportSubmode = transportSubmode
@@ -249,7 +247,6 @@ struct DepartureLineInfo: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         lineId = try container.decode(String.self, forKey: .lineId)
-        lineName = try container.decodeIfPresent(String.self, forKey: .lineName)
         lineNumber = try container.decode(String.self, forKey: .lineNumber)
         transportMode = try container.decodeIfPresent(TransportMode.self, forKey: .transportMode)
         transportSubmode = try container.decodeIfPresent(TransportSubMode.self, forKey: .transportSubmode)
@@ -330,7 +327,6 @@ struct DepartureLinkLabel: Hashable {
 struct FavouriteDeparture: Codable {
     let id: String
     let lineId: String
-    let lineName: String?
     let lineLineNumber: String
     let lineTransportationMode: TransportMode?
     let lineTransportationSubMode: TransportSubMode?
@@ -338,10 +334,9 @@ struct FavouriteDeparture: Codable {
     let quayPublicCode: String?
     let quayId: String
 
-    init(id: String, lineId: String, lineName: String?, lineLineNumber: String, lineTransportationMode: TransportMode?, lineTransportationSubMode: TransportSubMode?, quayName: String, quayPublicCode: String, quayId: String) {
+    init(id: String, lineId: String, lineLineNumber: String, lineTransportationMode: TransportMode?, lineTransportationSubMode: TransportSubMode?, quayName: String, quayPublicCode: String, quayId: String) {
         self.id = id
         self.lineId = lineId
-        self.lineName = lineName
         self.lineLineNumber = lineLineNumber
         self.lineTransportationMode = lineTransportationMode
         self.lineTransportationSubMode = lineTransportationSubMode
@@ -354,7 +349,6 @@ struct FavouriteDeparture: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
         lineId = try container.decode(String.self, forKey: .lineId)
-        lineName = try container.decodeIfPresent(String.self, forKey: .lineName)
         lineLineNumber = try container.decode(String.self, forKey: .lineLineNumber)
         lineTransportationMode = try container.decodeIfPresent(TransportMode.self, forKey: .lineTransportationMode)
         lineTransportationSubMode = try container.decodeIfPresent(TransportSubMode.self, forKey: .lineTransportationSubMode)
@@ -370,7 +364,6 @@ extension FavouriteDeparture {
     static let dummy: FavouriteDeparture = .init(
         id: "",
         lineId: "ATB:Line:2_2",
-        lineName: "Ranheim",
         lineLineNumber: "1",
         lineTransportationMode: TransportMode.bus,
         lineTransportationSubMode: TransportSubMode.undefined,
@@ -412,7 +405,6 @@ extension DepartureGroup {
     lineInfo:
     DepartureLineInfo(
         lineId: "",
-        lineName: "Ranheim",
         lineNumber: "1",
         transportMode: TransportMode.bus,
         transportSubmode: TransportSubMode.undefined,

--- a/ios/departureWidget/Structs.swift
+++ b/ios/departureWidget/Structs.swift
@@ -229,19 +229,37 @@ struct DepartureGroup: Codable {
     var departures: [DepartureTime]
 }
 
+struct DestinationDisplay: Codable {
+    let frontText: String?
+    let via: [String]?
+  
+    init(frontText: String?, via: [String]?) {
+        self.frontText = frontText
+        self.via = via
+    }
+  
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.frontText = try container.decodeIfPresent(String.self, forKey: .frontText)
+        self.via = try container.decodeIfPresent([String].self, forKey: .via)
+    }
+}
+
 struct DepartureLineInfo: Codable {
     let lineId: String
     let lineNumber: String
     let transportMode: TransportMode?
     let transportSubmode: TransportSubMode?
     let quayId: String
+    let destinationDisplay: DestinationDisplay?
 
-    init(lineId: String, lineNumber: String, transportMode: TransportMode?, transportSubmode: TransportSubMode?, quayId: String) {
+    init(lineId: String, lineNumber: String, transportMode: TransportMode?, transportSubmode: TransportSubMode?, quayId: String, destinationDisplay: DestinationDisplay) {
         self.lineId = lineId
         self.lineNumber = lineNumber
         self.transportMode = transportMode
         self.transportSubmode = transportSubmode
         self.quayId = quayId
+        self.destinationDisplay = destinationDisplay
     }
 
     init(from decoder: Decoder) throws {
@@ -251,6 +269,7 @@ struct DepartureLineInfo: Codable {
         transportMode = try container.decodeIfPresent(TransportMode.self, forKey: .transportMode)
         transportSubmode = try container.decodeIfPresent(TransportSubMode.self, forKey: .transportSubmode)
         quayId = try container.decode(String.self, forKey: .quayId)
+        destinationDisplay = try container.decodeIfPresent(DestinationDisplay.self, forKey: .destinationDisplay)
     }
 }
 
@@ -333,8 +352,9 @@ struct FavouriteDeparture: Codable {
     let quayName: String
     let quayPublicCode: String?
     let quayId: String
+    let destinationDisplay: DestinationDisplay?
 
-    init(id: String, lineId: String, lineLineNumber: String, lineTransportationMode: TransportMode?, lineTransportationSubMode: TransportSubMode?, quayName: String, quayPublicCode: String, quayId: String) {
+    init(id: String, lineId: String, lineLineNumber: String, lineTransportationMode: TransportMode?, lineTransportationSubMode: TransportSubMode?, quayName: String, quayPublicCode: String, quayId: String, destinationDisplay: DestinationDisplay) {
         self.id = id
         self.lineId = lineId
         self.lineLineNumber = lineLineNumber
@@ -343,6 +363,7 @@ struct FavouriteDeparture: Codable {
         self.quayName = quayName
         self.quayPublicCode = quayPublicCode
         self.quayId = quayId
+        self.destinationDisplay = destinationDisplay
     }
 
     init(from decoder: Decoder) throws {
@@ -355,10 +376,18 @@ struct FavouriteDeparture: Codable {
         quayName = try container.decode(String.self, forKey: .quayName)
         quayPublicCode = try container.decodeIfPresent(String.self, forKey: .quayPublicCode)
         quayId = try container.decode(String.self, forKey: .quayId)
+        destinationDisplay = try container.decodeIfPresent(DestinationDisplay.self, forKey: .destinationDisplay)
     }
 }
 
 // MARK: Extensions
+
+extension DestinationDisplay {
+    static let dummy: DestinationDisplay = .init(
+        frontText: "Ranheim",
+        via: []
+    )
+}
 
 extension FavouriteDeparture {
     static let dummy: FavouriteDeparture = .init(
@@ -369,7 +398,8 @@ extension FavouriteDeparture {
         lineTransportationSubMode: TransportSubMode.undefined,
         quayName: "Prinsens gate",
         quayPublicCode: "P1",
-        quayId: "NSR:Quay:71184"
+        quayId: "NSR:Quay:71184",
+        destinationDisplay: DestinationDisplay.dummy
     )
 }
 
@@ -408,7 +438,8 @@ extension DepartureGroup {
         lineNumber: "1",
         transportMode: TransportMode.bus,
         transportSubmode: TransportSubMode.undefined,
-        quayId: "NSR:Quay:71184"
+        quayId: "NSR:Quay:71184",
+        destinationDisplay: DestinationDisplay.dummy
     ),
     departures: [Int](0 ..< 10).map { index in
         let timeInterval = CGFloat(index) * 300

--- a/ios/departureWidget/WidgetViewModel.swift
+++ b/ios/departureWidget/WidgetViewModel.swift
@@ -29,8 +29,8 @@ struct WidgetViewModel {
         departureGroup?.lineInfo
     }
 
-    private var lineName: String? {
-        entry.favouriteDeparture?.lineName ?? NSLocalizedString("all_variations", comment: "")
+    private var frontText: String? {
+        entry.favouriteDeparture?.destinationDisplay?.frontText ?? NSLocalizedString("all_variations", comment: "")
     }
 
     private var lineNumber: String? {
@@ -89,11 +89,11 @@ struct WidgetViewModel {
     }
 
     var lineDetails: String? {
-        guard let lineName = lineName, let lineNumber = lineNumber else {
+        guard let frontText = frontText, let lineNumber = lineNumber else {
             return nil
         }
 
-        return "\(lineNumber) \(lineName)"
+        return "\(lineNumber) \(frontText)"
     }
 
     var transportModeIcon: Image? {


### PR DESCRIPTION
fixes issue described in https://mittatb.slack.com/archives/C0116FMPX4Y/p1739351827212559

Note: This adds destination display with `frontText` and `via` to the widget, but I haven't added logic to actually display the `via` data, only `frontText`.

<img width="300px" src="https://github.com/user-attachments/assets/838307ed-84bd-489d-bf1d-7ad07794578e">
