### PR TITLE
fix: Change MapBox version to 10.19.0 to avoid push to apple issues

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,7 +41,7 @@ $RNMapboxMapsImpl = 'mapbox'
 # Fix for: Apple Invalid Privacy Manifest
 # https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.17.0
 # This is a temporary fix until the next release of the Mapbox Maps SDK for React Native.
-$RNMapboxMapsVersion = '~> 10.18.2'
+$RNMapboxMapsVersion = '~> 10.19.0'
 
 target 'app' do
   config = use_native_modules!


### PR DESCRIPTION
it seems like the builds are failing (not while compiling) but instead when uploading the IPA to apple,

https://github.com/AtB-AS/mittatb-app/actions/runs/14058318894/job/39362780748

I found this:

https://github.com/mapbox/mapbox-maps-ios/issues/2233

there is a workaround but the recommendation is:

`We released Maps v10.19.0 version which doesn't contain bitcode anymore in it's binaries. I'd suggest you to give it a try and get rid of workarounds.`