### PR TITLE
fix: accessibility pay with bonus points checkbox

### DIFF
--- a/src/mobility/components/BikeStationBottomSheet.tsx
+++ b/src/mobility/components/BikeStationBottomSheet.tsx
@@ -67,7 +67,7 @@ export const BikeStationBottomSheet = ({
     FormFactor.Bicycle,
   );
 
-  const [useBonusPoints, setUseBonusPoints] = useState(false);
+  const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
   useDoOnceOnItemReceived(onStationReceived, station);
 
   return (
@@ -145,9 +145,9 @@ export const BikeStationBottomSheet = ({
               {isBonusProgramEnabled && bonusProduct && (
                 <PayWithBonusPointsCheckbox
                   bonusProduct={bonusProduct}
-                  isChecked={useBonusPoints}
+                  isChecked={payWithBonusPoints}
                   onPress={() =>
-                    setUseBonusPoints((useBonusPoints) => !useBonusPoints)
+                    setPayWithBonusPoints((useBonusPoints) => !useBonusPoints)
                   }
                   style={styles.useBonusPointsSection}
                 />

--- a/src/mobility/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/mobility/components/PayWithBonusPointsCheckbox.tsx
@@ -6,7 +6,7 @@ import {
   Section,
   SectionProps,
 } from '@atb/components/sections';
-import {ThemeText} from '@atb/components/text';
+import {ThemeText, screenReaderPause} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {BonusProductType} from '@atb/configuration/types';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -37,12 +37,25 @@ export const PayWithBonusPointsCheckbox = ({
   const userBonusPoints = 4; // TODO: get actual value using hook when available
   const disabled = userBonusPoints < bonusProduct.price.amount;
 
+  const a11yLabel =
+    (getTextForLanguage(bonusProduct.paymentDescription, language) ?? '') +
+    screenReaderPause +
+    t(BonusProgramTexts.costA11yLabel(bonusProduct.price.amount)) +
+    screenReaderPause +
+    t(BonusProgramTexts.youHave) +
+    userBonusPoints +
+    t(BonusProgramTexts.bonusPoints);
+
   return (
     <Section {...props}>
       <GenericClickableSectionItem
         active={isChecked}
         onPress={onPress}
+        onAccessibilityTap={onPress}
         disabled={disabled}
+        accessibilityRole="checkbox"
+        accessibilityState={{checked: isChecked}}
+        accessibilityLabel={a11yLabel}
       >
         <View style={styles.container}>
           <Checkbox checked={isChecked} />

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -1,5 +1,6 @@
 import {translation as _} from '../../commons';
 const BonusProgramTexts = {
+  bonusPoints: _('bonuspoeng', 'bonus points', 'bonuspoeng'),
   costA11yLabel: (amount: number) =>
     _(
       `Koster ${amount} bonuspoeng`,


### PR DESCRIPTION
Fixes accessibility role + state + label on PayWithBonusPointsCheckbox

Also fixes the name of a useState variable to not start with 'use'.

<img width=200 src="https://github.com/user-attachments/assets/cf706756-b250-491e-9cc9-82369fb4608a">
