### PR TITLE
feat: add debug menu for simulating remote token inspectability

### DIFF
--- a/src/mobile-token/MobileTokenContext.tsx
+++ b/src/mobile-token/MobileTokenContext.tsx
@@ -75,6 +75,8 @@ type MobileTokenContextState = {
     remoteTokenError: any;
     setSabotage: (attestationSabotage?: AttestationSabotage) => void;
     sabotage: AttestationSabotage | undefined;
+    setAllTokenInspectable: (inspectable?: boolean) => void;
+    allTokenInspectable: boolean | undefined;
   };
 };
 
@@ -97,6 +99,9 @@ export const MobileTokenContextProvider = ({children}: Props) => {
 
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [sabotage, setSabotage] = useState<AttestationSabotage | undefined>();
+  const [allTokenInspectable, setAllTokenInspectable] = useState<
+    boolean | undefined
+  >();
   const [secureContainer, setSecureContainer] = useState<string>();
 
   const traceId = useRef<string>(uuid());
@@ -152,6 +157,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     enabled && nativeToken !== undefined && secureContainer !== undefined,
     nativeToken?.tokenId,
     secureContainer,
+    allTokenInspectable,
   );
   const {mutate: checkRenewMutate} = usePreemptiveRenewTokenMutation(userId);
 
@@ -279,6 +285,10 @@ export const MobileTokenContextProvider = ({children}: Props) => {
             }
           },
           sabotage: sabotage,
+          setAllTokenInspectable: (inspectable?: boolean) => {
+            setAllTokenInspectable(inspectable);
+          },
+          allTokenInspectable: allTokenInspectable,
         },
       }}
     >
@@ -369,11 +379,12 @@ const useMobileTokenStatus = (
 const deviceInspectable = (
   token?: ActivatedToken,
   remoteTokens?: RemoteToken[],
+  debugInspectable?: boolean,
 ): boolean => {
   if (!token || !remoteTokens) return false;
   const matchingRemoteToken = remoteTokens.find((r) => r.id === token.tokenId);
   if (!matchingRemoteToken) return false;
-  return isInspectable(matchingRemoteToken);
+  return debugInspectable ?? isInspectable(matchingRemoteToken);
 };
 
 export const getIsInspectableFromStatus = (

--- a/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
+++ b/src/mobile-token/hooks/use-list-remote-tokens-query.tsx
@@ -18,6 +18,7 @@ export const useListRemoteTokensQuery = (
   enabled: boolean,
   tokenId?: string,
   secureContainer?: string,
+  allTokenInspectable?: boolean,
 ) => {
   const {userId} = useAuthContext();
   return useQuery({
@@ -38,7 +39,7 @@ export const useListRemoteTokensQuery = (
         (t): Token => ({
           ...t,
           isThisDevice: t.id === tokenId,
-          isInspectable: isInspectable(t),
+          isInspectable: allTokenInspectable ?? isInspectable(t),
           type: isTravelCardToken(t) ? 'travel-card' : 'mobile',
           travelCardId: getTravelCardId(t),
         }),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -97,6 +97,8 @@ export const Profile_DebugInfoScreen = () => {
       remoteTokenError,
       setSabotage,
       sabotage,
+      setAllTokenInspectable,
+      allTokenInspectable,
     },
   } = useMobileTokenContext();
   const {serverNow} = useTimeContext();
@@ -435,6 +437,7 @@ export const Profile_DebugInfoScreen = () => {
                 )}
                 <ThemeText>{`Mobile token status: ${mobileTokenStatus}`}</ThemeText>
                 <ThemeText>{`IsInspectable: ${isInspectable}`}</ThemeText>
+                <ThemeText>{`Override remote token inspectable: ${allTokenInspectable}`}</ThemeText>
                 <ThemeText>{`Native token status: ${nativeTokenStatus}`}</ThemeText>
                 <ThemeText>{`Native token error: ${nativeTokenError}`}</ThemeText>
                 <ThemeText>{`Remote tokens status: ${remoteTokensStatus}`}</ThemeText>
@@ -496,6 +499,32 @@ export const Profile_DebugInfoScreen = () => {
                       <DebugSabotage
                         sabotage={sabotage}
                         setSabotage={setSabotage}
+                      />
+                    </View>
+                  }
+                />
+                <ExpandableSectionItem
+                  text="Remote Token Inspectability"
+                  showIconText={true}
+                  expandContent={
+                    <View>
+                      <Button
+                        expanded={true}
+                        style={styles.button}
+                        text="Set no inspectable token"
+                        onPress={() => setAllTokenInspectable(false)}
+                      />
+                      <Button
+                        expanded={true}
+                        style={styles.button}
+                        text="Set all inspectable token"
+                        onPress={() => setAllTokenInspectable(true)}
+                      />
+                      <Button
+                        expanded={true}
+                        style={styles.button}
+                        text="Reset token inspectability to default"
+                        onPress={() => setAllTokenInspectable(undefined)}
                       />
                     </View>
                   }


### PR DESCRIPTION
Adding this menu to help the testers test simulating no remote tokens that are inspectable. 

<img src="https://github.com/user-attachments/assets/98e48a7d-ae2d-4f51-afcc-e05336116682" width="400"/>

Helps in testing this screen

<img src="https://github.com/user-attachments/assets/48016336-faa1-4704-8db2-e3dede6e0e58" width="400"/>
