### PR TITLE
feat: add event stream fare contract feature toggle

### DIFF
--- a/src/modules/event-stream/handle-stream-event.ts
+++ b/src/modules/event-stream/handle-stream-event.ts
@@ -5,9 +5,13 @@ import {fareContractsQueryKey} from '../ticketing/use-fare-contracts';
 export const handleStreamEvent = (
   streamEvent: StreamEvent,
   queryClient: QueryClient,
+  featureToggles: {
+    isEventStreamFareContractsEnabled?: boolean;
+  },
 ) => {
   switch (streamEvent.event) {
     case EventKind.FareContract:
+      if (!featureToggles.isEventStreamFareContractsEnabled) return;
       queryClient.invalidateQueries({
         queryKey: [fareContractsQueryKey],
       });

--- a/src/modules/event-stream/use-setup-event-stream.ts
+++ b/src/modules/event-stream/use-setup-event-stream.ts
@@ -12,7 +12,8 @@ import {jsonStringToObject} from '@atb/utils/object';
 export const useSetupEventStream = () => {
   const queryClient = useQueryClient();
   const {abtCustomerId} = useAuthContext();
-  const {isEventStreamEnabled} = useFeatureTogglesContext();
+  const {isEventStreamEnabled, isEventStreamFareContractsEnabled} =
+    useFeatureTogglesContext();
 
   const url = `${WS_API_BASE_URL}stream/v1`;
 
@@ -29,9 +30,11 @@ export const useSetupEventStream = () => {
       Bugsnag.leaveBreadcrumb('Received event from stream', {
         data: event.data,
       });
-      handleStreamEvent(streamEvent, queryClient);
+      handleStreamEvent(streamEvent, queryClient, {
+        isEventStreamFareContractsEnabled,
+      });
     },
-    [queryClient],
+    [queryClient, isEventStreamFareContractsEnabled],
   );
 
   const authenticate = useCallback((ws: WebSocket) => {

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -38,6 +38,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_event_stream',
   },
   {
+    name: 'isEventStreamFareContractsEnabled',
+    remoteConfigKey: 'enable_event_stream_fare_contracts',
+  },
+  {
     name: 'isFlexibleTransportEnabled',
     remoteConfigKey: 'enable_flexible_transport',
   },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -22,6 +22,7 @@ export type RemoteConfig = {
   enable_car_sharing_in_map: boolean;
   enable_city_bikes_in_map: boolean;
   enable_event_stream: boolean;
+  enable_event_stream_fare_contracts: boolean;
   enable_extended_onboarding: boolean;
   enable_flexible_transport: boolean;
   enable_from_travel_search_to_ticket_boat: boolean;
@@ -125,6 +126,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
   enable_event_stream: false,
+  enable_event_stream_fare_contracts: false,
   enable_tips_and_information: false,
   enable_token_fallback_on_timeout: true,
   enable_token_fallback: true,
@@ -205,6 +207,9 @@ export function getConfig(): RemoteConfig {
   const enable_event_stream =
     values['enable_event_stream']?.asBoolean() ??
     defaultRemoteConfig.enable_event_stream;
+  const enable_event_stream_fare_contracts =
+    values['enable_event_stream_fare_contracts']?.asBoolean() ??
+    defaultRemoteConfig.enable_event_stream_fare_contracts;
   const enable_extended_onboarding =
     values['enable_extended_onboarding']?.asBoolean() ??
     defaultRemoteConfig.enable_extended_onboarding;
@@ -381,6 +386,7 @@ export function getConfig(): RemoteConfig {
     enable_car_sharing_in_map,
     enable_city_bikes_in_map,
     enable_event_stream,
+    enable_event_stream_fare_contracts,
     enable_extended_onboarding,
     enable_flexible_transport,
     enable_from_travel_search_to_ticket_boat,

--- a/src/modules/ticketing/TicketingContext.tsx
+++ b/src/modules/ticketing/TicketingContext.tsx
@@ -142,10 +142,14 @@ export const TicketingContextProvider = ({children}: Props) => {
   const [state, dispatch] = useReducer(ticketingReducer, initialReducerState);
   const {userId} = useAuthContext();
   const {enable_ticketing} = useRemoteConfigContext();
-  const {isEventStreamEnabled} = useFeatureTogglesContext();
+  const {isEventStreamEnabled, isEventStreamFareContractsEnabled} =
+    useFeatureTogglesContext();
 
   const {data: fareContracts} = useGetFareContractsQuery({
-    enabled: enable_ticketing && isEventStreamEnabled,
+    enabled:
+      enable_ticketing &&
+      isEventStreamEnabled &&
+      isEventStreamFareContractsEnabled,
     availability: undefined,
   });
   useEffect(() => {
@@ -163,7 +167,7 @@ export const TicketingContextProvider = ({children}: Props) => {
       const removeListeners = setupFirestoreListeners(userId, {
         fareContracts: {
           onSnapshot: (fareContracts) => {
-            if (isEventStreamEnabled) {
+            if (isEventStreamEnabled && isEventStreamFareContractsEnabled) {
               Bugsnag.leaveBreadcrumb(
                 `Got Firestore snapshot with ${fareContracts.length} fare contracts, but not updating state since event stream is enabled.`,
               );
@@ -241,7 +245,12 @@ export const TicketingContextProvider = ({children}: Props) => {
       // Stop listening for updates when no longer required
       return () => removeListeners();
     }
-  }, [userId, enable_ticketing, isEventStreamEnabled]);
+  }, [
+    userId,
+    enable_ticketing,
+    isEventStreamEnabled,
+    isEventStreamFareContractsEnabled,
+  ]);
 
   return (
     <TicketingContext.Provider


### PR DESCRIPTION
Adds a new feature toggle (`enable_event_stream_fare_contracts` in remote config), that needs to be enabled in addition to `enable_event_stream`.

### Acceptance criteria

- [x] If `enable_event_stream` AND `enable_event_stream_fare_contracts` is enabled, fare contracts are fetched from the list endpoint.
- [x] If only `enable_event_stream` is enabled, fare contracts are fetched from firestore, and there are no request to the list endpoints. However, the websocket connection is established, but without affecting the app.
- [x] If only `enable_event_stream_fare_contracts` is enabled, fare contracts are also fetched from firestore, and there are no request to the list endpoints. The websocket connection is not established.