### PR TITLE
feat: add publicCode to global message contexts

### DIFF
--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -412,6 +412,8 @@ export const DepartureDetailsScreenComponent = ({
               fromZones:
                 fromCall?.quay?.tariffZones.map((zone) => zone.id) || null,
               toZones: toCall?.quay?.tariffZones.map((zone) => zone.id) || null,
+              publicCode: publicCode ?? null,
+              publicCodeAsNumber: Number.parseInt(publicCode ?? '') || null,
             }}
             style={styles.messageBox}
             textColor={backgroundColor}

--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -413,7 +413,6 @@ export const DepartureDetailsScreenComponent = ({
                 fromCall?.quay?.tariffZones.map((zone) => zone.id) || null,
               toZones: toCall?.quay?.tariffZones.map((zone) => zone.id) || null,
               publicCode: publicCode ?? null,
-              publicCodeAsNumber: Number.parseInt(publicCode ?? '') || null,
             }}
             style={styles.messageBox}
             textColor={backgroundColor}

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -166,6 +166,9 @@ export const Trip: React.FC<TripProps> = ({
             .map((l) => l.transportSubmode)
             .filter(isDefined),
           withinZoneIds: containingZones,
+          publicCodes: tripPattern.legs
+            .map((l) => l.line?.publicCode)
+            .filter(isDefined),
         }}
       />
       {error && (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -436,6 +436,11 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                   .map((leg) => leg.authority?.id)
                   .filter(isDefined)
                   .filter(onlyUniques),
+                publicCodes: tripPatterns
+                  .flatMap((tp) => tp.legs)
+                  .map((leg) => leg.line?.publicCode)
+                  .filter(isDefined)
+                  .filter(onlyUniques),
               }}
             />
           </View>


### PR DESCRIPTION
Adds `publicCode` / `publicCodes` as strings to departure details, trip details and trip results, so that we can add global messages for specific line numbers.

Also adds `publicCodeAsNumber` to departure details, so line numbers in a range can be targeted, which can be useful for cases like 100-999 for regional buses. This is harder to do with the rule engine when there is more than one public code.

### Acceptance criteria

- [ ] Able to use `publicCodes` as a rule variable on trip results and trip details. (with e.g. `contains`)
- [ ] Able to use `publicCode` as a rule variable on departure details. (with e.g. `equals`)
