### PR TITLE
fix: use id token validity instead of abt customer id for eventstream

### DIFF
--- a/src/modules/auth/AuthContext.tsx
+++ b/src/modules/auth/AuthContext.tsx
@@ -26,7 +26,7 @@ import {useUpdateAuthLanguageOnChange} from './use-update-auth-language-on-chang
 import {useFetchIdTokenWithCustomClaims} from './use-fetch-id-token-with-custom-claims';
 import Bugsnag from '@bugsnag/react-native';
 import isEqual from 'lodash.isequal';
-import {mapAuthenticationType} from './utils';
+import {mapAuthenticationType, secondsToTokenExpiry} from './utils';
 import {useClearQueriesOnUserChange} from './use-clear-queries-on-user-change';
 import {useUpdateIntercomOnUserChange} from '@atb/modules/auth';
 import {useLocaleContext} from '@atb/modules/locale';
@@ -132,6 +132,7 @@ type AuthContextState = {
   phoneNumber?: string;
   customerNumber?: number;
   abtCustomerId?: string;
+  isValidIdToken: boolean;
   signInWithPhoneNumber: (
     number: string,
     forceResend?: boolean,
@@ -179,6 +180,9 @@ export const AuthContextProvider = ({children}: PropsWithChildren<{}>) => {
         phoneNumber: state.user?.phoneNumber || undefined,
         customerNumber: state.idTokenResult?.claims['customer_number'],
         abtCustomerId: state.idTokenResult?.claims['abt_id'],
+        isValidIdToken: state.idTokenResult
+          ? secondsToTokenExpiry(state.idTokenResult) > 300
+          : false,
         signInWithPhoneNumber: useCallback(
           async (phoneNumberWithPrefix: string, forceResend?: boolean) => {
             if (!backendSmsEnabled) {

--- a/src/modules/event-stream/use-setup-event-stream.ts
+++ b/src/modules/event-stream/use-setup-event-stream.ts
@@ -11,7 +11,7 @@ import {jsonStringToObject} from '@atb/utils/object';
 
 export const useSetupEventStream = () => {
   const queryClient = useQueryClient();
-  const {abtCustomerId} = useAuthContext();
+  const {isValidIdToken} = useAuthContext();
   const {isEventStreamEnabled, isEventStreamFareContractsEnabled} =
     useFeatureTogglesContext();
 
@@ -43,9 +43,8 @@ export const useSetupEventStream = () => {
 
   useSubscription({
     url,
-    // When abtCustomerId is set, we also have the id token which is needed to
-    // authenticate.
-    enabled: isEventStreamEnabled && abtCustomerId !== undefined,
+    // When id token is valid, we connect to the stream
+    enabled: isEventStreamEnabled && isValidIdToken,
     onMessage,
     onOpen: authenticate,
   });


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20993

Instead of using `abtCustomerId`, we use the expiration time of the `idToken` itself.

So here I use the utility function `secondsToTokenExpiry` that is used on the hook `useRefreshIdTokenWhenNecessary`, for  a boolean parameter `isValidIdToken`.

- If the seconds to expiration date is **LESS** than 300 seconds, then the id token is not valid (it will be refreshed by the hook mentioned above)
- If the seconds to expiration date is **MORE** than 300 seconds, then the id token is valid.

Then the value is used on the `useSetupEventStream` hook, replacing the `abtCustomerId` as the flag to enable the hook.

This way we can prevent the websocket from connecting if the `idToken` is not valid.