### PR TITLE
refactor: Remove transitionPreset not serialisable warning

### DIFF
--- a/src/stacks-hierarchy/Root_LocationSearchByTextScreen/hooks.ts
+++ b/src/stacks-hierarchy/Root_LocationSearchByTextScreen/hooks.ts
@@ -1,11 +1,9 @@
-import {ParamListBase, RouteProp, useRoute} from '@react-navigation/native';
+import {RouteProp, useRoute} from '@react-navigation/native';
 import {Location} from '@atb/favorites';
 import {SelectableLocationType} from './types';
 import React, {useRef} from 'react';
 
-export function useLocationSearchValue<
-  T extends RouteProp<any, any> & {params: ParamListBase},
->(
+export function useLocationSearchValue<T extends RouteProp<any, any>>(
   callerRouteParam: keyof T['params'],
   defaultLocation?: Location,
 ): SelectableLocationType | undefined {
@@ -30,9 +28,7 @@ export function useLocationSearchValue<
   return location;
 }
 
-export function useOnlySingleLocation<
-  T extends RouteProp<any, any> & {params: ParamListBase},
->(
+export function useOnlySingleLocation<T extends RouteProp<any, any>>(
   callerRouteParam: keyof T['params'],
   defaultLocation?: Location,
 ): Location | undefined {

--- a/src/stacks-hierarchy/Root_LoginAvailableFareContractWarningScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginAvailableFareContractWarningScreen.tsx
@@ -10,7 +10,6 @@ import {useFareContracts, useTicketingContext} from '@atb/ticketing';
 import {useRemoteConfigContext} from '@atb/RemoteConfigContext';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {useTimeContext} from '@atb/time';
-import {TransitionPresets} from '@react-navigation/stack';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {FareContractOrReservation} from '@atb/fare-contracts/FareContractOrReservation';
 
@@ -42,7 +41,7 @@ export const Root_LoginAvailableFareContractWarningScreen = ({
       });
     } else {
       navigation.navigate('Root_LoginPhoneInputScreen', {
-        transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
+        transitionOverride: 'slide-from-bottom',
       });
     }
   };

--- a/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginOptionsScreen.tsx
@@ -24,7 +24,6 @@ import queryString from 'query-string';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {Button} from '@atb/components/button';
 import {ArrowRight, ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
-import {TransitionPresets} from '@react-navigation/stack';
 import {useFirestoreConfigurationContext} from '@atb/configuration';
 import {useOnboardingContext} from '@atb/onboarding';
 import {GlobalMessageContextEnum} from '@atb/global-messages';
@@ -39,7 +38,7 @@ export const Root_LoginOptionsScreen = ({
   route: {params},
 }: Props) => {
   const showGoBack = params?.showGoBack;
-  const transitionPreset = params?.transitionPreset;
+  const transitionPreset = params?.transitionOverride;
 
   const {t, language} = useTranslation();
   const styles = useStyles();
@@ -150,9 +149,7 @@ export const Root_LoginOptionsScreen = ({
           showGoBack
             ? {
                 type:
-                  transitionPreset === TransitionPresets.ModalSlideFromBottomIOS
-                    ? 'close'
-                    : 'back',
+                  transitionPreset === 'slide-from-bottom' ? 'close' : 'back',
               }
             : undefined
         }

--- a/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginPhoneInputScreen.tsx
@@ -14,7 +14,6 @@ import {ThemeText} from '@atb/components/text';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 
-import {TransitionPresets} from '@react-navigation/stack';
 import {PhoneInputSectionItem, Section} from '@atb/components/sections';
 import {Button} from '@atb/components/button';
 import {MessageInfoBox} from '@atb/components/message-info-box';
@@ -86,8 +85,7 @@ export const Root_LoginPhoneInputScreen = ({
       <FullScreenHeader
         leftButton={{
           type:
-            params?.transitionPreset ===
-            TransitionPresets.ModalSlideFromBottomIOS
+            params?.transitionOverride === 'slide-from-bottom'
               ? 'close'
               : 'back',
         }}

--- a/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
@@ -13,7 +13,6 @@ import {useTextForLanguage} from '@atb/translations/utils';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {useRemoteConfigContext} from '@atb/RemoteConfigContext';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
-import {TransitionPresets} from '@react-navigation/stack';
 import {useHasReservationOrAvailableFareContract} from '@atb/ticketing';
 
 const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
@@ -39,13 +38,13 @@ export const Root_LoginRequiredForFareProductScreen = ({
   const onNext = async () => {
     if (hasReservationOrAvailableFareContract) {
       navigation.navigate('Root_LoginAvailableFareContractWarningScreen', {
-        transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
+        transitionOverride: 'slide-from-bottom',
       });
     } else {
       if (enable_vipps_login) {
         navigation.navigate('Root_LoginOptionsScreen', {
           showGoBack: true,
-          transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
+          transitionOverride: 'slide-from-bottom',
         });
       } else {
         navigation.navigate('Root_LoginPhoneInputScreen', {});

--- a/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
@@ -2,7 +2,6 @@ import {useRemoteConfigContext} from '@atb/RemoteConfigContext';
 import React from 'react';
 import {AnonymousPurchaseConsequencesScreenComponent} from '@atb/anonymous-purchase-consequences-screen';
 import {RootStackParamList, RootStackScreenProps} from './navigation-types';
-import {TransitionPresets} from '@react-navigation/stack';
 import {useCompleteUserCreationOnboardingAndEnterApp} from '@atb/utils/use-complete-user-creation-onboarding-and-enter-app';
 import {useHasReservationOrAvailableFareContract} from '@atb/ticketing';
 
@@ -35,9 +34,7 @@ export const Root_PurchaseAsAnonymousConsequencesScreen = ({
       onPressContinueWithoutLogin={completeUserCreationOnboardingAndEnterApp}
       leftButton={{
         type:
-          params?.transitionPreset === TransitionPresets.ModalSlideFromBottomIOS
-            ? 'close'
-            : 'back',
+          params?.transitionOverride === 'slide-from-bottom' ? 'close' : 'back',
       }}
     />
   );

--- a/src/stacks-hierarchy/Root_ScooterHelp/Root_ContactScooterOperatorScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/Root_ContactScooterOperatorScreen.tsx
@@ -31,7 +31,6 @@ import {useProfileQuery} from '@atb/queries';
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {CustomerProfile} from '@atb/api/types/profile';
 import {useNavigation} from '@react-navigation/native';
-import {TransitionPresets} from '@react-navigation/stack';
 
 export type Root_ContactScooterOperatorScreenProps =
   RootStackScreenProps<'Root_ContactScooterOperatorScreen'>;
@@ -48,7 +47,7 @@ export const Root_ContactScooterOperatorScreen = ({
   const onSuccess = () => {
     navigation.navigate('Root_ContactScooterOperatorConfirmationScreen', {
       operatorName,
-      transitionPreset: TransitionPresets.SlideFromRightIOS,
+      transitionOverride: 'slide-from-right',
     });
   };
 

--- a/src/stacks-hierarchy/Root_ScooterHelp/Root_ScooterHelpScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/Root_ScooterHelpScreen.tsx
@@ -14,7 +14,6 @@ import {ContentHeading, ScreenHeading} from '@atb/components/heading';
 import {useNavigation} from '@react-navigation/native';
 import {useVehicle} from '@atb/mobility/use-vehicle';
 import {useFirestoreConfigurationContext} from '@atb/configuration';
-import {TransitionPresets} from '@react-navigation/stack';
 import {FullScreenView} from '@atb/components/screen-view';
 
 export type ScooterHelpScreenProps =
@@ -50,7 +49,7 @@ export const Root_ScooterHelpScreen = ({route}: ScooterHelpScreenProps) => {
                 navigation.navigate('Root_ContactScooterOperatorScreen', {
                   vehicleId,
                   operatorId,
-                  transitionPreset: TransitionPresets.SlideFromRightIOS,
+                  transitionOverride: 'slide-from-right',
                 });
               }}
             />
@@ -59,7 +58,7 @@ export const Root_ScooterHelpScreen = ({route}: ScooterHelpScreenProps) => {
             text={t(ScooterHelpTexts.reportParking)}
             onPress={() =>
               navigation.navigate('Root_ParkingViolationsSelectScreen', {
-                transitionPreset: TransitionPresets.SlideFromRightIOS,
+                transitionOverride: 'slide-from-right',
               })
             }
           />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_NearbyStopPlacesScreen.tsx
@@ -15,7 +15,7 @@ export const Dashboard_NearbyStopPlacesScreen = ({
   navigation,
   route,
 }: Props) => {
-  const fromLocation = useOnlySingleLocation('location');
+  const fromLocation = useOnlySingleLocation<typeof route>('location');
   const {t} = useTranslation();
 
   return (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DeparturesStack/Departures_NearbyStopPlacesScreen.tsx
@@ -12,7 +12,7 @@ export const Departures_NearbyStopPlacesScreen = ({
   navigation,
   route,
 }: Props) => {
-  const fromLocation = useOnlySingleLocation('location');
+  const fromLocation = useOnlySingleLocation<typeof route>('location');
   const {t} = useTranslation();
 
   return (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_NearbyStopPlacesScreen.tsx
@@ -12,7 +12,7 @@ import {NearbyStopPlacesScreenComponent} from '@atb/nearby-stop-places';
 type Props = ProfileScreenProps<'Profile_NearbyStopPlacesScreen'>;
 
 export const Profile_NearbyStopPlacesScreen = ({navigation, route}: Props) => {
-  const fromLocation = useOnlySingleLocation('location');
+  const fromLocation = useOnlySingleLocation<typeof route>('location');
 
   const {t} = useTranslation();
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -41,7 +41,6 @@ import {useAnalyticsContext} from '@atb/analytics';
 import {useStorybookContext} from '@atb/storybook/StorybookContext';
 import {ContentHeading} from '@atb/components/heading';
 import {FullScreenView} from '@atb/components/screen-view';
-import {TransitionPresets} from '@react-navigation/stack';
 import {formatPhoneNumber} from '@atb/utils/phone-number-utils';
 import {useFeatureTogglesContext} from '@atb/feature-toggles';
 
@@ -204,8 +203,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   } else if (enable_vipps_login) {
                     navigation.navigate('Root_LoginOptionsScreen', {
                       showGoBack: true,
-                      transitionPreset:
-                        TransitionPresets.ModalSlideFromBottomIOS,
+                      transitionOverride: 'slide-from-bottom',
                     });
                   } else {
                     navigation.navigate('Root_LoginPhoneInputScreen', {});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -14,7 +14,6 @@ import {useMobileTokenContext} from '@atb/mobile-token';
 import {TariffZoneWithMetadata} from '@atb/tariff-zones-selector';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {TariffZone} from '@atb/configuration';
-import {TransitionPresets} from '@react-navigation/stack';
 import {useGetFareProductsQuery} from '@atb/ticketing/use-get-fare-products-query';
 import {ErrorWithAccountMessage} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/ErrorWithAccountMessage';
 import {useRecentFareContracts} from '@atb/recent-fare-contracts/use-recent-fare-contracts';
@@ -163,7 +162,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
                 'Root_PurchaseAsAnonymousConsequencesScreen',
                 {
                   showLoginButton: true,
-                  transitionPreset: TransitionPresets.ModalSlideFromBottomIOS,
+                  transitionOverride: 'slide-from-bottom',
                 },
               )
             }

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -1,5 +1,5 @@
 import {NavigationProp, NavigatorScreenParams} from '@react-navigation/native';
-import {StackScreenProps, TransitionPreset} from '@react-navigation/stack';
+import {StackScreenProps} from '@react-navigation/stack';
 import {TabNavigatorStackParams} from '@atb/stacks-hierarchy/Root_TabNavigatorStack';
 import {Location, SearchLocation, StoredLocationFavorite} from '@atb/favorites';
 import {Root_LocationSearchByTextScreenParams} from '@atb/stacks-hierarchy/Root_LocationSearchByTextScreen';
@@ -149,13 +149,17 @@ export type RootStackScreenProps<T extends keyof RootStackParamList> =
   StackScreenProps<RootStackParamList, T>;
 
 export type CustomScreenParams = {
-  transitionPreset?: TransitionPreset;
+  /**
+   * Parameter which can be used to override the transition specified in the
+   * stack navigator.
+   */
+  transitionOverride?: 'slide-from-right' | 'slide-from-bottom';
 };
 
 /**
  * This type is meant to be used on every stack params specification. It both:
  * - Checks that each key in the stack param list ends with "Screen" or "Stack"
- * - Adds the CustomScreenParams to the mapped value type., which makes it
+ * - Adds the CustomScreenParams to the mapped value type, which makes it
  *   possible to set transition when navigating.
  */
 export type StackParams<

--- a/src/stacks-hierarchy/navigation-utils.ts
+++ b/src/stacks-hierarchy/navigation-utils.ts
@@ -2,6 +2,7 @@ import {CustomScreenParams} from '@atb/stacks-hierarchy/navigation-types';
 import {
   StackNavigationOptions,
   TransitionPreset,
+  TransitionPresets,
 } from '@react-navigation/stack';
 
 /**
@@ -18,5 +19,19 @@ export const screenOptions: (
   (defaultTransitionPreset, stackNavigationOptions) =>
   ({route}) => ({
     ...stackNavigationOptions,
-    ...(route.params?.transitionPreset ?? defaultTransitionPreset),
+    ...getTransitionPreset(route.params, defaultTransitionPreset),
   });
+
+const getTransitionPreset = (
+  params: CustomScreenParams | undefined,
+  defaultTransitionPreset: TransitionPreset,
+) => {
+  if (!params?.transitionOverride) return defaultTransitionPreset;
+
+  switch (params.transitionOverride) {
+    case 'slide-from-bottom':
+      return TransitionPresets.ModalSlideFromBottomIOS;
+    case 'slide-from-right':
+      return TransitionPresets.SlideFromRightIOS;
+  }
+};


### PR DESCRIPTION
### Background

We have the possibility to specify a transition when navigating, but
using this functionality gave this warning:
"Non-serializable values were found in the navigation state"

Instead of passing the actual TransitionPreset object as a param, now
the param instead is a string which will be mapped to a
TransitionPreset object before usage.

In addition renamed the param to transitionOverride to signal that
the param is ment to be used only for overriding the transition
specified in the stack navigator.

![Screenshot 2025-02-13 at 12 39 46](https://github.com/user-attachments/assets/40d2fab1-e026-4e61-805d-7e5d05d41d61)

### Acceptance criteria
- [ ] Navigation animations in the app are unchanged. Do some random sampling.