### PR TITLE
feat: add signed token as header to list token

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -135,7 +135,10 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     data: remoteTokens,
     status: remoteTokensStatus,
     error: remoteTokenError,
-  } = useListRemoteTokensQuery(enabled, nativeToken);
+  } = useListRemoteTokensQuery(
+    enabled && nativeToken !== undefined,
+    nativeToken,
+  );
   const {mutate: checkRenewMutate} = usePreemptiveRenewTokenMutation(userId);
 
   useEffect(() => {

--- a/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
+++ b/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
@@ -12,6 +12,7 @@ import {Token} from '@atb/mobile-token/types';
 import {v4 as uuid} from 'uuid';
 import {useAuthContext} from '@atb/auth';
 import {logToBugsnag} from '@atb/utils/bugsnag-utils';
+import {mobileTokenClient} from '../mobileTokenClient';
 
 export const LIST_REMOTE_TOKENS_QUERY_KEY = 'listRemoteTokens';
 
@@ -21,10 +22,17 @@ export const useListRemoteTokensQuery = (
 ) => {
   const {userId} = useAuthContext();
   return useQuery({
-    queryKey: [MOBILE_TOKEN_QUERY_KEY, LIST_REMOTE_TOKENS_QUERY_KEY, userId],
-    queryFn: () => {
+    queryKey: [
+      MOBILE_TOKEN_QUERY_KEY,
+      LIST_REMOTE_TOKENS_QUERY_KEY,
+      userId,
+      nativeToken,
+    ],
+    queryFn: async () => {
       logToBugsnag('Listing tokens for user ' + userId);
-      return tokenService.listTokens(uuid());
+      const secureContainer =
+        nativeToken && (await mobileTokenClient.encode(nativeToken));
+      return tokenService.listTokens(secureContainer, uuid());
     },
     enabled,
     select: (tokens) =>

--- a/src/mobile-token/tokenService.ts
+++ b/src/mobile-token/tokenService.ts
@@ -39,7 +39,10 @@ const IsEmulatorHeaderName = 'Atb-Is-Emulator';
 
 export type TokenService = RemoteTokenService & {
   removeToken: (tokenId: string, traceId: string) => Promise<boolean>;
-  listTokens: (traceId: string) => Promise<RemoteToken[]>;
+  listTokens: (
+    secureContainer: string | undefined,
+    traceId: string,
+  ) => Promise<RemoteToken[]>;
   toggle: (
     tokenId: string,
     traceId: string,
@@ -202,10 +205,11 @@ export const tokenService: TokenService = {
       )
       .then((res) => res.data.removed)
       .catch(handleError),
-  listTokens: async (traceId: string) =>
+  listTokens: async (secureContainer, traceId) =>
     client
       .get<ListResponse>('/tokens/v4/list', {
         headers: {
+          [SignedTokenHeaderName]: secureContainer,
           [CorrelationIdHeaderName]: traceId,
         },
         baseURL: await getBaseUrl(),


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/20216

some reference that may be useful: https://mittatb.slack.com/archives/C079LPXV1NF/p1742217909662349

Related to https://github.com/AtB-AS/abt-token-server/pull/95, which will utilize the stuff that we added in this PR.

The PR will add `signedToken` as header to the `/list` endpoint request, which in turn will allow the `list` function to `add inspection` rights if there are no tokens with that right on the list. 

Also now the list token will only fetched by the app when the native token (on-device token) is successfully fetched/generated, instead of being called regardless of the native token status. This is to accommodate the change to the `/list` function above, since the token inspection right is added when we call this endpoint.


### Acceptance criteria

- [ ] `Atb-Signed-Token` header is sent when app calls `/list` endpoint
- [ ] Try to prevent the token from being created (intercept `/init` or `/activate`), then the `/list` endpoint should not be called without any token. (can also use token Sabotage I think, to prevent token creation and trigger fallback)