### PR TITLE
feat: add feedback section item in Profile

### DIFF
--- a/src/components/screen-header/chat/ContactSheet.tsx
+++ b/src/components/screen-header/chat/ContactSheet.tsx
@@ -80,7 +80,7 @@ export const ContactSheet = ({onReportParkingViolation}: Props) => {
               rightIcon={{
                 svg: Chat,
                 notificationColor: unreadCount
-                  ? theme.color.status.valid.primary
+                  ? theme.color.status.error.primary
                   : undefined,
               }}
             />

--- a/src/components/screen-header/chat/use-chat-icon.tsx
+++ b/src/components/screen-header/chat/use-chat-icon.tsx
@@ -47,7 +47,7 @@ export const useChatIcon = (
           notification={
             unreadCount
               ? {
-                  color: theme.color.status.valid.primary,
+                  color: theme.color.status.error.primary,
                   backgroundColor: color,
                 }
               : undefined

--- a/src/components/theme-icon/NotificationIndicator.tsx
+++ b/src/components/theme-icon/NotificationIndicator.tsx
@@ -66,8 +66,8 @@ const getIndicatorSize = (
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   indicator: {
     position: 'absolute',
-    right: 0,
-    top: 0,
+    right: -4,
+    top: -2,
     borderRadius: theme.border.radius.large,
     zIndex: 10,
     overflow: 'hidden',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -74,7 +74,7 @@ export const Root_TabNavigatorStack = () => {
     }
     if (unreadCount) {
       return {
-        color: theme.color.status.valid.primary,
+        color: theme.color.status.error.primary,
         backgroundColor: interactiveColor.default,
       };
     }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/Root_TabNavigatorStack.tsx
@@ -38,6 +38,7 @@ import {
   useOnboardingNavigation,
 } from '@atb/modules/onboarding';
 import {useAuthContext} from '@atb/modules/auth';
+import {useChatUnreadCount} from '@atb/modules/chat';
 
 const Tab = createBottomTabNavigator<TabNavigatorStackParams>();
 
@@ -55,6 +56,7 @@ export const Root_TabNavigatorStack = () => {
   const {nextOnboardingSection} = useOnboardingFlow(true); // assumeUserCreationOnboarded true to ensure outdated userCreationOnboarded value not used
   const {goToScreen} = useOnboardingNavigation();
   const {customerNumber} = useAuthContext();
+  const unreadCount = useChatUnreadCount();
 
   useEffect(() => {
     if (!navigation.isFocused()) return; // only show onboarding screens from Root_TabNavigatorStack path
@@ -62,6 +64,21 @@ export const Root_TabNavigatorStack = () => {
     const nextOnboardingScreen = nextOnboardingSection?.initialScreen;
     nextOnboardingScreen?.name && goToScreen(false, nextOnboardingScreen);
   }, [nextOnboardingSection?.initialScreen, goToScreen, navigation]);
+
+  const getProfileNotification = (): ThemeIconProps['notification'] => {
+    if (customerNumber === undefined) {
+      return {
+        color: theme.color.status.error.primary,
+        backgroundColor: interactiveColor.default,
+      };
+    }
+    if (unreadCount) {
+      return {
+        color: theme.color.status.valid.primary,
+        backgroundColor: interactiveColor.default,
+      };
+    }
+  };
 
   return (
     <Tab.Navigator
@@ -140,12 +157,7 @@ export const Root_TabNavigatorStack = () => {
           ProfileFill,
           lineHeight,
           'profileTab',
-          customerNumber === undefined
-            ? {
-                color: theme.color.status.error.primary,
-                backgroundColor: interactiveColor.default,
-              }
-            : undefined,
+          getProfileNotification(),
         )}
       />
     </Tab.Navigator>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -77,7 +77,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const styles = useStyles();
   const {theme} = useThemeContext();
   const interactiveColor = theme.color.interactive[1];
-  const statusColor = theme.color.status.valid.primary;
+  const statusColor = theme.color.status.info.primary;
   const [searchTime, setSearchTime] = useState<TripSearchTime>({
     option: 'now',
     date: new Date().toISOString(),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -229,7 +229,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 leftIcon={{
                   svg: Chat,
                   notificationColor: unreadCount
-                    ? theme.color.status.valid.primary
+                    ? theme.color.status.error.primary
                     : undefined,
                 }}
                 text={t(ProfileTexts.sections.contact.chat)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -11,7 +11,7 @@ import {ThemeText} from '@atb/components/text';
 import {useAuthContext} from '@atb/modules/auth';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
-import {StyleSheet, Theme} from '@atb/theme';
+import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {ProfileTexts, useTranslation} from '@atb/translations';
 import {useIsLoading} from '@atb/utils/use-is-loading';
 import {useLocalConfig} from '@atb/utils/use-local-config';
@@ -39,6 +39,9 @@ import {Star} from '@atb/assets/svg/mono-icons/bonus';
 import {Favorite} from '@atb/assets/svg/mono-icons/places';
 import {Car} from '@atb/assets/svg/mono-icons/transportation';
 import {Info, Unknown} from '@atb/assets/svg/mono-icons/status';
+import {Chat} from '@atb/assets/svg/mono-icons/actions';
+import {useChatUnreadCount} from '@atb/modules/chat';
+import Intercom, {Space} from '@intercom/intercom-react-native';
 
 const buildNumber = getBuildNumber();
 const version = getVersion();
@@ -60,6 +63,9 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const [isLoading, setIsLoading] = useIsLoading(false);
   const {isBonusProgramEnabled, isSmartParkAndRideEnabled} =
     useFeatureTogglesContext();
+  const unreadCount = useChatUnreadCount();
+  const {theme} = useThemeContext();
+  const {enable_intercom} = useRemoteConfigContext();
 
   return (
     <>
@@ -218,6 +224,26 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
               }
               testID="contactButton"
             />
+            {enable_intercom && (
+              <LinkSectionItem
+                leftIcon={{
+                  svg: Chat,
+                  notificationColor: unreadCount
+                    ? theme.color.status.valid.primary
+                    : undefined,
+                }}
+                text={t(ProfileTexts.sections.contact.chat)}
+                onPress={() => {
+                  unreadCount
+                    ? Intercom.presentSpace(Space.messages)
+                    : Intercom.presentSpace(Space.home);
+                  analytics.logEvent(
+                    'Contact',
+                    'Send Intercom message clicked',
+                  );
+                }}
+              />
+            )}
           </Section>
           {(!!JSON.parse(IS_QA_ENV || 'false') ||
             __DEV__ ||

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -400,6 +400,11 @@ const ProfileTexts = {
         'Frequently asked questions',
         'Ofte stilte spørsmål',
       ),
+      chat: _(
+        'Gi tilbakemelding om appen',
+        'Give feedback about the app',
+        'Gi tilbakemelding om appen',
+      ),
     },
   },
   installId: {


### PR DESCRIPTION

- Adds a "Gi tilbakemeldinger om appen" section item to Profile
- Adds a notification indicator to the Profile icon in the tab bar that shows when the user has received a intercom message.
- Changes intercom notifications to be red/error, instead of green/valid.
- Some changes to notification indicators in general, done together with @oyvindmikkelsenatb
	- Offsets the notification indicator slightly away from the icon (globally).
	- Changes the travel search filter notification indicator to be blue/info instead of green/valid.

closes https://github.com/AtB-AS/kundevendt/issues/20068

<img width="300px" src="https://github.com/user-attachments/assets/aa920100-4b8c-4708-ab82-a8dd0c8c7c1e">
<img width="300px" src="https://github.com/user-attachments/assets/d7b4b0e2-caa4-4444-8379-cf4321e007d5">
