### PR TITLE
fix: sending in component name as string

### DIFF
--- a/src/modules/bonus/enrollment/BonusOnboarding_BuyTickets.tsx
+++ b/src/modules/bonus/enrollment/BonusOnboarding_BuyTickets.tsx
@@ -13,7 +13,7 @@ export const BonusOnboarding_BuyTicketsScreen = ({}: BuyTicketsScreenProps) => {
   const {t} = useTranslation();
 
   const {navigateToNextScreen} = useEnrollmentOnboarding(
-    BonusOnboarding_BuyTicketsScreen.name,
+    'BonusOnboarding_BuyTicketsScreen',
   );
 
   return (

--- a/src/modules/bonus/enrollment/BonusOnboarding_Download.tsx
+++ b/src/modules/bonus/enrollment/BonusOnboarding_Download.tsx
@@ -18,7 +18,7 @@ export type DownloadScreenProps =
 export const BonusOnboarding_DownloadScreen = ({}: DownloadScreenProps) => {
   const {t} = useTranslation();
   const {navigateToNextScreen} = useEnrollmentOnboarding(
-    BonusOnboarding_DownloadScreen.name,
+    'BonusOnboarding_DownloadScreen',
   );
 
   return (

--- a/src/modules/bonus/enrollment/BonusOnboarding_MoreTravelMethods.tsx
+++ b/src/modules/bonus/enrollment/BonusOnboarding_MoreTravelMethods.tsx
@@ -13,7 +13,7 @@ export const BonusOnboarding_MoreTravelMethodsScreen =
   ({}: MoreTravelMethodsScreenProps) => {
     const {t} = useTranslation();
     const {navigateToNextScreen} = useEnrollmentOnboarding(
-      BonusOnboarding_MoreTravelMethodsScreen.name,
+      'BonusOnboarding_MoreTravelMethodsScreen',
     );
 
     return (

--- a/src/modules/bonus/enrollment/BonusOnboarding_WelcomeScreen.tsx
+++ b/src/modules/bonus/enrollment/BonusOnboarding_WelcomeScreen.tsx
@@ -13,7 +13,7 @@ export const BonusOnboarding_WelcomeScreen = ({}: WelcomeScreenProps) => {
   const {t} = useTranslation();
 
   const {navigateToNextScreen} = useEnrollmentOnboarding(
-    BonusOnboarding_WelcomeScreen.name,
+    'BonusOnboarding_WelcomeScreen',
   );
 
   return (


### PR DESCRIPTION
This seems to work!

I think this shows that we should be careful using component.name in the future, seems to not work as expected in production on iOS