### PR TITLE
fix: correctly set duration consts and preemptiveRefreshPercent

### DIFF
--- a/src/modules/mobile-token/mobileTokenClient.ts
+++ b/src/modules/mobile-token/mobileTokenClient.ts
@@ -82,10 +82,10 @@ export const mobileTokenClient = {
   Check if token should be renewed. Will return true if either:
    - Token is expired
    - It is less than 12 hours until token expires
-   - Less than 10 % of the token validity time is left
+   - It has lived longer than 90% percent of its total time to live
    */
   shouldRenew: (token: ActivatedToken) =>
-    abtClient.shouldPreemptiveRenew(token, HALF_DAY_MS, 10),
+    abtClient.shouldPreemptiveRenew(token, HALF_DAY_MS, 90),
   currentTimeMillis: () => abtClient.getCurrentTimeMillis(),
   setDebugSabotage: (attestationSabotage: AttestationSabotage) =>
     abtClient.setAttestationSabotage(attestationSabotage),

--- a/src/utils/durations.ts
+++ b/src/utils/durations.ts
@@ -1,5 +1,5 @@
 export const ONE_SECOND_MS = 1000;
 export const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-export const HALF_DAY_MS = 12 * ONE_MINUTE_MS;
-export const ONE_DAY_MS = 24 * ONE_MINUTE_MS;
+export const HALF_DAY_MS = 12 * ONE_HOUR_MS;
+export const ONE_DAY_MS = 24 * ONE_HOUR_MS;


### PR DESCRIPTION
`ONE_DAY_MS` is not in use, but the `HALF_DAY_MS` const (which is 12 minutes instead of 12 hours), is used by

- shouldPreemptiveRenew in mobileTokenClient
- cacheTime and staleTime of useFetchOnBehalfOfAccountsQuery
- cacheTime and staleTime of useGeofencingZonesQuery

In the case of shouldPreemtiveRenew, this means that mobile tokens have been renewed when there was 12 minutes OR it has lived for 10% "of the tokens total time to live". The latter condition might have saved us from issues here, but it seems to be set by mistake.

From mobileTokenClient.ts:

```ts
  /*
  Check if token should be renewed. Will return true if either:
   - Token is expired
   - It is less than 12 hours until token expires
   - Less than 10 % of the token validity time is left
   */
  shouldRenew: (token: ActivatedToken) =>
    abtClient.shouldPreemptiveRenew(token, HALF_DAY_MS, 10),
```

> Less than 10 % of the token validity time is left

Sounds like this has it backwards. From the SDK:

```ts
/**
 * Returns true if the token has lived longer than this percent of the tokens total time to live.
 */
preemptiveRefreshPercent: number,
```

---

So, this changes the mobile token to use 12 hours remaining or 90% elapsed, instead of 12 minutes remaining or 10% elapsed 🙈