### PR TITLE
fix: use correct state for fare contract pull-to-refresh spinner

### DIFF
--- a/src/modules/ticketing/TicketingContext.tsx
+++ b/src/modules/ticketing/TicketingContext.tsx
@@ -13,7 +13,6 @@ type TicketingReducerState = {
   sentFareContracts: FareContractType[];
   reservations: Reservation[];
   rejectedReservations: Reservation[];
-  isRefreshingFareContracts: boolean;
   customerProfile: CustomerProfile | undefined;
 };
 
@@ -62,7 +61,6 @@ const ticketingReducer: TicketingReducer = (
         reservations: prevState.reservations.filter(
           (r) => !currentFareContractOrderIds.includes(r.orderId),
         ),
-        isRefreshingFareContracts: false,
       };
     }
     case 'UPDATE_SENT_FARE_CONTRACTS': {
@@ -75,7 +73,6 @@ const ticketingReducer: TicketingReducer = (
         reservations: prevState.reservations.filter(
           (r) => !currentFareContractOrderIds.includes(r.orderId),
         ),
-        isRefreshingFareContracts: false,
       };
     }
     case 'UPDATE_RESERVATIONS': {
@@ -122,10 +119,7 @@ type TicketingState = {
   findFareContractById: (id: string) => FareContractType | undefined;
 } & Pick<
   TicketingReducerState,
-  | 'reservations'
-  | 'isRefreshingFareContracts'
-  | 'customerProfile'
-  | 'rejectedReservations'
+  'reservations' | 'customerProfile' | 'rejectedReservations'
 >;
 
 const initialReducerState: TicketingReducerState = {
@@ -133,7 +127,6 @@ const initialReducerState: TicketingReducerState = {
   sentFareContracts: [],
   reservations: [],
   rejectedReservations: [],
-  isRefreshingFareContracts: false,
   customerProfile: undefined,
 };
 

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -22,11 +22,14 @@ type AvailabilityStatusInput = {
 export const useFareContracts = (
   availabilityStatus: AvailabilityStatusInput,
   now: number,
-): {fareContracts: FareContractType[]; refetch: () => void} => {
+): {
+  fareContracts: FareContractType[];
+  refetch: () => void;
+  isRefetching: boolean;
+} => {
   const {fareContracts: fareContractsFromFirestore} = useTicketingContext();
-  const {refetch: getFareContractsFromBackend} = useGetFareContractsQuery(
-    availabilityStatus.availability,
-  );
+  const {refetch: getFareContractsFromBackend, isRefetching} =
+    useGetFareContractsQuery(availabilityStatus.availability);
 
   const [fareContracts, setFareContracts] = useState(
     fareContractsFromFirestore,
@@ -53,7 +56,7 @@ export const useFareContracts = (
     return false;
   });
 
-  return {fareContracts: filteredFareContracts, refetch};
+  return {fareContracts: filteredFareContracts, refetch, isRefetching};
 };
 
 const useGetFareContractsQuery = (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -21,14 +21,14 @@ type Props =
 export const TicketTabNav_AvailableFareContractsTabScreen = ({
   navigation,
 }: Props) => {
-  const {reservations, sentFareContracts, isRefreshingFareContracts} =
-    useTicketingContext();
+  const {reservations, sentFareContracts} = useTicketingContext();
   const {serverNow} = useTimeContext();
   const analytics = useAnalyticsContext();
 
   const {
     fareContracts: availableFareContracts,
     refetch: refetchAvailableFareContracts,
+    isRefetching: isRefetchingAvailableFareContracts,
   } = useFareContracts({availability: 'available'}, serverNow);
   const {fareContracts: historicalFareContracts} = useFareContracts(
     {availability: 'historical'},
@@ -89,7 +89,7 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
         contentContainerStyle={styles.content}
         refreshControl={
           <RefreshControl
-            refreshing={isRefreshingFareContracts}
+            refreshing={isRefetchingAvailableFareContracts}
             onRefresh={() => {
               refetchAvailableFareContracts();
               analytics.logEvent('Ticketing', 'Pull to refresh tickets', {


### PR DESCRIPTION
The fare contracts pull-to-refresh feature was using some old state for the `refreshing` param, that was always false. We should instead use the `isRefetching` value from useQuery.

## Acceptance criteria

- [ ] The pull-to-refresh spinner stays in the spinning state until the `ticket/v4/list` call is completed.