### PR TITLE
test: e2e fix on filter

### DIFF
--- a/e2e/test/pageobjects/travelsearch.filter.page.ts
+++ b/e2e/test/pageobjects/travelsearch.filter.page.ts
@@ -12,6 +12,14 @@ class TravelSearchFilterPage {
   }
 
   /**
+   * Return number of filters available (including the 'all' option)
+   */
+  get numberOfFilters() {
+    const reqId = `//*[@resource-id="toggleItem"]`;
+    return $$(reqId).length;
+  }
+
+  /**
    * Open the time picker on the travel search results
    */
   async openTravelSearchTimePicker() {

--- a/e2e/test/specs/travelsearch.filter.e2e.ts
+++ b/e2e/test/specs/travelsearch.filter.e2e.ts
@@ -46,7 +46,11 @@ describe('Travel search filter', () => {
       // Filter out buses
       await AppHelper.scrollUpUntilId('tripSearchContentView', 'filterButton');
       await TravelsearchFilterPage.openFilter();
+      // Not considering the 'all' option
+      const filtersAvailable =
+        (await TravelsearchFilterPage.numberOfFilters) - 1;
       await TravelsearchFilterPage.toggleFilter('bus');
+      const filtersInUse = filtersAvailable - 1;
       await TravelsearchFilterPage.confirmFilter();
       await TravelsearchOverviewPage.waitForTravelSearchResults();
 
@@ -60,7 +64,9 @@ describe('Travel search filter', () => {
         'tripSearchContentView',
         'selectedFilterButton',
       );
-      await TravelsearchFilterPage.shouldShowSelectedFilter('5 of 7');
+      await TravelsearchFilterPage.shouldShowSelectedFilter(
+        `${filtersInUse} of ${filtersAvailable}`,
+      );
 
       // Remove the selected filters
       await TravelsearchFilterPage.removeSelectedFilter();

--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -75,6 +75,7 @@ export function ToggleSectionItem({
       }
       accessibilityLabel={text}
       {...accessibility}
+      testID="toggleItem"
     >
       <View style={{flexDirection: 'row'}}>
         {leftImage && (


### PR DESCRIPTION
A more generic fix to the problem of checking travel search filters in use for the E2E tests.

NOTE! Added a test-id to the ToggleSectionItem