### PR TITLE
fix: improve validity line animation

### DIFF
--- a/src/components/line-with-vertical-bars/LineWithVerticalBars.tsx
+++ b/src/components/line-with-vertical-bars/LineWithVerticalBars.tsx
@@ -122,7 +122,10 @@ const useStyles = StyleSheet.createThemeHook(() => ({
   },
   progressBar: {
     height: 12,
-    width: '100%',
+    // Make the animation slightly larger than the view to avoid glitches along
+    // the edges.
+    width: '104%',
+    marginLeft: '-2%',
     overflow: 'hidden',
   },
   verticalLine: {

--- a/src/modules/fare-contracts/components/WithValidityLine.tsx
+++ b/src/modules/fare-contracts/components/WithValidityLine.tsx
@@ -66,7 +66,7 @@ export const WithValidityLine = (props: Props) => {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flexDirection: 'column',
-    marginHorizontal: -theme.spacing.medium,
+    marginHorizontal: -theme.spacing.medium + theme.border.width.slim,
     borderTopRightRadius: theme.border.radius.regular,
     borderTopLeftRadius: theme.border.radius.regular,
     overflow: 'hidden',


### PR DESCRIPTION
Fix for the pixel peepers on the fare contract validity line. The line would overflow by 1px horizontally due to the section item border, and the animated lines would disappear a bit too early.

### Before and after

https://github.com/user-attachments/assets/f302873b-84eb-4753-abbc-edfc2d65301b

https://github.com/user-attachments/assets/716664ff-eedb-40e7-b2bb-35566cd40c7d

