### PR TITLE
feat: add debug menu to specify endpoint for mobile token server

### DIFF
--- a/src/mobile-token/DebugTokenServerAddress.tsx
+++ b/src/mobile-token/DebugTokenServerAddress.tsx
@@ -10,8 +10,7 @@ export const DebugTokenServerAddress = () => {
 
   const saveDebugIpAddress = async (ipAddress: string) => {
     if (ipAddress.length > 0) {
-      const fullAddress = `http://${ipAddress}:8080`;
-      await storage.set('@ATB_debug_token_server_ip_address', fullAddress);
+      await storage.set('@ATB_debug_token_server_ip_address', ipAddress);
     } else {
       await storage.remove('@ATB_debug_token_server_ip_address');
     }
@@ -34,8 +33,8 @@ export const DebugTokenServerAddress = () => {
       <TextInput
         onChangeText={(text) => setIpAddress(text)}
         value={ipAddress}
-        inputMode="numeric"
-        placeholder="e.g. 10.100.1.89 (Leave blank to use default)"
+        inputMode="text"
+        placeholder="e.g. http://10.100.1.89:8080 (Leave blank to use default)"
         clearButtonMode="always"
       />
       <Button

--- a/src/mobile-token/DebugTokenServerAddress.tsx
+++ b/src/mobile-token/DebugTokenServerAddress.tsx
@@ -1,0 +1,58 @@
+import {Button} from '@atb/components/button';
+import {ThemeText} from '@atb/components/text';
+import {storage} from '@atb/storage';
+import {StyleSheet} from '@atb/theme';
+import {useEffect, useState} from 'react';
+import {TextInput, View} from 'react-native';
+
+export const DebugTokenServerAddress = () => {
+  const [ipAddress, setIpAddress] = useState<string>('');
+
+  const saveDebugIpAddress = async (ipAddress: string) => {
+    if (ipAddress.length > 0) {
+      const fullAddress = `http://${ipAddress}:8080`;
+      await storage.set('@ATB_debug_token_server_ip_address', fullAddress);
+    } else {
+      await storage.remove('@ATB_debug_token_server_ip_address');
+    }
+  };
+
+  useEffect(() => {
+    const getStoredIpAddress = async () => {
+      const storedAddress = await storage.get(
+        '@ATB_debug_token_server_ip_address',
+      );
+      setIpAddress(storedAddress ?? '');
+    };
+    getStoredIpAddress();
+  }, []);
+
+  return (
+    <View>
+      <ThemeText>Server IP Address</ThemeText>
+
+      <TextInput
+        onChangeText={(text) => setIpAddress(text)}
+        value={ipAddress}
+        inputMode="numeric"
+        placeholder="e.g. 10.100.1.89 (Leave blank to use default)"
+        clearButtonMode="always"
+      />
+      <Button
+        onPress={async () => await saveDebugIpAddress(ipAddress)}
+        text="Use IP Address"
+        style={styles.button}
+        expanded={true}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    marginVertical: 8,
+  },
+  container: {
+    marginVertical: 8,
+  },
+});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -39,6 +39,7 @@ import {useOnboardingContext} from '@atb/onboarding';
 import Bugsnag from '@bugsnag/react-native';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {DebugSabotage} from '@atb/mobile-token/DebugSabotage';
+import {DebugTokenServerAddress} from '@atb/mobile-token/DebugTokenServerAddress';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -505,6 +506,15 @@ export const Profile_DebugInfoScreen = () => {
                         sabotage={sabotage}
                         setSabotage={setSabotage}
                       />
+                    </View>
+                  }
+                />
+                <ExpandableSectionItem
+                  text="Modify Server Endpoint"
+                  showIconText={true}
+                  expandContent={
+                    <View>
+                      <DebugTokenServerAddress />
                     </View>
                   }
                 />

--- a/src/storage/StorageModel.tsx
+++ b/src/storage/StorageModel.tsx
@@ -11,6 +11,7 @@ type StorageModelKeysTypes = keyof typeof StorageModelKeysEnum;
 export type StorageModel = {
   stored_user_locations: string;
   install_id: string;
+  '@ATB_debug_token_server_ip_address': string;
   '@ATB_feedback_display_stats': string;
   '@ATB_journey_search-history': string;
   '@ATB_last_mobile_token_user': string;


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20084

Pretty much self-explanatory, adds debug menu for specifying the mobile token server endpoint.
If there's a better alternative than using the `storage` function I would love to know more about it 😄 

[mobile token debug menu](https://github.com/user-attachments/assets/7388199e-0781-4877-9f66-8d5e9a62ff08)
