### PR TITLE
fix: renew token correctly in v3 mobile token

### DIFF
--- a/src/mobile-token/abtClientLogger.ts
+++ b/src/mobile-token/abtClientLogger.ts
@@ -33,7 +33,7 @@ export const remoteLogger: RemoteLogger = {
     notifyBugsnag(err, {
       errorGroupHash: 'token',
       metadata: {
-        error: 'Mobiletoken sdk remote logger error',
+        error: 'Mobiletoken sdk remote logger caught an error',
         ...errorToMetadata(err),
       },
     });

--- a/src/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/mobile-token/hooks/use-load-native-token-query.tsx
@@ -104,7 +104,6 @@ const loadNativeToken = async (userId: string, traceId: string) => {
             `Token needs renewal ${token.getTokenId()}`,
             errorToMetadata(err),
           );
-          logError(err, traceId);
           // if the token only needs renewal, renew it
           token = await mobileTokenClient.renew(token, traceId);
         } else if (tokenSdkErrorHandling === 'reset') {

--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -212,13 +212,13 @@ export const tokenService: TokenService = {
       includeCertificate: false,
     };
 
-    await abtClient.remoteClientCallHandler(
-      token.getContextId(),
-      tokenEncodingRequest,
-      traceId,
-      async (secureContainerToken, attestation) =>
-        client
-          .get('/tokens/v4/validate', {
+    await abtClient
+      .remoteClientCallHandler(
+        token.getContextId(),
+        tokenEncodingRequest,
+        traceId,
+        async (secureContainerToken, attestation) =>
+          client.get('/tokens/v4/validate', {
             headers: {
               [CorrelationIdHeaderName]: traceId,
               [SignedTokenHeaderName]: secureContainerToken,
@@ -228,8 +228,8 @@ export const tokenService: TokenService = {
             authWithIdToken: true,
             timeout: 15000,
             skipErrorLogging: isRemoteTokenStateError,
-          })
-          .catch(handleError),
-    );
+          }),
+      )
+      .catch(handleError);
   },
 };

--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -11,6 +11,7 @@ import {isDefined} from '@atb/utils/presence';
 import {
   parseRemoteError,
   RemoteTokenStateError,
+  TokenMustBeRenewedRemoteTokenStateError,
 } from '@entur-private/abt-token-server-javascript-interface';
 import Bugsnag from '@bugsnag/react-native';
 import {getAxiosErrorType} from '@atb/api/utils';
@@ -83,6 +84,10 @@ export const getMobileTokenErrorHandlingStrategy = (
     }
     errorResolution = err.resolution;
   } else if (err instanceof RemoteTokenStateError) {
+    if (err instanceof TokenMustBeRenewedRemoteTokenStateError) {
+      // only require renewal, do nothing
+      return 'unspecified';
+    }
     errorResolution = mapTokenErrorResolution(err);
   } else {
     return 'unspecified';


### PR DESCRIPTION
addresses https://github.com/AtB-AS/kundevendt/issues/19973#issuecomment-2671012285

- Moved the error handling to outer function on the `validate` service.
- Removed error logging on token renewal handling, it is not an error.
- Changed `Mobiletoken sdk remote logger error` to `Mobiletoken sdk remote logger caught an error` for clarity, that the error is caught by the remote logger, and **NOT** that the remote logger is error.
- Improved renewal handling by returning `unspecified` handling to prevent a `reset` call derived from the sdk suggestion.

Acceptance Criteria:
Same as https://github.com/AtB-AS/kundevendt/issues/19973