### PR TITLE
fix: Issue where bottomsheet stays open when navigating away from maptab

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreenV2.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreenV2.tsx
@@ -10,7 +10,6 @@ import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled'
 import {MapDisabledForScreenReader} from './components/MapDisabledForScreenReader';
 import {useFocusEffect} from '@react-navigation/native';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
-import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export type MapScreenParams = {
   initialFilters?: MapFilterType;
@@ -21,17 +20,14 @@ export const Map_RootScreenV2 = ({
 }: MapScreenProps<'Map_RootScreen'>) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
   const {close} = useBottomSheetContext();
-  const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
 
   useFocusEffect(
     useCallback(() => {
-      if (isShmoDeepIntegrationEnabled) {
-        return () => {
-          // on screen blur (navigating away from map tab), close bottomsheet
-          close();
-        };
-      }
-    }, [close, isShmoDeepIntegrationEnabled]),
+      return () => {
+        // on screen blur (navigating away from map tab), close bottomsheet
+        close();
+      };
+    }, [close]),
   );
 
   const navigateToQuay = useCallback(


### PR DESCRIPTION
There was a shmo featureflag wrapped around the focusEffect telling the bottomsheet to close when navigating. If this was going to stay we needed to add a featureflag for the tabHeight that pushed the bottomsheet up aswell, making it impossible to navigate in the tabs without the featureflag on