### PR TITLE
fix: Fixed booking appearing for periodic tickets, and handled errors better

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -150,7 +150,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     if (!isBookingEnabled) {
       return offerError;
     }
-    // From this point we know booking is enabled
     if (offerError && isLoadingBooking) {
       return undefined; // It's not possible to know if we should display this error until the booking request has completed
     }
@@ -159,7 +158,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       !isBookingError &&
       tripPatternsThatRequireBooking.length > 0
     ) {
-      return undefined; //
+      return undefined; // Do not display the error from the offer if we have trips that require booking
     }
     if (isBookingError) return {type: 'booking-error'};
     return offerError;

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/use-booking-trips.ts
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/use-booking-trips.ts
@@ -59,10 +59,14 @@ export function useBookingTrips({
 }
 
 function isValidSelection(selection: PurchaseSelectionType) {
+  const isBoatSingleFareProduct =
+    selection.fareProductTypeConfig.direction === 'one-way' &&
+    selection.fareProductTypeConfig.configuration.zoneSelectionMode ===
+      'multiple-stop-harbor';
   return (
     !!selection.stopPlaces?.from &&
     !!selection.stopPlaces?.to &&
-    selection.preassignedFareProduct.type === 'boat-single'
+    isBoatSingleFareProduct
   );
 }
 


### PR DESCRIPTION
Fixes some issues found when testing AtB-AS/kundevendt#20761

This PR does two things: 
1. Disables booking for all other ticket types than `boat-single`
2. Refactors error handling in PurchaseOverviewScreen, to take into consideration that we now have two sources for errors. The change is that if there is an error from the old offer-endpoint at this stage, it is disregarded in the case where we know this route has departures where booking is needed. 


### Acceptance criteria
- [x] Can move forward in the purchase process for Reis without changing date and time
- [x] Booking is not displayed in the purchase flow for periodic tickets