### PR TITLE
docs: remove ` from Release.md

### DIFF
--- a/docs/Release.md
+++ b/docs/Release.md
@@ -18,7 +18,7 @@ Now that a release branch is created, the version-number on master should be inc
 Version number can be updated by running the following command:
 
 ```bash
-./scripts/update-app-version.sh x.xx`
+./scripts/update-app-version.sh x.xx
 ```
 
 Then push your changes with commit message "chore: Bump to version x.xx".


### PR DESCRIPTION
This fixes an issue where a speck of dirt would appear on my screen every time I open Release.md. 

### Acceptance criteria

- [ ] I no longer have to wipe my screen in vain when I'm about to make an app release.
- [ ] We're still able to run `update-app-version.sh`
