### PR TITLE
feat: fetch server time from identity

### DIFF
--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -12,6 +12,13 @@ import {v4 as uuid} from 'uuid';
 
 export const VIPPS_CALLBACK_URL = `${APP_SCHEME}://auth/vipps`;
 
+export const getServerTime = async () => {
+  const response = await client.get('/identity/v1/time', {
+    authWithIdToken: false,
+  });
+  return response.data;
+};
+
 export const authenticateWithSms = async (
   phoneNumber: string,
   language: Language,

--- a/src/modules/time/use-server-time-query.ts
+++ b/src/modules/time/use-server-time-query.ts
@@ -1,0 +1,13 @@
+import {useQuery} from '@tanstack/react-query';
+import {ONE_MINUTE_MS} from '@atb/utils/durations';
+import {getServerTime} from '@atb/api/identity';
+
+export const useServerTimeQuery = (enabled: boolean) =>
+  useQuery({
+    queryKey: ['getServerTime'],
+    queryFn: () => getServerTime(),
+    staleTime: ONE_MINUTE_MS,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    enabled,
+  });


### PR DESCRIPTION
Uses the [new time endpoint](https://github.com/AtB-AS/identity/pull/61) to fetch server time instead of relying on the mobile token SDK.

### Acceptance criteria

- [ ] Reloads every 60s, on network reconnects and app reopen
- [ ] If the request fails, we fall back to device time.
- [ ] Server time is used for ticket validity info. The trip planner part of the app still uses device time.
