### PR TITLE
fix: fixed follow buss

### DIFF
--- a/src/fare-zones-selector/FareZonesSelectorMap.tsx
+++ b/src/fare-zones-selector/FareZonesSelectorMap.tsx
@@ -63,7 +63,7 @@ const FareZonesSelectorMap = ({
 
   const selectFeature = (event: OnPressEvent) => {
     const feature = event.features[0];
-    flyToLocation({coordinates: event.coordinates, mapCameraRef, mapViewRef});
+    flyToLocation({coordinates: event.coordinates, mapCameraRef});
     updateSelectedZones(feature.id as string);
   };
 
@@ -210,7 +210,6 @@ const FareZonesSelectorMap = ({
                       flyToLocation({
                         coordinates: location?.coordinates,
                         mapCameraRef,
-                        mapViewRef,
                       })
                     }
                   />

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -264,7 +264,6 @@ export const Map = (props: MapProps) => {
             <Stations
               stations={props.stations.stations}
               mapCameraRef={mapCameraRef}
-              mapViewRef={mapViewRef}
               onClusterClick={(feature) => {
                 onMapClick({
                   source: 'cluster-click',

--- a/src/modules/map/components/mobility/Stations.tsx
+++ b/src/modules/map/components/mobility/Stations.tsx
@@ -6,7 +6,7 @@ import {
   isClusterFeature,
 } from '@atb/modules/map';
 import {getAvailableVehicles} from '@atb/modules/mobility';
-import MapboxGL from '@rnmapbox/maps';
+import {Camera, ShapeSource} from '@rnmapbox/maps';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {Feature, FeatureCollection, GeoJSON, Point} from 'geojson';
 import React, {RefObject} from 'react';
@@ -17,8 +17,7 @@ import {CarStations} from './CarStations';
 
 type Props = {
   stations: StationFeatures;
-  mapCameraRef: RefObject<MapboxGL.Camera | null>;
-  mapViewRef: RefObject<MapboxGL.MapView | null>;
+  mapCameraRef: RefObject<Camera | null>;
   onClusterClick?: (feature: Feature<Point, Cluster>) => void;
 };
 
@@ -27,18 +26,13 @@ export type StationsWithCount = FeatureCollection<
   StationBasicFragment & {count: number}
 >;
 
-export const Stations = ({
-  stations,
-  onClusterClick,
-  mapCameraRef,
-  mapViewRef,
-}: Props) => {
+export const Stations = ({stations, onClusterClick, mapCameraRef}: Props) => {
   const bikeStations = stationsWithCount(stations.bicycles, FormFactor.Bicycle);
   const carStations = stationsWithCount(stations.cars, FormFactor.Car);
 
   const handleClusterClick = async (
     e: OnPressEvent,
-    clustersSource: RefObject<MapboxGL.ShapeSource | null>,
+    clustersSource: RefObject<ShapeSource | null>,
   ) => {
     const [feature] = e.features;
     if (isClusterFeature(feature)) {
@@ -47,8 +41,8 @@ export const Stations = ({
       flyToLocation({
         coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
         mapCameraRef,
-        mapViewRef,
         zoomLevel: clusterExpansionZoom,
+        animationDuration: 200,
       });
       onClusterClick && onClusterClick(feature);
     }

--- a/src/modules/map/components/mobility/Vehicles.tsx
+++ b/src/modules/map/components/mobility/Vehicles.tsx
@@ -43,7 +43,6 @@ export const Vehicles = ({
         coordinates: mapPositionToCoordinates(feature.geometry.coordinates),
         padding: SLIGHTLY_RAISED_MAP_PADDING,
         mapCameraRef,
-        mapViewRef,
         zoomLevel: toZoomLevel,
         animationDuration: Math.abs(fromZoomLevel - toZoomLevel) * 100,
       });

--- a/src/screen-components/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/screen-components/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -131,7 +131,6 @@ export const TravelDetailsMapScreenComponent = ({
       flyToLocation({
         coordinates: location,
         mapCameraRef,
-        mapViewRef,
         animationDuration: FOLLOW_ANIMATION_DURATION,
         animationMode: 'easeTo',
       });


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20788

Fixed the follow bus bug by using old logic for cases where calculations of distance is not needed. FlyTo function was originally reworked to calculate distance between where you are looking on the screen and a set of coordinates to fly to, so it can decide if it want to moveTo(skip animating on map) or animate a shorter distance to the target. We want to avoid a case where a user flies across a large distances resulting an excessive amounts of calls to the tileserver by moving across the map. But in some cases, like the follow bus. There is no need to have this logic when entering the map and following the bus. It still remains on the PositionArrow, to fly to your location. But not on the logic runs when rendering the component and follows the bus