### PR TITLE
chore: Update @react-native-async-storage+async-storage+1.19.8.patch

### DIFF
--- a/patches/@react-native-async-storage+async-storage+1.19.8.patch
+++ b/patches/@react-native-async-storage+async-storage+1.19.8.patch
@@ -51,11 +51,7 @@ index 4bfa945..62872e3 100644
 +// clang-format on
 +{
 +    [self _setGroupName: NULL];
-+    NSString *oldDirectory = RCTCreateStorageDirectoryPath(RCTStorageDirectory);
 +    [self _setGroupName: groupName];
-+    NSString *newDirectory = RCTCreateStorageDirectoryPath(RCTStorageDirectory);
-+    // Move files from previous location to a new one in the group
-+    RCTStorageDirectoryMigrationCheck(oldDirectory, newDirectory, YES);
 +    callback(@[RCTNullIfNil(nil)]);
 +}
 +


### PR DESCRIPTION
It removes the need to migrate from the async storage after all users have been fully moved to the new structure.

### Test prerequisites
- have some favorite departures/stop places

### Acceptance criteria: 

- [x] Updating from old version to new app version with the fix should work.
- [x] Selected favourites should not be removed when updating to new version.
- [x] If a new favourite is marked in the app, it is also shown in the widget.