### PR TITLE
fix: allow bus in map to overlap location puck

### DIFF
--- a/src/screen-components/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/screen-components/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -285,6 +285,7 @@ const LiveVehicleMarker = ({
   return (
     <MapboxGL.MarkerView
       coordinate={[vehicle.location.longitude, vehicle.location.latitude]}
+      allowOverlapWithPuck={true}
     >
       <View
         style={{


### PR DESCRIPTION
ref. https://github.com/AtB-AS/kundevendt/issues/20799
> Also relevant: look into avoiding that the icon gets hidden when the live icon and user location marker get too close.

<img width="300px" src="https://github.com/user-attachments/assets/bae2427a-4371-4c81-867c-014e04bb5621">

### Acceptance criteria

- [x] Bus in map icon isn't hidden when it gets close to the user puck