### PR TITLE
feat: token renewal failure should give fallback

### DIFF
--- a/src/modules/mobile-token/MobileTokenContext.tsx
+++ b/src/modules/mobile-token/MobileTokenContext.tsx
@@ -248,7 +248,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
    * checks token to see if we need to renew/reset, returns
    * for the users
    */
-  const {isRenewingOrResetting} = useValidateToken(
+  const {isRenewingOrResetting, shouldFallback} = useValidateToken(
     nativeToken,
     remoteTokens,
     traceId.current,
@@ -273,6 +273,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     nativeToken,
     remoteTokens,
     isRenewingOrResetting,
+    shouldFallback,
     isTimeout,
   );
 
@@ -410,6 +411,7 @@ const useMobileTokenStatus = (
   nativeToken: ActivatedToken | undefined,
   remoteTokens: RemoteToken[] | undefined,
   isRenewingOrResetting: boolean,
+  shouldFallback: boolean,
   isTimeout: boolean,
 ): MobileTokenStatus => {
   const {
@@ -420,7 +422,7 @@ const useMobileTokenStatus = (
 
   const fallbackStatus = use_trygg_overgang_qr_code ? 'staticQr' : 'fallback';
 
-  if (isTimeout)
+  if (isTimeout || shouldFallback)
     return enable_token_fallback_on_timeout ? fallbackStatus : 'loading';
 
   if (isRenewingOrResetting) return 'loading';

--- a/src/modules/mobile-token/MobileTokenContext.tsx
+++ b/src/modules/mobile-token/MobileTokenContext.tsx
@@ -248,7 +248,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
    * checks token to see if we need to renew/reset, returns
    * for the users
    */
-  const {isRenewingOrResetting, shouldFallback} = useValidateToken(
+  const {isRenewingOrResetting, isRenewOrResetError} = useValidateToken(
     nativeToken,
     remoteTokens,
     traceId.current,
@@ -273,7 +273,7 @@ export const MobileTokenContextProvider = ({children}: Props) => {
     nativeToken,
     remoteTokens,
     isRenewingOrResetting,
-    shouldFallback,
+    isRenewOrResetError,
     isTimeout,
   );
 

--- a/src/modules/mobile-token/hooks/use-validate-token.tsx
+++ b/src/modules/mobile-token/hooks/use-validate-token.tsx
@@ -191,5 +191,6 @@ export const useValidateToken = (
 
   return {
     isRenewingOrResetting,
+    shouldFallback: retryCount === RETRY_MAX_COUNT,
   };
 };

--- a/src/modules/mobile-token/hooks/use-validate-token.tsx
+++ b/src/modules/mobile-token/hooks/use-validate-token.tsx
@@ -191,6 +191,6 @@ export const useValidateToken = (
 
   return {
     isRenewingOrResetting,
-    shouldFallback: retryCount === RETRY_MAX_COUNT,
+    isRenewOrResetError: retryCount === RETRY_MAX_COUNT,
   };
 };


### PR DESCRIPTION
Handle cases where token renewal may be failed and we should give fallback to the users.

The logic here is: 

- If the retry count for the renewal process reaches the maximum retries (3 retries), then we assume an error is happening.
- Send this error status to the `useMobileTokenStatus` hook, where we return early there if: 
  - we have a timeout OR
  - we got a renewal error