### PR TITLE
ci: use `actions/cache@v3`

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -55,7 +55,7 @@ jobs:
           node-version: 18
       - name: Get potential cached node_modules
         if: env.ENV_FORCE_BUILD != 'true'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: modules-cache
         with:
           path: '**/node_modules'
@@ -76,7 +76,7 @@ jobs:
       - name: Override native config files
         run: bash ./scripts/android/override-config-files.sh
       - name: Get potential cached APK
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: apk-cache
         with:
           path: app-staging.apk

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
           ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/patches/**.patch') }}


### PR DESCRIPTION
Looks like v2 of the cache action has been deprecated, so migrating to v3. There is a v4 as well, but since we still use node 18 some places, it might make sense to stay at v3 for now.

Failing build: https://github.com/AtB-AS/mittatb-app/actions/runs/13628983280/job/38092354264?pr=5051