### PR TITLE
fix: add an object check on errorToMetadata function

### DIFF
--- a/src/utils/bugsnag-utils.ts
+++ b/src/utils/bugsnag-utils.ts
@@ -37,8 +37,12 @@ export const logToBugsnag = (message: string, metadata?: MetaData) =>
   Bugsnag.leaveBreadcrumb(message, metadata);
 
 export const errorToMetadata = (error: any) => {
-  const name = 'name' in error ? {errorName: error.name} : undefined;
-  const message =
-    'message' in error ? {errorMessage: error.message} : undefined;
-  return name || message ? {...name, ...message} : undefined;
+  if (typeof error === 'object') {
+    const name = 'name' in error ? {errorName: error.name} : undefined;
+    const message =
+      'message' in error ? {errorMessage: error.message} : undefined;
+    return name || message ? {...name, ...message} : undefined;
+  } else {
+    return undefined;
+  }
 };


### PR DESCRIPTION
In response to https://mittatb.slack.com/archives/C0116FMPX4Y/p1741270241971609