### PR TITLE
fix(spar): skip error logging when 400 for search-vehicle

### DIFF
--- a/src/modules/smart-park-and-ride/api/api.ts
+++ b/src/modules/smart-park-and-ride/api/api.ts
@@ -49,6 +49,7 @@ export const searchVehicleInformation = (
   return client
     .get(`/spar/v1/search-vehicle/${licensePlate}`, {
       authWithIdToken: true,
+      skipErrorLogging: (error) => error.response?.status === 400,
     })
     .then((response) => SvvVehicleInfoSchema.parse(response.data));
 };


### PR DESCRIPTION
Adds a `skipErrorLogging` for the search vehicle endpoint. We don't need error logging for failed searches.