### PR TITLE
fix: don't read zones if there are no zones on recent ticket results.

### DIFF
--- a/src/recent-fare-contracts/use-recent-fare-contracts.ts
+++ b/src/recent-fare-contracts/use-recent-fare-contracts.ts
@@ -121,11 +121,11 @@ const mapBackendRecentFareContracts = (
 
   const fromTariffZone = findReferenceDataById(
     tariffZones,
-    recentFareContract.zones[0],
+    recentFareContract.zones?.[0],
   );
   const toTariffZone = findReferenceDataById(
     tariffZones,
-    recentFareContract.zones.slice(-1)[0],
+    recentFareContract.zones?.slice(-1)?.[0],
   );
 
   const direction: TravelRightDirection | undefined = enumFromString(


### PR DESCRIPTION
Fixes a crash that happens when you have "Recent Tickets" purchased in around 2024, I think the newly updated recent tickets endpoint caused this, so we need to guard this by checking if the zones are defined or not in the code.

To test this, use test account 45645645 and open the ticket purchase screen.

Backend team will make a fix as well on their side.

Acceptance Criteria: 
- [ ] App does not crash if the recent ticket doesn't have zones, try account 45645645