### PR TITLE
refactor: remove use of useThemeColorForTransportMode

### DIFF
--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {StyleProp, View, ViewStyle} from 'react-native';
 
-import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
+import {StyleSheet, Theme} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
-import {useThemeColorForTransportMode} from '@atb/utils/use-transport-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemeText} from '@atb/components/text';
 import {getTransportModeSvg} from './utils';
@@ -34,9 +34,8 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
   testID,
 }) => {
   const {t} = useTranslation();
-  const {theme} = useThemeContext();
-  const themeColor = useThemeColorForTransportMode(mode, subMode, isFlexible);
-  const transportationColor = theme.color.transport[themeColor].primary;
+  const transportColor = useTransportColor(mode, subMode, isFlexible);
+  const transportationColor = transportColor.primary;
   const backgroundColor = disabled
     ? transportationColor.foreground.disabled
     : transportationColor.background;

--- a/src/modules/fare-contracts/components/InspectionSymbol.tsx
+++ b/src/modules/fare-contracts/components/InspectionSymbol.tsx
@@ -11,7 +11,7 @@ import {
   useFirestoreConfigurationContext,
 } from '@atb/configuration';
 import {Moon, Youth} from '@atb/assets/svg/mono-icons/ticketing';
-import {useThemeColorForTransportMode} from '@atb/utils/use-transport-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {ContrastColor} from '@atb/theme/colors';
 import {useMobileTokenContext} from '@atb/mobile-token';
 import {getTransportModeSvg} from '@atb/components/icon-box';
@@ -34,7 +34,7 @@ export const InspectionSymbol = ({
     (c) => c.type === preassignedFareProduct?.type,
   );
 
-  const transportColor = useThemeColorForTransportMode(
+  const transportColor = useTransportColor(
     fareProductTypeConfig?.transportModes[0].mode,
     fareProductTypeConfig?.transportModes[0].subMode,
   );
@@ -42,7 +42,7 @@ export const InspectionSymbol = ({
   const {isInspectable, mobileTokenStatus} = useMobileTokenContext();
 
   const themeColor = isInspectable
-    ? theme.color.transport[transportColor].primary
+    ? transportColor.primary
     : theme.color.status['warning'].primary;
 
   if (mobileTokenStatus === 'loading') {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProductTile.tsx
@@ -5,10 +5,8 @@ import {
   ProductTypeTransportModes,
 } from '@atb/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
-
-import {useThemeColorForTransportMode} from '@atb/utils/use-transport-color';
+import {useTransportColor} from '@atb/utils/use-transport-color';
 import {TicketingTile} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile';
-import {useThemeContext} from '@atb/theme';
 
 export const FareProductTile = ({
   accented = false,
@@ -23,12 +21,10 @@ export const FareProductTile = ({
   config: FareProductTypeConfig;
   productGroupTransportModes: ProductTypeTransportModes[];
 }) => {
-  const transportName = useThemeColorForTransportMode(
+  const transportColor = useTransportColor(
     productGroupTransportModes[0]?.mode,
     productGroupTransportModes[0]?.subMode,
   );
-  const {theme} = useThemeContext();
-  const transportColor = theme.color.transport[transportName];
   const title = useTextForLanguage(config.name);
   const description = useTextForLanguage(config.description);
   const accessibilityLabel = [title, description].join('. ');

--- a/src/utils/use-transport-color.ts
+++ b/src/utils/use-transport-color.ts
@@ -11,12 +11,12 @@ export function useTransportColor(
   subMode?: AnySubMode,
   isFlexible?: boolean,
 ): TransportColor<ContrastColor> {
-  const themeColor = useThemeColorForTransportMode(mode, subMode, isFlexible);
+  const themeColor = getTransportColorKey(mode, subMode, isFlexible);
   const {theme} = useThemeContext();
   return theme.color.transport[themeColor];
 }
 
-export const useThemeColorForTransportMode = (
+const getTransportColorKey = (
   mode?: AnyMode,
   subMode?: AnySubMode,
   isFlexible?: boolean,


### PR DESCRIPTION
The `useThemeColorForTransportMode` util wasn't really serving a purpose that the `useTransportColor` doesn't cover, so removing it as an export from `use-transport-color.ts`. 

### Acceptance criteria

No functional changes, but should make sure that

- [ ] Transport icons in ticket purchase have the correct color
- [ ] Fare product tiles still have the correct color
- [ ] Fare contract inspection symbols have the correct color
