### PR TITLE
fix: use fare contract id as key in active tickets list

### DIFF
--- a/src/modules/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/modules/fare-contracts/FareContractAndReservationsList.tsx
@@ -61,7 +61,11 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
               onPressFareContract(fcOrReservation.id);
             }
           }}
-          key={fcOrReservation.orderId}
+          key={
+            'id' in fcOrReservation
+              ? fcOrReservation.id
+              : fcOrReservation.orderId
+          }
           fcOrReservation={fcOrReservation}
           index={index}
         />


### PR DESCRIPTION
Order ID isn't a unique key for school tickets and frikort, since the order id is `""`. This caused duplicate tickets to appear in active tickets when a school ticket was activated.

### Acceptance criteria

- [ ] Using a account with several school tickets or frikort, activating a school ticket shouldn't cause duplicate tickets in active tickets.