### PR TITLE
feat: get bonus balance from bonus service

### DIFF
--- a/src/mobility/components/BikeStationBottomSheet.tsx
+++ b/src/mobility/components/BikeStationBottomSheet.tsx
@@ -153,7 +153,7 @@ export const BikeStationBottomSheet = ({
                       (payWithBonusPoints) => !payWithBonusPoints,
                     )
                   }
-                  style={styles.useBonusPointsSection}
+                  style={styles.payWithBonusPointsSection}
                 />
               )}
             </ScrollView>
@@ -216,7 +216,7 @@ const useSheetStyle = StyleSheet.createThemeHook((theme) => {
     operatorNameAndLogo: {
       flexDirection: 'row',
     },
-    useBonusPointsSection: {
+    payWithBonusPointsSection: {
       marginTop: theme.spacing.medium,
     },
   };

--- a/src/modules/bonus/api/api.ts
+++ b/src/modules/bonus/api/api.ts
@@ -1,6 +1,6 @@
 import {client} from '@atb/api';
 
-export const getBonusBalance = (): Promise<number | null> => {
+export const getBonusBalance = (): Promise<number> => {
   return client
     .get(`/bonus/v1/balance`, {
       authWithIdToken: true,

--- a/src/modules/bonus/api/api.ts
+++ b/src/modules/bonus/api/api.ts
@@ -1,0 +1,12 @@
+import {client} from '@atb/api';
+
+export const getBonusBalance = (): Promise<number | null> => {
+  return client
+    .get(`/bonus/v1/balance`, {
+      authWithIdToken: true,
+      skipErrorLogging: (error) => error.response?.status === 404,
+    })
+    .then((response) => {
+      return Number(response.data.balance);
+    });
+};

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -52,56 +52,60 @@ export const PayWithBonusPointsCheckbox = ({
     );
 
   return (
-    <Section {...props}>
-      <GenericClickableSectionItem
-        active={isChecked}
-        onPress={onPress}
-        disabled={disabled}
-        accessibilityRole="checkbox"
-        accessibilityState={{checked: isChecked}}
-        accessibilityLabel={a11yLabel}
-      >
-        <View style={styles.container}>
-          <Checkbox checked={isChecked} />
-          <View style={styles.textContainer}>
-            <ThemeText>
-              {getTextForLanguage(bonusProduct.paymentDescription, language) ??
-                ''}
-            </ThemeText>
-            {userBonusBalanceStatus === 'error' && (
-              <MessageInfoBox
-                type="error"
-                message={t(BonusProgramTexts.bonusProfile.noBonusBalance)}
-              />
-            )}
-            <View style={styles.currentPointsRow}>
-              <ThemeText typography="body__secondary" color="secondary">
-                {t(BonusProgramTexts.youHave)}{' '}
-                {(() => {
-                  switch (userBonusBalanceStatus) {
-                    case 'loading':
-                      return <ActivityIndicator />;
-                    case 'error':
-                      return '--';
-                    default:
-                      return userBonusBalance;
-                  }
-                })()}
+    <>
+      <Section {...props}>
+        <GenericClickableSectionItem
+          active={isChecked}
+          onPress={onPress}
+          disabled={disabled}
+          accessibilityRole="checkbox"
+          accessibilityState={{checked: isChecked}}
+          accessibilityLabel={a11yLabel}
+        >
+          <View style={styles.container}>
+            <Checkbox checked={isChecked} />
+            <View style={styles.textContainer}>
+              <ThemeText>
+                {getTextForLanguage(
+                  bonusProduct.paymentDescription,
+                  language,
+                ) ?? ''}
               </ThemeText>
-              <ThemeIcon
-                color={theme.color.foreground.dynamic.secondary}
-                svg={StarFill}
-                size="small"
-              />
+              <View style={styles.currentPointsRow}>
+                <ThemeText typography="body__secondary" color="secondary">
+                  {t(BonusProgramTexts.youHave)}{' '}
+                  {(() => {
+                    switch (userBonusBalanceStatus) {
+                      case 'loading':
+                        return <ActivityIndicator />;
+                      case 'error':
+                        return '--';
+                      default:
+                        return userBonusBalance;
+                    }
+                  })()}
+                </ThemeText>
+                <ThemeIcon
+                  color={theme.color.foreground.dynamic.secondary}
+                  svg={StarFill}
+                  size="small"
+                />
+              </View>
             </View>
+            <BonusPriceTag
+              amount={bonusProduct.price.amount}
+              style={{alignSelf: 'flex-start'}}
+            />
           </View>
-          <BonusPriceTag
-            amount={bonusProduct.price.amount}
-            style={{alignSelf: 'flex-start'}}
-          />
-        </View>
-      </GenericClickableSectionItem>
-    </Section>
+        </GenericClickableSectionItem>
+      </Section>
+      {userBonusBalanceStatus === 'error' && (
+        <MessageInfoBox
+          type="error"
+          message={t(BonusProgramTexts.bonusProfile.noBonusBalance)}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -45,8 +45,9 @@ export const PayWithBonusPointsCheckbox = ({
     screenReaderPause +
     t(
       BonusProgramTexts.yourBonusBalanceA11yLabel(
-        userBonusBalance,
-        userBonusBalanceStatus,
+        userBonusBalance && userBonusBalanceStatus === 'success'
+          ? userBonusBalance
+          : null,
       ),
     );
 

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -6,17 +6,16 @@ import {
   SectionProps,
 } from '@atb/components/sections';
 import {ThemeText, screenReaderPause} from '@atb/components/text';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {BonusProductType} from '@atb/configuration/types';
-import {StyleSheet, useThemeContext} from '@atb/theme';
-import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+import {StyleSheet} from '@atb/theme';
 import {
   BonusProgramTexts,
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {ActivityIndicator, View} from 'react-native';
+import {View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
+import {UserBonusBalance} from './UserBonusBalance';
 
 type Props = SectionProps & {
   bonusProduct: BonusProductType;
@@ -32,7 +31,6 @@ export const PayWithBonusPointsCheckbox = ({
 }: Props) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
-  const {theme} = useThemeContext();
 
   const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
@@ -47,7 +45,8 @@ export const PayWithBonusPointsCheckbox = ({
     screenReaderPause +
     t(
       BonusProgramTexts.yourBonusBalanceA11yLabel(
-        userBonusBalanceStatus === 'error' ? null : userBonusBalance,
+        userBonusBalance,
+        userBonusBalanceStatus,
       ),
     );
 
@@ -73,23 +72,9 @@ export const PayWithBonusPointsCheckbox = ({
               </ThemeText>
               <View style={styles.currentPointsRow}>
                 <ThemeText typography="body__secondary" color="secondary">
-                  {t(BonusProgramTexts.youHave)}{' '}
-                  {(() => {
-                    switch (userBonusBalanceStatus) {
-                      case 'loading':
-                        return <ActivityIndicator />;
-                      case 'error':
-                        return '--';
-                      default:
-                        return userBonusBalance;
-                    }
-                  })()}
+                  {t(BonusProgramTexts.youHave)}
                 </ThemeText>
-                <ThemeIcon
-                  color={theme.color.foreground.dynamic.secondary}
-                  svg={StarFill}
-                  size="small"
-                />
+                <UserBonusBalance size="small" />
               </View>
             </View>
             <BonusPriceTag

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -87,6 +87,7 @@ export const PayWithBonusPointsCheckbox = ({
       </Section>
       {userBonusBalanceStatus === 'error' && (
         <MessageInfoBox
+          style={styles.errorMessage}
           type="error"
           message={t(BonusProgramTexts.bonusProfile.noBonusBalance)}
         />
@@ -109,4 +110,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     gap: theme.spacing.xSmall,
   },
   textContainer: {flex: 1},
+  errorMessage: {
+    marginTop: theme.spacing.medium,
+  },
 }));

--- a/src/modules/bonus/components/UserBonusBalance.tsx
+++ b/src/modules/bonus/components/UserBonusBalance.tsx
@@ -1,0 +1,43 @@
+import {TextNames, useThemeContext} from '@atb/theme';
+import {ReactNode} from 'react';
+import {ActivityIndicator} from 'react-native';
+import {useBonusBalanceQuery} from '..';
+import {ThemeText} from '@atb/components/text';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+
+type Props = {
+  size: 'small' | 'large';
+};
+
+const TYPOGRAPHY_MAPPING: Record<Props['size'], TextNames> = {
+  small: 'body__secondary',
+  large: 'body__primary--jumbo--bold',
+};
+
+export const UserBonusBalance = ({size}: Props) => {
+  const {theme} = useThemeContext();
+
+  const {data: userBonusBalance, status: userBonusBalanceStatus} =
+    useBonusBalanceQuery();
+
+  let BonusBalance: number | ReactNode | null | undefined = userBonusBalance;
+  if (userBonusBalanceStatus === 'loading') {
+    BonusBalance = <ActivityIndicator />;
+  } else if (userBonusBalanceStatus === 'error') {
+    BonusBalance = '--';
+  }
+
+  return (
+    <>
+      <ThemeText typography={TYPOGRAPHY_MAPPING[size]} color="secondary">
+        {BonusBalance}
+      </ThemeText>
+      <ThemeIcon
+        color={theme.color.foreground.dynamic.secondary}
+        svg={StarFill}
+        size={size}
+      />
+    </>
+  );
+};

--- a/src/modules/bonus/components/UserBonusBalance.tsx
+++ b/src/modules/bonus/components/UserBonusBalance.tsx
@@ -1,5 +1,4 @@
 import {TextNames, useThemeContext} from '@atb/theme';
-import {ReactNode} from 'react';
 import {ActivityIndicator} from 'react-native';
 import {useBonusBalanceQuery} from '..';
 import {ThemeText} from '@atb/components/text';

--- a/src/modules/bonus/components/UserBonusBalance.tsx
+++ b/src/modules/bonus/components/UserBonusBalance.tsx
@@ -10,7 +10,7 @@ type Props = {
   size: 'small' | 'large';
 };
 
-const TYPOGRAPHY_MAPPING: Record<Props['size'], TextNames> = {
+const TYPOGRAPHY_BONUS_BALANCE: Record<Props['size'], TextNames> = {
   small: 'body__secondary',
   large: 'body__primary--jumbo--bold',
 };
@@ -21,18 +21,18 @@ export const UserBonusBalance = ({size}: Props) => {
   const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
 
-  let BonusBalance: number | ReactNode | null | undefined = userBonusBalance;
-  if (userBonusBalanceStatus === 'loading') {
-    BonusBalance = <ActivityIndicator />;
-  } else if (userBonusBalanceStatus === 'error') {
-    BonusBalance = '--';
-  }
-
   return (
     <>
-      <ThemeText typography={TYPOGRAPHY_MAPPING[size]} color="secondary">
-        {BonusBalance}
-      </ThemeText>
+      {userBonusBalanceStatus === 'loading' ? (
+        <ActivityIndicator />
+      ) : (
+        <ThemeText
+          typography={TYPOGRAPHY_BONUS_BALANCE[size]}
+          color="secondary"
+        >
+          {userBonusBalance ?? '--'}
+        </ThemeText>
+      )}
       <ThemeIcon
         color={theme.color.foreground.dynamic.secondary}
         svg={StarFill}

--- a/src/modules/bonus/components/index.tsx
+++ b/src/modules/bonus/components/index.tsx
@@ -1,2 +1,3 @@
 export {PayWithBonusPointsCheckbox} from './PayWithBonusPointsCheckbox';
 export {BonusPriceTag} from './BonusPriceTag';
+export {UserBonusBalance} from './UserBonusBalance';

--- a/src/modules/bonus/index.tsx
+++ b/src/modules/bonus/index.tsx
@@ -1,3 +1,3 @@
 export {BonusPriceTag, PayWithBonusPointsCheckbox} from './components';
-
 export {isActive, findRelevantBonusProduct} from './utils';
+export {useBonusBalanceQuery} from './queries/get-bonus-balance-query';

--- a/src/modules/bonus/index.tsx
+++ b/src/modules/bonus/index.tsx
@@ -1,3 +1,7 @@
-export {BonusPriceTag, PayWithBonusPointsCheckbox} from './components';
+export {
+  BonusPriceTag,
+  PayWithBonusPointsCheckbox,
+  UserBonusBalance,
+} from './components';
 export {isActive, findRelevantBonusProduct} from './utils';
 export {useBonusBalanceQuery} from './queries/get-bonus-balance-query';

--- a/src/modules/bonus/queries/get-bonus-balance-query.tsx
+++ b/src/modules/bonus/queries/get-bonus-balance-query.tsx
@@ -1,0 +1,12 @@
+import {useQuery} from '@tanstack/react-query';
+import {useAuthContext} from '@atb/auth';
+import {getBonusBalance} from '../api/api';
+
+export const useBonusBalanceQuery = () => {
+  const {userId, authStatus} = useAuthContext();
+  return useQuery({
+    queryKey: ['bonusUserBalance', userId],
+    queryFn: getBonusBalance,
+    enabled: authStatus === 'authenticated',
+  });
+};

--- a/src/modules/bonus/queries/get-bonus-balance-query.tsx
+++ b/src/modules/bonus/queries/get-bonus-balance-query.tsx
@@ -1,12 +1,15 @@
 import {useQuery} from '@tanstack/react-query';
 import {useAuthContext} from '@atb/auth';
 import {getBonusBalance} from '../api/api';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export const useBonusBalanceQuery = () => {
   const {userId, authStatus} = useAuthContext();
+  const {isBonusProgramEnabled} = useFeatureTogglesContext();
+
   return useQuery({
     queryKey: ['bonusUserBalance', userId],
     queryFn: getBonusBalance,
-    enabled: authStatus === 'authenticated',
+    enabled: authStatus === 'authenticated' && isBonusProgramEnabled,
   });
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -10,14 +10,18 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {View} from 'react-native';
+import {ActivityIndicator, View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemedCityBike} from '@atb/theme/ThemedAssets'; // TODO: update with new illustration when available
 import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
 import {ContentHeading} from '@atb/components/heading';
-import {BonusPriceTag, isActive} from '@atb/modules/bonus';
+import {
+  BonusPriceTag,
+  isActive,
+  useBonusBalanceQuery,
+} from '@atb/modules/bonus';
 import {useAuthContext} from '@atb/auth';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useFirestoreConfigurationContext} from '@atb/configuration';
@@ -28,12 +32,13 @@ export const Profile_BonusScreen = () => {
   const styles = useStyles();
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
+  const {data: userBonusPoints, status: userBonusPointsStatus} =
+    useBonusBalanceQuery();
   const {bonusProducts, mobilityOperators, bonusTexts} =
     useFirestoreConfigurationContext();
   const [currentlyOpenBonusProduct, setCurrentlyOpenBonusProduct] =
     useState<number>();
 
-  const userBonusPoints = 5; // TODO: get actual value when available
   const activeBonusProducts = bonusProducts?.filter(isActive);
 
   return (
@@ -52,29 +57,10 @@ export const Profile_BonusScreen = () => {
             />
           </View>
         )}
-        <Section>
-          <GenericSectionItem style={styles.horizontalContainer}>
-            <View
-              accessible
-              accessibilityLabel={t(
-                BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
-                  userBonusPoints,
-                ),
-              )}
-            >
-              <View style={styles.currentPointsDisplay}>
-                <ThemeText typography="body__primary--jumbo--bold">
-                  {userBonusPoints}
-                </ThemeText>
-                <ThemeIcon svg={StarFill} size="large" />
-              </View>
-              <ThemeText typography="body__secondary" color="secondary">
-                {t(BonusProgramTexts.bonusProfile.yourBonusPoints)}
-              </ThemeText>
-            </View>
-            <ThemedCityBike />
-          </GenericSectionItem>
-        </Section>
+        <UserBonusPointsSection
+          userBonusPoints={userBonusPoints}
+          userBonusPointsStatus={userBonusPointsStatus}
+        />
         <ContentHeading
           text={t(BonusProgramTexts.bonusProfile.spendPoints.heading)}
         />
@@ -179,6 +165,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     gap: theme.spacing.medium,
+    height: theme.typography['body__primary--jumbo'].lineHeight,
   },
   noAccount: {marginTop: theme.spacing.xSmall},
   bonusProductsContainer: {
@@ -197,3 +184,55 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     gap: theme.spacing.xSmall,
   },
 }));
+
+type UserBonusPointsSectionProps = {
+  userBonusPointsStatus: 'loading' | 'error' | 'success';
+  userBonusPoints: number | null | undefined;
+};
+
+function UserBonusPointsSection({
+  userBonusPointsStatus,
+  userBonusPoints,
+}: UserBonusPointsSectionProps): JSX.Element {
+  const styles = useStyles();
+  const {t} = useTranslation();
+
+  return (
+    <>
+      {userBonusPointsStatus === 'error' && (
+        <MessageInfoBox
+          type="error"
+          message="Vi klarer ikke å hente dine bonuspoeng nå. Du vil fortsatt tjene poeng som vanlig."
+        />
+      )}
+      <Section>
+        <GenericSectionItem style={styles.horizontalContainer}>
+          <View
+            accessible
+            accessibilityLabel={t(
+              BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
+                userBonusPointsStatus === 'error' ? 0 : userBonusPoints,
+              ),
+            )}
+          >
+            <View style={styles.currentPointsDisplay}>
+              {userBonusPointsStatus === 'loading' ? (
+                <ActivityIndicator />
+              ) : (
+                <ThemeText typography="body__primary--jumbo--bold">
+                  {userBonusPointsStatus === 'error' ? '--' : userBonusPoints}
+                </ThemeText>
+              )}
+              <ThemeIcon svg={StarFill} size="large" />
+            </View>
+
+            <ThemeText typography="body__secondary" color="secondary">
+              {t(BonusProgramTexts.bonusProfile.yourBonusPoints)}
+            </ThemeText>
+          </View>
+          <ThemedCityBike />
+        </GenericSectionItem>
+      </Section>
+    </>
+  );
+}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -10,15 +10,14 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {ActivityIndicator, View} from 'react-native';
+import {View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ThemeText} from '@atb/components/text';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemedCityBike} from '@atb/theme/ThemedAssets'; // TODO: update with new illustration when available
-import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
 import {ContentHeading} from '@atb/components/heading';
 import {
   BonusPriceTag,
+  UserBonusBalance,
   isActive,
   useBonusBalanceQuery,
 } from '@atb/modules/bonus';
@@ -32,8 +31,6 @@ export const Profile_BonusScreen = () => {
   const styles = useStyles();
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
-  const {data: userBonusBalance, status: userBonusBalanceStatus} =
-    useBonusBalanceQuery();
   const {bonusProducts, mobilityOperators, bonusTexts} =
     useFirestoreConfigurationContext();
   const [currentlyOpenBonusProduct, setCurrentlyOpenBonusProduct] =
@@ -57,10 +54,7 @@ export const Profile_BonusScreen = () => {
             />
           </View>
         )}
-        <UserBonusBalanceSection
-          userBonusBalance={userBonusBalance}
-          userBonusBalanceStatus={userBonusBalanceStatus}
-        />
+        <UserBonusBalanceSection />
         <ContentHeading
           text={t(BonusProgramTexts.bonusProfile.spendPoints.heading)}
         />
@@ -185,17 +179,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-type UserBonusBalanceSectionProps = {
-  userBonusBalanceStatus: 'loading' | 'error' | 'success';
-  userBonusBalance: number | null | undefined;
-};
-
-function UserBonusBalanceSection({
-  userBonusBalanceStatus,
-  userBonusBalance,
-}: UserBonusBalanceSectionProps): JSX.Element {
+function UserBonusBalanceSection(): JSX.Element {
   const styles = useStyles();
   const {t} = useTranslation();
+  const {data: userBonusBalance, status: userBonusBalanceStatus} =
+    useBonusBalanceQuery();
 
   return (
     <>
@@ -205,19 +193,13 @@ function UserBonusBalanceSection({
             accessible
             accessibilityLabel={t(
               BonusProgramTexts.yourBonusBalanceA11yLabel(
-                userBonusBalanceStatus === 'error' ? null : userBonusBalance,
+                userBonusBalance,
+                userBonusBalanceStatus,
               ),
             )}
           >
             <View style={styles.currentBalanceDisplay}>
-              {userBonusBalanceStatus === 'loading' ? (
-                <ActivityIndicator />
-              ) : (
-                <ThemeText typography="body__primary--jumbo--bold">
-                  {userBonusBalanceStatus === 'error' ? '--' : userBonusBalance}
-                </ThemeText>
-              )}
-              <ThemeIcon svg={StarFill} size="large" />
+              <UserBonusBalance size="large" />
             </View>
 
             <ThemeText typography="body__secondary" color="secondary">

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -193,8 +193,9 @@ function UserBonusBalanceSection(): JSX.Element {
             accessible
             accessibilityLabel={t(
               BonusProgramTexts.yourBonusBalanceA11yLabel(
-                userBonusBalance,
-                userBonusBalanceStatus,
+                userBonusBalance && userBonusBalanceStatus === 'success'
+                  ? userBonusBalance
+                  : null,
               ),
             )}
           >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -199,12 +199,6 @@ function UserBonusBalanceSection({
 
   return (
     <>
-      {userBonusBalanceStatus === 'error' && (
-        <MessageInfoBox
-          type="error"
-          message={t(BonusProgramTexts.bonusProfile.noBonusBalance)}
-        />
-      )}
       <Section>
         <GenericSectionItem style={styles.horizontalContainer}>
           <View
@@ -233,6 +227,12 @@ function UserBonusBalanceSection({
           <ThemedCityBike />
         </GenericSectionItem>
       </Section>
+      {userBonusBalanceStatus === 'error' && (
+        <MessageInfoBox
+          type="error"
+          message={t(BonusProgramTexts.bonusProfile.noBonusBalance)}
+        />
+      )}
     </>
   );
 }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -202,7 +202,7 @@ function UserBonusBalanceSection({
       {userBonusBalanceStatus === 'error' && (
         <MessageInfoBox
           type="error"
-          message="Vi klarer ikke å hente dine bonuspoeng nå. Du vil fortsatt tjene poeng som vanlig."
+          message={t(BonusProgramTexts.bonusProfile.noBonusBalance)}
         />
       )}
       <Section>
@@ -210,8 +210,8 @@ function UserBonusBalanceSection({
           <View
             accessible
             accessibilityLabel={t(
-              BonusProgramTexts.bonusProfile.yourBonusBalanceA11yLabel(
-                userBonusBalanceStatus === 'error' ? 0 : userBonusBalance,
+              BonusProgramTexts.yourBonusBalanceA11yLabel(
+                userBonusBalanceStatus === 'error' ? null : userBonusBalance,
               ),
             )}
           >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -32,7 +32,7 @@ export const Profile_BonusScreen = () => {
   const styles = useStyles();
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
-  const {data: userBonusPoints, status: userBonusPointsStatus} =
+  const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
   const {bonusProducts, mobilityOperators, bonusTexts} =
     useFirestoreConfigurationContext();
@@ -57,9 +57,9 @@ export const Profile_BonusScreen = () => {
             />
           </View>
         )}
-        <UserBonusPointsSection
-          userBonusPoints={userBonusPoints}
-          userBonusPointsStatus={userBonusPointsStatus}
+        <UserBonusBalanceSection
+          userBonusBalance={userBonusBalance}
+          userBonusBalanceStatus={userBonusBalanceStatus}
         />
         <ContentHeading
           text={t(BonusProgramTexts.bonusProfile.spendPoints.heading)}
@@ -161,7 +161,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
     gap: theme.spacing.small,
   },
-  currentPointsDisplay: {
+  currentBalanceDisplay: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: theme.spacing.medium,
@@ -185,21 +185,21 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
 }));
 
-type UserBonusPointsSectionProps = {
-  userBonusPointsStatus: 'loading' | 'error' | 'success';
-  userBonusPoints: number | null | undefined;
+type UserBonusBalanceSectionProps = {
+  userBonusBalanceStatus: 'loading' | 'error' | 'success';
+  userBonusBalance: number | null | undefined;
 };
 
-function UserBonusPointsSection({
-  userBonusPointsStatus,
-  userBonusPoints,
-}: UserBonusPointsSectionProps): JSX.Element {
+function UserBonusBalanceSection({
+  userBonusBalanceStatus,
+  userBonusBalance,
+}: UserBonusBalanceSectionProps): JSX.Element {
   const styles = useStyles();
   const {t} = useTranslation();
 
   return (
     <>
-      {userBonusPointsStatus === 'error' && (
+      {userBonusBalanceStatus === 'error' && (
         <MessageInfoBox
           type="error"
           message="Vi klarer ikke å hente dine bonuspoeng nå. Du vil fortsatt tjene poeng som vanlig."
@@ -210,17 +210,17 @@ function UserBonusPointsSection({
           <View
             accessible
             accessibilityLabel={t(
-              BonusProgramTexts.bonusProfile.yourBonusPointsA11yLabel(
-                userBonusPointsStatus === 'error' ? 0 : userBonusPoints,
+              BonusProgramTexts.bonusProfile.yourBonusBalanceA11yLabel(
+                userBonusBalanceStatus === 'error' ? 0 : userBonusBalance,
               ),
             )}
           >
-            <View style={styles.currentPointsDisplay}>
-              {userBonusPointsStatus === 'loading' ? (
+            <View style={styles.currentBalanceDisplay}>
+              {userBonusBalanceStatus === 'loading' ? (
                 <ActivityIndicator />
               ) : (
                 <ThemeText typography="body__primary--jumbo--bold">
-                  {userBonusPointsStatus === 'error' ? '--' : userBonusPoints}
+                  {userBonusBalanceStatus === 'error' ? '--' : userBonusBalance}
                 </ThemeText>
               )}
               <ThemeIcon svg={StarFill} size="large" />

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -42,14 +42,14 @@ const BonusProgramTexts = {
       'Logg inn for å tene og bruke poeng',
     ),
     noBonusBalance: _(
-      'Vi klarer ikke hente bonuspoengene dine akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
-      'We are unable to fetch your bonus points right now. You will still earn points as usual.',
-      'Me klarer ikkje henta bonuspoenga dine akkurat no. Du vil framleis tena poeng som vanleg.',
+      'Vi klarer ikke vise poengene dine akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
+      'We are unable to display your points right now. You will still earn points as usual.',
+      'Me klarer ikkje visa poenga dine akkurat no. Du vil framleis tena poeng som vanleg.',
     ),
     noBonusProducts: _(
-      'Vi klarer ikke hente fordelene akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
-      'We are unable to fetch the benefits right now. You will still earn points as usual.',
-      'Me klarer ikkje hente fordelane akkurat no. Du vil framleis tene poeng som vanleg.',
+      'Vi klarer ikke vise fordelene akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
+      'We are unable to display the benefits right now. You will still earn points as usual.',
+      'Me klarer ikkje visa fordelane akkurat no. Du vil framleis tene poeng som vanleg.',
     ),
     readMore: {
       heading: _('Les mer', 'Read more', 'Les meir'),

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -10,12 +10,17 @@ const BonusProgramTexts = {
 
   youHave: _('Du har ', 'You have ', 'Du har '),
 
-  yourBonusBalanceA11yLabel: (bonusBalance: number | null | undefined) =>
-    _(
-      `Du har ${bonusBalance ?? 'ukjent antall'} bonuspoeng`,
-      `You have ${bonusBalance ?? 'unknown number of'} bonus points`,
-      `Du har ${bonusBalance ?? 'ukjent mengde'} bonuspoeng`,
-    ),
+  yourBonusBalanceA11yLabel: (
+    bonusBalance: number | null | undefined,
+    bonusBalanceStatus: 'loading' | 'error' | 'success',
+  ) => {
+    const isValid = bonusBalance && bonusBalanceStatus === 'success';
+    return _(
+      `Du har ${isValid ? bonusBalance : 'ukjent antall'} bonuspoeng`,
+      `You have ${isValid ? bonusBalance : 'unknown number of'} bonus points`,
+      `Du har ${isValid ? bonusBalance : 'ukjent mengde'} bonuspoeng`,
+    );
+  },
 
   bonusProfile: {
     header: {

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -10,6 +10,13 @@ const BonusProgramTexts = {
 
   youHave: _('Du har ', 'You have ', 'Du har '),
 
+  yourBonusBalanceA11yLabel: (bonusBalance: number | null | undefined) =>
+    _(
+      `Du har ${bonusBalance ?? 'ukjent antall'} bonuspoeng`,
+      `You have ${bonusBalance ?? 'unknown number of'} bonus points`,
+      `Du har ${bonusBalance ?? 'ukjent mengde'} bonuspoeng`,
+    ),
+
   bonusProfile: {
     header: {
       title: _('Bonus', 'Bonus', 'Bonus'),
@@ -19,12 +26,6 @@ const BonusProgramTexts = {
       'Your bonus points',
       'Bonuspoenga dine',
     ),
-    yourBonusBalanceA11yLabel: (bonusBalance: number | null | undefined) =>
-      _(
-        `Du har ${bonusBalance ?? 'ukjent antall'} bonuspoeng`,
-        `You have ${bonusBalance ?? 'unknown number of'} bonus points`,
-        `Du har ${bonusBalance ?? 'ukjent tal på'} bonuspoeng`,
-      ),
 
     spendPoints: {
       heading: _('Våre bonuser', 'Our bonuses', 'Bonusane våre'),

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -10,15 +10,11 @@ const BonusProgramTexts = {
 
   youHave: _('Du har ', 'You have ', 'Du har '),
 
-  yourBonusBalanceA11yLabel: (
-    bonusBalance: number | null | undefined,
-    bonusBalanceStatus: 'loading' | 'error' | 'success',
-  ) => {
-    const isValid = bonusBalance && bonusBalanceStatus === 'success';
+  yourBonusBalanceA11yLabel: (bonusBalance: number | null) => {
     return _(
-      `Du har ${isValid ? bonusBalance : 'ukjent antall'} bonuspoeng`,
-      `You have ${isValid ? bonusBalance : 'unknown number of'} bonus points`,
-      `Du har ${isValid ? bonusBalance : 'ukjent mengde'} bonuspoeng`,
+      `Du har ${bonusBalance ?? 'ukjent antall'} bonuspoeng`,
+      `You have ${bonusBalance ?? 'unknown number of'} bonus points`,
+      `Du har ${bonusBalance ?? 'ukjent mengde'} bonuspoeng`,
     );
   },
 

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -19,11 +19,11 @@ const BonusProgramTexts = {
       'Your bonus points',
       'Bonuspoenga dine',
     ),
-    yourBonusPointsA11yLabel: (bonuspoints: number | null | undefined) =>
+    yourBonusBalanceA11yLabel: (bonusBalance: number | null | undefined) =>
       _(
-        `Du har ${bonuspoints ?? 'ukjent antall'} bonuspoeng`,
-        `You have ${bonuspoints ?? 'unknown number of'} bonus points`,
-        `Du har ${bonuspoints ?? 'ukjent tal på'} bonuspoeng`,
+        `Du har ${bonusBalance ?? 'ukjent antall'} bonuspoeng`,
+        `You have ${bonusBalance ?? 'unknown number of'} bonus points`,
+        `Du har ${bonusBalance ?? 'ukjent tal på'} bonuspoeng`,
       ),
 
     spendPoints: {
@@ -40,7 +40,7 @@ const BonusProgramTexts = {
       'Log in to earn and spend points',
       'Logg inn for å tene og bruke poeng',
     ),
-    noBonusPoints: _(
+    noBonusBalance: _(
       'Vi klarer ikke hente bonuspoengene dine akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
       'We are unable to fetch your bonus points right now. You will still earn points as usual.',
       'Me klarer ikkje henta bonuspoenga dine akkurat no. Du vil framleis tena poeng som vanleg.',

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -19,11 +19,11 @@ const BonusProgramTexts = {
       'Your bonus points',
       'Bonuspoenga dine',
     ),
-    yourBonusPointsA11yLabel: (bonuspoints: number) =>
+    yourBonusPointsA11yLabel: (bonuspoints: number | null | undefined) =>
       _(
-        `Du har ${bonuspoints} bonuspoeng`,
-        `You have ${bonuspoints} bonus points`,
-        `Du har ${bonuspoints} bonuspoeng`,
+        `Du har ${bonuspoints ?? 'ukjent antall'} bonuspoeng`,
+        `You have ${bonuspoints ?? 'unknown number of'} bonus points`,
+        `Du har ${bonuspoints ?? 'ukjent tal på'} bonuspoeng`,
       ),
 
     spendPoints: {
@@ -39,6 +39,11 @@ const BonusProgramTexts = {
       'Logg inn for å tjene og bruke poeng',
       'Log in to earn and spend points',
       'Logg inn for å tene og bruke poeng',
+    ),
+    noBonusPoints: _(
+      'Vi klarer ikke hente bonuspoengene dine akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
+      'We are unable to fetch your bonus points right now. You will still earn points as usual.',
+      'Me klarer ikkje henta bonuspoenga dine akkurat no. Du vil framleis tena poeng som vanleg.',
     ),
     noBonusProducts: _(
       'Vi klarer ikke hente fordelene akkurat nå. Du vil fortsatt tjene poeng som vanlig.',


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/19986

The bonus point balance is now retrieved from the bonus service backend

<img width=200 src="https://github.com/user-attachments/assets/2c6f393a-b51b-44d6-ac57-ee838b55f4df">
<img width=200 src="https://github.com/user-attachments/assets/c4d31179-6259-424e-91a8-a33c5aa46d7e">
<img width=200 src="https://github.com/user-attachments/assets/7345d61a-cd22-4037-bdbc-d55de3bcdcbd">

Also add loading and error views when unable to get bonus points: 

<img width=180 src="https://github.com/user-attachments/assets/6bad7727-8ca9-4b11-9144-197e8a7dc1a1">
<img width=180 src="https://github.com/user-attachments/assets/894ae07a-4c3c-4533-bc43-1b9c9aa2337b">
<img width=180 src="https://github.com/user-attachments/assets/41f33fa5-3248-47d6-8cee-bda54b7f6b98">
<img width=180 src="https://github.com/user-attachments/assets/5f1795c9-76df-4d8d-9a1c-62225505e6bb">

