### PR TITLE
chore: bump generate-assets to v18.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^7.1.0",
-    "@atb-as/generate-assets": "^18.1.0",
+    "@atb-as/generate-assets": "^18.1.1",
     "@atb-as/theme": "^14.1.0",
     "@atb-as/utils": "^3.5.0",
     "@bugsnag/react-native": "^7.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     zod "^3.24.4"
     zod-to-json-schema "^3.24.5"
 
-"@atb-as/generate-assets@^18.1.0":
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-18.1.0.tgz#d15e0b9c6167c277dcddc6a30d196d414676321e"
-  integrity sha512-DKarGy20JKcKY5z1lofFWvNOSoKSH6wLiUctqoQf0WsQxtXXMwE1qh9Ec0ZOqc3xVEjK/69Ata7ZxklETiE+Uw==
+"@atb-as/generate-assets@^18.1.1":
+  version "18.1.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-18.1.1.tgz#57aced670943488ca9dabca74f99a79d8be3287c"
+  integrity sha512-SK54eyjUtotEnLUi7m+h6VJwixPTy4xpE8JqBnlWs4vVRSc/24l/MAf3TzmtoacYG9HXoYtqmT+NNnotDWqdTQ==
   dependencies:
     "@atb-as/theme" "14.0.1"
     commander "^9.4.0"
@@ -1358,7 +1358,20 @@
     "@babel/parser" "^7.26.9"
     "@babel/types" "^7.26.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.26.8", "@babel/traverse@^7.26.9":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
+  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.25.3", "@babel/traverse@^7.26.8", "@babel/traverse@^7.26.9":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
   integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==


### PR DESCRIPTION
Changes from https://github.com/AtB-AS/design-system/pull/326

Fixes dark mode of the privacy icon added in https://github.com/AtB-AS/kundevendt/issues/20067