### PR TITLE
feat: added forceEnd when there is no active booking

### DIFF
--- a/src/modules/map/hooks/use-active-shmo-booking.tsx
+++ b/src/modules/map/hooks/use-active-shmo-booking.tsx
@@ -64,6 +64,7 @@ export const useShmoActiveBottomSheet = (
             openBottomSheet(
               () => (
                 <ActiveScooterSheet
+                  onForceClose={mapSelectionCloseCallback}
                   onActiveBookingReceived={flyToUserLocation}
                   navigateSupportCallback={() => {
                     closeBottomSheet();

--- a/src/modules/mobility/components/ShmoTripCard.tsx
+++ b/src/modules/mobility/components/ShmoTripCard.tsx
@@ -4,19 +4,18 @@ import {Section} from '@atb/components/sections';
 import {ShmoTripDetailsSectionItem} from './ShmoTripDetailsSectionItem';
 import {useTimeContext} from '@atb/modules/time';
 import {useTransportColor} from '@atb/utils/use-transport-color';
-import {useShmoBookingQuery} from '../queries/use-shmo-booking-query';
+
 import {ShmoBooking, ShmoBookingState} from '@atb/api/types/mobility';
 import {LineWithVerticalBars} from '@atb/components/line-with-vertical-bars';
 
 type ShmoTripCardProps = {
-  bookingId: ShmoBooking['bookingId'];
+  shmoBooking: ShmoBooking;
 };
 
-export const ShmoTripCard = ({bookingId}: ShmoTripCardProps) => {
+export const ShmoTripCard = ({shmoBooking}: ShmoTripCardProps) => {
   const styles = useStyles();
   const {serverNow} = useTimeContext();
   const backgroundColor = useTransportColor('scooter', 'escooter');
-  const {data: shmoBooking} = useShmoBookingQuery(bookingId, 15000);
 
   return (
     <Section style={styles.container}>

--- a/src/modules/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/modules/mobility/queries/use-active-shmo-booking-query.tsx
@@ -1,22 +1,39 @@
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {getActiveShmoBooking} from '@atb/api/mobility';
 import {ONE_MINUTE_MS} from '@atb/utils/durations';
 import {useAcceptLanguage} from '@atb/api/use-accept-language';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {useEffect} from 'react';
+import {getShmoBookingQueryKey} from './use-shmo-booking-query';
 
 export const getActiveShmoBookingQueryKey = (acceptLanguage: string) => [
   'GET_ACTIVE_SHMO_BOOKING_QUERY_KEY',
   acceptLanguage,
 ];
 
-export const useActiveShmoBookingQuery = () => {
+export const useActiveShmoBookingQuery = (
+  refetchInterval: number | false = false,
+) => {
   const acceptLanguage = useAcceptLanguage();
+  const queryClient = useQueryClient();
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
-  return useQuery({
+  const res = useQuery({
     enabled: isShmoDeepIntegrationEnabled,
     queryKey: getActiveShmoBookingQueryKey(acceptLanguage),
     queryFn: ({signal}) => getActiveShmoBooking(acceptLanguage, {signal}),
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
+    refetchInterval,
   });
+
+  useEffect(() => {
+    if (res.status === 'success' && res.data) {
+      queryClient.setQueryData(
+        getShmoBookingQueryKey(res.data.bookingId, acceptLanguage),
+        res.data,
+      );
+    }
+  }, [res.status, res.data, queryClient, acceptLanguage]);
+
+  return res;
 };


### PR DESCRIPTION
Closes http://github.com/AtB-AS/kundevendt/issues/20598

We need to handle cases where entur force end the trip without a user action. So if entur ends the trip, they will set the booking to FINISHED so we skip the photo stage and just closes the scootersheet and cleans up the state