### PR TITLE
feat: ignore ferry in from travel search to ticketing

### DIFF
--- a/src/operator-config/index.ts
+++ b/src/operator-config/index.ts
@@ -1,9 +1,7 @@
 import {TripPattern} from '@atb/api/types/trips';
-import {
-  Mode,
-  TransportSubmode,
-} from '@atb/api/types/generated/journey_planner_v3_types';
+import {TransportSubmode} from '@atb/api/types/generated/journey_planner_v3_types';
 import {AUTHORITY} from '@env';
+import {isFreeLeg} from '@atb/travel-details-screens/utils';
 
 const currentAppAuthorityId = AUTHORITY ?? 'ATB:Authority:2';
 
@@ -12,7 +10,7 @@ export function hasLegsWeCantSellTicketsFor(
   validModes: string[],
 ) {
   return tripPattern.legs.some(function (leg) {
-    if (leg.mode == Mode.Foot || leg.mode == Mode.Bicycle) {
+    if (isFreeLeg(leg)) {
       return false;
     }
     if (leg.authority?.id !== currentAppAuthorityId) {

--- a/src/travel-details-screens/utils.ts
+++ b/src/travel-details-screens/utils.ts
@@ -17,6 +17,7 @@ import {
   DestinationDisplay,
   Mode,
   TariffZone,
+  TransportSubmode,
 } from '@atb/api/types/generated/journey_planner_v3_types';
 import {dictionary, Language, TranslateFunction} from '@atb/translations';
 import {APP_ORG} from '@env';
@@ -506,4 +507,17 @@ export function getLineAndTimeA11yLabel(
   ]
     .filter(isDefined)
     .join(screenReaderPause);
+}
+
+export function getNonFreeLegs(legs: Leg[]) {
+  return legs.filter((leg) => !isFreeLeg(leg));
+}
+export function isFreeLeg(leg: Leg) {
+  return (
+    leg.mode === Mode.Foot ||
+    leg.mode === Mode.Bicycle ||
+    // Ferry trips are free for travellers without a car
+    leg.transportSubmode === TransportSubmode.LocalCarFerry ||
+    leg.transportSubmode === TransportSubmode.LocalPassengerFerry
+  );
 }


### PR DESCRIPTION
Background: https://mittatb.slack.com/archives/C025NUF4WA0/p1745320924053039

<img width="300px" src="https://github.com/user-attachments/assets/ed9b65ea-f386-49f3-8d35-d4ced6aefff4">

### Acceptance criteria

- [ ] Trip searches that includes ferry allows the purchase of single tickets
- [ ] The suggested ticket doesn't include the ferry zones (e.g. in the example above, the ticket should be from Trondheim S to Flakk, not to Rørvik)
- [ ] Trips that has only ferry, don't suggest tickets