### PR TITLE
refactor: Moved padding from ResultItem to ResultRow

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -314,9 +314,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.color.background.neutral[2].background,
   },
   detailsContainer: {
-    paddingHorizontal: theme.spacing.medium,
     paddingTop: theme.spacing.medium,
-    paddingBottom: theme.spacing.small,
     flexDirection: 'row',
   },
   lineContainer: {
@@ -381,8 +379,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
-    paddingHorizontal: theme.spacing.medium,
-    paddingTop: theme.spacing.medium,
   },
   row: {
     flexDirection: 'row',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow.tsx
@@ -84,6 +84,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     backgroundColor: theme.color.background.neutral[0].background,
     borderRadius: theme.border.radius.regular,
     marginTop: theme.spacing.small,
+    paddingHorizontal: theme.spacing.medium,
+    paddingTop: theme.spacing.medium,
+    rowGap: theme.spacing.small,
   },
 }));
 


### PR DESCRIPTION
Moves the padding, such that the core ResultItem (which is used in booking) does not have padding, but the TravelSearch still looks the same. 