### PR TITLE
feat: hide fare contract validity seconds when >10 minutes

### DIFF
--- a/src/modules/fare-contracts/__tests__/fare-contract-validity-units.test.ts
+++ b/src/modules/fare-contracts/__tests__/fare-contract-validity-units.test.ts
@@ -53,23 +53,30 @@ describe('fareContractValidityUnits', () => {
     });
   });
 
-  describe('minutes range (60 seconds to 59 minutes, 59 seconds)', () => {
+  describe('minutes range (60 seconds to 9 minutes, 59 seconds)', () => {
     it('should return minutes and seconds units for 60 seconds', () => {
       expect(fareContractValidityUnits(SECONDS_IN_MINUTE)).toEqual(['m', 's']);
     });
 
-    it('should return minutes and seconds units for 30 minutes', () => {
-      expect(fareContractValidityUnits(30 * SECONDS_IN_MINUTE)).toEqual([
+    it('should return minutes and seconds units for 9 minutes 59 seconds', () => {
+      expect(fareContractValidityUnits(10 * SECONDS_IN_MINUTE - 1)).toEqual([
         'm',
         's',
       ]);
     });
+  });
 
-    it('should return minutes and seconds units for 59 minutes, 59 seconds', () => {
-      expect(fareContractValidityUnits(SECONDS_IN_HOUR - 1)).toEqual([
-        'm',
-        's',
-      ]);
+  describe('minutes and second range (10 minutes to 59 minutes, 59 seconds)', () => {
+    it('should return minutes units for 10 minutes', () => {
+      expect(fareContractValidityUnits(10 * SECONDS_IN_MINUTE)).toEqual(['m']);
+    });
+
+    it('should return minutes units for 30 minutes', () => {
+      expect(fareContractValidityUnits(30 * SECONDS_IN_MINUTE)).toEqual(['m']);
+    });
+
+    it('should return minutes units for 59 minutes, 59 seconds', () => {
+      expect(fareContractValidityUnits(SECONDS_IN_HOUR - 1)).toEqual(['m']);
     });
   });
 

--- a/src/modules/fare-contracts/fare-contract-validity-units.ts
+++ b/src/modules/fare-contracts/fare-contract-validity-units.ts
@@ -3,7 +3,7 @@ import type {UnitMapType} from './types';
 
 /**
  * These are following the rules from AtB-AS/kundevendt#4220, which apply for validityDuration of FareContracts
- * https://github.com/AtB-AS/kundevendt/issues/4220#issuecomment-2615206325
+ * https://github.com/AtB-AS/kundevendt/issues/4220
  * @param seconds
  */
 
@@ -12,13 +12,18 @@ export function fareContractValidityUnits(
 ): humanizeDuration.Unit[] {
   const oneMinuteInSeconds = 60;
   const oneHourInSeconds = oneMinuteInSeconds * 60;
+  const tenMinutesInSeconds = oneMinuteInSeconds * 10;
   const oneDayInSeconds = oneHourInSeconds * 24;
   const sevenDaysInSeconds = oneDayInSeconds * 7;
   const unitMap: UnitMapType = [
     {range: {low: -Infinity, high: oneMinuteInSeconds - 1}, units: ['s']},
     {
-      range: {low: oneMinuteInSeconds, high: oneHourInSeconds - 1},
+      range: {low: oneMinuteInSeconds, high: tenMinutesInSeconds - 1},
       units: ['m', 's'],
+    },
+    {
+      range: {low: tenMinutesInSeconds, high: oneHourInSeconds - 1},
+      units: ['m'],
     },
     {
       range: {low: oneHourInSeconds, high: oneDayInSeconds - 1},


### PR DESCRIPTION
Quickwin: Clarified with @Aliaaen that counting seconds from one hour and down on fare contracts is a bit excessive, and can cause some some layout shifting every second due to line breaks. Instead, this PR will hide seconds when validity time is >10 minutes.

### Acceptance criteria

- [ ] When a fare contract has between 1 and 10 minutes left, minutes and seconds are shown 
- [ ] When a fare contract has between 10 minutes and 1 hour, only minutes are shown