### PR TITLE
fix: update padding on top section in my profile

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -209,27 +209,27 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 />
               )}
             </Section>
-          </View>
 
-          <Section>
-            <LinkSectionItem
-              text={t(ProfileTexts.sections.settings.heading)}
-              onPress={() => navigation.navigate('Profile_SettingsScreen')}
-              testID="settingsButton"
-            />
-          </Section>
-          {isBonusProgramEnabled && (
             <Section>
               <LinkSectionItem
-                text={t(
-                  ProfileTexts.sections.account.linkSectionItems.bonus.label,
-                )}
-                onPress={() => navigation.navigate('Profile_BonusScreen')}
-                testID="BonusButton"
-                label="new"
+                text={t(ProfileTexts.sections.settings.heading)}
+                onPress={() => navigation.navigate('Profile_SettingsScreen')}
+                testID="settingsButton"
               />
             </Section>
-          )}
+            {isBonusProgramEnabled && (
+              <Section>
+                <LinkSectionItem
+                  text={t(
+                    ProfileTexts.sections.account.linkSectionItems.bonus.label,
+                  )}
+                  onPress={() => navigation.navigate('Profile_BonusScreen')}
+                  testID="BonusButton"
+                  label="new"
+                />
+              </Section>
+            )}
+          </View>
 
           <ContentHeading
             text={t(ProfileTexts.sections.travelAndPurchases.heading)}


### PR DESCRIPTION
Items under "My account" should have medium padding according to [Figma](https://www.figma.com/design/zdZwvobgpEWSagKt0tderx/App?node-id=33082-21132&t=OObkchPhDTYuvzb3-0). 

### Before/after
<div>
<img width="300px" src="https://github.com/user-attachments/assets/6569a5d5-e66e-4437-894d-2794d8413eac">
<img width="300px" src="https://github.com/user-attachments/assets/59b89925-2545-4454-8337-95741b29ebbd">
</div>