### PR TITLE
fix: bonus profile screen feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
-    "@atb-as/config-specs": "^5.8.0",
+    "@atb-as/config-specs": "^5.10.1",
     "@atb-as/generate-assets": "^15.1.1",
     "@atb-as/theme": "^13.1.4",
     "@atb-as/utils": "^3.0.0",

--- a/src/bonus/BonusPriceTag.tsx
+++ b/src/bonus/BonusPriceTag.tsx
@@ -24,6 +24,7 @@ export const BonusPriceTag = ({amount, ...props}: Props) => {
     </View>
   );
 };
+
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     backgroundColor: theme.color.background.neutral[0].background,

--- a/src/bonus/BonusPriceTag.tsx
+++ b/src/bonus/BonusPriceTag.tsx
@@ -15,18 +15,23 @@ export const BonusPriceTag = ({price, ...props}: Props) => {
 
   return (
     <View {...props} style={[styles.container, props.style]}>
-      <ThemeText>{price}</ThemeText>
+      <ThemeText
+        accessible={true}
+        accessibilityLabel={t(BonusProgramTexts.costA11yLabel(price))}
+      >
+        {price}
+      </ThemeText>
       <ThemeIcon
         svg={StarFill}
         size="small"
-        accessibilityHint={t(BonusProgramTexts.bonuspoints)}
+        accessibilityLabel={t(BonusProgramTexts.bonuspoints)}
       />
     </View>
   );
 };
-
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
+    backgroundColor: theme.color.background.neutral[0].background,
     borderColor: theme.color.foreground.inverse.secondary,
     borderWidth: theme.border.width.slim,
     borderRadius: theme.border.radius.regular,

