### PR TITLE
refactor: Use state for purchase selection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -33,10 +33,7 @@ import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from './utils';
 import {useAuthContext} from '@atb/auth';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import {
-  type PurchaseSelectionType,
-  useSelectableUserProfiles,
-} from '@atb/modules/purchase-selection';
+import {useSelectableUserProfiles} from '@atb/modules/purchase-selection';
 import {useProductAlternatives} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-product-alternatives';
 import {useOtherDeviceIsInspectableWarning} from '@atb/modules/fare-contracts';
 
@@ -50,7 +47,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const {t, language} = useTranslation();
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
-  const selection = params.selection;
+
+  const [selection, setSelection] = useState(params.selection);
+  useEffect(() => setSelection(params.selection), [params.selection]);
 
   const isFree = params.selection.stopPlaces?.to?.isFree || false;
 
@@ -59,9 +58,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     selection.preassignedFareProduct,
   );
   const inspectableTokenWarningText = useOtherDeviceIsInspectableWarning();
-
-  const setSelection = (s: PurchaseSelectionType) =>
-    navigation.setParams({selection: s});
 
   const [isOnBehalfOfToggle, setIsOnBehalfOfToggle] = useState<boolean>(false);
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -36,6 +36,7 @@ import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {useSelectableUserProfiles} from '@atb/modules/purchase-selection';
 import {useProductAlternatives} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-product-alternatives';
 import {useOtherDeviceIsInspectableWarning} from '@atb/modules/fare-contracts';
+import {useParamAsState} from '@atb/utils/use-param-as-state';
 
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
 
@@ -48,8 +49,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
 
-  const [selection, setSelection] = useState(params.selection);
-  useEffect(() => setSelection(params.selection), [params.selection]);
+  const [selection, setSelection] = useParamAsState(params.selection);
 
   const isFree = params.selection.stopPlaces?.to?.isFree || false;
 

--- a/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseTariffZonesSearchByMapScreen.tsx
@@ -8,14 +8,16 @@ import {
   TariffZonesSelectorButtons,
   TariffZonesSelectorMap,
 } from '@atb/tariff-zones-selector';
