### PR TITLE
fix: move on-behalf of

### DIFF
--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/TitleAndDescription.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/TitleAndDescription.tsx
@@ -1,9 +1,14 @@
-import {OnBehalfOfTexts, useTranslation} from '@atb/translations';
+import {
+  OnBehalfOfTexts,
+  PurchaseOverviewTexts,
+  useTranslation,
+} from '@atb/translations';
 import {View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import {ContrastColor} from '@atb/theme/colors';
 import {StyleSheet} from '@atb/theme';
 import {forwardRef} from 'react';
+import React from 'react';
 
 export const TitleAndDescription = forwardRef<any, {themeColor: ContrastColor}>(
   ({themeColor}, focusRef) => {
@@ -26,7 +31,7 @@ export const TitleAndDescription = forwardRef<any, {themeColor: ContrastColor}>(
             color={themeColor}
             style={styles.description}
           >
-            {t(OnBehalfOfTexts.chooseReceiver.description)}
+            {t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
           </ThemeText>
         </View>
       </>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -31,14 +31,12 @@ import {
 
 type TravellerSelectionProps = {
   selection: PurchaseSelectionType;
-  isOnBehalfOfToggle: boolean;
-  onSave: (selection: PurchaseSelectionType, onBehalfOfToggle: boolean) => void;
+  onSave: (selection: PurchaseSelectionType) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function TravellerSelection({
   selection,
-  isOnBehalfOfToggle,
   onSave,
   style,
 }: TravellerSelectionProps) {
@@ -100,10 +98,6 @@ export function TravellerSelection({
           .map((u) => `${u.count} ${getReferenceDataName(u, language)}`)
           .join(', ');
 
-  const sendingToOthersAccessibility = isOnBehalfOfToggle
-    ? screenReaderPause + t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)
-    : '';
-
   const travellerInfo = !canSelectUserProfile
     ? getTextForLanguage(
         selection.userProfilesWithCount[0].alternativeDescriptions,
@@ -127,7 +121,6 @@ export function TravellerSelection({
           )) +
       ' ' +
       travellersDetailsText +
-      sendingToOthersAccessibility +
       travellerInfo +
       screenReaderPause,
     accessibilityHint: canSelectUserProfile
@@ -140,9 +133,8 @@ export function TravellerSelection({
       () => (
         <TravellerSelectionSheet
           selection={selection}
-          isOnBehalfOfToggle={isOnBehalfOfToggle}
-          onSave={(selection, onBehalfOfToggle) => {
-            onSave(selection, onBehalfOfToggle);
+          onSave={(selection) => {
+            onSave(selection);
             closeBottomSheet();
           }}
         />
@@ -166,11 +158,6 @@ export function TravellerSelection({
         {!canSelectUserProfile && (
           <ThemeText typography="body__secondary" color="secondary">
             {travellerInfo}
-          </ThemeText>
-        )}
-        {isOnBehalfOfToggle && canSelectUserProfile && (
-          <ThemeText typography="body__secondary" color="secondary">
-            {t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
           </ThemeText>
         )}
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -1,7 +1,7 @@
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {ScrollView} from 'react-native';
-import React, {useState} from 'react';
+import React from 'react';
 import {StyleSheet} from '@atb/theme';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {Button} from '@atb/components/button';
@@ -13,19 +13,13 @@ import {
   type PurchaseSelectionType,
   usePurchaseSelectionBuilder,
 } from '@atb/modules/purchase-selection';
-import {Section, ToggleSectionItem} from '@atb/components/sections';
-import {HoldingHands} from '@atb/assets/svg/color/images';
-import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import {useAuthContext} from '@atb/auth';
 
 type TravellerSelectionSheetProps = {
   selection: PurchaseSelectionType;
-  isOnBehalfOfToggle: boolean;
-  onSave: (selection: PurchaseSelectionType, onBehalfOfToggle: boolean) => void;
+  onSave: (selection: PurchaseSelectionType) => void;
 };
 export const TravellerSelectionSheet = ({
   selection,
-  isOnBehalfOfToggle,
   onSave,
 }: TravellerSelectionSheetProps) => {
   const {t} = useTranslation();
@@ -36,14 +30,10 @@ export const TravellerSelectionSheet = ({
     selection.fareProductTypeConfig.configuration.travellerSelectionMode;
 
   const userCountState = useUserCountState(selection);
-  const [isTravelerOnBehalfOfToggle, setIsTravelerOnBehalfOfToggle] =
-    useState<boolean>(isOnBehalfOfToggle);
 
   const noProfilesSelected = userCountState.userProfilesWithCount.every(
     (u) => !u.count,
   );
-
-  const shouldShowOnBehalfOf = useShouldShowOnBehalfOf(selection);
 
   return (
     <BottomSheetContainer
@@ -56,19 +46,6 @@ export const TravellerSelectionSheet = ({
         ) : (
           <SingleTravellerSelection {...userCountState} />
         )}
-        {shouldShowOnBehalfOf && (
-          <Section style={styles.onBehalfOfContainer}>
-            <ToggleSectionItem
-              leftImage={<HoldingHands />}
-              text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
-              subtext={t(PurchaseOverviewTexts.onBehalfOf.sectionSubText)}
-              value={isTravelerOnBehalfOfToggle}
-              textType="body__primary--bold"
-              onValueChange={setIsTravelerOnBehalfOfToggle}
-              testID="onBehalfOfToggle"
-            />
-          </Section>
-        )}
       </ScrollView>
       <FullScreenFooter>
         <Button
@@ -80,7 +57,7 @@ export const TravellerSelectionSheet = ({
               .fromSelection(selection)
               .userProfiles(userCountState.userProfilesWithCount)
               .build();
-            onSave(newSelection, isTravelerOnBehalfOfToggle);
+            onSave(newSelection);
           }}
           rightIcon={{svg: Confirm}}
           testID="confirmButton"
@@ -88,14 +65,6 @@ export const TravellerSelectionSheet = ({
       </FullScreenFooter>
     </BottomSheetContainer>
   );
-};
-
-const useShouldShowOnBehalfOf = (selection: PurchaseSelectionType) => {
-  const isOnBehalfOfEnabled =
-    useFeatureTogglesContext().isOnBehalfOfEnabled &&
-    selection.fareProductTypeConfig.configuration.onBehalfOfEnabled;
-  const isLoggedIn = useAuthContext().authenticationType === 'phone';
-  return isOnBehalfOfEnabled && isLoggedIn;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -210,7 +210,7 @@ const PurchaseOverviewTexts = {
     ),
     button: {
       payment: _('Til betaling', 'To payment', 'Til betaling'),
-      sendToOthers: _('Gå videre', 'Continue', 'Gå vidare'),
+      sendToOthers: _('Select recipient', 'Select recipient', 'Vel mottakar'),
     },
     ordinaryPriceA11yLabel: (priceString: string) =>
       _(
@@ -247,16 +247,16 @@ const PurchaseOverviewTexts = {
     ),
   },
   onBehalfOf: {
-    sectionTitle: _('Kjøp til andre', 'Buy for others', 'Kjøp til andre'),
     sectionSubText: _(
       'Den du kjøper billett til, må være innlogget i AtB-appen for å få billetten.',
-      'The person you buy a ticket for, must be logged in to the AtB app to get the ticket.',
+      'The person you buy a ticket for, must be logged in to the AtB to recieve the ticket.',
       'Den du kjøper billett til, må vere logga inn i AtB-appen for å få billetten.',
     ),
+
     sendToOthersText: _(
-      'Sendes til noen andre',
-      'Sending to someone else',
-      'Sendast til nokon andre',
+      'Send billetten til noen andre',
+      'Send the ticket to someone else',
+      'Send biletten til nokon andre',
     ),
   },
   ticketInformation: {


### PR DESCRIPTION
### Closes https://github.com/AtB-AS/kundevendt/issues/18202

**On-behalf-of** element is modified and moved to another place - right to the **`Purchase Overview Screen`**. 

| First Header  | Second Header |
| ------------- | ------------- |
| ![simulator_screenshot_A7913BEA-8E2D-4808-8941-20DCA45D0759](https://github.com/user-attachments/assets/a17b4cce-5a44-42d6-9d1e-4862a5a5abf8) | ![simulator_screenshot_9FF01ABD-1B3A-4C56-9605-3A5D93ED05A5](https://github.com/user-attachments/assets/cd8b8c5d-cc98-45ed-80bf-7d8f6ba5b2af)|
| ![simulator_screenshot_33B97A1D-2F22-4EC5-887C-0AB24DF23E55](https://github.com/user-attachments/assets/a6e9136d-6acd-46d4-83e5-a79f57119222)  | ![simulator_screenshot_173C60D1-E413-4480-A829-E34FFF490B0C](https://github.com/user-attachments/assets/f6c0ccf1-b00d-42b8-a7d1-a127fa2f64ee) |
| ![simulator_screenshot_0BA662FC-D9ED-44C1-992C-6E5BAB179288](https://github.com/user-attachments/assets/2532d644-2a06-4af6-87ee-95331c476d11) | ![simulator_screenshot_80989E7C-37DC-4382-B5AA-4698FB8B43D7](https://github.com/user-attachments/assets/af7d73f0-30e4-40f2-8a39-eb0583675107)|













