### PR TITLE
refactor: update token toggle styling

### DIFF
--- a/src/components/message-info-text/MessageInfoText.tsx
+++ b/src/components/message-info-text/MessageInfoText.tsx
@@ -9,6 +9,7 @@ import {ContrastColor, TextColor} from '@atb/theme/colors';
 export type MessageInfoTextProps = {
   type: Statuses;
   message: string;
+  a11yLabel?: string;
   style?: StyleProp<ViewStyle>;
   testID?: string;
   iconPosition?: 'right' | 'left';
@@ -20,6 +21,7 @@ export const MessageInfoText = ({
   type,
   style,
   message,
+  a11yLabel,
   iconPosition = 'left',
   testID,
   textColor,
@@ -35,7 +37,7 @@ export const MessageInfoText = ({
       style={[styles.container, style]}
       accessible={true}
       testID={testID}
-      accessibilityLabel={message}
+      accessibilityLabel={a11yLabel ?? message}
     >
       {iconPosition === 'left' && (
         <ThemeIcon

--- a/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -20,6 +20,7 @@ import {getDeviceNameWithUnitInfo} from './utils';
 import {TokenToggleInfo} from '@atb/token-toggle-info';
 import {useTokenToggleDetailsQuery} from '@atb/mobile-token/use-token-toggle-details';
 import {useOnboardingContext} from '@atb/onboarding';
+import {ContentHeading} from '@atb/components/heading';
 
 type Props = {onAfterSave: () => void};
 
@@ -107,7 +108,6 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
                 setSelectedType('travel-card');
                 setSelectedToken(travelCardToken);
               }}
-              style={styles.leftRadioBox}
               testID="selectTravelcard"
               interactiveColor={theme.color.interactive[2]}
             />
@@ -137,7 +137,6 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
           <MessageInfoBox
             type="warning"
             message={t(TravelTokenTexts.toggleToken.noTravelCard)}
-            style={styles.errorMessageBox}
             isMarkdown={true}
           />
         )}
@@ -145,36 +144,33 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
           <MessageInfoBox
             type="warning"
             message={t(TravelTokenTexts.toggleToken.noMobileToken)}
-            style={styles.errorMessageBox}
             isMarkdown={false}
           />
         )}
         {selectedType === 'mobile' && mobileTokens?.length ? (
-          <RadioGroupSection<Token>
-            type="spacious"
-            style={styles.selectDeviceSection}
-            items={mobileTokens}
-            keyExtractor={(token) => token.id}
-            itemToText={(token) => getDeviceNameWithUnitInfo(t, token)}
-            selected={selectedToken}
-            onSelect={setSelectedToken}
-            headerText={t(
-              TravelTokenTexts.toggleToken.radioBox.phone.selection.heading,
-            )}
-          />
+          <>
+            <ContentHeading
+              text={t(
+                TravelTokenTexts.toggleToken.radioBox.phone.selection.heading,
+              )}
+            />
+            <RadioGroupSection<Token>
+              items={mobileTokens}
+              keyExtractor={(token) => token.id}
+              itemToText={(token) => getDeviceNameWithUnitInfo(t, token)}
+              selected={selectedToken}
+              onSelect={setSelectedToken}
+            />
+          </>
         ) : null}
         {toggleMutation.isError && (
           <MessageInfoBox
             type="error"
             message={t(dictionary.genericErrorMsg)}
-            style={styles.errorMessageBox}
           />
         )}
         {data?.toggleLimit !== undefined && (
-          <TokenToggleInfo
-            style={styles.tokenInfo}
-            textColor={theme.color.background.accent[0]}
-          />
+          <TokenToggleInfo textColor={theme.color.background.accent[0]} />
         )}
         {toggleMutation.isLoading ? (
           <ActivityIndicator size="large" />
@@ -198,27 +194,12 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     backgroundColor: theme.color.background.accent[0].background,
     flex: 1,
   },
-  tokenInfo: {
-    flexDirection: 'row',
-    marginTop: theme.spacing.small,
-    marginBottom: theme.spacing.large,
-  },
   scrollView: {
     padding: theme.spacing.medium,
+    gap: theme.spacing.medium,
   },
   radioArea: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: theme.spacing.medium,
-    alignContent: 'center',
-  },
-  leftRadioBox: {
-    marginRight: theme.spacing.medium,
-  },
-  selectDeviceSection: {
-    marginBottom: theme.spacing.medium,
-  },
-  errorMessageBox: {
-    marginBottom: theme.spacing.medium,
+    gap: theme.spacing.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/Profile_TravelTokenScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelTokenScreen/Profile_TravelTokenScreen.tsx
@@ -33,7 +33,7 @@ export const Profile_TravelTokenScreen = () => {
         <Section>
           {data?.toggleLimit !== undefined && (
             <GenericSectionItem>
-              <TokenToggleInfo style={styles.tokenInfoView} />
+              <TokenToggleInfo />
             </GenericSectionItem>
           )}
         </Section>
@@ -52,5 +52,4 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     rowGap: theme.spacing.medium,
     padding: theme.spacing.medium,
   },
-  tokenInfoView: {flexDirection: 'row'},
 }));

