### PR TITLE
feat: map v2 remaining maps

### DIFF
--- a/src/components/map/ExploreLocationMap.tsx
+++ b/src/components/map/ExploreLocationMap.tsx
@@ -8,7 +8,7 @@ import MapboxGL, {LocationPuck} from '@rnmapbox/maps';
 import {Feature} from 'geojson';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
-import {MapCameraConfig, MapViewConfig} from './MapConfig';
+import {MapCameraConfig} from './MapConfig';
 import {SelectionPin} from './components/SelectionPin';
 import {LocationBar} from './components/LocationBar';
 import {PositionArrow} from './components/PositionArrow';
@@ -18,8 +18,8 @@ import {SelectionLocationCallback} from './types';
 import {isFeaturePoint} from './utils';
 import {Location} from '@atb/favorites';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import {useMapboxJsonStyle} from './hooks/use-mapbox-json-style';
 import {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
+import {useMapViewConfig} from './hooks/use-map-view-config';
 
 type ExploreLocationMapProps = {
   initialLocation?: Location;
@@ -67,11 +67,7 @@ export const ExploreLocationMap = ({
     }
   };
 
-  const mapboxJsonStyle = useMapboxJsonStyle(false);
-
-  const customMapViewConfigProps = isMapV2Enabled
-    ? {styleURL: undefined, styleJSON: mapboxJsonStyle}
-    : {};
+  const mapViewConfig = useMapViewConfig(false);
 
   return (
     <View style={styles.container}>
@@ -87,11 +83,7 @@ export const ExploreLocationMap = ({
           pitchEnabled={false}
           onPress={onFeatureClick}
           testID="exploreLocationMapView"
-          {...{
-            ...MapViewConfig,
-            // only updating Map.tsx for now.
-            ...customMapViewConfigProps,
-          }}
+          {...mapViewConfig}
         >
           <MapboxGL.Camera
             ref={mapCameraRef}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -10,7 +10,7 @@ import {Feature, Position} from 'geojson';
 import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
-import {MapCameraConfig, MapViewConfig} from './MapConfig';
+import {MapCameraConfig} from './MapConfig';
 import {PositionArrow} from './components/PositionArrow';
 import {Stations, Vehicles} from './components/mobility';
 import {useControlPositionsStyle} from './hooks/use-control-styles';
@@ -29,6 +29,7 @@ import isEqual from 'lodash.isequal';
 import {
   GeofencingZones,
   useGeofencingZoneTextContent,
+  useMapViewConfig,
 } from '@atb/components/map';
 import {ExternalRealtimeMapButton} from './components/external-realtime-map/ExternalRealtimeMapButton';
 
@@ -52,6 +53,8 @@ export const Map = (props: MapProps) => {
   const mapViewRef = useRef<MapboxGL.MapView>(null);
   const styles = useMapStyles();
   const controlStyles = useControlPositionsStyle(false);
+
+  const mapViewConfig = useMapViewConfig(false);
 
   const startingCoordinates = useMemo(
     () =>
@@ -234,7 +237,7 @@ export const Map = (props: MapProps) => {
           onMapIdle={onMapIdle}
           onPress={onFeatureClick}
           testID="mapView"
-          {...MapViewConfig}
+          {...mapViewConfig}
         >
           <MapboxGL.Camera
             ref={mapCameraRef}

--- a/src/components/map/MapConfig.ts
+++ b/src/components/map/MapConfig.ts
@@ -1,24 +1,5 @@
-import {Platform} from 'react-native';
-import {MAPBOX_STOP_PLACES_STYLE_URL} from '@env';
 import {CameraStop} from '@rnmapbox/maps';
 import {Dimensions} from 'react-native';
-
-export const MapViewConfig = {
-  // todo remove MapViewConfig from this file
-  compassEnabled: true,
-  scaleBarEnabled: false,
-  // `mapbox` (v10) Adds compass offset `compassViewMargins` is still supported but generates issues:
-  // Mapbox error fireEvent failed: <rnmapbox_maps.RCTMGLEvent: 0x6000028a0fe0>
-  compassPosition: {
-    top: 60,
-    right: Platform.select({default: 10, android: 6}),
-  },
-  attributionPosition: Platform.select({
-    default: {bottom: 8, left: 95},
-    android: {bottom: 5, left: 120},
-  }),
-  styleURL: MAPBOX_STOP_PLACES_STYLE_URL,
-};
 
 export const MapCameraConfig: CameraStop = {
   animationMode: 'moveTo',

--- a/src/components/map/MapConfig.ts
+++ b/src/components/map/MapConfig.ts
@@ -4,6 +4,7 @@ import {CameraStop} from '@rnmapbox/maps';
 import {Dimensions} from 'react-native';
 
 export const MapViewConfig = {
+  // todo remove MapViewConfig from this file
   compassEnabled: true,
   scaleBarEnabled: false,
   // `mapbox` (v10) Adds compass offset `compassViewMargins` is still supported but generates issues:

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -9,11 +9,7 @@ import {Feature, GeoJsonProperties, Geometry, Position} from 'geojson';
 import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
-import {
-  MapCameraConfig,
-  MapViewConfig,
-  SLIGHTLY_RAISED_MAP_PADDING,
-} from './MapConfig';
+import {MapCameraConfig, SLIGHTLY_RAISED_MAP_PADDING} from './MapConfig';
 import {PositionArrow} from './components/PositionArrow';
 import {useControlPositionsStyle} from './hooks/use-control-styles';
 import {useMapSelectionChangeEffect} from './hooks/use-map-selection-change-effect';
@@ -34,6 +30,7 @@ import {
 import {
   GeofencingZones,
   useGeofencingZoneTextContent,
+  useMapViewConfig,
 } from '@atb/components/map';
 import {ExternalRealtimeMapButton} from './components/external-realtime-map/ExternalRealtimeMapButton';
 
@@ -51,7 +48,6 @@ import {ScanButton} from './components/ScanButton';
 import {useActiveShmoBookingQuery} from '@atb/mobility/queries/use-active-shmo-booking-query';
 import {AutoSelectableBottomSheetType, useMapContext} from '@atb/MapContext';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import {useMapboxJsonStyle} from './hooks/use-mapbox-json-style';
 import {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {VehiclesAndStations} from './components/mobility/VehiclesAndStations';
@@ -66,6 +62,7 @@ export const MapV2 = (props: MapProps) => {
   const controlStyles = useControlPositionsStyle(false);
   const isFocused = useIsFocused();
   const shouldShowVehiclesAndStations = isFocused; // don't send tile requests while in the background, and always get fresh data upon enter
+  const mapViewConfig = useMapViewConfig(shouldShowVehiclesAndStations);
 
   const startingCoordinates = useMemo(
     () =>
@@ -86,8 +83,6 @@ export const MapV2 = (props: MapProps) => {
     );
 
   const {bottomSheetCurrentlyAutoSelected} = useMapContext();
-
-  const mapboxJsonStyle = useMapboxJsonStyle(shouldShowVehiclesAndStations);
 
   const aVehicleIsAutoSelected =
     bottomSheetCurrentlyAutoSelected?.type ===
@@ -246,12 +241,7 @@ export const MapV2 = (props: MapProps) => {
           pitchEnabled={false}
           onPress={onFeatureClick}
           testID="mapView"
-          {...{
-            ...MapViewConfig,
-            // only updating Map.tsx for now.
-            styleURL: undefined,
-            styleJSON: mapboxJsonStyle,
-          }}
+          {...mapViewConfig}
         >
           <MapboxGL.Camera
             ref={mapCameraRef}

--- a/src/components/map/hooks/use-map-view-config.ts
+++ b/src/components/map/hooks/use-map-view-config.ts
@@ -21,11 +21,11 @@ const MapViewStaticConfig = {
 export const useMapViewConfig = (shouldShowVehiclesAndStations: boolean) => {
   const {isMapV2Enabled} = useFeatureTogglesContext();
   const mapboxJsonStyle = useMapboxJsonStyle(shouldShowVehiclesAndStations);
+  const configMapV1 = {styleURL: MAPBOX_STOP_PLACES_STYLE_URL};
+  const configMapV2 = {styleJSON: mapboxJsonStyle};
 
   return {
     ...MapViewStaticConfig,
-    ...{
-      styleURL: isMapV2Enabled ? mapboxJsonStyle : MAPBOX_STOP_PLACES_STYLE_URL,
-    },
+    ...(isMapV2Enabled ? configMapV2 : configMapV1),
   };
 };

--- a/src/components/map/hooks/use-map-view-config.ts
+++ b/src/components/map/hooks/use-map-view-config.ts
@@ -2,6 +2,7 @@ import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {MAPBOX_STOP_PLACES_STYLE_URL} from '@env';
 import {Platform} from 'react-native';
 import {useMapboxJsonStyle} from './use-mapbox-json-style';
+import {useThemeContext} from '@atb/theme';
 
 const MapViewStaticConfig = {
   compassEnabled: true,
@@ -18,10 +19,19 @@ const MapViewStaticConfig = {
   }),
 };
 
-export const useMapViewConfig = (shouldShowVehiclesAndStations: boolean) => {
+export const useMapViewConfig = (
+  shouldShowVehiclesAndStations: boolean,
+  useDarkModeForV1: boolean = false,
+) => {
+  const {themeName} = useThemeContext();
   const {isMapV2Enabled} = useFeatureTogglesContext();
   const mapboxJsonStyle = useMapboxJsonStyle(shouldShowVehiclesAndStations);
-  const configMapV1 = {styleURL: MAPBOX_STOP_PLACES_STYLE_URL};
+  const configMapV1 = {
+    styleURL:
+      useDarkModeForV1 && themeName === 'dark'
+        ? 'mapbox://styles/mapbox/dark-v10'
+        : MAPBOX_STOP_PLACES_STYLE_URL,
+  };
   const configMapV2 = {styleJSON: mapboxJsonStyle};
 
   return {

--- a/src/components/map/hooks/use-map-view-config.ts
+++ b/src/components/map/hooks/use-map-view-config.ts
@@ -1,0 +1,31 @@
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {MAPBOX_STOP_PLACES_STYLE_URL} from '@env';
+import {Platform} from 'react-native';
+import {useMapboxJsonStyle} from './use-mapbox-json-style';
+
+const MapViewStaticConfig = {
+  compassEnabled: true,
+  scaleBarEnabled: false,
+  // `mapbox` (v10) Adds compass offset `compassViewMargins` is still supported but generates issues:
+  // Mapbox error fireEvent failed: <rnmapbox_maps.RCTMGLEvent: 0x6000028a0fe0>
+  compassPosition: {
+    top: 60,
+    right: Platform.select({default: 10, android: 6}),
+  },
+  attributionPosition: Platform.select({
+    default: {bottom: 8, left: 95},
+    android: {bottom: 5, left: 120},
+  }),
+};
+
+export const useMapViewConfig = (shouldShowVehiclesAndStations: boolean) => {
+  const {isMapV2Enabled} = useFeatureTogglesContext();
+  const mapboxJsonStyle = useMapboxJsonStyle(shouldShowVehiclesAndStations);
+
+  return {
+    ...MapViewStaticConfig,
+    ...{
+      styleURL: isMapV2Enabled ? mapboxJsonStyle : MAPBOX_STOP_PLACES_STYLE_URL,
+    },
+  };
+};

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -3,7 +3,6 @@ export {PositionArrow} from './components/PositionArrow';
 export {shadows} from './components/shadows';
 export {SelectionPin} from './components/SelectionPin';
 export {
-  MapViewConfig,
   MapCameraConfig,
   SCOOTERS_MAX_CLUSTER_LEVEL,
   SCOOTERS_MAX_ZOOM_LEVEL,

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -14,6 +14,7 @@ export {useControlPositionsStyle} from './hooks/use-control-styles';
 export {Map} from './Map';
 export {MapV2} from './MapV2';
 export {ExploreLocationMap} from './ExploreLocationMap';
+export {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
 export {
   flyToLocation,
   zoomIn,

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -54,6 +54,7 @@ export type {
 } from './types';
 export {useUserMapFilters} from './hooks/use-map-filter';
 export {useGeofencingZoneTextContent} from './hooks/use-geofencing-zone-text-content';
+export {useMapViewConfig} from './hooks/use-map-view-config.ts';
 export {Stations, GeofencingZones} from './components/mobility';
 export {usePreProcessedGeofencingZones} from './hooks/use-pre-processed-geofencing-zones';
 export {useMapSymbolStyles} from './hooks/use-map-symbol-styles';

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -15,6 +15,7 @@ export {Map} from './Map';
 export {MapV2} from './MapV2';
 export {ExploreLocationMap} from './ExploreLocationMap';
 export {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
+export {VehiclesAndStations} from './components/mobility/VehiclesAndStations.tsx';
 export {
   flyToLocation,
   zoomIn,

--- a/src/stacks-hierarchy/Root_ScooterHelp/components/UserCoordinatesMap.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/components/UserCoordinatesMap.tsx
@@ -2,8 +2,8 @@ import {Coordinates} from '@atb/utils/coordinates';
 import MapboxGL from '@rnmapbox/maps';
 import {
   MapCameraConfig,
-  MapViewConfig,
   SelectionPin,
+  useMapViewConfig,
 } from '@atb/components/map';
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {useRef} from 'react';
@@ -14,12 +14,13 @@ type Props = {
 };
 export const UserCoordinatesMap = ({userCoordinates, style}: Props) => {
   const cameraRef = useRef<MapboxGL.Camera>(null);
+  const mapViewConfig = useMapViewConfig(false);
 
   return (
     <View style={[{flex: 1}, style]}>
       {userCoordinates && (
         <MapboxGL.MapView
-          {...MapViewConfig}
+          {...mapViewConfig}
           compassEnabled={false}
           zoomEnabled={false}
           scrollEnabled={false}

--- a/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
+++ b/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
@@ -4,12 +4,14 @@ import {ActivityIndicator, View} from 'react-native';
 import {Button} from '@atb/components/button';
 import {Language, TariffZonesTexts, useTranslation} from '@atb/translations';
 import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
+
 import {
   flyToLocation,
   hitboxCoveringIconOnly,
   MapCameraConfig,
-  MapViewConfig,
+  NationalStopRegistryFeatures,
   PositionArrow,
+  useMapViewConfig,
 } from '@atb/components/map';
 import hexToRgba from 'hex-to-rgba';
 import React, {useRef} from 'react';
@@ -27,6 +29,7 @@ import {
   usePurchaseSelectionBuilder,
   useSelectableTariffZones,
 } from '@atb/modules/purchase-selection';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 type Props = {
   selection: PurchaseSelectionType;
@@ -89,6 +92,9 @@ const TariffZonesSelectorMap = ({
     onSelect(newSelection);
   };
 
+  const mapViewConfig = useMapViewConfig(false);
+  const {isMapV2Enabled} = useFeatureTogglesContext();
+
   return (
     <>
       {a11yContext.isScreenReaderEnabled ? (
@@ -129,8 +135,14 @@ const TariffZonesSelectorMap = ({
             style={{
               flex: 1,
             }}
-            {...MapViewConfig}
+            {...mapViewConfig}
           >
+            {isMapV2Enabled && (
+              <NationalStopRegistryFeatures
+                selectedFeaturePropertyId={undefined}
+                onMapItemClick={undefined}
+              />
+            )}
             <MapboxGL.ShapeSource
               id="tariffZonesShape"
               shape={featureCollection}

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -162,6 +162,14 @@ export const TravelDetailsMapScreenComponent = ({
             onMapItemClick={undefined}
           />
         )}
+        {isMapV2Enabled && (
+          <VehiclesAndStations
+            selectedFeatureId={undefined}
+            onPress={undefined}
+            showVehicles={false}
+            showStations={true}
+          />
+        )}
         <MapboxGL.UserLocation
           showsUserHeadingIndicator
           renderMode={UserLocationRenderMode.Native}
@@ -190,14 +198,6 @@ export const TravelDetailsMapScreenComponent = ({
             zoomLevel={zoomLevel}
             heading={cameraHeading}
             isError={isLiveConnected}
-          />
-        )}
-        {isMapV2Enabled && (
-          <VehiclesAndStations
-            selectedFeatureId={undefined}
-            onPress={undefined}
-            showVehicles={false}
-            showStations={true}
           />
         )}
       </MapboxGL.MapView>

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -11,9 +11,11 @@ import {
   MapCameraConfig,
   MapFilterType,
   MapLeg,
-  MapViewConfig,
+  NationalStopRegistryFeatures,
   PositionArrow,
   useControlPositionsStyle,
+  useMapViewConfig,
+  VehiclesAndStations,
 } from '@atb/components/map';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useGeolocationContext} from '@atb/GeolocationContext';
@@ -38,6 +40,7 @@ import {
   MapState,
   RegionPayload,
 } from '@rnmapbox/maps/lib/typescript/src/components/MapView';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export type TravelDetailsMapScreenParams = {
   legs: MapLeg[];
@@ -70,6 +73,9 @@ export const TravelDetailsMapScreenComponent = ({
   const mapViewRef = useRef<MapboxGL.MapView>(null);
   const {location: geolocation} = useGeolocationContext();
   const isFocusedAndActive = useIsFocusedAndActive();
+
+  const {isMapV2Enabled} = useFeatureTogglesContext();
+  const mapViewConfig = useMapViewConfig(true);
 
   const features = useMemo(() => createMapLines(legs), [legs]);
   const bounds = !vehicleWithPosition ? getMapBounds(features) : undefined;
@@ -138,7 +144,7 @@ export const TravelDetailsMapScreenComponent = ({
         ref={mapViewRef}
         style={styles.map}
         pitchEnabled={false}
-        {...MapViewConfig}
+        {...mapViewConfig}
         {...mapCameraTrackingMethod}
         onMapIdle={onMapIdle}
       >
@@ -150,6 +156,12 @@ export const TravelDetailsMapScreenComponent = ({
           centerCoordinate={vehicleWithPosition ? centerPosition : undefined}
           animationDuration={0}
         />
+        {isMapV2Enabled && (
+          <NationalStopRegistryFeatures
+            selectedFeaturePropertyId={undefined}
+            onMapItemClick={undefined}
+          />
+        )}
         <MapboxGL.UserLocation
           showsUserHeadingIndicator
           renderMode={UserLocationRenderMode.Native}
@@ -178,6 +190,14 @@ export const TravelDetailsMapScreenComponent = ({
             zoomLevel={zoomLevel}
             heading={cameraHeading}
             isError={isLiveConnected}
+          />
+        )}
+        {isMapV2Enabled && (
+          <VehiclesAndStations
+            selectedFeatureId={undefined}
+            onPress={undefined}
+            showVehicles={false}
+            showStations={true}
           />
         )}
       </MapboxGL.MapView>

--- a/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -1,6 +1,6 @@
-import {MapCameraConfig, MapLeg, MapViewConfig} from '@atb/components/map';
+import {MapCameraConfig, MapLeg, useMapViewConfig} from '@atb/components/map';
 
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {MapTexts, useTranslation} from '@atb/translations';
 import {useDisableMapCheck} from '@atb/utils/use-disable-map-check';
 import MapboxGL from '@rnmapbox/maps';
@@ -31,13 +31,14 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
   buttonText,
   onExpand,
 }) => {
-  const {themeName} = useThemeContext();
   const disableMap = useDisableMapCheck();
   const {t} = useTranslation();
   const cameraRef = useRef<MapboxGL.Camera>(null);
 
   const features = useMemo(() => createMapLines(mapLegs), [mapLegs]);
   const bounds = useMemo(() => getMapBounds(features), [features]);
+
+  const mapViewConfig = useMapViewConfig(false);
 
   /*
    * Workaround for iOS as setting default bounds on camera is not working fully
@@ -57,8 +58,6 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
 
   const styles = useStyles();
 
-  const darkmode = themeName === 'dark';
-
   if (disableMap) {
     return null;
   }
@@ -71,8 +70,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
           scrollEnabled={false}
           rotateEnabled={false}
           zoomEnabled={false}
-          {...MapViewConfig}
-          styleURL={darkmode ? 'mapbox://styles/mapbox/dark-v10' : undefined}
+          {...mapViewConfig}
           compassEnabled={false}
           onPress={onExpand}
         >

--- a/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -38,7 +38,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
   const features = useMemo(() => createMapLines(mapLegs), [mapLegs]);
   const bounds = useMemo(() => getMapBounds(features), [features]);
 
-  const mapViewConfig = useMapViewConfig(false);
+  const mapViewConfig = useMapViewConfig(false, true);
 
   /*
    * Workaround for iOS as setting default bounds on camera is not working fully


### PR DESCRIPTION
This uses the new map for all remaining maps in the app, supporting everything as before + dark mode as well.

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/66b1d934-6edf-4d7f-b2a2-ed344bbfc030" /> | <img width="200" src="https://github.com/user-attachments/assets/9ba199c0-c6f9-42e8-96c2-b12badf37c6f" /> |
| <img width="200" src="https://github.com/user-attachments/assets/ebdf8cc9-4519-4752-badb-4e5a3eed04a8" /> | <img width="200" src="https://github.com/user-attachments/assets/d50974fc-1707-4089-a34c-6edd63eb8a75" /> |
| <img width="200" src="https://github.com/user-attachments/assets/fe799ab2-0f0a-4baa-9cf0-913aa4a2ab5a" /> | <img width="200" src="https://github.com/user-attachments/assets/e0961884-3d74-423c-a82d-75c2d6142776" /> |
| <img width="200" src="https://github.com/user-attachments/assets/4242bce6-de31-40d8-9b65-e57b86d3662a" /> | <img width="200" src="https://github.com/user-attachments/assets/1f342442-061a-4af8-9db3-ecf721901240" /> |
| <img width="200" src="https://github.com/user-attachments/assets/dd61d32d-0ae5-4f0a-96b7-7b35828119f1" /> | <img width="200" src="https://github.com/user-attachments/assets/a82b2753-cdff-4884-90db-2aa539bacf1c" /> |
| <img width="200" src="https://github.com/user-attachments/assets/7b831c28-8782-45a4-a6b0-0c5a271210fa" /> | <img width="200" src="https://github.com/user-attachments/assets/51cd164e-1c4e-462c-b576-3388b889e3fc" /> |
| <img width="200" src="https://github.com/user-attachments/assets/3f0b6cba-627e-4949-9d3e-6496f4403abb" /> | <img width="200" src="https://github.com/user-attachments/assets/76c18e64-1f01-4a7b-9d64-a9f39fa2eeec" /> |



Resolves https://github.com/AtB-AS/kundevendt/issues/20249