### PR TITLE
feat(spar): add vehicle registration screen

### DIFF
--- a/src/modules/smart-park-and-ride/api/api.ts
+++ b/src/modules/smart-park-and-ride/api/api.ts
@@ -1,0 +1,9 @@
+import {client} from '@atb/api';
+
+export const addVehicle = (licensePlate: string): Promise<void> => {
+  return client.post(
+    `/spar/v1/vehicle-registration`,
+    {licensePlate},
+    {authWithIdToken: true},
+  );
+};

--- a/src/modules/smart-park-and-ride/index.tsx
+++ b/src/modules/smart-park-and-ride/index.tsx
@@ -1,0 +1,1 @@
+export {useAddVehicle} from './queries/use-add-vehicle-query';

--- a/src/modules/smart-park-and-ride/queries/use-add-vehicle-query.ts
+++ b/src/modules/smart-park-and-ride/queries/use-add-vehicle-query.ts
@@ -1,0 +1,13 @@
+import {useMutation} from '@tanstack/react-query';
+import {addVehicle} from '../api/api';
+import {useAuthContext} from '@atb/modules/auth';
+
+export const useAddVehicle = (licensePlate: string, onSuccess: () => void) => {
+  const {userId} = useAuthContext();
+
+  return useMutation({
+    mutationKey: ['addSmartParkAndRideVehicle', userId, licensePlate],
+    mutationFn: () => addVehicle(licensePlate),
+    onSuccess,
+  });
+};

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -76,6 +76,7 @@ import {Root_ParkingPhotoScreen} from './Root_ParkingPhotoScreen';
 import {Root_TripSelectionScreen} from '@atb/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen';
 import {useSetupEventStream} from '@atb/modules/event-stream';
 import {useSetupReactQueryWindowFocus} from '@atb/queries';
