### PR TITLE
feat: Minimize vehicle clusters

### DIFF
--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -31,12 +31,16 @@ export const useMapSymbolStyles = ({
 
   const featureId: Expression = ['get', 'id'];
   const selectedFeatureId = selectedFeaturePropertyId || ''; // because mapbox style expressions don't like undefined
-  const isSelected: Expression = ['==', featureId, selectedFeatureId];
-  const noFeatureSelected: Expression = ['==', selectedFeatureId, ''];
+  const thisFeatureIsSelected: Expression = [
+    '==',
+    featureId,
+    selectedFeatureId,
+  ];
+  const noFeatureIsSelected: Expression = ['==', selectedFeatureId, ''];
   const isMinimized: Expression = [
     'all',
-    ['!', isSelected],
-    ['!', noFeatureSelected],
+    ['!', thisFeatureIsSelected],
+    ['!', noFeatureIsSelected],
   ];
 
   const countPropName = 'count';
@@ -51,7 +55,7 @@ export const useMapSymbolStyles = ({
 
   const mapItemIconNonClusterState: Expression = [
     'case',
-    isSelected,
+    thisFeatureIsSelected,
     'selected',
     ['case', isMinimized, 'minimized', 'default'],
   ];
@@ -246,7 +250,7 @@ export const useMapSymbolStyles = ({
     textAllowOverlap: true,
   };
   return {
-    isSelected,
+    isSelected: thisFeatureIsSelected,
     iconStyle,
     textStyle,
   };

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -62,12 +62,13 @@ export const useMapSymbolStyles = ({
     mapItemIconNonClusterState,
   ];
 
-  const iconFullSize: Expression = [
-    'case',
-    pinType === 'station' ? true : isCluster,
-    0.855,
-    1,
+  const reduceIconSize: Expression = [
+    'all',
+    ['any', pinType === 'station', isCluster],
+    ['!', isMinimized],
   ];
+
+  const iconFullSize: Expression = ['case', reduceIconSize, 0.855, 1];
 
   const iconSize: Expression = [
     'interpolate',
@@ -199,7 +200,7 @@ export const useMapSymbolStyles = ({
   const textOffset: Expression = [
     'case',
     isMinimized,
-    [0.4, -0.15],
+    [0.44, -0.15],
     [
       'step',
       numberOfUnits,

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -200,7 +200,7 @@ export const useMapSymbolStyles = ({
   const textOffset: Expression = [
     'case',
     isMinimized,
-    [0.44, -0.15],
+    [0.44, -0.175],
     [
       'step',
       numberOfUnits,
@@ -213,11 +213,16 @@ export const useMapSymbolStyles = ({
   const getCountAdjustedTextSize: (baseSize: number) => Expression = (
     baseSize,
   ) => [
-    'step',
-    numberOfUnits,
+    'case',
+    isMinimized,
     baseSize * textSizeFactor * 12.6,
-    100,
-    baseSize * textSizeFactor * 10.8,
+    [
+      'step',
+      numberOfUnits,
+      baseSize * textSizeFactor * 12.6,
+      100,
+      baseSize * textSizeFactor * 10.8,
+    ],
   ];
 
   const textSize: Expression = [

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -31,15 +31,11 @@ export const useMapSymbolStyles = ({
 
   const featureId: Expression = ['get', 'id'];
   const selectedFeatureId = selectedFeaturePropertyId || ''; // because mapbox style expressions don't like undefined
-  const thisFeatureIsSelected: Expression = [
-    '==',
-    featureId,
-    selectedFeatureId,
-  ];
   const noFeatureIsSelected: Expression = ['==', selectedFeatureId, ''];
+  const isSelected: Expression = ['==', featureId, selectedFeatureId];
   const isMinimized: Expression = [
     'all',
-    ['!', thisFeatureIsSelected],
+    ['!', isSelected],
     ['!', noFeatureIsSelected],
   ];
 
@@ -55,7 +51,7 @@ export const useMapSymbolStyles = ({
 
   const mapItemIconNonClusterState: Expression = [
     'case',
-    thisFeatureIsSelected,
+    isSelected,
     'selected',
     ['case', isMinimized, 'minimized', 'default'],
   ];
@@ -250,7 +246,7 @@ export const useMapSymbolStyles = ({
     textAllowOverlap: true,
   };
   return {
-    isSelected: thisFeatureIsSelected,
+    isSelected,
     iconStyle,
     textStyle,
   };

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -32,6 +32,12 @@ export const useMapSymbolStyles = ({
   const featureId: Expression = ['get', 'id'];
   const selectedFeatureId = selectedFeaturePropertyId || ''; // because mapbox style expressions don't like undefined
   const isSelected: Expression = ['==', featureId, selectedFeatureId];
+  const noFeatureSelected: Expression = ['==', selectedFeatureId, ''];
+  const isMinimized: Expression = [
+    'all',
+    ['!', isSelected],
+    ['!', noFeatureSelected],
+  ];
 
   const countPropName = 'count';
   const count: Expression = ['get', countPropName];
@@ -47,12 +53,12 @@ export const useMapSymbolStyles = ({
     'case',
     isSelected,
     'selected',
-    ['case', ['==', selectedFeatureId, ''], 'default', 'minimized'],
+    ['case', isMinimized, 'minimized', 'default'],
   ];
   const mapItemIconState: Expression = [
     'case',
     isCluster,
-    'cluster',
+    ['case', isMinimized, 'cluster_minimized', 'cluster'],
     mapItemIconNonClusterState,
   ];
 
@@ -173,6 +179,8 @@ export const useMapSymbolStyles = ({
   const numberOfUnits = pinType == 'vehicle' ? count : numVehiclesAvailable;
   const numberOfUnitsLimitedAt99Plus: Expression = [
     'case',
+    isMinimized,
+    '+',
     ['>', numberOfUnits, 99],
     '99+',
     numberOfUnits,
@@ -189,11 +197,16 @@ export const useMapSymbolStyles = ({
       : ['case', isCluster, numberOfUnitsLimitedAt99Plus, ''];
 
   const textOffset: Expression = [
-    'step',
-    numberOfUnits,
-    [0.82 * textOffsetXFactor, -0.15],
-    100,
-    [1.0 * textOffsetXFactor, -0.15],
+    'case',
+    isMinimized,
+    [0.4, -0.15],
+    [
+      'step',
+      numberOfUnits,
+      [0.82 * textOffsetXFactor, -0.15],
+      100,
+      [1.0 * textOffsetXFactor, -0.15],
+    ],
   ];
 
   const getCountAdjustedTextSize: (baseSize: number) => Expression = (

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -31,12 +31,12 @@ export const useMapSymbolStyles = ({
 
   const featureId: Expression = ['get', 'id'];
   const selectedFeatureId = selectedFeaturePropertyId || ''; // because mapbox style expressions don't like undefined
-  const noFeatureIsSelected: Expression = ['==', selectedFeatureId, ''];
+  const nothingIsSelected: Expression = ['==', selectedFeatureId, ''];
   const isSelected: Expression = ['==', featureId, selectedFeatureId];
   const isMinimized: Expression = [
     'all',
     ['!', isSelected],
-    ['!', noFeatureIsSelected],
+    ['!', nothingIsSelected],
   ];
 
   const countPropName = 'count';


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20290

Now every type of map icon is minimized when another map item is selected, including vehicle clusters.
A `+` is shown instead of the cluster count in this state.


| Before | After |
|--------|-------|
| <img width="250" src="https://github.com/user-attachments/assets/ed18414a-6963-42d8-a816-6980c5b89d15" /> | <img width="250" src="https://github.com/user-attachments/assets/92408339-8fc1-4561-8f6f-a577f4a918fd" /> |
| <img width="250" src="https://github.com/user-attachments/assets/4a5e5712-51db-4e67-ac8b-43ce931109e2" /> | <img width="250" src="https://github.com/user-attachments/assets/b9628225-abee-4530-9c07-8814cc2da53c" /> |
