### PR TITLE
fix: Always refetch shmo items on mount

### DIFF
--- a/src/modules/mobility/queries/use-bike-station-query.tsx
+++ b/src/modules/mobility/queries/use-bike-station-query.tsx
@@ -8,4 +8,5 @@ export const useBikeStationQuery = (id: string) =>
     queryFn: ({signal}) => getBikeStation(id, {signal}),
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
+    refetchOnMount: 'always',
   });

--- a/src/modules/mobility/queries/use-bike-station-query.tsx
+++ b/src/modules/mobility/queries/use-bike-station-query.tsx
@@ -9,4 +9,5 @@ export const useBikeStationQuery = (id: string) =>
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
     refetchOnMount: 'always',
+    retry: 5,
   });

--- a/src/modules/mobility/queries/use-car-station-query.tsx
+++ b/src/modules/mobility/queries/use-car-station-query.tsx
@@ -8,4 +8,5 @@ export const useCarStationQuery = (id: string) =>
     queryFn: ({signal}) => getCarStation(id, {signal}),
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
+    refetchOnMount: 'always',
   });

--- a/src/modules/mobility/queries/use-car-station-query.tsx
+++ b/src/modules/mobility/queries/use-car-station-query.tsx
@@ -9,4 +9,5 @@ export const useCarStationQuery = (id: string) =>
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
     refetchOnMount: 'always',
+    retry: 5,
   });

--- a/src/modules/mobility/queries/use-vehicle-query.tsx
+++ b/src/modules/mobility/queries/use-vehicle-query.tsx
@@ -8,4 +8,5 @@ export const useVehicleQuery = (id: string) =>
     queryFn: ({signal}) => getVehicle(id, {signal}),
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
+    refetchOnMount: 'always',
   });

--- a/src/modules/mobility/queries/use-vehicle-query.tsx
+++ b/src/modules/mobility/queries/use-vehicle-query.tsx
@@ -9,4 +9,5 @@ export const useVehicleQuery = (id: string) =>
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
     refetchOnMount: 'always',
+    retry: 5,
   });


### PR DESCRIPTION
E.g. when scanning a vehicle very shortly after someone else has parked it, the GBFS data may not be updated yet.
If so, the user will get an error, and because of caching, this would continue to show as a missing vehicle even after the data has been updated.
To fix this, vehicles and stations are always refetched with this PR.

Acceptance Criteria:
Every time a bottom sheet is opened, a new request should be sent to get the data
   - [ ] Scooters
      - [ ] From clicking on map
      - [ ] From scanning (both starting from selected, and non-selected bottom sheet state)
   - [ ] Bicycle Stations
      - [ ] From clicking on map
   - [ ] Car Sharing Stations
      - [ ] From clicking on map
- [ ] Requests should not be fired tooooo many times/at other times