### PR TITLE
feat: Message if no departures (no quays) for a stop place

### DIFF
--- a/src/place-screen/PlaceScreenComponent.tsx
+++ b/src/place-screen/PlaceScreenComponent.tsx
@@ -70,7 +70,7 @@ export const PlaceScreenComponent = ({
   let missingStopData = false;
 
   if (stopsDetailsData && place.quays === undefined) {
-    if (stopsDetailsData.stopPlaces[0]) {
+    if (stopsDetailsData.stopPlaces[0].quays?.length) {
       place = stopsDetailsData.stopPlaces[0];
     } else {
       missingStopData = true;


### PR DESCRIPTION
There was already an error message in the departures view, but it didn't show if no quays. Changed the logic so the error is shown also if no quays.

Before/After:
<div>
<img width=350 src="https://github.com/user-attachments/assets/0ced2956-691d-4330-9d06-057301228843" />
<img width=350 src="https://github.com/user-attachments/assets/1a64c64d-01ce-4577-8db8-23aa3b2dc06b" />
</div>
