### PR TITLE
feat: enable mobile token on iOS simulator

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -24,8 +24,6 @@ import {
 } from '@entur-private/abt-mobile-client-sdk';
 import {isInspectable, MOBILE_TOKEN_QUERY_KEY, wipeToken} from './utils';
 
-import DeviceInfo from 'react-native-device-info';
-import {Platform} from 'react-native';
 import {tokenService} from './tokenService';
 import {QueryStatus, useQueryClient} from '@tanstack/react-query';
 import {useInterval} from '@atb/utils/use-interval';
@@ -90,7 +88,6 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
   const {updateMetadata} = useIntercomMetadata();
 
   const {token_timeout_in_seconds} = useRemoteConfigContext();
-  const mobileTokenEnabled = hasEnabledMobileToken();
 
   const [isTimeout, setIsTimeout] = useState(false);
 
@@ -100,11 +97,7 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
 
   useEffect(() => setIsLoggingOut(false), [userId]);
 
-  const enabled =
-    mobileTokenEnabled &&
-    !!userId &&
-    authStatus === 'authenticated' &&
-    !isLoggingOut;
+  const enabled = !!userId && authStatus === 'authenticated' && !isLoggingOut;
 
   const {
     data: nativeToken,
@@ -263,10 +256,6 @@ export const MobileTokenContextProvider: React.FC = ({children}) => {
   );
 };
 
-/** Not enabled on mobile token simulator */
-const hasEnabledMobileToken = () =>
-  Platform.OS === 'android' || !DeviceInfo.isEmulatorSync();
-
 export function useMobileTokenContext() {
   const context = useContext(MobileTokenContext);
   if (context === undefined) {
@@ -312,10 +301,6 @@ const useMobileTokenStatus = (
   } = useRemoteConfigContext();
 
   const fallbackStatus = use_trygg_overgang_qr_code ? 'staticQr' : 'fallback';
-  // Treat iOS emulator as fallback
-  if (Platform.OS === 'ios' && DeviceInfo.isEmulatorSync()) {
-    return fallbackStatus;
-  }
 
   if (isTimeout)
     return enable_token_fallback_on_timeout ? fallbackStatus : 'loading';


### PR DESCRIPTION
With the introduction of non-attested tokens in SDK v3.x.x, we can now use mobile token on iOS Simulators.

This PR will enable that functionality. 🎉  