### PR TITLE
refactor: Moved DateSelection from place-screen to date-picker

### DIFF
--- a/src/components/date-selection/DatePickerSheet.tsx
+++ b/src/components/date-selection/DatePickerSheet.tsx
@@ -18,7 +18,7 @@ import {animateNextChange} from '@atb/utils/animation';
 import type {
   DateOptionAndText,
   DateOptionAndValue,
-} from '@atb/date-picker/types';
+} from '@atb/components/date-selection';
 import {default as RNDatePicker} from 'react-native-date-picker';
 import {getTimeZoneOffsetInMinutes, parseDate} from '@atb/utils/date';
 import {useLocaleContext} from '@atb/modules/locale';

--- a/src/components/date-selection/DateSelection.tsx
+++ b/src/components/date-selection/DateSelection.tsx
@@ -18,9 +18,9 @@ import {useFontScale} from '@atb/utils/use-font-scale';
 import {addDays, isToday, parseISO} from 'date-fns';
 import React, {RefObject, useRef} from 'react';
 import {View} from 'react-native';
-import {DepartureDateOptions, DepartureSearchTime} from '../types';
-import {DatePickerSheet} from '@atb/date-picker';
+import {DatePickerSheet} from './DatePickerSheet';
 import type {ContrastColor} from '@atb-as/theme';
+import {DepartureDateOptions, type DepartureSearchTime} from './types';
 
 type DateSelectionProps = {
   searchTime: DepartureSearchTime;

--- a/src/components/date-selection/index.ts
+++ b/src/components/date-selection/index.ts
@@ -1,0 +1,7 @@
+export {DatePickerSheet} from './DatePickerSheet';
+export {DateSelection} from './DateSelection';
+export type {
+  DateOptionAndValue,
+  DateOptionAndText,
+  DepartureSearchTime,
+} from './types';

--- a/src/components/date-selection/types.ts
+++ b/src/components/date-selection/types.ts
@@ -1,0 +1,12 @@
+export type DateOptionAndText<T extends string> = {
+  option: T;
+  text: string;
+  selected?: boolean;
+};
+export type DateOptionAndValue<T extends string> = {
+  option: T;
+  date: string;
+};
+export const DepartureDateOptions = ['now', 'departure'] as const;
+export type DepartureDateOptionType = (typeof DepartureDateOptions)[number];
+export type DepartureSearchTime = DateOptionAndValue<DepartureDateOptionType>;

--- a/src/date-picker/index.ts
+++ b/src/date-picker/index.ts
@@ -1,2 +1,0 @@
-export {DatePickerSheet} from './DatePickerSheet';
-export type {DateOptionAndValue} from './types';

--- a/src/date-picker/types.ts
+++ b/src/date-picker/types.ts
@@ -1,9 +1,0 @@
-export type DateOptionAndText<T extends string> = {
-  option: T;
-  text: string;
-  selected?: boolean;
-};
-export type DateOptionAndValue<T extends string> = {
-  option: T;
-  date: string;
-};

--- a/src/modules/map/components/DeparturesDialogSheet.tsx
+++ b/src/modules/map/components/DeparturesDialogSheet.tsx
@@ -3,11 +3,6 @@ import React, {useState} from 'react';
 import {ActivityIndicator, View} from 'react-native';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {DeparturesTexts, dictionary, useTranslation} from '@atb/translations';
-import {
-  DepartureSearchTime,
-  StopPlacesView,
-  useStopsDetailsDataQuery,
-} from '@atb/screen-components/place-screen';
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Feature, Point} from 'geojson';
@@ -15,6 +10,11 @@ import {Location, SearchLocation} from '@atb/modules/favorites';
 import {NavigateToTripSearchCallback} from '../types';
 import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 import {isDefined} from '@atb/utils/presence';
