### PR TITLE
refactor: use secure container for list remote token query

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -59,6 +59,7 @@ type MobileTokenContextState = {
   clearTokenAtLogout: () => Promise<void>;
   getTokenToggleDetails: () => Promise<TokenLimitResponse | undefined>;
   nativeToken?: ActivatedToken;
+  secureContainer?: string;
   /**
    * Low level debug details and functions of the mobile token process, for the
    * debug screen
@@ -237,6 +238,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
         }, [queryClient, nativeToken]),
         getTokenToggleDetails,
         nativeToken,
+        secureContainer,
         debug: {
           nativeTokenStatus,
           remoteTokensStatus,

--- a/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
+++ b/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
@@ -12,13 +12,13 @@ import {Token} from '@atb/mobile-token/types';
 import {v4 as uuid} from 'uuid';
 import {useAuthContext} from '@atb/auth';
 import {logToBugsnag} from '@atb/utils/bugsnag-utils';
-import {mobileTokenClient} from '../mobileTokenClient';
 
 export const LIST_REMOTE_TOKENS_QUERY_KEY = 'listRemoteTokens';
 
 export const useListRemoteTokensQuery = (
   enabled: boolean,
-  nativeToken?: ActivatedToken,
+  tokenId?: string,
+  secureContainer?: string,
 ) => {
   const {userId} = useAuthContext();
   return useQuery({
@@ -26,20 +26,19 @@ export const useListRemoteTokensQuery = (
       MOBILE_TOKEN_QUERY_KEY,
       LIST_REMOTE_TOKENS_QUERY_KEY,
       userId,
-      nativeToken,
+      tokenId,
+      secureContainer,
     ],
     queryFn: async () => {
       logToBugsnag('Listing tokens for user ' + userId);
-      const secureContainer =
-        nativeToken && (await mobileTokenClient.encode(nativeToken));
-      return tokenService.listTokens(secureContainer, uuid());
+      return await tokenService.listTokens(secureContainer, uuid());
     },
     enabled,
     select: (tokens) =>
       tokens.map(
         (t): Token => ({
           ...t,
-          isThisDevice: t.id === nativeToken?.tokenId,
+          isThisDevice: t.id === tokenId,
           isInspectable: isInspectable(t),
           type: isTravelCardToken(t) ? 'travel-card' : 'mobile',
           travelCardId: getTravelCardId(t),

--- a/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
+++ b/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
@@ -1,6 +1,5 @@
 import {useQuery} from '@tanstack/react-query';
 import {tokenService} from '@atb/mobile-token/tokenService';
-import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
 import {
   getTravelCardId,
   isInspectable,

--- a/src/mobile-token/hooks/use-preemptive-renew-token-mutation.tsx
+++ b/src/mobile-token/hooks/use-preemptive-renew-token-mutation.tsx
@@ -2,7 +2,6 @@ import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import Bugsnag from '@bugsnag/react-native';
 import {mobileTokenClient} from '../mobileTokenClient';
-import {LIST_REMOTE_TOKENS_QUERY_KEY} from './use-list-remote-tokens-query';
 import {LOAD_NATIVE_TOKEN_QUERY_KEY} from './use-load-native-token-query';
 import {
   getMobileTokenErrorHandlingStrategy,
@@ -42,10 +41,6 @@ export const usePreemptiveRenewTokenMutation = (userId?: string) => {
     },
     onSuccess: (renewedToken) => {
       if (renewedToken) {
-        queryClient.invalidateQueries([
-          MOBILE_TOKEN_QUERY_KEY,
-          LIST_REMOTE_TOKENS_QUERY_KEY,
-        ]);
         queryClient.setQueryData(
           [MOBILE_TOKEN_QUERY_KEY, LOAD_NATIVE_TOKEN_QUERY_KEY, userId],
           renewedToken,


### PR DESCRIPTION
part of https://github.com/AtB-AS/kundevendt/issues/20216#issuecomment-2747955834

Uses `securecontainer` string instead of whole native token object for list remote token query.

This should be merged before https://github.com/AtB-AS/mittatb-app/pull/5104