### PR TITLE
feat: add icons to LinkSectionItems in Profile

### DIFF
--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -6,7 +6,7 @@ import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
 import {StyleSheet} from '@atb/theme';
-import {ContrastColor, TextNames} from '@atb/theme/colors';
+import {ContrastColor, InteractiveColor, TextNames} from '@atb/theme/colors';
 import {LabelType} from '@atb/modules/configuration';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useTranslation} from '@atb/translations';
@@ -27,7 +27,8 @@ type Props = SectionItemProps<{
   /* Label will be placed by the icon. "Beta", "New", etc. */
   label?: LabelType;
   onPress?(event: GestureResponderEvent): void;
-  icon?: IconProps;
+  leftIcon?: IconProps;
+  rightIcon?: IconProps;
   disabled?: boolean;
   accessibility?: AccessibilityProps;
   textType?: TextNames;
@@ -40,7 +41,8 @@ export const LinkSectionItem = forwardRef<any, Props>(
       onPress,
       subtitle,
       label,
-      icon = {svg: ArrowRight},
+      leftIcon,
+      rightIcon = {svg: ArrowRight},
       accessibility,
       disabled,
       textType,
@@ -81,6 +83,9 @@ export const LinkSectionItem = forwardRef<any, Props>(
         <View
           style={[style.spaceBetween, disabledStyle, linkSectionItemStyle.gap]}
         >
+          {leftIcon && (
+            <Icon icon={leftIcon} interactiveColor={interactiveColor} />
+          )}
           <ThemeText
             style={[
               contentContainer,
@@ -97,19 +102,8 @@ export const LinkSectionItem = forwardRef<any, Props>(
               customStyle={{alignSelf: 'center'}}
             />
           )}
-          {icon && (
-            <ThemeIcon
-              svg={icon.svg}
-              color={icon.color}
-              notification={
-                icon.notificationColor
-                  ? {
-                      color: icon.notificationColor,
-                      backgroundColor: interactiveColor.default,
-                    }
-                  : undefined
-              }
-            />
+          {rightIcon && (
+            <Icon icon={rightIcon} interactiveColor={interactiveColor} />
           )}
         </View>
         {subtitle && (
@@ -123,6 +117,29 @@ export const LinkSectionItem = forwardRef<any, Props>(
     );
   },
 );
+
+const Icon = ({
+  icon,
+  interactiveColor,
+}: {
+  icon: IconProps;
+  interactiveColor: InteractiveColor;
+}) => {
+  return (
+    <ThemeIcon
+      svg={icon.svg}
+      color={icon.color}
+      notification={
+        icon.notificationColor
+          ? {
+              color: icon.notificationColor,
+              backgroundColor: interactiveColor.default,
+            }
+          : undefined
+      }
+    />
+  );
+};
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   disabled: {opacity: 0.2},

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -1,21 +1,25 @@
 import React, {forwardRef} from 'react';
 import {AccessibilityProps, GestureResponderEvent, View} from 'react-native';
 import {ThemeText, screenReaderPause} from '@atb/components/text';
-import {
-  NavigationIcon,
-  isNavigationIcon,
-  NavigationIconTypes,
-} from '@atb/components/theme-icon';
+import {ThemeIcon} from '@atb/components/theme-icon';
 import {useSectionItem} from '../use-section-item';
 import {SectionItemProps} from '../types';
 import {useSectionStyle} from '../use-section-style';
 import {StyleSheet} from '@atb/theme';
-import {TextNames} from '@atb/theme/colors';
+import {ContrastColor, TextNames} from '@atb/theme/colors';
 import {LabelType} from '@atb/modules/configuration';
 import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {useTranslation} from '@atb/translations';
 import {TagInfoTexts} from '@atb/translations/components/TagInfo';
 import {Tag} from '@atb/components/tag';
+import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
+import {IconColor} from '@atb/components/theme-icon/ThemeIcon';
+
+type IconProps = {
+  svg: ({fill}: {fill: string}) => JSX.Element;
+  color?: IconColor;
+  notificationColor?: ContrastColor;
+};
 
 type Props = SectionItemProps<{
   text: string;
@@ -23,7 +27,7 @@ type Props = SectionItemProps<{
   /* Label will be placed by the icon. "Beta", "New", etc. */
   label?: LabelType;
   onPress?(event: GestureResponderEvent): void;
-  icon?: NavigationIconTypes | JSX.Element;
+  icon?: IconProps;
   disabled?: boolean;
   accessibility?: AccessibilityProps;
   textType?: TextNames;
@@ -36,7 +40,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
       onPress,
       subtitle,
       label,
-      icon,
+      icon = {svg: ArrowRight},
       accessibility,
       disabled,
       textType,
@@ -50,15 +54,6 @@ export const LinkSectionItem = forwardRef<any, Props>(
       useSectionItem(props);
     const style = useSectionStyle();
     const linkSectionItemStyle = useStyles();
-    const iconEl =
-      isNavigationIcon(icon) || !icon ? (
-        <NavigationIcon
-          mode={icon}
-          color={interactiveColor.default.foreground.primary}
-        />
-      ) : (
-        icon
-      );
     const disabledStyle = disabled ? linkSectionItemStyle.disabled : undefined;
     const accessibilityWithOverrides = disabled
       ? {...accessibility, accessibilityHint: undefined}
@@ -102,7 +97,20 @@ export const LinkSectionItem = forwardRef<any, Props>(
               customStyle={{alignSelf: 'center'}}
             />
           )}
-          {iconEl}
+          {icon && (
+            <ThemeIcon
+              svg={icon.svg}
+              color={icon.color}
+              notification={
+                icon.notificationColor
+                  ? {
+                      color: icon.notificationColor,
+                      backgroundColor: interactiveColor.default,
+                    }
+                  : undefined
+              }
+            />
+          )}
         </View>
         {subtitle && (
           <View style={disabledStyle}>

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -13,7 +13,7 @@ import {useTranslation} from '@atb/translations';
 import {TagInfoTexts} from '@atb/translations/components/TagInfo';
 import {Tag} from '@atb/components/tag';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
-import {IconColor} from '@atb/components/theme-icon/ThemeIcon';
+import {IconColor} from '@atb/components/theme-icon';
 
 type IconProps = {
   svg: ({fill}: {fill: string}) => JSX.Element;

--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -17,9 +17,10 @@ import {
 import React from 'react';
 import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
 
+export type IconColor = ContrastColor | TextColor | Statuses | ColorValue;
 export type ThemeIconProps = {
   svg(props: SvgProps): JSX.Element;
-  color?: ContrastColor | TextColor | ColorValue;
+  color?: IconColor;
   size?: keyof Theme['icon']['size'];
   customSize?: number;
   notification?: Omit<NotificationIndicatorProps, 'iconSize'>;
@@ -70,7 +71,7 @@ export const ThemeIcon = ({
   );
 };
 
-function useColor(color?: ContrastColor | TextColor | Statuses | ColorValue) {
+function useColor(color?: IconColor) {
   const {theme} = useThemeContext();
   if (typeof color === 'object') {
     return color.foreground.primary;

--- a/src/components/theme-icon/index.ts
+++ b/src/components/theme-icon/index.ts
@@ -2,3 +2,4 @@ export {ThemeIcon} from './ThemeIcon';
 export {NavigationIcon, isNavigationIcon} from './NavigationIcon';
 export type {ThemeIconProps} from './ThemeIcon';
 export type {NavigationIconTypes} from './NavigationIcon';
+export type {IconColor} from './ThemeIcon';

--- a/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -36,7 +36,7 @@ export function ActivateNowSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.activateNow.startNow)}
       onPress={onPress}
-      icon={<ThemeIcon svg={TicketValid} />}
+      icon={{svg: TicketValid}}
       ref={onCloseFocusRef}
       {...sectionProps}
     />

--- a/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -1,7 +1,6 @@
 import {TicketValid} from '@atb/assets/svg/mono-icons/ticketing';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {RefObject, useRef} from 'react';
 import {ActivateNowBottomSheet} from './ActivateNowBottomSheet';

--- a/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -36,7 +36,7 @@ export function ActivateNowSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.activateNow.startNow)}
       onPress={onPress}
-      icon={{svg: TicketValid}}
+      rightIcon={{svg: TicketValid}}
       ref={onCloseFocusRef}
       {...sectionProps}
     />

--- a/src/modules/fare-contracts/components/ConsumeCarnetSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetSectionItem.tsx
@@ -39,7 +39,7 @@ export function ConsumeCarnetSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.carnet.activateCarnet)}
       onPress={onPress}
-      icon={<ThemeIcon svg={TicketValid} color={interactiveColor.default} />}
+      icon={{svg: TicketValid, color: interactiveColor.default}}
       interactiveColor={interactiveColor}
       ref={onCloseFocusRef}
       {...sectionProps}

--- a/src/modules/fare-contracts/components/ConsumeCarnetSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetSectionItem.tsx
@@ -1,7 +1,6 @@
 import {TicketValid} from '@atb/assets/svg/mono-icons/ticketing';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {useThemeContext} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {RefObject, useRef} from 'react';

--- a/src/modules/fare-contracts/components/ConsumeCarnetSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetSectionItem.tsx
@@ -39,7 +39,7 @@ export function ConsumeCarnetSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.carnet.activateCarnet)}
       onPress={onPress}
-      icon={{svg: TicketValid, color: interactiveColor.default}}
+      rightIcon={{svg: TicketValid, color: interactiveColor.default}}
       interactiveColor={interactiveColor}
       ref={onCloseFocusRef}
       {...sectionProps}

--- a/src/modules/fare-contracts/components/RefundSectionItem.tsx
+++ b/src/modules/fare-contracts/components/RefundSectionItem.tsx
@@ -40,7 +40,7 @@ export function RefundSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.refund.refund)}
       onPress={onPress}
-      icon={<ThemeIcon svg={TicketInvalid} />}
+      icon={{svg: TicketInvalid}}
       ref={onCloseFocusRef}
       {...sectionProps}
     />

--- a/src/modules/fare-contracts/components/RefundSectionItem.tsx
+++ b/src/modules/fare-contracts/components/RefundSectionItem.tsx
@@ -1,7 +1,6 @@
 import {TicketInvalid} from '@atb/assets/svg/mono-icons/ticketing';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {RefObject, useRef} from 'react';
 import {RefundBottomSheet} from './RefundBottomSheet';

--- a/src/modules/fare-contracts/components/RefundSectionItem.tsx
+++ b/src/modules/fare-contracts/components/RefundSectionItem.tsx
@@ -40,7 +40,7 @@ export function RefundSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.refund.refund)}
       onPress={onPress}
-      icon={{svg: TicketInvalid}}
+      rightIcon={{svg: TicketInvalid}}
       ref={onCloseFocusRef}
       {...sectionProps}
     />

--- a/src/modules/storybook/stories/Section.stories.tsx
+++ b/src/modules/storybook/stories/Section.stories.tsx
@@ -141,7 +141,10 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
                 <InternalLabeledSectionItem label="InternalLabeledSectionItem">
                   <ThemeText>Content</ThemeText>
                 </InternalLabeledSectionItem>
-                <LinkSectionItem text="LinkSectionItem" />
+                <LinkSectionItem
+                  text="LinkSectionItem"
+                  leftIcon={{svg: Warning, color: 'info'}}
+                />
                 <LocationInputSectionItem
                   label="LocationInputSectionItem"
                   onPress={() => {}}

--- a/src/screen-components/favorite-departures/FavoriteDeparturesScreenComponent.tsx
+++ b/src/screen-components/favorite-departures/FavoriteDeparturesScreenComponent.tsx
@@ -78,7 +78,7 @@ export const FavoriteDeparturesScreenComponent = ({
             text={t(FavoriteDeparturesTexts.favoriteItemAdd.label)}
             onPress={onPressAddFavorite}
             testID="addFavoriteDeparture"
-            icon={<ThemeIcon svg={Add} />}
+            icon={{svg: Add}}
           />
         </Section>
       </View>

--- a/src/screen-components/favorite-departures/FavoriteDeparturesScreenComponent.tsx
+++ b/src/screen-components/favorite-departures/FavoriteDeparturesScreenComponent.tsx
@@ -78,7 +78,7 @@ export const FavoriteDeparturesScreenComponent = ({
             text={t(FavoriteDeparturesTexts.favoriteItemAdd.label)}
             onPress={onPressAddFavorite}
             testID="addFavoriteDeparture"
-            icon={{svg: Add}}
+            rightIcon={{svg: Add}}
           />
         </Section>
       </View>

--- a/src/screen-components/favorite-departures/FavoriteDeparturesScreenComponent.tsx
+++ b/src/screen-components/favorite-departures/FavoriteDeparturesScreenComponent.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {Alert, View} from 'react-native';
 import {animateNextChange} from '@atb/utils/animation';
 import {Add} from '@atb/assets/svg/mono-icons/actions';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {
   FavoriteDepartureSectionItem,
   LinkSectionItem,

--- a/src/screen-components/place-screen/components/QuaySection.tsx
+++ b/src/screen-components/place-screen/components/QuaySection.tsx
@@ -169,7 +169,6 @@ export function QuaySection({
         )}
         {shouldShowMoreItemsLink && (
           <LinkSectionItem
-            icon="arrow-right"
             text={t(DeparturesTexts.quaySection.moreDepartures)}
             textType="body__primary--bold"
             onPress={() => navigateToQuay(quay)}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -22,6 +22,7 @@ import {
 } from '@atb/components/sections';
 import {ContentHeading} from '@atb/components/heading';
 import {BorderedInfoBox} from '@atb/components/bordered-info-box';
+import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 
 type Props = {
   userProfiles: UserProfileWithCountAndOffer[];
@@ -121,7 +122,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
         {expanded && (
           <LinkSectionItem
             text={t(PurchaseOverviewTexts.flexDiscount.link)}
-            icon="external-link"
+            icon={{svg: ExternalLink}}
             onPress={() => Linking.openURL(flex_ticket_url)}
             accessibility={{
               accessibilityHint: t(PurchaseOverviewTexts.flexDiscount.a11yHint),

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -122,7 +122,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
         {expanded && (
           <LinkSectionItem
             text={t(PurchaseOverviewTexts.flexDiscount.link)}
-            icon={{svg: ExternalLink}}
+            rightIcon={{svg: ExternalLink}}
             onPress={() => Linking.openURL(flex_ticket_url)}
             accessibility={{
               accessibilityHint: t(PurchaseOverviewTexts.flexDiscount.a11yHint),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -107,7 +107,7 @@ export const Announcement = ({announcement, style}: Props) => {
             )
           }
           textType="body__secondary"
-          icon={
+          rightIcon={
             announcement.actionButton?.actionType === ActionType.external
               ? {svg: ExternalLink}
               : {svg: ArrowRight}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcement.tsx
@@ -26,6 +26,7 @@ import {animateNextChange} from '@atb/utils/animation';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import Bugsnag from '@bugsnag/react-native';
 import {RefObject, useRef} from 'react';
+import {ArrowRight, ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 
 type Props = {
   announcement: AnnouncementType;
@@ -108,8 +109,8 @@ export const Announcement = ({announcement, style}: Props) => {
           textType="body__secondary"
           icon={
             announcement.actionButton?.actionType === ActionType.external
-              ? 'external-link'
-              : 'arrow-right'
+              ? {svg: ExternalLink}
+              : {svg: ArrowRight}
           }
           accessibility={{
             accessibilityHint: t(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -100,7 +100,7 @@ export const DeparturesWidget = ({
             textType="body__secondary"
             text={t(FavoriteDeparturesTexts.favoriteItemAdd.label)}
             onPress={onAddFavouriteDeparture}
-            icon={{svg: Add}}
+            rightIcon={{svg: Add}}
             testID="addFavoriteDeparture"
           />
         </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -100,7 +100,7 @@ export const DeparturesWidget = ({
             textType="body__secondary"
             text={t(FavoriteDeparturesTexts.favoriteItemAdd.label)}
             onPress={onAddFavouriteDeparture}
-            icon={<ThemeIcon svg={Add} />}
+            icon={{svg: Add}}
             testID="addFavoriteDeparture"
           />
         </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -21,7 +21,6 @@ import haversineDistance from 'haversine-distance';
 import React, {useEffect} from 'react';
 import {ActivityIndicator, StyleProp, View, ViewStyle} from 'react-native';
 import {useFavoriteDepartureData} from '../use-favorite-departure-data';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemedNoFavouriteDepartureImage} from '@atb/theme/ThemedAssets';
 import {
   GenericSectionItem,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -177,7 +177,7 @@ export const Profile_BonusScreen = () => {
         <Section>
           <LinkSectionItem
             text={t(BonusProgramTexts.bonusProfile.feedback.button)}
-            icon={{svg: Chat}}
+            rightIcon={{svg: Chat}}
             onPress={() => {
               analytics.logEvent('Bonus', 'Feedback button clicked');
               Intercom.presentSpace(Space.home);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -177,9 +177,7 @@ export const Profile_BonusScreen = () => {
         <Section>
           <LinkSectionItem
             text={t(BonusProgramTexts.bonusProfile.feedback.button)}
-            icon={
-              <ThemeIcon color={theme.color.background.accent[0]} svg={Chat} />
-            }
+            icon={{svg: Chat}}
             onPress={() => {
               analytics.logEvent('Bonus', 'Feedback button clicked');
               Intercom.presentSpace(Space.home);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -22,7 +22,11 @@ import {
 import {useGlobalMessagesContext} from '@atb/modules/global-messages';
 import {APP_GROUP_NAME} from '@env';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {ExpandLess, ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
+import {
+  ArrowUpLeft,
+  ExpandLess,
+  ExpandMore,
+} from '@atb/assets/svg/mono-icons/navigation';
 import {DebugOverride} from './components/DebugOverride';
 import {
   ButtonSectionItem,
@@ -226,12 +230,12 @@ export const Profile_DebugInfoScreen = () => {
           />
           <LinkSectionItem
             text="Copy link to customer in Firestore (staging)"
-            icon="arrow-upleft"
+            icon={{svg: ArrowUpLeft}}
             onPress={() => copyFirestoreLink()}
           />
           <LinkSectionItem
             text="Copy ID token"
-            icon="arrow-upleft"
+            icon={{svg: ArrowUpLeft}}
             onPress={() => copyIdToken()}
           />
           <LinkSectionItem

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -230,12 +230,12 @@ export const Profile_DebugInfoScreen = () => {
           />
           <LinkSectionItem
             text="Copy link to customer in Firestore (staging)"
-            icon={{svg: ArrowUpLeft}}
+            rightIcon={{svg: ArrowUpLeft}}
             onPress={() => copyFirestoreLink()}
           />
           <LinkSectionItem
             text="Copy ID token"
-            icon={{svg: ArrowUpLeft}}
+            rightIcon={{svg: ArrowUpLeft}}
             onPress={() => copyIdToken()}
           />
           <LinkSectionItem

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -110,7 +110,7 @@ export const Profile_DeleteProfileScreen = () => {
           }}
           onPress={() => showDeleteAlert()}
           disabled={hasAvailableFareContracts}
-          icon={{svg: Delete, color: 'error'}}
+          rightIcon={{svg: Delete, color: 'error'}}
         />
       </Section>
     </FullScreenView>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -110,7 +110,7 @@ export const Profile_DeleteProfileScreen = () => {
           }}
           onPress={() => showDeleteAlert()}
           disabled={hasAvailableFareContracts}
-          icon={<ThemeIcon svg={Delete} color="error" />}
+          icon={{svg: Delete, color: 'error'}}
         />
       </Section>
     </FullScreenView>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -11,7 +11,6 @@ import {FullScreenView} from '@atb/components/screen-view';
 import {ThemeText} from '@atb/components/text';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {LinkSectionItem, Section} from '@atb/components/sections';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {useTimeContext} from '@atb/modules/time';
 import {useBeaconsContext} from '@atb/modules/beacons';
 import {tGlobal} from '@atb/modules/locale';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -1092,25 +1092,25 @@ export const Profile_DesignSystemScreen = ({
             text="Disabled link"
             onPress={() => {}}
             disabled
-            icon={{svg: Edit}}
+            rightIcon={{svg: Edit}}
           />
           <LinkSectionItem
             text="Some longer text"
             onPress={() => {}}
-            icon={{svg: Edit}}
+            rightIcon={{svg: Edit}}
           />
           <LinkSectionItem
             text="Dangerous Link Item"
             subtitle="Subtitle text"
             onPress={() => {}}
-            icon={{svg: Delete, color: 'error'}}
+            rightIcon={{svg: Delete, color: 'error'}}
           />
           <LinkSectionItem
             text="Disabled Dangerous Link Item text"
             subtitle="Disabled Subtitle text"
             disabled={true}
             onPress={() => {}}
-            icon={{svg: Delete, color: 'error'}}
+            rightIcon={{svg: Delete, color: 'error'}}
           />
           <LinkSectionItem
             text="Link with interactiveColor"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -1092,25 +1092,25 @@ export const Profile_DesignSystemScreen = ({
             text="Disabled link"
             onPress={() => {}}
             disabled
-            icon={<ThemeIcon svg={Edit} />}
+            icon={{svg: Edit}}
           />
           <LinkSectionItem
             text="Some longer text"
             onPress={() => {}}
-            icon={<ThemeIcon svg={Edit} />}
+            icon={{svg: Edit}}
           />
           <LinkSectionItem
             text="Dangerous Link Item"
             subtitle="Subtitle text"
             onPress={() => {}}
-            icon={<ThemeIcon svg={Delete} color="error" />}
+            icon={{svg: Delete, color: 'error'}}
           />
           <LinkSectionItem
             text="Disabled Dangerous Link Item text"
             subtitle="Disabled Subtitle text"
             disabled={true}
             onPress={() => {}}
-            icon={<ThemeIcon svg={Delete} color="error" />}
+            icon={{svg: Delete, color: 'error'}}
           />
           <LinkSectionItem
             text="Link with interactiveColor"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
@@ -76,14 +76,14 @@ export const Profile_FavoriteListScreen = ({navigation}: Props) => {
             <LinkSectionItem
               text={t(FavoriteListTexts.buttons.changeOrder)}
               onPress={onSortClick}
-              icon={<ThemeIcon svg={SvgReorder} />}
+              icon={{svg: SvgReorder}}
               testID="changeOrderButton"
             />
           )}
           <LinkSectionItem
             text={t(FavoriteListTexts.buttons.addFavorite)}
             onPress={onAddButtonClick}
-            icon={<ThemeIcon svg={Add} />}
+            icon={{svg: Add}}
             testID="addFavoriteButton"
           />
         </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
@@ -1,7 +1,6 @@
 import {Add} from '@atb/assets/svg/mono-icons/actions';
 import SvgReorder from '@atb/assets/svg/mono-icons/actions/Reorder';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {
   StoredLocationFavorite,
   useFavoritesContext,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FavoriteListScreen.tsx
@@ -76,14 +76,14 @@ export const Profile_FavoriteListScreen = ({navigation}: Props) => {
             <LinkSectionItem
               text={t(FavoriteListTexts.buttons.changeOrder)}
               onPress={onSortClick}
-              icon={{svg: SvgReorder}}
+              rightIcon={{svg: SvgReorder}}
               testID="changeOrderButton"
             />
           )}
           <LinkSectionItem
             text={t(FavoriteListTexts.buttons.addFavorite)}
             onPress={onAddButtonClick}
-            icon={{svg: Add}}
+            rightIcon={{svg: Add}}
             testID="addFavoriteButton"
           />
         </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
@@ -15,6 +15,7 @@ import Bugsnag from '@bugsnag/react-native';
 import {Support} from '@atb/assets/svg/mono-icons/actions';
 import {CustomerServiceText} from '@atb/translations/screens/subscreens/CustomerService';
 import {ThemedContactIllustration} from '@atb/theme/ThemedAssets';
+import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 
 export const Profile_HelpAndContactScreen = () => {
   const style = useStyle();
@@ -67,7 +68,7 @@ export const Profile_HelpAndContactScreen = () => {
             {!!contactFormUrl?.trim() && (
               <LinkSectionItem
                 text={t(ProfileTexts.sections.contact.contactForm)}
-                icon="external-link"
+                rightIcon={{svg: ExternalLink}}
                 onPress={() => openLink(contactFormUrl)}
                 accessibility={{
                   accessibilityHint: t(
@@ -81,7 +82,7 @@ export const Profile_HelpAndContactScreen = () => {
             {!!lostAndFoundUrl?.trim() && (
               <LinkSectionItem
                 text={t(ProfileTexts.sections.contact.lostAndFound)}
-                icon="external-link"
+                rightIcon={{svg: ExternalLink}}
                 onPress={() => openLink(lostAndFoundUrl)}
                 accessibility={{
                   accessibilityHint: t(
@@ -95,7 +96,7 @@ export const Profile_HelpAndContactScreen = () => {
             {!!refundInfoUrl?.trim() && (
               <LinkSectionItem
                 text={t(ProfileTexts.sections.contact.refund)}
-                icon="external-link"
+                rightIcon={{svg: ExternalLink}}
                 onPress={() => openLink(refundInfoUrl)}
                 accessibility={{
                   accessibilityHint: t(
@@ -109,7 +110,7 @@ export const Profile_HelpAndContactScreen = () => {
             {!!frequentlyAskedQuestionsUrl?.trim() && (
               <LinkSectionItem
                 text={t(ProfileTexts.sections.contact.frequentlyAskedQuestions)}
-                icon="external-link"
+                rightIcon={{svg: ExternalLink}}
                 onPress={() => openLink(frequentlyAskedQuestionsUrl)}
                 accessibility={{
                   accessibilityHint: t(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
@@ -50,7 +50,7 @@ export const Profile_InformationScreen = () => {
         <Section>
           {ticketingInfoUrl && (
             <LinkSectionItem
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.ticketing
                   .label,
@@ -68,7 +68,7 @@ export const Profile_InformationScreen = () => {
           )}
           {termsInfoUrl && (
             <LinkSectionItem
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.terms.label,
               )}
@@ -86,7 +86,7 @@ export const Profile_InformationScreen = () => {
 
           {inspectionInfoUrl && (
             <LinkSectionItem
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.inspection
                   .label,
@@ -105,7 +105,7 @@ export const Profile_InformationScreen = () => {
 
           {refundInfoUrl && (
             <LinkSectionItem
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.refund.label,
               )}
@@ -122,7 +122,7 @@ export const Profile_InformationScreen = () => {
           )}
           {a11yStatementUrl && (
             <LinkSectionItem
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems
                   .accessibilityStatement.label,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
@@ -50,7 +50,7 @@ export const Profile_InformationScreen = () => {
         <Section>
           {ticketingInfoUrl && (
             <LinkSectionItem
-              icon={<ThemeIcon svg={ExternalLink} />}
+              icon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.ticketing
                   .label,
@@ -68,7 +68,7 @@ export const Profile_InformationScreen = () => {
           )}
           {termsInfoUrl && (
             <LinkSectionItem
-              icon={<ThemeIcon svg={ExternalLink} />}
+              icon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.terms.label,
               )}
@@ -86,7 +86,7 @@ export const Profile_InformationScreen = () => {
 
           {inspectionInfoUrl && (
             <LinkSectionItem
-              icon={<ThemeIcon svg={ExternalLink} />}
+              icon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.inspection
                   .label,
@@ -105,7 +105,7 @@ export const Profile_InformationScreen = () => {
 
           {refundInfoUrl && (
             <LinkSectionItem
-              icon={<ThemeIcon svg={ExternalLink} />}
+              icon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems.refund.label,
               )}
@@ -122,7 +122,7 @@ export const Profile_InformationScreen = () => {
           )}
           {a11yStatementUrl && (
             <LinkSectionItem
-              icon={<ThemeIcon svg={ExternalLink} />}
+              icon={{svg: ExternalLink}}
               text={t(
                 ProfileTexts.sections.information.linkSectionItems
                   .accessibilityStatement.label,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import {Linking, View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -87,7 +87,7 @@ export const Profile_PaymentMethodsScreen = () => {
           <LinkSectionItem
             text={t(PaymentMethodsTexts.addPaymentMethod)}
             onPress={onAddRecurringPayment}
-            icon={<ThemeIcon svg={Add} />}
+            icon={{svg: Add}}
           />
         </Section>
         <MessageInfoBox

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -87,7 +87,7 @@ export const Profile_PaymentMethodsScreen = () => {
           <LinkSectionItem
             text={t(PaymentMethodsTexts.addPaymentMethod)}
             onPress={onAddRecurringPayment}
-            icon={{svg: Add}}
+            rightIcon={{svg: Add}}
           />
         </Section>
         <MessageInfoBox

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -8,7 +8,6 @@ import {
   Section,
 } from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {humanizePaymentType, RecurringPayment} from '@atb/modules/ticketing';
 import {useTranslation} from '@atb/translations';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -130,7 +130,7 @@ export const Profile_PrivacyScreen = () => {
             text={t(
               ProfileTexts.sections.privacy.linkSectionItems.privacy.label,
             )}
-            icon={{svg: ExternalLink}}
+            rightIcon={{svg: ExternalLink}}
             accessibility={{
               accessibilityHint: t(
                 ProfileTexts.sections.privacy.linkSectionItems.privacy.a11yHint,
@@ -151,7 +151,7 @@ export const Profile_PrivacyScreen = () => {
               subtitle={t(
                 PrivacySettingsTexts.sections.items.controlPanel.subTitle,
               )}
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               accessibility={{
                 accessibilityHint: t(
                   PrivacySettingsTexts.sections.items.controlPanel.a11yHint,
@@ -181,7 +181,7 @@ export const Profile_PrivacyScreen = () => {
                 ),
                 accessibilityRole: 'link',
               }}
-              icon={{svg: ExternalLink}}
+              rightIcon={{svg: ExternalLink}}
               testID="dataSharingInfoButton"
               onPress={async () => {
                 Linking.openURL(dataSharingInfoUrl);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PrivacyScreen.tsx
@@ -25,6 +25,7 @@ import {
 import {FullScreenView} from '@atb/components/screen-view';
 import {ContentHeading, ScreenHeading} from '@atb/components/heading';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 
 export const Profile_PrivacyScreen = () => {
   const {t, language} = useTranslation();
@@ -129,7 +130,7 @@ export const Profile_PrivacyScreen = () => {
             text={t(
               ProfileTexts.sections.privacy.linkSectionItems.privacy.label,
             )}
-            icon="external-link"
+            icon={{svg: ExternalLink}}
             accessibility={{
               accessibilityHint: t(
                 ProfileTexts.sections.privacy.linkSectionItems.privacy.a11yHint,
@@ -150,7 +151,7 @@ export const Profile_PrivacyScreen = () => {
               subtitle={t(
                 PrivacySettingsTexts.sections.items.controlPanel.subTitle,
               )}
-              icon="external-link"
+              icon={{svg: ExternalLink}}
               accessibility={{
                 accessibilityHint: t(
                   PrivacySettingsTexts.sections.items.controlPanel.a11yHint,
@@ -180,7 +181,7 @@ export const Profile_PrivacyScreen = () => {
                 ),
                 accessibilityRole: 'link',
               }}
-              icon="external-link"
+              icon={{svg: ExternalLink}}
               testID="dataSharingInfoButton"
               onPress={async () => {
                 Linking.openURL(dataSharingInfoUrl);

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -1,4 +1,9 @@
-import {LogIn, LogOut} from '@atb/assets/svg/mono-icons/profile';
+import {
+  LogIn,
+  LogOut,
+  NewConcept,
+  Settings,
+} from '@atb/assets/svg/mono-icons/profile';
 import {ActivityIndicatorOverlay} from '@atb/components/activity-indicator-overlay';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {LinkSectionItem, Section} from '@atb/components/sections';
@@ -29,6 +34,11 @@ import {
 import {ClickableCopy} from './components/ClickableCopy';
 import {UserInfo} from './components/UserInfo';
 import {Button} from '@atb/components/button';
+import {Card, Receipt} from '@atb/assets/svg/mono-icons/ticketing';
+import {Star} from '@atb/assets/svg/mono-icons/bonus';
+import {Favorite} from '@atb/assets/svg/mono-icons/places';
+import {Car} from '@atb/assets/svg/mono-icons/transportation';
+import {Info, Unknown} from '@atb/assets/svg/mono-icons/status';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -100,6 +110,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             <Section>
               <LinkSectionItem
                 text={t(ProfileTexts.sections.settings.heading)}
+                leftIcon={{svg: Settings}}
                 onPress={() => navigation.navigate('Profile_SettingsScreen')}
                 testID="settingsButton"
               />
@@ -110,6 +121,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   text={t(
                     ProfileTexts.sections.account.linkSectionItems.bonus.label,
                   )}
+                  leftIcon={{svg: Star}}
                   onPress={() => navigation.navigate('Profile_BonusScreen')}
                   testID="BonusButton"
                   label="new"
@@ -127,6 +139,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 ProfileTexts.sections.account.linkSectionItems.ticketHistory
                   .label,
               )}
+              leftIcon={{svg: Receipt}}
               onPress={() =>
                 navigation.navigate('Profile_TicketHistorySelectionScreen')
               }
@@ -138,6 +151,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   ProfileTexts.sections.account.linkSectionItems.paymentMethods
                     .label,
                 )}
+                leftIcon={{svg: Card}}
                 onPress={() =>
                   navigation.navigate('Profile_PaymentMethodsScreen')
                 }
@@ -145,6 +159,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             )}
             <LinkSectionItem
               text={t(ProfileTexts.sections.favorites.heading)}
+              leftIcon={{svg: Favorite}}
               onPress={() => navigation.navigate('Profile_FavoriteScreen')}
               testID="favoriteButton"
             />
@@ -154,6 +169,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   ProfileTexts.sections.account.linkSectionItems
                     .smartParkAndRide.label,
                 )}
+                leftIcon={{svg: Car}}
                 onPress={() =>
                   navigation.navigate('Profile_SmartParkAndRideScreen')
                 }
@@ -170,6 +186,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 ProfileTexts.sections.settings.linkSectionItems.enrollment
                   .label,
               )}
+              leftIcon={{svg: NewConcept}}
               onPress={() => navigation.navigate('Profile_EnrollmentScreen')}
               testID="invitationCodeButton"
             />
@@ -182,6 +199,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               <Section>
                 <LinkSectionItem
                   text={t(ProfileTexts.sections.information.label)}
+                  leftIcon={{svg: Info}}
                   onPress={() =>
                     navigation.navigate('Profile_InformationScreen')
                   }
@@ -193,6 +211,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
           <ContentHeading text={t(ProfileTexts.sections.contact.heading)} />
           <Section>
             <LinkSectionItem
+              leftIcon={{svg: Unknown}}
               text={t(ProfileTexts.sections.contact.helpAndContact)}
               onPress={() =>
                 navigation.navigate('Profile_HelpAndContactScreen')

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SettingsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SettingsScreen.tsx
@@ -9,6 +9,17 @@ import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {ProfileScreenProps} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types';
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
 import {useAuthContext} from '@atb/modules/auth';
+import {AccesstbilityCircle} from '@atb/assets/svg/mono-icons/miscellaneous';
+import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
+import {Phone} from '@atb/assets/svg/mono-icons/devices';
+import {Profile} from '@atb/assets/svg/mono-icons/tab-bar';
+import {
+  Language,
+  Notification,
+  Privacy,
+  Theme as ThemeIcon,
+} from '@atb/assets/svg/mono-icons/profile';
+import {House} from '@atb/assets/svg/mono-icons/places';
 
 type ProfileProps = ProfileScreenProps<'Profile_SettingsScreen'>;
 
@@ -48,6 +59,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
               text={t(
                 ProfileTexts.sections.settings.linkSectionItems.travelAid.label,
               )}
+              leftIcon={{svg: AccesstbilityCircle}}
               onPress={() => navigation.navigate('Profile_TravelAidScreen')}
               testID="travelAidButton"
             />
@@ -59,6 +71,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
                 ProfileTexts.sections.settings.linkSectionItems.userProfile
                   .label,
               )}
+              leftIcon={{svg: Travellers}}
               onPress={() =>
                 navigation.navigate('Profile_DefaultUserProfileScreen')
               }
@@ -79,6 +92,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
                         .travelToken.label,
                     )
               }
+              leftIcon={{svg: Phone}}
               onPress={() => navigation.navigate('Profile_TravelTokenScreen')}
               testID="travelTokenButton"
             />
@@ -89,6 +103,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
                 ProfileTexts.sections.account.linkSectionItems.editProfile
                   .label,
               )}
+              leftIcon={{svg: Profile}}
               onPress={() => navigation.navigate('Profile_EditProfileScreen')}
             />
           )}
@@ -102,6 +117,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.appearance.label,
             )}
+            leftIcon={{svg: ThemeIcon}}
             onPress={() => navigation.navigate('Profile_AppearanceScreen')}
             testID="appearanceButton"
           />
@@ -109,6 +125,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.startScreen.label,
             )}
+            leftIcon={{svg: House}}
             onPress={() =>
               navigation.navigate('Profile_SelectStartScreenScreen')
             }
@@ -118,6 +135,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.language.label,
             )}
+            leftIcon={{svg: Language}}
             onPress={() => navigation.navigate('Profile_LanguageScreen')}
             testID="languageButton"
           />
@@ -125,6 +143,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
             text={t(
               ProfileTexts.sections.settings.linkSectionItems.privacy.label,
             )}
+            leftIcon={{svg: Privacy}}
             onPress={() => navigation.navigate('Profile_PrivacyScreen')}
             testID="privacyButton"
           />
@@ -134,6 +153,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
                 ProfileTexts.sections.settings.linkSectionItems.notifications
                   .label,
               )}
+              leftIcon={{svg: Notification}}
               onPress={() => navigation.navigate('Profile_NotificationsScreen')}
               testID="notificationsButton"
             />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -71,7 +71,7 @@ export const Profile_SmartParkAndRideScreen = () => {
                 transitionOverride: 'slide-from-right',
               })
             }
-            icon={<ThemeIcon svg={Add} />}
+            icon={{svg: Add}}
           />
         </Section>
       </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -71,7 +71,7 @@ export const Profile_SmartParkAndRideScreen = () => {
                 transitionOverride: 'slide-from-right',
               })
             }
-            icon={{svg: Add}}
+            rightIcon={{svg: Add}}
           />
         </Section>
       </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -8,7 +8,6 @@ import {
   Section,
   SelectionInlineSectionItem,
 } from '@atb/components/sections';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {Add, Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ContentHeading} from '@atb/components/heading';
 import {useNavigation} from '@react-navigation/native';


### PR DESCRIPTION
Adds `rightIcon` and `leftIcon` props to LinkSectionItem, using the same patterns as the Button component, as well as adds icons to the Profile and Settings page.

<img width="300px" src="https://github.com/user-attachments/assets/ddaf6a69-993d-4c5f-a670-56563263a880">
<img width="300px" src="https://github.com/user-attachments/assets/4dfc5c35-adca-48cc-8c26-fd117894e2e0">

closes https://github.com/AtB-AS/kundevendt/issues/20067
