### PR TITLE
feat: Unite autoSelectedFeature and mapSelectionSelectedFeature

### DIFF
--- a/src/components/map/components/ScanButton.tsx
+++ b/src/components/map/components/ScanButton.tsx
@@ -9,7 +9,14 @@ import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 
-export const ScanButton = () => {
+type ScanButtonProps = {
+  /*
+    onPressCallback is currently used to reset selectedFeature state from useUpdateBottomSheetWhenSelectedEntityChanges.
+    This can be removed if the reset function comes from MapContext instead.
+   */
+  onPressCallback: () => void;
+};
+export const ScanButton = ({onPressCallback}: ScanButtonProps) => {
   const {theme} = useThemeContext();
   const interactiveColor = theme.color.interactive[2];
   const styles = useStyles();
@@ -30,6 +37,7 @@ export const ScanButton = () => {
         closeBottomSheet();
         analytics.logEvent('Map', 'Scan');
         navigation.navigate('Root_ScanQrCodeScreen');
+        onPressCallback();
       }}
       text={t(MapTexts.qr.scan)}
       rightIcon={{svg: Qr}}

--- a/src/components/map/components/SelectedFeatureIcon.tsx
+++ b/src/components/map/components/SelectedFeatureIcon.tsx
@@ -86,6 +86,7 @@ function getPinType(selectedFeatureProperties?: GeoJsonProperties): PinType {
     case 'Quay':
       return 'stop';
     default:
+      // would be nice to have a better check than this
       if (selectedFeatureProperties?.is_virtual_station !== undefined) {
         return 'station';
       } else {

--- a/src/components/map/hooks/use-map-selection-change-effect.tsx
+++ b/src/components/map/hooks/use-map-selection-change-effect.tsx
@@ -74,5 +74,6 @@ export const useMapSelectionChangeEffect = (
     onMapClick,
     selectedFeature,
     onReportParkingViolation,
+    closeCallback,
   };
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20281

The key line in this PR:
```ts
const selectedFeature = mapSelectionSelectedFeature || autoSelectedFeature;
```
The auto selected feature state (used to select a feature after QR scanning) is now mapped into exactly the same kinda object as the selectedFeature we've had from before.

The one-to-one mapping fixes the [issue](https://github.com/AtB-AS/kundevendt/issues/20281) out of the box.