### PR TITLE
feat: simplified the previous payment logic

### DIFF
--- a/src/modules/map/MapContext.tsx
+++ b/src/modules/map/MapContext.tsx
@@ -4,8 +4,6 @@ import {Feature, GeoJsonProperties, Point} from 'geojson';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 type AutoSelectedFeature = Feature<Point, GeoJsonProperties> | undefined;
 import {ShmoBookingState} from '@atb/api/types/mobility';
-import {PaymentMethod} from '@atb/modules/payment';
-import {useSelectedShmoPaymentMethod} from '@atb/modules/payment';
 
 type MapContextState = {
   bottomSheetToAutoSelect?: AutoSelectableBottomSheet;
@@ -18,8 +16,6 @@ type MapContextState = {
   ) => void;
   setAutoSelectedMapItem: (mapItemToAutoSelect?: AutoSelectableMapItem) => void;
   autoSelectedFeature?: AutoSelectedFeature;
-  selectedShmoPaymentMethod?: PaymentMethod;
-  setSelectedShmoPaymentMethod: (paymentMethod: PaymentMethod) => void;
 };
 
 const MapContext = createContext<MapContextState | undefined>(undefined);
@@ -46,9 +42,6 @@ type Props = {
 export const MapContextProvider = ({children}: Props) => {
   const [bottomSheetToAutoSelect, setBottomSheetToAutoSelect] =
     useState<AutoSelectableBottomSheet>();
-
-  const [selectedShmoPaymentMethod, setSelectedShmoPaymentMethod] =
-    useSelectedShmoPaymentMethod();
 
   const [
     bottomSheetCurrentlyAutoSelected,
@@ -92,8 +85,6 @@ export const MapContextProvider = ({children}: Props) => {
         setBottomSheetCurrentlyAutoSelected,
         setAutoSelectedMapItem,
         autoSelectedFeature,
-        selectedShmoPaymentMethod,
-        setSelectedShmoPaymentMethod,
       }}
     >
       {children}

--- a/src/modules/mobility/components/sheets/ScooterSheet.tsx
+++ b/src/modules/mobility/components/sheets/ScooterSheet.tsx
@@ -29,9 +29,8 @@ import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {Section} from '@atb/components/sections';
 import {
   PaymentSelectionSectionItem,
-  usePreviousPaymentMethods,
+  useSelectedShmoPaymentMethod,
 } from '@atb/modules/payment';
-import {useMapContext} from '@atb/modules/map';
 
 type Props = {
   selectPaymentMethod: () => void;
@@ -74,15 +73,10 @@ export const ScooterSheet = ({
   const operatorIsIntegrationEnabled = mobilityOperators?.find(
     (e) => e.id === operatorId,
   )?.isDeepIntegrationEnabled;
-  const {selectedShmoPaymentMethod} = useMapContext();
-  const {recurringPaymentMethods} = usePreviousPaymentMethods();
-
-  const defaultPaymentMethod =
-    selectedShmoPaymentMethod ??
-    recurringPaymentMethods?.[recurringPaymentMethods.length - 1];
 
   const {isLoading: shmoReqIsLoading, hasBlockers} = useShmoRequirements();
   const {operatorBenefit} = useOperatorBenefit(operatorId);
+  const selectedPaymentMethod = useSelectedShmoPaymentMethod();
 
   useDoOnceOnItemReceived(onVehicleReceived, vehicle);
 
@@ -121,14 +115,14 @@ export const ScooterSheet = ({
                 operatorName={operatorName}
                 brandLogoUrl={brandLogoUrl}
               />
-              {defaultPaymentMethod &&
+              {selectedPaymentMethod &&
                 isShmoDeepIntegrationEnabled &&
                 isMapV2Enabled &&
                 !hasBlockers &&
                 operatorIsIntegrationEnabled && (
                   <Section style={styles.paymentWrapper}>
                     <PaymentSelectionSectionItem
-                      paymentMethod={defaultPaymentMethod}
+                      paymentMethod={selectedPaymentMethod}
                       onPress={selectPaymentMethod}
                     />
                   </Section>
@@ -145,7 +139,7 @@ export const ScooterSheet = ({
                     onStartOnboarding={startOnboardingCallback}
                     vehicleId={id}
                     operatorId={operatorId}
-                    paymentMethod={defaultPaymentMethod}
+                    paymentMethod={selectedPaymentMethod}
                   />
                   <Button
                     expanded={true}

--- a/src/modules/mobility/components/sheets/SelectShmoPaymentMethodsSheet.tsx
+++ b/src/modules/mobility/components/sheets/SelectShmoPaymentMethodsSheet.tsx
@@ -17,6 +17,7 @@ import {
 } from '@atb/modules/payment';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useAuthContext} from '@atb/modules/auth';
+import {useMutation} from '@tanstack/react-query';
 
 type Props = {
   onSelect: () => void;
@@ -39,7 +40,14 @@ export const SelectShmoPaymentMethodSheet = ({
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
     PaymentMethod | undefined
   >();
-  const [isLoading, setIsLoading] = useState(false);
+
+  const {mutate: savePrevPaymentMethod, isLoading} = useMutation({
+    mutationFn: (params: {userId: string; paymentMethod: PaymentMethod}) =>
+      savePreviousPaymentMethodByUser(params.userId, params.paymentMethod),
+    onSuccess() {
+      onSelect();
+    },
+  });
 
   useEffect(() => {
     if (defaultPaymentMethod) {
@@ -97,13 +105,13 @@ export const SelectShmoPaymentMethodSheet = ({
                   selectedPaymentMethod.recurringPayment &&
                   userId
                 ) {
-                  setIsLoading(true);
-                  await savePreviousPaymentMethodByUser(userId, {
-                    paymentType: selectedPaymentMethod?.paymentType,
-                    recurringPayment: selectedPaymentMethod.recurringPayment,
+                  savePrevPaymentMethod({
+                    userId,
+                    paymentMethod: {
+                      paymentType: selectedPaymentMethod?.paymentType,
+                      recurringPayment: selectedPaymentMethod.recurringPayment,
+                    },
                   });
-                  setIsLoading(false);
-                  onSelect();
                 }
               }}
               disabled={!selectedPaymentMethod}

--- a/src/modules/mobility/components/sheets/SelectShmoPaymentMethodsSheet.tsx
+++ b/src/modules/mobility/components/sheets/SelectShmoPaymentMethodsSheet.tsx
@@ -44,9 +44,7 @@ export const SelectShmoPaymentMethodSheet = ({
   const {mutate: savePrevPaymentMethod, isLoading} = useMutation({
     mutationFn: (params: {userId: string; paymentMethod: PaymentMethod}) =>
       savePreviousPaymentMethodByUser(params.userId, params.paymentMethod),
-    onSuccess() {
-      onSelect();
-    },
+    onSuccess: onSelect,
   });
 
   useEffect(() => {

--- a/src/modules/payment/hooks/use-selected-shmo-payment-method.tsx
+++ b/src/modules/payment/hooks/use-selected-shmo-payment-method.tsx
@@ -1,43 +1,18 @@
-import {useEffect, useState} from 'react';
-import {PaymentMethod} from '../types';
 import {usePreviousPaymentMethods} from '../previous-payment-utils';
 import {isCardPaymentMethod} from '../utils';
 
-export const useSelectedShmoPaymentMethod = (): [
-  PaymentMethod | undefined,
-  React.Dispatch<React.SetStateAction<PaymentMethod | undefined>>,
-] => {
-  const [selectedShmoPaymentMethod, setSelectedShmoPaymentMethod] = useState<
-    PaymentMethod | undefined
-  >(undefined);
-
+export const useSelectedShmoPaymentMethod = () => {
   const {previousPaymentMethod, recurringPaymentMethods} =
     usePreviousPaymentMethods();
 
-  useEffect(() => {
-    // If we have a previous card payment method (previousPaymentMethod might be set later so we need to check it)
-    if (previousPaymentMethod !== undefined) {
-      const previousCardPaymentMethod = isCardPaymentMethod(
-        previousPaymentMethod,
-      )
-        ? previousPaymentMethod
-        : undefined;
+  const previousCardPaymentMethod = isCardPaymentMethod(previousPaymentMethod)
+    ? previousPaymentMethod
+    : undefined;
 
-      // If we have a valid card payment method, use it
-      if (previousCardPaymentMethod) {
-        setSelectedShmoPaymentMethod(previousCardPaymentMethod);
-        // This is bestcase scenario, we can return
-        return;
-      }
-    }
+  const selectedShmoPaymentMethod =
+    previousCardPaymentMethod ??
+    (recurringPaymentMethods &&
+      recurringPaymentMethods[recurringPaymentMethods.length - 1]);
 
-    //use fallback
-    if (recurringPaymentMethods?.length) {
-      const fallbackPaymentMethod =
-        recurringPaymentMethods[recurringPaymentMethods.length - 1];
-      setSelectedShmoPaymentMethod(fallbackPaymentMethod);
-    }
-  }, [previousPaymentMethod, recurringPaymentMethods]);
-
-  return [selectedShmoPaymentMethod, setSelectedShmoPaymentMethod];
+  return selectedShmoPaymentMethod;
 };


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20604

Ended up reworking how we keep track of paymentcards in the shmo payment bottomsheet. Now we only rely on the last used card, and when we select cards in the bottomsheet we save the card to last used instead of setting it to state