### PR TITLE
fix: edit storybook radio button

### DIFF
--- a/src/storybook/stories/Section.stories.tsx
+++ b/src/storybook/stories/Section.stories.tsx
@@ -79,6 +79,23 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
                   onPress={() => {}}
                   selected={false}
                 />
+                <RadioSectionItem
+                  text="RadioSectionItem selected"
+                  onPress={() => {}}
+                  selected={true}
+                />
+                <RadioSectionItem
+                  text="RadioSectionItem transparent"
+                  onPress={() => {}}
+                  selected={false}
+                  transparent
+                />
+                <RadioSectionItem
+                  text="RadioSectionItem transparent selected"
+                  onPress={() => {}}
+                  selected={true}
+                  transparent
+                />
                 <CounterSectionItem
                   text="CounterSectionItem"
                   count={2}
@@ -191,12 +208,25 @@ export const RadioSection: Meta<SectionMetaProps> = {
         args={{
           ...args,
           children: (
-            <RadioGroupSection
-              items={['Radio group option 1', 'Radio group option 2']}
-              keyExtractor={(s) => s}
-              itemToText={(t) => t}
-              selected="Radio group option 1"
-            />
+            <View style={{rowGap: 20}}>
+              <RadioGroupSection
+                items={['Radio group option 1', 'Radio group option 2']}
+                keyExtractor={(s) => s}
+                itemToText={(t) => t}
+                selected="Radio group option 1"
+              />
+
+              <RadioGroupSection
+                items={[
+                  'Spacious radio group option 1',
+                  'Spacious radio group option 2',
+                ]}
+                keyExtractor={(s) => s}
+                itemToText={(t) => t}
+                selected="Spacious radio group option 1"
+                type="spacious"
+              />
+            </View>
           ),
         }}
       />

--- a/src/storybook/stories/Section.stories.tsx
+++ b/src/storybook/stories/Section.stories.tsx
@@ -208,25 +208,12 @@ export const RadioSection: Meta<SectionMetaProps> = {
         args={{
           ...args,
           children: (
-            <View style={{rowGap: 20}}>
-              <RadioGroupSection
-                items={['Radio group option 1', 'Radio group option 2']}
-                keyExtractor={(s) => s}
-                itemToText={(t) => t}
-                selected="Radio group option 1"
-              />
-
-              <RadioGroupSection
-                items={[
-                  'Spacious radio group option 1',
-                  'Spacious radio group option 2',
-                ]}
-                keyExtractor={(s) => s}
-                itemToText={(t) => t}
-                selected="Spacious radio group option 1"
-                type="spacious"
-              />
-            </View>
+            <RadioGroupSection
+              items={['Radio group option 1', 'Radio group option 2']}
+              keyExtractor={(s) => s}
+              itemToText={(t) => t}
+              selected="Radio group option 1"
+            />
           ),
         }}
       />


### PR DESCRIPTION
### Closes https://github.com/AtB-AS/kundevendt/issues/20015
From implementation of https://github.com/AtB-AS/kundevendt/issues/18735.

I hope it added some visible functionality for `RadioGroupSection` and `RadioSectionItem` components.



| Radio Section | Listed Section Items |
|--------|--------|
| ![simulator_screenshot_D9A60063-8B29-4DB8-97EC-23A0D553B6A7](https://github.com/user-attachments/assets/c566990f-8590-4c7a-b1a7-e317dee423b7) | ![simulator_screenshot_205D63DA-4359-45A3-BF4A-C4C44BF8393E](https://github.com/user-attachments/assets/4bac21b3-5556-402c-8911-3415af33b4f5) | 