### PR TITLE
feat: sort ticket history page by creation

### DIFF
--- a/src/modules/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/modules/fare-contracts/FareContractAndReservationsList.tsx
@@ -3,7 +3,7 @@ import {FareContractOrReservation} from './FareContractOrReservation';
 import {Reservation} from '@atb/modules/ticketing';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {EmptyState} from '@atb/components/empty-state';
-import {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation-by-validity-and-creation';
+import {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation';
 import {getFareContractInfo} from './utils';
 import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';

--- a/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
+++ b/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
@@ -2,7 +2,10 @@ import type {ValidityStatus} from '../utils';
 import {Reservation} from '@atb/modules/ticketing';
 
 import {addMinutes} from 'date-fns';
-import {sortFcOrReservationByValidityAndCreation} from '../sort-fc-or-reservation-by-validity-and-creation';
+import {
+  sortFcOrReservationByCreation,
+  sortFcOrReservationByValidityAndCreation,
+} from '../sort-fc-or-reservation';
 import {FareContractType, TravelRightType} from '@atb-as/utils';
 
 type MockedFareContract = FareContractType & {
@@ -128,5 +131,29 @@ describe('Sort by Validity', () => {
     });
 
     expect(ids).toEqual(['2', '1', '4', '3']);
+  });
+});
+
+describe('Sort by creation', () => {
+  it('sortFcOrReservationByCreation sorts by created', () => {
+    const fareContracts = [
+      mockupReservation('1', 'valid', -10),
+      mockupFareContract('3', 'valid', -30),
+      mockupFareContract('2', 'valid', -20),
+      mockupReservation('5', 'valid', -50),
+      mockupFareContract('4', 'valid', -40),
+    ];
+    const sorted = sortFcOrReservationByCreation(fareContracts);
+
+    const ids: string[] = sorted.map((fcOrReservation) => {
+      const isFareContract = 'travelRights' in fcOrReservation;
+      if (isFareContract) {
+        return fcOrReservation.id;
+      } else {
+        return fcOrReservation.orderId;
+      }
+    });
+
+    expect(ids).toEqual(['1', '2', '3', '4', '5']);
   });
 });

--- a/src/modules/fare-contracts/index.ts
+++ b/src/modules/fare-contracts/index.ts
@@ -9,7 +9,10 @@ export {
 } from './utils';
 export type {UserProfileWithCount} from './types';
 export {FareContractOrReservation} from './FareContractOrReservation';
-export {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation-by-validity-and-creation';
+export {
+  sortFcOrReservationByValidityAndCreation,
+  sortFcOrReservationByCreation,
+} from './sort-fc-or-reservation';
 export {getFareContractInfoDetails} from './sections/FareContractInfoDetailsSectionItem';
 export {CompactFareContractInfo} from './CompactFareContractInfo';
 export {FareContractDetailItem} from './components/FareContractDetailItem';

--- a/src/modules/fare-contracts/sort-fc-or-reservation.ts
+++ b/src/modules/fare-contracts/sort-fc-or-reservation.ts
@@ -32,3 +32,12 @@ export const sortFcOrReservationByValidityAndCreation = (
     return b.created.getTime() - a.created.getTime();
   });
 };
+
+export const sortFcOrReservationByCreation = (
+  fcOrReservations: (Reservation | FareContractType)[],
+): (FareContractType | Reservation)[] => {
+  return fcOrReservations.sort((a, b) => {
+    // Make sure most recent dates comes first
+    return b.created.getTime() - a.created.getTime();
+  });
+};

--- a/src/screen-components/ticket-history/TicketHistoryScreenComponent.tsx
+++ b/src/screen-components/ticket-history/TicketHistoryScreenComponent.tsx
@@ -12,13 +12,12 @@ import {TicketHistoryModeTexts} from '@atb/translations/screens/Ticketing';
 import {useAuthContext} from '@atb/modules/auth';
 import React from 'react';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {getFareContractInfo} from '@atb/modules/fare-contracts';
-import {sortFcOrReservationByValidityAndCreation} from '@atb/modules/fare-contracts';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {FlatList} from 'react-native-gesture-handler';
 import {FareContractOrReservation} from '@atb/modules/fare-contracts';
 import {EmptyState} from '@atb/components/empty-state';
 import {ThemedHoldingHands, ThemedTicketTilted} from '@atb/theme/ThemedAssets';
+import {sortFcOrReservationByCreation} from '@atb/modules/fare-contracts';
 
 type Props = TicketHistoryScreenParams & {
   onPressFareContract: (fareContractId: string) => void;
@@ -50,14 +49,10 @@ export const TicketHistoryScreenComponent = ({
     customerAccountId,
   );
 
-  const sortedItems = sortFcOrReservationByValidityAndCreation(
-    customerAccountId,
-    serverNow,
-    [...fareContractsToShow, ...reservationsToShow],
-    (currentTime, fareContract, currentUserId) =>
-      getFareContractInfo(currentTime, fareContract, currentUserId)
-        .validityStatus,
-  );
+  const sortedItems = sortFcOrReservationByCreation([
+    ...fareContractsToShow,
+    ...reservationsToShow,
+  ]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
Had a talk with @Mariblaas, and we agreed that it doesn't make sense to show reservations at the top of ticket history. We should rather always sort by creation date, so that the user doesn't have to scroll past lots of old cancelled payments before reaching their previous purchase.

## Acceptance criteria

- [ ] In ticket history, tickets and reservations are always sorted by date.
- [ ] Active tickets should be unaffected.