### PR TITLE
fix: rename new concepts header and remove unused text

### DIFF
--- a/src/translations/screens/subscreens/Enrollment.ts
+++ b/src/translations/screens/subscreens/Enrollment.ts
@@ -1,15 +1,10 @@
 import {translation as _} from '../../commons';
 const EnrollmentTexts = {
-  header: _('Ny funksjonalitet', 'New features', 'Ny funksjonalitet'),
+  header: _('Nye konsepter', 'New concepts', 'Ny konsepter'),
   info: _(
     'Vi tester nye konsepter i appen, på et mindre antall brukere. Har du fått en kode for å bli med? Skriv den inn her!',
     'We are trying out new concepts in the app with small groups of users. Got a code to join? Enter it here!',
     'Me testar nye konsept i appen, på nokre få brukarar. Har du fått ein kode for å bli med? Skriv den inn her!',
-  ),
-  betaButtonLabel: _(
-    'Jeg har kode til ny funkjonalitet',
-    'I have a code for new features',
-    'Eg har kode til ny funksjonalitet',
   ),
   success: _(
     'Du ble innrullert i den lukkede gruppen!',


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/21088

Updates header text for new concepts screen.
Also removes unused text.

<img width=200 src=https://github.com/user-attachments/assets/693ed4c1-063e-4ba0-92a0-3f677a913ebf>
<img width=200 src=https://github.com/user-attachments/assets/a677288c-55d4-4fcc-82de-8fb82ae55dce>
