### PR TITLE
fix: Only query phone number for sent fcs

### DIFF
--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}


### PR DESCRIPTION
The main change of this PR to resolve the bug was changing from this
```ts
useGetPhoneByAccountIdQuery(fc.customerAccountId)
```

to this:
```ts
useGetPhoneByAccountIdQuery(isSent ? fc.customerAccountId : undefined)
```

The rest is just a refactor to encapsulate the logic regarding showing the sent to phone number.