### PR TITLE
fix: sort fare contracts by validity

### DIFF
--- a/src/modules/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/modules/fare-contracts/FareContractAndReservationsList.tsx
@@ -4,7 +4,6 @@ import {Reservation} from '@atb/modules/ticketing';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {EmptyState} from '@atb/components/empty-state';
 import {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation';
-import {getFareContractInfo} from './utils';
 import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
 import type {EmptyStateProps} from '@atb/components/empty-state';
@@ -40,9 +39,6 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
       abtCustomerId,
       now,
       fcOrReservations,
-      (currentTime, fareContract, currentUserId) =>
-        getFareContractInfo(currentTime, fareContract, currentUserId)
-          .validityStatus,
     );
 
   return (

--- a/src/modules/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/modules/fare-contracts/FareContractAndReservationsList.tsx
@@ -3,12 +3,11 @@ import {FareContractOrReservation} from './FareContractOrReservation';
 import {Reservation} from '@atb/modules/ticketing';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {EmptyState} from '@atb/components/empty-state';
-import {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation';
+import {getSortedFareContractsAndReservations} from './sort-fc-or-reservation';
 import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
 import type {EmptyStateProps} from '@atb/components/empty-state';
 import {FareContractType} from '@atb-as/utils';
-import {useAuthContext} from '@atb/modules/auth';
 
 type Props = {
   reservations: Reservation[];
@@ -30,23 +29,19 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
 }) => {
   const styles = useStyles();
   const analytics = useAnalyticsContext();
-  const {abtCustomerId} = useAuthContext();
 
-  const fcOrReservations = [...fareContracts, ...reservations];
-
-  const fareContractsAndReservationsSorted =
-    sortFcOrReservationByValidityAndCreation(
-      abtCustomerId,
-      now,
-      fcOrReservations,
-    );
+  const fcAndReservations = getSortedFareContractsAndReservations(
+    fareContracts,
+    reservations,
+    now,
+  );
 
   return (
     <View style={styles.container}>
-      {!fareContractsAndReservationsSorted.length && (
+      {!fcAndReservations.length && (
         <EmptyState {...emptyStateConfig} testID="fareContracts" />
       )}
-      {fareContractsAndReservationsSorted?.map((fcOrReservation, index) => (
+      {fcAndReservations?.map((fcOrReservation, index) => (
         <FareContractOrReservation
           now={now}
           onPressFareContract={() => {

--- a/src/modules/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/modules/fare-contracts/FareContractAndReservationsList.tsx
@@ -3,11 +3,13 @@ import {FareContractOrReservation} from './FareContractOrReservation';
 import {Reservation} from '@atb/modules/ticketing';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {EmptyState} from '@atb/components/empty-state';
+import {sortFcOrReservationByValidityAndCreation} from './sort-fc-or-reservation';
+import {getFareContractInfo} from './utils';
 import {StyleSheet} from '@atb/theme';
 import {View} from 'react-native';
 import type {EmptyStateProps} from '@atb/components/empty-state';
 import {FareContractType} from '@atb-as/utils';
-import {getSortedFareContractsAndReservations} from '@atb/modules/fare-contracts';
+import {useAuthContext} from '@atb/modules/auth';
 
 type Props = {
   reservations: Reservation[];
@@ -29,8 +31,19 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
 }) => {
   const styles = useStyles();
   const analytics = useAnalyticsContext();
+  const {abtCustomerId} = useAuthContext();
+
+  const fcOrReservations = [...fareContracts, ...reservations];
+
   const fareContractsAndReservationsSorted =
-    getSortedFareContractsAndReservations([...fareContracts, ...reservations]);
+    sortFcOrReservationByValidityAndCreation(
+      abtCustomerId,
+      now,
+      fcOrReservations,
+      (currentTime, fareContract, currentUserId) =>
+        getFareContractInfo(currentTime, fareContract, currentUserId)
+          .validityStatus,
+    );
 
   return (
     <View style={styles.container}>

--- a/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
+++ b/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
@@ -1,156 +1,138 @@
-import type {ValidityStatus} from '../utils';
-import {Reservation} from '@atb/modules/ticketing';
-
-import {addMinutes} from 'date-fns';
+import {PaymentStatus, Reservation} from '@atb/modules/ticketing';
 import {
+  getSortedFareContractsAndReservations,
   sortFcOrReservationByCreation,
-  sortFcOrReservationByValidityAndCreation,
 } from '../sort-fc-or-reservation';
-import {FareContractType, TravelRightType} from '@atb-as/utils';
+import {
+  FareContractState,
+  FareContractType,
+  TravelRightType,
+} from '@atb-as/utils';
+import {ONE_HOUR_MS, ONE_MINUTE_MS} from '@atb/utils/durations';
 
-type MockedFareContract = FareContractType & {
-  validityStatus: ValidityStatus;
-};
-
-type MockedReservation = Reservation & {
-  validityStatus: ValidityStatus;
-};
+const now = new Date('2000-01-01T12:00:00Z').valueOf();
 
 function mockupFareContract(
-  id: string,
-  validityStatus: ValidityStatus,
-  minutes: number,
-): MockedFareContract {
+  testRef: string,
+  startDate: Date,
+): FareContractType & {testRef: string} {
   return {
-    id: id,
-    created: addMinutes(new Date(), minutes),
-    version: '1',
-    customerAccountId: '1',
-    purchasedBy: '1',
-    orderId: '1',
-    state: 0,
-    totalAmount: '0',
-    travelRights: [{} as any as TravelRightType],
-    qrCode: '',
-    validityStatus: validityStatus,
-    paymentType: ['VISA'],
-    totalTaxAmount: '0',
-  };
+    testRef,
+    state: FareContractState.Activated,
+    created: startDate,
+    travelRights: [
+      {
+        startDateTime: startDate,
+        endDateTime: new Date(now + ONE_HOUR_MS),
+      } as unknown as TravelRightType,
+    ],
+  } as unknown as FareContractType & {testRef: string};
+}
+
+function mockupCarnet(
+  testRef: string,
+  startDate: Date,
+): FareContractType & {testRef: string} {
+  const base = mockupFareContract(testRef, new Date(now - ONE_HOUR_MS));
+  return {
+    ...base,
+    travelRights: [
+      {
+        ...base.travelRights[0],
+        maximumNumberOfAccesses: 1,
+        numberOfUsedAccesses: 1,
+        usedAccesses: [
+          {
+            startDateTime: startDate,
+            endDateTime: new Date(now + ONE_HOUR_MS),
+          },
+        ],
+      },
+    ],
+  } as FareContractType & {testRef: string};
 }
 
 function mockupReservation(
-  id: string,
-  validityStatus: ValidityStatus,
-  minutes: number,
-): MockedReservation {
+  testRef: string,
+  createdDate: Date,
+  paymentStatus: PaymentStatus,
+): Reservation {
   return {
-    orderId: id,
-    created: addMinutes(new Date(), minutes),
-    paymentId: 1,
-    transactionId: 1,
-    paymentType: 2,
-    url: 'http://example.com',
-    validityStatus: validityStatus,
-  };
+    testRef,
+    created: createdDate,
+    paymentStatus,
+  } as unknown as Reservation & {testRef: string};
 }
 
 describe('Sort by Validity', () => {
-  const now = Date.now();
-
-  it('Should sort fc or reservation by validity first', async () => {
-    const fcOrReservations: (FareContractType | Reservation)[] = [
-      mockupFareContract('1', 'valid', -1),
-      mockupFareContract('2', 'valid', -2),
-      mockupReservation('3', 'valid', 0),
+  it('Should sort reservation by created date', () => {
+    const fareContracts: FareContractType[] = [];
+    const reservations: Reservation[] = [
+      mockupReservation('2', new Date(now - ONE_MINUTE_MS * 2), 'INITIATE'),
+      mockupReservation('1', new Date(now - ONE_MINUTE_MS * 1), 'INITIATE'),
+      mockupReservation('3', new Date(now - ONE_MINUTE_MS * 3), 'INITIATE'),
     ];
-
-    const result = sortFcOrReservationByValidityAndCreation(
-      '',
+    const result = getSortedFareContractsAndReservations(
+      fareContracts,
+      reservations,
       now,
-      fcOrReservations,
-    );
-    const ids: string[] = result.map((fcOrReservation) => {
-      const isFareContract = 'travelRights' in fcOrReservation;
-      if (isFareContract) {
-        return fcOrReservation.id;
-      } else {
-        return fcOrReservation.orderId;
-      }
-    });
+    ) as (FareContractType | (Reservation & {testRef: string}))[];
 
-    expect(ids).toEqual(['3', '1', '2']);
+    expect(result.map((r) => (r as any).testRef)).toEqual(['1', '2', '3']);
   });
 
-  it('Reservation should be first if reservation is being processing', async () => {
-    const fcOrReservations: (FareContractType | Reservation)[] = [
-      mockupFareContract('1', 'valid', -1),
-      mockupReservation('3', 'reserving', 0),
-      mockupFareContract('2', 'valid', 0),
+  it('Should sort fc and reservation by validity', async () => {
+    const fareContracts: FareContractType[] = [
+      mockupFareContract('3', new Date(now - ONE_MINUTE_MS * 3)),
+      mockupFareContract('1', new Date(now - ONE_MINUTE_MS * 1)),
+      mockupFareContract('4', new Date(now + ONE_MINUTE_MS * 1)),
     ];
 
-    const result = sortFcOrReservationByValidityAndCreation(
-      '',
-      now,
-      fcOrReservations,
-    );
-    const ids: string[] = result.map((fcOrReservation) => {
-      const isFareContract = 'travelRights' in fcOrReservation;
-      if (isFareContract) {
-        return fcOrReservation.id;
-      } else {
-        return fcOrReservation.orderId;
-      }
-    });
+    const reservations: Reservation[] = [
+      mockupReservation('2', new Date(now - ONE_MINUTE_MS * 2), 'INITIATE'),
+    ];
 
-    expect(ids).toEqual(['3', '2', '1']);
+    const result = getSortedFareContractsAndReservations(
+      fareContracts,
+      reservations,
+      now,
+    ) as (FareContractType | (Reservation & {testRef: string}))[];
+    expect(result.map((i) => (i as any).testRef)).toEqual(['1', '2', '3', '4']);
   });
 
-  it('Multiple reservations and valid fare contracts', async () => {
-    const fcOrReservations: (FareContractType | Reservation)[] = [
-      mockupReservation('1', 'reserving', 0),
-      mockupReservation('2', 'reserving', 0.1),
-      mockupFareContract('3', 'valid', 0.1),
-      mockupFareContract('4', 'valid', 0.11),
+  it('Should place inactive carnet behind active fare contracts', () => {
+    const fareContracts: FareContractType[] = [
+      mockupCarnet('1', new Date(now + ONE_MINUTE_MS)),
+      mockupFareContract('2', new Date(now - ONE_MINUTE_MS)),
     ];
-
-    const result = sortFcOrReservationByValidityAndCreation(
-      '',
+    const reservations: Reservation[] = [];
+    const result = getSortedFareContractsAndReservations(
+      fareContracts,
+      reservations,
       now,
-      fcOrReservations,
-    );
-    const ids: string[] = result.map((fcOrReservation) => {
-      const isFareContract = 'travelRights' in fcOrReservation;
-      if (isFareContract) {
-        return fcOrReservation.id;
-      } else {
-        return fcOrReservation.orderId;
-      }
-    });
+    ) as (FareContractType | (Reservation & {testRef: string}))[];
 
-    expect(ids).toEqual(['2', '1', '4', '3']);
+    expect(result.map((i) => (i as any).testRef)).toEqual(['2', '1']);
   });
 });
 
 describe('Sort by creation', () => {
   it('sortFcOrReservationByCreation sorts by created', () => {
-    const fareContracts = [
-      mockupReservation('1', 'valid', -10),
-      mockupFareContract('3', 'valid', -30),
-      mockupFareContract('2', 'valid', -20),
-      mockupReservation('5', 'valid', -50),
-      mockupFareContract('4', 'valid', -40),
+    const fcAndReservations = [
+      mockupReservation('1', new Date(-10), 'INITIATE'),
+      mockupFareContract('3', new Date(-30)),
+      mockupFareContract('2', new Date(-20)),
+      mockupReservation('5', new Date(-50), 'INITIATE'),
+      mockupFareContract('4', new Date(-40)),
     ];
-    const sorted = sortFcOrReservationByCreation(fareContracts);
+    const sorted = sortFcOrReservationByCreation(fcAndReservations);
 
-    const ids: string[] = sorted.map((fcOrReservation) => {
-      const isFareContract = 'travelRights' in fcOrReservation;
-      if (isFareContract) {
-        return fcOrReservation.id;
-      } else {
-        return fcOrReservation.orderId;
-      }
-    });
-
-    expect(ids).toEqual(['1', '2', '3', '4', '5']);
+    expect(sorted.map((item) => (item as any).testRef)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+    ]);
   });
 });

--- a/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
+++ b/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
@@ -68,7 +68,6 @@ describe('Sort by Validity', () => {
       '',
       now,
       fcOrReservations,
-      (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
     );
     const ids: string[] = result.map((fcOrReservation) => {
       const isFareContract = 'travelRights' in fcOrReservation;
@@ -93,7 +92,6 @@ describe('Sort by Validity', () => {
       '',
       now,
       fcOrReservations,
-      (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
     );
     const ids: string[] = result.map((fcOrReservation) => {
       const isFareContract = 'travelRights' in fcOrReservation;
@@ -119,7 +117,6 @@ describe('Sort by Validity', () => {
       '',
       now,
       fcOrReservations,
-      (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
     );
     const ids: string[] = result.map((fcOrReservation) => {
       const isFareContract = 'travelRights' in fcOrReservation;

--- a/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
+++ b/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
@@ -114,6 +114,21 @@ describe('Sort by Validity', () => {
 
     expect(result.map((i) => (i as any).testRef)).toEqual(['2', '1']);
   });
+
+  it('Should sort inactive fare contracts by created date', () => {
+    const fareContracts: FareContractType[] = [
+      mockupFareContract('2', new Date(now - ONE_MINUTE_MS * 2)),
+      mockupFareContract('1', new Date(now - ONE_MINUTE_MS * 1)),
+    ];
+    const reservations: Reservation[] = [];
+    const result = getSortedFareContractsAndReservations(
+      fareContracts,
+      reservations,
+      now,
+    ) as (FareContractType | (Reservation & {testRef: string}))[];
+
+    expect(result.map((i) => (i as any).testRef)).toEqual(['1', '2']);
+  });
 });
 
 describe('Sort by creation', () => {

--- a/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
+++ b/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
@@ -1,14 +1,18 @@
 import type {ValidityStatus} from '../utils';
-import {PaymentStatus, Reservation} from '@atb/modules/ticketing';
+import {Reservation} from '@atb/modules/ticketing';
 
 import {addMinutes} from 'date-fns';
 import {
   sortFcOrReservationByCreation,
-  getSortedFareContractsAndReservations,
+  sortFcOrReservationByValidityAndCreation,
 } from '../sort-fc-or-reservation';
 import {FareContractType, TravelRightType} from '@atb-as/utils';
 
 type MockedFareContract = FareContractType & {
+  validityStatus: ValidityStatus;
+};
+
+type MockedReservation = Reservation & {
   validityStatus: ValidityStatus;
 };
 
@@ -36,9 +40,9 @@ function mockupFareContract(
 
 function mockupReservation(
   id: string,
-  paymentStatus: PaymentStatus,
+  validityStatus: ValidityStatus,
   minutes: number,
-): Reservation {
+): MockedReservation {
   return {
     orderId: id,
     created: addMinutes(new Date(), minutes),
@@ -46,19 +50,26 @@ function mockupReservation(
     transactionId: 1,
     paymentType: 2,
     url: 'http://example.com',
-    paymentStatus: paymentStatus,
+    validityStatus: validityStatus,
   };
 }
 
 describe('Sort by Validity', () => {
+  const now = Date.now();
+
   it('Should sort fc or reservation by validity first', async () => {
     const fcOrReservations: (FareContractType | Reservation)[] = [
       mockupFareContract('1', 'valid', -1),
       mockupFareContract('2', 'valid', -2),
-      mockupReservation('3', 'INITIATE', 0),
+      mockupReservation('3', 'valid', 0),
     ];
 
-    const result = getSortedFareContractsAndReservations(fcOrReservations);
+    const result = sortFcOrReservationByValidityAndCreation(
+      '',
+      now,
+      fcOrReservations,
+      (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
+    );
     const ids: string[] = result.map((fcOrReservation) => {
       const isFareContract = 'travelRights' in fcOrReservation;
       if (isFareContract) {
@@ -74,11 +85,16 @@ describe('Sort by Validity', () => {
   it('Reservation should be first if reservation is being processing', async () => {
     const fcOrReservations: (FareContractType | Reservation)[] = [
       mockupFareContract('1', 'valid', -1),
-      mockupReservation('3', 'INITIATE', 0),
+      mockupReservation('3', 'reserving', 0),
       mockupFareContract('2', 'valid', 0),
     ];
 
-    const result = getSortedFareContractsAndReservations(fcOrReservations);
+    const result = sortFcOrReservationByValidityAndCreation(
+      '',
+      now,
+      fcOrReservations,
+      (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
+    );
     const ids: string[] = result.map((fcOrReservation) => {
       const isFareContract = 'travelRights' in fcOrReservation;
       if (isFareContract) {
@@ -93,13 +109,18 @@ describe('Sort by Validity', () => {
 
   it('Multiple reservations and valid fare contracts', async () => {
     const fcOrReservations: (FareContractType | Reservation)[] = [
-      mockupReservation('1', 'INITIATE', 0),
-      mockupReservation('2', 'INITIATE', 0.1),
+      mockupReservation('1', 'reserving', 0),
+      mockupReservation('2', 'reserving', 0.1),
       mockupFareContract('3', 'valid', 0.1),
       mockupFareContract('4', 'valid', 0.11),
     ];
 
-    const result = getSortedFareContractsAndReservations(fcOrReservations);
+    const result = sortFcOrReservationByValidityAndCreation(
+      '',
+      now,
+      fcOrReservations,
+      (_, fareContract) => (fareContract as MockedFareContract).validityStatus,
+    );
     const ids: string[] = result.map((fcOrReservation) => {
       const isFareContract = 'travelRights' in fcOrReservation;
       if (isFareContract) {
@@ -109,55 +130,17 @@ describe('Sort by Validity', () => {
       }
     });
 
-    expect(ids).toEqual(['4', '2', '3', '1']);
-  });
-
-  it('Multiple cancellations and valid fare contracts', async () => {
-    const fcOrReservations: (FareContractType | Reservation)[] = [
-      mockupReservation('1', 'CANCEL', 0),
-      mockupReservation('2', 'CANCEL', 0.1),
-      mockupFareContract('4', 'valid', 0.2),
-    ];
-
-    const result = getSortedFareContractsAndReservations(fcOrReservations);
-    const ids: string[] = result.map((fcOrReservation) =>
-      'travelRights' in fcOrReservation
-        ? fcOrReservation.id
-        : fcOrReservation.orderId,
-    );
-
-    expect(ids).toEqual(['4']);
-  });
-
-  it('Multiple cancellations between valid fare contracts', async () => {
-    const fcOrReservations: (FareContractType | Reservation)[] = [
-      mockupReservation('1', 'CANCEL', 0),
-      mockupReservation('2', 'CANCEL', 0),
-      mockupReservation('3', 'CANCEL', 0),
-      mockupReservation('4', 'CANCEL', 0),
-      mockupFareContract('5', 'valid', 0.2),
-      mockupReservation('6', 'CANCEL', 0.1),
-      mockupFareContract('7', 'valid', 0.3),
-    ];
-
-    const result = getSortedFareContractsAndReservations(fcOrReservations);
-    const ids: string[] = result.map((fcOrReservation) =>
-      'travelRights' in fcOrReservation
-        ? fcOrReservation.id
-        : fcOrReservation.orderId,
-    );
-
-    expect(ids).toEqual(['7', '5']);
+    expect(ids).toEqual(['2', '1', '4', '3']);
   });
 });
 
 describe('Sort by creation', () => {
   it('sortFcOrReservationByCreation sorts by created', () => {
     const fareContracts = [
-      mockupReservation('1', 'INITIATE', -10),
+      mockupReservation('1', 'valid', -10),
       mockupFareContract('3', 'valid', -30),
       mockupFareContract('2', 'valid', -20),
-      mockupReservation('5', 'INITIATE', -50),
+      mockupReservation('5', 'valid', -50),
       mockupFareContract('4', 'valid', -40),
     ];
     const sorted = sortFcOrReservationByCreation(fareContracts);

--- a/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
+++ b/src/modules/fare-contracts/__tests__/sort-fc-or-reservation.test.ts
@@ -81,6 +81,22 @@ describe('Sort by Validity', () => {
     expect(result.map((r) => (r as any).testRef)).toEqual(['1', '2', '3']);
   });
 
+  it('Should show only the most recent failed reservation', () => {
+    const fareContracts: FareContractType[] = [];
+    const reservations: Reservation[] = [
+      mockupReservation('2', new Date(now - ONE_MINUTE_MS * 2), 'REJECT'),
+      mockupReservation('1', new Date(now - ONE_MINUTE_MS * 1), 'CANCEL'),
+      mockupReservation('3', new Date(now - ONE_MINUTE_MS * 3), 'CANCEL'),
+    ];
+    const result = getSortedFareContractsAndReservations(
+      fareContracts,
+      reservations,
+      now,
+    ) as (FareContractType | (Reservation & {testRef: string}))[];
+
+    expect(result.map((r) => (r as any).testRef)).toEqual(['1']);
+  });
+
   it('Should sort fc and reservation by validity', async () => {
     const fareContracts: FareContractType[] = [
       mockupFareContract('3', new Date(now - ONE_MINUTE_MS * 3)),

--- a/src/modules/fare-contracts/index.ts
+++ b/src/modules/fare-contracts/index.ts
@@ -10,8 +10,8 @@ export {
 export type {UserProfileWithCount} from './types';
 export {FareContractOrReservation} from './FareContractOrReservation';
 export {
+  sortFcOrReservationByValidityAndCreation,
   sortFcOrReservationByCreation,
-  getSortedFareContractsAndReservations,
 } from './sort-fc-or-reservation';
 export {getFareContractInfoDetails} from './sections/FareContractInfoDetailsSectionItem';
 export {CompactFareContractInfo} from './CompactFareContractInfo';

--- a/src/modules/fare-contracts/index.ts
+++ b/src/modules/fare-contracts/index.ts
@@ -10,7 +10,7 @@ export {
 export type {UserProfileWithCount} from './types';
 export {FareContractOrReservation} from './FareContractOrReservation';
 export {
-  sortFcOrReservationByValidityAndCreation,
+  getSortedFareContractsAndReservations,
   sortFcOrReservationByCreation,
 } from './sort-fc-or-reservation';
 export {getFareContractInfoDetails} from './sections/FareContractInfoDetailsSectionItem';

--- a/src/modules/fare-contracts/sort-fc-or-reservation.ts
+++ b/src/modules/fare-contracts/sort-fc-or-reservation.ts
@@ -7,8 +7,9 @@ export const getSortedFareContractsAndReservations = (
   reservations: Reservation[],
   now: number,
 ): (FareContractType | Reservation)[] => {
-  // Should show at most one "failed" reservation.
-  const mostRecentFailedReservation = reservations.find(
+  // Should show only the most recent "failed" reservation.
+  const sortedReservations = sortFcOrReservationByCreation(reservations);
+  const mostRecentFailedReservation = sortedReservations.find(
     (reservation) =>
       !('travelRights' in reservation) &&
       (reservation.paymentStatus === 'CANCEL' ||

--- a/src/modules/fare-contracts/sort-fc-or-reservation.ts
+++ b/src/modules/fare-contracts/sort-fc-or-reservation.ts
@@ -23,7 +23,7 @@ export const getSortedFareContractsAndReservations = (
     return getAvailabilityStatus(fc, now).status === 'valid';
   });
 
-  // Not valid fare contracts (e.g. inactive carnets) should come last, and be
+  // Non-valid fare contracts (e.g. inactive carnets) should come last, and be
   // sorted by creation date.
   const otherFareContracts = sortFcOrReservationByCreation(
     fareContracts.filter(
@@ -31,7 +31,7 @@ export const getSortedFareContractsAndReservations = (
     ),
   );
 
-  // Sort everything but the non-active fare contracts by creation date.
+  // Sort everything but the non-valid fare contracts by creation date.
   const sortedFareContractsAndReservations = sortFcOrReservationByCreation(
     [
       mostRecentFailedReservation,

--- a/src/modules/fare-contracts/sort-fc-or-reservation.ts
+++ b/src/modules/fare-contracts/sort-fc-or-reservation.ts
@@ -1,19 +1,36 @@
 import {Reservation} from '@atb/modules/ticketing';
+import type {ValidityStatus} from './utils';
 import {FareContractType} from '@atb-as/utils';
 
-export const getSortedFareContractsAndReservations = (
+export const sortFcOrReservationByValidityAndCreation = (
+  userId: string | undefined,
+  now: number,
   fcOrReservations: (Reservation | FareContractType)[],
+  getFareContractStatus: (
+    now: number,
+    fc: FareContractType,
+    currentUserId?: string,
+  ) => ValidityStatus | undefined,
 ): (FareContractType | Reservation)[] => {
-  let fcFound = false;
-  return sortFcOrReservationByCreation(fcOrReservations).filter((item) =>
-    'travelRights' in item
-      ? (fcFound = true)
-      : !(
-          (item.paymentStatus === 'CANCEL' ||
-            item.paymentStatus === 'REJECT') &&
-          fcFound
-        ),
-  );
+  const getFcOrReservationOrder = (
+    fcOrReservation: FareContractType | Reservation,
+  ) => {
+    const isFareContract = 'travelRights' in fcOrReservation;
+    // Make reservations go first, then fare contracts
+    if (!isFareContract) return -1;
+
+    const validityStatus = getFareContractStatus(now, fcOrReservation, userId);
+    return validityStatus === 'valid' ? 0 : 1;
+  };
+
+  return fcOrReservations.sort((a, b) => {
+    const orderA = getFcOrReservationOrder(a);
+    const orderB = getFcOrReservationOrder(b);
+    // Negative return value for a - b means "place a before b"
+    if (orderA !== orderB) return orderA - orderB;
+    // Make sure most recent dates comes first
+    return b.created.getTime() - a.created.getTime();
+  });
 };
 
 export const sortFcOrReservationByCreation = (

--- a/src/modules/fare-contracts/sort-fc-or-reservation.ts
+++ b/src/modules/fare-contracts/sort-fc-or-reservation.ts
@@ -1,16 +1,11 @@
 import {Reservation} from '@atb/modules/ticketing';
-import type {ValidityStatus} from './utils';
+import {getFareContractInfo} from './utils';
 import {FareContractType} from '@atb-as/utils';
 
 export const sortFcOrReservationByValidityAndCreation = (
   userId: string | undefined,
   now: number,
   fcOrReservations: (Reservation | FareContractType)[],
-  getFareContractStatus: (
-    now: number,
-    fc: FareContractType,
-    currentUserId?: string,
-  ) => ValidityStatus | undefined,
 ): (FareContractType | Reservation)[] => {
   const getFcOrReservationOrder = (
     fcOrReservation: FareContractType | Reservation,
@@ -19,7 +14,11 @@ export const sortFcOrReservationByValidityAndCreation = (
     // Make reservations go first, then fare contracts
     if (!isFareContract) return -1;
 
-    const validityStatus = getFareContractStatus(now, fcOrReservation, userId);
+    const validityStatus = getFareContractInfo(
+      now,
+      fcOrReservation,
+      userId,
+    ).validityStatus;
     return validityStatus === 'valid' ? 0 : 1;
   };
 

--- a/src/modules/fare-contracts/sort-fc-or-reservation.ts
+++ b/src/modules/fare-contracts/sort-fc-or-reservation.ts
@@ -23,9 +23,12 @@ export const getSortedFareContractsAndReservations = (
     return getAvailabilityStatus(fc, now).status === 'valid';
   });
 
-  // Not valid fare contracts (e.g. inactive carnets) should come last
-  const otherFareContracts = fareContracts.filter(
-    (fc) => getAvailabilityStatus(fc, now).status !== 'valid',
+  // Not valid fare contracts (e.g. inactive carnets) should come last, and be
+  // sorted by creation date.
+  const otherFareContracts = sortFcOrReservationByCreation(
+    fareContracts.filter(
+      (fc) => getAvailabilityStatus(fc, now).status !== 'valid',
+    ),
   );
 
   // Sort everything but the non-active fare contracts by creation date.

--- a/src/modules/fare-contracts/utils.ts
+++ b/src/modules/fare-contracts/utils.ts
@@ -1,32 +1,32 @@
 import {
-  getLastUsedAccess,
-  isSentOrReceivedFareContract,
   Reservation,
+  isSentOrReceivedFareContract,
+  getLastUsedAccess,
 } from '@atb/modules/ticketing';
 import {
-  FareContractState,
   FareContractType,
-  getAccesses,
-  TravelRightType,
+  FareContractState,
   UsedAccessType,
+  TravelRightType,
 } from '@atb-as/utils';
 import {
-  FareZone,
   findReferenceDataById,
   getReferenceDataName,
   PreassignedFareProduct,
+  FareZone,
   useFirestoreConfigurationContext,
   UserProfile,
 } from '@atb/modules/configuration';
 import {UserProfileWithCount} from '@atb/modules/fare-contracts';
 import {
   FareContractTexts,
-  FareZonesTexts,
   Language,
+  FareZonesTexts,
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
+import {getAccesses} from '@atb-as/utils';
 import {useAuthContext} from '@atb/modules/auth';
 import {useCallback, useMemo} from 'react';
 


### PR DESCRIPTION
After https://github.com/AtB-AS/mittatb-app/pull/5277, we no longer sort fare contracts by validity, which means upcoming fare contracts or inactive carnets can show above other active fare contracts. This makes the rules we have on sorting more explicit, and improves the tests to reflect the rules.

### Acceptance criteria

- [ ] Only the most recent "failed" reservation is shown
- [ ] Processing reservations are all shown as before
- [ ] Inactive carnets show always below active tickets, even though they were bought after an active ticket
- [ ] Tickets that start in the future always show below active tickets, even though they were bought after an active ticket
