### PR TITLE
feat: use stream service to reload fare contracts

### DIFF
--- a/src/modules/event-stream/handle-stream-event.ts
+++ b/src/modules/event-stream/handle-stream-event.ts
@@ -1,0 +1,16 @@
+import {QueryClient} from '@tanstack/react-query';
+import {EventKind, StreamEvent} from './types';
+import {fareContractsQueryKey} from '../ticketing/use-fare-contracts';
+
+export const handleStreamEvent = (
+  streamEvent: StreamEvent,
+  queryClient: QueryClient,
+) => {
+  switch (streamEvent.event) {
+    case EventKind.FareContract:
+      queryClient.invalidateQueries({
+        queryKey: [fareContractsQueryKey],
+      });
+      break;
+  }
+};

--- a/src/modules/event-stream/index.ts
+++ b/src/modules/event-stream/index.ts
@@ -1,0 +1,1 @@
+export {useSetupEventStream} from './use-setup-event-stream';

--- a/src/modules/event-stream/types.ts
+++ b/src/modules/event-stream/types.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod';
+
+export enum EventKind {
+  FareContract = 'FARE_CONTRACT',
+}
+
+export const StreamEvent = z.object({
+  event: z.nativeEnum(EventKind),
+});
+export type StreamEvent = z.infer<typeof StreamEvent>;

--- a/src/modules/event-stream/use-setup-event-stream.ts
+++ b/src/modules/event-stream/use-setup-event-stream.ts
@@ -1,0 +1,48 @@
+import {useSubscription} from '@atb/api/use-subscription';
+import {useQueryClient} from '@tanstack/react-query';
+import {useCallback} from 'react';
+import {WS_API_BASE_URL} from '@env';
+import {getIdTokenGlobal, useAuthContext} from '../auth';
+import Bugsnag from '@bugsnag/react-native';
+import {handleStreamEvent} from './handle-stream-event';
+import {StreamEvent} from './types';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+
+export const useSetupEventStream = () => {
+  const queryClient = useQueryClient();
+  const {abtCustomerId} = useAuthContext();
+  const {isEventStreamEnabled} = useFeatureTogglesContext();
+
+  const url = `${WS_API_BASE_URL}stream/v1`;
+
+  const onMessage = useCallback(
+    (event: WebSocketMessageEvent) => {
+      const message = StreamEvent.safeParse(JSON.parse(event.data));
+      if (!message.success) {
+        Bugsnag.leaveBreadcrumb('Received unknown message from stream', {
+          data: event.data,
+        });
+        return;
+      }
+      const streamEvent = message.data;
+      Bugsnag.leaveBreadcrumb('Received event from stream', {
+        data: event.data,
+      });
+      handleStreamEvent(streamEvent, queryClient);
+    },
+    [queryClient],
+  );
+
+  const authenticate = useCallback((ws: WebSocket) => {
+    ws.send(`AUTH ${getIdTokenGlobal()}`);
+  }, []);
+
+  useSubscription({
+    url,
+    // When abtCustomerId is set, we also have the id token which is needed to
+    // authenticate.
+    enabled: isEventStreamEnabled && abtCustomerId !== undefined,
+    onMessage,
+    onOpen: authenticate,
+  });
+};

