### PR TITLE
fix: use expanded true for buttons in onboarding screens

### DIFF
--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/Root_ConsiderTravelTokenChangeScreen.tsx
@@ -56,7 +56,7 @@ export const Root_ConsiderTravelTokenChangeScreen = () => {
       footerButton={{
         onPress: onPressContinue,
         text: t(ConsiderTravelTokenChangeTexts.nextButton),
-        expanded: false,
+        expanded: true,
       }}
     >
       <View ref={focusRef} accessible>

--- a/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/components/NoTravelTokenInfo.tsx
+++ b/src/stacks-hierarchy/Root_ConsiderTravelTokenChangeScreen/components/NoTravelTokenInfo.tsx
@@ -29,7 +29,7 @@ export function NoTravelTokenInfo({
       footerButton={{
         onPress: onPressFooterButton,
         text: t(MobileTokenOnboardingTexts.ok),
-        expanded: false,
+        expanded: true,
       }}
     >
       <ThemeText

--- a/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseAsAnonymousConsequencesScreen.tsx
@@ -78,7 +78,7 @@ export const AnonymousPurchaseConsequencesScreenComponent = ({
     accessibilityHint: t(
       AnonymousPurchasesTexts.consequences.button.login.a11yHint,
     ),
-    expanded: false,
+    expanded: true,
   };
 
   const continueWithoutLoginButton = {
@@ -88,7 +88,7 @@ export const AnonymousPurchaseConsequencesScreenComponent = ({
       AnonymousPurchasesTexts.consequences.button.accept.a11yHint,
     ),
     rightIcon: onPressLogin ? undefined : {svg: ArrowRight},
-    expanded: false,
+    expanded: true,
   };
 
   return (


### PR DESCRIPTION
Fixes observations from https://mittatb.slack.com/archives/C0116FMPX4Y/p1751958946526719