### PR TITLE
fix: give vipps button on reservations some width to prevent overflow

### DIFF
--- a/src/modules/fare-contracts/PurchaseReservation.tsx
+++ b/src/modules/fare-contracts/PurchaseReservation.tsx
@@ -5,7 +5,7 @@ import {Reservation, PaymentType, useTicketingContext} from '@atb/ticketing';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import Bugsnag from '@bugsnag/react-native';
 import React from 'react';
-import {Linking} from 'react-native';
+import {Linking, View} from 'react-native';
 import {formatToLongDateTime} from '@atb/utils/date';
 import {fromUnixTime} from 'date-fns';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
@@ -81,14 +81,16 @@ export const PurchaseReservation: React.FC<Props> = ({reservation}) => {
           </ThemeText>
           {reservation.paymentType === PaymentType.Vipps &&
             status === 'reserving' && (
-              <Button
-                expanded={true}
-                onPress={() => openVippsUrl(reservation.url)}
-                accessibilityRole="link"
-                text={t(TicketingTexts.reservation.goToVipps)}
-                mode="tertiary"
-                backgroundColor={theme.color.background.neutral[0]}
-              />
+              <View style={styles.vippsLinkContainer}>
+                <Button
+                  expanded={true}
+                  onPress={() => openVippsUrl(reservation.url)}
+                  accessibilityRole="link"
+                  text={t(TicketingTexts.reservation.goToVipps)}
+                  mode="tertiary"
+                  backgroundColor={theme.color.background.neutral[0]}
+                />
+              </View>
             )}
         </GenericSectionItem>
       </Section>
@@ -102,5 +104,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   statusText: {
     textAlign: 'center',
+  },
+  vippsLinkContainer: {
+    flex: 1,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -31,7 +31,7 @@ export const Profile_FareContractsScreen = () => {
     orderId: 'DW2N19A6',
     paymentId: 870266,
     paymentStatus: 'CREATE',
-    paymentType: 3,
+    paymentType: 2,
     // shouldStartNow: true,
     transactionId: 858879,
     url: 'https://test.epayment.nets.eu/Terminal/default.aspx?merchantId=12003727&transactionId=0643eeff83a1467f85a577cac32c36ed',


### PR DESCRIPTION
There was a bug with flex layout in reservations, where the "Go to vipps for payment" would get 0 width, and a lot of height on android. The theory is that this could lead to double purchases because users couldn't find their active ticket, because it's hidden below a reservation.

closes https://github.com/AtB-AS/kundevendt/issues/20293

### Before/after

<div>
<img width="400px" src="https://github.com/user-attachments/assets/f9a5849c-067d-42eb-911a-862c68723c52">
<img width="400px" src="https://github.com/user-attachments/assets/9d29b0d4-1fde-4378-a92b-48e93906df9e">
</div>