### PR TITLE
feat: add link to Smart Park & Ride screen

### DIFF
--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -161,6 +161,10 @@ export const toggleSpecifications = [
     name: 'isInAppReviewForAnnouncementsEnabled',
     remoteConfigKey: 'enable_in_app_review_for_announcements',
   },
+  {
+    name: 'isSmartParkAndRideEnabled',
+    remoteConfigKey: 'enable_smart_park_and_ride',
+  },
 ] as const satisfies readonly FeatureToggleSpecification[];
 
 /**

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -58,6 +58,7 @@ export type RemoteConfig = {
   enable_vipps_login: boolean;
   enable_in_app_review: boolean;
   enable_in_app_review_for_announcements: boolean;
+  enable_smart_park_and_ride: boolean;
   favourite_departures_poll_interval: number;
   feedback_questions: string;
   fetch_id_token_retry_count: number;
@@ -137,6 +138,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_vipps_login: false,
   enable_in_app_review: false,
   enable_in_app_review_for_announcements: false,
+  enable_smart_park_and_ride: false,
   favourite_departures_poll_interval: 30000,
   feedback_questions: '',
   fetch_id_token_retry_count: 3,
@@ -307,6 +309,9 @@ export function getConfig(): RemoteConfig {
   const enable_in_app_review_for_announcements =
     values['enable_in_app_review_for_announcements']?.asBoolean() ??
     defaultRemoteConfig.enable_in_app_review_for_announcements;
+  const enable_smart_park_and_ride =
+    values['enable_smart_park_and_ride']?.asBoolean() ??
+    defaultRemoteConfig.enable_smart_park_and_ride;
   const favourite_departures_poll_interval =
     values['favourite_departures_poll_interval']?.asNumber() ??
     defaultRemoteConfig.favourite_departures_poll_interval;
@@ -422,6 +427,7 @@ export function getConfig(): RemoteConfig {
     enable_vipps_login,
     enable_in_app_review,
     enable_in_app_review_for_announcements,
+    enable_smart_park_and_ride,
     favourite_departures_poll_interval,
     feedback_questions,
     fetch_id_token_retry_count,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -1,14 +1,21 @@
 import {LogIn, LogOut} from '@atb/assets/svg/mono-icons/profile';
-import {useAuthContext} from '@atb/modules/auth';
 import {ActivityIndicatorOverlay} from '@atb/components/activity-indicator-overlay';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
+import {
+  GenericSectionItem,
+  LinkSectionItem,
+  MessageSectionItem,
+  Section,
+} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
+import {useAuthContext} from '@atb/modules/auth';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
 import {StyleSheet, Theme} from '@atb/theme';
-import {dictionary, ProfileTexts, useTranslation} from '@atb/translations';
+import {ProfileTexts, dictionary, useTranslation} from '@atb/translations';
 import {numberToAccessibilityString} from '@atb/utils/accessibility';
+import {useIsLoading} from '@atb/utils/use-is-loading';
 import {useLocalConfig} from '@atb/utils/use-local-config';
 import Bugsnag from '@bugsnag/react-native';
 import {APP_ORG_NUMBER, IS_QA_ENV} from '@env';
@@ -17,25 +24,18 @@ import {ActivityIndicator, View} from 'react-native';
 import {getBuildNumber, getVersion} from 'react-native-device-info';
 import {ProfileScreenProps} from './navigation-types';
 import {destructiveAlert} from './utils';
-import {useIsLoading} from '@atb/utils/use-is-loading';
-import {
-  GenericSectionItem,
-  LinkSectionItem,
-  MessageSectionItem,
-  Section,
-} from '@atb/components/sections';
 
-import {ClickableCopy} from './components/ClickableCopy';
-import {useAnalyticsContext} from '@atb/modules/analytics';
-import {useStorybookContext} from '@atb/modules/storybook';
 import {ContentHeading} from '@atb/components/heading';
 import {FullScreenView} from '@atb/components/screen-view';
-import {formatPhoneNumber} from '@atb/utils/phone-number-utils';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {useStorybookContext} from '@atb/modules/storybook';
 import {
   useHasReservationOrAvailableFareContract,
   useTicketingContext,
 } from '@atb/modules/ticketing';
+import {formatPhoneNumber} from '@atb/utils/phone-number-utils';
+import {ClickableCopy} from './components/ClickableCopy';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -65,7 +65,8 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const [isLoading, setIsLoading] = useIsLoading(false);
 
   const phoneNumber = authPhoneNumber && formatPhoneNumber(authPhoneNumber);
-  const {isBonusProgramEnabled} = useFeatureTogglesContext();
+  const {isBonusProgramEnabled, isSmartParkAndRideEnabled} =
+    useFeatureTogglesContext();
 
   const {logEvent} = useAnalyticsContext();
 
@@ -267,6 +268,19 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
                 onPress={() => navigation.navigate('Profile_BonusScreen')}
                 testID="BonusButton"
+              />
+            )}
+            {isSmartParkAndRideEnabled && (
+              <LinkSectionItem
+                text={t(
+                  ProfileTexts.sections.account.linkSectionItems
+                    .smartParkAndRide.label,
+                )}
+                onPress={() =>
+                  navigation.navigate('Profile_SmartParkAndRideScreen')
+                }
+                label="beta"
+                testID="smartParkAndRideButton"
               />
             )}
           </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -1,0 +1,38 @@
+import {StyleSheet} from '@atb/theme';
+import {useTranslation} from '@atb/translations';
+import {View} from 'react-native';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ThemeText} from '@atb/components/text';
+import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
+
+export const Profile_SmartParkAndRideScreen = () => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+
+  return (
+    <FullScreenView
+      headerProps={{
+        title: t(SmartParkAndRideTexts.header.title),
+        leftButton: {type: 'back', withIcon: true},
+      }}
+    >
+      <View style={styles.container}>
+        <ThemeText typography="body__primary--jumbo--bold" style={styles.text}>
+          {t(SmartParkAndRideTexts.todo)}
+        </ThemeText>
+      </View>
+    </FullScreenView>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    rowGap: theme.spacing.small,
+    marginTop: theme.spacing.large,
+    margin: theme.spacing.medium,
+    display: 'flex',
+  },
+  text: {
+    textAlign: 'center',
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -27,6 +27,7 @@ import {Profile_TicketHistorySelectionScreen} from './Profile_TicketHistorySelec
 import {Profile_TravelAidScreen} from './Profile_TravelAidScreen';
 import {Profile_TravelAidInformationScreen} from './Profile_TravelAidInformationScreen.tsx';
 import {Profile_BonusScreen} from './Profile_BonusScreen.tsx';
+import {Profile_SmartParkAndRideScreen} from './Profile_SmartParkAndRideScreen.tsx';
 import {Profile_SettingsScreen} from './Profile_SettingsScreen';
 import {Profile_FavoriteScreen} from './Profile_FavoriteScreen';
 import {Profile_InformationScreen} from './Profile_InformationScreen';
@@ -53,6 +54,10 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_BonusScreen"
         component={Profile_BonusScreen}
+      />
+      <Stack.Screen
+        name="Profile_SmartParkAndRideScreen"
+        component={Profile_SmartParkAndRideScreen}
       />
       <Stack.Screen
         name="Profile_PaymentMethodsScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -14,6 +14,7 @@ export type ProfileStackParams = StackParams<{
   Profile_TicketHistoryScreen: TicketHistoryScreenParams;
   Profile_TicketHistorySelectionScreen: undefined;
   Profile_BonusScreen: undefined;
+  Profile_SmartParkAndRideScreen: undefined;
   Profile_DeleteProfileScreen: undefined;
   Profile_EditProfileScreen: undefined;
   Profile_FavoriteListScreen: undefined;

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -36,6 +36,13 @@ const ProfileTexts = {
         bonus: {
           label: _('Bonus', 'Bonus', 'Bonus'),
         },
+        smartParkAndRide: {
+          label: _(
+            'Smart Park & Ride',
+            'Smart Park & Ride',
+            'Smart Park & Ride',
+          ),
+        },
         paymentMethods: {
           label: _('Betalingskort', 'Payment cards', 'Betalingskort'),
         },

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -1,0 +1,14 @@
+import {translation as _} from '../../commons';
+
+const SmartParkAndRideTexts = {
+  header: {
+    title: _('Smart Park & Ride', 'Smart Park & Ride', 'Smart Park & Ride'),
+  },
+  todo: _(
+    'Smart Park & Ride kommer snart!',
+    'Smart Park & Ride coming soon!',
+    'Smart Park & Ride kjem snart!',
+  ),
+};
+
+export default SmartParkAndRideTexts;


### PR DESCRIPTION
Adds a link to the Smart Park & Ride screen under the "Discover" section on the profile page. The target page is at the moment just a placeholder for what's to come.

The link is hidden behind a feature flag.

closes https://github.com/AtB-AS/kundevendt/issues/20813