### PR TITLE
fix: add a11y message for expired/expiring cards in payment

### DIFF
--- a/src/modules/payment/ExpiryMessage.tsx
+++ b/src/modules/payment/ExpiryMessage.tsx
@@ -1,6 +1,6 @@
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {Statuses, StyleSheet, Theme} from '@atb/theme';
-import {useTranslation} from '@atb/translations';
+import {Language, TranslateFunction, useTranslation} from '@atb/translations';
 import PaymentMethodsTexts from '@atb/translations/screens/subscreens/PaymentMethods';
 import {formatToShortDateWithYear} from '@atb/utils/date';
 import {addDays, parseISO} from 'date-fns';
@@ -30,11 +30,19 @@ const useMessage = (
   recurringPayment?: RecurringPayment,
 ): {type: Statuses; message: string} | null => {
   const {t, language} = useTranslation();
-  const now = Date.now();
-  const inThirtyDays = addDays(now, 30).getTime();
 
+  return getExpiryMessageInfo(recurringPayment, t, language);
+};
+
+const getExpiryMessageInfo = (
+  recurringPayment: RecurringPayment | undefined,
+  t: TranslateFunction,
+  language: Language,
+): {type: Statuses; message: string} | null => {
   if (!recurringPayment) return null;
 
+  const now = Date.now();
+  const inThirtyDays = addDays(now, 30).getTime();
   const expiresAt = parseISO(recurringPayment.expiresAt).getTime();
   const cardExpiresAt = parseISO(recurringPayment.cardExpiresAt).getTime();
 
@@ -76,6 +84,15 @@ const useMessage = (
   }
 
   return null;
+};
+
+export const getExpiryMessageText = (
+  recurringPayment: RecurringPayment | undefined,
+  t: TranslateFunction,
+  language: Language,
+): string | null => {
+  const messageInfo = getExpiryMessageInfo(recurringPayment, t, language);
+  return messageInfo ? messageInfo.message : null;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({

--- a/src/modules/payment/SinglePaymentMethod.tsx
+++ b/src/modules/payment/SinglePaymentMethod.tsx
@@ -7,7 +7,7 @@ import {View} from 'react-native';
 import {getRadioA11y, RadioIcon} from '@atb/components/radio';
 import {ThemeText} from '@atb/components/text';
 import {PaymentBrand} from './PaymentBrand';
-import {ExpiryMessage} from './ExpiryMessage';
+import {ExpiryMessage, getExpiryMessageText} from './ExpiryMessage';
 
 type SinglePaymentMethodProps = {
   paymentMethod: PaymentMethod;
@@ -22,7 +22,7 @@ export const SinglePaymentMethod = ({
   onSelect,
   index,
 }: SinglePaymentMethodProps) => {
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const styles = useStyles();
 
   function getPaymentTexts(method: PaymentMethod): {
@@ -34,12 +34,12 @@ export const SinglePaymentMethod = ({
     if (method.recurringPayment) {
       return {
         text: paymentTypeName,
-        label: t(
+        label: `${t(
           PurchaseConfirmationTexts.paymentWithStoredCard.a11yLabel(
             paymentTypeName,
             method.recurringPayment.maskedPan,
           ),
-        ),
+        )} ${getExpiryMessageText(method.recurringPayment, t, language)}`,
         hint: t(PurchaseConfirmationTexts.paymentWithStoredCard.a11yHint),
       };
     } else {
@@ -50,7 +50,7 @@ export const SinglePaymentMethod = ({
             paymentTypeName,
           ),
         ),
-        hint: t(PurchaseConfirmationTexts.paymentWithDefaultServices.a11Hint),
+        hint: t(PurchaseConfirmationTexts.paymentWithDefaultServices.a11yHint),
       };
     }
   }

--- a/src/translations/screens/subscreens/PurchaseConfirmation.ts
+++ b/src/translations/screens/subscreens/PurchaseConfirmation.ts
@@ -112,7 +112,7 @@ const PurchaseConfirmationTexts = {
   paymentWithDefaultServices: {
     a11yLabel: (brand: string) =>
       _(`Betal med ${brand}`, `Pay with ${brand}`, `Betal med ${brand}`),
-    a11Hint: _(
+    a11yHint: _(
       'Aktivér for velge denne betalingsmåten',
       'Activate to select this payment method',
       'Aktivér for å velje denne betalingsmetoden',


### PR DESCRIPTION
Accessibility message for expired or expiring cards were missing in the payment bottom sheet. 

The recurring payment's a11y label should now have the expiry message embedded in it.

fixes https://github.com/AtB-AS/kundevendt/issues/20096