### PR TITLE
chore: update ios xcode version

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -24,7 +24,7 @@ jobs:
         org: [atb, nfk, fram, troms]
     environment: ${{ matrix.org }}
     timeout-minutes: 360
-    runs-on: macOS-13
+    runs-on: macOS-14
     env:
       KEYCHAIN_NAME: "CI"
     steps:

--- a/.github/workflows/build-store-ios.yml
+++ b/.github/workflows/build-store-ios.yml
@@ -12,7 +12,7 @@ jobs:
         org: [atb, nfk, fram, troms]
     environment: ${{ matrix.org }}
     timeout-minutes: 360
-    runs-on: macOS-13
+    runs-on: macOS-14
     env:
       KEYCHAIN_NAME: "CI"
     steps:

--- a/.github/workflows/inspect-variable.yml
+++ b/.github/workflows/inspect-variable.yml
@@ -20,7 +20,7 @@ jobs:
     name: Inspect
     environment: ${{ inputs.org }}
     timeout-minutes: 5
-    runs-on: macOS-13
+    runs-on: macOS-14
     steps:
       - name: Curl variable
         run: curl -X POST https://us-central1-atb-mobility-platform.cloudfunctions.net/logbody -d "$VARIABLE"

--- a/.github/workflows/ios-certificates.yml
+++ b/.github/workflows/ios-certificates.yml
@@ -16,7 +16,7 @@ jobs:
     name: Nuke certificates
     environment: ${{ inputs.org }}
     timeout-minutes: 180
-    runs-on: macOS-13
+    runs-on: macOS-14
     strategy:
       matrix:
         environment: [ development, adhoc, appstore ]
@@ -49,7 +49,7 @@ jobs:
     environment: ${{ inputs.org }}
     timeout-minutes: 180
     needs: nuke-certificates
-    runs-on: macOS-13
+    runs-on: macOS-14
     strategy:
       matrix:
         environment: [ development, adhoc, appstore ]


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20165

iOS SDK 18 is available on xcode 16, which is available on target `macos-14` and later. So updating the runner to run on `macos-14`