### PR TITLE
fix: fix crash on Android for Apple Pass Presentation Suppression

### DIFF
--- a/src/modules/native-bridges/pass-presentation.ts
+++ b/src/modules/native-bridges/pass-presentation.ts
@@ -9,7 +9,7 @@ interface PassPresentationBridge {
 
 const PassPresentationBridge =
   NativeModules.PassPresentationBridge as PassPresentationBridge;
-if (!PassPresentationBridge) {
+if (Platform.OS === 'ios' && !PassPresentationBridge) {
   throw new Error(
     'PassPresentationBridge module is not linked. Please check your native module setup.',
   );


### PR DESCRIPTION
When showing tickets on Android, there will be crash caused by module not linked issue, solution is just to add a check if the running platform is iOS.