### PR TITLE
feat(spar): show error when edit/delete fails

### DIFF
--- a/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideAddScreen.tsx
+++ b/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideAddScreen.tsx
@@ -72,10 +72,8 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     rowGap: theme.spacing.small,
     margin: theme.spacing.large,
-    display: 'flex',
   },
   content: {
-    display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     gap: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideEditScreen.tsx
+++ b/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideEditScreen.tsx
@@ -7,13 +7,14 @@ import {StyleSheet, useThemeContext} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import {useState} from 'react';
-import {Alert} from 'react-native';
+import {Alert, View} from 'react-native';
 import {RootStackScreenProps} from '..';
 import {ScreenHeading} from '@atb/components/heading';
 import {
   useEditVehicleRegistrationMutation,
   useDeleteVehicleRegistrationMutation,
 } from '@atb/modules/smart-park-and-ride';
+import {MessageInfoBox} from '@atb/components/message-info-box';
 
 type Props = RootStackScreenProps<'Root_SmartParkAndRideEditScreen'>;
 
@@ -29,18 +30,23 @@ export const Root_SmartParkAndRideEditScreen = ({
   const {theme} = useThemeContext();
 
   const onSuccess = () => navigation.goBack();
-  const {mutateAsync: handleEditVehicleRegistration} =
-    useEditVehicleRegistrationMutation(
-      params.vehicleRegistration.id,
-      licensePlate,
-      onSuccess,
-    );
 
-  const {mutateAsync: handleDeleteVehicleRegistration} =
-    useDeleteVehicleRegistrationMutation(
-      params.vehicleRegistration.id,
-      onSuccess,
-    );
+  const {
+    mutate: editVehicleRegistrationMutate,
+    isError: editVehicleRegistrationIsError,
+  } = useEditVehicleRegistrationMutation(
+    params.vehicleRegistration.id,
+    licensePlate,
+    onSuccess,
+  );
+
+  const {
+    mutate: deleteVehicleRegistrationMutate,
+    isError: deleteVehicleRegistrationIsError,
+  } = useDeleteVehicleRegistrationMutation(
+    params.vehicleRegistration.id,
+    onSuccess,
+  );
 
   const showDeleteConfirmation = () => {
     Alert.alert(
@@ -54,7 +60,7 @@ export const Root_SmartParkAndRideEditScreen = ({
         {
           text: t(SmartParkAndRideTexts.edit.delete.confirmation.confirm),
           style: 'destructive',
-          onPress: () => handleDeleteVehicleRegistration(),
+          onPress: () => deleteVehicleRegistrationMutate(),
         },
       ],
     );
@@ -77,7 +83,7 @@ export const Root_SmartParkAndRideEditScreen = ({
         <FullScreenFooter>
           <Button
             expanded={true}
-            onPress={() => handleEditVehicleRegistration()}
+            onPress={() => editVehicleRegistrationMutate()}
             text={t(SmartParkAndRideTexts.edit.button)}
             rightIcon={{svg: Confirm}}
             mode="primary"
@@ -94,26 +100,43 @@ export const Root_SmartParkAndRideEditScreen = ({
         </FullScreenFooter>
       }
     >
-      <Section style={styles.content}>
-        <TextInputSectionItem
-          label={t(SmartParkAndRideTexts.edit.inputs.licensePlate.label)}
-          placeholder={t(
-            SmartParkAndRideTexts.edit.inputs.licensePlate.placeholder,
-          )}
-          onChangeText={setLicensePlate}
-          autoCapitalize="characters"
-          value={licensePlate}
-          inlineLabel={false}
-          autoFocus={true}
-        />
-      </Section>
+      <View style={styles.container}>
+        <Section>
+          <TextInputSectionItem
+            label={t(SmartParkAndRideTexts.edit.inputs.licensePlate.label)}
+            placeholder={t(
+              SmartParkAndRideTexts.edit.inputs.licensePlate.placeholder,
+            )}
+            onChangeText={setLicensePlate}
+            autoCapitalize="characters"
+            value={licensePlate}
+            inlineLabel={false}
+            autoFocus={true}
+          />
+        </Section>
+
+        {editVehicleRegistrationIsError && (
+          <MessageInfoBox
+            type="error"
+            message={t(SmartParkAndRideTexts.edit.error)}
+          />
+        )}
+        {deleteVehicleRegistrationIsError && (
+          <MessageInfoBox
+            type="error"
+            message={t(SmartParkAndRideTexts.edit.delete.error)}
+          />
+        )}
+      </View>
     </FullScreenView>
   );
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  content: {
-    margin: theme.spacing.medium,
+  container: {
+    padding: theme.spacing.medium,
+    display: 'flex',
+    gap: theme.spacing.medium,
   },
   deleteButton: {
     marginTop: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideEditScreen.tsx
+++ b/src/stacks-hierarchy/Root_SmartParkAndRide/Root_SmartParkAndRideEditScreen.tsx
@@ -135,7 +135,6 @@ export const Root_SmartParkAndRideEditScreen = ({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     padding: theme.spacing.medium,
-    display: 'flex',
     gap: theme.spacing.medium,
   },
   deleteButton: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -80,7 +80,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     rowGap: theme.spacing.small,
     marginTop: theme.spacing.large,
     margin: theme.spacing.medium,
-    display: 'flex',
   },
   text: {
     textAlign: 'center',

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -61,6 +61,11 @@ const SmartParkAndRideTexts = {
       },
     },
     button: _('Lagre', 'Save', 'Lagre'),
+    error: _(
+      'Vi klarte ikke lagre endringer. Prøv igjen.',
+      'We could not save changes. Please try again.',
+      'Vi klarte ikkje lagre endringar. Prøv igjen.',
+    ),
     delete: {
       button: _('Fjern kjøretøy', 'Remove vehicle', 'Fjern køyretøy'),
       confirmation: {
@@ -73,6 +78,11 @@ const SmartParkAndRideTexts = {
         cancel: _('Avbryt', 'Cancel', 'Avbryt'),
         confirm: _('Fjern', 'Remove', 'Fjern'),
       },
+      error: _(
+        'Vi klarte ikke fjerne kjøretøyet. Prøv igjen.',
+        'We could not remove the vehicle. Please try again.',
+        'Vi klarte ikkje fjerne køyretøyet. Prøv igjen.',
+      ),
     },
   },
   a11y: {


### PR DESCRIPTION
Implement error handling to display messages when editing or deleting vehicle registrations fails. 

Note: I am aware that both of the error messages are showing at the same time, if the user gets in a situation that can provoke both errors at the same time. I see it as okay.

<details><summary>Screenshots</summary>
<p>

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9b61e6fa-2238-47bf-b5cb-44d2cd9c4c97" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5a60db6a-b486-4481-a87f-173f65177b7b" />


</p>
</details> 