### PR TITLE
feat: add active and interActiveColor to section item

### DIFF
--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -9,8 +9,8 @@ import {
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
-import {StyleSheet, useThemeContext} from '@atb/theme';
-import {InteractiveColor, TextNames} from '@atb/theme/colors';
+import {StyleSheet} from '@atb/theme';
+import {TextNames} from '@atb/theme/colors';
 import {LabelInfo} from '@atb/components/label-info';
 import {LabelType} from '@atb/configuration';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
@@ -77,7 +77,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
             : accessibilityLabel
         }
         accessibilityState={{disabled}}
-        style={[topContainer]}
+        style={topContainer}
         testID={testID}
         ref={forwardedRef}
         collapsable={false}

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -48,12 +48,15 @@ export const LinkSectionItem = forwardRef<any, Props>(
     forwardedRef,
   ) => {
     const {t} = useTranslation();
-    const {contentContainer, topContainer} = useSectionItem(props);
+    const {
+      contentContainer,
+      topContainer,
+      interactiveColor: genericSectionInteractiveColor,
+    } = useSectionItem(props);
     const style = useSectionStyle();
     const linkSectionItemStyle = useStyles();
-    const {theme} = useThemeContext();
     const themeColor =
-      interactiveColor?.default ?? theme.color.interactive[2].default;
+      interactiveColor?.default ?? genericSectionInteractiveColor.default;
     const iconEl =
       isNavigationIcon(icon) || !icon ? (
         <NavigationIcon mode={icon} fill={themeColor.foreground.primary} />
@@ -78,7 +81,10 @@ export const LinkSectionItem = forwardRef<any, Props>(
             : accessibilityLabel
         }
         accessibilityState={{disabled}}
-        style={[topContainer, {backgroundColor: themeColor.background}]}
+        style={[
+          topContainer,
+          interactiveColor && {backgroundColor: themeColor.background},
+        ]}
         testID={testID}
         ref={forwardedRef}
         collapsable={false}

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -27,7 +27,6 @@ type Props = SectionItemProps<{
   disabled?: boolean;
   accessibility?: AccessibilityProps;
   textType?: TextNames;
-  interactiveColor?: InteractiveColor;
 }>;
 
 export const LinkSectionItem = forwardRef<any, Props>(
@@ -42,24 +41,21 @@ export const LinkSectionItem = forwardRef<any, Props>(
       disabled,
       textType,
       testID,
-      interactiveColor,
       ...props
     },
     forwardedRef,
   ) => {
     const {t} = useTranslation();
-    const {
-      contentContainer,
-      topContainer,
-      interactiveColor: genericSectionInteractiveColor,
-    } = useSectionItem(props);
+    const {contentContainer, topContainer, interactiveColor} =
+      useSectionItem(props);
     const style = useSectionStyle();
     const linkSectionItemStyle = useStyles();
-    const themeColor =
-      interactiveColor?.default ?? genericSectionInteractiveColor.default;
     const iconEl =
       isNavigationIcon(icon) || !icon ? (
-        <NavigationIcon mode={icon} fill={themeColor.foreground.primary} />
+        <NavigationIcon
+          mode={icon}
+          fill={interactiveColor.default.foreground.primary}
+        />
       ) : (
         icon
       );
@@ -81,10 +77,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
             : accessibilityLabel
         }
         accessibilityState={{disabled}}
-        style={[
-          topContainer,
-          interactiveColor && {backgroundColor: themeColor.background},
-        ]}
+        style={[topContainer]}
         testID={testID}
         ref={forwardedRef}
         collapsable={false}
@@ -92,7 +85,10 @@ export const LinkSectionItem = forwardRef<any, Props>(
       >
         <View style={[style.spaceBetween, disabledStyle]}>
           <ThemeText
-            style={[contentContainer, {color: themeColor.foreground.primary}]}
+            style={[
+              contentContainer,
+              {color: interactiveColor.default.foreground.primary},
+            ]}
             typography={textType}
           >
             {text}

--- a/src/components/sections/items/RadioSectionItem.tsx
+++ b/src/components/sections/items/RadioSectionItem.tsx
@@ -42,16 +42,15 @@ export function RadioSectionItem({
   rightAction,
   ...props
 }: Props) {
-  const {contentContainer, topContainer} = useSectionItem(props);
+  const {contentContainer, topContainer} = useSectionItem({
+    ...props,
+    active: selected,
+  });
   const style = useSectionStyle();
   const styles = useStyles();
   const {theme} = useThemeContext();
   const {t} = useTranslation();
   const color = theme.color.interactive[2];
-
-  const backgroundColor = selected
-    ? color.active.background
-    : color.default.background;
 
   const textColor = selected
     ? color.active.foreground.primary
@@ -65,7 +64,7 @@ export function RadioSectionItem({
     t(selected ? dictionary.selected : dictionary.unselected);
 
   return (
-    <View style={[style.spaceBetween, topContainer, {backgroundColor}]}>
+    <View style={[style.spaceBetween, topContainer]}>
       <PressableOpacity
         onPress={() => onPress(!selected)}
         style={styles.mainContent}

--- a/src/components/sections/use-section-item.ts
+++ b/src/components/sections/use-section-item.ts
@@ -14,6 +14,7 @@ export type BaseSectionItemProps = {
   radiusSize?: keyof Theme['border']['radius'];
   testID?: string;
   active?: boolean;
+  interactiveColor?: InteractiveColor;
 };
 
 export type SectionReturnType = {
@@ -30,9 +31,10 @@ export function useSectionItem({
   radius,
   radiusSize,
   active,
+  interactiveColor: customInteractiveColor,
 }: BaseSectionItemProps): SectionReturnType {
   const {theme} = useThemeContext();
-  const interactiveColor = getInteractiveColor(theme);
+  const interactiveColor = customInteractiveColor ?? getInteractiveColor(theme);
 
   const topContainer: ViewStyle = {
     ...mapToPadding(theme, type),
@@ -40,8 +42,8 @@ export function useSectionItem({
     backgroundColor: transparent
       ? undefined
       : interactiveColor[active ? 'active' : 'default'].background,
-    borderColor: active ? interactiveColor.outline.background : undefined,
-    borderWidth: active ? theme.border.width.slim : undefined,
+    borderColor: interactiveColor[active ? 'outline' : 'default'].background,
+    borderWidth: theme.border.width.slim,
   };
   const contentContainer: ViewStyle = {
     flex: 1,
@@ -60,13 +62,13 @@ function mapToPadding(theme: Theme, type: ContainerSizingType): Padding {
   switch (type) {
     case 'block':
       return {
-        paddingVertical: theme.spacing.medium,
-        paddingHorizontal: theme.spacing.medium,
+        paddingVertical: theme.spacing.medium - theme.border.width.slim,
+        paddingHorizontal: theme.spacing.medium - theme.border.width.slim,
       };
     case 'spacious':
       return {
-        paddingVertical: theme.spacing.large,
-        paddingHorizontal: theme.spacing.medium,
+        paddingVertical: theme.spacing.large - theme.border.width.slim,
+        paddingHorizontal: theme.spacing.medium - theme.border.width.slim,
       };
   }
 }

--- a/src/components/sections/use-section-item.ts
+++ b/src/components/sections/use-section-item.ts
@@ -1,5 +1,10 @@
 import {ViewStyle} from 'react-native';
-import {Theme, useThemeContext} from '@atb/theme';
+import {
+  ContrastColor,
+  InteractiveColor,
+  Theme,
+  useThemeContext,
+} from '@atb/theme';
 import {ContainerSizingType, RadiusModeType} from './types';
 
 export type BaseSectionItemProps = {
@@ -8,27 +13,35 @@ export type BaseSectionItemProps = {
   radius?: RadiusModeType;
   radiusSize?: keyof Theme['border']['radius'];
   testID?: string;
+  active?: boolean;
 };
 
 export type SectionReturnType = {
   topContainer: ViewStyle;
   contentContainer: ViewStyle;
+  interactiveColor: InteractiveColor<ContrastColor>;
 };
+
+const getInteractiveColor = (theme: Theme) => theme.color.interactive[2];
 
 export function useSectionItem({
   transparent = false,
   type = 'block',
   radius,
   radiusSize,
+  active,
 }: BaseSectionItemProps): SectionReturnType {
   const {theme} = useThemeContext();
+  const interactiveColor = getInteractiveColor(theme);
 
   const topContainer: ViewStyle = {
     ...mapToPadding(theme, type),
     ...mapToBorderRadius(theme, radiusSize, radius),
     backgroundColor: transparent
       ? undefined
-      : theme.color.background.neutral[0].background,
+      : interactiveColor[active ? 'active' : 'default'].background,
+    borderColor: active ? interactiveColor.outline.background : undefined,
+    borderWidth: active ? theme.border.width.slim : undefined,
   };
   const contentContainer: ViewStyle = {
     flex: 1,
@@ -37,6 +50,7 @@ export function useSectionItem({
   return {
     topContainer,
     contentContainer,
+    interactiveColor,
   };
 }
 

--- a/src/components/sections/use-section-item.ts
+++ b/src/components/sections/use-section-item.ts
@@ -42,7 +42,11 @@ export function useSectionItem({
     backgroundColor: transparent
       ? undefined
       : interactiveColor[active ? 'active' : 'default'].background,
-    borderColor: interactiveColor[active ? 'outline' : 'default'].background,
+    borderColor: active
+      ? interactiveColor.outline.background
+      : transparent
+      ? 'transparent'
+      : interactiveColor.default.background,
     borderWidth: theme.border.width.slim,
   };
   const contentContainer: ViewStyle = {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -967,6 +967,11 @@ export const Profile_DesignSystemScreen = ({
           <GenericSectionItem active>
             <ThemeText>Active generic section item</ThemeText>
           </GenericSectionItem>
+          <GenericSectionItem interactiveColor={theme.color.interactive[0]}>
+            <ThemeText color={theme.color.foreground.light.primary}>
+              Generic section item with interactiveColor
+            </ThemeText>
+          </GenericSectionItem>
         </Section>
 
         <Section style={styles.section}>
@@ -1055,6 +1060,11 @@ export const Profile_DesignSystemScreen = ({
           <LinkSectionItem
             text="Link with interactiveColor"
             interactiveColor={theme.color.interactive[0]}
+          />
+          <LinkSectionItem
+            text="Active link with interactveColor"
+            interactiveColor={theme.color.interactive[0]}
+            active
           />
           <LinkSectionItem text="Link with label" label="new" />
           <LinkSectionItem active text="Active link" />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -964,8 +964,14 @@ export const Profile_DesignSystemScreen = ({
           <GenericSectionItem>
             <ThemeText>Generic section item</ThemeText>
           </GenericSectionItem>
+          <GenericSectionItem transparent>
+            <ThemeText>Transparent generic section item</ThemeText>
+          </GenericSectionItem>
           <GenericSectionItem active>
             <ThemeText>Active generic section item</ThemeText>
+          </GenericSectionItem>
+          <GenericSectionItem active transparent>
+            <ThemeText>Active transparent generic section item</ThemeText>
           </GenericSectionItem>
           <GenericSectionItem interactiveColor={theme.color.interactive[0]}>
             <ThemeText color={theme.color.foreground.light.primary}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -961,6 +961,15 @@ export const Profile_DesignSystemScreen = ({
         </Section>
 
         <Section style={styles.section}>
+          <GenericSectionItem>
+            <ThemeText>Generic section item</ThemeText>
+          </GenericSectionItem>
+          <GenericSectionItem active>
+            <ThemeText>Active generic section item</ThemeText>
+          </GenericSectionItem>
+        </Section>
+
+        <Section style={styles.section}>
           <ToggleSectionItem
             text="Some short text"
             leftImage={<ThemeIcon svg={Bus} />}
@@ -977,6 +986,15 @@ export const Profile_DesignSystemScreen = ({
             leftIcon={Bus}
             selected={selected}
             onPress={() => setSelected(!selected)}
+          />
+          <RadioSectionItem
+            text="With right action"
+            selected={selected}
+            onPress={() => setSelected(!selected)}
+            rightAction={{
+              onPress: presser,
+              icon: Delete,
+            }}
           />
           <RadioSectionItem
             text="With right action"
@@ -1011,7 +1029,7 @@ export const Profile_DesignSystemScreen = ({
           />
 
           <LinkSectionItem
-            text="Some longer text"
+            text="Disabled link"
             onPress={() => {}}
             disabled
             icon={<ThemeIcon svg={Edit} />}
@@ -1034,7 +1052,12 @@ export const Profile_DesignSystemScreen = ({
             onPress={() => {}}
             icon={<ThemeIcon svg={Delete} color="error" />}
           />
+          <LinkSectionItem
+            text="Link with interactiveColor"
+            interactiveColor={theme.color.interactive[0]}
+          />
           <LinkSectionItem text="Link with label" label="new" />
+          <LinkSectionItem active text="Active link" />
         </Section>
 
         <Section style={styles.section}>


### PR DESCRIPTION
Adds active and interActiveColor as props for all section items

Uses active for radio button section items instead of separate styling

Part of https://github.com/AtB-AS/kundevendt/issues/19988

<img width=200 src="https://github.com/user-attachments/assets/425f856d-2d3b-43b8-b75e-26b75025d531">
<img width=200 src="https://github.com/user-attachments/assets/ccf2ff4a-11fb-4ac4-862d-56844662e18c">
<img width=200 src="https://github.com/user-attachments/assets/e9c24ef6-9977-47f6-806e-ee7f82f71618">

