### PR TITLE
fix(spar): move profile page link

### DIFF
--- a/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideAddScreen.tsx
+++ b/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideAddScreen.tsx
@@ -31,6 +31,7 @@ export const Root_SmartParkAndRideAddScreen = ({navigation}: Props) => {
       headerProps={{
         title: t(SmartParkAndRideTexts.add.header.title),
         leftButton: {type: 'back', withIcon: true},
+        color: theme.color.background.neutral[1],
       }}
       footer={
         <FullScreenFooter>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -261,18 +261,6 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               onPress={() => navigation.navigate('Profile_FavoriteScreen')}
               testID="favoriteButton"
             />
-          </Section>
-
-          <ContentHeading text={t(ProfileTexts.sections.newFeatures.heading)} />
-          <Section>
-            <LinkSectionItem
-              text={t(
-                ProfileTexts.sections.settings.linkSectionItems.enrollment
-                  .label,
-              )}
-              onPress={() => navigation.navigate('Profile_EnrollmentScreen')}
-              testID="invitationCodeButton"
-            />
             {isSmartParkAndRideEnabled && (
               <LinkSectionItem
                 text={t(
@@ -286,6 +274,18 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 testID="smartParkAndRideButton"
               />
             )}
+          </Section>
+
+          <ContentHeading text={t(ProfileTexts.sections.newFeatures.heading)} />
+          <Section>
+            <LinkSectionItem
+              text={t(
+                ProfileTexts.sections.settings.linkSectionItems.enrollment
+                  .label,
+              )}
+              onPress={() => navigation.navigate('Profile_EnrollmentScreen')}
+              testID="invitationCodeButton"
+            />
           </Section>
           {enable_ticketing && (
             <>

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -38,9 +38,9 @@ const ProfileTexts = {
         },
         smartParkAndRide: {
           label: _(
-            'Smart Park & Ride',
-            'Smart Park & Ride',
-            'Smart Park & Ride',
+            'Parkering på Ranheim',
+            'Parking at Ranheim',
+            'Parkering på Ranheim',
           ),
         },
         paymentMethods: {

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -2,7 +2,11 @@ import {translation as _} from '../../commons';
 
 const SmartParkAndRideTexts = {
   header: {
-    title: _('Smart Park & Ride', 'Smart Park & Ride', 'Smart Park & Ride'),
+    title: _(
+      'Parkering på Ranheim',
+      'Parking at Ranheim',
+      'Parkering på Ranheim',
+    ),
   },
   content: {
     heading: _('Dine kjøretøy', 'Your vehicles', 'Dine køyretøy'),


### PR DESCRIPTION
Reorganize the profile page layout by moving the enrollment link section to improve user navigation. Update text for the Smart Park & Ride label to reflect the correct translation.