### PR TITLE
feat: Support dott instead of tier map icon

### DIFF
--- a/src/components/map/hooks/use-map-symbol-styles.ts
+++ b/src/components/map/hooks/use-map-symbol-styles.ts
@@ -92,8 +92,8 @@ export const useMapSymbolStyles = (
       'ryde',
       ['==', ['slice', systemId, 0, 3], 'voi'],
       'voi',
-      ['==', ['slice', systemId, 0, 4], 'tier'],
-      'tier',
+      ['==', ['slice', systemId, 0, 4], 'dott'],
+      'dott',
       'generic',
     ],
   ];

--- a/src/components/map/mapbox-styles/pin-types.ts
+++ b/src/components/map/mapbox-styles/pin-types.ts
@@ -24,7 +24,7 @@ export type VehicleIconCode =
 
 export type StationIconCode = 'sharedcar' | 'citybike';
 
-export type PinScooterCompany = 'generic' | 'voi' | 'ryde' | 'tier'; // todo: change 'tier' to 'dott' when sprite ready
+export type PinScooterCompany = 'generic' | 'voi' | 'ryde' | 'dott';
 
 export type LiveVehiclePinState =
   | 'active'


### PR DESCRIPTION
Tier has merged with Dott, and the system id now starts with `dott` instead of `tier`.
<div>
<img width="250" src="https://github.com/user-attachments/assets/889e12d2-7b90-4aab-a7c3-8048dcf59929" />

<img width="250" src="https://github.com/user-attachments/assets/11200838-058b-4f24-b8d3-81ca2e933ee3" />
</div>

<div>
<img width="250" src="https://github.com/user-attachments/assets/40624146-6bac-41b2-b776-b899ffdc6487" />

<img width="250" src="https://github.com/user-attachments/assets/cbecd29a-bd58-478f-807d-c3ccc4b12dea" />
</div>