--- a/src/configuration/FirestoreConfigurationContext.tsx
+++ b/src/configuration/FirestoreConfigurationContext.tsx
@@ -27,6 +27,7 @@ import {
   FirestoreConfigStatus,
   NotificationConfigType,
   BonusProductType,
+  BonusTextsType,
 } from './types';
 import {
   mapLanguageAndTextType,
@@ -37,6 +38,7 @@ import {
   mapToMobilityOperators,
   mapToScooterFaqs,
   mapToBonusProducts,
+  mapToBonusTexts,
   mapToBenefitIdsRequiringValueCode,
   mapToNotificationConfig,
   mapToTransportModeFilterOptions,
@@ -74,6 +76,7 @@ type ConfigurationContextState = {
   mobilityOperators: MobilityOperatorType[] | undefined;
   scooterFaqs: ScooterFaqType[] | undefined;
   bonusProducts: BonusProductType[] | undefined;
+  bonusTexts: BonusTextsType | undefined;
   benefitIdsRequiringValueCode: OperatorBenefitIdType[] | undefined;
   harborConnectionOverrides: HarborConnectionOverrideType[] | undefined;
   firestoreConfigStatus: FirestoreConfigStatus;
@@ -117,6 +120,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
   >([]);
   const [scooterFaqs, setScooterFaqs] = useState<ScooterFaqType[]>([]);
   const [bonusProducts, setBonusProducts] = useState<BonusProductType[]>([]);
+  const [bonusTexts, setBonusTexts] = useState<BonusTextsType>();
   const [benefitIdsRequiringValueCode, setBenefitIdsRequiringValueCode] =
     useState<OperatorBenefitIdType[]>([]);
   const [harborConnectionOverrides, setHarborConnectionOverrides] = useState<
@@ -219,6 +223,11 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
             setBonusProducts(bonusProducts);
           }
 
+          const bonusTexts = getBonusTextsFromSnapshot(snapshot);
+          if (bonusTexts) {
+            setBonusTexts(bonusTexts);
+          }
+
           const benefitIdsRequiringValueCode =
             getBenefitIdsRequiringValueCodeFromSnapshot(snapshot);
           if (benefitIdsRequiringValueCode) {
@@ -299,6 +308,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
       mobilityOperators,
       scooterFaqs,
       bonusProducts,
+      bonusTexts,
       benefitIdsRequiringValueCode,
       harborConnectionOverrides,
       notificationConfig,
@@ -322,6 +332,7 @@ export const FirestoreConfigurationContextProvider: React.FC = ({children}) => {
     mobilityOperators,
     scooterFaqs,
     bonusProducts,
+    bonusTexts,
     benefitIdsRequiringValueCode,
     harborConnectionOverrides,
     notificationConfig,
@@ -614,6 +625,13 @@ function getBonusProductsFromSnapshot(
 ): BonusProductType[] | undefined {
   const products = snapshot.docs.find((doc) => doc.id == 'mobility');
   return mapToBonusProducts(products?.get('bonusProducts'));
+}
+
+function getBonusTextsFromSnapshot(
+  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
+): BonusTextsType | undefined {
+  const texts = snapshot.docs.find((doc) => doc.id == 'mobility');
+  return mapToBonusTexts(texts?.get('bonusTexts'));
 }
 
 function getBenefitIdsRequiringValueCodeFromSnapshot(

--- a/src/configuration/converters.ts
+++ b/src/configuration/converters.ts
@@ -9,6 +9,7 @@ import {
   OperatorBenefitId,
   ScooterFaq,
   BonusProduct,
+  BonusTexts,
 } from './types';
 import {LanguageAndTextType} from '@atb/translations/types';
 import Bugsnag from '@bugsnag/react-native';
@@ -169,6 +170,15 @@ export function mapToBonusProducts(bonusProducts?: any) {
       return parseResult.data;
     })
     .filter(isDefined);
+}
+
+export function mapToBonusTexts(bonusTexts?: any) {
+  if (!bonusTexts) return;
+  const parseResult = BonusTexts.safeParse(bonusTexts);
+  if (!parseResult.success) {
+    return;
+  }
+  return parseResult.data;
 }
 
 export function mapToBenefitIdsRequiringValueCode(

--- a/src/mobility/__tests__/use-is-eligible-for-benefit.test.ts
+++ b/src/mobility/__tests__/use-is-eligible-for-benefit.test.ts
@@ -40,7 +40,7 @@ const trdBysykkelFreeUnlockOperatorBenefit: OperatorBenefitType = {
     {
       lang: 'en',
       value:
-        'Your periodic ticket includes free use of city bikes from Trondheim Bysykkel.',
+        'Your periodic ticket includes free use of city bikes from Trondheim City Bike.',
     },
     {
       lang: 'nno',
@@ -62,7 +62,7 @@ const trdBysykkelFreeUnlockOperatorBenefit: OperatorBenefitType = {
     {
       lang: 'en',
       value:
-        'Our periodic tickets include free use of city bikes from Trondheim Bysykkel.',
+        'Our periodic tickets include free use of city bikes from Trondheim City Bike.',
     },
     {
       lang: 'nno',
@@ -74,7 +74,7 @@ const trdBysykkelFreeUnlockOperatorBenefit: OperatorBenefitType = {
     url: 'https://app.trondheimbysykkel.no/voucher/{VALUE_CODE}',
     name: [
       {lang: 'nob', value: 'Aktiver hos Trondheim Bysykkel'},
-      {lang: 'en', value: 'Activate at Trondheim Bysykkel'},
+      {lang: 'en', value: 'Activate at Trondheim City Bike'},
       {lang: 'nno', value: 'Aktiver hos Trondheim Bysykkel'},
     ],
   },
@@ -87,7 +87,7 @@ const trdBysykkelFreeUnlockOperatorBenefit: OperatorBenefitType = {
     {
       lang: 'en',
       value:
-        'The ticket includes free use of city bikes from Trondheim Bysykkel.',
+        'The ticket includes free use of city bikes from Trondheim City Bike.',
     },
     {
       lang: 'nno',
@@ -114,7 +114,7 @@ const trdBysykkelFreeUseOperatorBenefit: OperatorBenefitType = {
     {
       lang: 'en',
       value:
-        'Your periodic ticket includes free use of city bikes from Trondheim Bysykkel.',
+        'Your periodic ticket includes free use of city bikes from Trondheim City Bike.',
     },
     {
       lang: 'nno',
@@ -136,7 +136,7 @@ const trdBysykkelFreeUseOperatorBenefit: OperatorBenefitType = {
     {
       lang: 'en',
       value:
-        'Our periodic tickets include free use of city bikes from Trondheim Bysykkel.',
+        'Our periodic tickets include free use of city bikes from Trondheim City Bike.',
     },
     {
       lang: 'nno',
@@ -148,7 +148,7 @@ const trdBysykkelFreeUseOperatorBenefit: OperatorBenefitType = {
     url: 'https://trondheimbysykkel.no/kjop/at-b-gratis',
     name: [
       {lang: 'nob', value: 'Aktiver hos Trondheim Bysykkel'},
-      {lang: 'en', value: 'Activate at Trondheim Bysykkel'},
+      {lang: 'en', value: 'Activate at Trondheim City Bike'},
       {lang: 'nno', value: 'Aktiver hos Trondheim Bysykkel'},
     ],
   },
@@ -161,7 +161,7 @@ const trdBysykkelFreeUseOperatorBenefit: OperatorBenefitType = {
     {
       lang: 'en',
       value:
-        'The ticket includes free use of city bikes from Trondheim Bysykkel.',
+        'The ticket includes free use of city bikes from Trondheim City Bike.',
     },
     {
       lang: 'nno',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -32,11 +32,12 @@ export const Profile_BonusScreen = () => {
   const styles = useStyles();
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
-  const {bonusProducts, mobilityOperators} = useFirestoreConfigurationContext();
+  const {bonusProducts, mobilityOperators, bonusTexts} =
+    useFirestoreConfigurationContext();
   const [currentlyOpenBonusProduct, setCurrentlyOpenBonusProduct] =
     useState<number>();
 
-  const currentPoints = 5; // TODO: get actual value when available
+  const userBonusPoints = 5; // TODO: get actual value when available
   const activeBonusProducts = bonusProducts?.filter(isActive);
 
   return (
@@ -63,11 +64,11 @@ export const Profile_BonusScreen = () => {
                   typography="body__primary--jumbo--bold"
                   accessibilityLabel={t(
                     BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
-                      currentPoints,
+                      userBonusPoints,
                     ),
                   )}
                 >
-                  {currentPoints}
+                  {userBonusPoints}
                 </ThemeText>
                 <ThemeIcon
                   svg={StarFill}
@@ -151,10 +152,16 @@ export const Profile_BonusScreen = () => {
               <ThemedCityBike />
               <View style={styles.bonusProgramDescription}>
                 <ThemeText typography="body__primary--bold">
-                  {t(BonusProgramTexts.bonusProfile.readMore.info.title)}
+                  {getTextForLanguage(
+                    bonusTexts?.howBonusWorks.title,
+                    language,
+                  ) ?? ''}
                 </ThemeText>
                 <ThemeText typography="body__secondary" color="secondary">
-                  {t(BonusProgramTexts.bonusProfile.readMore.info.description)}
+                  {getTextForLanguage(
+                    bonusTexts?.howBonusWorks.description,
+                    language,
+                  ) ?? ''}
                 </ThemeText>
               </View>
             </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -47,6 +47,14 @@ export const Profile_BonusScreen = () => {
       }}
     >
       <View style={styles.container}>
+        {authenticationType !== 'phone' && (
+          <View style={styles.noAccount}>
+            <MessageInfoBox
+              type="warning"
+              message={t(BonusProgramTexts.bonusProfile.noProfile)}
+            />
+          </View>
+        )}
         <Section>
           <GenericSectionItem style={styles.horizontalContainer}>
             <View>
@@ -75,14 +83,6 @@ export const Profile_BonusScreen = () => {
             <ThemedCityBike />
           </GenericSectionItem>
         </Section>
-        {authenticationType !== 'phone' && (
-          <View style={styles.noAccount}>
-            <MessageInfoBox
-              type="warning"
-              message={t(BonusProgramTexts.bonusProfile.noProfile)}
-            />
-          </View>
-        )}
         <ContentHeading
           text={t(BonusProgramTexts.bonusProfile.spendPoints.heading)}
         />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -58,24 +58,19 @@ export const Profile_BonusScreen = () => {
         )}
         <Section>
           <GenericSectionItem style={styles.horizontalContainer}>
-            <View>
+            <View
+              accessible
+              accessibilityLabel={t(
+                BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
+                  userBonusPoints,
+                ),
+              )}
+            >
               <View style={styles.currentPointsDisplay}>
-                <ThemeText
-                  typography="body__primary--jumbo--bold"
-                  accessibilityLabel={t(
-                    BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
-                      userBonusPoints,
-                    ),
-                  )}
-                >
+                <ThemeText typography="body__primary--jumbo--bold">
                   {userBonusPoints}
                 </ThemeText>
-                <ThemeIcon
-                  svg={StarFill}
-                  size="large"
-                  accessible
-                  accessibilityLabel={t(BonusProgramTexts.bonuspoints)}
-                />
+                <ThemeIcon svg={StarFill} size="large" />
               </View>
               <ThemeText typography="body__secondary" color="secondary">
                 {t(BonusProgramTexts.bonusProfile.yourBonusPoints)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -37,11 +37,12 @@ export const Profile_BonusScreen = () => {
     useState<number>();
 
   const currentPoints = 5; // TODO: get actual value when available
+  const activeBonusProducts = bonusProducts?.filter(isActive);
 
   return (
     <FullScreenView
       headerProps={{
-        title: t(BonusProgramTexts.header.title),
+        title: t(BonusProgramTexts.bonusProfile.header.title),
         leftButton: {type: 'back', withIcon: true},
       }}
     >
@@ -50,17 +51,25 @@ export const Profile_BonusScreen = () => {
           <GenericSectionItem style={styles.horizontalContainer}>
             <View>
               <View style={styles.currentPointsDisplay}>
-                <ThemeText typography="body__primary--jumbo--bold">
+                <ThemeText
+                  typography="body__primary--jumbo--bold"
+                  accessibilityLabel={t(
+                    BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
+                      currentPoints,
+                    ),
+                  )}
+                >
                   {currentPoints}
                 </ThemeText>
                 <ThemeIcon
                   svg={StarFill}
                   size="large"
-                  accessibilityHint={t(BonusProgramTexts.bonuspoints)}
+                  accessible
+                  accessibilityLabel={t(BonusProgramTexts.bonuspoints)}
                 />
               </View>
               <ThemeText typography="body__secondary" color="secondary">
-                {t(BonusProgramTexts.yourBonusPoints)}
+                {t(BonusProgramTexts.bonusProfile.yourBonusPoints)}
               </ThemeText>
             </View>
             <ThemedCityBike />
@@ -70,69 +79,82 @@ export const Profile_BonusScreen = () => {
           <View style={styles.noAccount}>
             <MessageInfoBox
               type="warning"
-              message={t(BonusProgramTexts.noProfile)}
+              message={t(BonusProgramTexts.bonusProfile.noProfile)}
             />
           </View>
         )}
-        <ContentHeading text={t(BonusProgramTexts.spendPoints.heading)} />
-        <View style={styles.bonusProductsContainer}>
-          {bonusProducts?.filter(isActive).map((bonusProduct, index) => (
-            <Section>
-              <ExpandableSectionItem
-                expanded={currentlyOpenBonusProduct === index}
-                onPress={() => {
-                  setCurrentlyOpenBonusProduct(index);
-                }}
-                text={
-                  getTextForLanguage(
-                    bonusProduct.productDescription.title,
-                    language,
-                  ) ?? ''
-                }
-                showIconText={false}
-                prefixNode={
-                  <BrandingImage
-                    logoUrl={findOperatorBrandImageUrl(
-                      bonusProduct.operatorId,
-                      mobilityOperators,
-                    )}
-                    logoSize={theme.typography['heading--big'].fontSize}
-                    style={styles.logo}
-                  />
-                }
-                suffixNode={
-                  <BonusPriceTag
-                    price={bonusProduct.price.amount}
-                    style={styles.bonusPriceTag}
-                  />
-                }
-                expandContent={
-                  <ThemeText
-                    isMarkdown={true}
-                    typography="body__secondary"
-                    color="secondary"
-                  >
-                    {getTextForLanguage(
-                      bonusProduct.productDescription.description,
+        <ContentHeading
+          text={t(BonusProgramTexts.bonusProfile.spendPoints.heading)}
+        />
+        {activeBonusProducts?.length === 0 ? (
+          <View style={styles.noAccount}>
+            <MessageInfoBox
+              type="error"
+              message={t(BonusProgramTexts.bonusProfile.noBonusProducts)}
+            />
+          </View>
+        ) : (
+          <View style={styles.bonusProductsContainer}>
+            {activeBonusProducts?.map((bonusProduct, index) => (
+              <Section key={bonusProduct.id}>
+                <ExpandableSectionItem
+                  expanded={currentlyOpenBonusProduct === index}
+                  onPress={() => {
+                    setCurrentlyOpenBonusProduct(index);
+                  }}
+                  text={
+                    getTextForLanguage(
+                      bonusProduct.productDescription.title,
                       language,
-                    ) ?? ''}
-                  </ThemeText>
-                }
-              />
-            </Section>
-          ))}
-        </View>
-        <ContentHeading text={t(BonusProgramTexts.readMore.heading)} />
+                    ) ?? ''
+                  }
+                  showIconText={false}
+                  prefixNode={
+                    <BrandingImage
+                      logoUrl={findOperatorBrandImageUrl(
+                        bonusProduct.operatorId,
+                        mobilityOperators,
+                      )}
+                      logoSize={theme.typography['heading--big'].fontSize}
+                      style={styles.logo}
+                    />
+                  }
+                  suffixNode={
+                    <BonusPriceTag
+                      price={bonusProduct.price.amount}
+                      style={styles.bonusPriceTag}
+                    />
+                  }
+                  expandContent={
+                    <ThemeText
+                      isMarkdown={true}
+                      typography="body__secondary"
+                      color="secondary"
+                    >
+                      {getTextForLanguage(
+                        bonusProduct.productDescription.description,
+                        language,
+                      ) ?? ''}
+                    </ThemeText>
+                  }
+                />
+              </Section>
+            ))}
+          </View>
+        )}
+        <ContentHeading
+          text={t(BonusProgramTexts.bonusProfile.readMore.heading)}
+        />
         <Section>
           <GenericSectionItem>
             <View style={styles.horizontalContainer}>
               <ThemedCityBike />
               <View style={styles.bonusProgramDescription}>
                 <ThemeText typography="body__primary--bold">
-                  {t(BonusProgramTexts.readMore.info.title)}
+                  {t(BonusProgramTexts.bonusProfile.readMore.info.title)}
                 </ThemeText>
                 <ThemeText typography="body__secondary" color="secondary">
-                  {t(BonusProgramTexts.readMore.info.description)}
+                  {t(BonusProgramTexts.bonusProfile.readMore.info.description)}
                 </ThemeText>
               </View>
             </View>

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -41,18 +41,6 @@ const BonusProgramTexts = {
     ),
     readMore: {
       heading: _('Les mer', 'Read more', 'Les meir'),
-      info: {
-        title: _(
-          'Hvordan funker Bonus?',
-          'How does the Bonus work?',
-          'Korleis fungerer bonus?',
-        ),
-        description: _(
-          'Tjen poeng hver gang du kjøper en billett for buss eller trikk i sone A.',
-          'Earn points every time you buy a bus or tram ticket in zone A.',
-          'Ten poeng kvar gong du kjøper ein billett for buss eller trikk i sone A.',
-        ),
-      },
     },
   },
   youHave: _('Du har ', 'You have ', 'Du har '),

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -1,36 +1,68 @@
 import {translation as _} from '../../commons';
 const BonusProgramTexts = {
   bonuspoints: _('Bonuspoeng', 'Bonus points', 'Bonuspoeng'),
-  header: {
-    title: _('Bonus', 'Bonus', 'Bonus'),
-  },
-  yourBonusPoints: _(
-    'Dine bonuspoeng',
-    'Your bonus points',
-    'Bonuspoenga dine',
-  ),
-  spendPoints: {
-    heading: _('Bruk poeng på', 'Spend points on', 'Bruk poeng på'),
-  },
-  noProfile: _(
-    'Du må logge inn for å få tilgang til Bonus.',
-    'You must log in to get access to Bonus.',
-    'Du må logga inn for å få tilgang til Bonus.',
-  ),
-  readMore: {
-    heading: _('Les mer', 'Read more', 'Les meir'),
-    info: {
-      title: _(
-        'Hvordan funker Bonus?',
-        'How does the Bonus work?',
-        'Korleis fungerer bonus?',
-      ),
-      description: _(
-        'Tjen poeng hver gang du kjøper en billett for buss eller trikk i sone A.',
-        'Earn points every time you buy a bus or tram ticket in zone A.',
-        'Ten poeng kvar gong du kjøper ein billett for buss eller trikk i sone A.',
-      ),
+  costA11yLabel: (price: number) =>
+    _(`Koster ${price}`, `Costs ${price}`, `Kostar ${price}`),
+
+  bonusProfile: {
+    header: {
+      title: _('Bonus', 'Bonus', 'Bonus'),
     },
+    yourBonusPoints: _(
+      'Dine bonuspoeng',
+      'Your bonus points',
+      'Bonuspoenga dine',
+    ),
+    yourBonusPointsA11yLabel: (bonuspoints: number) =>
+      _(
+        `Du har ${bonuspoints}`,
+        `You have ${bonuspoints}`,
+        `Du har ${bonuspoints}`,
+      ),
+
+    spendPoints: {
+      heading: _('Våre bonuser', 'Our bonuses', 'Bonusane våre'),
+    },
+    noData: _(
+      'Vi klarer ikke hente informasjon om Bonus. Sjekk om du har internett din og prøv på nytt.',
+      'We are unable to fetch information about Bonus. Check your internet connection and try again.',
+      'Me klarar ikkje hente informasjon om Bonus. Sjekk om du har internett og prøv på nytt.',
+    ),
+
+    noProfile: _(
+      'Logg inn for å tjene og bruke poeng',
+      'Log in to earn and spend points',
+      'Logg inn for å tene og bruke poeng',
+    ),
+    noBonusProducts: _(
+      'Vi klarer ikke hente fordelene akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
+      'We are unable to fetch the benefits right now. You will still earn points as usual.',
+      'Me klarer ikkje hente fordelane akkurat no. Du vil framleis tene poeng som vanleg.',
+    ),
+    readMore: {
+      heading: _('Les mer', 'Read more', 'Les meir'),
+      info: {
+        title: _(
+          'Hvordan funker Bonus?',
+          'How does the Bonus work?',
+          'Korleis fungerer bonus?',
+        ),
+        description: _(
+          'Tjen poeng hver gang du kjøper en billett for buss eller trikk i sone A.',
+          'Earn points every time you buy a bus or tram ticket in zone A.',
+          'Ten poeng kvar gong du kjøper ein billett for buss eller trikk i sone A.',
+        ),
+      },
+    },
+  },
+  youHave: _('Du har ', 'You have ', 'Du har '),
+  checkbox: {
+    a11yLabel: _('Bruk bonuspoeng', 'Use bonus points', 'Bruk bonuspoeng'),
+    a11yHint: _(
+      'Aktiver for å bruke bonuspoeng',
+      'Activate to use bonus points',
+      'Aktiver for å bruke bonuspoeng',
+    ),
   },
 };
 export default BonusProgramTexts;

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -1,12 +1,13 @@
 import {translation as _} from '../../commons';
 const BonusProgramTexts = {
-  bonuspoints: _('Bonuspoeng', 'Bonus points', 'Bonuspoeng'),
   costA11yLabel: (amount: number) =>
     _(
       `Koster ${amount} bonuspoeng`,
       `Costs ${amount} bonus points`,
       `Kostar ${amount} bonuspoeng`,
     ),
+
+  youHave: _('Du har ', 'You have ', 'Du har '),
 
   bonusProfile: {
     header: {
@@ -19,9 +20,9 @@ const BonusProgramTexts = {
     ),
     yourBonusPointsA11yLabel: (bonuspoints: number) =>
       _(
-        `Du har ${bonuspoints}`,
-        `You have ${bonuspoints}`,
-        `Du har ${bonuspoints}`,
+        `Du har ${bonuspoints} bonuspoeng`,
+        `You have ${bonuspoints} bonuspoints`,
+        `Du har ${bonuspoints} bonuspoeng`,
       ),
 
     spendPoints: {
@@ -47,6 +48,5 @@ const BonusProgramTexts = {
       heading: _('Les mer', 'Read more', 'Les meir'),
     },
   },
-  youHave: _('Du har ', 'You have ', 'Du har '),
 };
 export default BonusProgramTexts;

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -21,7 +21,7 @@ const BonusProgramTexts = {
     yourBonusPointsA11yLabel: (bonuspoints: number) =>
       _(
         `Du har ${bonuspoints} bonuspoeng`,
-        `You have ${bonuspoints} bonuspoints`,
+        `You have ${bonuspoints} bonus points`,
         `Du har ${bonuspoints} bonuspoeng`,
       ),
 
@@ -29,7 +29,7 @@ const BonusProgramTexts = {
       heading: _('Våre bonuser', 'Our bonuses', 'Bonusane våre'),
     },
     noData: _(
-      'Vi klarer ikke hente informasjon om Bonus. Sjekk om du har internett din og prøv på nytt.',
+      'Vi klarer ikke hente informasjon om Bonus. Sjekk om du har internett og prøv på nytt.',
       'We are unable to fetch information about Bonus. Check your internet connection and try again.',
       'Me klarar ikkje hente informasjon om Bonus. Sjekk om du har internett og prøv på nytt.',
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atb-as/config-specs@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-5.8.0.tgz#b4cddbaf11139f07b31d6eedc9b903d5fb92a3cc"
-  integrity sha512-uDYLOI8108xN7TdRgo4gNS5TZSCw/mXe6oi7D5JVFPTDPVMQbU7wM4Qs9KDizC5km/4WfuKnzMJGvP3B3jyJ6w==
+"@atb-as/config-specs@^5.10.1":
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-5.10.1.tgz#ce69a80a6c41c36e9a4bdc44dc69d5ae4c2073c7"
+  integrity sha512-UEiPuGJB+YCNZyAnfkkU5R4D1/Rw80XspUfOubCJ2Cq5IR1Jb750fJWMNeKDAYY3es9PkQyuWejZH9n/bqjkIg==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
Resolves feedback from testing and design on:
- https://github.com/AtB-AS/kundevendt/issues/19827

Specifically:
- accessibility improvements
- configurable text from firestore
- improved error messages
- Trondheim Bysykkel -> Trondheim City Bike for english


<img width=200 src="https://github.com/user-attachments/assets/a1b173b0-a278-4bb2-8ca2-fa232a28ed32">
<img width=200 src="https://github.com/user-attachments/assets/02ea4b0e-9fde-45e1-81f5-fd0e13e5518d">
