### PR TITLE
feat: new style for payment option in app/webshop

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {AccessibilityProps, StyleProp, View, ViewStyle} from 'react-native';
-import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 import {StyleSheet} from '@atb/theme';
 import {Theme} from '@atb/theme/colors';
+import SvgCheckboxChecked from '@atb/assets/svg/color/icons/input/CheckboxChecked';
 
 type CheckedProps = {
   checked: boolean;
@@ -12,7 +12,8 @@ type CheckedProps = {
 };
 
 const getDefaultColor = (theme: Theme) => theme.color.background.neutral[0];
-const getCheckedColor = (theme: Theme) => theme.color.background.accent[3];
+const getCheckedColor = (theme: Theme) =>
+  theme.color.interactive[2].outline.background;
 
 export const Checkbox: React.FC<CheckedProps> = ({
   checked,
@@ -26,30 +27,23 @@ export const Checkbox: React.FC<CheckedProps> = ({
       accessibilityRole="checkbox"
       accessibilityState={{selected: checked}}
       {...accessibility}
-      style={[
-        style,
-        styles.saveCheckbox,
-        checked ? styles.saveCheckboxChecked : styles.saveCheckboxDefault,
-      ]}
+      style={[style, styles.saveCheckbox, styles.saveCheckboxDefault]}
       testID={testID ? `${testID}Checkbox` : 'checkbox'}
     >
-      {checked ? <Confirm fill="white" /> : null}
+      {checked ? <SvgCheckboxChecked width={20} /> : null}
     </View>
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   saveCheckbox: {
-    height: theme.icon.size.normal,
-    width: theme.icon.size.normal,
+    height: theme.spacing.large,
+    width: theme.spacing.large,
     borderRadius: theme.border.radius.small,
     borderWidth: theme.border.width.medium,
-    borderColor: getCheckedColor(theme).background,
+    borderColor: getCheckedColor(theme),
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  saveCheckboxChecked: {
-    backgroundColor: getCheckedColor(theme).background,
   },
   saveCheckboxDefault: {
     backgroundColor: getDefaultColor(theme).background,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PaymentBrand.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PaymentBrand.tsx
@@ -8,13 +8,14 @@ import {
   Visa,
 } from '@atb/assets/svg/color/icons/ticketing';
 import {useFontScale} from '@atb/utils/use-font-scale';
+import {Card} from '@atb/assets/svg/mono-icons/ticketing';
 
 export type Brand = {
-  paymentType: PaymentType;
+  paymentType: PaymentType | undefined;
   size?: number;
 };
 
-export const PaymentBrand: React.FC<Brand> = ({paymentType, size = 40}) => {
+export const PaymentBrand: React.FC<Brand> = ({paymentType, size = 20}) => {
   const fontScale = useFontScale();
   return (
     <View style={{aspectRatio: 1, height: size * fontScale}}>
@@ -26,7 +27,7 @@ export const PaymentBrand: React.FC<Brand> = ({paymentType, size = 40}) => {
 const Logo = ({
   paymentType,
 }: {
-  paymentType: PaymentType;
+  paymentType: PaymentType | undefined;
 }): JSX.Element | null => {
   switch (paymentType) {
     case PaymentType.Visa:
@@ -38,6 +39,6 @@ const Logo = ({
     case PaymentType.Amex:
       return <Amex height="100%" width="100%" />;
     default:
-      return null;
+      return <Card height="100%" width="100%" />;
   }
 };

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PaymentSelectionCard.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PaymentSelectionCard.tsx
@@ -1,0 +1,138 @@
+import {PressableOpacity} from '@atb/components/pressable-opacity';
+import {ThemeText} from '@atb/components/text';
+
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import {humanizePaymentType, PaymentType} from '@atb/ticketing';
+import {useTranslation} from '@atb/translations';
+import React from 'react';
+
+import {useFontScale} from '@atb/utils/use-font-scale';
+import {PaymentBrand} from './PaymentBrand';
+import PaymentMethodsTexts from '@atb/translations/screens/subscreens/PaymentMethods';
+import {MessageInfoText} from '@atb/components/message-info-text';
+import SelectPaymentMethodTexts from '@atb/translations/screens/subscreens/SelectPaymentMethodTexts';
+import SvgEdit from '@atb/assets/svg/mono-icons/actions/Edit';
+import {View} from 'react-native';
+import {PaymentMethod} from '@atb/stacks-hierarchy/types';
+
+export type Brand = {
+  paymentType: PaymentType | undefined;
+  size?: number;
+};
+
+export const PaymentSelectionCard = (props: {
+  card: PaymentMethod;
+  startAction: Function;
+}) => {
+  const {card, startAction} = props;
+  const paymentName = humanizePaymentType(card.paymentType);
+  const style = useStyles();
+  const {theme} = useThemeContext();
+  const {t} = useTranslation();
+  const fontScale = useFontScale();
+  const multiplePaymentMethods = !(
+    card.recurringCard || card.paymentType === PaymentType.Vipps
+  );
+
+  return (
+    <View style={style.card}>
+      <View style={style.cardTop}>
+        <PaymentBrand
+          paymentType={multiplePaymentMethods ? undefined : card.paymentType}
+        />
+        <View style={style.paymentMethod}>
+          <ThemeText>
+            {multiplePaymentMethods
+              ? t(SelectPaymentMethodTexts.multiple_payment.title)
+              : paymentName}
+          </ThemeText>
+          {!multiplePaymentMethods &&
+            card.paymentType !== PaymentType.Vipps && (
+              <ThemeText
+                style={style.maskedPan}
+                accessibilityLabel={t(
+                  PaymentMethodsTexts.a11y.cardInfo(
+                    paymentName,
+                    card.recurringCard?.masked_pan ?? '',
+                  ),
+                )}
+              >
+                **** {card.recurringCard?.masked_pan}
+              </ThemeText>
+            )}
+        </View>
+
+        <View style={style.cardIcons}>
+          <PressableOpacity
+            accessibilityLabel={t(
+              PaymentMethodsTexts.a11y.deleteCardIcon(
+                paymentName,
+                card.recurringCard?.masked_pan ?? '',
+              ),
+            )}
+            style={style.actionButton}
+            onPress={() => {
+              startAction();
+            }}
+          >
+            <ThemeText>{t(PaymentMethodsTexts.editPaymentMethod)}</ThemeText>
+            <SvgEdit
+              height={21 * fontScale}
+              width={21 * fontScale}
+              fill={theme.color.foreground.dynamic.primary}
+            />
+          </PressableOpacity>
+        </View>
+      </View>
+      {false && (
+        <>
+          {/* this is just a template for the future message implementation */}
+          <MessageInfoText
+            style={style.warningMessage}
+            message="Expiration messsage"
+            type="warning"
+          />
+        </>
+      )}
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  warningMessage: {
+    marginBottom: theme.spacing.medium,
+  },
+
+  card: {flex: 1, paddingVertical: theme.spacing.small},
+  cardTop: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  cardIcons: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexGrow: 1,
+    justifyContent: 'flex-end',
+  },
+  paymentMethod: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: theme.spacing.xSmall,
+    paddingLeft: theme.spacing.medium,
+    marginRight: 'auto',
+  },
+  maskedPan: {
+    color: theme.color.foreground.dynamic.secondary,
+  },
+
+  actionButton: {
+    marginLeft: theme.spacing.medium,
+    display: 'flex',
+    flexDirection: 'row',
+    columnGap: theme.spacing.small,
+    paddingHorizontal: theme.spacing.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -10,7 +10,6 @@ import {
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {PaymentBrand} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PaymentBrand';
-import {getExpireDate} from '@atb/stacks-hierarchy/utils';
 import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {
   addPaymentMethod,
@@ -179,18 +178,20 @@ const Card = (props: {
   return (
     <View style={style.card}>
       <View style={style.cardTop}>
-        <View>
+        <PaymentBrand paymentType={card.payment_type} />
+        <View style={style.paymentMethod}>
+          <ThemeText>{paymentName}</ThemeText>
           <ThemeText
+            style={style.maskedPan}
             accessibilityLabel={t(
               PaymentMethodsTexts.a11y.cardInfo(paymentName, card.masked_pan),
             )}
           >
-            {paymentName} **** {card.masked_pan}
+            **** {card.masked_pan}
           </ThemeText>
         </View>
 
         <View style={style.cardIcons}>
-          <PaymentBrand paymentType={card.payment_type} />
           <PressableOpacity
             accessibilityLabel={t(
               PaymentMethodsTexts.a11y.deleteCardIcon(
@@ -198,7 +199,7 @@ const Card = (props: {
                 card.masked_pan,
               ),
             )}
-            style={{marginLeft: theme.spacing.medium}}
+            style={style.actionButton}
             onPress={() => {
               destructiveAlert({
                 alertTitleString: t(PaymentMethodsTexts.deleteModal.title),
@@ -213,18 +214,25 @@ const Card = (props: {
               });
             }}
           >
+            <ThemeText>
+              {t(PaymentMethodsTexts.deleteModal.confirmButton)}
+            </ThemeText>
             <SvgDelete
               height={21 * fontScale}
               width={21 * fontScale}
-              fill={theme.color.interactive.destructive.default.background}
+              fill={theme.color.foreground.dynamic.primary}
             />
           </PressableOpacity>
         </View>
       </View>
-
-      <ThemeText color="secondary" typography="body__secondary">
-        {getExpireDate(card.expires_at)}
-      </ThemeText>
+      {/* this is just a template for the future message implementation
+          {paymentMethod.recurringCard && (
+            <MessageInfoText
+              style={styles.warningMessage}
+              message="Expiration messsage"
+              type="warning"
+            />
+          )} */}
     </View>
   );
 };
@@ -317,5 +325,25 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     alignItems: 'center',
     flexGrow: 1,
     justifyContent: 'flex-end',
+  },
+  paymentMethod: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: theme.spacing.xSmall,
+    paddingLeft: theme.spacing.medium,
+    marginRight: 'auto',
+  },
+  maskedPan: {
+    color: theme.color.foreground.dynamic.secondary,
+  },
+
+  actionButton: {
+    marginLeft: theme.spacing.medium,
+    display: 'flex',
+    flexDirection: 'row',
+    columnGap: theme.spacing.xSmall,
+  },
+  warningMessage: {
+    paddingTop: theme.spacing.medium,
   },
 }));

--- a/src/stacks-hierarchy/utils.ts
+++ b/src/stacks-hierarchy/utils.ts
@@ -15,7 +15,7 @@ export function getExpireDate(iso: string): string {
   // and the date that shows on the card is the month before the card expires
   // Example: The card expires the moment the date is 02.2021, but the date on the card is 01.2021
   date.setDate(date.getDate() - 1);
-  return format(date, 'MM/yy');
+  return format(date, 'dd.MM.yy');
 }
 
 export function translateErrorType(

--- a/src/translations/screens/subscreens/AnonymousPurchases.ts
+++ b/src/translations/screens/subscreens/AnonymousPurchases.ts
@@ -89,6 +89,11 @@ const AnonymousPurchases = {
         ),
       },
     },
+    select_payment_method: _(
+      'Logg inn for å lagre kort for fremtidige kjøp',
+      'Log in to save cards for future purchases',
+      'Logg inn for å lagra kort for framtidige kjøp',
+    ),
   },
   unknown_error: _(
     'Oops - noe gikk galt. Supert om du prøver på nytt 🤞',

--- a/src/translations/screens/subscreens/PaymentMethods.ts
+++ b/src/translations/screens/subscreens/PaymentMethods.ts
@@ -25,7 +25,7 @@ const PaymentMethodsTexts = {
       'Are you sure you want to remove this payment card?',
       'Er du sikker på at du vil fjerne dette betalingskortet?',
     ),
-    confirmButton: _('Fjern', 'Remove', 'Fjern'),
+    confirmButton: _('Fjern kort', 'Remove card', 'Fjern kort'),
     cancelButton: _('Avbryt', 'Cancel', 'Avbryt'),
   },
   a11y: {
@@ -52,6 +52,7 @@ const PaymentMethodsTexts = {
     'Payment with Vipps is available when purchasing a ticket',
     'Betaling med Vipps er tilgjengeleg ved kjøp av billett',
   ),
+  editPaymentMethod: _('Endre', 'Edit', 'Endre'),
 };
 
 export default PaymentMethodsTexts;

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -131,6 +131,17 @@ const PurchaseConfirmationTexts = {
       'Aktivér for å velje dette kortet',
     ),
   },
+
+  paymentWithMultiplePaymentMethods: {
+    a11yLabel: (brands: string) =>
+      _(`Betal med ${brands}`, `Pay with ${brands}`, `Betal med $${brands}`),
+    a11Hint: _(
+      'Aktivér for velge disse betalingsmåtene',
+      'Activate to select these payment methods',
+      'Aktivér for å velje desse betalingsmåtane',
+    ),
+  },
+
   choosePaymentMethod: {
     text: _('Velg betalingsmåte', 'Choose payment option', 'Vel betalingsmåte'),
     a11yHint: _(
@@ -151,26 +162,12 @@ const PurchaseConfirmationTexts = {
       'Aktiver for å endre betalingsmåte',
     ),
   },
-  payWithVipps: {
-    text: _('Betal med Vipps', 'Pay with Vipps', 'Betale med Vipps'),
+
+  payTotal: {
+    text: (total: string) =>
+      _(`Betal ${total} kr`, `Pay ${total} kr`, `Betal ${total} kr`),
   },
-  payWithVisa: {
-    text: _('Betal med Visa', 'Pay with Visa', 'Betale med Visa'),
-  },
-  payWithMasterCard: {
-    text: _(
-      'Betal med MasterCard',
-      'Pay with MasterCard',
-      'Betal med MasterCard',
-    ),
-  },
-  payWithAmex: {
-    text: _(
-      'Betal med American Express',
-      'Pay with American Express',
-      'Betal med American Express',
-    ),
-  },
+
   ordinaryPricePrefix: _(`Ord. pris`, `Ord. price`, `Ord. pris`),
   ordinaryPricePrefixA11yLabel: _(
     `Ordinær pris`,

--- a/src/translations/screens/subscreens/SelectPaymentMethodTexts.ts
+++ b/src/translations/screens/subscreens/SelectPaymentMethodTexts.ts
@@ -16,14 +16,21 @@ const SelectPaymentMethodTexts = {
       'Aktiver for å bekrefte val av betalingsmåte',
     ),
   },
-  save_payment_method_description: {
+  multiple_payment: {
+    title: _('Nytt kort', 'New card', 'Nytt kort'),
     text: _(
-      'Lagre bankkortet for fremtidige betalinger',
-      'Save the payment card for future usage',
-      'Lagre betalingskortet for framtidige betalingar',
+      'Vil du lagre bankkortet for fremtidige betalinger?',
+      'Would you like to save your bank card for future payments?',
+      'Vil du lagre bankkortet for framtidige betalingar?',
+    ),
+    information: _(
+      'Vi lagrer kortinformasjonen i opptil 3 år.',
+      'We store the card information for up to 3 years.',
+      'Vi lagrar kortinformasjonen i opptil 3 år.',
     ),
   },
-  save_card: _('Lagre kort', 'Save card', 'Lagre kort'),
+  save_card: _('Lagre bankkort', 'Save bank card', 'Lagre bankkort'),
+
   a11yHint: {
     notSave: _(
       'Aktiver for ikke å lagre kort',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18186

### If user is **logged in**:


Profile saved cards           |  Preselected last saved payment option
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-05 at 14 08 15](https://github.com/user-attachments/assets/b0d25d6c-25be-4590-8846-c21ab1c4465a)|  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-05 at 14 08 55](https://github.com/user-attachments/assets/7d471255-ac63-4ea9-9ebd-6d97360ca1d5)

User clicks on `Edit`         |  If selects `New Card`
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-05 at 14 09 05](https://github.com/user-attachments/assets/10530df1-94be-4067-9546-9682e9d5c9fb)| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-05 at 14 09 21](https://github.com/user-attachments/assets/6e5682c3-c7f0-40e2-9b93-22ff5a9c1354)


### If user **is anonymous**:

Two options to select    |  If selects `New Card`
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-05 at 14 10 14](https://github.com/user-attachments/assets/7ef864dd-0f42-4a36-9cc2-8081d2896a5e) |  ![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-05 at 14 10 19](https://github.com/user-attachments/assets/70fb2b07-36a3-43f4-88d1-74a160a31af1)


I have tried to create a `PaymentSelectionCard` component for both **delete** and **edit**  card functionalities, but I have encountered some issues with types. For **delete**, we should use `RecurringPayment`, but for **edit**, we should use `PaymentMethod`.

The main goal was to split one payment selection component into three: `SinglePaymentMethod` for 'Vipps', `MultiplePaymentMethodsRadioSection` for the group of payment methods, and `PaymentSelectionCard` for actions such as delete and edit.















