### PR TITLE
chore: Update cache version to 2 to take the new ruby version

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -46,7 +46,7 @@ runs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Get potential cached dependencies
         uses: actions/cache@v3

--- a/.github/actions/setup-certs/action.yml
+++ b/.github/actions/setup-certs/action.yml
@@ -49,5 +49,5 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
-        cache-version: 1
+        cache-version: 2
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/actions/update-devices/action.yml
+++ b/.github/actions/update-devices/action.yml
@@ -49,7 +49,7 @@ runs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Update devices and provisioning profiles
         shell: bash

--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1.0
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Set environment
         run: bash ./scripts/override-environment.sh $APP_ENVIRONMENT ${{ matrix.org }}

--- a/.github/workflows/build-store-android.yml
+++ b/.github/workflows/build-store-android.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1.0
-          cache-version: 1
+          cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Get Github-release data
         if: matrix.org == 'atb'


### PR DESCRIPTION
On the previous version we updated the ruby version but seems like we need to tell the ruby version action that the cache has changed or we need to reset it according to https://github.com/ruby/setup-ruby?tab=readme-ov-file#caching-bundle-install-manually this is because the build are stick on old versions of ruby.