### PR TITLE
fix: fixed undefined tabbarheight

### DIFF
--- a/src/components/map/MapV2.tsx
+++ b/src/components/map/MapV2.tsx
@@ -61,11 +61,11 @@ export const MapV2 = (props: MapProps) => {
   const {getCurrentCoordinates} = useGeolocationContext();
   const mapCameraRef = useRef<MapboxGL.Camera>(null);
   const mapViewRef = useRef<MapboxGL.MapView>(null);
-  const controlStyles = useControlPositionsStyle(false);
+  const tabBarHeight = useBottomTabBarHeight();
+  const controlStyles = useControlPositionsStyle(false, tabBarHeight);
   const isFocused = useIsFocused();
   const shouldShowVehiclesAndStations = isFocused; // don't send tile requests while in the background, and always get fresh data upon enter
   const mapViewConfig = useMapViewConfig({shouldShowVehiclesAndStations});
-  const tabBarHeight = useBottomTabBarHeight();
 
   const startingCoordinates = useMemo(
     () =>

--- a/src/components/map/hooks/use-control-styles.ts
+++ b/src/components/map/hooks/use-control-styles.ts
@@ -4,14 +4,15 @@ import {ViewStyle} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {useBottomNavigationStyles} from '@atb/utils/navigation';
-import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 
-export function useControlPositionsStyle(extraPaddingBottom = false) {
+export function useControlPositionsStyle(
+  extraPaddingBottom = false,
+  bottomTabBarHeight = 0,
+) {
   const {top, bottom} = useSafeAreaInsets();
   const {theme} = useThemeContext();
   const {height: bottomSheetHeight} = useBottomSheetContext();
   const {minHeight} = useBottomNavigationStyles();
-  const bottomTabBarHeight = useBottomTabBarHeight();
 
   const bottomPaddingIfBottomSheetIsOpen = bottomSheetHeight
     ? bottomSheetHeight - minHeight + bottomTabBarHeight


### PR DESCRIPTION
import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs'

useBottomTabBarHeight was used in a component thats used multiple places, but it needs to be used in a tab screen component. So in some cases it was undefined. 

Fixed it by passing it as a prop with default value 0. So its only affected when used in the targeted screen component

Closes http://github.com/AtB-AS/kundevendt/issues/20077