### PR TITLE
fix: hide `Show Trip` button if no polyline is received

### DIFF
--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -199,6 +199,7 @@ export const DepartureDetailsScreenComponent = ({
 
   const shouldShowMapButton =
     mapData &&
+    mapData.mapLegs.length > 0 &&
     !screenReaderEnabled &&
     !isLoading &&
     estimatedCallsWithMetadata.length > 0 &&


### PR DESCRIPTION
refer to this slack message: https://mittatb.slack.com/archives/C0116FMPX4Y/p1748107469811009

The app crashes because no polyline data is received from the BFF, so the solution here should be to hide the "Show Trip" button if we don't receive any polyline data from BFF. Which should completely fix this bugsnag issue: https://app.bugsnag.com/atb-as/mittatb/errors/6788c603c88e184232652ed0?filters[event.since]=all&filters[app.release_stage]=store

I have put a fix from the BFF side here: https://github.com/AtB-AS/atb-bff/pull/390