### PR TITLE
feat: implement token status endpoint

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -114,17 +114,16 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
 
   useEffect(() => {
     if (nativeTokenStatus === 'success') {
-      const tokenId = nativeToken.tokenId;
       const tokenStatus = nativeToken.isAttested()
         ? 'attested'
         : 'non-attested';
 
       updateMetadata({
-        'AtB-Mobile-Token-Id': tokenId,
+        'AtB-Mobile-Token-Id': nativeToken.tokenId,
         'AtB-Mobile-Token-Status': tokenStatus,
         'AtB-Mobile-Token-Error-Correlation-Id': undefined,
       });
-      tokenService.postTokenStatus(tokenId, tokenStatus, undefined);
+      tokenService.postTokenStatus(nativeToken.tokenId, tokenStatus, undefined);
     } else if (nativeTokenStatus === 'error') {
       updateMetadata({
         'AtB-Mobile-Token-Id': undefined,

--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -41,9 +41,9 @@ export type TokenService = RemoteTokenService & {
   validate: (token: ActivatedToken, traceId: string) => Promise<void>;
   getTokenToggleDetails: () => Promise<TokenLimitResponse>;
   postTokenStatus: (
-    tokenId: string,
+    tokenId: string | undefined,
     tokenStatus: string,
-    traceId: string,
+    traceId: string | undefined,
   ) => Promise<void>;
 };
 

--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -40,6 +40,11 @@ export type TokenService = RemoteTokenService & {
   ) => Promise<RemoteToken[]>;
   validate: (token: ActivatedToken, traceId: string) => Promise<void>;
   getTokenToggleDetails: () => Promise<TokenLimitResponse>;
+  postTokenStatus: (
+    tokenId: string,
+    tokenStatus: string,
+    traceId: string,
+  ) => Promise<void>;
 };
 
 const handleError = (err: any) => {
@@ -230,6 +235,20 @@ export const tokenService: TokenService = {
             skipErrorLogging: isRemoteTokenStateError,
           })
           .catch(handleError),
+    );
+  },
+  postTokenStatus: async (tokenId, tokenStatus, traceId) => {
+    await client.post(
+      '/token/v1/status',
+      {
+        mobileTokenId: tokenId,
+        mobileTokenStatus: tokenStatus,
+        mobileTokenErrorCorrelationId: traceId,
+      },
+      {
+        authWithIdToken: true,
+        timeout: 15000,
+      },
     );
   },
 };


### PR DESCRIPTION
closes: https://github.com/AtB-AS/kundevendt/issues/19963

Changes: 
- Implement endpoint for sending token status to /token/v1/status.
- Send token status along with intercom metadata update.
- Add condition to send the token status when the query status is not `loading`, so that only the final error/success state will be sent. Without the query status, it will send the status update when the query is still on initialization/empty state.

Please let me know if checking for `query status !== 'loading'` is not the correct solution here, I've looked into `isLoading` and `isFetching` and it seems that checking on `isLoading` is the way to go.