### PR TITLE
fix: Use boat icon instead of ferry icon for boat

### DIFF
--- a/src/components/map/components/national-stop-registry-features/nsr-layers.ts
+++ b/src/components/map/components/national-stop-registry-features/nsr-layers.ts
@@ -92,7 +92,7 @@ export const nsrSymbolLayers: NsrSymbolLayer[] = [
   },
   {
     id: 'boat.nsr.api',
-    iconCode: 'ferry',
+    iconCode: 'boat',
     showAsDefaultAtZoomLevel: 10,
     filter: [
       'all',

--- a/src/components/map/mapbox-styles/pin-types.ts
+++ b/src/components/map/mapbox-styles/pin-types.ts
@@ -2,7 +2,7 @@ import {Theme, Themes} from '@atb-as/theme';
 
 export type NsrPinIconCode =
   | 'commuterparking'
-  | 'ferry'
+  | 'boat'
   | 'tram'
   | 'metroandtram'
   | 'metro'


### PR DESCRIPTION
Fixes a bug where the ferry icon was used for boat as well in the map.

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/bb64ffd6-176c-4497-9a41-e4c898483b36" /> | <img width="200" src="https://github.com/user-attachments/assets/a15ba379-7cff-41db-854a-2865f4ae6bfe" /> |


