### PR TITLE
fix: Remove Stations From TravelDetailsMapScreenComponent

### DIFF
--- a/src/components/map/ExploreLocationMap.tsx
+++ b/src/components/map/ExploreLocationMap.tsx
@@ -67,7 +67,7 @@ export const ExploreLocationMap = ({
     }
   };
 
-  const mapViewConfig = useMapViewConfig(false);
+  const mapViewConfig = useMapViewConfig();
 
   return (
     <View style={styles.container}>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -54,7 +54,7 @@ export const Map = (props: MapProps) => {
   const styles = useMapStyles();
   const controlStyles = useControlPositionsStyle(false);
 
-  const mapViewConfig = useMapViewConfig(false);
+  const mapViewConfig = useMapViewConfig();
 
   const startingCoordinates = useMemo(
     () =>

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -62,7 +62,7 @@ export const MapV2 = (props: MapProps) => {
   const controlStyles = useControlPositionsStyle(false);
   const isFocused = useIsFocused();
   const shouldShowVehiclesAndStations = isFocused; // don't send tile requests while in the background, and always get fresh data upon enter
-  const mapViewConfig = useMapViewConfig(shouldShowVehiclesAndStations);
+  const mapViewConfig = useMapViewConfig({shouldShowVehiclesAndStations});
 
   const startingCoordinates = useMemo(
     () =>

--- a/src/components/map/hooks/use-map-view-config.ts
+++ b/src/components/map/hooks/use-map-view-config.ts
@@ -19,10 +19,17 @@ const MapViewStaticConfig = {
   }),
 };
 
+type MapViewConfigOptions = {
+  shouldShowVehiclesAndStations?: boolean;
+  useDarkModeForV1?: boolean;
+};
+
 export const useMapViewConfig = (
-  shouldShowVehiclesAndStations: boolean,
-  useDarkModeForV1: boolean = false,
+  mapViewConfigOptions?: MapViewConfigOptions,
 ) => {
+  const {shouldShowVehiclesAndStations = false, useDarkModeForV1 = false} =
+    mapViewConfigOptions || {};
+
   const {themeName} = useThemeContext();
   const {isMapV2Enabled} = useFeatureTogglesContext();
   const mapboxJsonStyle = useMapboxJsonStyle(shouldShowVehiclesAndStations);

--- a/src/stacks-hierarchy/Root_ScooterHelp/components/UserCoordinatesMap.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/components/UserCoordinatesMap.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 export const UserCoordinatesMap = ({userCoordinates, style}: Props) => {
   const cameraRef = useRef<MapboxGL.Camera>(null);
-  const mapViewConfig = useMapViewConfig(false);
+  const mapViewConfig = useMapViewConfig();
 
   return (
     <View style={[{flex: 1}, style]}>

--- a/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
+++ b/src/tariff-zones-selector/TariffZonesSelectorMap.tsx
@@ -92,7 +92,7 @@ const TariffZonesSelectorMap = ({
     onSelect(newSelection);
   };
 
-  const mapViewConfig = useMapViewConfig(false);
+  const mapViewConfig = useMapViewConfig();
   const {isMapV2Enabled} = useFeatureTogglesContext();
 
   return (

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -74,7 +74,7 @@ export const TravelDetailsMapScreenComponent = ({
   const isFocusedAndActive = useIsFocusedAndActive();
 
   const {isMapV2Enabled} = useFeatureTogglesContext();
-  const mapViewConfig = useMapViewConfig(true);
+  const mapViewConfig = useMapViewConfig(false);
 
   const features = useMemo(() => createMapLines(legs), [legs]);
   const bounds = !vehicleWithPosition ? getMapBounds(features) : undefined;

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -74,7 +74,7 @@ export const TravelDetailsMapScreenComponent = ({
   const isFocusedAndActive = useIsFocusedAndActive();
 
   const {isMapV2Enabled} = useFeatureTogglesContext();
-  const mapViewConfig = useMapViewConfig(false);
+  const mapViewConfig = useMapViewConfig();
 
   const features = useMemo(() => createMapLines(legs), [legs]);
   const bounds = !vehicleWithPosition ? getMapBounds(features) : undefined;

--- a/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -15,7 +15,6 @@ import {
   PositionArrow,
   useControlPositionsStyle,
   useMapViewConfig,
-  VehiclesAndStations,
 } from '@atb/components/map';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useGeolocationContext} from '@atb/GeolocationContext';
@@ -160,14 +159,6 @@ export const TravelDetailsMapScreenComponent = ({
           <NationalStopRegistryFeatures
             selectedFeaturePropertyId={undefined}
             onMapItemClick={undefined}
-          />
-        )}
-        {isMapV2Enabled && (
-          <VehiclesAndStations
-            selectedFeatureId={undefined}
-            onPress={undefined}
-            showVehicles={false}
-            showStations={true}
           />
         )}
         <MapboxGL.UserLocation

--- a/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -38,7 +38,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
   const features = useMemo(() => createMapLines(mapLegs), [mapLegs]);
   const bounds = useMemo(() => getMapBounds(features), [features]);
 
-  const mapViewConfig = useMapViewConfig(false, true);
+  const mapViewConfig = useMapViewConfig({useDarkModeForV1: true});
 
   /*
    * Workaround for iOS as setting default bounds on camera is not working fully


### PR DESCRIPTION
Stations were included in this map in https://github.com/AtB-AS/mittatb-app/pull/5084, but wasn't there from before, so shouldn't be there now at least.