### PR TITLE
ci: upgrade github actions to ruby 3.1.0

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: "18"
     required: false
   ruby-version:
-    default: "2.7.6"
+    default: "3.1.0"
     required: false
   xcode-version:
     default: "latest-stable"

--- a/.github/actions/setup-certs/action.yml
+++ b/.github/actions/setup-certs/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
   ruby-version:
     description: "The ruby version to use"
-    default: "2.7.6"
+    default: "3.1.0"
     required: false
   keychain-name:
     description: "The keychain name where the keys are going to be stored"

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
   ruby-version:
     description: "The ruby version to use"
-    default: "2.7.6"
+    default: "3.1.0"
     required: false
   keychain-name:
     description: "The keychain name where the keys are going to be stored"

--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.6
+          ruby-version: 3.1.0
           cache-version: 1
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Set environment

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup ruby and bundle install
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.6
+          ruby-version: 3.1.0
           cache-version: 1
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Get Github-release data


### PR DESCRIPTION
Builds are failing after https://github.com/AtB-AS/mittatb-app/pull/5041: https://github.com/AtB-AS/mittatb-app/actions/runs/13833005678/job/38701432685