### PR TITLE
fix: set minimum iOS version for widget to 16.6

### DIFF
--- a/ios/atb.xcodeproj/project.pbxproj
+++ b/ios/atb.xcodeproj/project.pbxproj
@@ -891,7 +891,7 @@
 				INFOPLIST_FILE = AtbAppIntent/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = AtbAppIntent;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -938,7 +938,7 @@
 				INFOPLIST_FILE = AtbAppIntent/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = AtbAppIntent;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1156,7 +1156,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = departureWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "We need your location to show bus departures near you";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1209,7 +1209,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = departureWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "We need your location to show bus departures near you";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Some of the features used in c0d3da03 requires iOS 16, and makes the build fail, since it targets iOS 15 and above. It's easier to bump the minimum version than to add version checks, and will affect a negligible amount of users, so I propose we do that for the widget and intent. (not the app itself)