### PR TITLE
fix: prevent LinkSectionItems from growing vertically to fit tag

### DIFF
--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -99,7 +99,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
             <Tag
               labels={[t(TagInfoTexts.labels[label].text)]}
               tagType="primary"
-              customStyle={{alignSelf: 'center'}}
+              customStyle={linkSectionItemStyle.tag}
             />
           )}
           {rightIcon && (
@@ -144,4 +144,10 @@ const Icon = ({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   disabled: {opacity: 0.2},
   gap: {gap: theme.spacing.small},
+  tag: {
+    alignSelf: 'center',
+    // Slight hack to prevent the section item from growing beyond normal size
+    // to fit the tag.
+    marginVertical: -theme.spacing.xSmall,
+  },
 }));


### PR DESCRIPTION
https://github.com/AtB-AS/mittatb-app/pull/5333#issuecomment-3073363038 

I'm not proud of this, but it was too easy of a fix not to do 🙈 

<img width="300px" src="https://github.com/user-attachments/assets/39afa39f-03d0-4b64-b6c2-eca4504de331">
