### PR TITLE
fix: bonus product design and checkbox text and functionality

### DIFF
--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -17,17 +17,18 @@ import {View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {UserBonusBalance} from './UserBonusBalance';
 import {isDefined} from '@atb/utils/presence';
+import {useEffect} from 'react';
 
 type Props = SectionProps & {
   bonusProduct: BonusProductType;
   isChecked: boolean;
-  onPress: () => void;
+  setIsChecked: (checked: boolean) => void;
 };
 
 export const PayWithBonusPointsCheckbox = ({
   bonusProduct,
   isChecked,
-  onPress,
+  setIsChecked,
   ...props
 }: Props) => {
   const styles = useStyles();
@@ -43,6 +44,12 @@ export const PayWithBonusPointsCheckbox = ({
     userBonusBalanceStatus === 'error';
 
   const isDisabled = isError || userBonusBalance < bonusProduct.price.amount;
+
+  useEffect(() => {
+    if (isDisabled && isChecked) {
+      setIsChecked(false);
+    }
+  }, [isDisabled, isChecked, setIsChecked]);
 
   const a11yLabel =
     (getTextForLanguage(bonusProduct.paymentDescription, language) ?? '') +
@@ -62,7 +69,7 @@ export const PayWithBonusPointsCheckbox = ({
       <Section {...props}>
         <GenericClickableSectionItem
           active={isChecked}
-          onPress={onPress}
+          onPress={() => setIsChecked(!isChecked)}
           disabled={isDisabled}
           accessibilityRole="checkbox"
           accessibilityState={{checked: isChecked}}
@@ -82,9 +89,12 @@ export const PayWithBonusPointsCheckbox = ({
                   {t(BonusProgramTexts.youHave)}
                 </ThemeText>
                 <UserBonusBalance
-                  size="small"
+                  typography="body__secondary"
                   color={theme.color.foreground.dynamic.secondary}
                 />
+                <ThemeText typography="body__secondary" color="secondary">
+                  {t(BonusProgramTexts.points)}
+                </ThemeText>
               </View>
             </View>
             <BonusPriceTag

--- a/src/modules/bonus/components/UserBonusBalance.tsx
+++ b/src/modules/bonus/components/UserBonusBalance.tsx
@@ -2,21 +2,14 @@ import {TextNames} from '@atb/theme';
 import {ActivityIndicator} from 'react-native';
 import {useBonusBalanceQuery} from '..';
 import {ThemeText} from '@atb/components/text';
-import {ThemeIcon} from '@atb/components/theme-icon';
-import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
 import {isDefined} from '@atb/utils/presence';
 
 type Props = {
-  size: 'small' | 'large';
+  typography: TextNames;
   color: string;
 };
 
-const TYPOGRAPHY_BONUS_BALANCE: Record<Props['size'], TextNames> = {
-  small: 'body__secondary',
-  large: 'body__primary--jumbo--bold',
-};
-
-export const UserBonusBalance = ({color, size}: Props) => {
+export const UserBonusBalance = ({color, typography}: Props) => {
   const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
 
@@ -25,7 +18,7 @@ export const UserBonusBalance = ({color, size}: Props) => {
       {userBonusBalanceStatus === 'loading' ? (
         <ActivityIndicator />
       ) : (
-        <ThemeText typography={TYPOGRAPHY_BONUS_BALANCE[size]} color={color}>
+        <ThemeText typography={typography} color={color}>
           {isDefined(userBonusBalance) &&
           typeof userBonusBalance === 'number' &&
           !Number.isNaN(userBonusBalance)
@@ -33,7 +26,6 @@ export const UserBonusBalance = ({color, size}: Props) => {
             : '--'}
         </ThemeText>
       )}
-      <ThemeIcon color={color} svg={StarFill} size={size} />
     </>
   );
 };

--- a/src/modules/mobility/components/BikeStationBottomSheet.tsx
+++ b/src/modules/mobility/components/BikeStationBottomSheet.tsx
@@ -147,11 +147,7 @@ export const BikeStationBottomSheet = ({
                 <PayWithBonusPointsCheckbox
                   bonusProduct={bonusProduct}
                   isChecked={payWithBonusPoints}
-                  onPress={() =>
-                    setPayWithBonusPoints(
-                      (payWithBonusPoints) => !payWithBonusPoints,
-                    )
-                  }
+                  setIsChecked={setPayWithBonusPoints}
                   style={styles.payWithBonusPointsSection}
                 />
               )}

--- a/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
@@ -135,11 +135,7 @@ export const CarSharingStationBottomSheet = ({
                 <PayWithBonusPointsCheckbox
                   bonusProduct={bonusProduct}
                   isChecked={payWithBonusPoints}
-                  onPress={() =>
-                    setPayWithBonusPoints(
-                      (payWithBonusPoints) => !payWithBonusPoints,
-                    )
-                  }
+                  setIsChecked={setPayWithBonusPoints}
                   style={styles.payWithBonusPointsSection}
                 />
               )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -26,6 +26,8 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {BrandingImage, findOperatorBrandImageUrl} from '@atb/modules/mobility';
 import {isDefined} from '@atb/utils/presence';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
 
 export const Profile_BonusScreen = () => {
   const {t, language} = useTranslation();
@@ -68,10 +70,11 @@ export const Profile_BonusScreen = () => {
           </View>
         ) : (
           <View style={styles.bonusProductsContainer}>
-            {activeBonusProducts?.map((bonusProduct, index) => (
-              <Section key={bonusProduct.id}>
+            <Section>
+              {activeBonusProducts?.map((bonusProduct, index) => (
                 <ExpandableSectionItem
                   expanded={currentlyOpenBonusProduct === index}
+                  key={bonusProduct.id}
                   onPress={() => {
                     setCurrentlyOpenBonusProduct(index);
                   }}
@@ -111,8 +114,8 @@ export const Profile_BonusScreen = () => {
                     </ThemeText>
                   }
                 />
-              </Section>
-            ))}
+              ))}
+            </Section>
           </View>
         )}
         <ContentHeading
@@ -208,8 +211,13 @@ function UserBonusBalanceSection(): JSX.Element {
           >
             <View style={styles.currentBalanceDisplay}>
               <UserBonusBalance
-                size="large"
+                typography="body__primary--jumbo--bold"
                 color={theme.color.foreground.dynamic.primary}
+              />
+              <ThemeIcon
+                color={theme.color.foreground.dynamic.primary}
+                svg={StarFill}
+                size="large"
               />
             </View>
 

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -1,6 +1,7 @@
 import {translation as _} from '../../commons';
 const BonusProgramTexts = {
   bonusPoints: _('bonuspoeng', 'bonus points', 'bonuspoeng'),
+  points: _('poeng', 'points', 'poeng'),
   costA11yLabel: (amount: number) =>
     _(
       `Koster ${amount} bonuspoeng`,
@@ -8,7 +9,7 @@ const BonusProgramTexts = {
       `Kostar ${amount} bonuspoeng`,
     ),
 
-  youHave: _('Du har ', 'You have ', 'Du har '),
+  youHave: _('Du har', 'You have', 'Du har'),
 
   yourBonusBalanceA11yLabel: (bonusBalance: number | null) => {
     return _(


### PR DESCRIPTION
closes: https://github.com/AtB-AS/kundevendt/issues/20886


<img width=200 src=https://github.com/user-attachments/assets/cecbbb9d-54a8-4a45-ac26-422881e441e7>
<img width=200 src=https://github.com/user-attachments/assets/b5ad166f-6492-4b9d-a114-ea64561173ce>

Updates design and fixes related to bonus. Specifically:

On the profile page:
1. Put bonus products in same section (instead of separate sections)

For the checkbox on Bonus products in bottom sheets:
1. fix so that the checkbox is always unchecked when it is disabled
2. Change from 'Du har 42 ★' to 'Du har 42 poeng'