+import {useParamAsState} from '@atb/utils/use-param-as-state';
 
 type Props = RootStackScreenProps<'Root_PurchaseTariffZonesSearchByMapScreen'>;
 
 export const Root_PurchaseTariffZonesSearchByMapScreen = ({
   navigation,
-  route,
+  route: {params},
 }: Props) => {
-  const {selection} = route.params;
+  const [selection, setSelection] = useParamAsState(params.selection);
+
   const selectionMode =
     selection.fareProductTypeConfig.configuration.zoneSelectionMode;
   const isApplicableOnSingleZoneOnly =
@@ -68,7 +70,7 @@ export const Root_PurchaseTariffZonesSearchByMapScreen = ({
         selectNext={selectNext}
         isApplicableOnSingleZoneOnly={isApplicableOnSingleZoneOnly}
         onSelect={(selection) => {
-          navigation.setParams({selection});
+          setSelection(selection);
           setSelectNext((prev) =>
             isApplicableOnSingleZoneOnly
               ? 'from'

--- a/src/utils/__tests__/use-param-as-state.test.ts
+++ b/src/utils/__tests__/use-param-as-state.test.ts
@@ -1,0 +1,85 @@
+import {renderHook, act} from '@testing-library/react-hooks';
+import {useParamAsState} from '../use-param-as-state';
+
+const TEST_OBJECT = {val: 5};
+
+describe('useParamAsState', () => {
+  it('should initialize state with the provided param', () => {
+    const {result} = renderHook(() => useParamAsState(5));
+    expect(result.current[0]).toBe(5);
+  });
+
+  it('should work when param changes', () => {
+    const {result, rerender} = renderHook(({param}) => useParamAsState(param), {
+      initialProps: {param: 5 as number | undefined},
+    });
+    expect(result.current[0]).toBe(5);
+
+    rerender({param: 10});
+    expect(result.current[0]).toBe(10);
+
+    rerender({param: 10});
+    expect(result.current[0]).toBe(10);
+
+    rerender({param: undefined});
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('should work with setState', () => {
+    const {result} = renderHook(() => useParamAsState<number | undefined>(5));
+    expect(result.current[0]).toBe(5);
+    const setState = result.current[1];
+
+    act(() => setState(10));
+    expect(result.current[0]).toBe(10);
+
+    act(() => setState(undefined));
+    expect(result.current[0]).toBeUndefined();
+
+    act(() => setState(8));
+    expect(result.current[0]).toBe(8);
+  });
+
+  it('should work with both param change and setState', () => {
+    const {result, rerender} = renderHook(({param}) => useParamAsState(param), {
+      initialProps: {param: 5 as number | undefined},
+    });
+    expect(result.current[0]).toBe(5);
+    const setState = result.current[1];
+
+    rerender({param: 10});
+    expect(result.current[0]).toBe(10);
+
+    act(() => setState(undefined));
+    expect(result.current[0]).toBeUndefined();
+
+    rerender({param: 8});
+    expect(result.current[0]).toBe(8);
+
+    act(() => setState(3));
+    expect(result.current[0]).toBe(3);
+  });
+
+  it('should by default update state if non-stable-reference even if equal', () => {
+    const {result, rerender} = renderHook((param) => useParamAsState(param), {
+      initialProps: TEST_OBJECT,
+    });
+
+    expect(result.current[0]).toBe(TEST_OBJECT);
+    rerender({...TEST_OBJECT});
+    expect(result.current[0]).not.toBe(TEST_OBJECT);
+    expect(result.current[0]).toStrictEqual(TEST_OBJECT);
+  });
+
+  it('should not update state if equal non-stable-reference if checkEquality is true', () => {
+    const {result, rerender} = renderHook(
+      (param) => useParamAsState(param, true),
+      {initialProps: TEST_OBJECT},
+    );
+
+    expect(result.current[0]).toBe(TEST_OBJECT);
+    rerender({...TEST_OBJECT});
+    expect(result.current[0]).toBe(TEST_OBJECT);
+    expect(result.current[0]).toStrictEqual(TEST_OBJECT);
+  });
+});

--- a/src/utils/use-param-as-state.ts
+++ b/src/utils/use-param-as-state.ts
@@ -2,8 +2,8 @@ import {type Dispatch, type SetStateAction, useEffect, useState} from 'react';
 import isEqual from 'lodash.isequal';
 
 /**
- * Utility hook to sync a React state with a parameter. If the parameter changes
- * it will update the React state.
+ * Utility hook to sync a parameter to React state. If the parameter changes it
+ * will update the React state.
  *
  * @param param the param which will cause state change when updated
  * @param checkEquality set to true if the state should remain unchanged if the

--- a/src/utils/use-param-as-state.ts
+++ b/src/utils/use-param-as-state.ts
@@ -1,0 +1,26 @@
+import {type Dispatch, type SetStateAction, useEffect, useState} from 'react';
+import isEqual from 'lodash.isequal';
+
+/**
+ * Utility hook to sync a React state with a parameter. If the parameter changes
+ * it will update the React state.
+ *
+ * @param param the param which will cause state change when updated
+ * @param checkEquality set to true if the state should remain unchanged if the
+ * updated param deep equals the existing state
+ *
+ */
+export function useParamAsState<T>(
+  param: T,
+  checkEquality?: boolean,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState(param);
+  useEffect(
+    () =>
+      setValue((prev) =>
+        checkEquality && isEqual(prev, param) ? prev : param,
+      ),
+    [param, checkEquality],
+  );
+  return [value, setValue];
+}


### PR DESCRIPTION
Use state for the purchase selection object instead of relying on `setParams`. This is to reduce PostHog screen events, which are created when using `setParams`.