### PR TITLE
chore: add mode specifier

### DIFF
--- a/scripts/android/run-android.sh
+++ b/scripts/android/run-android.sh
@@ -8,5 +8,5 @@ appId=$(envprop 'ANDROID_APPLICATION_ID')
 if [ "$(envprop 'KETTLE_API_KEY')" ]; then
   react-native run-android --appId "$appId" --mode=beaconsDebug
 else
-  react-native run-android --appId "$appId"
+  react-native run-android --appId "$appId" --mode=appDebug
 fi


### PR DESCRIPTION
This PR will fix an issue when you want to run the app on Android using `yarn android` for the OMS partner. (e.g. if you run `yarn setup dev troms/nfk/fram`)

The error is:
```
Cannot locate tasks that match 'app:installDebug' as task 'installDebug' is ambiguous in project ':app'.
Candidates are: 'installAppDebug', 'installAppDebugAndroidTest', 'installBeaconsDebug', 'installBeaconsDebugAndroidTest'. 
```

The fix is just to add `-mode=appDebug` if the `KETTLE_API_KEY` doesn't exist in the `.env` file