### PR TITLE
feat: move bottomsheet above tabbar

### DIFF
--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -14,16 +14,15 @@ export function AnimatedBottomSheet({
   animatedOffset,
   children,
   onLayout,
-  tabBarHeight,
+  bottomOffset = 0,
 }: {
   animatedOffset: Animated.Value;
   children: ReactNode;
-  tabBarHeight?: number;
+  bottomOffset?: number;
   onLayout: (ev: LayoutChangeEvent) => void;
 }) {
   const styles = useStyles();
   const {height: windowHeight} = useWindowDimensions();
-  const bottomOffset = tabBarHeight ?? 0;
   const translateY = useMemo(
     () =>
       animatedOffset.interpolate({
@@ -37,7 +36,7 @@ export function AnimatedBottomSheet({
     <View
       style={{
         position: 'absolute',
-        bottom: tabBarHeight,
+        bottom: bottomOffset,
         left: 0,
         right: 0,
         height: windowHeight,

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react-native';
 import React, {ReactNode, useMemo} from 'react';
 import {StyleSheet, Theme} from '@atb/theme';
+import {shadows} from '../map';
 
 const getThemeColor = (theme: Theme) => theme.color.background.neutral[1];
 
@@ -49,6 +50,7 @@ export function AnimatedBottomSheet({
           ...styles.bottomSheet,
           transform: [{translateY}],
           maxHeight: windowHeight,
+          ...shadows,
         }}
         onLayout={onLayout}
       >

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -1,4 +1,9 @@
-import {Animated, LayoutChangeEvent, useWindowDimensions} from 'react-native';
+import {
+  Animated,
+  LayoutChangeEvent,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import React, {ReactNode, useMemo} from 'react';
 import {StyleSheet, Theme} from '@atb/theme';
 
@@ -8,36 +13,48 @@ export function AnimatedBottomSheet({
   animatedOffset,
   children,
   onLayout,
+  tabBarHeight,
 }: {
   animatedOffset: Animated.Value;
   children: ReactNode;
+  tabBarHeight?: number;
   onLayout: (ev: LayoutChangeEvent) => void;
 }) {
   const styles = useStyles();
   const {height: windowHeight} = useWindowDimensions();
+  const bottomOffset = tabBarHeight ?? 0;
   const translateY = useMemo(
     () =>
       animatedOffset.interpolate({
         inputRange: [0, 1],
-        outputRange: [windowHeight, 0],
+        outputRange: [windowHeight + bottomOffset, 0],
+        extrapolate: 'clamp',
       }),
-    [animatedOffset, windowHeight],
+    [animatedOffset, bottomOffset, windowHeight],
   );
   return (
-    <Animated.View
+    <View
       style={{
-        ...styles.bottomSheet,
-        transform: [
-          {
-            translateY,
-          },
-        ],
-        maxHeight: windowHeight,
+        position: 'absolute',
+        bottom: tabBarHeight,
+        left: 0,
+        right: 0,
+        height: windowHeight,
+        overflow: 'hidden',
+        pointerEvents: 'box-none',
       }}
-      onLayout={onLayout}
     >
-      {children}
-    </Animated.View>
+      <Animated.View
+        style={{
+          ...styles.bottomSheet,
+          transform: [{translateY}],
+          maxHeight: windowHeight,
+        }}
+        onLayout={onLayout}
+      >
+        {children}
+      </Animated.View>
+    </View>
   );
 }
 

--- a/src/components/bottom-sheet/BottomSheetContainer.tsx
+++ b/src/components/bottom-sheet/BottomSheetContainer.tsx
@@ -11,6 +11,7 @@ export type BottomSheetContainerProps = {
   onClose?: () => void;
   focusTitleOnLoad?: boolean;
   disableClose?: boolean;
+  disableHeader?: boolean;
 };
 
 export function BottomSheetContainer({
@@ -22,6 +23,7 @@ export function BottomSheetContainer({
   onClose,
   focusTitleOnLoad = true,
   disableClose = false,
+  disableHeader,
 }: BottomSheetContainerProps) {
   const {height: windowHeight} = useWindowDimensions();
   const maxHeight = windowHeight * maxHeightValue;
@@ -33,6 +35,7 @@ export function BottomSheetContainer({
         title={title}
         focusTitleOnLoad={focusTitleOnLoad}
         disableClose={disableClose}
+        disableHeader={disableHeader}
       />
       {children}
     </View>

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -30,6 +30,7 @@ type BottomSheetState = {
     /** Ref to component which should be focused on sheet close */
     onCloseFocusRef: RefObject<any>,
     useBackdrop?: boolean,
+    tabBarHeight?: number,
   ) => void;
   isOpen: () => boolean;
   close: () => void;
@@ -52,12 +53,16 @@ export const BottomSheetContextProvider = ({children}: Props) => {
   const [contentFunction, setContentFunction] = useState<() => ReactNode>(
     () => () => null,
   );
+  const [tabBarHeight, setTabBarHeight] = useState<number | undefined>(
+    undefined,
+  );
 
   const onOpenFocusRef = useFocusOnLoad();
   const refToFocusOnClose = useRef<RefObject<any>>(undefined);
 
   const close = useCallback(() => {
     setContentFunction(() => () => null);
+    setTabBarHeight(undefined);
     setIsOpen(false);
     if (refToFocusOnClose.current) {
       giveFocus(refToFocusOnClose.current);
@@ -70,11 +75,13 @@ export const BottomSheetContextProvider = ({children}: Props) => {
       contentFunction: () => ReactNode,
       onCloseFocusRef: RefObject<any>,
       useBackdrop: boolean = true,
+      tabBarHeight?: number,
     ) => {
       setContentFunction(() => contentFunction);
       setBackdropEnabled(useBackdrop);
       setIsOpen(true);
       refToFocusOnClose.current = onCloseFocusRef;
+      setTabBarHeight(tabBarHeight);
     },
     [],
   );
@@ -118,6 +125,7 @@ export const BottomSheetContextProvider = ({children}: Props) => {
         height={height}
         setHeight={setHeight}
         contentFunction={contentFunction}
+        tabBarHeight={tabBarHeight}
       />
     </BottomSheetContext.Provider>
   );
@@ -130,6 +138,7 @@ const BottomSheetOnBackDrop = ({
   height,
   setHeight,
   contentFunction,
+  tabBarHeight,
 }: {
   isBackdropEnabled: boolean;
   isOpen: boolean;
@@ -137,6 +146,7 @@ const BottomSheetOnBackDrop = ({
   height: number;
   setHeight: (height: number) => void;
   contentFunction: () => ReactNode;
+  tabBarHeight?: number;
 }) => {
   const onLayout = ({nativeEvent}: LayoutChangeEvent) => {
     setHeight(nativeEvent.layout.height);
@@ -151,7 +161,7 @@ const BottomSheetOnBackDrop = ({
         easing: Easing.out(Easing.exp),
         useNativeDriver: true,
       }).start(),
-    [animatedOffset, isOpen],
+    [animatedOffset, isOpen, tabBarHeight],
   );
 
   return (
@@ -162,7 +172,11 @@ const BottomSheetOnBackDrop = ({
           <ClickableBackground isOpen={isOpen} close={close} height={height} />
         </>
       )}
-      <AnimatedBottomSheet animatedOffset={animatedOffset} onLayout={onLayout}>
+      <AnimatedBottomSheet
+        animatedOffset={animatedOffset}
+        onLayout={onLayout}
+        tabBarHeight={tabBarHeight}
+      >
         {contentFunction()}
       </AnimatedBottomSheet>
     </>

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -30,6 +30,10 @@ type BottomSheetState = {
     /** Ref to component which should be focused on sheet close */
     onCloseFocusRef: RefObject<any>,
     useBackdrop?: boolean,
+    /**
+     * Make sure if you use this prop in a tabscreen, that you handle navigating away by closing the bottomsheet.
+     * Example in Map_RootScreenV2 useEffect
+     */
     tabBarHeight?: number,
   ) => void;
   isOpen: () => boolean;

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -57,9 +57,7 @@ export const BottomSheetContextProvider = ({children}: Props) => {
   const [contentFunction, setContentFunction] = useState<() => ReactNode>(
     () => () => null,
   );
-  const [tabBarHeight, setTabBarHeight] = useState<number | undefined>(
-    undefined,
-  );
+  const [tabBarHeight, setTabBarHeight] = useState<number>();
 
   const onOpenFocusRef = useFocusOnLoad();
   const refToFocusOnClose = useRef<RefObject<any>>(undefined);
@@ -129,7 +127,7 @@ export const BottomSheetContextProvider = ({children}: Props) => {
         height={height}
         setHeight={setHeight}
         contentFunction={contentFunction}
-        tabBarHeight={tabBarHeight}
+        bottomOffset={tabBarHeight}
       />
     </BottomSheetContext.Provider>
   );
@@ -142,7 +140,7 @@ const BottomSheetOnBackDrop = ({
   height,
   setHeight,
   contentFunction,
-  tabBarHeight,
+  bottomOffset,
 }: {
   isBackdropEnabled: boolean;
   isOpen: boolean;
@@ -150,7 +148,7 @@ const BottomSheetOnBackDrop = ({
   height: number;
   setHeight: (height: number) => void;
   contentFunction: () => ReactNode;
-  tabBarHeight?: number;
+  bottomOffset?: number;
 }) => {
   const onLayout = ({nativeEvent}: LayoutChangeEvent) => {
     setHeight(nativeEvent.layout.height);
@@ -179,7 +177,7 @@ const BottomSheetOnBackDrop = ({
       <AnimatedBottomSheet
         animatedOffset={animatedOffset}
         onLayout={onLayout}
-        tabBarHeight={tabBarHeight}
+        bottomOffset={bottomOffset}
       >
         {contentFunction()}
       </AnimatedBottomSheet>

--- a/src/components/bottom-sheet/BottomSheetContext.tsx
+++ b/src/components/bottom-sheet/BottomSheetContext.tsx
@@ -165,7 +165,7 @@ const BottomSheetOnBackDrop = ({
         easing: Easing.out(Easing.exp),
         useNativeDriver: true,
       }).start(),
-    [animatedOffset, isOpen, tabBarHeight],
+    [animatedOffset, isOpen],
   );
 
   return (

--- a/src/components/bottom-sheet/BottomSheetHeader.tsx
+++ b/src/components/bottom-sheet/BottomSheetHeader.tsx
@@ -13,6 +13,7 @@ type BottomSheetHeaderWithoutNavigationProps = {
   onClose?: () => void;
   focusTitleOnLoad: boolean;
   disableClose?: boolean;
+  disableHeader?: boolean;
 };
 
 export const BottomSheetHeader = ({
@@ -20,6 +21,7 @@ export const BottomSheetHeader = ({
   onClose,
   focusTitleOnLoad,
   disableClose = false,
+  disableHeader = false,
 }: BottomSheetHeaderWithoutNavigationProps) => {
   const styles = useStyle();
   const {t} = useTranslation();
@@ -41,6 +43,9 @@ export const BottomSheetHeader = ({
     foreground: {primary: textColor},
   } = themeColor.default;
 
+  if (disableHeader) {
+    return <View style={styles.headerBar} />;
+  }
   return (
     <View style={styles.container}>
       {/*Placeholder to center the title correctly*/}
@@ -91,7 +96,15 @@ const useStyle = StyleSheet.createThemeHook((theme) => {
       padding: theme.spacing.small,
       borderRadius: 100,
     },
-
+    headerBar: {
+      width: 75,
+      height: theme.spacing.small,
+      alignSelf: 'center',
+      borderRadius: theme.border.radius.large,
+      marginTop: theme.spacing.xSmall,
+      marginBottom: theme.spacing.medium,
+      backgroundColor: theme.color.background.neutral[3].background,
+    },
     headerTitle: {alignItems: 'center', flex: 1},
   };
 });

--- a/src/components/map/MapConfig.ts
+++ b/src/components/map/MapConfig.ts
@@ -10,7 +10,7 @@ export const SCOOTERS_MAX_ZOOM_LEVEL = 22;
 export const SCOOTERS_CLUSTER_RADIUS = 40;
 
 const {height: screenHeight} = Dimensions.get('screen');
-const basePadding = screenHeight * 0.1;
+const basePadding = screenHeight * 0.2;
 
 export const SLIGHTLY_RAISED_MAP_PADDING = {
   paddingTop: basePadding,

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -25,7 +25,7 @@ import {
   isQuayFeature,
   mapPositionToCoordinates,
   flyToLocation,
-  getTabBarPaddingBottom,
+  getMapPadding,
 } from './utils';
 import {
   GeofencingZones,
@@ -228,7 +228,7 @@ export const MapV2 = (props: MapProps) => {
           coordinates: mapPositionToCoordinates(
             featureToSelect.geometry.coordinates,
           ),
-          padding: getTabBarPaddingBottom(tabBarHeight),
+          padding: getMapPadding(tabBarHeight),
 
           mapCameraRef,
           zoomLevel: toZoomLevel,

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -223,7 +223,12 @@ export const MapV2 = (props: MapProps) => {
           coordinates: mapPositionToCoordinates(
             featureToSelect.geometry.coordinates,
           ),
-          padding: SLIGHTLY_RAISED_MAP_PADDING,
+          padding: {
+            ...SLIGHTLY_RAISED_MAP_PADDING,
+            paddingBottom:
+              SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + tabBarHeight,
+          },
+
           mapCameraRef,
           zoomLevel: toZoomLevel,
           animationDuration: 200,
@@ -237,7 +242,7 @@ export const MapV2 = (props: MapProps) => {
         });
       }
     },
-    [onMapClick, activeShmoBooking],
+    [activeShmoBooking?.state, tabBarHeight, onMapClick],
   );
 
   return (

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -8,7 +8,7 @@ import {Feature, GeoJsonProperties, Geometry, Position} from 'geojson';
 import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import {View} from 'react-native';
-import {MapCameraConfig, SLIGHTLY_RAISED_MAP_PADDING} from './MapConfig';
+import {MapCameraConfig} from './MapConfig';
 import {PositionArrow} from './components/PositionArrow';
 import {useControlPositionsStyle} from './hooks/use-control-styles';
 import {useMapSelectionChangeEffect} from './hooks/use-map-selection-change-effect';
@@ -25,6 +25,7 @@ import {
   isQuayFeature,
   mapPositionToCoordinates,
   flyToLocation,
+  getTabBarPaddingBottom,
 } from './utils';
 import {
   GeofencingZones,
@@ -223,11 +224,7 @@ export const MapV2 = (props: MapProps) => {
           coordinates: mapPositionToCoordinates(
             featureToSelect.geometry.coordinates,
           ),
-          padding: {
-            ...SLIGHTLY_RAISED_MAP_PADDING,
-            paddingBottom:
-              SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + tabBarHeight,
-          },
+          padding: getTabBarPaddingBottom(tabBarHeight),
 
           mapCameraRef,
           zoomLevel: toZoomLevel,

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -53,6 +53,7 @@ import {useIsFocused} from '@react-navigation/native';
 import {useShmoActiveBottomSheet} from './hooks/use-active-shmo-booking';
 import {SelectedFeatureIcon} from './components/SelectedFeatureIcon';
 import {ShmoBookingState} from '@atb/api/types/mobility';
+import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 
 export const MapV2 = (props: MapProps) => {
   const {initialLocation, includeSnackbar} = props;
@@ -63,6 +64,7 @@ export const MapV2 = (props: MapProps) => {
   const isFocused = useIsFocused();
   const shouldShowVehiclesAndStations = isFocused; // don't send tile requests while in the background, and always get fresh data upon enter
   const mapViewConfig = useMapViewConfig({shouldShowVehiclesAndStations});
+  const tabBarHeight = useBottomTabBarHeight();
 
   const startingCoordinates = useMemo(
     () =>
@@ -84,6 +86,7 @@ export const MapV2 = (props: MapProps) => {
     startingCoordinates,
     true,
     true,
+    tabBarHeight,
   );
 
   const {autoSelectedFeature} = useMapContext();
@@ -98,7 +101,11 @@ export const MapV2 = (props: MapProps) => {
   const showGeofencingZones =
     isGeofencingZonesEnabled && selectedFeatureIsAVehicle;
 
-  useShmoActiveBottomSheet(mapCameraRef, mapSelectionCloseCallback);
+  useShmoActiveBottomSheet(
+    mapCameraRef,
+    mapSelectionCloseCallback,
+    tabBarHeight,
+  );
 
   const {getGeofencingZoneTextContent} = useGeofencingZoneTextContent();
   const {snackbarProps, showSnackbar, hideSnackbar} = useSnackbar();
@@ -112,7 +119,7 @@ export const MapV2 = (props: MapProps) => {
     !activeShmoBookingIsLoading &&
     (!selectedFeature || selectedFeatureIsAVehicle);
 
-  useAutoSelectMapItem(mapCameraRef, onReportParkingViolation);
+  useAutoSelectMapItem(mapCameraRef, onReportParkingViolation, tabBarHeight);
 
   useEffect(() => {
     // hide the snackbar when the bottom sheet is closed

--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -96,8 +96,11 @@ export const MapV2 = (props: MapProps) => {
   const selectedFeatureIsAVehicle =
     isScooterV2(selectedFeature) || isBicycleV2(selectedFeature);
 
-  const {isGeofencingZonesEnabled, isShmoDeepIntegrationEnabled} =
-    useFeatureTogglesContext();
+  const {
+    isGeofencingZonesEnabled,
+    isShmoDeepIntegrationEnabled,
+    isMapV2Enabled,
+  } = useFeatureTogglesContext();
 
   const showGeofencingZones =
     isGeofencingZonesEnabled && selectedFeatureIsAVehicle;
@@ -116,6 +119,7 @@ export const MapV2 = (props: MapProps) => {
 
   const showScanButton =
     isShmoDeepIntegrationEnabled &&
+    isMapV2Enabled &&
     !activeShmoBooking &&
     !activeShmoBookingIsLoading &&
     (!selectedFeature || selectedFeatureIsAVehicle);

--- a/src/components/map/components/external-realtime-map/ExternalRealtimeMapSheet.tsx
+++ b/src/components/map/components/external-realtime-map/ExternalRealtimeMapSheet.tsx
@@ -7,7 +7,6 @@ import {Button} from '@atb/components/button';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {ThemeText} from '@atb/components/text';
 import {ScrollView} from 'react-native-gesture-handler';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 
 type ExternalRealtimeMapLinkSheetProps = {
@@ -52,12 +51,11 @@ export const ExternalRealtimeMapSheet = ({
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     container: {
       backgroundColor: theme.color.background.neutral[1].background,
       marginHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     contentContainer: {
       rowGap: theme.spacing.medium,

--- a/src/components/map/hooks/use-active-shmo-booking.tsx
+++ b/src/components/map/hooks/use-active-shmo-booking.tsx
@@ -17,6 +17,7 @@ import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 export const useShmoActiveBottomSheet = (
   mapCameraRef: React.RefObject<CameraRef | null>,
   mapSelectionCloseCallback: () => void,
+  tabBarHeight?: number,
 ) => {
   const {data: activeBooking} = useActiveShmoBookingQuery();
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
@@ -82,6 +83,7 @@ export const useShmoActiveBottomSheet = (
               ),
               onCloseFocusRef,
               false,
+              tabBarHeight,
             );
             break;
           default:
@@ -103,5 +105,6 @@ export const useShmoActiveBottomSheet = (
     activeBooking,
     isShmoDeepIntegrationEnabled,
     mapSelectionCloseCallback,
+    tabBarHeight,
   ]);
 };

--- a/src/components/map/hooks/use-active-shmo-booking.tsx
+++ b/src/components/map/hooks/use-active-shmo-booking.tsx
@@ -67,7 +67,6 @@ export const useShmoActiveBottomSheet = (
             openBottomSheet(
               () => (
                 <ActiveScooterSheet
-                  onClose={closeBottomSheet}
                   onActiveBookingReceived={flyToUserLocation}
                   navigateSupportCallback={() => {
                     closeBottomSheet();

--- a/src/components/map/hooks/use-active-shmo-booking.tsx
+++ b/src/components/map/hooks/use-active-shmo-booking.tsx
@@ -2,7 +2,7 @@ import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {useMapContext} from '@atb/MapContext';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import React, {RefObject, useCallback, useEffect, useRef} from 'react';
-import {flyToLocation, getTabBarPaddingBottom} from '../utils';
+import {flyToLocation, getMapPadding} from '../utils';
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/src/components/Camera';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
@@ -44,7 +44,7 @@ export const useShmoActiveBottomSheet = (
           latitude: coordinates?.latitude ?? 0,
           longitude: coordinates?.longitude ?? 0,
         },
-        padding: getTabBarPaddingBottom(tabBarHeight),
+        padding: getMapPadding(tabBarHeight),
         mapCameraRef,
         zoomLevel: 15,
       });

--- a/src/components/map/hooks/use-active-shmo-booking.tsx
+++ b/src/components/map/hooks/use-active-shmo-booking.tsx
@@ -2,9 +2,8 @@ import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {useMapContext} from '@atb/MapContext';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import React, {RefObject, useCallback, useEffect, useRef} from 'react';
-import {flyToLocation} from '../utils';
+import {flyToLocation, getTabBarPaddingBottom} from '../utils';
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/src/components/Camera';
-import {SLIGHTLY_RAISED_MAP_PADDING} from '@atb/components/map';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {useActiveShmoBookingQuery} from '@atb/mobility/queries/use-active-shmo-booking-query';
@@ -45,11 +44,7 @@ export const useShmoActiveBottomSheet = (
           latitude: coordinates?.latitude ?? 0,
           longitude: coordinates?.longitude ?? 0,
         },
-        padding: {
-          ...SLIGHTLY_RAISED_MAP_PADDING,
-          paddingBottom:
-            SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + (tabBarHeight ?? 0),
-        },
+        padding: getTabBarPaddingBottom(tabBarHeight),
         mapCameraRef,
         zoomLevel: 15,
       });

--- a/src/components/map/hooks/use-active-shmo-booking.tsx
+++ b/src/components/map/hooks/use-active-shmo-booking.tsx
@@ -45,11 +45,15 @@ export const useShmoActiveBottomSheet = (
           latitude: coordinates?.latitude ?? 0,
           longitude: coordinates?.longitude ?? 0,
         },
-        padding: SLIGHTLY_RAISED_MAP_PADDING,
+        padding: {
+          ...SLIGHTLY_RAISED_MAP_PADDING,
+          paddingBottom:
+            SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + (tabBarHeight ?? 0),
+        },
         mapCameraRef,
         zoomLevel: 15,
       });
-  }, [mapCameraRef, getCurrentCoordinates]);
+  }, [getCurrentCoordinates, mapCameraRef, tabBarHeight]);
 
   useEffect(() => {
     if (!isFocused || !isShmoDeepIntegrationEnabled) return;

--- a/src/components/map/hooks/use-auto-select-map-item.tsx
+++ b/src/components/map/hooks/use-auto-select-map-item.tsx
@@ -8,7 +8,7 @@ import {
   CarSharingStationBottomSheet,
   ScooterSheet,
 } from '@atb/mobility';
-import {flyToLocation, getTabBarPaddingBottom} from '../utils';
+import {flyToLocation, getMapPadding} from '../utils';
 
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/src/components/Camera';
 import {BicycleSheet} from '@atb/mobility/components/BicycleSheet';
@@ -84,7 +84,7 @@ export const useAutoSelectMapItem = (
               latitude: mapItem.lat,
               longitude: mapItem.lon,
             },
-            padding: getTabBarPaddingBottom(tabBarHeight),
+            padding: getMapPadding(tabBarHeight),
             mapCameraRef,
             zoomLevel: 19, // no clustering at this zoom level
           });

--- a/src/components/map/hooks/use-auto-select-map-item.tsx
+++ b/src/components/map/hooks/use-auto-select-map-item.tsx
@@ -85,13 +85,17 @@ export const useAutoSelectMapItem = (
               latitude: mapItem.lat,
               longitude: mapItem.lon,
             },
-            padding: SLIGHTLY_RAISED_MAP_PADDING,
+            padding: {
+              ...SLIGHTLY_RAISED_MAP_PADDING,
+              paddingBottom:
+                SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + (tabBarHeight ?? 0),
+            },
             mapCameraRef,
             zoomLevel: 19, // no clustering at this zoom level
           });
       });
     },
-    [mapCameraRef, setAutoSelectedMapItem],
+    [mapCameraRef, setAutoSelectedMapItem, tabBarHeight],
   );
 
   /**
@@ -110,63 +114,52 @@ export const useAutoSelectMapItem = (
               ShmoBookingState.FINISHED
             ) {
               if (isShmoDeepIntegrationEnabled) {
-                openBottomSheet(
-                  () => (
-                    <FinishedScooterSheet
-                      bookingId={bottomSheetToAutoSelect.id}
-                      onClose={closeBottomSheet}
-                      navigateSupportCallback={(operatorId, bookingId) => {
-                        closeBottomSheet();
-                        navigation.navigate('Root_ScooterHelpScreen', {
-                          operatorId,
-                          bookingId,
-                        });
-                      }}
-                    />
-                  ),
-                  onCloseFocusRef,
-                  false,
-                  tabBarHeight,
+                BottomSheetComponent = (
+                  <FinishedScooterSheet
+                    bookingId={bottomSheetToAutoSelect.id}
+                    onClose={closeBottomSheet}
+                    navigateSupportCallback={(operatorId, bookingId) => {
+                      closeBottomSheet();
+                      navigation.navigate('Root_ScooterHelpScreen', {
+                        operatorId,
+                        bookingId,
+                      });
+                    }}
+                  />
                 );
               }
             } else {
-              openBottomSheet(
-                () => (
-                  <ScooterSheet
-                    vehicleId={bottomSheetToAutoSelect.id}
-                    onClose={closeBottomSheet}
-                    onVehicleReceived={flyToMapItemLocation}
-                    onReportParkingViolation={onReportParkingViolation}
-                    navigateSupportCallback={closeBottomSheet}
-                    navigation={navigation}
-                    loginCallback={() => {
-                      closeBottomSheet();
-                      if (hasReservationOrAvailableFareContract) {
-                        navigation.navigate(
-                          'Root_LoginAvailableFareContractWarningScreen',
-                          {},
-                        );
-                      } else if (enable_vipps_login) {
-                        navigation.navigate('Root_LoginOptionsScreen', {
-                          showGoBack: true,
-                          transitionOverride: 'slide-from-bottom',
-                        });
-                      } else {
-                        navigation.navigate('Root_LoginPhoneInputScreen', {});
-                      }
-                    }}
-                    startOnboardingCallback={() => {
-                      closeBottomSheet();
-                      navigation.navigate('Root_ShmoOnboardingScreen');
-                    }}
-                  />
-                ),
-                onCloseFocusRef,
-                false,
-                tabBarHeight,
+              BottomSheetComponent = (
+                <ScooterSheet
+                  vehicleId={bottomSheetToAutoSelect.id}
+                  onClose={closeBottomSheet}
+                  onVehicleReceived={flyToMapItemLocation}
+                  onReportParkingViolation={onReportParkingViolation}
+                  navigateSupportCallback={closeBottomSheet}
+                  navigation={navigation}
+                  loginCallback={() => {
+                    closeBottomSheet();
+                    if (hasReservationOrAvailableFareContract) {
+                      navigation.navigate(
+                        'Root_LoginAvailableFareContractWarningScreen',
+                        {},
+                      );
+                    } else if (enable_vipps_login) {
+                      navigation.navigate('Root_LoginOptionsScreen', {
+                        showGoBack: true,
+                        transitionOverride: 'slide-from-bottom',
+                      });
+                    } else {
+                      navigation.navigate('Root_LoginPhoneInputScreen', {});
+                    }
+                  }}
+                  startOnboardingCallback={() => {
+                    closeBottomSheet();
+                    navigation.navigate('Root_ShmoOnboardingScreen');
+                  }}
+                />
               );
             }
-
             break;
           case AutoSelectableBottomSheetType.Bicycle:
             BottomSheetComponent = (
@@ -200,7 +193,12 @@ export const useAutoSelectMapItem = (
         }
 
         if (!!BottomSheetComponent) {
-          openBottomSheet(() => BottomSheetComponent, onCloseFocusRef, false);
+          openBottomSheet(
+            () => BottomSheetComponent,
+            onCloseFocusRef,
+            false,
+            tabBarHeight,
+          );
         }
         setBottomSheetCurrentlyAutoSelected(bottomSheetToAutoSelect);
         setBottomSheetToAutoSelect(undefined);

--- a/src/components/map/hooks/use-auto-select-map-item.tsx
+++ b/src/components/map/hooks/use-auto-select-map-item.tsx
@@ -38,6 +38,7 @@ export type AutoSelectableMapItem =
 export const useAutoSelectMapItem = (
   mapCameraRef: React.RefObject<CameraRef | null>,
   onReportParkingViolation: () => void,
+  tabBarHeight?: number,
 ) => {
   const {
     bottomSheetToAutoSelect,
@@ -109,50 +110,60 @@ export const useAutoSelectMapItem = (
               ShmoBookingState.FINISHED
             ) {
               if (isShmoDeepIntegrationEnabled) {
-                BottomSheetComponent = (
-                  <FinishedScooterSheet
-                    bookingId={bottomSheetToAutoSelect.id}
-                    onClose={closeBottomSheet}
-                    navigateSupportCallback={(operatorId, bookingId) => {
-                      closeBottomSheet();
-                      navigation.navigate('Root_ScooterHelpScreen', {
-                        operatorId,
-                        bookingId,
-                      });
-                    }}
-                  />
+                openBottomSheet(
+                  () => (
+                    <FinishedScooterSheet
+                      bookingId={bottomSheetToAutoSelect.id}
+                      onClose={closeBottomSheet}
+                      navigateSupportCallback={(operatorId, bookingId) => {
+                        closeBottomSheet();
+                        navigation.navigate('Root_ScooterHelpScreen', {
+                          operatorId,
+                          bookingId,
+                        });
+                      }}
+                    />
+                  ),
+                  onCloseFocusRef,
+                  false,
+                  tabBarHeight,
                 );
               }
             } else {
-              BottomSheetComponent = (
-                <ScooterSheet
-                  vehicleId={bottomSheetToAutoSelect.id}
-                  onClose={closeBottomSheet}
-                  onVehicleReceived={flyToMapItemLocation}
-                  onReportParkingViolation={onReportParkingViolation}
-                  navigateSupportCallback={closeBottomSheet}
-                  navigation={navigation}
-                  loginCallback={() => {
-                    closeBottomSheet();
-                    if (hasReservationOrAvailableFareContract) {
-                      navigation.navigate(
-                        'Root_LoginAvailableFareContractWarningScreen',
-                        {},
-                      );
-                    } else if (enable_vipps_login) {
-                      navigation.navigate('Root_LoginOptionsScreen', {
-                        showGoBack: true,
-                        transitionOverride: 'slide-from-bottom',
-                      });
-                    } else {
-                      navigation.navigate('Root_LoginPhoneInputScreen', {});
-                    }
-                  }}
-                  startOnboardingCallback={() => {
-                    closeBottomSheet();
-                    navigation.navigate('Root_ShmoOnboardingScreen');
-                  }}
-                />
+              openBottomSheet(
+                () => (
+                  <ScooterSheet
+                    vehicleId={bottomSheetToAutoSelect.id}
+                    onClose={closeBottomSheet}
+                    onVehicleReceived={flyToMapItemLocation}
+                    onReportParkingViolation={onReportParkingViolation}
+                    navigateSupportCallback={closeBottomSheet}
+                    navigation={navigation}
+                    loginCallback={() => {
+                      closeBottomSheet();
+                      if (hasReservationOrAvailableFareContract) {
+                        navigation.navigate(
+                          'Root_LoginAvailableFareContractWarningScreen',
+                          {},
+                        );
+                      } else if (enable_vipps_login) {
+                        navigation.navigate('Root_LoginOptionsScreen', {
+                          showGoBack: true,
+                          transitionOverride: 'slide-from-bottom',
+                        });
+                      } else {
+                        navigation.navigate('Root_LoginPhoneInputScreen', {});
+                      }
+                    }}
+                    startOnboardingCallback={() => {
+                      closeBottomSheet();
+                      navigation.navigate('Root_ShmoOnboardingScreen');
+                    }}
+                  />
+                ),
+                onCloseFocusRef,
+                false,
+                tabBarHeight,
               );
             }
 
@@ -212,5 +223,6 @@ export const useAutoSelectMapItem = (
     hasReservationOrAvailableFareContract,
     close,
     isShmoDeepIntegrationEnabled,
+    tabBarHeight,
   ]);
 };

--- a/src/components/map/hooks/use-auto-select-map-item.tsx
+++ b/src/components/map/hooks/use-auto-select-map-item.tsx
@@ -8,7 +8,7 @@ import {
   CarSharingStationBottomSheet,
   ScooterSheet,
 } from '@atb/mobility';
-import {flyToLocation} from '../utils';
+import {flyToLocation, getTabBarPaddingBottom} from '../utils';
 
 import {CameraRef} from '@rnmapbox/maps/lib/typescript/src/components/Camera';
 import {BicycleSheet} from '@atb/mobility/components/BicycleSheet';
@@ -16,7 +16,6 @@ import {
   BikeStationFragment,
   CarStationFragment,
 } from '@atb/api/types/generated/fragments/stations';
-import {SLIGHTLY_RAISED_MAP_PADDING} from '@atb/components/map';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {useHasReservationOrAvailableFareContract} from '@atb/ticketing';
@@ -85,11 +84,7 @@ export const useAutoSelectMapItem = (
               latitude: mapItem.lat,
               longitude: mapItem.lon,
             },
-            padding: {
-              ...SLIGHTLY_RAISED_MAP_PADDING,
-              paddingBottom:
-                SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + (tabBarHeight ?? 0),
-            },
+            padding: getTabBarPaddingBottom(tabBarHeight),
             mapCameraRef,
             zoomLevel: 19, // no clustering at this zoom level
           });

--- a/src/components/map/hooks/use-control-styles.ts
+++ b/src/components/map/hooks/use-control-styles.ts
@@ -4,15 +4,17 @@ import {ViewStyle} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {useBottomNavigationStyles} from '@atb/utils/navigation';
+import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 
 export function useControlPositionsStyle(extraPaddingBottom = false) {
   const {top, bottom} = useSafeAreaInsets();
   const {theme} = useThemeContext();
   const {height: bottomSheetHeight} = useBottomSheetContext();
   const {minHeight} = useBottomNavigationStyles();
+  const bottomTabBarHeight = useBottomTabBarHeight();
 
   const bottomPaddingIfBottomSheetIsOpen = bottomSheetHeight
-    ? bottomSheetHeight - minHeight
+    ? bottomSheetHeight - minHeight + bottomTabBarHeight
     : 0;
 
   return useMemo<{

--- a/src/components/map/hooks/use-map-selection-change-effect.tsx
+++ b/src/components/map/hooks/use-map-selection-change-effect.tsx
@@ -25,6 +25,7 @@ export const useMapSelectionChangeEffect = (
   startingCoordinates: Coordinates,
   disableShouldShowMapLines?: boolean,
   disableShouldZoomToFeature?: boolean,
+  tabBarHeight?: number,
 ) => {
   const [mapSelectionAction, setMapSelectionAction] = useState<
     MapSelectionActionType | undefined
@@ -55,6 +56,7 @@ export const useMapSelectionChangeEffect = (
       mapSelectionAction,
       mapViewRef,
       closeCallback,
+      tabBarHeight,
     );
 
   const onMapClick = useCallback(

--- a/src/components/map/hooks/use-map-selection-change-effect.tsx
+++ b/src/components/map/hooks/use-map-selection-change-effect.tsx
@@ -48,7 +48,7 @@ export const useMapSelectionChangeEffect = (
 
   const closeCallback = useCallback(() => setMapSelectionAction(undefined), []);
 
-  useTriggerCameraMoveEffect(cameraFocusMode, mapCameraRef);
+  useTriggerCameraMoveEffect(cameraFocusMode, mapCameraRef, tabBarHeight);
   const {selectedFeature, onReportParkingViolation} =
     useUpdateBottomSheetWhenSelectedEntityChanges(
       mapProps,

--- a/src/components/map/hooks/use-trigger-camera-move-effect.tsx
+++ b/src/components/map/hooks/use-trigger-camera-move-effect.tsx
@@ -5,10 +5,14 @@ import MapboxGL from '@rnmapbox/maps';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {useBottomNavigationStyles} from '@atb/utils/navigation';
 import {Coordinates} from '@atb/utils/coordinates';
-import {fitBounds, flyToLocation, mapPositionToCoordinates} from '../utils';
+import {
+  fitBounds,
+  flyToLocation,
+  getTabBarPaddingBottom,
+  mapPositionToCoordinates,
+} from '../utils';
 import {CameraFocusModeType, MapPadding} from '../types';
 import {Dimensions, Platform, StatusBar} from 'react-native';
-import {SLIGHTLY_RAISED_MAP_PADDING} from '@atb/components/map';
 
 type BoundingBox = {
   xMin: number;
@@ -119,11 +123,7 @@ const moveCameraToEntity = (
   if (!padding) {
     flyToLocation({
       coordinates,
-      padding: {
-        ...SLIGHTLY_RAISED_MAP_PADDING,
-        paddingBottom:
-          SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + (tabBarHeight ?? 0),
-      },
+      padding: getTabBarPaddingBottom(tabBarHeight),
       mapCameraRef,
       animationMode: 'easeTo',
     });

--- a/src/components/map/hooks/use-trigger-camera-move-effect.tsx
+++ b/src/components/map/hooks/use-trigger-camera-move-effect.tsx
@@ -8,7 +8,7 @@ import {Coordinates} from '@atb/utils/coordinates';
 import {
   fitBounds,
   flyToLocation,
-  getTabBarPaddingBottom,
+  getMapPadding,
   mapPositionToCoordinates,
 } from '../utils';
 import {CameraFocusModeType, MapPadding} from '../types';
@@ -123,7 +123,7 @@ const moveCameraToEntity = (
   if (!padding) {
     flyToLocation({
       coordinates,
-      padding: getTabBarPaddingBottom(tabBarHeight),
+      padding: getMapPadding(tabBarHeight),
       mapCameraRef,
       animationMode: 'easeTo',
     });

--- a/src/components/map/hooks/use-trigger-camera-move-effect.tsx
+++ b/src/components/map/hooks/use-trigger-camera-move-effect.tsx
@@ -29,6 +29,7 @@ const DEFAULT_PADDING_DISPLACEMENT = 0.003;
 export const useTriggerCameraMoveEffect = (
   cameraFocusMode: CameraFocusModeType | undefined,
   mapCameraRef: RefObject<MapboxGL.Camera | null>,
+  tabBarHeight?: number,
 ) => {
   const {height: bottomSheetHeight} = useBottomSheetContext();
   const padding = useCalculatePaddings();
@@ -55,6 +56,7 @@ export const useTriggerCameraMoveEffect = (
         cameraFocusMode.entityFeature,
         cameraFocusMode.zoomTo ? padding : undefined,
         mapCameraRef,
+        tabBarHeight,
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -109,6 +111,7 @@ const moveCameraToEntity = (
   entityFeature: Feature<Point>,
   padding: MapPadding | undefined,
   mapCameraRef: RefObject<MapboxGL.Camera | null>,
+  tabBarHeight?: number,
 ) => {
   const coordinates = mapPositionToCoordinates(
     entityFeature.geometry.coordinates,
@@ -116,7 +119,11 @@ const moveCameraToEntity = (
   if (!padding) {
     flyToLocation({
       coordinates,
-      padding: SLIGHTLY_RAISED_MAP_PADDING,
+      padding: {
+        ...SLIGHTLY_RAISED_MAP_PADDING,
+        paddingBottom:
+          SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + (tabBarHeight ?? 0),
+      },
       mapCameraRef,
       animationMode: 'easeTo',
     });

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -111,6 +111,8 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
             />
           ),
           onCloseFocusRef,
+          true,
+          tabBarHeight,
         );
         return;
       }
@@ -124,6 +126,8 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
             />
           ),
           onCloseFocusRef,
+          true,
+          tabBarHeight,
         );
         return;
       }
@@ -155,6 +159,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
           ),
           onCloseFocusRef,
           false,
+          tabBarHeight,
         );
       } else if (
         isMapV2Enabled
@@ -171,6 +176,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
           ),
           onCloseFocusRef,
           false,
+          tabBarHeight,
         );
       } else if (
         isMapV2Enabled
@@ -187,6 +193,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
           ),
           onCloseFocusRef,
           false,
+          tabBarHeight,
         );
       } else if (
         isMapV2Enabled
@@ -245,6 +252,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
           },
           onCloseFocusRef,
           false,
+          tabBarHeight,
         );
       } else if (isParkAndRide(selectedFeature)) {
         openBottomSheet(
@@ -266,6 +274,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
           },
           onCloseFocusRef,
           false,
+          tabBarHeight,
         );
       } else {
         closeBottomSheet();

--- a/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
+++ b/src/components/map/hooks/use-update-bottom-sheet-when-selected-entity-changes.tsx
@@ -46,6 +46,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
   mapSelectionAction: MapSelectionActionType | undefined,
   mapViewRef: RefObject<MapboxGL.MapView | null>,
   closeCallback: () => void,
+  tabBarHeight?: number,
 ): {
   selectedFeature: Feature<Point, GeoJsonProperties> | undefined;
   onReportParkingViolation: () => void;
@@ -226,6 +227,7 @@ export const useUpdateBottomSheetWhenSelectedEntityChanges = (
           },
           onCloseFocusRef,
           false,
+          tabBarHeight,
         );
       } else if (
         isMapV2Enabled

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -24,6 +24,7 @@ import {
 } from '@atb/api/types/mobility';
 import distance from '@turf/distance';
 import {isStation} from '@atb/mobility/utils';
+import {SLIGHTLY_RAISED_MAP_PADDING} from './MapConfig';
 
 export const hitboxCoveringIconOnly = {width: 1, height: 1};
 
@@ -173,6 +174,17 @@ export function flyToLocation({
       animationMode,
       animationDuration: animationDuration ?? 750,
     });
+}
+
+export function getTabBarPaddingBottom(tabBarHeight: number | undefined) {
+  if (tabBarHeight) {
+    return {
+      ...SLIGHTLY_RAISED_MAP_PADDING,
+      paddingBottom: SLIGHTLY_RAISED_MAP_PADDING.paddingBottom + tabBarHeight,
+    };
+  } else {
+    return SLIGHTLY_RAISED_MAP_PADDING;
+  }
 }
 
 export const toFeaturePoint = <

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -176,7 +176,7 @@ export function flyToLocation({
     });
 }
 
-export function getTabBarPaddingBottom(tabBarHeight: number | undefined) {
+export function getMapPadding(tabBarHeight: number | undefined) {
   if (tabBarHeight) {
     return {
       ...SLIGHTLY_RAISED_MAP_PADDING,

--- a/src/mobility/components/BicycleSheet.tsx
+++ b/src/mobility/components/BicycleSheet.tsx
@@ -20,7 +20,6 @@ import {formatRange} from '@atb/mobility/utils';
 import {useVehicle} from '@atb/mobility/use-vehicle';
 import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useOperatorBenefit} from '@atb/mobility/use-operator-benefit';
 import {OperatorActionButton} from '@atb/mobility/components/OperatorActionButton';
 import {OperatorBenefit} from '@atb/mobility/components/OperatorBenefit';
@@ -157,10 +156,9 @@ export const BicycleSheet = ({
 };
 
 const useSheetStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     container: {
       paddingHorizontal: theme.spacing.medium,
@@ -174,7 +172,7 @@ const useSheetStyle = StyleSheet.createThemeHook((theme) => {
       marginBottom: theme.spacing.medium,
     },
     footer: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
       marginHorizontal: theme.spacing.medium,
     },
     operatorNameAndLogo: {

--- a/src/mobility/components/BikeStationBottomSheet.tsx
+++ b/src/mobility/components/BikeStationBottomSheet.tsx
@@ -11,7 +11,6 @@ import {StyleSheet} from '@atb/theme';
 import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {useBikeStation} from '@atb/mobility/use-bike-station';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useOperatorBenefit} from '@atb/mobility/use-operator-benefit';
 import {OperatorBenefit} from '@atb/mobility/components/OperatorBenefit';
 import {OperatorActionButton} from '@atb/mobility/components/OperatorActionButton';
@@ -184,10 +183,9 @@ export const BikeStationBottomSheet = ({
 };
 
 const useSheetStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     operatorBenefit: {
       marginBottom: theme.spacing.medium,
@@ -206,7 +204,7 @@ const useSheetStyle = StyleSheet.createThemeHook((theme) => {
       marginTop: theme.spacing.small,
     },
     footer: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
       marginHorizontal: theme.spacing.medium,
     },
     mobilityStatContainer: {

--- a/src/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/mobility/components/CarSharingStationBottomSheet.tsx
@@ -16,7 +16,6 @@ import {
   CarAvailabilityFragment,
   CarStationFragment,
 } from '@atb/api/types/generated/fragments/stations';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useOperatorBenefit} from '@atb/mobility/use-operator-benefit';
 import {OperatorActionButton} from '@atb/mobility/components/OperatorActionButton';
 import {OperatorBenefit} from '@atb/mobility/components/OperatorBenefit';
@@ -145,10 +144,9 @@ export const CarSharingStationBottomSheet = ({
 };
 
 const useSheetStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     operatorBenefit: {
       marginBottom: theme.spacing.medium,
@@ -165,7 +163,7 @@ const useSheetStyle = StyleSheet.createThemeHook((theme) => {
       marginBottom: theme.spacing.medium,
     },
     footer: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
       marginHorizontal: theme.spacing.medium,
     },
     icon: {

--- a/src/mobility/components/ParkAndRideBottomSheet.tsx
+++ b/src/mobility/components/ParkAndRideBottomSheet.tsx
@@ -6,7 +6,6 @@ import {StyleSheet} from '@atb/theme';
 import {Bicycle} from '@atb/assets/svg/mono-icons/transportation';
 import {ParkAndRideTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {ScrollView, View} from 'react-native';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
   NavigateToTripSearchCallback,
   ParkingType,
@@ -129,11 +128,10 @@ export const ParkAndRideBottomSheet = ({
 };
 
 const useSheetStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     container: {
       paddingHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     buttonsContainer: {
       paddingHorizontal: theme.spacing.medium,

--- a/src/mobility/components/filter/MapFilterSheet.tsx
+++ b/src/mobility/components/filter/MapFilterSheet.tsx
@@ -15,7 +15,6 @@ import {StyleSheet} from '@atb/theme';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {Button} from '@atb/components/button';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MobilityFilters} from '@atb/mobility/components/filter/MobilityFilters';
 
 type MapFilterSheetProps = {
@@ -86,10 +85,9 @@ export const MapFilterSheet = ({
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     container: {
       marginHorizontal: theme.spacing.medium,

--- a/src/mobility/components/sheets/ActiveScooterSheet.tsx
+++ b/src/mobility/components/sheets/ActiveScooterSheet.tsx
@@ -8,7 +8,6 @@ import {
 } from '@atb/translations/screens/subscreens/MobilityTexts';
 import {ActivityIndicator, Alert, ScrollView, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Button} from '@atb/components/button';
 import {useDoOnceOnItemReceived} from '../../use-do-once-on-item-received';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
@@ -159,10 +158,9 @@ export const ActiveScooterSheet = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     operatorBenefit: {
       marginBottom: theme.spacing.medium,
@@ -171,7 +169,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       marginBottom: theme.spacing.medium,
     },
     footer: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
       marginHorizontal: theme.spacing.medium,
       gap: theme.spacing.medium,
     },

--- a/src/mobility/components/sheets/ActiveScooterSheet.tsx
+++ b/src/mobility/components/sheets/ActiveScooterSheet.tsx
@@ -10,7 +10,6 @@ import {ActivityIndicator, Alert, ScrollView, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Button} from '@atb/components/button';
-import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {useDoOnceOnItemReceived} from '../../use-do-once-on-item-received';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {VehicleCard} from '../VehicleCard';
@@ -25,14 +24,12 @@ import {ShmoTripCard} from '../ShmoTripCard';
 import {formatErrorMessage} from '@atb/mobility/utils';
 
 type Props = {
-  onClose: () => void;
   onActiveBookingReceived?: () => void;
   navigateSupportCallback: () => void;
   photoNavigation: (bookingId: string) => void;
 };
 
 export const ActiveScooterSheet = ({
-  onClose,
   onActiveBookingReceived,
   navigateSupportCallback,
   photoNavigation,
@@ -89,12 +86,7 @@ export const ActiveScooterSheet = ({
   };
 
   return (
-    <BottomSheetContainer
-      title={t(MobilityTexts.formFactor(FormFactor.Scooter))}
-      maxHeightValue={0.7}
-      onClose={onClose}
-      disableClose={sendShmoBookingEventIsLoading}
-    >
+    <BottomSheetContainer maxHeightValue={0.7} disableHeader={true}>
       {isShmoDeepIntegrationEnabled && (
         <>
           {isLoading && (

--- a/src/mobility/components/sheets/FinishedScooterSheet.tsx
+++ b/src/mobility/components/sheets/FinishedScooterSheet.tsx
@@ -8,7 +8,6 @@ import {
 } from '@atb/translations/screens/subscreens/MobilityTexts';
 import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Button} from '@atb/components/button';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
@@ -112,16 +111,15 @@ export const FinishedScooterSheet = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     container: {
       marginBottom: theme.spacing.medium,
     },
     footer: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
       marginHorizontal: theme.spacing.medium,
       gap: theme.spacing.medium,
     },

--- a/src/mobility/components/sheets/ScooterSheet.tsx
+++ b/src/mobility/components/sheets/ScooterSheet.tsx
@@ -69,8 +69,11 @@ export const ScooterSheet = ({
   useDoOnceOnItemReceived(onVehicleReceived, vehicle);
   const {mobilityOperators} = useOperators();
 
-  const {isParkingViolationsReportingEnabled, isShmoDeepIntegrationEnabled} =
-    useFeatureTogglesContext();
+  const {
+    isParkingViolationsReportingEnabled,
+    isShmoDeepIntegrationEnabled,
+    isMapV2Enabled,
+  } = useFeatureTogglesContext();
 
   return (
     <BottomSheetContainer
@@ -104,6 +107,7 @@ export const ScooterSheet = ({
             </ScrollView>
             <View style={styles.footer}>
               {isShmoDeepIntegrationEnabled &&
+              isMapV2Enabled &&
               operatorId &&
               mobilityOperators?.find((e) => e.id === operatorId)
                 ?.isDeepIntegrationEnabled ? (

--- a/src/mobility/components/sheets/ScooterSheet.tsx
+++ b/src/mobility/components/sheets/ScooterSheet.tsx
@@ -13,7 +13,6 @@ import {
 import {useVehicle} from '@atb/mobility/use-vehicle';
 import {ActivityIndicator, ScrollView, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Button} from '@atb/components/button';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {useOperatorBenefit} from '@atb/mobility/use-operator-benefit';
@@ -170,10 +169,9 @@ export const ScooterSheet = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
   return {
     activityIndicator: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
     },
     operatorBenefit: {
       marginBottom: theme.spacing.medium,
@@ -185,7 +183,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       gap: theme.spacing.medium,
     },
     footer: {
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: theme.spacing.medium,
       marginHorizontal: theme.spacing.medium,
     },
     parkingViolationsButton: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreenV2.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreenV2.tsx
@@ -8,6 +8,9 @@ import {MapScreenProps} from './navigation-types';
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
 import {MapDisabledForScreenReader} from './components/MapDisabledForScreenReader';
+import {useFocusEffect} from '@react-navigation/native';
+import {useBottomSheetContext} from '@atb/components/bottom-sheet';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export type MapScreenParams = {
   initialFilters?: MapFilterType;
@@ -17,6 +20,19 @@ export const Map_RootScreenV2 = ({
   navigation,
 }: MapScreenProps<'Map_RootScreen'>) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
+  const {close} = useBottomSheetContext();
+  const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isShmoDeepIntegrationEnabled) {
+        return () => {
+          // on screen blur (navigating away from map tab), close bottomsheet
+          close();
+        };
+      }
+    }, [close, isShmoDeepIntegrationEnabled]),
+  );
 
   const navigateToQuay = useCallback(
     (place: StopPlace, quay: Quay) => {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20077

* moved bottomsheet above tabbar on demand
* made bottomsheet close when navigating away from the maptab

<img src="https://github.com/user-attachments/assets/4f41515b-3bb2-465a-b6d1-4a953919f6fa" width="350" />

you could review commit for commit
