### PR TITLE
feat: Added support for onBehalfOf together with booking

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -140,15 +140,18 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   });
 
   const onPressBuy = () => {
+    if (isBookingEnabled && tripPatternsThatRequireBooking.length > 0) {
+      navigation.push(
+        'Root_TripSelectionScreen',
+        rootPurchaseConfirmationScreenParams,
+      );
+      return;
+    }
     if (selection.isOnBehalfOf) {
       navigation.navigate(
         'Root_ChooseTicketRecipientScreen',
         rootPurchaseConfirmationScreenParams,
       );
-      return;
-    }
-    if (isBookingEnabled && tripPatternsThatRequireBooking.length > 0) {
-      navigation.push('Root_TripSelectionScreen', {selection});
       return;
     }
     navigation.navigate(
@@ -157,11 +160,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     );
   };
   const summaryButtonText = () => {
-    if (selection.isOnBehalfOf) {
-      return t(PurchaseOverviewTexts.summary.button.sendToOthers);
-    }
     if (isBookingEnabled && tripPatternsThatRequireBooking.length > 0) {
       return t(PurchaseOverviewTexts.summary.button.selectDeparture);
+    }
+    if (selection.isOnBehalfOf) {
+      return t(PurchaseOverviewTexts.summary.button.sendToOthers);
     }
     return t(PurchaseOverviewTexts.summary.button.payment);
   };

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
@@ -79,14 +79,21 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
       </GenericSectionItem>
       <Button
         onPress={() => {
-          navigation.navigate({
-            name: 'Root_PurchaseConfirmationScreen',
-            params: {
-              mode: 'Ticket',
-              selection: selection,
-            },
-            merge: true,
-          });
+          if (selection.isOnBehalfOf) {
+            navigation.navigate('Root_ChooseTicketRecipientScreen', {
+              selection,
+              mode: params.mode,
+            });
+          } else {
+            navigation.navigate({
+              name: 'Root_PurchaseConfirmationScreen',
+              params: {
+                mode: params.mode,
+                selection: selection,
+              },
+              merge: true,
+            });
+          }
         }}
         expanded={false}
         text="Bekreft"

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -96,6 +96,7 @@ type Root_ConfirmationScreenParams = {
 
 type Root_TripSearchScreenParams = {
   selection: PurchaseSelectionType;
+  mode?: 'Ticket' | 'TravelSearch';
 };
 
 export type NextScreenParams<


### PR DESCRIPTION
Closes AtB-AS/kundevendt#20832

Changes the purchase flow such that if a ticket is for a bookable route **and** is onBehalfOf someone, you are sent to the `ChooseTicketRecepientScreen` after selecting a departure. 