--- a/src/token-toggle-info/TokenToggleInfo.tsx
+++ b/src/token-toggle-info/TokenToggleInfo.tsx
@@ -1,52 +1,41 @@
 import {TravelTokenTexts, useTranslation} from '@atb/translations';
-import {ActivityIndicator, StyleProp, View, ViewStyle} from 'react-native';
-import {ThemeIcon} from '@atb/components/theme-icon';
-import {ThemeText} from '@atb/components/text';
+import {ActivityIndicator} from 'react-native';
 import {
   formatToShortDateWithYear,
   formatToVerboseFullDate,
 } from '@atb/utils/date';
-import {StyleSheet, useThemeContext} from '@atb/theme';
-import {ContrastColor, Mode} from '@atb/theme/colors';
+import {StyleSheet} from '@atb/theme';
+import {ContrastColor, Statuses} from '@atb/theme/colors';
 import {useTokenToggleDetailsQuery} from '@atb/mobile-token/use-token-toggle-details';
-import {messageTypeToIcon} from '@atb/utils/message-type-to-icon';
+import {MessageInfoText} from '@atb/components/message-info-text';
 
 type TokenToggleInfoProps = {
-  style?: StyleProp<ViewStyle>;
   textColor?: ContrastColor;
 };
 
-export const TokenToggleInfo = ({style, textColor}: TokenToggleInfoProps) => {
+export const TokenToggleInfo = ({textColor}: TokenToggleInfoProps) => {
   const styles = useStyles();
   const {data, isLoading} = useTokenToggleDetailsQuery();
 
   const limit = data?.toggleLimit ?? 0;
 
   return isLoading ? (
-    <ActivityIndicator style={[styles.loader, style]} />
+    <ActivityIndicator style={styles.loader} />
   ) : (
-    <TokenToggleContent
-      toggleLimit={limit}
-      textColor={textColor}
-      style={style}
-    />
+    <TokenToggleContent toggleLimit={limit} textColor={textColor} />
   );
 };
 
 type TokenToggleContentProps = {
-  style?: StyleProp<ViewStyle>;
   toggleLimit: number;
   textColor?: ContrastColor;
 };
 
 const TokenToggleContent = ({
-  style,
   toggleLimit,
   textColor,
 }: TokenToggleContentProps) => {
   const {t, language} = useTranslation();
-  const {themeName} = useThemeContext();
-  const styles = useStyles();
   const now = new Date();
   const nextMonthStartDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
@@ -83,39 +72,27 @@ const TokenToggleContent = ({
   };
 
   return (
-    <View style={style}>
-      <ThemeIcon svg={getToggleInfoIcon(toggleLimit, themeName)} />
-      <ThemeText
-        style={styles.content}
-        accessibilityLabel={getToggleInfo(
-          toggleLimit,
-          countRenewalDateA11yLabel,
-        )}
-        color={textColor}
-        accessible={true}
-      >
-        {getToggleInfo(toggleLimit, countRenewalDate)}
-      </ThemeText>
-    </View>
+    <MessageInfoText
+      message={getToggleInfo(toggleLimit, countRenewalDate)}
+      type={getToggleInfoIcon(toggleLimit)}
+      a11yLabel={getToggleInfo(toggleLimit, countRenewalDateA11yLabel)}
+      textColor={textColor}
+    />
   );
 };
 
-const getToggleInfoIcon = (toggleLimit: number, themeName: Mode) => {
+const getToggleInfoIcon = (toggleLimit: number): Statuses => {
   switch (toggleLimit) {
     case 0:
-      return messageTypeToIcon('error', true, themeName);
+      return 'error';
     case 1:
-      return messageTypeToIcon('warning', true, themeName);
+      return 'warning';
     default:
-      return messageTypeToIcon('info', true, themeName);
+      return 'info';
   }
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  content: {
-    marginLeft: theme.spacing.xSmall,
-    flex: 1,
-  },
+const useStyles = StyleSheet.createThemeHook(() => ({
   loader: {
     alignSelf: 'center',
     flex: 1,


### PR DESCRIPTION
Refactors parts of the token toggle styling, which had some outdated solutions, in addition to being out of sync with [figma](https://www.figma.com/design/zdZwvobgpEWSagKt0tderx/App?node-id=15538-66699&t=xaRfD4CVRy4cliEJ-0). It's still not quite in line with figma, but a bit closer.

### Before/After

<div>
<img width="300px" src="https://github.com/user-attachments/assets/f510f048-74b3-41f3-947b-abfb6163646b">
<img width="300px" src="https://github.com/user-attachments/assets/036fab95-e430-4aea-9710-d9a30b9b2495">
</div>

### Acceptance criteria

- [ ] Token toggling works, and looks ok, closer to [sketches](https://www.figma.com/design/zdZwvobgpEWSagKt0tderx/App?node-id=15538-66699&t=xaRfD4CVRy4cliEJ-0).