### PR TITLE
chore: Update the cache version of ruby version

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -46,7 +46,7 @@ runs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Get potential cached dependencies
         uses: actions/cache@v3

--- a/.github/actions/setup-certs/action.yml
+++ b/.github/actions/setup-certs/action.yml
@@ -49,5 +49,5 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
-        cache-version: 1
+        cache-version: 2
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -49,7 +49,7 @@ runs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Update devices and provisioning profiles
         shell: bash

--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1.0
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Set environment
         run: bash ./scripts/override-environment.sh $APP_ENVIRONMENT ${{ matrix.org }}

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1.0
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Get Github-release data
         if: matrix.org == 'atb'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,7 +41,7 @@ $RNMapboxMapsImpl = 'mapbox'
 # Fix for: Apple Invalid Privacy Manifest
 # https://github.com/mapbox/mapbox-maps-ios/releases/tag/v10.17.0
 # This is a temporary fix until the next release of the Mapbox Maps SDK for React Native.
-$RNMapboxMapsVersion = '~> 10.18.2'
+$RNMapboxMapsVersion = '~> 10.19.0'
 
 target 'app' do
   config = use_native_modules!

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1208,15 +1208,15 @@ PODS:
     - React-Core
   - KettleKit (1.3.1)
   - leveldb-library (1.22.6)
-  - MapboxCommon (23.10.1)
-  - MapboxCoreMaps (10.18.0):
-    - MapboxCommon (~> 23.10)
-  - MapboxMaps (10.18.2):
-    - MapboxCommon (= 23.10.1)
-    - MapboxCoreMaps (= 10.18.0)
-    - MapboxMobileEvents (= 1.0.10)
+  - MapboxCommon (23.11.4)
+  - MapboxCoreMaps (10.19.2):
+    - MapboxCommon (~> 23.11)
+  - MapboxMaps (10.19.4):
+    - MapboxCommon (= 23.11.4)
+    - MapboxCoreMaps (= 10.19.2)
+    - MapboxMobileEvents (= 2.0.0)
     - Turf (= 2.8.0)
-  - MapboxMobileEvents (1.0.10)
+  - MapboxMobileEvents (2.0.0)
   - nanopb (2.30909.1):
     - nanopb/decode (= 2.30909.1)
     - nanopb/encode (= 2.30909.1)
@@ -2905,13 +2905,13 @@ PODS:
   - RNLocalize (3.2.1):
     - React-Core
   - rnmapbox-maps (10.1.37):
-    - MapboxMaps (~> 10.18.2)
+    - MapboxMaps (~> 10.19.0)
     - React
     - React-Core
     - rnmapbox-maps/DynamicLibrary (= 10.1.37)
     - Turf
   - rnmapbox-maps/DynamicLibrary (10.1.37):
-    - MapboxMaps (~> 10.18.2)
+    - MapboxMaps (~> 10.19.0)
     - React
     - React-Core
     - Turf
@@ -3470,13 +3470,13 @@ SPEC CHECKSUMS:
   intercom-react-native: 6219f7c600720acd4d1ebb37c632b25806128936
   KettleKit: 607b72ed627477a08450e5e5762c21dba1f461e3
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
-  MapboxCommon: 0ff437e44988da6856e280d00ffb266564ed0487
-  MapboxCoreMaps: f1bd9405f5b9d3e343f2fe4138775299699a22fb
-  MapboxMaps: e76b14f52c54c40b76ddecd04f40448e6f35a864
-  MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
+  MapboxCommon: cc47fafe3fe5408ca49240aa80fa64f27f275711
+  MapboxCoreMaps: 35685edba03e44468aed57c3dfd7f8795edafda8
+  MapboxMaps: f87023cf0d72b180b40ea0b6fb4b2d7db6b73b71
+  MapboxMobileEvents: d044b9edbe0ec7df60f6c2c9634fe9a7f449266b
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 7691283dd69fed46f6653d376de6fa83aaad774c
   RCTRequired: eac044a04629288f272ee6706e31f81f3a2b4bfe
   RCTTypeSafety: cfe499e127eda6dd46e5080e12d80d0bfe667228
@@ -3558,7 +3558,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 4a7cce66468343e82d601e8f6cdc0148b18b6c6b
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
   RNLocalize: e7378161f0b6a6365407eb2377aab46cc38047d8
-  rnmapbox-maps: d76b53404ad8d3a0b776bfd5ca2709fbf282ec83
+  rnmapbox-maps: 7820ed38f3feb24d67edea9d3fe43e0477e6de7b
   RNPermissions: 8f723aff8930c269b8faebf8cde4a7bcffd21b8d
   RNReanimated: 25ec70669c387101a4c8e671fcc58cffda76da88
   RNScreens: 4a5446dc4d922b2375df14c3a3f30bfc7719f6b1
@@ -3573,6 +3573,6 @@ SPEC CHECKSUMS:
   VisualCodeViewiOSLib: 0ceefd7499b52d4bca9d30774efd575b77fd6183
   Yoga: d213adae4f2c5518e9b19f919afa25a73848ecfb
 
-PODFILE CHECKSUM: d85c2074775bec338320bc105871822ec860d881
+PODFILE CHECKSUM: 2ebe08035639ef289935e3b349f8d00d9532c812
 
 COCOAPODS: 1.15.2

--- a/src/modules/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/modules/fare-contracts/CompactFareContractInfo.tsx
@@ -78,17 +78,24 @@ const CompactFareContractInfoTexts = (
   } = props;
   const {language} = useTranslation();
   const styles = useStyles();
+  const firstTravelRight = props.fareContract.travelRights[0];
 
   return (
     <View style={styles.textsContainer}>
       <ThemeText typography="body__primary--bold" style={styles.expireTime}>
         {timeUntilExpire}
       </ThemeText>
-      {userProfilesWithCount.map((u) => (
-        <ThemeText key={u.id} typography="body__secondary" color="secondary">
-          {userProfileCountAndName(u, language)}
+      {firstTravelRight.travelerName ? (
+        <ThemeText typography="body__secondary" color="secondary">
+          {firstTravelRight.travelerName}
         </ThemeText>
-      ))}
+      ) : (
+        userProfilesWithCount.map((u) => (
+          <ThemeText key={u.id} typography="body__secondary" color="secondary">
+            {userProfileCountAndName(u, language)}
+          </ThemeText>
+        ))
+      )}
       {productName && (
         <ThemeText typography="body__secondary" color="secondary">
           {productName}

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -259,9 +259,9 @@ const FareContractTexts = {
       'Aktiver ein enkeltbillett',
     ),
     bottomSheetDescription: _(
-      'Billetten blir gyldig med en gang. Man kan bare aktivere én enkeltbillett fra klippekortet om gangen.',
-      'The ticket becomes valid immediately. You can only activate one single ticket from the punch card at a time.',
-      'Billetten blir gyldig med ein gong. Du kan berre aktivere ein enkeltbillett frå klippekortet om gongen.',
+      'Billetten blir gyldig med en gang du starter den. Kun en billett kan aktiveres av gangen.',
+      'The ticket becomes valid as soon as you start it. Only one ticket can be activated at a time.',
+      'Billetten blir gyldig med ein gong du startar den. Berre ein billett kan aktiverast av gangen.',
     ),
     genericError: _(
       'En feil har oppstått under aktivering av billetten. Vennligst prøv igjen.',


### PR DESCRIPTION
On the previous version we updated the ruby version but seems like we need to tell the ruby version action that the cache has changed or we need to reset it according to https://github.com/ruby/setup-ruby?tab=readme-ov-file#caching-bundle-install-manually this is because the build are stick on old versions of ruby.