### PR TITLE
fix: prevent crash on Android when selecting favorite departure

### DIFF
--- a/src/modules/native-bridges/widget-updater.ts
+++ b/src/modules/native-bridges/widget-updater.ts
@@ -1,4 +1,4 @@
-import {NativeModules} from 'react-native';
+import {NativeModules, Platform} from 'react-native';
 
 // Found in /ios/BridgeModules/WidgetUpdaterBridge.m
 interface WidgetUpdaterBridge {
@@ -7,7 +7,7 @@ interface WidgetUpdaterBridge {
 
 const WidgetUpdaterBridge =
   NativeModules.WidgetUpdaterBridge as WidgetUpdaterBridge;
-if (!WidgetUpdaterBridge) {
+if (Platform.OS === 'ios' && !WidgetUpdaterBridge) {
   throw new Error(
     'WidgetUpdaterBridge module is not linked. Please check your native module setup.',
   );

--- a/src/modules/native-bridges/widget-updater.ts
+++ b/src/modules/native-bridges/widget-updater.ts
@@ -13,4 +13,5 @@ if (Platform.OS === 'ios' && !WidgetUpdaterBridge) {
   );
 }
 
-export const refreshWidgets = Platform.OS === 'ios' && WidgetUpdaterBridge.refreshWidgets;
+export const refreshWidgets =
+  Platform.OS === 'ios' ? WidgetUpdaterBridge.refreshWidgets : () => {};

--- a/src/modules/native-bridges/widget-updater.ts
+++ b/src/modules/native-bridges/widget-updater.ts
@@ -13,4 +13,4 @@ if (Platform.OS === 'ios' && !WidgetUpdaterBridge) {
   );
 }
 
-export const refreshWidgets = WidgetUpdaterBridge.refreshWidgets;
+export const refreshWidgets = Platform.OS === 'ios' && WidgetUpdaterBridge.refreshWidgets;


### PR DESCRIPTION
Fixes issue `Cannot read property 'refreshWidgets' of null` from [BugSnag](https://app.bugsnag.com/atb-as/mittatb/errors?filters[event.since]=all&filters[app.release_stage][]=store&filters[app.release_stage][]=production&filters[search][]=refresh&filters[search][]=widgets&filters[app.type]=android)

### Steps to reproduce
1. Go to departures/avganger
2. Select any bus stops
3. Select any bus departures
4. Mark as favorite
5. Select any options that are shown on the bottom sheet
6. App crashes


### Acceptance Criteria
- [ ] Mark as favorite does not crash the app on Android
- [ ] Mark as favorite works as intended on iOS and Android