### PR TITLE
refactor: Simplify button color selection

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -205,9 +205,9 @@ export const Button = React.forwardRef<any, ButtonProps>((props, ref) => {
  * Get the button colors based on the input props to the button. The returned
  * mainContrastColor is the ContrastColor for the background and text of the
  * button. In addition, a borderColorValue is returned for the border color. We
- * can't really use a ContrastColor for this value since sometimes the color is
- * background color and sometimes a foreground color, based on the mode and
- * state of the button.
+ * can't really use a ContrastColor for the border color since sometimes the
+ * color is background color and sometimes a foreground color, based on the mode
+ * and state of the button.
  */
 const getButtonColors = (
   props: ButtonProps,


### PR DESCRIPTION
### Background
When doing stuff in the `Button` component it was really hard to find out of the color selection flow, as we had the variables `backgroundColor`, `buttonColor`, `textColorBasedOnBackground`, `textColor`, `borderColor`, `backgroundColorValue`, in addition to the `DefaultModeStyles` with `ButtonSettings` for each mode. I tried to gather and simplify this into a more simple `getButtonColors` helper.

Tip: Strip whitespace in the PR diff

### Acceptance criteria
- [ ] Buttons around the app looks as before. Test with DesignSystem screen, Storybook, and random sampling in the app.