### PR TITLE
fix: handle reattestation error during validate

### DIFF
--- a/src/mobile-token/utils.ts
+++ b/src/mobile-token/utils.ts
@@ -12,6 +12,8 @@ import {
   parseRemoteError,
   RemoteTokenStateError,
   TokenMustBeRenewedRemoteTokenStateError,
+  TokenReattestationRemoteTokenStateError,
+  TokenReattestationRequiredError,
 } from '@entur-private/abt-token-server-javascript-interface';
 import Bugsnag from '@bugsnag/react-native';
 import {getAxiosErrorType} from '@atb/api/utils';
@@ -84,8 +86,12 @@ export const getMobileTokenErrorHandlingStrategy = (
     }
     errorResolution = err.resolution;
   } else if (err instanceof RemoteTokenStateError) {
-    if (err instanceof TokenMustBeRenewedRemoteTokenStateError) {
-      // only require renewal, do nothing
+    if (
+      err instanceof TokenMustBeRenewedRemoteTokenStateError ||
+      err instanceof TokenReattestationRemoteTokenStateError ||
+      err instanceof TokenReattestationRequiredError
+    ) {
+      // only require renewal or reattestation, do nothing
       return 'unspecified';
     }
     errorResolution = mapTokenErrorResolution(err);


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/19973

Currently reattestation of mobile token leads to a `reset` instead, in this PR I added a handling so that reattestation issues are handled appropriately.

The problem is that inside the `validate` call, we have 2 function. The outer part is provided from the SDK to add a reattestation header to wrap the actual validate function, while the inner part is calling the validate endpoint. (see the code)

- If we put `catch(handleError)` on the inner part: Reattestation works, Renewal doesn't work.
- If we put `catch(handleError)` on the outer part: Reattestation doesn't work, Renewal works.

So the solution is to differentiate the error handling for both part. Reattestation is handled on the inner part, while Renewal and others are handled on the outer part.

**Acceptance Criteria:**
- [ ] Reattestation works
- [ ] Renewal from expiration works
- [ ] Upgrading from v2 to v3 works