### PR TITLE
feat: add token renewal logic based on token and device details

### DIFF
--- a/src/mobile-token/hooks/use-validate-token.tsx
+++ b/src/mobile-token/hooks/use-validate-token.tsx
@@ -15,6 +15,7 @@ import {LOAD_NATIVE_TOKEN_QUERY_KEY} from './use-load-native-token-query';
 import {useAuthContext} from '@atb/auth';
 
 const RETRY_MAX_COUNT = 3;
+const MOBILE_TOKEN_LIBRARY_VERSION = '3.3.2';
 
 /**
  * This hook is used to check if the token needs renewal/reset.
@@ -26,14 +27,14 @@ const RETRY_MAX_COUNT = 3;
  * If the local token id doesn't exit in remote tokens list, the
  * remote token might be expired or removed, do this:
  *
- *      1.  Try renewing the token
- *      2a. If the renewal success, good
- *      2b. If renewal fails, check the error, in a normal operation
+ *    1.  Try renewing the token
+ *        - If the renewal success, good
+ *        - If renewal fails, check the error, in a normal operation
  *          it should return TokenMustBeReplacedError.
- *      3.  Wipe the token and re-create token.
- *      4.  Reset the queries so it can re-check if the token is
- *          created properly.
- *      5.  If the token creation/renewal fails, show fallback
+ *    2.  Wipe the token and re-create token.
+ *    3.  Reset the queries so it can re-check if the token is
+ *        created properly.
+ *    4.  If the token creation/renewal fails, show fallback
  *
  *
  * If the local token has a counterpart remote token, do a check whether
@@ -50,9 +51,6 @@ const RETRY_MAX_COUNT = 3;
  * - Device ID
  *
  */