--- a/src/modules/event-stream/use-setup-event-stream.ts
+++ b/src/modules/event-stream/use-setup-event-stream.ts
@@ -7,6 +7,7 @@ import Bugsnag from '@bugsnag/react-native';
 import {handleStreamEvent} from './handle-stream-event';
 import {StreamEvent} from './types';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {jsonStringToObject} from '@atb/utils/object';
 
 export const useSetupEventStream = () => {
   const queryClient = useQueryClient();
@@ -17,7 +18,7 @@ export const useSetupEventStream = () => {
 
   const onMessage = useCallback(
     (event: WebSocketMessageEvent) => {
-      const message = StreamEvent.safeParse(JSON.parse(event.data));
+      const message = StreamEvent.safeParse(jsonStringToObject(event.data));
       if (!message.success) {
         Bugsnag.leaveBreadcrumb('Received unknown message from stream', {
           data: event.data,

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -30,6 +30,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_city_bikes_in_map',
   },
   {
+    name: 'isEventStreamEnabled',
+    remoteConfigKey: 'enable_event_stream',
+  },
+  {
     name: 'isFlexibleTransportEnabled',
     remoteConfigKey: 'enable_flexible_transport',
   },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -20,6 +20,7 @@ export type RemoteConfig = {
   enable_bonus_program: boolean;
   enable_car_sharing_in_map: boolean;
   enable_city_bikes_in_map: boolean;
+  enable_event_stream: boolean;
   enable_extended_onboarding: boolean;
   enable_flexible_transport: boolean;
   enable_from_travel_search_to_ticket_boat: boolean;
@@ -121,6 +122,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_show_valid_time_info: true,
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
+  enable_event_stream: false,
   enable_tips_and_information: false,
   enable_token_fallback_on_timeout: true,
   enable_token_fallback: true,
@@ -196,6 +198,9 @@ export function getConfig(): RemoteConfig {
   const enable_city_bikes_in_map =
     values['enable_city_bikes_in_map']?.asBoolean() ??
     defaultRemoteConfig.enable_city_bikes_in_map;
+  const enable_event_stream =
+    values['enable_event_stream']?.asBoolean() ??
+    defaultRemoteConfig.enable_event_stream;
   const enable_extended_onboarding =
     values['enable_extended_onboarding']?.asBoolean() ??
     defaultRemoteConfig.enable_extended_onboarding;
@@ -370,6 +375,7 @@ export function getConfig(): RemoteConfig {
     enable_bonus_program,
     enable_car_sharing_in_map,
     enable_city_bikes_in_map,
+    enable_event_stream,
     enable_extended_onboarding,
     enable_flexible_transport,
     enable_from_travel_search_to_ticket_boat,

--- a/src/modules/ticketing/TicketingContext.tsx
+++ b/src/modules/ticketing/TicketingContext.tsx
@@ -7,6 +7,9 @@ import {differenceInMinutes} from 'date-fns';
 import {CustomerProfile} from '.';
 import {setupFirestoreListeners} from './firestore';
 import {logToBugsnag, notifyBugsnag} from '@atb/utils/bugsnag-utils';
+import {useGetFareContractsQuery} from './use-fare-contracts';
+import Bugsnag from '@bugsnag/react-native';
+import {useFeatureTogglesContext} from '../feature-toggles';
 
 type TicketingReducerState = {
   fareContracts: FareContractType[];
@@ -137,9 +140,20 @@ type Props = {
 const TicketingContext = createContext<TicketingState | undefined>(undefined);
 export const TicketingContextProvider = ({children}: Props) => {
   const [state, dispatch] = useReducer(ticketingReducer, initialReducerState);
-
   const {userId} = useAuthContext();
   const {enable_ticketing} = useRemoteConfigContext();
+  const {isEventStreamEnabled} = useFeatureTogglesContext();
+
+  const {data: fareContracts} = useGetFareContractsQuery({
+    enabled: enable_ticketing && isEventStreamEnabled,
+    availability: undefined,
+  });
+  useEffect(() => {
+    dispatch({
+      type: 'UPDATE_FARE_CONTRACTS',
+      fareContracts: fareContracts ?? [],
+    });
+  }, [fareContracts]);
 
   useEffect(() => {
     if (userId && enable_ticketing) {
@@ -148,8 +162,15 @@ export const TicketingContextProvider = ({children}: Props) => {
       );
       const removeListeners = setupFirestoreListeners(userId, {
         fareContracts: {
-          onSnapshot: (fareContracts) =>
-            dispatch({type: 'UPDATE_FARE_CONTRACTS', fareContracts}),
+          onSnapshot: (fareContracts) => {
+            if (isEventStreamEnabled) {
+              Bugsnag.leaveBreadcrumb(
+                `Got Firestore snapshot with ${fareContracts.length} fare contracts, but not updating state since event stream is enabled.`,
+              );
+            } else {
+              dispatch({type: 'UPDATE_FARE_CONTRACTS', fareContracts});
+            }
+          },
           onError: (err) =>
             notifyBugsnag(err, {
               metadata: {
@@ -220,7 +241,7 @@ export const TicketingContextProvider = ({children}: Props) => {
       // Stop listening for updates when no longer required
       return () => removeListeners();
     }
-  }, [userId, enable_ticketing]);
+  }, [userId, enable_ticketing, isEventStreamEnabled]);
 
   return (
     <TicketingContext.Provider

--- a/src/modules/ticketing/api.ts
+++ b/src/modules/ticketing/api.ts
@@ -17,6 +17,7 @@ import {
 import {PreassignedFareProduct} from '@atb/modules/configuration';
 import {convertIsoStringFieldsToDate} from '@atb/utils/date';
 import capitalize from 'lodash/capitalize';
+import qs from 'query-string';
 
 export async function listRecentFareContracts(): Promise<RecentOrderDetails[]> {
   const url = 'sales/v1/order/recent';
@@ -198,16 +199,20 @@ export async function getFareProducts(): Promise<PreassignedFareProduct[]> {
 }
 
 export async function getFareContracts(
-  availability: 'available' | 'historical',
+  availability: 'available' | 'historical' | undefined,
 ): Promise<FareContractType[]> {
-  const url = `ticket/v4/list?availability=${capitalize(availability)}`;
+  const url = qs.stringifyUrl({
+    url: 'ticket/v4/list',
+    query: {
+      availability: availability ? capitalize(availability) : undefined,
+    },
+  });
   const response = await client.get(url, {
     authWithIdToken: true,
   });
   const fareContracts = response.data.fareContracts.map(
     convertIsoStringFieldsToDate,
   );
-  // TODO: Log errors during parsing
   return fareContracts.filter(
     (fc: any) => FareContractType.safeParse(fc).success,
   );

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -29,7 +29,10 @@ export const useFareContracts = (
 } => {
   const {fareContracts: fareContractsFromFirestore} = useTicketingContext();
   const {refetch: getFareContractsFromBackend, isRefetching} =
-    useGetFareContractsQuery(availabilityStatus.availability);
+    useGetFareContractsQuery({
+      enabled: false,
+      availability: availabilityStatus.availability,
+    });
 
   const [fareContracts, setFareContracts] = useState(
     fareContractsFromFirestore,
@@ -58,15 +61,19 @@ export const useFareContracts = (
 
   return {fareContracts: filteredFareContracts, refetch, isRefetching};
 };
-
-const useGetFareContractsQuery = (
-  availability: AvailabilityStatusInput['availability'],
-) => {
-  const {userId} = useAuthContext();
+export const fareContractsQueryKey = 'FETCH_FARE_CONTRACTS';
+export const useGetFareContractsQuery = (props: {
+  enabled: boolean;
+  availability: AvailabilityStatusInput['availability'] | undefined;
+}) => {
+  const {abtCustomerId} = useAuthContext();
   return useQuery({
-    queryKey: ['FETCH_FARE_CONTRACTS', availability, userId],
-    queryFn: () => getFareContracts(availability),
-    enabled: false,
+    queryKey: [fareContractsQueryKey, abtCustomerId, props.availability],
+    queryFn: () => getFareContracts(props.availability),
+    enabled: props.enabled && !!abtCustomerId,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchOnMount: false,
     retry: 0,
   });
 };

--- a/src/queries/ReactQueryProvider.tsx
+++ b/src/queries/ReactQueryProvider.tsx
@@ -11,6 +11,7 @@ const queryClient = new QueryClient({
         }
         return failureCount < 3; // Default is 3
       },
+      refetchOnWindowFocus: false,
     },
   },
 });

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -2,3 +2,4 @@ export {ReactQueryProvider} from './ReactQueryProvider';
 export {useHarborsQuery} from './use-harbors-query';
 export {useProfileQuery} from './get-profile-query';
 export {useProfileUpdateMutation} from './update-profile-query';
+export {useSetupReactQueryWindowFocus} from './use-setup-react-query-window-focus';

--- a/src/queries/use-setup-react-query-window-focus.tsx
+++ b/src/queries/use-setup-react-query-window-focus.tsx
@@ -1,0 +1,17 @@
+import {AppState, AppStateStatus} from 'react-native';
+import {focusManager} from '@tanstack/react-query';
+import {useCallback, useEffect} from 'react';
+
+/**
+ * https://tanstack.com/query/v4/docs/framework/react/guides/window-focus-refetching#managing-focus-in-react-native
+ */
+export const useSetupReactQueryWindowFocus = () => {
+  const onAppStateChange = useCallback((status: AppStateStatus) => {
+    focusManager.setFocused(status === 'active');
+  }, []);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', onAppStateChange);
+    return () => subscription.remove();
+  }, [onAppStateChange]);
+};

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -73,6 +73,7 @@ import {ServiceJourneyDeparture} from '@atb/screen-components/travel-details-scr
 import {parseParamAsInt} from './utils';
 import {AnalyticsContextProvider} from '@atb/modules/analytics';
 import {Root_ParkingPhotoScreen} from './Root_ParkingPhotoScreen';
+import {useSetupEventStream} from '@atb/modules/event-stream';
 import {useSetupReactQueryWindowFocus} from '@atb/queries';
 
 type ResultState = PartialState<NavigationState> & {
@@ -91,6 +92,7 @@ export const RootStack = () => {
   useBeaconsContext();
   useTestIds();
   useSetupReactQueryWindowFocus();
+  useSetupEventStream();
 
   // init Intercom user
   useRegisterIntercomUser();

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -73,6 +73,7 @@ import {ServiceJourneyDeparture} from '@atb/screen-components/travel-details-scr
 import {parseParamAsInt} from './utils';
 import {AnalyticsContextProvider} from '@atb/modules/analytics';
 import {Root_ParkingPhotoScreen} from './Root_ParkingPhotoScreen';
+import {useSetupReactQueryWindowFocus} from '@atb/queries';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -89,6 +90,7 @@ export const RootStack = () => {
 
   useBeaconsContext();
   useTestIds();
+  useSetupReactQueryWindowFocus();
 
   // init Intercom user
   useRegisterIntercomUser();

--- a/src/utils/__tests__/json-string-to-object.test.ts
+++ b/src/utils/__tests__/json-string-to-object.test.ts
@@ -1,0 +1,38 @@
+import {jsonStringToObject} from '../object';
+
+describe('jsonStringToObject', () => {
+  it('Should return undefined for invalid JSON', async () => {
+    const result = jsonStringToObject('invalid json');
+    expect(result).toBeUndefined();
+  });
+  it('Should return undefined for empty string', async () => {
+    const result = jsonStringToObject('');
+    expect(result).toBeUndefined();
+  });
+  it('Should return undefined for null', async () => {
+    const result = jsonStringToObject(null);
+    expect(result).toBeUndefined();
+  });
+  it('Should return undefined for undefined', async () => {
+    const result = jsonStringToObject(undefined);
+    expect(result).toBeUndefined();
+  });
+  it('Should return undefined for number', async () => {
+    const result = jsonStringToObject(123);
+    expect(result).toBeUndefined();
+  });
+  it('Should return undefined for array', async () => {
+    const result = jsonStringToObject([1, 2, 3]);
+    expect(result).toBeUndefined();
+  });
+  it('Should return undefined for boolean', async () => {
+    const result = jsonStringToObject(false);
+    expect(result).toBeUndefined();
+    const resultTrue = jsonStringToObject(true);
+    expect(resultTrue).toBeUndefined();
+  });
+  it('Should return parsed object for valid JSON', async () => {
+    const result = jsonStringToObject('{"key": "value"}');
+    expect(result).toEqual({key: 'value'});
+  });
+});

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -66,3 +66,21 @@ export function hasProp<K extends PropertyKey>(
 ): obj is Record<K, unknown> {
   return obj != null && typeof obj === 'object' && key in obj;
 }
+
+/**
+ * Attempts to parse any data as a JSON string into an object. If the result is
+ * not a valid object, it returns undefined.
+ */
+export function jsonStringToObject(data?: any): object | undefined {
+  try {
+    const result = JSON.parse(data);
+
+    // If the result is null, return undefined
+    if (!result) return undefined;
+
+    // If the result is not an object, return undefined
+    if (typeof result !== 'object') return undefined;
+
+    return result;
+  } catch (e) {}
+}


### PR DESCRIPTION
This implements the first iteration of using the [stream service](https://github.com/AtB-AS/stream/) to rely on websocket events to fetch fare contracts from the backend, outside of firestore. It's feature toggled, which means we'll be able to roll out gradually.

It works like this: 

1. On app launch, a websocket connection is created to `/stream/v1`. The thought is to keep this connection open as long as the app is running.
2. When the app receives a message on the format `{ event: "FARE_CONTRACT" }`, we tell the react query client to invalidate queries with queryKey `"FETCH_FARE_CONTRACTS"`, which will make fare contract data stale globally, and cause a reload wherever it's used.
4. In the ticketing context, we'll ignore fare contract snapshots from Firestore (as long as the feature toggle is enabled), and instead update it though `useGetFareContractsQuery`. The data will then propagate throughout the app, just like the firestore data did.

closes https://github.com/AtB-AS/kundevendt/issues/20460

---

This should make it possible to start testing the integration, but there are still some parts missing:

- Storage of fare contract data on device, so that if the user is without internet connection for a while, we should store the previous result.
- Some indication that the websocket connection is lost. Maybe time to revisit https://github.com/AtB-AS/kundevendt/issues/9427
