### PR TITLE
fix: Missing requires booking text on trip result

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -506,9 +506,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacing.medium,
     paddingVertical: theme.spacing.small,
   },
-  footerNotice: {
-    flexDirection: 'row',
-  },
+  footerNotice: {flex: 1},
   fromPlaceText: {
     flex: 3,
   },


### PR DESCRIPTION
### Background
https://mittatb.slack.com/archives/C0116FMPX4Y/p1740747250532429

### Solution
<div>
<img width=350 src="https://github.com/user-attachments/assets/fa0e711b-c9b9-45d0-b4c2-fc3379c65568" />
<img width=350 src="https://github.com/user-attachments/assets/7e39c8c9-6e56-41e6-9c97-732bfc10e865" />
</div>

### Acceptance criteria
- [ ] The requires booking text is shown in both light and dark mode