### PR TITLE
feat: Add Slot Layers

### DIFF
--- a/src/modules/map/components/SelectedFeatureIcon.tsx
+++ b/src/modules/map/components/SelectedFeatureIcon.tsx
@@ -4,6 +4,7 @@ import {Feature, GeoJsonProperties, Point} from 'geojson';
 import {hitboxCoveringIconOnly, useMapSymbolStyles} from '@atb/modules/map';
 import {Expression} from '@rnmapbox/maps/src/utils/MapboxStyles';
 import {PinType} from '../mapbox-styles/pin-types';
+import {MapSlotLayerId} from '../hooks/use-mapbox-json-style';
 
 export const SelectedFeatureIcon = ({
   selectedFeature,
@@ -66,6 +67,7 @@ export const SelectedFeatureIcon = ({
     >
       <MapboxGL.SymbolLayer
         id="selected-vehicle-symbol-layer"
+        aboveLayerID={MapSlotLayerId.SelectedFeature}
         style={{
           ...customTextStyle,
           iconImage,

--- a/src/modules/map/components/mobility/GeofencingZones.tsx
+++ b/src/modules/map/components/mobility/GeofencingZones.tsx
@@ -10,6 +10,7 @@ import {useVehicleQuery} from '@atb/modules/mobility';
 
 import {hitboxCoveringIconOnly} from '@atb/modules/map';
 import {VehicleExtendedFragment} from '@atb/api/types/generated/fragments/vehicles';
+import {MapSlotLayerId} from '../../hooks/use-mapbox-json-style';
 
 type GeofencingZonesProps = {
   selectedVehicleId: string;
@@ -77,7 +78,7 @@ const GeofencingZone = ({geofencingZone}: GeofencingZoneProps) => {
           fillColor: bgColor,
           fillOpacity,
         }}
-        aboveLayerID="country-label"
+        aboveLayerID={MapSlotLayerId.GeofencingZones}
       />
       <MapboxGL.LineLayer
         id="tariffZonesLine"
@@ -86,7 +87,7 @@ const GeofencingZone = ({geofencingZone}: GeofencingZoneProps) => {
           lineColor: bgColor,
           lineOpacity,
         }}
-        aboveLayerID="country-label"
+        aboveLayerID={MapSlotLayerId.GeofencingZones}
       />
     </MapboxGL.ShapeSource>
   );

--- a/src/modules/map/components/mobility/VehiclesAndStations.tsx
+++ b/src/modules/map/components/mobility/VehiclesAndStations.tsx
@@ -8,7 +8,10 @@ import {
   TileLayerName,
   useTileUrlTemplate,
 } from '../../hooks/use-tile-url-template';
-import {StyleJsonVectorSource} from '../../hooks/use-mapbox-json-style';
+import {
+  MapSlotLayerId,
+  StyleJsonVectorSource,
+} from '../../hooks/use-mapbox-json-style';
 import {
   Expression,
   FilterExpression,
@@ -44,6 +47,7 @@ export const VehiclesWithClusters = ({
       sourceID={vehiclesAndStationsVectorSourceId}
       sourceLayerID="combined_layer"
       minZoomLevel={14}
+      aboveLayerID={MapSlotLayerId.Vehicles}
       filter={filter}
       style={style}
     />
@@ -90,6 +94,7 @@ export const Stations = ({
       sourceID={vehiclesAndStationsVectorSourceId}
       sourceLayerID="stations"
       minZoomLevel={14}
+      aboveLayerID={MapSlotLayerId.Stations}
       filter={filter}
       style={style}
     />

--- a/src/modules/map/components/national-stop-registry-features/NationalStopRegistryFeatures.tsx
+++ b/src/modules/map/components/national-stop-registry-features/NationalStopRegistryFeatures.tsx
@@ -7,6 +7,7 @@ import {useNsrSymbolLayers} from './use-nsr-symbol-layers';
 import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/src/types/OnPressEvent';
 import {Props as SymbolLayerProps} from '@rnmapbox/maps/lib/typescript/src/components/SymbolLayer';
 import {hitboxCoveringIconOnly} from '../../utils';
+import {MapSlotLayerId} from '../../hooks/use-mapbox-json-style';
 
 /**
  * @property {string} selectedFeaturePropertyId - Should be the id from properties, which is the NSR id. This is needed to hide the selected feature.
@@ -52,4 +53,4 @@ export const NationalStopRegistryFeatures = ({
 };
 
 const getPreviousLayerId = (nsrSymbolLayers: SymbolLayerProps[], i: number) =>
-  nsrSymbolLayers?.[i - 1]?.id ?? 'poi-stadium';
+  nsrSymbolLayers?.[i - 1]?.id ?? MapSlotLayerId.NSRItems;

--- a/src/modules/map/hooks/use-mapbox-json-style.tsx
+++ b/src/modules/map/hooks/use-mapbox-json-style.tsx
@@ -6,7 +6,7 @@ import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {useVehiclesAndStationsVectorSource} from '../components/mobility/VehiclesAndStations';
 
-// since zIndex doesn't work in mapbox, but aboveLayerId does, add some slot layer ids to use
+// since layerIndex doesn't work in mapbox, but aboveLayerId does, add some slot layer ids to use
 export enum MapSlotLayerId {
   GeofencingZones = 'geofencingZones',
   Vehicles = 'vehicles',

--- a/src/modules/map/hooks/use-mapbox-json-style.tsx
+++ b/src/modules/map/hooks/use-mapbox-json-style.tsx
@@ -6,6 +6,31 @@ import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {useVehiclesAndStationsVectorSource} from '../components/mobility/VehiclesAndStations';
 
+// since zIndex doesn't work in mapbox, but aboveLayerId does, add some slot layer ids to use
+export enum MapSlotLayerId {
+  Vehicles = 'vehicles',
+  Stations = 'stations',
+  NSRItems = 'NSRItems',
+}
+
+const slotSourceKey = 'slotSource';
+// This source only exists for slots layers, no data is fetched.
+const slotSource: StyleJsonVectorSourcesObj = {
+  [slotSourceKey]: {type: 'vector'}, // type is required, but otherwise doesn't matter here.
+};
+
+// the order of this list, determines which layers render on top. Last is on top.
+const slotLayerIds: MapSlotLayerId[] = [
+  MapSlotLayerId.Vehicles,
+  MapSlotLayerId.Stations,
+  MapSlotLayerId.NSRItems,
+];
+const slotLayers = slotLayerIds.map((slotLayerId) => ({
+  id: slotLayerId,
+  type: 'symbol', // type is required, but otherwise doesn't matter here.
+  source: slotSourceKey,
+}));
+
 export const useMapboxJsonStyle: (
   includeVehiclesAndStationsVectorSource: boolean,
 ) => string | undefined = (includeVehiclesAndStationsVectorSource) => {
@@ -21,12 +46,13 @@ export const useMapboxJsonStyle: (
     source: vehiclesAndStationsVectorSource,
   } = useVehiclesAndStationsVectorSource();
 
-  const themedStyleWithExtendedSources = useMemo(() => {
+  const themedStyleWithExtendedSourcesAndSlotLayers = useMemo(() => {
     const themedStyle =
       themeName === 'dark' ? mapboxDarkStyle : mapboxLightStyle;
 
-    const extendedSources: Record<string, StyleJsonVectorSource> = {
+    const extendedSources: StyleJsonVectorSourcesObj = {
       ...themedStyle.sources,
+      ...slotSource,
       ...(includeVehiclesAndStationsVectorSource
         ? {
             [vehiclesAndStationsVectorSourceId]:
@@ -35,9 +61,12 @@ export const useMapboxJsonStyle: (
         : undefined),
     };
 
+    const layersWithSlots = [...themedStyle.layers, ...slotLayers];
+
     return {
       ...themedStyle,
       sources: extendedSources,
+      layers: layersWithSlots,
     };
   }, [
     includeVehiclesAndStationsVectorSource,
@@ -49,10 +78,10 @@ export const useMapboxJsonStyle: (
   const mapboxJsonStyle = useMemo(
     () =>
       JSON.stringify({
-        ...themedStyleWithExtendedSources,
+        ...themedStyleWithExtendedSourcesAndSlotLayers,
         sprite: mapboxSpriteUrl + themeName,
       }),
-    [themeName, mapboxSpriteUrl, themedStyleWithExtendedSources],
+    [themeName, mapboxSpriteUrl, themedStyleWithExtendedSourcesAndSlotLayers],
   );
 
   return mapboxJsonStyle;
@@ -79,3 +108,4 @@ export type StyleJsonVectorSource = {
   url?: string;
   volatile?: boolean;
 };
+type StyleJsonVectorSourcesObj = Record<string, StyleJsonVectorSource>;

--- a/src/modules/map/hooks/use-mapbox-json-style.tsx
+++ b/src/modules/map/hooks/use-mapbox-json-style.tsx
@@ -8,9 +8,11 @@ import {useVehiclesAndStationsVectorSource} from '../components/mobility/Vehicle
 
 // since zIndex doesn't work in mapbox, but aboveLayerId does, add some slot layer ids to use
 export enum MapSlotLayerId {
+  GeofencingZones = 'geofencingZones',
   Vehicles = 'vehicles',
   Stations = 'stations',
-  NSRItems = 'NSRItems',
+  NSRItems = 'nsrItems',
+  SelectedFeature = 'selectedFeature',
 }
 
 const slotSourceKey = 'slotSource';
@@ -21,9 +23,11 @@ const slotSource: StyleJsonVectorSourcesObj = {
 
 // the order of this list, determines which layers render on top. Last is on top.
 const slotLayerIds: MapSlotLayerId[] = [
+  MapSlotLayerId.GeofencingZones,
   MapSlotLayerId.Vehicles,
   MapSlotLayerId.Stations,
   MapSlotLayerId.NSRItems,
+  MapSlotLayerId.SelectedFeature,
 ];
 const slotLayers = slotLayerIds.map((slotLayerId) => ({
   id: slotLayerId,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20702

There is a problem in mapbox that `layerIndex` doesn't work.
However, using `aboveLayerId` works well.
In this PR, new placeholder layers are added so that we have full control over the layer order.
Current order, from bottom to top:
```ts
const slotLayerIds: MapSlotLayerId[] = [
  MapSlotLayerId.GeofencingZones, // bottom
  MapSlotLayerId.Vehicles,
  MapSlotLayerId.Stations,
  MapSlotLayerId.NSRItems,
  MapSlotLayerId.SelectedFeature, // top
];
```
How to place a `SymbolLayer`:
```ts
aboveLayerID={MapSlotLayerId.Stations}
```