### PR TITLE
fix: bonus balance null value

### DIFF
--- a/src/modules/bonus/api/api.ts
+++ b/src/modules/bonus/api/api.ts
@@ -11,6 +11,8 @@ export const getBonusBalance = (isLoggedIn: boolean): Promise<number> => {
       skipErrorLogging: (error) => error.response?.status === 404,
     })
     .then((response) => {
-      return Number(response.data.balance);
+      const value =
+        response.data.balance === null ? NaN : Number(response.data.balance);
+      return value;
     });
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/19986#issuecomment-2786117709

Fix the issue that Number(null) is 0, when null in bonus balance should be displayed as --

<img width= 200 src=https://github.com/user-attachments/assets/77e4d1a7-4855-48ad-b3fe-e1315d0c7361>
