### PR TITLE
fix: Remove yarn workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
Builds are failing randomly, but more recently, and it might be because some machines have different versions of yarn, and the workspace is something needed for recent versions of yarn.