### PR TITLE
fix: improve mobile token error logging

### DIFF
--- a/src/mobile-token/abtClientLogger.ts
+++ b/src/mobile-token/abtClientLogger.ts
@@ -14,12 +14,19 @@ export const localLogger: ClientLogger = {
     logToBugsnag('Mobiletoken sdk info message: ' + msg, {metadata: metadata});
   },
   warn: (msg, err, metadata?) => {
-    logToBugsnag('Mobiletoken sdk info message: ' + msg, metadata);
-    const onError = toOnErrorCallback('warning', msg, metadata);
+    logToBugsnag(`Mobiletoken sdk warn message: ${msg} ${err}`, {
+      'name': metadata?.name,
+      'message' : metadata?.message,
+      'stack' : metadata?.stack
+    });    const onError = toOnErrorCallback('warning', msg, metadata);
     if (err) notifyBugsnag(err, {errorGroupHash: 'token', metadata: onError});
   },
   error: (msg, err, metadata?) => {
-    logToBugsnag('Mobiletoken sdk info message: ' + msg, metadata);
+    logToBugsnag(`Mobiletoken sdk error message: ${msg} ${err}`, {
+      'name': metadata?.name,
+      'message' : metadata?.message,
+      'stack' : metadata?.stack
+    });
     const onError = toOnErrorCallback('error', msg, metadata);
     if (err) notifyBugsnag(err, {errorGroupHash: 'token', metadata: onError});
   },

--- a/src/mobile-token/abtClientLogger.ts
+++ b/src/mobile-token/abtClientLogger.ts
@@ -15,17 +15,18 @@ export const localLogger: ClientLogger = {
   },
   warn: (msg, err, metadata?) => {
     logToBugsnag(`Mobiletoken sdk warn message: ${msg} ${err}`, {
-      'name': metadata?.name,
-      'message' : metadata?.message,
-      'stack' : metadata?.stack
-    });    const onError = toOnErrorCallback('warning', msg, metadata);
+      name: metadata?.name,
+      message: metadata?.message,
+      stack: metadata?.stack,
+    });
+    const onError = toOnErrorCallback('warning', msg, metadata);
     if (err) notifyBugsnag(err, {errorGroupHash: 'token', metadata: onError});
   },
   error: (msg, err, metadata?) => {
     logToBugsnag(`Mobiletoken sdk error message: ${msg} ${err}`, {
-      'name': metadata?.name,
-      'message' : metadata?.message,
-      'stack' : metadata?.stack
+      name: metadata?.name,
+      message: metadata?.message,
+      stack: metadata?.stack,
     });
     const onError = toOnErrorCallback('error', msg, metadata);
     if (err) notifyBugsnag(err, {errorGroupHash: 'token', metadata: onError});


### PR DESCRIPTION
Ref: [Slack thread](https://mittatb.slack.com/archives/C03DTC05VRQ/p1741605296772459?thread_ts=1741602504.740099&cid=C03DTC05VRQ)

Also maybe part of https://github.com/AtB-AS/kundevendt/issues/20215

Thomas from Entur notified us that our logging leaves many details out, so he asked if there are possibilities to improve it.

This PR will update the breadcrumb logging as shown below, hopefully will expose the `metadata` part more, and shows the `stack` if any.

from
```
  error: (msg, err, metadata?) => {
    logToBugsnag('Mobiletoken sdk info message: ' + msg, metadata);
    const onError = toOnErrorCallback('warning', msg, metadata);
    if (err) notifyBugsnag(err, {errorGroupHash: 'token', metadata: onError});
  }
```

to
```
  error: (msg, err, metadata?) => {
    logToBugsnag(`Mobiletoken sdk error message: ${msg} ${err}`, {
      'name': metadata?.name,
      'message' : metadata?.message,
      'stack' : metadata?.stack
    });
    const onError = toOnErrorCallback('error', msg, metadata);
    if (err) notifyBugsnag(err, {errorGroupHash: 'token', metadata: onError});
  }
```


#### Acceptance criteria

- [ ] Error message on Bugsnag now shows the metadata properly (may need to be tested in prod?)