+import type {DepartureSearchTime} from 'src/components/date-selection';
+import {
+  StopPlacesView,
+  useStopsDetailsDataQuery,
+} from '@atb/screen-components/place-screen';
 
 type DeparturesDialogSheetProps = {
   onClose: () => void;

--- a/src/modules/map/components/DeparturesDialogSheet.tsx
+++ b/src/modules/map/components/DeparturesDialogSheet.tsx
@@ -10,11 +10,11 @@ import {Location, SearchLocation} from '@atb/modules/favorites';
 import {NavigateToTripSearchCallback} from '../types';
 import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 import {isDefined} from '@atb/utils/presence';
-import type {DepartureSearchTime} from 'src/components/date-selection';
 import {
   StopPlacesView,
   useStopsDetailsDataQuery,
 } from '@atb/screen-components/place-screen';
+import type {DepartureSearchTime} from '@atb/components/date-selection';
 
 type DeparturesDialogSheetProps = {
   onClose: () => void;

--- a/src/screen-components/place-screen/PlaceScreenComponent.tsx
+++ b/src/screen-components/place-screen/PlaceScreenComponent.tsx
@@ -1,7 +1,6 @@
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {Button} from '@atb/components/button';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {DepartureSearchTime} from './types';
 import {StyleSheet, type Theme, useThemeContext} from '@atb/theme';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import {useIsFocused} from '@react-navigation/native';
@@ -13,7 +12,8 @@ import {ServiceJourneyDeparture} from '@atb/screen-components/travel-details-scr
 import {StopPlaceAndQuaySelection} from './components/StopPlaceAndQuaySelection';
 import {QuayView} from './components/QuayView';
 import {StopPlacesView} from './components/StopPlacesView';
-import {useStopsDetailsDataQuery} from '@atb/screen-components/place-screen';
+import type {DepartureSearchTime} from 'src/components/date-selection';
+import {useStopsDetailsDataQuery} from './hooks/use-stops-details-data-query';
 
 export type PlaceScreenParams = {
   place: StopPlace;

--- a/src/screen-components/place-screen/components/QuayView.tsx
+++ b/src/screen-components/place-screen/components/QuayView.tsx
@@ -2,7 +2,10 @@ import {Quay, StopPlace} from '@atb/api/types/departures';
 import {StyleSheet} from '@atb/theme';
 import React, {useEffect} from 'react';
 import {RefreshControl, SectionList, SectionListData, View} from 'react-native';
-import {DateSelection} from '@atb/components/date-selection';
+import {
+  DateSelection,
+  type DepartureSearchTime,
+} from '@atb/components/date-selection';
 import {FavoriteToggle} from './FavoriteToggle';
 import {QuaySection} from './QuaySection';
 import {useDeparturesData} from '../hooks/use-departures-data';
@@ -12,7 +15,6 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {DeparturesTexts, dictionary, useTranslation} from '@atb/translations';
 import {useIsFocused} from '@react-navigation/native';
 import type {ContrastColor} from '@atb-as/theme';
-import type {DepartureSearchTime} from 'src/components/date-selection';
 import {useFavoritesContext} from '@atb/modules/favorites';
 
 const NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 1000;

--- a/src/screen-components/place-screen/components/QuayView.tsx
+++ b/src/screen-components/place-screen/components/QuayView.tsx
@@ -1,10 +1,8 @@
 import {Quay, StopPlace} from '@atb/api/types/departures';
-import {useFavoritesContext} from '@atb/modules/favorites';
-import {DepartureSearchTime} from '../types';
 import {StyleSheet} from '@atb/theme';
 import React, {useEffect} from 'react';
 import {RefreshControl, SectionList, SectionListData, View} from 'react-native';
-import {DateSelection} from './DateSelection';
+import {DateSelection} from '@atb/components/date-selection';
 import {FavoriteToggle} from './FavoriteToggle';
 import {QuaySection} from './QuaySection';
 import {useDeparturesData} from '../hooks/use-departures-data';
@@ -14,6 +12,8 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {DeparturesTexts, dictionary, useTranslation} from '@atb/translations';
 import {useIsFocused} from '@react-navigation/native';
 import type {ContrastColor} from '@atb-as/theme';
+import type {DepartureSearchTime} from 'src/components/date-selection';
+import {useFavoritesContext} from '@atb/modules/favorites';
 
 const NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 1000;
 

--- a/src/screen-components/place-screen/components/StopPlacesView.tsx
+++ b/src/screen-components/place-screen/components/StopPlacesView.tsx
@@ -1,16 +1,9 @@
 import {Quay, StopPlace} from '@atb/api/types/departures';
-import {
-  useFavoritesContext,
-  UserFavoriteDepartures,
-} from '@atb/modules/favorites';
-import {DepartureSearchTime, StopPlaceAndQuay} from '../types';
 import {StyleSheet} from '@atb/theme';
 import React, {useEffect, useMemo} from 'react';
 import {RefreshControl, SectionList, SectionListData, View} from 'react-native';
 import {QuaySection} from './QuaySection';
 import {FavoriteToggle} from './FavoriteToggle';
-import {DateSelection} from './DateSelection';
-import {StopPlacesMode} from '@atb/screen-components/nearby-stop-places';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {DeparturesTexts, dictionary, useTranslation} from '@atb/translations';
 import {Button} from '@atb/components/button';
@@ -20,6 +13,16 @@ import {useDeparturesData} from '../hooks/use-departures-data';
 import {WalkingDistance} from '@atb/components/walking-distance';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import type {ContrastColor} from '@atb-as/theme';
+import {
+  DateSelection,
+  type DepartureSearchTime,
+} from 'src/components/date-selection';
+import type {StopPlacesMode} from '@atb/screen-components/nearby-stop-places';
+import {
+  useFavoritesContext,
+  type UserFavoriteDepartures,
+} from '@atb/modules/favorites';
+import type {StopPlaceAndQuay} from '@atb/screen-components/place-screen';
 
 const NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 5;
 const NUMBER_OF_DEPARTURES_IN_BUFFER = 5;

--- a/src/screen-components/place-screen/components/StopPlacesView.tsx
+++ b/src/screen-components/place-screen/components/StopPlacesView.tsx
@@ -16,7 +16,7 @@ import type {ContrastColor} from '@atb-as/theme';
 import {
   DateSelection,
   type DepartureSearchTime,
-} from 'src/components/date-selection';
+} from '@atb/components/date-selection';
 import type {StopPlacesMode} from '@atb/screen-components/nearby-stop-places';
 import {
   useFavoritesContext,

--- a/src/screen-components/place-screen/index.tsx
+++ b/src/screen-components/place-screen/index.tsx
@@ -1,6 +1,5 @@
 export {PlaceScreenComponent} from './PlaceScreenComponent';
 export {StopPlacesView} from './components/StopPlacesView';
-export type {DepartureSearchTime} from './types';
 export type {PlaceScreenParams} from './PlaceScreenComponent';
-
 export {useStopsDetailsDataQuery} from './hooks/use-stops-details-data-query';
+export type {StopPlaceAndQuay} from './types';

--- a/src/screen-components/place-screen/types.ts
+++ b/src/screen-components/place-screen/types.ts
@@ -1,8 +1,3 @@
 import {Quay, StopPlace} from '@atb/api/types/departures';
-import type {DateOptionAndValue} from '@atb/date-picker';
-
-export const DepartureDateOptions = ['now', 'departure'] as const;
-export type DepartureDateOptionType = (typeof DepartureDateOptions)[number];
-export type DepartureSearchTime = DateOptionAndValue<DepartureDateOptionType>;
 
 export type StopPlaceAndQuay = {stopPlace: StopPlace; quay: Quay};

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -8,7 +8,7 @@ import {
   type PurchaseSelectionType,
   usePurchaseSelectionBuilder,
 } from '@atb/modules/purchase-selection';
-import {DatePickerSheet} from 'src/components/date-selection';
+import {DatePickerSheet} from '@atb/components/date-selection';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {Edit} from '@atb/assets/svg/mono-icons/actions';

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -8,7 +8,7 @@ import {
   type PurchaseSelectionType,
   usePurchaseSelectionBuilder,
 } from '@atb/modules/purchase-selection';
-import {DatePickerSheet} from '@atb/date-picker';
+import {DatePickerSheet} from 'src/components/date-selection';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {Edit} from '@atb/assets/svg/mono-icons/actions';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
@@ -26,7 +26,11 @@ import {animateNextChange} from '@atb/utils/animation';
 
 import {flatten} from 'lodash';
 import {DepartureLineInfo} from '@atb/api/departures/types';
+<<<<<<< HEAD
 import type {DateOptionAndValue} from 'src/components/date-selection';
+=======
+import type {DateOptionAndValue} from '@atb/date-selection';
+>>>>>>> 3ae31bfef (refactor: Renamed src/* imports to @atb/* imports)
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW = 7;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
@@ -26,7 +26,7 @@ import {animateNextChange} from '@atb/utils/animation';
 
 import {flatten} from 'lodash';
 import {DepartureLineInfo} from '@atb/api/departures/types';
-import type {DateOptionAndValue} from '@atb/date-picker';
+import type {DateOptionAndValue} from 'src/components/date-selection';
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW = 7;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departure-data.ts
@@ -26,11 +26,7 @@ import {animateNextChange} from '@atb/utils/animation';
 
 import {flatten} from 'lodash';
 import {DepartureLineInfo} from '@atb/api/departures/types';
-<<<<<<< HEAD
-import type {DateOptionAndValue} from 'src/components/date-selection';
-=======
-import type {DateOptionAndValue} from '@atb/date-selection';
->>>>>>> 3ae31bfef (refactor: Renamed src/* imports to @atb/* imports)
+import type {DateOptionAndValue} from '@atb/components/date-selection';
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW = 7;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -60,7 +60,7 @@ import {
 import {isDefined} from '@atb/utils/presence';
 import {onlyUniques} from '@atb/utils/only-uniques';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
-import {DatePickerSheet} from '@atb/date-picker';
+import {DatePickerSheet} from 'src/components/date-selection';
 
 type RootProps = DashboardScreenProps<'Dashboard_TripSearchScreen'>;
 
@@ -539,6 +539,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
     </View>
   );
 };
+
 function useLocations(
   currentLocation: GeoLocation | undefined,
 ): SearchForLocations {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -60,7 +60,7 @@ import {
 import {isDefined} from '@atb/utils/presence';
 import {onlyUniques} from '@atb/utils/only-uniques';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
-import {DatePickerSheet} from 'src/components/date-selection';
+import {DatePickerSheet} from '@atb/components/date-selection';
 
 type RootProps = DashboardScreenProps<'Dashboard_TripSearchScreen'>;
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query.tsx
@@ -13,7 +13,7 @@ import {TravelSearchFiltersSelectionType} from '@atb/modules/travel-search-filte
 import {TravelSearchPreferenceWithSelectionType} from '@atb/modules/travel-search-filters';
 import {TravelSearchPreferenceParameterType} from '@atb-as/config-specs';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import type {DateOptionAndValue} from 'src/components/date-selection';
+import type {DateOptionAndValue} from '@atb/components/date-selection';
 
 export const useNonTransitTripsQuery = (
   fromLocation: Location | undefined,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-non-transit-trips-query.tsx
@@ -13,7 +13,7 @@ import {TravelSearchFiltersSelectionType} from '@atb/modules/travel-search-filte
 import {TravelSearchPreferenceWithSelectionType} from '@atb/modules/travel-search-filters';
 import {TravelSearchPreferenceParameterType} from '@atb-as/config-specs';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import type {DateOptionAndValue} from '@atb/date-picker';
+import type {DateOptionAndValue} from 'src/components/date-selection';
 
 export const useNonTransitTripsQuery = (
   fromLocation: Location | undefined,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
@@ -16,7 +16,7 @@ import {TravelSearchTransportModesType} from '@atb-as/config-specs';
 import {enumFromString} from '@atb/utils/enum-from-string';
 import {isDefined} from '@atb/utils/presence';
 import {FeatureCategory} from '@atb/sdk';
-import type {DateOptionAndValue} from '@atb/date-picker';
+import type {DateOptionAndValue} from 'src/components/date-selection';
 import type {TripSearchTime} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/types';
 import {
   Language,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
@@ -16,7 +16,6 @@ import {TravelSearchTransportModesType} from '@atb-as/config-specs';
 import {enumFromString} from '@atb/utils/enum-from-string';
 import {isDefined} from '@atb/utils/presence';
 import {FeatureCategory} from '@atb/sdk';
-import type {DateOptionAndValue} from 'src/components/date-selection';
 import type {TripSearchTime} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/types';
 import {
   Language,
@@ -24,6 +23,7 @@ import {
   TripSearchTexts,
 } from '@atb/translations';
 import {formatToLongDateTime} from '@atb/utils/date';
+import type {DateOptionAndValue} from '@atb/components/date-selection';
 
 export type TimeSearch = {
   searchTime: DateOptionAndValue<'now' | 'departure' | 'arrival'>;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/types.ts
@@ -1,5 +1,5 @@
-import {Location} from '@atb/modules/favorites';
-import type {DateOptionAndValue} from '@atb/date-picker/types';
+import type {DateOptionAndValue} from '@atb/components/date-selection';
+import type {Location} from '@atb/modules/favorites';
 
 export type SearchForLocations = {
   from?: Location;


### PR DESCRIPTION
The DateSelection-component is widely used in the app, not just in the place-screen component. For this reason I propose moving it in together with the `DatePickerSheet`, since those two are very reliant on each other. 

Also renamed the component to `date-selection`, since the component is a little broader than just picking a date (previous day, next day, now etc). 