### PR TITLE
fix: use correct text color for button loading indicator

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -187,7 +187,10 @@ export const Button = React.forwardRef<any, ButtonProps>((props, ref) => {
         {(rightIcon || loading) && (
           <View style={rightStyling}>
             {loading ? (
-              <ActivityIndicator size="small" color={styleText.color} />
+              <ActivityIndicator
+                size="small"
+                color={mainContrastColor.foreground.primary}
+              />
             ) : (
               rightIcon && (
                 <ButtonIcon


### PR DESCRIPTION

There was an issue in the app where the loading indicator on buttons don't get the correct color, and would sometimes be almost invisible:

![Screenshot 2025-03-19 at 16 10 11](https://github.com/user-attachments/assets/637711f3-77e9-4924-9284-ac500de56da9)

This fixes this by setting it to the same color as the text color:

<div>
<img width="220px" src="https://github.com/user-attachments/assets/dfa86cda-8870-41d9-bc03-6da7f3d70d7c">
<img width="220px" src="https://github.com/user-attachments/assets/5da14396-7356-4dcf-948a-81bbcdb9653a">
<img width="220px" src="https://github.com/user-attachments/assets/ff09141f-22a7-41ce-b12c-1a702b7e851b">
</div>


### Acceptance criteria

- [ ] Loading indicators on buttons are always visible, and have the same color as the text
	- You can use storybook to verify this :)