### PR TITLE
fix: use util function for license plate a11y text

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -15,6 +15,7 @@ import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {Car} from '@atb/assets/svg/mono-icons/transportation';
 import {useVehicleRegistrationsQuery} from '@atb/modules/smart-park-and-ride';
+import {spellOut} from '@atb/utils/accessibility';
 
 export const Profile_SmartParkAndRideScreen = () => {
   const {t} = useTranslation();
@@ -69,9 +70,9 @@ export const Profile_SmartParkAndRideScreen = () => {
 };
 
 const getAccessibilityLabel = (licensePlate: string, t: TranslateFunction) => {
-  return `${t(SmartParkAndRideTexts.a11y.carIcon)}. ${licensePlate
-    .split('')
-    .join('. ')}. ${t(SmartParkAndRideTexts.a11y.button)}`;
+  return `${t(SmartParkAndRideTexts.a11y.carIcon)}. ${spellOut(
+    licensePlate,
+  )}. ${t(SmartParkAndRideTexts.a11y.button)}`;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({


### PR DESCRIPTION
Use the existing util function, `spellOut`, instead of adding periods to the a11y label. Android didn't handle the periods well.

related https://github.com/AtB-AS/kundevendt/issues/20818