### PR TITLE
feat: new mobile token endpoint error handling

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -13,8 +13,8 @@ type HttpError = z.infer<typeof HttpError>;
 export const ErrorResponse = z.object({
   http: HttpError,
   kind: z.string(),
-  message: z.string().optional(),
-  details: z.array(z.unknown()).optional(),
+  message: z.string().nullish(),
+  details: z.array(z.unknown()).nullish(),
 });
 export type ErrorResponse = z.infer<typeof ErrorResponse>;
 

--- a/src/modules/mobile-token/MobileTokenContext.tsx
+++ b/src/modules/mobile-token/MobileTokenContext.tsx
@@ -467,7 +467,7 @@ const deviceInspectable = (
  * Determines if a mobile token status is inspectable.
  *
  * Inspectable means that the token has the `TICKET_INSPECTION` right on the backoffice.
- * 
+ *
  * @param mobileTokenStatus - The current status of the mobile token.
  *   - `'success-and-inspectable'`: The token is successfully generated and can be inspected.
  *   - `'fallback'`: The token is in a fallback state and can be inspected.

--- a/src/modules/mobile-token/MobileTokenContext.tsx
+++ b/src/modules/mobile-token/MobileTokenContext.tsx
@@ -110,12 +110,20 @@ export const MobileTokenContextProvider = ({children}: Props) => {
 
   const enabled = !!userId && authStatus === 'authenticated' && !isLoggingOut;
 
+  /**
+   * Fetch the local token (if available), if there are no local token,
+   * we request a new token from remote in here as well.
+   */
   const {
     data: nativeToken,
     status: nativeTokenStatus,
     error: nativeTokenError,
   } = useLoadNativeTokenQuery(enabled, userId, traceId.current);
 
+  /**
+   * Send the token statistics (success/error) to backend to update
+   * also process the secure container so we can fetch the token list.
+   */
   useEffect(() => {
     setSecureContainer(undefined);
 
@@ -150,6 +158,10 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     }
   }, [nativeToken, nativeTokenStatus, updateMetadata]);
 
+  /**
+   * fetch the list of remote token, this is the list of tokens you see
+   * in the token toggle screen.
+   */
   const {
     data: remoteTokens,
     status: remoteTokensStatus,
@@ -160,8 +172,25 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     secureContainer,
     allTokenInspectable,
   );
+
+  /**
+   * Try to pre-emptively renew the token if it is about to expire
+   */
   const {mutate: checkRenewMutate} = usePreemptiveRenewTokenMutation(userId);
 
+  /**
+   * Invalidates the list of mobile tokens in the query cache whenever relevant dependencies change.
+   *
+   * - Logs a breadcrumb to Bugsnag for traceability.
+   * - Calls `invalidateQueries` on the query client to refresh the token list.
+   * - Ensures that the UI and data remain in sync after changes to the native token, user, or secure container.
+   *
+   * Dependencies:
+   * - `queryClient`: The React Query client instance.
+   * - `userId`: The current user's ID.
+   * - `nativeToken?.tokenId`: The ID of the loaded native token.
+   * - `secureContainer`: The encoded secure container string.
+   */
   useEffect(() => {
     logToBugsnag('Invalidating list tokens query after token change', {
       tokenId: nativeToken?.tokenId,
@@ -175,6 +204,19 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     ]);
   }, [queryClient, userId, nativeToken?.tokenId, secureContainer]);
 
+  /**
+   * Handles timeout logic for loading the native token.
+   *
+   * - When the native token status is 'loading', starts a timeout using `timeoutHandler`.
+   *   If the timeout elapses before the token loads, sets the `isTimeout` state to true
+   *   and reports the timeout error to Bugsnag.
+   * - If the native token status changes to anything other than 'loading', cancels any
+   *   existing timeout and resets the `isTimeout` state to false.
+   *
+   * Dependencies:
+   * - `nativeTokenStatus`: Triggers effect when the loading status changes.
+   * - `token_timeout_in_seconds`: Timeout duration from remote config.
+   */
   useEffect(() => {
     if (nativeTokenStatus === 'loading') {
       cancelTimeoutHandler = timeoutHandler(() => {
@@ -201,12 +243,22 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     }
   }, [nativeTokenStatus, token_timeout_in_seconds]);
 
+  /**
+   * `isRenewingOrResetting` to show/hide the loading status
+   * checks token to see if we need to renew/reset, returns
+   * for the users
+   */
   const {isRenewingOrResetting} = useValidateToken(
     nativeToken,
     remoteTokens,
     traceId.current,
   );
 
+  /**
+   * Periodically checks if the native token should be preemptively renewed.
+   * Ensures that the token remains valid and up-to-date without user intervention.
+   *
+   */
   useInterval(
     () => checkRenewMutate({token: nativeToken, traceId: uuid()}),
     [checkRenewMutate, nativeToken],
@@ -329,6 +381,29 @@ function timeoutHandler<T>(fn: () => T, timeoutInSeconds: number): () => void {
   };
 }
 
+/**
+ * Determines the overall status of the mobile token process based on various factors.
+ *
+ * Considers the loading and error status of both the native token and remote tokens.
+ * Takes into account whether the token is currently being renewed or reset, or if a timeout has occurred.
+ * Supports fallback modes based on remote config flags, including static QR code fallback.
+ *
+ * Logic:
+ * - If a timeout has occurred, returns a fallback status or 'loading' based on config.
+ * - If a renewal or reset is in progress, returns 'loading'.
+ * - If the native token is loading or has errored, returns 'loading' or a fallback/error status.
+ * - If the native token is loaded successfully, checks the remote tokens status:
+ *   - If remote tokens are loading or errored, returns 'loading' or a fallback/error status.
+ *   - If both are successful, determines if the device is inspectable and returns the appropriate status.
+ *
+ * @param loadNativeTokenStatus Status of loading the native token (React Query).
+ * @param remoteTokensStatus Status of loading the remote tokens (React Query).
+ * @param nativeToken The loaded native token, if available.
+ * @param remoteTokens The list of remote tokens, if available.
+ * @param isRenewingOrResetting Whether a renewal or reset operation is in progress. (from `useValidateToken`)
+ * @param isTimeout Whether a timeout has occurred while loading tokens.
+ * @returns The computed MobileTokenStatus string.
+ */
 const useMobileTokenStatus = (
   loadNativeTokenStatus: QueryStatus,
   remoteTokensStatus: QueryStatus,
@@ -388,6 +463,20 @@ const deviceInspectable = (
   return debugInspectable ?? isInspectable(matchingRemoteToken);
 };
 
+/**
+ * Determines if a mobile token status is inspectable.
+ *
+ * Inspectable means that the token has the `TICKET_INSPECTION` right on the backoffice.
+ * 
+ * @param mobileTokenStatus - The current status of the mobile token.
+ *   - `'success-and-inspectable'`: The token is successfully generated and can be inspected.
+ *   - `'fallback'`: The token is in a fallback state and can be inspected.
+ *   - `'staticQr'`: The token is represented as a static QR and can be inspected.
+ *   - `'error'`: The token generation failed and is not inspectable.
+ *   - `'success-not-inspectable'`: The token is generated but cannot be inspected.
+ *   - `'loading'`: The token is in the process of being generated and is not inspectable.
+ * @returns `true` if the status is inspectable, otherwise `false`.
+ */
 export const getIsInspectableFromStatus = (
   mobileTokenStatus: MobileTokenStatus,
 ): boolean => {

--- a/src/modules/mobile-token/MobileTokenContext.tsx
+++ b/src/modules/mobile-token/MobileTokenContext.tsx
@@ -117,9 +117,10 @@ export const MobileTokenContextProvider = ({children}: Props) => {
   } = useLoadNativeTokenQuery(enabled, userId, traceId.current);
 
   useEffect(() => {
+    setSecureContainer(undefined);
+
     const loadSecureContainer = async () => {
       if (nativeToken) {
-        setSecureContainer(undefined);
         await mobileTokenClient.encode(nativeToken).then((secureContainer) => {
           setSecureContainer(secureContainer);
         });

--- a/src/modules/mobile-token/hooks/use-get-signed-token-query.tsx
+++ b/src/modules/mobile-token/hooks/use-get-signed-token-query.tsx
@@ -1,14 +1,8 @@
-import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 import {mobileTokenClient} from '../mobileTokenClient';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
 import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
-import {
-  getMobileTokenErrorHandlingStrategy,
-  getSdkErrorTokenIds,
-  MOBILE_TOKEN_QUERY_KEY,
-  wipeToken,
-} from '../utils';
-import {v4 as uuid} from 'uuid';
+import {MOBILE_TOKEN_QUERY_KEY} from '../utils';
 
 const TEN_SECONDS_MS = 1000 * 10;
 
@@ -21,7 +15,6 @@ const GET_SIGNED_TOKEN_QUERY_KEY = 'getSignedToken';
  */
 export const useGetSignedTokenQuery = () => {
   const {nativeToken} = useMobileTokenContext();
-  const queryClient = useQueryClient();
   return useQuery({
     queryKey: [MOBILE_TOKEN_QUERY_KEY, GET_SIGNED_TOKEN_QUERY_KEY, nativeToken],
     queryFn: async () => {
@@ -36,16 +29,7 @@ export const useGetSignedTokenQuery = () => {
             description: 'Error encoding signed token',
           },
         });
-        const errHandling = getMobileTokenErrorHandlingStrategy(err);
-        switch (errHandling) {
-          case 'reset':
-            await wipeToken(getSdkErrorTokenIds(err), uuid());
-            queryClient.resetQueries([MOBILE_TOKEN_QUERY_KEY]);
-            break;
-          case 'unspecified':
-            throw err;
-        }
-        throw err;
+        return undefined;
       }
     },
     refetchInterval: TEN_SECONDS_MS,

--- a/src/modules/mobile-token/hooks/use-load-native-token-query.tsx
+++ b/src/modules/mobile-token/hooks/use-load-native-token-query.tsx
@@ -2,12 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 import {storage} from '@atb/modules/storage';
 import {ActivatedToken} from '@entur-private/abt-mobile-client-sdk';
 import {mobileTokenClient} from '../mobileTokenClient';
-import {
-  getMobileTokenErrorHandlingStrategy,
-  getSdkErrorTokenIds,
-  MOBILE_TOKEN_QUERY_KEY,
-  wipeToken,
-} from '../utils';
+import {MOBILE_TOKEN_QUERY_KEY} from '../utils';
 import {errorToMetadata, logToBugsnag} from '@atb/utils/bugsnag-utils';
 import Bugsnag from '@bugsnag/react-native';
 
@@ -62,21 +57,7 @@ const loadNativeToken = async (userId: string, traceId: string) => {
       token = await mobileTokenClient.get(traceId);
     } catch (err: any) {
       logToBugsnag(`Get token error ${err}`, errorToMetadata(err));
-      const errHandling = getMobileTokenErrorHandlingStrategy(err);
-      switch (errHandling) {
-        case 'reset':
-          logToBugsnag(`Get token needs to reset token`, errorToMetadata(err));
-          await wipeToken(getSdkErrorTokenIds(err), traceId);
-          logError(err, traceId);
-          break;
-        case 'unspecified':
-          logToBugsnag(
-            `Get token error unspecified resolution`,
-            errorToMetadata(err),
-          );
-          logError(err, traceId);
-          throw err;
-      }
+      logError(err, traceId);
     }
   }
 

--- a/src/modules/mobile-token/hooks/use-preemptive-renew-token-mutation.tsx
+++ b/src/modules/mobile-token/hooks/use-preemptive-renew-token-mutation.tsx
@@ -11,6 +11,20 @@ import {
 } from '../utils';
 import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
 
+/**
+ * Custom React hook for preemptively renewing a mobile token if it is about to expire.
+ *
+ * - Checks if the provided token should be renewed using `mobileTokenClient.shouldRenew`,
+ *   which calls `shouldRenewPreemptively` from the SDK
+ * - If renewal is needed, calls `mobileTokenClient.renew` and updates the query cache with the new token.
+ * - On success, updates the cached token data for the current user.
+ * - On error, reports the error to Bugsnag and applies an error handling strategy:
+ *   - If the strategy is 'reset', wipes the affected tokens and resets the query cache.
+ *   - If the strategy is 'unspecified', no further action is taken.
+ *
+ * @param userId The current user's ID (optional).
+ * @returns A mutation object for triggering token renewal.
+ */
 export const usePreemptiveRenewTokenMutation = (userId?: string) => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/modules/mobile-token/tokenService.ts
+++ b/src/modules/mobile-token/tokenService.ts
@@ -18,7 +18,7 @@ import {
   TokenLimitResponse,
 } from './types';
 import {getDeviceName} from 'react-native-device-info';
-import {isRemoteTokenStateError, parseBffCallErrors} from './utils';
+import {isRemoteTokenStateError, parseTokenServerErrors} from './utils';
 import {storage} from '@atb/modules/storage';
 import {API_BASE_URL} from '@env';
 import {getCurrentUserIdGlobal} from '@atb/modules/auth';
@@ -49,7 +49,7 @@ export type TokenService = RemoteTokenService & {
 };
 
 const handleError = (err: any) => {
-  throw parseBffCallErrors(err.response?.data);
+  throw parseTokenServerErrors(err.response?.data);
 };
 
 const getBaseUrl = async () => {


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20605

This adds implementation of error handling for the new token server endpoint.

Also in this PR:
- More inline documentation for various mobile-token related functions & hooks
- Removes redundant error checking
- use `nullish` instead of `optional` for the `ErrorResponse`