### PR TITLE
feat: show expiry message for saved payment card

### DIFF
--- a/src/modules/payment/ExpiryMessage.tsx
+++ b/src/modules/payment/ExpiryMessage.tsx
@@ -1,0 +1,76 @@
+import {MessageInfoText} from '@atb/components/message-info-text';
+import {Statuses, StyleSheet, Theme} from '@atb/theme';
+import {useTranslation} from '@atb/translations';
+import PaymentMethodsTexts from '@atb/translations/screens/subscreens/PaymentMethods';
+import {formatToShortDateWithYear} from '@atb/utils/date';
+import {addDays, parseISO} from 'date-fns';
+import {View} from 'react-native';
+import {RecurringPayment} from '../ticketing';
+
+export const ExpiryMessage = ({
+  recurringPayment,
+}: {
+  recurringPayment?: RecurringPayment;
+}) => {
+  const {t, language} = useTranslation();
+  const styles = useStyles();
+  const now = Date.now();
+  const inThirtyDays = addDays(now, 30).getTime();
+
+  if (!recurringPayment) return null;
+
+  const expiresAt = parseISO(recurringPayment.expiresAt).getTime();
+  const cardExpiresAt = parseISO(recurringPayment.cardExpiresAt).getTime();
+
+  let message: {type: Statuses; message: string} | null = null;
+
+  // Check expired states first (highest priority)
+  if (cardExpiresAt < now) {
+    message = {
+      type: 'error',
+      message: t(PaymentMethodsTexts.expiryMessages.cardExpired),
+    };
+  } else if (expiresAt < now) {
+    message = {
+      type: 'error',
+      message: t(PaymentMethodsTexts.expiryMessages.cardRegistrationExpired),
+    };
+  }
+  // Then check "expiring soon" states - show the one that expires first
+  else if (cardExpiresAt < inThirtyDays || expiresAt < inThirtyDays) {
+    // Compare which one expires first
+    if (cardExpiresAt < expiresAt) {
+      message = {
+        type: 'warning',
+        message: t(
+          PaymentMethodsTexts.expiryMessages.cardExpiring(
+            formatToShortDateWithYear(recurringPayment.cardExpiresAt, language),
+          ),
+        ),
+      };
+    } else {
+      message = {
+        type: 'warning',
+        message: t(
+          PaymentMethodsTexts.expiryMessages.cardRegistrationExpiring(
+            formatToShortDateWithYear(recurringPayment.expiresAt, language),
+          ),
+        ),
+      };
+    }
+  }
+
+  if (!message) return null;
+
+  return (
+    <View style={styles.warningMessage}>
+      <MessageInfoText type={message.type} message={message.message} />
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
+  warningMessage: {
+    paddingTop: theme.spacing.medium,
+  },
+}));

--- a/src/modules/payment/SinglePaymentMethod.tsx
+++ b/src/modules/payment/SinglePaymentMethod.tsx
@@ -7,6 +7,7 @@ import {View} from 'react-native';
 import {getRadioA11y, RadioIcon} from '@atb/components/radio';
 import {ThemeText} from '@atb/components/text';
 import {PaymentBrand} from './PaymentBrand';