+import {Root_SmartParkAndRideAddScreen} from './Root_SmartParkAndRideAddScreen';
 
 type ResultState = PartialState<NavigationState> & {
   state?: ResultState;
@@ -449,6 +450,10 @@ export const RootStack = () => {
                 <Stack.Screen
                   name="Root_ParkingPhotoScreen"
                   component={Root_ParkingPhotoScreen}
+                />
+                <Stack.Screen
+                  name="Root_SmartParkAndRideAddScreen"
+                  component={Root_SmartParkAndRideAddScreen}
                 />
               </Stack.Navigator>
             </AnalyticsContextProvider>

--- a/src/stacks-hierarchy/Root_SmartParkAndRideAddScreen.tsx
+++ b/src/stacks-hierarchy/Root_SmartParkAndRideAddScreen.tsx
@@ -1,0 +1,93 @@
+import {Confirm} from '@atb/assets/svg/mono-icons/actions';
+import {Button} from '@atb/components/button';
+import {FullScreenView} from '@atb/components/screen-view';
+import {Section, TextInputSectionItem} from '@atb/components/sections';
+import {ThemeText} from '@atb/components/text';
+import {useAddVehicle} from '@atb/modules/smart-park-and-ride';
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import {ThemedBundlingCarSharing} from '@atb/theme/ThemedAssets';
+import {useTranslation} from '@atb/translations';
+import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
+import {useState} from 'react';
+import {View} from 'react-native';
+import {RootStackScreenProps} from '.';
+
+type Props = RootStackScreenProps<'Root_SmartParkAndRideAddScreen'>;
+
+export const Root_SmartParkAndRideAddScreen = ({navigation}: Props) => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+  const [licensePlate, setLicensePlate] = useState('');
+  const {theme} = useThemeContext();
+  const interactiveColor = theme.color.interactive[0];
+
+  const onSuccess = () => navigation.goBack();
+  const {mutateAsync: handleAddVehicle} = useAddVehicle(
+    licensePlate,
+    onSuccess,
+  );
+
+  return (
+    <FullScreenView
+      headerProps={{
+        title: t(SmartParkAndRideTexts.add.header.title),
+        leftButton: {type: 'back', withIcon: true},
+      }}
+    >
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <ThemedBundlingCarSharing style={styles.illustration} />
+          <ThemeText typography="body__primary--big--bold">
+            {t(SmartParkAndRideTexts.add.content.title)}
+          </ThemeText>
+          <ThemeText typography="body__primary">
+            {t(SmartParkAndRideTexts.add.content.text)}
+          </ThemeText>
+        </View>
+        <Section>
+          <TextInputSectionItem
+            label={t(SmartParkAndRideTexts.add.input.label)}
+            placeholder={t(SmartParkAndRideTexts.add.input.placeholder)}
+            onChangeText={setLicensePlate}
+            autoCapitalize="characters"
+            value={licensePlate}
+            inlineLabel={false}
+            autoFocus={true}
+          />
+        </Section>
+
+        <Button
+          expanded={true}
+          onPress={() => handleAddVehicle()}
+          text={t(SmartParkAndRideTexts.add.button)}
+          rightIcon={{svg: Confirm}}
+          interactiveColor={interactiveColor}
+          style={styles.button}
+        />
+      </View>
+    </FullScreenView>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    rowGap: theme.spacing.small,
+    margin: theme.spacing.large,
+    display: 'flex',
+    flexGrow: 1,
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing.medium,
+    marginTop: theme.spacing.xLarge * 3,
+    marginBottom: theme.spacing.xLarge,
+  },
+  illustration: {
+    marginBottom: theme.spacing.xLarge,
+  },
+  button: {
+    marginTop: 'auto',
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -2,12 +2,18 @@ import {StyleSheet} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
-import {ThemeText} from '@atb/components/text';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
+import {LinkSectionItem, Section} from '@atb/components/sections';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Add} from '@atb/assets/svg/mono-icons/actions';
+import {ContentHeading} from '@atb/components/heading';
+import {useNavigation} from '@react-navigation/native';
+import {RootNavigationProps} from '@atb/stacks-hierarchy';
 
 export const Profile_SmartParkAndRideScreen = () => {
   const {t} = useTranslation();
   const styles = useStyles();
+  const navigation = useNavigation<RootNavigationProps>();
 
   return (
     <FullScreenView
@@ -17,9 +23,18 @@ export const Profile_SmartParkAndRideScreen = () => {
       }}
     >
       <View style={styles.container}>
-        <ThemeText typography="body__primary--jumbo--bold" style={styles.text}>
-          {t(SmartParkAndRideTexts.todo)}
-        </ThemeText>
+        <ContentHeading text={t(SmartParkAndRideTexts.content.heading)} />
+        <Section>
+          <LinkSectionItem
+            text={t(SmartParkAndRideTexts.content.addVehicle)}
+            onPress={() =>
+              navigation.navigate('Root_SmartParkAndRideAddScreen', {
+                transitionOverride: 'slide-from-right',
+              })
+            }
+            icon={<ThemeIcon svg={Add} />}
+          />
+        </Section>
       </View>
     </FullScreenView>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -27,7 +27,7 @@ import {Profile_TicketHistorySelectionScreen} from './Profile_TicketHistorySelec
 import {Profile_TravelAidScreen} from './Profile_TravelAidScreen';
 import {Profile_TravelAidInformationScreen} from './Profile_TravelAidInformationScreen.tsx';
 import {Profile_BonusScreen} from './Profile_BonusScreen.tsx';
-import {Profile_SmartParkAndRideScreen} from './Profile_SmartParkAndRideScreen.tsx';
+import {Profile_SmartParkAndRideScreen} from './Profile_SmartParkAndRideScreen';
 import {Profile_SettingsScreen} from './Profile_SettingsScreen';
 import {Profile_FavoriteScreen} from './Profile_FavoriteScreen';
 import {Profile_InformationScreen} from './Profile_InformationScreen';

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -147,6 +147,7 @@ export type RootStackParamList = StackParams<{
   Root_ConfirmationScreen: Root_ConfirmationScreenParams;
   Root_ParkingPhotoScreen: Root_ParkingPhotoScreenParams;
   Root_TripSelectionScreen: Root_TripSearchScreenParams;
+  Root_SmartParkAndRideAddScreen: undefined;
 }>;
 
 export type RootNavigationProps = NavigationProp<RootStackParamList>;

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -4,11 +4,32 @@ const SmartParkAndRideTexts = {
   header: {
     title: _('Smart Park & Ride', 'Smart Park & Ride', 'Smart Park & Ride'),
   },
-  todo: _(
-    'Smart Park & Ride kommer snart!',
-    'Smart Park & Ride coming soon!',
-    'Smart Park & Ride kjem snart!',
-  ),
+  content: {
+    heading: _('Dine kjøretøy', 'Your vehicles', 'Dine køyretøy'),
+    addVehicle: _('Legg til kjøretøy', 'Add vehicle', 'Legg til køyretøy'),
+  },
+  add: {
+    header: {
+      title: _('Legg til kjøretøy', 'Add vehicle', 'Legg til køyretøy'),
+    },
+    content: {
+      title: _('Legg til kjøretøy', 'Add vehicle', 'Legg til køyretøy'),
+      text: _(
+        'Du kan legge til to kjøretøy.',
+        'You can add two vehicles.',
+        'Du kan leggje til to køyretøy.',
+      ),
+    },
+    input: {
+      label: _('Skiltnummer', 'License plate', 'Skiltnummer'),
+      placeholder: _(
+        'Skriv inn skiltnummer',
+        'Enter license plate',
+        'Skriv inn skiltnummer',
+      ),
+    },
+    button: _('Legg til kjøretøy', 'Add vehicle', 'Legg til køyretøy'),
+  },
 };
 
 export default SmartParkAndRideTexts;


### PR DESCRIPTION
Adds a (rudimentary) screen for registering a vehicle. This screen will be further improved with other tasks, such as error handling etc.

There is on visual feedback for whether the user successfully was able to register a vehicle or not, but it can be seen in the database.

closes https://github.com/AtB-AS/kundevendt/issues/20816