### PR TITLE
feat: let the user cancel ongoing payments

### DIFF
--- a/src/in-app-browser/in-app-browser.tsx
+++ b/src/in-app-browser/in-app-browser.tsx
@@ -11,6 +11,7 @@ export async function openInAppBrowser(
   dismissButtonStyle: 'cancel' | 'close' | 'done',
   successUrl?: string,
   onSuccess?: (url: string) => void,
+  onCancel?: () => void,
 ) {
   const statusBarStyle = StatusBar.pushStackEntry({
     barStyle: successUrl ? 'light-content' : 'dark-content',
@@ -18,13 +19,16 @@ export async function openInAppBrowser(
   });
   try {
     if (!successUrl) {
-      await InAppBrowser.open(url, {
+      const result = await InAppBrowser.open(url, {
         animated: true,
         dismissButtonStyle,
         // Android: Makes the InAppBrowser stay open after the app goes to
         // background. Needs to be true for Vipps login and BankID.
         showInRecents: true,
       });
+      if (result.type === 'cancel') {
+        onCancel?.();
+      }
     } else {
       const result = await InAppBrowser.openAuth(url, successUrl, {
         animated: true,
@@ -38,6 +42,9 @@ export async function openInAppBrowser(
       });
       if (result.type === 'success') {
         onSuccess?.(result.url);
+      }
+      if (result.type === 'cancel') {
+        onCancel?.();
       }
     }
   } catch (error: any) {

--- a/src/modules/fare-contracts/utils.ts
+++ b/src/modules/fare-contracts/utils.ts
@@ -300,6 +300,11 @@ export function getFareContractInfo(
   };
 }
 
+/**
+ * Map reservation paymentStatus to a more "intuitive" status. Note that
+ * - CREDIT and CANCEL are filtered out in the Ticketing Context
+ * - AUTHENTICATE, CREATE, IMPORT and INITIATE are all considered "reserving"
+ */
 export const getReservationStatus = (reservation: Reservation) => {
   const paymentStatus = reservation.paymentStatus;
   switch (paymentStatus) {

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -119,13 +119,12 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     recipient,
     shouldSavePaymentMethod,
   });
-  const cancelPaymentMutation = useCancelPaymentMutation();
-  useEffect(() => {
-    if (cancelPaymentMutation.isSuccess) {
+  const cancelPaymentMutation = useCancelPaymentMutation({
+    onSuccess: () => {
       cancelPaymentMutation.reset();
       reserveMutation.reset();
-    }
-  }, [cancelPaymentMutation, reserveMutation]);
+    },
+  });
 
   useOpenVippsAfterReservation(
     reserveMutation.data?.url,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -213,7 +213,10 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             reserveMutation.reset();
             setVippsNotInstalledError(false);
             if (reserveMutation.isSuccess) {
-              cancelPaymentMutation.mutate(reserveMutation.data);
+              cancelPaymentMutation.mutate({
+                reservation: reserveMutation.data,
+                isUser: false,
+              });
               analytics.logEvent('Ticketing', 'Payment cancelled');
             }
             setSelectedPaymentMethod(paymentMethod);
@@ -237,7 +240,10 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           type: 'back',
           onPress: () => {
             if (reserveMutation.isSuccess) {
-              cancelPaymentMutation.mutate(reserveMutation.data);
+              cancelPaymentMutation.mutate({
+                reservation: reserveMutation.data,
+                isUser: false,
+              });
               analytics.logEvent('Ticketing', 'Payment cancelled');
             }
             navigation.pop();
@@ -324,7 +330,10 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           onGoToPayment={goToPayment}
           onCancelPayment={() => {
             if (reserveMutation.isSuccess) {
-              cancelPaymentMutation.mutate(reserveMutation.data);
+              cancelPaymentMutation.mutate({
+                reservation: reserveMutation.data,
+                isUser: true,
+              });
             }
           }}
         />

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -14,7 +14,7 @@ import {
 import {RootStackScreenProps} from '@atb/stacks-hierarchy/navigation-types';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
-  OfferReservation,
+  ReserveOfferResponse,
   PaymentType,
   ReserveOffer,
   useTicketingContext,
@@ -111,16 +111,16 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     paymentMethod,
     recipient,
     shouldSavePaymentMethod,
-    onSuccess: (data) => {
+    onSuccess: (reserveOfferResponse) => {
       if (paymentMethod?.paymentType !== PaymentType.Vipps) {
         openInAppBrowser(
-          data.url,
+          reserveOfferResponse.url,
           'cancel',
           `${APP_SCHEME}://purchase-callback`,
           onPaymentCompleted,
           () =>
             cancelPaymentMutation.mutate({
-              reservation: data,
+              reserveOfferResponse,
               isUser: false,
             }),
         );
@@ -201,7 +201,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             setVippsNotInstalledError(false);
             if (reserveMutation.data) {
               cancelPaymentMutation.mutate({
-                reservation: reserveMutation.data,
+                reserveOfferResponse: reserveMutation.data,
                 isUser: false,
               });
             }
@@ -227,7 +227,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           onPress: () => {
             if (reserveMutation.data) {
               cancelPaymentMutation.mutate({
-                reservation: reserveMutation.data,
+                reserveOfferResponse: reserveMutation.data,
                 isUser: false,
               });
             }
@@ -314,7 +314,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           mode={params.mode}
           onCloseFocusRef={onCloseFocusRef}
           totalPrice={totalPrice}
-          reserve={reserveMutation.data}
+          reserveOfferResponse={reserveMutation.data}
           reserveStatus={reserveMutation.status}
           paymentMethod={paymentMethod}
           onSelectPaymentMethod={selectPaymentMethod}
@@ -322,7 +322,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           onCancelPayment={() => {
             if (reserveMutation.data) {
               cancelPaymentMutation.mutate({
-                reservation: reserveMutation.data,
+                reserveOfferResponse: reserveMutation.data,
                 isUser: true,
               });
             }
@@ -339,7 +339,7 @@ type PaymentButtonProps = {
   totalPrice: number;
   mode: 'TravelSearch' | 'Ticket' | undefined;
   onCloseFocusRef: RefObject<any>;
-  reserve: OfferReservation | undefined;
+  reserveOfferResponse: ReserveOfferResponse | undefined;
   reserveStatus: MutationStatus;
   paymentMethod: PaymentMethod | undefined;
   onSelectPaymentMethod: () => void;
@@ -352,7 +352,7 @@ const PaymentButton = ({
   totalPrice,
   mode,
   onCloseFocusRef,
-  reserve,
+  reserveOfferResponse,
   reserveStatus,
   paymentMethod,
   onSelectPaymentMethod,
@@ -366,7 +366,9 @@ const PaymentButton = ({
   const totalPriceString = formatNumberToString(totalPrice, language);
 
   const {reservations} = useTicketingContext();
-  const reservation = reservations.find((r) => r.orderId === reserve?.order_id);
+  const reservation = reservations.find(
+    (r) => r.orderId === reserveOfferResponse?.order_id,
+  );
   const isReserving =
     !!reservation && getReservationStatus(reservation) === 'reserving';
 

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -317,6 +317,12 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             />
           </Section>
         )}
+        {cancelPaymentMutation.status === 'error' && (
+          <MessageInfoBox
+            message={t(PurchaseConfirmationTexts.cancelPaymentError)}
+            type="error"
+          />
+        )}
         <PaymentButton
           isSearchingOffer={isSearchingOffer}
           isOfferError={!!offerError}

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -118,6 +118,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           'cancel',
           `${APP_SCHEME}://purchase-callback`,
           onPaymentCompleted,
+          () =>
+            cancelPaymentMutation.mutate({
+              reservation: data,
+              isUser: false,
+            }),
         );
       }
     },
@@ -126,6 +131,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     onSuccess: () => {
       cancelPaymentMutation.reset();
       reserveMutation.reset();
+      analytics.logEvent('Ticketing', 'Payment cancelled');
     },
   });
 
@@ -192,14 +198,12 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             paymentMethod: PaymentMethod,
             shouldSavePaymentMethod: boolean,
           ) => {
-            reserveMutation.reset();
             setVippsNotInstalledError(false);
-            if (reserveMutation.isSuccess) {
+            if (reserveMutation.data) {
               cancelPaymentMutation.mutate({
                 reservation: reserveMutation.data,
                 isUser: false,
               });
-              analytics.logEvent('Ticketing', 'Payment cancelled');
             }
             setSelectedPaymentMethod(paymentMethod);
             setShouldSavePaymentMethod(shouldSavePaymentMethod);
@@ -221,12 +225,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
         leftButton: {
           type: 'back',
           onPress: () => {
-            if (reserveMutation.isSuccess) {
+            if (reserveMutation.data) {
               cancelPaymentMutation.mutate({
                 reservation: reserveMutation.data,
                 isUser: false,
               });
-              analytics.logEvent('Ticketing', 'Payment cancelled');
             }
             navigation.pop();
           },
@@ -317,7 +320,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           onSelectPaymentMethod={selectPaymentMethod}
           onGoToPayment={goToPayment}
           onCancelPayment={() => {
-            if (reserveMutation.isSuccess) {
+            if (reserveMutation.data) {
               cancelPaymentMutation.mutate({
                 reservation: reserveMutation.data,
                 isUser: true,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -25,14 +25,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {addMinutes} from 'date-fns';
-import React, {
-  RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, {RefObject, useCallback, useMemo, useRef, useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {useOfferState} from '../Root_PurchaseOverviewScreen/use-offer-state';
 import {
@@ -118,6 +111,16 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     paymentMethod,
     recipient,
     shouldSavePaymentMethod,
+    onSuccess: (data) => {
+      if (paymentMethod?.paymentType !== PaymentType.Vipps) {
+        openInAppBrowser(
+          data.url,
+          'cancel',
+          `${APP_SCHEME}://purchase-callback`,
+          onPaymentCompleted,
+        );
+      }
+    },
   });
   const cancelPaymentMutation = useCancelPaymentMutation({
     onSuccess: () => {
@@ -151,26 +154,6 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     userId,
     paymentMethod?.paymentType,
     reserveMutation.data?.recurring_payment_id,
-  ]);
-
-  useEffect(() => {
-    if (
-      reserveMutation.isSuccess &&
-      paymentMethod?.paymentType !== PaymentType.Vipps &&
-      reserveMutation.data.url
-    ) {
-      openInAppBrowser(
-        reserveMutation.data.url,
-        'cancel',
-        `${APP_SCHEME}://purchase-callback`,
-        onPaymentCompleted,
-      );
-    }
-  }, [
-    reserveMutation.isSuccess,
-    reserveMutation.data?.url,
-    paymentMethod?.paymentType,
-    onPaymentCompleted,
   ]);
 
   // When deep link {APP_SCHEME}://purchase-callback is called, save payment

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-cancel-payment-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-cancel-payment-mutation.ts
@@ -1,8 +1,13 @@
 import {cancelPayment, OfferReservation} from '@atb/ticketing';
 import {useMutation} from '@tanstack/react-query';
 
+type Params = {
+  reservation: OfferReservation;
+  /** Whether or not the cancellation was triggered manually by a user */
+  isUser: boolean;
+};
 export const useCancelPaymentMutation = () =>
   useMutation({
-    mutationFn: (reservation: OfferReservation) =>
-      cancelPayment(reservation.payment_id, reservation.transaction_id),
+    mutationFn: ({reservation, isUser}: Params) =>
+      cancelPayment(reservation.payment_id, reservation.transaction_id, isUser),
   });

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-cancel-payment-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-cancel-payment-mutation.ts
@@ -6,8 +6,13 @@ type Params = {
   /** Whether or not the cancellation was triggered manually by a user */
   isUser: boolean;
 };
-export const useCancelPaymentMutation = () =>
+export const useCancelPaymentMutation = ({
+  onSuccess,
+}: {
+  onSuccess?: () => void;
+}) =>
   useMutation({
     mutationFn: ({reservation, isUser}: Params) =>
       cancelPayment(reservation.payment_id, reservation.transaction_id, isUser),
+    onSuccess,
   });

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-cancel-payment-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-cancel-payment-mutation.ts
@@ -1,8 +1,8 @@
-import {cancelPayment, OfferReservation} from '@atb/ticketing';
+import {cancelPayment, ReserveOfferResponse} from '@atb/ticketing';
 import {useMutation} from '@tanstack/react-query';
 
 type Params = {
-  reservation: OfferReservation;
+  reserveOfferResponse: ReserveOfferResponse;
   /** Whether or not the cancellation was triggered manually by a user */
   isUser: boolean;
 };
@@ -12,7 +12,11 @@ export const useCancelPaymentMutation = ({
   onSuccess?: () => void;
 }) =>
   useMutation({
-    mutationFn: ({reservation, isUser}: Params) =>
-      cancelPayment(reservation.payment_id, reservation.transaction_id, isUser),
+    mutationFn: ({reserveOfferResponse, isUser}: Params) =>
+      cancelPayment(
+        reserveOfferResponse.payment_id,
+        reserveOfferResponse.transaction_id,
+        isUser,
+      ),
     onSuccess,
   });

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-reserve-offer-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-reserve-offer-mutation.ts
@@ -15,6 +15,7 @@ type Args = {
   paymentMethod?: PaymentMethod;
   recipient?: TicketRecipientType;
   shouldSavePaymentMethod: boolean;
+  onSuccess?: (reservation: OfferReservation) => void;
 };
 
 export const useReserveOfferMutation = ({
@@ -22,6 +23,7 @@ export const useReserveOfferMutation = ({
   paymentMethod,
   recipient,
   shouldSavePaymentMethod,
+  onSuccess,
 }: Args) => {
   const {abtCustomerId, phoneNumber} = useAuthContext();
   const {enable_auto_sale: autoSale} = useRemoteConfigContext();
@@ -44,10 +46,11 @@ export const useReserveOfferMutation = ({
         recipient,
       });
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       if (recipient?.name) {
         queryClient.invalidateQueries([FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY]);
       }
+      onSuccess?.(data);
     },
   });
 };

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-reserve-offer-mutation.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-reserve-offer-mutation.ts
@@ -1,6 +1,6 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {
-  OfferReservation,
+  ReserveOfferResponse,
   ReserveOffer,
   TicketRecipientType,
   reserveOffers,
@@ -15,7 +15,7 @@ type Args = {
   paymentMethod?: PaymentMethod;
   recipient?: TicketRecipientType;
   shouldSavePaymentMethod: boolean;
-  onSuccess?: (reservation: OfferReservation) => void;
+  onSuccess?: (reserveOfferResponse: ReserveOfferResponse) => void;
 };
 
 export const useReserveOfferMutation = ({
@@ -30,7 +30,7 @@ export const useReserveOfferMutation = ({
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (): Promise<OfferReservation> => {
+    mutationFn: async (): Promise<ReserveOfferResponse> => {
       if (!paymentMethod) {
         return Promise.reject(new Error('No payment method provided'));
       }

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -170,11 +170,12 @@ export async function reserveOffers({
 }
 
 export async function cancelPayment(
-  payment_id: number,
-  transaction_id: number,
+  paymentId: number,
+  transactionId: number,
+  isUser: boolean,
 ): Promise<void> {
-  const url = `ticket/v3/payments/${payment_id}/transactions/${transaction_id}/cancel`;
-  await client.put(url, {}, {authWithIdToken: true});
+  const url = `ticket/v3/payments/${paymentId}/transactions/${transactionId}/cancel?isUser=${isUser}`;
+  await client.put(url, undefined, {authWithIdToken: true});
 }
 
 export async function getFareProducts(): Promise<PreassignedFareProduct[]> {

--- a/src/ticketing/api.ts
+++ b/src/ticketing/api.ts
@@ -1,11 +1,11 @@
 import {APP_SCHEME} from '@env';
 import {AxiosRequestConfig} from 'axios';
-import {AddPaymentMethodResponse, ReserveOfferRequestBody} from '.';
+import {AddPaymentMethodResponse, ReserveOfferRequest} from '.';
 import {FareContractType} from '@atb-as/utils';
 import {client} from '../api';
 import {
   Offer,
-  OfferReservation,
+  ReserveOfferResponse,
   PaymentType,
   RecentFareContractBackend,
   RecurringPayment,
@@ -146,9 +146,9 @@ export async function reserveOffers({
   phoneNumber,
   recipient,
   ...rest
-}: ReserveOfferParams): Promise<OfferReservation> {
+}: ReserveOfferParams): Promise<ReserveOfferResponse> {
   const url = 'ticket/v3/reserve';
-  const body: ReserveOfferRequestBody = {
+  const body: ReserveOfferRequest = {
     payment_redirect_url: `${APP_SCHEME}://purchase-callback`,
     offers,
     payment_type: paymentType,
@@ -162,7 +162,7 @@ export async function reserveOffers({
       ? {alias: recipient.name, phone_number: recipient.phoneNumber}
       : undefined,
   };
-  const response = await client.post<OfferReservation>(url, body, {
+  const response = await client.post<ReserveOfferResponse>(url, body, {
     ...opts,
     authWithIdToken: true,
   });

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -116,7 +116,11 @@ export type ReserveOffer = {
   count: number;
 };
 
-export type ReserveOfferRequestBody = {
+/**
+ * Defined by `ReserveOfferRequest` in
+ * https://github.com/AtB-AS/sales/blob/main/sales-service/src/handlers/sales/reserve.rs
+ */
+export type ReserveOfferRequest = {
   offers: ReserveOffer[];
   /**
    * Recurring payment id should be provided if using a previously stored
@@ -157,7 +161,11 @@ export type TicketRecipientType = {
   name?: string;
 };
 
-export type OfferReservation = {
+/**
+ * Defined by `ReserveOfferResponse` in
+ * https://github.com/AtB-AS/sales/blob/main/sales-service/src/handlers/sales/reserve.rs
+ */
+export type ReserveOfferResponse = {
   order_id: string;
   payment_id: number;
   transaction_id: number;

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -148,6 +148,11 @@ const PurchaseConfirmationTexts = {
     'Venter på betaling',
   ),
   cancelPayment: _('Avbryt kjøp', 'Cancel purchase', 'Avbryt kjøp'),
+  cancelPaymentError: _(
+    'Vi klarte ikke å avbryte kjøpet ditt. Vennligst sjekk om du har mottatt billetten, eller kontakt kundesenteret.',
+    'We were unable to cancel your purchase. Please check if you have received the ticket, or contact customer service.',
+    'Vi klarte ikkje å avbryte kjøpet ditt. Vennligst sjekk om du har mottatt billetten, eller ta kontakt med kundesenteret.',
+  ),
 
   choosePaymentMethod: {
     text: _('Velg betalingsmåte', 'Choose payment option', 'Vel betalingsmåte'),

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -142,6 +142,13 @@ const PurchaseConfirmationTexts = {
     ),
   },
 
+  waitingForPayment: _(
+    'Venter på betaling',
+    'Waiting for payment',
+    'Venter på betaling',
+  ),
+  cancelPayment: _('Avbryt kjøp', 'Cancel purchase', 'Avbryt kjøp'),
+
   choosePaymentMethod: {
     text: _('Velg betalingsmåte', 'Choose payment option', 'Vel betalingsmåte'),
     a11yHint: _(


### PR DESCRIPTION
_Might make sense to review one commit at a time_

This PR allows the user to cancel ongoing payments, and prevents several purchase flows going at once. 

Also sets a `isUser` query parameter for all cancel calls, indicating whether or not it was manually triggered by the user. This should allow us to monitor the amount of people who use the button.

https://github.com/user-attachments/assets/b850216c-88f6-4316-85fe-f4a4057dc629

closes https://github.com/AtB-AS/kundevendt/issues/20293
