### PR TITLE
fix: update time context every second

### DIFF
--- a/src/modules/time/TimeContext.tsx
+++ b/src/modules/time/TimeContext.tsx
@@ -1,11 +1,12 @@
 import React, {createContext, useContext, useEffect, useState} from 'react';
-import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {z} from 'zod';
+import {useInterval} from '@atb/utils/use-interval';
 import {useServerTimeQuery} from './use-server-time-query';
+import {useFeatureTogglesContext} from '../feature-toggles';
 
 type TimeContextState = {
   /**
-   * The current time in milliseconds, updated every 2.5 seconds. This is based
+   * The current time in milliseconds, updated every second. This is based
    * on server time when possible, and can be safely used for checking the
    * validity of fare contracts.
    */
@@ -14,13 +15,15 @@ type TimeContextState = {
 
 const TimeContext = createContext<TimeContextState | undefined>(undefined);
 
-// The number of milliseconds the device time is ahead of server time.
-let serverDiff = 0;
+/**
+ * The number of milliseconds the device time is ahead of server time.
+ */
+let serverTimeOffsetGlobal = 0;
 
 /**
- * Returns the current time in milliseconds.
+ * Returns the current UNIX time in milliseconds.
  */
-export const getServerNow = () => Date.now() - serverDiff;
+export const getServerNowGlobal = () => Date.now() - serverTimeOffsetGlobal;
 
 type Props = {
   children: React.ReactNode;
@@ -40,13 +43,17 @@ export const TimeContextProvider = ({children}: Props) => {
   useEffect(() => {
     const timeData = TimeResult.safeParse(data).data;
     if (timeData?.timestampMs) {
-      serverDiff = Date.now() - timeData.timestampMs;
-      setServerNow(timeData.timestampMs);
-    } else {
-      serverDiff = 0;
-      setServerNow(Date.now());
+      serverTimeOffsetGlobal = timeData.timestampMs - Date.now();
     }
   }, [data]);
+
+  useInterval(
+    () => setServerNow(Date.now() - serverTimeOffsetGlobal),
+    [],
+    1000,
+    false,
+    true,
+  );
 
   return (
     <TimeContext.Provider

--- a/src/modules/time/index.ts
+++ b/src/modules/time/index.ts
@@ -1,1 +1,5 @@
-export {TimeContextProvider, useTimeContext, getServerNow} from './TimeContext';
+export {
+  TimeContextProvider,
+  useTimeContext,
+  getServerNowGlobal,
+} from './TimeContext';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -1,7 +1,7 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {Alert, Linking, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -111,6 +111,7 @@ export const Profile_DebugInfoScreen = () => {
     },
   } = useMobileTokenContext();
   const {serverNow} = useTimeContext();
+  const serverTimeOffset = useMemo(() => Date.now() - serverNow, [serverNow]);
 
   const {
     fcmToken,
@@ -179,6 +180,9 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
         <Section style={styles.section}>
+          <GenericSectionItem>
+            <ThemeText>{`Device is ${serverTimeOffset}ms ahead of server time`}</ThemeText>
+          </GenericSectionItem>
           <LinkSectionItem
             text="Reset shareTravelHabits session counter"
             onPress={() => storage.set(shareTravelHabitsSessionCountKey, '0')}


### PR DESCRIPTION
Some logic that to update the time context's `now` was overwritten in https://github.com/AtB-AS/mittatb-app/pull/5342, so adding it back here. Also improves on some names and comments, and add display of server time offset in the debug menu 🕺 

<img width="300px" src="https://github.com/user-attachments/assets/12dfcb9c-d342-4bba-9165-68375b7064ba">
