### PR TITLE
fix: support tinted variant of widget

### DIFF
--- a/ios/departureWidget/Views/ChipView.swift
+++ b/ios/departureWidget/Views/ChipView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ChipView: View {
+    @Environment(\.widgetRenderingMode) var widgetRenderingMode
+
     let departure: DepartureLinkLabel
 
     var body: some View {
@@ -10,7 +12,7 @@ struct ChipView: View {
                     .lineLimit(1)
                     .fixedSize()
                     .padding(8)
-                    .background(Color("TimeTileBackgroundColor"))
+                    .background(Color("TimeTileBackgroundColor").opacity(widgetRenderingMode == .accented ? 0.2 : 1))
                     .cornerRadius(8)
                     .font(DefaultFonts.bold)
             }

--- a/ios/departureWidget/Views/DepartureTimesView.swift
+++ b/ios/departureWidget/Views/DepartureTimesView.swift
@@ -40,6 +40,7 @@ struct DepartureTimesView: View {
                         .frame(width: K.iconWidth)
                         .padding(8)
                         .foregroundColor(K.lineInformationColor)
+                        .widgetAccentable()
                 }
             }
 

--- a/ios/departureWidget/Views/WidgetInfoView.swift
+++ b/ios/departureWidget/Views/WidgetInfoView.swift
@@ -11,6 +11,8 @@ private enum K {
 }
 
 struct WidgetInfoView: View {
+    @Environment(\.widgetRenderingMode) var widgetRenderingMode
+
     let widgetFamily: WidgetFamily
     var viewModel: WidgetViewModel
 
@@ -67,13 +69,14 @@ struct WidgetInfoView: View {
                                         .foregroundColor(viewModel.transportModeIconForegroundColor)
                                         .padding(K.transportIconSize / 7)
                                         .frame(width: K.transportIconSize, height: K.transportIconSize)
-                                        .background(viewModel.transportModeIconBackgroundColor)
+                                        .background(viewModel.transportModeIconBackgroundColor?.opacity(widgetRenderingMode == .accented ? 0.2 : 1))
                                         .cornerRadius(K.transportIconCornerRadius)
+                                        .widgetAccentable()
                                 }
 
                                 Text(viewModel.lineDetails ?? noLineInfoText)
                                     .lineLimit(1)
-                                    .foregroundColor(K.lineInformationColor)
+                                    .foregroundColor(widgetRenderingMode == .accented ? .secondary : K.lineInformationColor)
 
                                 Spacer()
                             }


### PR DESCRIPTION
This fixes an issue where the widget would have unreadable information if tinted/accented mode is enabled on iOS 18.

<img width="300px" src="https://github.com/user-attachments/assets/b4dd765f-0ac1-4630-9a01-18a98c63a0f4">

## Acceptance criteria

- [ ] Widget has readable information when the home screen is set to Tinted (edit home screen -> Edit -> Customize -> Tinted)
- [ ] The widget still works with older iOS versions (Older than iOS 18)