### PR TITLE
 feat(spar): add information page 

### DIFF
--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
@@ -49,7 +49,7 @@ export const SmartParkAndRideOnboarding_AutomaticRegistrationScreen = () => {
         expanded: true,
         rightIcon: {svg: Confirm},
       }}
-      testID="benefitsSmartParkAndRideOnboarding"
+      testID="smartParkAndRideOnboardingAutomaticRegistration"
     />
   );
 };

--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_InformationScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_InformationScreen.tsx
@@ -29,7 +29,7 @@ export const SmartParkAndRideOnboarding_InformationScreen = () => {
         expanded: true,
         rightIcon: {svg: ArrowRight},
       }}
-      testID="welcomeSmartParkAndRideOnboarding"
+      testID="smartParkAndRideOnboardingInformation"
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -108,15 +108,22 @@ const Profile_SmartParkAndRideScreenContent = () => {
           </View>
         )}
 
-        <HowItWorksSection />
+        <HowItWorksSection
+          onPress={() => {
+            navigation.navigate('Root_SmartParkAndRideOnboardingStack');
+          }}
+        />
       </View>
     </FullScreenView>
   );
 };
 
-const HowItWorksSection = () => {
+type HowItWorksSectionProps = {
+  onPress: () => void;
+};
+
+const HowItWorksSection = ({onPress}: HowItWorksSectionProps) => {
   const {t} = useTranslation();
-  const navigation = useNavigation<RootNavigationProps>();
   const styles = useStyles();
 
   return (
@@ -144,9 +151,7 @@ const HowItWorksSection = () => {
         </GenericSectionItem>
         <LinkSectionItem
           text={t(SmartParkAndRideTexts.howItWorks.link)}
-          onPress={() => {
-            navigation.navigate('Root_SmartParkAndRideOnboardingStack');
-          }}
+          onPress={onPress}
         />
       </Section>
     </>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -4,6 +4,7 @@ import {View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import {
+  GenericSectionItem,
   LinkSectionItem,
   Section,
   SelectionInlineSectionItem,
@@ -24,6 +25,7 @@ import {
 import {spellOut} from '@atb/utils/accessibility';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
 import {useEffect} from 'react';
+import {ThemedBundlingCarSharing} from '@atb/theme/ThemedAssets';
 
 const MAX_VEHICLE_REGISTRATIONS = 2;
 
@@ -105,8 +107,49 @@ const Profile_SmartParkAndRideScreenContent = () => {
             <ThemeText>{t(SmartParkAndRideTexts.add.max)}</ThemeText>
           </View>
         )}
+
+        <HowItWorksSection />
       </View>
     </FullScreenView>
+  );
+};
+
+const HowItWorksSection = () => {
+  const {t} = useTranslation();
+  const navigation = useNavigation<RootNavigationProps>();
+  const styles = useStyles();
+
+  return (
+    <>
+      <ContentHeading text={t(SmartParkAndRideTexts.howItWorks.heading)} />
+      <Section>
+        <GenericSectionItem>
+          <View style={styles.horizontalContainer}>
+            <ThemedBundlingCarSharing
+              height={61}
+              width={61}
+              style={{
+                alignSelf: 'flex-start',
+              }}
+            />
+            <View style={styles.howItWorks}>
+              <ThemeText typography="body__primary--bold">
+                {t(SmartParkAndRideTexts.howItWorks.title)}
+              </ThemeText>
+              <ThemeText typography="body__secondary" color="secondary">
+                {t(SmartParkAndRideTexts.howItWorks.description)}
+              </ThemeText>
+            </View>
+          </View>
+        </GenericSectionItem>
+        <LinkSectionItem
+          text={t(SmartParkAndRideTexts.howItWorks.link)}
+          onPress={() => {
+            navigation.navigate('Root_SmartParkAndRideOnboardingStack');
+          }}
+        />
+      </Section>
+    </>
   );
 };
 
@@ -144,6 +187,15 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
     gap: theme.spacing.small,
     marginTop: theme.spacing.xSmall,
+  },
+  horizontalContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.medium,
+  },
+  howItWorks: {
+    flex: 1,
+    gap: theme.spacing.xSmall,
   },
 }));
 

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -12,6 +12,16 @@ const SmartParkAndRideTexts = {
     heading: _('Dine kjøretøy', 'Your vehicles', 'Dine køyretøy'),
     addVehicle: _('Legg til kjøretøy', 'Add vehicle', 'Legg til køyretøy'),
   },
+  howItWorks: {
+    heading: _('Les mer', 'Read more', 'Les meir'),
+    title: _('Hvordan funker det?', 'How does it work?', 'Korleis funkar det?'),
+    description: _(
+      'Med gyldig billett fra AtB kan du stå gratis på Ranheim Fabrikker i 48 timer.',
+      'With a valid ticket from AtB, you can park for free at Ranheim Fabrikker for 48 hours.',
+      'Med gyldig billett frå AtB kan du stå gratis på Ranheim Fabrikker i 48 timar.',
+    ),
+    link: _('Sånn funker det', 'How it works', 'Slik fungerer det'),
+  },
   add: {
     header: {
       title: _('Legg til kjøretøy', 'Add vehicle', 'Legg til køyretøy'),


### PR DESCRIPTION
Add section to inform the user how it works. It navigates to the onboarding stack.


<details><summary>Screenshots</summary>
<p>

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/cb7a7173-84c9-47ea-8192-f99dda4ee10b" />

</p>
</details> 


fixes https://github.com/AtB-AS/kundevendt/issues/20819