### PR TITLE
feat: add error message for school ticket consumption

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,5 +1,22 @@
 import axios, {AxiosError, Cancel} from 'axios';
 import {FirebaseAuthIdHeaderName, RequestIdHeaderName} from './headers';
+import {z} from 'zod';
+
+/** https://github.com/AtB-AS/amp-rs/blob/main/amp-http/src/lib.rs */
+const HttpError = z.object({
+  code: z.number(),
+  message: z.string(),
+});
+type HttpError = z.infer<typeof HttpError>;
+
+/** https://github.com/AtB-AS/amp-rs/blob/main/amp-http/src/lib.rs */
+export const ErrorResponse = z.object({
+  http: HttpError,
+  kind: z.string(),
+  message: z.string().optional(),
+  details: z.array(z.unknown()).optional(),
+});
+export type ErrorResponse = z.infer<typeof ErrorResponse>;
 
 export type ErrorType =
   | 'unknown'
@@ -59,5 +76,11 @@ export const getAxiosErrorMetadata = (error: AxiosError): ErrorMetadata => ({
   responseStatusText: error?.response?.statusText,
   responseData: JSON.stringify(error?.response?.data || 'No response data'),
 });
+
+export const getErrorResponse = (
+  error: AxiosError,
+): ErrorResponse | undefined => {
+  return ErrorResponse.safeParse(error?.response?.data).data;
+};
 
 export const stringifyUrl = (url: string, query: string) => `${url}?${query}`;

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -263,6 +263,16 @@ const FareContractTexts = {
       'The ticket becomes valid as soon as you start it. Only one ticket can be activated at a time.',
       'Billetten blir gyldig med ein gong du startar den. Berre ein billett kan aktiverast av gangen.',
     ),
+    schoolErrorTitle: _(
+      'Kunne ikke aktivere denne billetten nå',
+      'Could not activate this ticket right now',
+      'Kunne ikkje aktivere denne billetten no',
+    ),
+    schoolErrorMessage: _(
+      'Du har enten prøvd å aktivere på et tidspunkt som ikke er tillatt, eller brukt opp de tilgjengelige billettene dine.',
+      'You have either tried to activate outside the allowed time, or you have used all of your available tickets.',
+      'Du har enten prøvd å aktivere på eit tidspunkt som ikkje er tillaten, eller brukt opp dei tilgjengelege billettane dine.',
+    ),
     genericError: _(
       'En feil har oppstått under aktivering av billetten. Vennligst prøv igjen.',
       'An error occurred while activating the ticket. Please try again.',


### PR DESCRIPTION
Adds a school-ticket specific error message based on https://github.com/AtB-AS/ticket/pull/29 and https://www.figma.com/design/ufJRKSCxQzNpFVlrKsdaKd/Skoleskyss?node-id=510-19558&t=c3Lu2M3gXCnmeb4T-0

<img width="300px" src="https://github.com/user-attachments/assets/a0bbd045-5b75-4d9a-b87a-3bb92a0903d9">

### Acceptance criteria

- [ ] The warning is shown when consuming a school ticket for the third time in a day and on school off days.
- [ ] Regular carnets are unaffected, and show the old error message in case of errors.