### PR TITLE
test: fix e2e filter tests

### DIFF
--- a/e2e/test/pageobjects/travelsearch.filter.page.ts
+++ b/e2e/test/pageobjects/travelsearch.filter.page.ts
@@ -1,6 +1,7 @@
 import ElementHelper from '../utils/element.helper.ts';
 import AppHelper from '../utils/app.helper.ts';
 import TravelsearchOverviewPage from './travelsearch.overview.page.js';
+import {$} from '@wdio/globals';
 
 class TravelSearchFilterPage {
   /**
@@ -54,24 +55,37 @@ class TravelSearchFilterPage {
    * Toggle on of the filters (or the 'all' option)
    * @param type type of filter to toggle (default: allModes)
    */
-  async toggleFilter(type: string = 'allModes') {
+  async toggleTransportModeFilter(type: string = 'allModes') {
     const reqId = `//*[@resource-id="${type}Toggle"]`;
     await $(reqId).click();
     await AppHelper.pause();
   }
 
   /**
-   * Confirm the chosen filter options
-   * @param saveFilter possibility to save the filter (default: false)
+   * Set the walk speed
+   * @param speed type of walk speed to use in search
    */
-  async confirmFilter(saveFilter: boolean = false) {
+  async setWalkSpeed(speed: 'slow' | 'normal' | 'fast') {
+    const reqId = `//*[@resource-id="${speed}Button"]`;
+    await $(reqId).click();
+    await AppHelper.pause();
+  }
+
+  /**
+   * Check that the given walk speed is enabled
+   * @param speed type of walk speed
+   */
+  async walkSpeedIsEnabled(speed: 'slow' | 'normal' | 'fast') {
+    const reqId = `//*[@resource-id="${speed}Button"]`;
+    await ElementHelper.waitForElement('id', `${speed}Button`);
+    expect(await $(reqId).isEnabled()).toBe(true);
+  }
+
+  /**
+   * Confirm the chosen filter options
+   */
+  async confirmFilter() {
     const reqId = `//*[@resource-id="confirmButton"]`;
-    const saveId = `//*[@resource-id="saveFilterCheckbox"]`;
-    // Save filter or not
-    if (saveFilter) {
-      await AppHelper.scrollDownUntilId('filterView', 'saveFilterCheckbox');
-      await $(saveId).click();
-    }
     await $(reqId).click();
     await AppHelper.pause();
   }

--- a/e2e/test/specs/travelsearch.filter.e2e.ts
+++ b/e2e/test/specs/travelsearch.filter.e2e.ts
@@ -49,7 +49,7 @@ describe('Travel search filter', () => {
       // Not considering the 'all' option
       const filtersAvailable =
         (await TravelsearchFilterPage.numberOfFilters) - 1;
-      await TravelsearchFilterPage.toggleFilter('bus');
+      await TravelsearchFilterPage.toggleTransportModeFilter('bus');
       const filtersInUse = filtersAvailable - 1;
       await TravelsearchFilterPage.confirmFilter();
       await TravelsearchOverviewPage.waitForTravelSearchResults();
@@ -87,7 +87,7 @@ describe('Travel search filter', () => {
   });
 
   /**
-   * Saving the filter choice should use the saved filter for new searches
+   * Changing the filter choice 'walkSpeed' should be saved for new searches
    */
   it('should save filter choices', async () => {
     const departure = 'Prinsens gate';
@@ -104,14 +104,9 @@ describe('Travel search filter', () => {
 
       // Filter out buses
       await TravelsearchFilterPage.openFilter();
-      await TravelsearchFilterPage.toggleFilter('bus');
-      await TravelsearchFilterPage.confirmFilter(true);
+      await TravelsearchFilterPage.setWalkSpeed('slow');
+      await TravelsearchFilterPage.confirmFilter();
       await TravelsearchOverviewPage.waitForTravelSearchResults();
-
-      // Filters are enabled
-      await expect(
-        await TravelsearchFilterPage.selectedFilterButton.isExisting(),
-      ).toBe(true);
 
       await NavigationHelper.tapMenu('assistant');
       await NavigationHelper.tapMenu('assistant');
@@ -126,14 +121,10 @@ describe('Travel search filter', () => {
       await SearchPage.setSearchLocation(arrival);
       await TravelsearchOverviewPage.waitForTravelSearchResults();
 
-      // Filters are enabled
-      await expect(
-        await TravelsearchFilterPage.selectedFilterButton.isExisting(),
-      ).toBe(true);
-
-      // Remove filter
-      await TravelsearchFilterPage.removeSelectedFilter();
-      await TravelsearchOverviewPage.waitForTravelSearchResults();
+      // Walk speed is still changed
+      await TravelsearchFilterPage.openFilter();
+      await TravelsearchFilterPage.walkSpeedIsEnabled('slow');
+      await TravelsearchFilterPage.confirmFilter();
     } catch (errMsg) {
       await AppHelper.screenshot('error_travelsearch_save_filter');
       throw errMsg;
@@ -141,7 +132,7 @@ describe('Travel search filter', () => {
   });
 
   /**
-   * Not saving the filter choice should NOT use the last filter for new searches
+   * Changing the filter choice 'transport mode' should NOT be saved for new searches
    */
   it('should not save filter choices', async () => {
     const departure = 'Prinsens gate';
@@ -161,8 +152,8 @@ describe('Travel search filter', () => {
 
       // Filter out buses
       await TravelsearchFilterPage.openFilter();
-      await TravelsearchFilterPage.toggleFilter('bus');
-      await TravelsearchFilterPage.confirmFilter(false);
+      await TravelsearchFilterPage.toggleTransportModeFilter('bus');
+      await TravelsearchFilterPage.confirmFilter();
       await TravelsearchOverviewPage.waitForTravelSearchResults();
 
       // Filters are enabled

--- a/src/components/radio/RadioSegments.tsx
+++ b/src/components/radio/RadioSegments.tsx
@@ -78,6 +78,7 @@ export function RadioSegments({
                 padding: theme.spacing.medium - borderWidth,
               },
             ]}
+            testID={`${option.text.toLowerCase().replace(' ', '')}Button`}
           >
             <ThemeText
               typography={


### PR DESCRIPTION
A fix for the E2E filter tests after https://github.com/AtB-AS/mittatb-app/pull/5300:
- Transport mode filters should NOT be saved for next search
- Preferences like walk speed should be saved for next search

NOTE! Added a test-id on the filter preferences.