### PR TITLE
test: extract jest mocks to __mocks__ folder

### DIFF
--- a/__mocks__/hooks.ts
+++ b/__mocks__/hooks.ts
@@ -1,0 +1,4 @@
+import React from 'react';
+
+jest.spyOn(React, 'useCallback').mockImplementation((f) => f);
+jest.spyOn(React, 'useMemo').mockImplementation((f) => f());

--- a/__mocks__/imports.ts
+++ b/__mocks__/imports.ts
@@ -1,0 +1,30 @@
+import {LoadingParams} from '@atb/screen-components/loading-screen';
+
+jest.mock('@bugsnag/react-native', () => {});
+jest.mock('@entur-private/abt-mobile-client-sdk', () => {});
+jest.mock('@entur-private/abt-token-server-javascript-interface', () => {});
+jest.mock('@react-native-async-storage/async-storage', () => ({}));
+jest.mock('@react-native-firebase/auth', () => {});
+jest.mock('@react-native-firebase/remote-config', () => {});
+jest.mock('react-native-device-info', () => {});
+jest.mock('react-native-inappbrowser-reborn', () => {});
+
+jest.mock('@atb/api', () => {});
+jest.mock('@atb/modules/configuration', () => {});
+jest.mock('@atb/modules/mobile-token', () => {});
+jest.mock('@atb/modules/ticketing', () => {});
+jest.mock('@atb/modules/time', () => {});
+
+const DEFAULT_AUTH_STATUS: LoadingParams = {
+  isLoadingAppState: false,
+  authStatus: 'authenticated',
+  firestoreConfigStatus: 'success',
+  remoteConfigIsLoaded: true,
+};
+jest.mock('@atb/modules/auth', () => ({
+  useAuthContext: () => ({
+    authStatus: DEFAULT_AUTH_STATUS,
+    abtCustomerId: '1',
+    retryAuth: () => {},
+  }),
+}));

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -13,9 +13,6 @@ import {
 } from '@atb/utils/date';
 import {Language} from '@atb/translations/commons';
 
-jest.mock('@react-native-async-storage/async-storage', () => ({}));
-jest.mock('@bugsnag/react-native', () => ({}));
-
 describe('IterateWithNext', () => {
   it('iterates correctly', () => {
     const empty_array = [] as number[];

--- a/src/modules/fare-contracts/__tests__/fare-contract-validity-units.test.ts
+++ b/src/modules/fare-contracts/__tests__/fare-contract-validity-units.test.ts
@@ -1,35 +1,4 @@
 import {fareContractValidityUnits} from '../fare-contract-validity-units';
-import {LoadingParams} from '@atb/screen-components/loading-screen';
-import React from 'react';
-
-const DEFAULT_MOCK_STATE: LoadingParams = {
-  isLoadingAppState: false,
-  authStatus: 'authenticated',
-  firestoreConfigStatus: 'success',
-  remoteConfigIsLoaded: true,
-};
-
-jest.mock('@atb/modules/mobile-token', () => {});
-jest.mock('@atb/modules/ticketing', () => {});
-jest.mock('@atb/modules/configuration', () => {});
-jest.mock('@atb/api', () => {});
-jest.mock('@atb/modules/time', () => {});
-jest.mock('@react-native-firebase/remote-config', () => {});
-jest.mock('@entur-private/abt-mobile-client-sdk', () => {});
-jest.mock('@bugsnag/react-native', () => {});
-jest.mock('@react-native-firebase/auth', () => {});
-jest.mock('@entur-private/abt-token-server-javascript-interface', () => {});
-jest.mock('react-native-device-info', () => {});
-jest.mock('react-native-inappbrowser-reborn', () => {});
-jest.mock('@atb/modules/auth', () => ({
-  useAuthContext: () => ({
-    authStatus: DEFAULT_MOCK_STATE,
-    abtCustomerId: '1',
-    retryAuth: () => {},
-  }),
-}));
-jest.spyOn(React, 'useCallback').mockImplementation((f) => f);
-jest.spyOn(React, 'useMemo').mockImplementation((f) => f());
 
 describe('fareContractValidityUnits', () => {
   // Constants for readability and maintainability

--- a/src/screen-components/travel-details-screens/__tests__/get-should-show-live-vehicle.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/get-should-show-live-vehicle.test.ts
@@ -1,9 +1,6 @@
 import {getShouldShowLiveVehicle} from '../utils';
 import {EstimatedCallWithMetadata} from '../use-departure-data';
 
-jest.mock('@react-native-async-storage/async-storage', () => ({}));
-jest.mock('@bugsnag/react-native', () => ({}));
-
 const estimatedCallsWhichDepartInGivenMinutes = (
   minutesToDeparture: number,
 ): EstimatedCallWithMetadata[] => {

--- a/src/screen-components/travel-details-screens/__tests__/has-short-wait-time-and-not-guaranteed-correspondance.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/has-short-wait-time-and-not-guaranteed-correspondance.test.ts
@@ -1,9 +1,6 @@
 import {hasShortWaitTimeAndNotGuaranteedCorrespondence} from '../utils';
 import {Leg} from '@atb/api/types/trips';
 
-jest.mock('@react-native-async-storage/async-storage', () => ({}));
-jest.mock('@bugsnag/react-native', () => ({}));
-
 describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
   it('should be false when no short wait time.', () => {
     const legs = [


### PR DESCRIPTION
By putting mocks of common imports and hooks in `__mocks__/`, they will apply to all tests in the repo. This way, we can be slightly less careful about which imports are present in the files we tests.