### PR TITLE
feat: change to new token server endpoint

### DIFF
--- a/src/modules/mobile-token/hooks/use-validate-token.tsx
+++ b/src/modules/mobile-token/hooks/use-validate-token.tsx
@@ -178,7 +178,7 @@ export const useValidateToken = (
 
       if (token && token.type === 'mobile') {
         checkShouldRenew(token).then((shouldRenew) => {
-          if (shouldRenew) {
+          if (shouldRenew && retryCount < RETRY_MAX_COUNT) {
             logToBugsnag(
               'Token should be renewed because there are difference between details on the token and the device',
             );

--- a/src/modules/mobile-token/tokenService.ts
+++ b/src/modules/mobile-token/tokenService.ts
@@ -77,7 +77,7 @@ export const tokenService: TokenService = {
       deviceInfoType: deviceInfo.type,
     };
     return await client
-      .post<InitiateTokenResponse>('/tokens/v4/init', data, {
+      .post<InitiateTokenResponse>('/token/v1/init', data, {
         headers: {
           [CorrelationIdHeaderName]: traceId,
           [IsEmulatorHeaderName]: String(await isEmulator()),
@@ -93,7 +93,7 @@ export const tokenService: TokenService = {
   activateNewMobileToken: async (pendingToken, correlationId) =>
     client
       .post<CompleteTokenInitializationResponse>(
-        '/tokens/v4/activate',
+        '/token/v1/activate',
         pendingToken.toJSON(),
         {
           headers: {
@@ -109,7 +109,7 @@ export const tokenService: TokenService = {
       .catch(handleError),
   initiateMobileTokenRenewal: async (token, secureContainer, correlationId) =>
     client
-      .post<InitiateTokenRenewalResponse>('/tokens/v4/renew', undefined, {
+      .post<InitiateTokenRenewalResponse>('/token/v1/renew', undefined, {
         headers: {
           [CorrelationIdHeaderName]: correlationId,
           [SignedTokenHeaderName]: secureContainer,
@@ -129,7 +129,7 @@ export const tokenService: TokenService = {
   ) =>
     client
       .post<CompleteTokenRenawalResponse>(
-        '/tokens/v4/complete',
+        '/token/v1/complete',
         pendingToken.toJSON(),
         {
           headers: {
@@ -151,7 +151,7 @@ export const tokenService: TokenService = {
     correlationId,
   ) =>
     client
-      .get<GetTokenDetailsResponse>('/tokens/v4/details', {
+      .get<GetTokenDetailsResponse>('/token/v1/details', {
         headers: {
           [CorrelationIdHeaderName]: correlationId,
           [SignedTokenHeaderName]: secureContainer,
@@ -167,7 +167,7 @@ export const tokenService: TokenService = {
       .catch(handleError),
   getMobileTokenDetails: async (token, secureContainer, traceId) =>
     client
-      .get<GetTokenDetailsResponse>('/tokens/v4/details', {
+      .get<GetTokenDetailsResponse>('/token/v1/details', {
         headers: {
           [CorrelationIdHeaderName]: traceId,
           [SignedTokenHeaderName]: secureContainer,
@@ -182,7 +182,7 @@ export const tokenService: TokenService = {
   removeToken: async (tokenId: string, traceId: string): Promise<boolean> =>
     client
       .post<RemoveTokenResponse>(
-        '/tokens/v4/remove',
+        '/token/v1/remove',
         {tokenId},
         {
           headers: {
@@ -198,7 +198,7 @@ export const tokenService: TokenService = {
       .catch(handleError),
   listTokens: async (secureContainer, traceId) =>
     client
-      .get<ListResponse>('/tokens/v4/list', {
+      .get<ListResponse>('/token/v1/list', {
         headers: {
           [SignedTokenHeaderName]: secureContainer,
           [CorrelationIdHeaderName]: traceId,
@@ -217,7 +217,7 @@ export const tokenService: TokenService = {
   ) =>
     client
       .post<ToggleResponse>(
-        '/tokens/v4/toggle',
+        '/token/v1/toggle',
         {tokenId, bypassRestrictions},
         {
           headers: {
@@ -234,7 +234,7 @@ export const tokenService: TokenService = {
 
   getTokenToggleDetails: async () =>
     client
-      .get<TokenLimitResponse>('/tokens/v4/toggle/details', {
+      .get<TokenLimitResponse>('/token/v1/toggle/details', {
         baseURL: await getBaseUrl(),
         authWithIdToken: true,
         timeout: 15000,


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20603

The changing of endpoint itself is trivial, but to make this work, it requires the PR below from Platform Team (all merged and ready)
- [Fixing cleanup function](https://github.com/AtB-AS/token/pull/29), before the PR, the newly activated token is immediately removed, causing the token to always turn to fallback state.
- [Expose device details](https://github.com/AtB-AS/token/pull/28), without this PR, tokens will always be renewed once it is activated, because the logic check returns undefined.
- [Change to v1 instead of v4](https://github.com/AtB-AS/token/pull/27), fixes routing issue
- [Add inspection](https://github.com/AtB-AS/token/pull/25), fixes missing inspection issue.