### PR TITLE
feat: add bonus illustrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "5.16.0",
-    "@atb-as/generate-assets": "17.2.2",
+    "@atb-as/generate-assets": "17.3.0",
     "@atb-as/theme": "^14.0.1",
     "@atb-as/utils": "^3.4.0",
     "@bugsnag/react-native": "^7.25.0",

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -13,7 +13,10 @@ import {
 import {View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ThemeText} from '@atb/components/text';
-import {ThemedCityBike} from '@atb/theme/ThemedAssets'; // TODO: update with new illustration when available
+import {
+  ThemedBonusBagHug,
+  ThemedBonusTransaction,
+} from '@atb/theme/ThemedAssets';
 import {ContentHeading} from '@atb/components/heading';
 import {
   BonusPriceTag,
@@ -121,7 +124,7 @@ export const Profile_BonusScreen = () => {
         <Section>
           <GenericSectionItem>
             <View style={styles.horizontalContainer}>
-              <ThemedCityBike />
+              <ThemedBonusTransaction height={61} width={61} />
               <View style={styles.bonusProgramDescription}>
                 <ThemeText typography="body__primary--bold">
                   {getTextForLanguage(
@@ -154,7 +157,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    gap: theme.spacing.small,
+    gap: theme.spacing.medium,
   },
   currentBalanceDisplay: {
     flexDirection: 'row',
@@ -218,7 +221,7 @@ function UserBonusBalanceSection(): JSX.Element {
               {t(BonusProgramTexts.bonusProfile.yourBonusPoints)}
             </ThemeText>
           </View>
-          <ThemedCityBike />
+          <ThemedBonusBagHug height={61} width={61} />
         </GenericSectionItem>
       </Section>
       {isError && (

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -47,6 +47,22 @@ import {
   CityBike as CityBikeLight,
   ParkAndRide as ParkAndRideLight,
 } from '@atb/assets/svg/color/images/mobility/light';
+import {
+  BonusBag as BonusBagLight,
+  BonusBagCarry as BonusBagCarryLight,
+  BonusBagHug as BonusBagHugLight,
+  BonusMap as BonusMapLight,
+  BonusTransaction as BonusTransactionLight,
+  BonusTrashCan as BonusTrashCanLight,
+} from '@atb/assets/svg/color/images/bonus/light';
+import {
+  BonusBag as BonusBagDark,
+  BonusBagCarry as BonusBagCarryDark,
+  BonusBagHug as BonusBagHugDark,
+  BonusMap as BonusMapDark,
+  BonusTransaction as BonusTransactionDark,
+  BonusTrashCan as BonusTrashCanDark,
+} from '@atb/assets/svg/color/images/bonus/dark';
 import {useThemeContext} from '@atb/theme/ThemeContext';
 import {SvgProps} from 'react-native-svg';
 
@@ -190,4 +206,49 @@ export const ThemedBeacons = ({...props}: SvgProps) => {
   const Beacons = themeName === 'dark' ? BeaconsDark : BeaconsLight;
 
   return <Beacons {...props} />;
+};
+
+export const ThemedBonusBag = ({...props}: SvgProps) => {
+  const {themeName} = useThemeContext();
+  const BonusBag = themeName === 'dark' ? BonusBagDark : BonusBagLight;
+
+  return <BonusBag {...props} />;
+};
+
+export const ThemedBonusBagCarry = ({...props}: SvgProps) => {
+  const {themeName} = useThemeContext();
+  const BonusBagCarry =
+    themeName === 'dark' ? BonusBagCarryDark : BonusBagCarryLight;
+
+  return <BonusBagCarry {...props} />;
+};
+
+export const ThemedBonusBagHug = ({...props}: SvgProps) => {
+  const {themeName} = useThemeContext();
+  const BonusBagHug = themeName === 'dark' ? BonusBagHugDark : BonusBagHugLight;
+
+  return <BonusBagHug {...props} />;
+};
+
+export const ThemedBonusMap = ({...props}: SvgProps) => {
+  const {themeName} = useThemeContext();
+  const BonusMap = themeName === 'dark' ? BonusMapDark : BonusMapLight;
+
+  return <BonusMap {...props} />;
+};
+
+export const ThemedBonusTransaction = ({...props}: SvgProps) => {
+  const {themeName} = useThemeContext();
+  const BonusTransaction =
+    themeName === 'dark' ? BonusTransactionDark : BonusTransactionLight;
+
+  return <BonusTransaction {...props} />;
+};
+
+export const ThemedBonusTrashCan = ({...props}: SvgProps) => {
+  const {themeName} = useThemeContext();
+  const BonusTrashCan =
+    themeName === 'dark' ? BonusTrashCanDark : BonusTrashCanLight;
+
+  return <BonusTrashCan {...props} />;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     zod "^3.24.4"
     zod-to-json-schema "^3.24.5"
 
-"@atb-as/generate-assets@17.2.2":
-  version "17.2.2"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-17.2.2.tgz#e0372ac78a2e68ba3e23f03b40b81ad17b6d8f5b"
-  integrity sha512-tA1nwpwjoM4oOGnU4T/wg77NsGPnh4OgwEJpT9lpLapMjVAeeiwkny7iQlMH5TVszigPKAwDpQpeNiIDpKO+5Q==
+"@atb-as/generate-assets@17.3.0":
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-17.3.0.tgz#59dcb2d2bb6ba1a90e4ada03179a3ed5986234d5"
+  integrity sha512-qLpPXyiovyW/MNHy4qM2fb6onmulg9u6kb89Aq1nCuRj3ZLS4JPycHyrj2mUv0iRXJG6sVQIBszcdMtwtkcuQg==
   dependencies:
     "@atb-as/theme" "^14.0.1"
     commander "^9.4.0"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/20669

Adds correct illustrations to bonus profile page

<img width=200 src=https://github.com/user-attachments/assets/87cb7ef4-95f1-4359-8567-6494afcc0fa8>
<img width=200 src=https://github.com/user-attachments/assets/9905b9e2-035f-499e-a3e7-801a8fbb202c>
