### PR TITLE
Separate explore location map

### DIFF
--- a/src/components/map/ExploreLocationMap.tsx
+++ b/src/components/map/ExploreLocationMap.tsx
@@ -1,0 +1,133 @@
+import {
+  getCurrentCoordinatesGlobal,
+  useGeolocationContext,
+} from '@atb/GeolocationContext';
+import {FOCUS_ORIGIN} from '@atb/api/geocoder';
+import {StyleSheet} from '@atb/theme';
+import MapboxGL, {LocationPuck} from '@rnmapbox/maps';
+import {Feature} from 'geojson';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
+import {View} from 'react-native';
+import {MapCameraConfig, MapViewConfig} from './MapConfig';
+import {SelectionPin} from './components/SelectionPin';
+import {LocationBar} from './components/LocationBar';
+import {PositionArrow} from './components/PositionArrow';
+import {useControlPositionsStyle} from './hooks/use-control-styles';
+import {SelectionLocationCallback} from './types';
+
+import {isFeaturePoint} from './utils';
+import {Location} from '@atb/favorites';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {useMapboxJsonStyle} from './hooks/use-mapbox-json-style';
+import {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
+
+type ExploreLocationMapProps = {
+  initialLocation?: Location;
+  onLocationSelect: SelectionLocationCallback;
+};
+
+export const ExploreLocationMap = ({
+  initialLocation,
+  onLocationSelect,
+}: ExploreLocationMapProps) => {
+  const {isMapV2Enabled} = useFeatureTogglesContext();
+  const {getCurrentCoordinates} = useGeolocationContext();
+  const mapCameraRef = useRef<MapboxGL.Camera>(null);
+  const styles = useMapStyles();
+  const controlStyles = useControlPositionsStyle(true);
+
+  const startingCoordinates = useMemo(
+    () =>
+      initialLocation && initialLocation?.resultType !== 'geolocation'
+        ? initialLocation.coordinates
+        : getCurrentCoordinatesGlobal() || FOCUS_ORIGIN,
+    [initialLocation],
+  );
+
+  const [selectedCoordinates, setSelectedCoordinates] =
+    useState(startingCoordinates);
+
+  const onFeatureClick = useCallback(async (feature: Feature) => {
+    if (!isFeaturePoint(feature)) return;
+
+    const {coordinates: positionClicked} = feature.geometry;
+    setSelectedCoordinates({
+      longitude: positionClicked[0],
+      latitude: positionClicked[1],
+    });
+  }, []);
+
+  const onPositionArrowClick = async () => {
+    const coordinates = await getCurrentCoordinates(true);
+    if (coordinates) {
+      mapCameraRef.current?.flyTo(
+        [coordinates.longitude, coordinates.latitude],
+        200,
+      );
+    }
+  };
+
+  const mapboxJsonStyle = useMapboxJsonStyle(false);
+
+  const customMapViewConfigProps = isMapV2Enabled
+    ? {styleURL: undefined, styleJSON: mapboxJsonStyle}
+    : {};
+
+  return (
+    <View style={styles.container}>
+      <LocationBar
+        coordinates={selectedCoordinates || startingCoordinates}
+        onSelect={onLocationSelect}
+      />
+      <View style={{flex: 1}}>
+        <MapboxGL.MapView
+          style={{
+            flex: 1,
+          }}
+          pitchEnabled={false}
+          onPress={onFeatureClick}
+          testID="exploreLocationMapView"
+          {...{
+            ...MapViewConfig,
+            // only updating Map.tsx for now.
+            ...customMapViewConfigProps,
+          }}
+        >
+          <MapboxGL.Camera
+            ref={mapCameraRef}
+            zoomLevel={15}
+            centerCoordinate={[
+              startingCoordinates.longitude,
+              startingCoordinates.latitude,
+            ]}
+            {...MapCameraConfig}
+          />
+
+          {isMapV2Enabled && (
+            <NationalStopRegistryFeatures
+              selectedFeaturePropertyId={undefined}
+              onMapItemClick={undefined}
+            />
+          )}
+
+          <LocationPuck puckBearing="heading" puckBearingEnabled={true} />
+          {selectedCoordinates && (
+            <SelectionPin coordinates={selectedCoordinates} id="selectionPin" />
+          )}
+        </MapboxGL.MapView>
+        <View
+          style={[
+            controlStyles.mapButtonsContainer,
+            controlStyles.mapButtonsContainerRight,
+          ]}
+        >
+          <PositionArrow onPress={onPositionArrowClick} />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const useMapStyles = StyleSheet.createThemeHook(() => ({
+  container: {flex: 1},
+}));

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -11,8 +11,6 @@ import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import {MapCameraConfig, MapViewConfig} from './MapConfig';
-import {SelectionPin} from './components/SelectionPin';
-import {LocationBar} from './components/LocationBar';
 import {PositionArrow} from './components/PositionArrow';
 import {Stations, Vehicles} from './components/mobility';
 import {useControlPositionsStyle} from './hooks/use-control-styles';
@@ -53,9 +51,7 @@ export const Map = (props: MapProps) => {
   const mapCameraRef = useRef<MapboxGL.Camera>(null);
   const mapViewRef = useRef<MapboxGL.MapView>(null);
   const styles = useMapStyles();
-  const controlStyles = useControlPositionsStyle(
-    props.selectionMode === 'ExploreLocation',
-  );
+  const controlStyles = useControlPositionsStyle(false);
 
   const startingCoordinates = useMemo(
     () =>
@@ -65,18 +61,13 @@ export const Map = (props: MapProps) => {
     [initialLocation],
   );
 
-  const {
-    mapLines,
-    selectedCoordinates,
-    onMapClick,
-    selectedFeature,
-    onReportParkingViolation,
-  } = useMapSelectionChangeEffect(
-    props,
-    mapViewRef,
-    mapCameraRef,
-    startingCoordinates,
-  );
+  const {mapLines, onMapClick, selectedFeature, onReportParkingViolation} =
+    useMapSelectionChangeEffect(
+      props,
+      mapViewRef,
+      mapCameraRef,
+      startingCoordinates,
+    );
 
   const {bottomSheetCurrentlyAutoSelected} = useMapContext();
 
@@ -104,7 +95,6 @@ export const Map = (props: MapProps) => {
 
   const showScanButton =
     isShmoDeepIntegrationEnabled &&
-    props.selectionMode === 'ExploreEntities' &&
     !activeShmoBooking &&
     !activeShmoBookingIsLoading &&
     (!selectedFeature || selectedFeatureIsAVehicle || aVehicleIsAutoSelected);
@@ -233,12 +223,6 @@ export const Map = (props: MapProps) => {
 
   return (
     <View style={styles.container}>
-      {props.selectionMode === 'ExploreLocation' && (
-        <LocationBar
-          coordinates={selectedCoordinates || startingCoordinates}
-          onSelect={props.onLocationSelect}
-        />
-      )}
       <View style={{flex: 1}}>
         <MapboxGL.MapView
           ref={mapViewRef}
@@ -274,9 +258,6 @@ export const Map = (props: MapProps) => {
 
           {mapLines && <MapRoute lines={mapLines} />}
           <LocationPuck puckBearing="heading" puckBearingEnabled={true} />
-          {props.selectionMode === 'ExploreLocation' && selectedCoordinates && (
-            <SelectionPin coordinates={selectedCoordinates} id="selectionPin" />
-          )}
           {props.vehicles && (
             <Vehicles
               vehicles={props.vehicles.vehicles}
@@ -332,14 +313,13 @@ export const Map = (props: MapProps) => {
             }}
           />
         </View>
-        {isShmoDeepIntegrationEnabled &&
-          props.selectionMode === 'ExploreEntities' && (
-            <ShmoTesting
-              selectedVehicleId={selectedFeature?.properties?.id}
-              showSelectedFeature={showSelectedFeature}
-              setShowSelectedFeature={setShowSelectedFeature}
-            />
-          )}
+        {isShmoDeepIntegrationEnabled && (
+          <ShmoTesting
+            selectedVehicleId={selectedFeature?.properties?.id}
+            showSelectedFeature={showSelectedFeature}
+            setShowSelectedFeature={setShowSelectedFeature}
+          />
+        )}
         {showScanButton && <ScanButton />}
         {includeSnackbar && <Snackbar {...snackbarProps} />}
       </View>

--- a/src/components/map/hooks/use-decide-camera-focus-mode.tsx
+++ b/src/components/map/hooks/use-decide-camera-focus-mode.tsx
@@ -1,9 +1,4 @@
-import {
-  CameraFocusModeType,
-  MapLeg,
-  MapSelectionActionType,
-  MapSelectionMode,
-} from '../types';
+import {CameraFocusModeType, MapLeg, MapSelectionActionType} from '../types';
 import {Coordinates} from '@atb/utils/coordinates';
 import {RefObject, useEffect, useState} from 'react';
 import {Feature, Point} from 'geojson';
@@ -31,7 +26,6 @@ const MAX_LIMIT_TO_SHOW_WALKING_TRIP = 5000;
  * the map lines back from the hook so the Map-component can draw them.
  */
 export const useDecideCameraFocusMode = (
-  selectionMode: MapSelectionMode,
   fromCoords: Coordinates | undefined,
   mapSelectionAction: MapSelectionActionType | undefined,
   mapViewRef: RefObject<MapboxGL.MapView | null>,
@@ -73,31 +67,18 @@ export const useDecideCameraFocusMode = (
         return;
       }
 
-      switch (selectionMode) {
-        case 'ExploreLocation': {
-          setCameraFocusMode({
-            mode: 'coordinates',
-            coordinates: mapPositionToCoordinates(
-              mapSelectionAction.feature.geometry.coordinates,
-            ),
-          });
-          break;
-        }
-        case 'ExploreEntities': {
-          const entityFeature = await findEntityAtClick(
-            mapSelectionAction.feature,
-            mapViewRef,
-          );
-          setCameraFocusMode(
-            await getFocusMode(
-              entityFeature,
-              fromCoords,
-              !!disableShouldShowMapLines,
-              !!disableShouldZoomToFeature,
-            ),
-          );
-        }
-      }
+      const entityFeature = await findEntityAtClick(
+        mapSelectionAction.feature,
+        mapViewRef,
+      );
+      setCameraFocusMode(
+        await getFocusMode(
+          entityFeature,
+          fromCoords,
+          !!disableShouldShowMapLines,
+          !!disableShouldZoomToFeature,
+        ),
+      );
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapSelectionAction]);

--- a/src/components/map/hooks/use-map-selection-change-effect.tsx
+++ b/src/components/map/hooks/use-map-selection-change-effect.tsx
@@ -1,5 +1,4 @@
-import {RefObject, useCallback, useMemo, useState} from 'react';
-import {getCoordinatesFromMapSelectionAction} from '../utils';
+import {RefObject, useCallback, useState} from 'react';
 import MapboxGL from '@rnmapbox/maps';
 import {useGeolocationContext} from '@atb/GeolocationContext';
 import {MapProps, MapSelectionActionType} from '../types';
@@ -35,7 +34,6 @@ export const useMapSelectionChangeEffect = (
   const {setBottomSheetCurrentlyAutoSelected} = useMapContext();
 
   const cameraFocusMode = useDecideCameraFocusMode(
-    mapProps.selectionMode,
     fromCoords,
     mapSelectionAction,
     mapViewRef,
@@ -68,21 +66,12 @@ export const useMapSelectionChangeEffect = (
     [currentLocation?.coordinates, setBottomSheetCurrentlyAutoSelected],
   );
 
-  const selectedCoordinates = useMemo(
-    () =>
-      mapSelectionAction
-        ? getCoordinatesFromMapSelectionAction(mapSelectionAction)
-        : undefined,
-    [mapSelectionAction],
-  );
-
   return {
     mapLines:
       cameraFocusMode?.mode === 'map-lines'
         ? cameraFocusMode.mapLines
         : undefined,
     onMapClick,
-    selectedCoordinates,
     selectedFeature,
     onReportParkingViolation,
   };

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -96,7 +96,6 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
   useEffect(() => {
     (async function () {
       if (!isFocused) return;
-      if (mapProps.selectionMode !== 'ExploreEntities') return;
 
       if (mapSelectionAction?.source === 'filters-button') {
         openBottomSheet(

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -13,6 +13,7 @@ export {
 export {useControlPositionsStyle} from './hooks/use-control-styles';
 export {Map} from './Map';
 export {MapV2} from './MapV2';
+export {ExploreLocationMap} from './ExploreLocationMap';
 export {
   flyToLocation,
   zoomIn,

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -33,17 +33,6 @@ import {GeofencingZoneKeys, GeofencingZoneStyle} from '@atb-as/theme';
 import {ContrastColor} from '@atb/theme/colors';
 import {ClusterOfVehiclesProperties} from '@atb/api/types/mobility';
 
-/**
- * MapSelectionMode: Parameter to decide how on-select/ on-click on the map
- * should behave
- *  - ExploreEntities: If only the map entities (Bus, Trams stops etc.) should be
- *    interactable, and will open a bottom sheet with details for the entity.
- *  - ExploreLocation: If every selected location should be interactable. It
- *    also shows the Location bar on top of the Map to show the currently
- *    selected location
- */
-export type MapSelectionMode = 'ExploreEntities' | 'ExploreLocation';
-
 export type SelectionLocationCallback = (
   selectedLocation?: GeoLocation | SearchLocation,
 ) => void;
@@ -103,18 +92,10 @@ export type MapProps = {
   vehicles?: VehiclesState; // V1 only
   stations?: StationsState; // V1 only
   includeSnackbar?: boolean;
-} & (
-  | {
-      selectionMode: 'ExploreLocation';
-      onLocationSelect: SelectionLocationCallback;
-    }
-  | {
-      selectionMode: 'ExploreEntities';
-      navigateToQuay: NavigateToQuayCallback;
-      navigateToDetails: NavigateToDetailsCallback;
-      navigateToTripSearch: NavigateToTripSearchCallback;
-    }
-);
+  navigateToQuay: NavigateToQuayCallback;
+  navigateToDetails: NavigateToDetailsCallback;
+  navigateToTripSearch: NavigateToTripSearchCallback;
+};
 
 export type Cluster = {
   cluster_id: number;

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -11,10 +11,8 @@ import {
   Point,
   Polygon,
   Position,
-  GeoJSON,
 } from 'geojson';
 import {
-  MapSelectionActionType,
   MapPadding,
   ParkingType,
   GeofencingZoneCustomProps,
@@ -128,23 +126,6 @@ export const mapPositionToCoordinates = (p: Position): Coordinates => ({
   longitude: p[0],
   latitude: p[1],
 });
-
-export const getCoordinatesFromMapSelectionAction = (
-  sc: MapSelectionActionType,
-) => {
-  switch (sc.source) {
-    case 'my-position':
-      return sc.coords;
-    case 'map-item':
-    case 'map-click':
-    case 'cluster-click':
-    case 'cluster-click-v2':
-      return mapPositionToCoordinates(sc.feature.geometry.coordinates);
-    case 'filters-button':
-    case 'external-map-button':
-      return undefined;
-  }
-};
 
 export const getFeaturesAtClick = async (
   clickedFeature: Feature<Point>,

--- a/src/stacks-hierarchy/Root_LocationSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByMapScreen.tsx
@@ -3,10 +3,9 @@ import {StyleSheet} from '@atb/theme';
 import {LocationSearchTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {View} from 'react-native';
-import {Map, MapV2} from '@atb/components/map';
+import {ExploreLocationMap} from '@atb/components/map';
 import {Location} from '@atb/favorites';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
-import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export type Props = RootStackScreenProps<'Root_LocationSearchByMapScreen'>;
 
@@ -16,8 +15,6 @@ export const Root_LocationSearchByMapScreen: React.FC<Props> = ({
     params: {callerRouteName, callerRouteParam, initialLocation},
   },
 }) => {
-  const {isMapV2Enabled} = useFeatureTogglesContext();
-
   const onLocationSelect = (selectedLocation?: Location) => {
     navigation.navigate({
       name: callerRouteName as any,
@@ -36,19 +33,10 @@ export const Root_LocationSearchByMapScreen: React.FC<Props> = ({
         title={t(LocationSearchTexts.mapSelection.header.title)}
         leftButton={{type: 'back'}}
       />
-      {isMapV2Enabled ? (
-        <MapV2
-          onLocationSelect={onLocationSelect}
-          initialLocation={initialLocation}
-          selectionMode="ExploreLocation"
-        />
-      ) : (
-        <Map
-          onLocationSelect={onLocationSelect}
-          initialLocation={initialLocation}
-          selectionMode="ExploreLocation"
-        />
-      )}
+      <ExploreLocationMap
+        onLocationSelect={onLocationSelect}
+        initialLocation={initialLocation}
+      />
     </View>
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
@@ -72,7 +72,6 @@ export const Map_RootScreen = ({
     <>
       <StatusBarOnFocus barStyle="dark-content" backgroundColor="#00000000" />
       <Map
-        selectionMode="ExploreEntities"
         vehicles={vehicles}
         stations={stations}
         navigateToQuay={navigateToQuay}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreenV2.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreenV2.tsx
@@ -71,7 +71,6 @@ export const Map_RootScreenV2 = ({
 
   return (
     <MapV2
-      selectionMode="ExploreEntities"
       navigateToQuay={navigateToQuay}
       navigateToDetails={navigateToDetails}
       navigateToTripSearch={navigateToTripSearch}


### PR DESCRIPTION
This cleans up the code by separating the explore location mode in the map to its own component, and fixes the bug where an item on the map was selected when clicked.

| Before (icons minimized when they shouldn't be) | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/2c384d13-85f2-4cff-93e1-4071ac34d573" /> | <img width="200" src="https://github.com/user-attachments/assets/f46c6374-79b7-4d21-a2dc-73603690d110" /> |


Part of https://github.com/AtB-AS/kundevendt/issues/19216