-
-const MOBILE_TOKEN_LIBRARY_VERSION = '3.3.2';
-
 export const useValidateToken = (
   nativeToken: ActivatedToken | undefined,
   remoteTokens: RemoteToken[] | undefined,

--- a/src/mobile-token/hooks/use-validate-token.tsx
+++ b/src/mobile-token/hooks/use-validate-token.tsx
@@ -1,0 +1,139 @@
+import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
+import {RemoteToken} from '../types';
+import {useQueryClient} from '@tanstack/react-query';
+import {useEffect, useState} from 'react';
+import {mobileTokenClient} from '../mobileTokenClient';
+import {
+  getMobileTokenErrorHandlingStrategy,
+  MOBILE_TOKEN_QUERY_KEY,
+  wipeToken,
+} from '../utils';
+import {logToBugsnag} from '@atb/utils/bugsnag-utils';
+import DeviceInfo from 'react-native-device-info';
+import {Platform} from 'react-native';
+
+const RETRY_MAX_COUNT = 3;
+
+/**
+ * This hook is used to check if the token needs renewal/reset.
+ *
+ * After loading both local/native token and remote tokens list,
+ * check if the local token has a counterpart remote token.
+ *
+ * If the local token id exists in remote tokens list id, do nothing.
+ * If the local token id doesn't exit in remote tokens list, the
+ * remote token might be expired or removed, do this:
+ *
+ *      1.  Try renewing the token
+ *      2a. If the renewal success, good
+ *      2b. If renewal fails, check the error, in a normal operation
+ *          it should return TokenMustBeReplacedError.
+ *      3.  Wipe the token and re-create token.
+ *      4.  Reset the queries so it can re-check if the token is
+ *          created properly.
+ *      5.  If the token creation/renewal fails, show fallback
+ *
+ *
+ * If the local token has a counterpart remote token, do a check whether
+ * we need to renew the token or not. If any of the information on the
+ * remote token details is different to the local token information,
+ * renew the token.
+ *
+ * The information that we use to check token renewal are:
+ * - OS version
+ * - OS API Level
+ * - App version
+ * - App version code (build number)
+ * - Library version
+ * - Device ID
+ *
+ */
+export const useValidateToken = (
+  nativeToken: ActivatedToken | undefined,
+  remoteTokens: RemoteToken[] | undefined,
+  traceId: string,
+) => {
+  const queryClient = useQueryClient();
+  const [retryCount, setRetryCount] = useState<number>(0);
+  const [isRenewingOrResetting, setIsRenewingOrResetting] = useState(false);
+
+  useEffect(() => {
+    const renewOrResetToken = async (
+      token: ActivatedToken,
+      traceId: string,
+    ) => {
+      try {
+        logToBugsnag(`Try renewing token ${token.tokenId}`);
+        setIsRenewingOrResetting(true);
+        const renewedToken = await mobileTokenClient.renew(token, traceId);
+        logToBugsnag(`Succesfully renewed token ${renewedToken.tokenId}`);
+      } catch (error: any) {
+        logToBugsnag(
+          `Error renewing token ${token.tokenId} with trace ID ${traceId}`,
+        );
+        if (getMobileTokenErrorHandlingStrategy(error) === 'reset') {
+          logToBugsnag(`Error handling during renewal suggests resetting`);
+          logToBugsnag(
+            `Wiping token ${token.tokenId} with trace ID ${traceId}`,
+          );
+          await wipeToken([token.tokenId], traceId);
+          logToBugsnag(`Token wiped`);
+        }
+      } finally {
+        logToBugsnag(`Resetting queries to restart token process`);
+        queryClient.resetQueries([MOBILE_TOKEN_QUERY_KEY]);
+        setIsRenewingOrResetting(false);
+        setRetryCount((previous) => previous + 1);
+      }
+    };
+
+    const checkShouldRenew = async (remoteToken: RemoteToken) => {
+      const apiLevel =
+        Platform.OS === 'ios'
+          ? DeviceInfo.getSystemVersion()
+          : DeviceInfo.getApiLevelSync();
+      const isOsVersionSame =
+        remoteToken.osVersion === DeviceInfo.getSystemVersion();
+      const isOsApiLevelSame = remoteToken.osApiLevel === apiLevel.toString();
+      const isAppVersionSame =
+        remoteToken.appVersion === DeviceInfo.getVersion();
+      const isAppVersionCodeSame =
+        remoteToken.appVersionCode === DeviceInfo.getBuildNumber();
+      const isDeviceIdSame =
+        remoteToken.deviceId === (await DeviceInfo.getUniqueId());
+      // match the library version here with the package.json version;
+      const isLibraryVersionSame = remoteToken.libraryVersion === '3.3.2';
+
+      return !(
+        isOsVersionSame &&
+        isOsApiLevelSame &&
+        isAppVersionSame &&
+        isAppVersionCodeSame &&
+        isDeviceIdSame &&
+        isLibraryVersionSame
+      );
+    };
+
+    if (remoteTokens && nativeToken) {
+      const token = remoteTokens.find(
+        (token) => token.id === nativeToken.tokenId,
+      );
+      if (!token && retryCount < RETRY_MAX_COUNT) {
+        logToBugsnag(
+          `Token ${nativeToken.tokenId} does not exist on remote, should try to renew or reset the token.`,
+        );
+        renewOrResetToken(nativeToken, traceId);
+      }
+
+      if (token && token.type === 'mobile') {
+        checkShouldRenew(token).then((shouldRenew) => {
+          if (shouldRenew) renewOrResetToken(nativeToken, traceId);
+        });
+      }
+    }
+  }, [queryClient, nativeToken, remoteTokens, retryCount, traceId]);
+
+  return {
+    isRenewingOrResetting,
+  };
+};

--- a/src/mobile-token/hooks/use-validate-token.tsx
+++ b/src/mobile-token/hooks/use-validate-token.tsx
@@ -118,7 +118,8 @@ export const useValidateToken = (
       const isDeviceIdSame =
         remoteToken.deviceId === (await DeviceInfo.getUniqueId());
       // match the library version here with the package.json version;
-      const isLibraryVersionSame = remoteToken.libraryVersion === MOBILE_TOKEN_LIBRARY_VERSION;
+      const isLibraryVersionSame =
+        remoteToken.libraryVersion === MOBILE_TOKEN_LIBRARY_VERSION;
 
       logToBugsnag(
         `Checking token details to see if we should renew the token`,
@@ -177,7 +178,9 @@ export const useValidateToken = (
       if (token && token.type === 'mobile') {
         checkShouldRenew(token).then((shouldRenew) => {
           if (shouldRenew) {
-            logToBugsnag('Token should be renewed because there are difference between details on the token and the device')
+            logToBugsnag(
+              'Token should be renewed because there are difference between details on the token and the device',
+            );
             renewOrResetToken(nativeToken, traceId);
           }
         });

--- a/src/mobile-token/index.ts
+++ b/src/mobile-token/index.ts
@@ -4,3 +4,4 @@ export {
 } from './MobileTokenContext';
 export type {Token, MobileTokenStatus} from './types';
 export {useToggleTokenMutation} from './hooks/use-toggle-token-mutation';
+export {useValidateToken} from './hooks/use-validate-token';

--- a/src/mobile-token/types.ts
+++ b/src/mobile-token/types.ts
@@ -16,6 +16,12 @@ export type RemoteToken = {
   type: string;
   state: string;
   allowedActions: string[];
+  deviceId?: string;
+  libraryVersion?: string;
+  appVersion?: string;
+  appVersionCode?: string;
+  osVersion?: string;
+  osApiLevel?: string;
   keyValues?: KeyValue[];
 };
 


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/20216#issuecomment-2747889695

This PR will add logic for token renewal based on remote token details and device details. The remote token details came from this PR https://github.com/AtB-AS/abt-token-server/pull/96. 

Token renewal logic:

- Get local token
- Get remote tokens
- Check if local token id exists on remote tokens
- Get the remote token that has the same id as local
- Find the details of that remote token, and compare to the current device situation (app version, OS level, device ID, etc.).
- If any of the details are different between device situation and remote token details, renew the token.

I made a custom hook for this PR and moved all renewal/reset logic into the hook `use-validate-token`.

### Acceptance criteria
- [ ] Updating from older version of app should renew the token