### PR TITLE
fix: always use backoff for websocket reconnects

### DIFF
--- a/src/api/use-subscription.ts
+++ b/src/api/use-subscription.ts
@@ -41,7 +41,8 @@ export function useSubscription({
         // 1001: "going away", such as a server going down or a browser having
         //       navigated away from a page.
         // 1006: The connection was closed abnormally, but not by the server.
-        //       Can be caused by the Android websocket implementation.
+        //       Can be returned by the Android or iOS websocket implementations
+        //       on issues like network errors.
         const expectedCodes = [1000, 1001, 1006];
 
         if (event.code && !expectedCodes.includes(event.code)) {


### PR DESCRIPTION
Fixes an issue where the event stream connection was aggressively trying to reconnect when the connection was closed with code 1001. See https://mittatb.slack.com/archives/C02DL21RK7C/p1751010497949739. Now we always use `retryWithCappedBackoff`, regardless of error code.

## Acceptance criteria

- [x] When a websocket is closed with event code 1001 (or any other code), the app retries with exponential backoff, capped at 10s. With this, I expect we'll see a _lot_ less websocket errors in prod.