### PR TITLE
refactor: remove validate function from mobile token process

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -202,7 +202,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
    *      3.  Wipe the token and re-create token.
    *      4.  Reset the queries so it can re-check if the token is
    *          created properly.
-   *      5.  If the token is not found until 3 times,
+   *      5.  If the token creation/renewal fails, show fallback
    */
   useEffect(() => {
     const renewOrResetToken = async (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -90,7 +90,6 @@ export const Profile_DebugInfoScreen = () => {
       nativeTokenStatus,
       remoteTokensStatus,
       createToken: initToken,
-      validateToken,
       removeRemoteToken,
       renewToken,
       wipeToken,
@@ -461,14 +460,6 @@ export const Profile_DebugInfoScreen = () => {
                     style={styles.button}
                     text="Wipe token"
                     onPress={wipeToken}
-                  />
-                )}
-                {nativeToken && (
-                  <Button
-                    expanded={true}
-                    style={styles.button}
-                    text="Validate token"
-                    onPress={validateToken}
                   />
                 )}
                 {nativeToken && (


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20216

some reference that may be useful: https://mittatb.slack.com/archives/C079LPXV1NF/p1742217909662349

> ~~Requires https://github.com/AtB-AS/mittatb-app/pull/5079 and https://github.com/AtB-AS/abt-token-server/pull/95 to be merged first~~ (NOW MERGED)

This PR will remove the `validate()` function from the app, also removes the `Validate token` debug menu.

For handling of the current validate function: 

#### Adds inspection right if there are no other inspection right on any other tokens
Handled by https://github.com/AtB-AS/mittatb-app/pull/5079 and https://github.com/AtB-AS/abt-token-server/pull/95 

#### Token Renewal AND Reset (if needed)
`MobileTokenContext` now handles the renewal and resetting of token as needed. In order to detect this, it will need to check if the local token exists on the remote, if local token doesn't exist on remote, assume that it is expired first, try renewing the token. If it throws an error `TokenMustBeReplaced`, then proceed to reset the token. Either the token is renewed or resetted, the token process will be restarted. There is also a limit of how many renew attempts can be done, to prevent the user from being stuck in a renewal loop and might end up without any usable ticket/token, once the renewal loop ended (reached max retry count), the fallback should be displayed.

#### Token reattestation
Removed, reattestation is not needed because we retrieve tickets from firebase.


### Acceptance Criteria

- [ ] Token renewal and reset works as previous (try expiring and removing token from backoffice)
- [ ] Inspection right is added when there are no other token with inspection
- [ ] Token is valid during inspection (of course with a valid ticket)