### PR TITLE
fix: make spacing even on spacious sections

### DIFF
--- a/src/components/sections/items/CounterSectionItem.tsx
+++ b/src/components/sections/items/CounterSectionItem.tsx
@@ -153,7 +153,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       flex: 1,
       flexDirection: 'row',
       alignItems: 'center',
-      padding: theme.spacing.medium,
     },
     countActions: {
       flexDirection: 'row',

--- a/src/components/sections/use-section-item.ts
+++ b/src/components/sections/use-section-item.ts
@@ -60,19 +60,17 @@ export function useSectionItem({
   };
 }
 
-type Padding = Pick<ViewStyle, 'paddingVertical' | 'paddingHorizontal'>;
+type Padding = Pick<ViewStyle, 'padding'>;
 
 function mapToPadding(theme: Theme, type: ContainerSizingType): Padding {
   switch (type) {
     case 'block':
       return {
-        paddingVertical: theme.spacing.medium - theme.border.width.slim,
-        paddingHorizontal: theme.spacing.medium - theme.border.width.slim,
+        padding: theme.spacing.medium - theme.border.width.slim,
       };
     case 'spacious':
       return {
-        paddingVertical: theme.spacing.large - theme.border.width.slim,
-        paddingHorizontal: theme.spacing.medium - theme.border.width.slim,
+        padding: theme.spacing.large - theme.border.width.slim,
       };
   }
 }

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -47,7 +47,6 @@ export function MultipleTravellersSelection({
           count={u.count}
           addCount={() => addTraveller(u.userTypeString)}
           removeCount={() => removeTraveller(u.userTypeString)}
-          type="spacious"
           testID={'counterInput_' + u.userTypeString.toLowerCase()}
           color={theme.color.interactive[2]}
           subtext={getTextForLanguage(u.alternativeDescriptions, language)}


### PR DESCRIPTION
Reverts a change made in https://github.com/AtB-AS/mittatb-app/pull/4896. Seems the padding change to spacious sections is no longer needed for fare contracts. This makes padding even for sections 

- in the following bottom sheets:
	- External realtime map sheet
	- Activate now
	- Consume carnet
	- Situations
- the mobile token toggle radio buttons (which is due to change anyway)
- the "multiple traveller selection" component in the purchase flow was spacious, but it was overridden by internal styles. I cleaned this up a bit.

<div>
<img width="300px" src="https://github.com/user-attachments/assets/b554cbeb-bfc6-48f9-8177-f4e2ea74c5f1">
<img width="300px" src="https://github.com/user-attachments/assets/c54dd911-c4e8-488f-9127-b1943921a023">
</div>


### Acceptance criteria

- [ ] The sections mentioned above look good, and have even spacing above and below the content