### PR TITLE
feat(spar): hide add button if max no. of vehicles

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -1,4 +1,4 @@
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {TranslateFunction, useTranslation} from '@atb/translations';
 import {View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
@@ -10,6 +10,8 @@ import {
 } from '@atb/components/sections';
 import {Add, Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ContentHeading} from '@atb/components/heading';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {ThemeText} from '@atb/components/text';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {CarFill} from '@atb/assets/svg/mono-icons/transportation';
@@ -18,12 +20,19 @@ import {
   VehicleRegistration,
 } from '@atb/modules/smart-park-and-ride';
 import {spellOut} from '@atb/utils/accessibility';
+import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
+
+const MAX_VEHICLE_REGISTRATIONS = 2;
 
 export const Profile_SmartParkAndRideScreen = () => {
   const {t} = useTranslation();
+  const {themeName} = useThemeContext();
   const styles = useStyles();
   const navigation = useNavigation<RootNavigationProps>();
   const {data: vehicleRegistrations} = useVehicleRegistrationsQuery();
+
+  const canAddVehicleRegistrations =
+    (vehicleRegistrations?.length ?? 0) < MAX_VEHICLE_REGISTRATIONS;
 
   return (
     <FullScreenView
@@ -63,16 +72,25 @@ export const Profile_SmartParkAndRideScreen = () => {
             />
           ))}
 
-          <LinkSectionItem
-            text={t(SmartParkAndRideTexts.content.addVehicle)}
-            onPress={() =>
-              navigation.navigate('Root_SmartParkAndRideAddScreen', {
-                transitionOverride: 'slide-from-right',
-              })
-            }
-            rightIcon={{svg: Add}}
-          />
+          {canAddVehicleRegistrations && (
+            <LinkSectionItem
+              text={t(SmartParkAndRideTexts.content.addVehicle)}
+              onPress={() =>
+                navigation.navigate('Root_SmartParkAndRideAddScreen', {
+                  transitionOverride: 'slide-from-right',
+                })
+              }
+              rightIcon={{svg: Add}}
+            />
+          )}
         </Section>
+
+        {!canAddVehicleRegistrations && (
+          <View style={styles.maxVehiclesInfo}>
+            <ThemeIcon svg={statusTypeToIcon('info', true, themeName)} />
+            <ThemeText>{t(SmartParkAndRideTexts.add.max)}</ThemeText>
+          </View>
+        )}
       </View>
     </FullScreenView>
   );
@@ -106,5 +124,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   text: {
     textAlign: 'center',
+  },
+  maxVehiclesInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.small,
+    marginTop: theme.spacing.xSmall,
   },
 }));

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -24,6 +24,11 @@ const SmartParkAndRideTexts = {
         'Skriv inn skiltnummer og valfritt namn. Du kan leggje til maks to køyretøy.',
       ),
     },
+    max: _(
+      'Du kan legge til maks to kjøretøy',
+      'You can add a maximum of two vehicles',
+      'Du kan leggje til maks to køyretøy',
+    ),
     inputs: {
       nickname: {
         label: _('Navn', 'Name', 'Namn'),


### PR DESCRIPTION
Added a conditional check to hide the add button if the number of registered vehicles has been met, and show information text if so.

<details><summary>Screenshots</summary>
<p>

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/596b5d55-affe-462a-875b-014e1749e92f" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9c40f679-3e89-4759-a0d6-cdac219f772e" />


</p>
</details> 