### PR TITLE
refactor!: change casing of refund options response

### DIFF
--- a/src/modules/fare-contracts/components/RefundBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/RefundBottomSheet.tsx
@@ -81,7 +81,7 @@ export const RefundBottomSheet = ({orderId, fareProductType, state}: Props) => {
           expanded={true}
           onPress={() => refund(orderId)}
           text={t(FareContractTexts.refund.confirm)}
-          disabled={!refundOptions?.is_refundable}
+          disabled={!refundOptions?.isRefundable}
           loading={
             refundStatus === 'loading' || refundOptionsStatus === 'loading'
           }

--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -215,7 +215,7 @@ export const DetailsContent: React.FC<Props> = ({
           testID="receiptButton"
         />
       )}
-      {refundOptions?.is_refundable && (
+      {refundOptions?.isRefundable && (
         <RefundSectionItem
           orderId={fc.orderId}
           fareProductType={preassignedFareProduct?.type}

--- a/src/ticketing/types.ts
+++ b/src/ticketing/types.ts
@@ -208,5 +208,5 @@ export type AddPaymentMethodResponse = {
  * https://github.com/AtB-AS/sales/blob/main/sales-service/src/handlers/sales/refund.rs
  */
 export type RefundOptions = {
-  is_refundable: boolean;
+  isRefundable: boolean;
 };


### PR DESCRIPTION
Changing the casing of `is_refundable` → `isRefundable`. We figured it was better to do this change now before refund is released to users, to be consistent with the casing in the responses from backend.



Backend PR: https://github.com/AtB-AS/sales/pull/43