### PR TITLE
test: tweak on travelsearch filter test

### DIFF
--- a/e2e/test/specs/travelsearch.filter.e2e.ts
+++ b/e2e/test/specs/travelsearch.filter.e2e.ts
@@ -23,8 +23,9 @@ describe('Travel search filter', () => {
    * Note! One danger is if the search is unlucky and only get bus options in the initial search
    */
   it('should filter transport modes correctly', async () => {
-    const departure = 'Marienborg stasjon';
+    const departure = 'Cecilienborg';
     const arrival = 'Melhus skysstasjon';
+    const numResultsToCheck = 8;
 
     try {
       await ElementHelper.waitForElement('id', 'searchFromButton');
@@ -38,7 +39,9 @@ describe('Travel search filter', () => {
 
       // Check number of transport modes
       const numberOfModesInitial =
-        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch(6);
+        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch(
+          numResultsToCheck,
+        );
 
       // Filter out buses
       await AppHelper.scrollUpUntilId('tripSearchContentView', 'filterButton');
@@ -49,7 +52,9 @@ describe('Travel search filter', () => {
 
       // Verify
       const numberOfModesWithFilter =
-        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch(6);
+        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch(
+          numResultsToCheck,
+        );
       expect(numberOfModesWithFilter).toBeLessThan(numberOfModesInitial);
       await AppHelper.scrollUpUntilId(
         'tripSearchContentView',
@@ -63,7 +68,9 @@ describe('Travel search filter', () => {
 
       // Verify
       const numberOfModes =
-        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch(6);
+        await TravelsearchOverviewPage.getNumberOfTransportModesInSearch(
+          numResultsToCheck,
+        );
       expect(numberOfModes).toEqual(numberOfModesInitial);
       await AppHelper.scrollUpUntilId('tripSearchContentView', 'filterButton');
       await expect(TravelsearchFilterPage.selectedFilterButton).not.toExist();


### PR DESCRIPTION
The only error that sometimes happen for the E2E-tests are if in the travelsearch filter test we don't get a mix of trip patterns with either only bus or only train legs. Then, filtering out buses don't make any change to number of transport means in the X first results that are checked.

Change 1: Departure from `Marienborg stasjon` > `Cecilienborg`
Change 2: Check first `6` trips > `8` trips