### PR TITLE
fix: Hide price for booking on PurchaseConfirmationScreen

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -361,7 +361,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             isFree={isFree}
             isError={!!error || !canProceed}
             originalPrice={originalPrice}
-            price={totalPrice}
+            price={
+              tripPatternsThatRequireBooking.length > 0 ? undefined : totalPrice
+            }
             summaryButtonText={summaryButtonText()}
             onPressBuy={() => {
               analytics.logEvent('Ticketing', 'Purchase summary clicked', {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
@@ -10,7 +10,7 @@ import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 
 type Props = {
   selection: PurchaseSelectionType;
-  price: number;
+  price?: number;
   originalPrice: number;
   isFree: boolean;
   isLoading: boolean;
@@ -35,7 +35,9 @@ export function Summary({
   const {t, language} = useTranslation();
   const {theme} = useThemeContext();
 
-  const formattedPrice = formatNumberToString(price, language);
+  const formattedPrice = !!price
+    ? formatNumberToString(price, language)
+    : undefined;
   const formattedOriginalPrice = formatNumberToString(originalPrice, language);
   const hasSelection = selection.userProfilesWithCount.some((u) => u.count);
 
@@ -45,9 +47,7 @@ export function Summary({
 
   return (
     <View style={style}>
-      {isLoading ? (
-        <ActivityIndicator size="large" />
-      ) : (
+      {!!formattedPrice ? (
         <ThemeText
           typography="body__primary--bold"
           style={styles.price}
@@ -55,8 +55,10 @@ export function Summary({
         >
           {t(PurchaseOverviewTexts.summary.price(formattedPrice))}
         </ThemeText>
-      )}
-      {!isLoading && originalPrice !== price && (
+      ) : isLoading ? (
+        <ActivityIndicator size="large" />
+      ) : null}
+      {!isLoading && !!formattedPrice && originalPrice !== price && (
         <ThemeText
           typography="body__tertiary--strike"
           style={styles.originalPrice}


### PR DESCRIPTION
Fix related to AtB-AS/kundevendt#20761

Hides the price when booking is required, since we don't have a real offer before a departure is chosen. 