+import {ExpiryMessage} from './ExpiryMessage';
 
 type SinglePaymentMethodProps = {
   paymentMethod: PaymentMethod;
@@ -94,6 +95,8 @@ export const SinglePaymentMethod = ({
               <PaymentBrand paymentType={paymentMethod.paymentType} />
             </View>
           </View>
+
+          <ExpiryMessage recurringPayment={paymentMethod.recurringPayment} />
         </View>
       </PressableOpacity>
     </View>

--- a/src/modules/payment/index.ts
+++ b/src/modules/payment/index.ts
@@ -12,6 +12,7 @@ export {
 export {PaymentSelectionSectionItem} from './PaymentSelectionSectionItem';
 export {SelectPaymentMethodSheet} from './SelectPaymentMethodSheet';
 export {PaymentBrand} from './PaymentBrand';
+export {ExpiryMessage} from './ExpiryMessage';
 export {SinglePaymentMethod} from './SinglePaymentMethod';
 export {MultiplePaymentMethodsRadioSection} from './MultiplePaymentMethodsRadioSection';
 export {isCardPaymentMethod} from './utils';

--- a/src/modules/payment/previous-payment-utils.ts
+++ b/src/modules/payment/previous-payment-utils.ts
@@ -44,16 +44,19 @@ export function usePreviousPaymentMethods(): {
       if (!enabledPaymentTypes.includes(paymentMethod.paymentType))
         return false;
 
-      const now = Date.now();
-      // Either the card registration has expired or the card itself has
-      // expired. If either of these is true, the payment method is invalid.
-      const expired =
-        paymentMethod.recurringPayment &&
-        (parseISO(paymentMethod.recurringPayment.expiresAt).getTime() < now ||
-          parseISO(paymentMethod.recurringPayment.cardExpiresAt).getTime() <
-            now);
+      if (paymentMethod.recurringPayment) {
+        const now = Date.now();
+        // Card registration has expired
+        if (parseISO(paymentMethod.recurringPayment.expiresAt).getTime() < now)
+          return false;
+        // Card has expired
+        if (
+          parseISO(paymentMethod.recurringPayment.cardExpiresAt).getTime() < now
+        )
+          return false;
+      }
 
-      return !expired;
+      return true;
     },
     [recurringPayments, paymentTypes],
   );

--- a/src/modules/payment/previous-payment-utils.ts
+++ b/src/modules/payment/previous-payment-utils.ts
@@ -44,14 +44,16 @@ export function usePreviousPaymentMethods(): {
       if (!enabledPaymentTypes.includes(paymentMethod.paymentType))
         return false;
 
-      // Card has expired
+      const now = Date.now();
+      // Either the card registration has expired or the card itself has
+      // expired. If either of these is true, the payment method is invalid.
       const expired =
         paymentMethod.recurringPayment &&
-        parseISO(paymentMethod.recurringPayment.expiresAt).getTime() <
-          Date.now();
-      if (expired) return false;
+        (parseISO(paymentMethod.recurringPayment.expiresAt).getTime() < now ||
+          parseISO(paymentMethod.recurringPayment.cardExpiresAt).getTime() <
+            now);
 
-      return true;
+      return !expired;
     },
     [recurringPayments, paymentTypes],
   );

--- a/src/modules/ticketing/types.ts
+++ b/src/modules/ticketing/types.ts
@@ -28,6 +28,7 @@ export enum PaymentType {
 export type RecurringPayment = {
   id: number;
   expiresAt: string;
+  cardExpiresAt: string;
   maskedPan: string;
   paymentType: number;
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -19,7 +19,7 @@ import {RefreshControl, View} from 'react-native';
 import {destructiveAlert} from './utils';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
-import {PaymentBrand} from '@atb/modules/payment';
+import {ExpiryMessage, PaymentBrand} from '@atb/modules/payment';
 import {useRecurringPayment} from '@atb/modules/ticketing';
 
 export const Profile_PaymentMethodsScreen = () => {
@@ -160,6 +160,8 @@ const Card = (props: {
           </PressableOpacity>
         </View>
       </View>
+
+      <ExpiryMessage recurringPayment={card} />
     </View>
   );
 };
@@ -211,8 +213,5 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
     display: 'flex',
     flexDirection: 'row',
     columnGap: theme.spacing.xSmall,
-  },
-  warningMessage: {
-    paddingTop: theme.spacing.medium,
   },
 }));

--- a/src/translations/screens/subscreens/PaymentMethods.ts
+++ b/src/translations/screens/subscreens/PaymentMethods.ts
@@ -71,6 +71,30 @@ const PaymentMethodsTexts = {
     'Betaling med Vipps er tilgjengeleg ved kjøp av billett',
   ),
   editPaymentMethod: _('Endre', 'Edit', 'Endre'),
+  expiryMessages: {
+    cardExpired: _(
+      'Kortet er utløpt',
+      'The card has expired',
+      'Kortet er utløpt',
+    ),
+    cardExpiring: (date: string) =>
+      _(
+        `Kortet utløper ${date}`,
+        `The card expires ${date}`,
+        `Kortet utløper ${date}`,
+      ),
+    cardRegistrationExpired: _(
+      'Du må legge til kortet på nytt for å betale',
+      'You need to re-add the card to pay',
+      'Du må legge til kortet på nytt for å betale',
+    ),
+    cardRegistrationExpiring: (date: string) =>
+      _(
+        `Du må legge til kortet på nytt ${date}`,
+        `You need to re-add the card ${date}`,
+        `Du må legge til kortet på nytt ${date}`,
+      ),
+  },
 };
 
 export default PaymentMethodsTexts;


### PR DESCRIPTION
Add functionality to show card or registration expiry dates, displaying appropriate messages for expired or soon-to-expire payment cards.

<details><summary>Screenshots</summary>
<p>



![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 12 56 33](https://github.com/user-attachments/assets/40a5e62d-7871-49a1-90b1-3112acb237f8)


![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 12 56 23](https://github.com/user-attachments/assets/834efbb3-da20-4678-81ae-776e714b8669)

</p>
</details> 


closes https://github.com/AtB-AS/kundevendt/issues/20096