### PR TITLE
fix: use local state to show and hide flex transport info

### DIFF
--- a/src/modules/popover/types.ts
+++ b/src/modules/popover/types.ts
@@ -1,4 +1,3 @@
 export type PopOverKey =
-  | 'trip-search-flexible-transport-dismissed'
   | 'on-behalf-of-new-feature-introduction'
   | 'on-behalf-of-sent-tickets-button';

--- a/src/modules/travel-search-filters/index.tsx
+++ b/src/modules/travel-search-filters/index.tsx
@@ -1,7 +1,6 @@
 export {useFiltersContext, FiltersContextProvider} from './FiltersContext';
 export type {
   TravelSearchFiltersSelectionType,
-  FlexibleTransportOptionTypeWithSelectionType,
   TransportModeFilterOptionWithSelectionType,
   TravelSearchPreferenceWithSelectionType,
 } from './types';

--- a/src/modules/travel-search-filters/types.ts
+++ b/src/modules/travel-search-filters/types.ts
@@ -1,7 +1,4 @@
-import {
-  FlexibleTransportOptionType,
-  TransportModeFilterOptionType,
-} from '@atb/modules/configuration';
+import {TransportModeFilterOptionType} from '@atb/modules/configuration';
 import {
   TravelSearchPreferenceOptionIdType,
   TravelSearchPreferenceType,
@@ -10,9 +7,6 @@ import {
 export type TransportModeFilterOptionWithSelectionType =
   TransportModeFilterOptionType & {selected: boolean};
 
-export type FlexibleTransportOptionTypeWithSelectionType =
-  FlexibleTransportOptionType & {enabled: boolean};
-
 export type TravelSearchPreferenceWithSelectionType =
   TravelSearchPreferenceType & {
     selectedOption: TravelSearchPreferenceOptionIdType;
@@ -20,6 +14,5 @@ export type TravelSearchPreferenceWithSelectionType =
 
 export type TravelSearchFiltersSelectionType = {
   transportModes?: TransportModeFilterOptionWithSelectionType[];
-  flexibleTransport?: FlexibleTransportOptionTypeWithSelectionType;
   travelSearchPreferences?: TravelSearchPreferenceWithSelectionType[];
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -50,7 +50,6 @@ import {useNonTransitTripsQuery} from '@atb/stacks-hierarchy/Root_TabNavigatorSt
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
-import {usePopOverContext} from '@atb/modules/popover';
 import {areDefaultFiltersSelected, getSearchTimeLabel} from './utils';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {
@@ -88,7 +87,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const [updatingLocation] = useState<boolean>(false);
   const analytics = useAnalyticsContext();
   const isFocused = useIsFocusedAndActive();
-  const {addPopOver} = usePopOverContext();
   const filterButtonWrapperRef = useRef(null);
   const filterButtonRef = useRef(null);
 
@@ -117,12 +115,9 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const isEmptyResult = !isSearching && !tripPatterns?.length;
   const noResultReasons = computeNoResultReasons(t, searchTime, from, to);
   const isValidLocations = isValidTripLocations(from, to);
-  const isFlexibleTransportSelected =
-    filtersState.filtersSelection?.transportModes?.find(
-      (mode) => mode.id === 'flexibleTransport',
-    )?.selected;
-  const isFlexibleTransportEnabled =
-    isFlexibleTransportEnabledInRemoteConfig && isFlexibleTransportSelected;
+  const [flexibleTransportInfoDismissed, setFlexibleTransportInfoDismissed] =
+    useState(false);
+  const isFlexibleTransportEnabled = isFlexibleTransportEnabledInRemoteConfig;
 
   const [searchStateMessage, setSearchStateMessage] = useState<
     string | undefined
@@ -453,6 +448,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 />
               )}
               {isFlexibleTransportEnabled &&
+                !flexibleTransportInfoDismissed &&
                 (tripPatterns.length > 0 ||
                   searchState === 'search-empty-result') &&
                 !error && (
@@ -460,12 +456,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                     from={from}
                     to={to}
                     onDismiss={() => {
-                      filtersState.enabled &&
-                        filtersState.disableFlexibleTransport();
-                      addPopOver({
-                        oneTimeKey: 'trip-search-flexible-transport-dismissed',
-                        target: filterButtonWrapperRef,
-                      });
+                      setFlexibleTransportInfoDismissed(true);
                       analytics.logEvent(
                         'Flexible transport',
                         'Message box dismissed',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
@@ -19,7 +19,6 @@ import {Phone} from '@atb/assets/svg/mono-icons/devices';
 import {CityZone} from '@atb/modules/configuration';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
-import {ThemedBestillMaxi} from '@atb/theme/ThemedAssets';
 
 type ActionButton = {
   id: string;
@@ -62,7 +61,6 @@ export const CityZoneMessage: React.FC<CityZoneMessageProps> = ({
       <Section style={style.cityZoneMessage}>
         <CityZoneBox
           message={t(CityBoxMessageTexts.message(fromCityZone.name))}
-          icon={() => <ThemedBestillMaxi width={60} height={54} />}
           onDismiss={onDismiss}
           actionButtons={actionButtons}
         />
@@ -74,18 +72,12 @@ export const CityZoneMessage: React.FC<CityZoneMessageProps> = ({
 };
 
 type CityZoneBoxProps = {
-  icon: (props: SvgProps) => JSX.Element;
   message: string;
   onDismiss?: () => void;
   actionButtons?: ActionButton[];
 };
 
-const CityZoneBox = ({
-  icon,
-  message,
-  actionButtons,
-  onDismiss,
-}: CityZoneBoxProps) => {
+const CityZoneBox = ({message, actionButtons, onDismiss}: CityZoneBoxProps) => {
   const {theme} = useThemeContext();
   const styles = useStyle();
   const {t} = useTranslation();
@@ -96,9 +88,6 @@ const CityZoneBox = ({
   } = generalColor;
   return (
     <View style={[styles.container, {backgroundColor}]} accessible={false}>
-      <View style={styles.icon}>
-        <ThemeIcon svg={icon} />
-      </View>
       <View style={styles.content}>
         <ThemeText style={styles.message} color={generalColor}>
           {message}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -3,10 +3,7 @@ import React, {RefObject, useState} from 'react';
 import {TravelSearchFiltersBottomSheet} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {useFiltersContext} from '@atb/modules/travel-search-filters';
-import {
-  FlexibleTransportOptionTypeWithSelectionType,
-  TravelSearchFiltersSelectionType,
-} from '@atb/modules/travel-search-filters';
+import {TravelSearchFiltersSelectionType} from '@atb/modules/travel-search-filters';
 import {TravelSearchPreferenceWithSelectionType} from '@atb/modules/travel-search-filters';
 
 type TravelSearchFiltersState =
@@ -16,7 +13,6 @@ type TravelSearchFiltersState =
       filtersSelection: TravelSearchFiltersSelectionType;
       anyFiltersApplied: boolean;
       resetTransportModes: () => void;
-      disableFlexibleTransport: () => void;
     }
   | {enabled: false; filtersSelection?: undefined};
 
@@ -81,10 +77,9 @@ export const useTravelSearchFiltersState = ({
     enabled: true,
     openBottomSheet,
     filtersSelection,
-    anyFiltersApplied:
-      filtersSelection.transportModes?.some((m) => !m.selected) ||
-      !filtersSelection.flexibleTransport?.enabled ||
-      false,
+    anyFiltersApplied: !!filtersSelection.transportModes?.some(
+      (m) => !m.selected,
+    ),
     resetTransportModes: () => {
       const filtersWithInitialTransportModes = {
         ...filtersSelection,
@@ -92,17 +87,6 @@ export const useTravelSearchFiltersState = ({
       };
       setFilters(filtersWithInitialTransportModes);
       setFiltersSelection(filtersWithInitialTransportModes);
-    },
-    disableFlexibleTransport: () => {
-      const filtersWithFlexibleTransportDisabled = {
-        ...filtersSelection,
-        flexibleTransport: {
-          ...filtersSelection.flexibleTransport,
-          enabled: false,
-        } as FlexibleTransportOptionTypeWithSelectionType,
-      };
-      setFilters(filtersWithFlexibleTransportDisabled);
-      setFiltersSelection(filtersWithFlexibleTransportDisabled);
     },
   };
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
@@ -278,6 +278,5 @@ function toLoggableFiltersSelection(
     transportModes: filterSelection.transportModes?.map((t) => ({
       [t.id]: t.selected,
     })),
-    flexibleTransportEnabled: filterSelection.flexibleTransport?.enabled,
   };
 }

--- a/src/translations/components/OneTimePopOver.ts
+++ b/src/translations/components/OneTimePopOver.ts
@@ -7,18 +7,6 @@ type PopOverText = {
 };
 
 const OneTimePopOverTexts: {[key in PopOverKey]: PopOverText} = {
-  'trip-search-flexible-transport-dismissed': {
-    heading: _(
-      'Filter er slått av',
-      'Filter is turned off',
-      'Filter er slått av',
-    ),
-    text: _(
-      'Tips om bestillingstransport kan skrus på igjen i filter.',
-      'Flexible transport travel suggestions can be turned on again in filters.',
-      'Tips om bestillingstransport kan skruast på igjen i filter.',
-    ),
-  },
   'on-behalf-of-new-feature-introduction': {
     heading: _('Nyhet!', 'New!', 'Nyhet!'),
     text: _(


### PR DESCRIPTION
- Stores the dismissed state only per travel search, and not permanently in filters. This fixes https://github.com/AtB-AS/kundevendt/issues/21086
- Cleans up some filter logic that we don't need anymore when flexible transport isn't an option.
- Removes the illustration in the info box, to make it more compact.

### Before / after

<div>
<img width="300px" src="https://github.com/user-attachments/assets/fbbbc023-1884-4f3a-b5a8-3210e75d4d04">
<img width="300px" src="https://github.com/user-attachments/assets/b169644c-074b-42aa-8120-3fe0570f9610">
</div>

fixes https://github.com/AtB-AS/kundevendt/issues/21086