### PR TITLE
feat: use products api instead of firestore

### DIFF
--- a/src/components/screen-header/use-ticket-info.tsx
+++ b/src/components/screen-header/use-ticket-info.tsx
@@ -1,9 +1,11 @@
 import {
   PreassignedFareProduct,
   findReferenceDataById,
-  useFirestoreConfigurationContext,
 } from '@atb/modules/configuration';
-import {useTicketingContext} from '@atb/modules/ticketing';
+import {
+  useGetFareProductsQuery,
+  useTicketingContext,
+} from '@atb/modules/ticketing';
 import {FareContractType} from '@atb-as/utils';
 
 type TicketInfoParams = {
@@ -22,7 +24,7 @@ export const useTicketInfo = (fareContractId: string): TicketInfo => {
   const fareContract = findFareContractById(fareContractId);
   const firstTravelRight = fareContract?.travelRights[0];
 
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
     firstTravelRight?.fareProductRef || '',

--- a/src/modules/configuration/FirestoreConfigurationContext.tsx
+++ b/src/modules/configuration/FirestoreConfigurationContext.tsx
@@ -62,6 +62,7 @@ export type AppTexts = {
 };
 
 type ConfigurationContextState = {
+  /** @deprecated Use useGetFareProductsQuery instead */
   preassignedFareProducts: PreassignedFareProduct[];
   fareProductGroups: FareProductGroupType[];
   fareZones: FareZone[];

--- a/src/modules/fare-contracts/FareContractView.tsx
+++ b/src/modules/fare-contracts/FareContractView.tsx
@@ -12,6 +12,7 @@ import {useOperatorBenefitsForFareProduct} from '@atb/modules/mobility';
 import {
   isCanBeConsumedNowFareContract,
   isCanBeActivatedNowFareContract,
+  useGetFareProductsQuery,
 } from '@atb/modules/ticketing';
 import {FareContractType} from '@atb-as/utils';
 import {ConsumeCarnetSectionItem} from './components/ConsumeCarnetSectionItem';
@@ -25,10 +26,7 @@ import {TravelInfoSectionItem} from './components/TravelInfoSectionItem';
 import {ValidityTime} from './components/ValidityTime';
 import {FareContractShmoHeaderSectionItem} from './sections/FareContractShmoHeaderSectionItem';
 import {ShmoTripDetailsSectionItem} from '@atb/modules/mobility';
-import {
-  findReferenceDataById,
-  useFirestoreConfigurationContext,
-} from '@atb/modules/configuration';
+import {findReferenceDataById} from '@atb/modules/configuration';
 import {
   EarnedBonusPointsSectionItem,
   useBonusAmountEarnedQuery,
@@ -65,7 +63,7 @@ export const FareContractView: React.FC<Props> = ({
   );
 
   const firstTravelRight = fareContract.travelRights[0];
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
     firstTravelRight.fareProductRef,

--- a/src/modules/fare-contracts/components/FareContractDescription.tsx
+++ b/src/modules/fare-contracts/components/FareContractDescription.tsx
@@ -1,12 +1,10 @@
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import React from 'react';
 import {type FareContractType} from '@atb-as/utils';
-import {
-  findReferenceDataById,
-  useFirestoreConfigurationContext,
-} from '@atb/modules/configuration';
+import {findReferenceDataById} from '@atb/modules/configuration';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 type Props = {
   fc: FareContractType;
@@ -14,7 +12,7 @@ type Props = {
 };
 
 export const Description = ({fc, testID}: Props) => {
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {language} = useTranslation();
   const {theme} = useThemeContext();
   const styles = useStyles();

--- a/src/modules/fare-contracts/components/FareContractFromTo.tsx
+++ b/src/modules/fare-contracts/components/FareContractFromTo.tsx
@@ -8,6 +8,7 @@ import {
   findReferenceDataById,
   useFirestoreConfigurationContext,
 } from '@atb/modules/configuration';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 type FareContractFromToBaseProps = {
   backgroundColor: ContrastColor;
@@ -94,8 +95,8 @@ type FareContractFromToControllerDataType =
 function useFareContractFromToController(
   fcOrRfc: FareContractType | RecentFareContractType,
 ): FareContractFromToControllerDataType {
-  const {fareProductTypeConfigs, preassignedFareProducts} =
-    useFirestoreConfigurationContext();
+  const {fareProductTypeConfigs} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
 
   if (isFareContract(fcOrRfc)) {
     const firstTravelRight = fcOrRfc.travelRights.at(0);

--- a/src/modules/fare-contracts/components/ProductName.tsx
+++ b/src/modules/fare-contracts/components/ProductName.tsx
@@ -4,10 +4,10 @@ import {type FareContractType} from '@atb-as/utils';
 import {
   findReferenceDataById,
   getReferenceDataName,
-  useFirestoreConfigurationContext,
 } from '@atb/modules/configuration';
 import {useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 type Props = {
   fc: FareContractType;
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export const ProductName = ({fc, testID}: Props) => {
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {language} = useTranslation();
   const {theme} = useThemeContext();
   const styles = useStyles();

--- a/src/modules/fare-contracts/components/TravelInfoSectionItem.tsx
+++ b/src/modules/fare-contracts/components/TravelInfoSectionItem.tsx
@@ -6,7 +6,10 @@ import {
   useGetPhoneByAccountIdQuery,
   useFetchOnBehalfOfAccountsQuery,
 } from '@atb/modules/on-behalf-of';
-import {isSentOrReceivedFareContract} from '@atb/modules/ticketing';
+import {
+  isSentOrReceivedFareContract,
+  useGetFareProductsQuery,
+} from '@atb/modules/ticketing';
 import {getAccesses, type FareContractType} from '@atb-as/utils';
 import {View} from 'react-native';
 import {FareContractFromTo} from './FareContractFromTo';
@@ -41,8 +44,9 @@ export const TravelInfoSectionItem = ({fc}: Props) => {
   const {validityStatus, numberOfUsedAccesses, maximumNumberOfAccesses} =
     getFareContractInfo(serverNow, fc, currentUserId);
   const firstTravelRight = fc.travelRights[0];
-  const {userProfiles, fareProductTypeConfigs, preassignedFareProducts} =
+  const {userProfiles, fareProductTypeConfigs} =
     useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const preassignedFareProduct = findReferenceDataById(
     preassignedFareProducts,
     firstTravelRight.fareProductRef,

--- a/src/modules/fare-contracts/components/WithValidityLine.tsx
+++ b/src/modules/fare-contracts/components/WithValidityLine.tsx
@@ -2,15 +2,15 @@ import {StyleSheet} from '@atb/theme';
 import {ValidityLine} from './ValidityLine';
 import {View} from 'react-native';
 import React, {type PropsWithChildren} from 'react';
-import type {Reservation} from '@atb/modules/ticketing';
+import {
+  useGetFareProductsQuery,
+  type Reservation,
+} from '@atb/modules/ticketing';
 import {FareContractType} from '@atb-as/utils';
 import {getFareContractInfo, getReservationStatus} from '../utils';
 import {useTimeContext} from '@atb/modules/time';
 import {useAuthContext} from '@atb/modules/auth';
-import {
-  findReferenceDataById,
-  useFirestoreConfigurationContext,
-} from '@atb/modules/configuration';
+import {findReferenceDataById} from '@atb/modules/configuration';
 
 type Props = PropsWithChildren<
   | {
@@ -23,7 +23,7 @@ export const WithValidityLine = (props: Props) => {
   const styles = useStyles();
   const {serverNow} = useTimeContext();
   const {abtCustomerId: currentUserId} = useAuthContext();
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
 
   if ('reservation' in props) {
     return (

--- a/src/modules/notifications/use-has-fare-contract-with-activated-notification.tsx
+++ b/src/modules/notifications/use-has-fare-contract-with-activated-notification.tsx
@@ -1,14 +1,14 @@
+import {findReferenceDataById} from '@atb/modules/configuration';
 import {
-  findReferenceDataById,
-  useFirestoreConfigurationContext,
-} from '@atb/modules/configuration';
-import {useFareContracts} from '@atb/modules/ticketing';
+  useFareContracts,
+  useGetFareProductsQuery,
+} from '@atb/modules/ticketing';
 import {useNotificationsContext} from './use-push-notifications';
 import {useTimeContext} from '@atb/modules/time';
 
 export function useHasFareContractWithActivatedNotification(): boolean {
   const {config: notificationsConfig} = useNotificationsContext();
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {serverNow} = useTimeContext();
   const {fareContracts: validFareContracts} = useFareContracts(
     {availability: 'available', status: 'valid'},

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -6,6 +6,7 @@ import {getFareContracts} from '@atb/modules/ticketing';
 import {useAuthContext} from '@atb/modules/auth';
 import {getAvailabilityStatus, AvailabilityStatus} from '@atb-as/utils';
 import {isDefined} from '@atb/utils/presence';
+import {ONE_WEEK_MS} from '@atb/utils/durations';
 
 type AvailabilityStatusInput = {
   availability: Exclude<AvailabilityStatus['availability'], 'invalid'>;
@@ -81,7 +82,7 @@ export const useGetFareContractsQuery = (props: {
     refetchOnReconnect: true,
     refetchOnMount: false,
     retry: 0,
-    cacheTime: 1000 * 60 * 60 * 24 * 7, // 7 days
+    cacheTime: ONE_WEEK_MS,
     meta: {
       persistInAsyncStorage: true,
     },

--- a/src/modules/ticketing/use-get-fare-products-query.tsx
+++ b/src/modules/ticketing/use-get-fare-products-query.tsx
@@ -12,8 +12,11 @@ export const useGetFareProductsQuery = () => {
     initialDataUpdatedAt: 0,
     queryKey: ['getProducts', userId],
     queryFn: getFareProducts,
-    cacheTime: ONE_HOUR_MS,
+    cacheTime: 1000 * 60 * 60 * 24 * 7, // 7 days
     staleTime: ONE_HOUR_MS,
     enabled: authStatus === 'authenticated',
+    meta: {
+      persistInAsyncStorage: true,
+    },
   });
 };

--- a/src/modules/ticketing/use-get-fare-products-query.tsx
+++ b/src/modules/ticketing/use-get-fare-products-query.tsx
@@ -2,7 +2,7 @@ import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {getFareProducts} from '@atb/modules/ticketing';
 import {useQuery} from '@tanstack/react-query';
 import {useAuthContext} from '@atb/modules/auth';
-import {ONE_HOUR_MS} from '@atb/utils/durations';
+import {ONE_HOUR_MS, ONE_WEEK_MS} from '@atb/utils/durations';
 
 export const useGetFareProductsQuery = () => {
   const {preassignedFareProducts} = useFirestoreConfigurationContext();
@@ -12,7 +12,7 @@ export const useGetFareProductsQuery = () => {
     initialDataUpdatedAt: 0,
     queryKey: ['getProducts', userId],
     queryFn: getFareProducts,
-    cacheTime: 1000 * 60 * 60 * 24 * 7, // 7 days
+    cacheTime: ONE_WEEK_MS,
     staleTime: ONE_HOUR_MS,
     enabled: authStatus === 'authenticated',
     meta: {

--- a/src/modules/ticketing/use-get-fare-products-query.tsx
+++ b/src/modules/ticketing/use-get-fare-products-query.tsx
@@ -1,14 +1,12 @@
-import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {getFareProducts} from '@atb/modules/ticketing';
 import {useQuery} from '@tanstack/react-query';
 import {useAuthContext} from '@atb/modules/auth';
 import {ONE_HOUR_MS, ONE_WEEK_MS} from '@atb/utils/durations';
 
 export const useGetFareProductsQuery = () => {
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
   const {userId, authStatus} = useAuthContext();
   return useQuery({
-    initialData: preassignedFareProducts,
+    initialData: [],
     initialDataUpdatedAt: 0,
     queryKey: ['getProducts', userId],
     queryFn: getFareProducts,

--- a/src/recent-fare-contracts/use-recent-fare-contracts.ts
+++ b/src/recent-fare-contracts/use-recent-fare-contracts.ts
@@ -10,6 +10,7 @@ import {
 import {
   listRecentFareContracts,
   RecentOrderDetails,
+  useGetFareProductsQuery,
   useTicketingContext,
 } from '@atb/modules/ticketing';
 import {TravelRightDirection} from '@atb-as/utils';
@@ -197,12 +198,9 @@ const mapToLastThreeUniqueRecentFareContracts = (
 export const useRecentFareContracts = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const {fareContracts} = useTicketingContext();
-  const {
-    preassignedFareProducts,
-    fareProductTypeConfigs,
-    fareZones,
-    userProfiles,
-  } = useFirestoreConfigurationContext();
+  const {fareProductTypeConfigs, fareZones, userProfiles} =
+    useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
 
   const fetchRecentFareContracts = async () => {
     dispatch({type: 'FETCH'});

--- a/src/recent-fare-contracts/use-recent-fare-contracts.ts
+++ b/src/recent-fare-contracts/use-recent-fare-contracts.ts
@@ -21,14 +21,14 @@ import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
 import {enumFromString} from '@atb/utils/enum-from-string';
 
 type State = {
-  error: boolean;
-  loading: boolean;
+  isError: boolean;
+  isLoading: boolean;
   recentFareContracts: RecentOrderDetails[];
 };
 
 const initialState: State = {
-  error: false,
-  loading: true,
+  isError: false,
+  isLoading: true,
   recentFareContracts: [],
 };
 
@@ -44,20 +44,20 @@ const reducer: Reducer = (prevState, action): State => {
     case 'FETCH':
       return {
         ...prevState,
-        loading: true,
-        error: false,
+        isLoading: true,
+        isError: false,
       };
     case 'ERROR':
       return {
         ...prevState,
-        loading: false,
-        error: true,
+        isLoading: false,
+        isError: true,
       };
     case 'SUCCESS':
       return {
         ...prevState,
-        loading: false,
-        error: false,
+        isLoading: false,
+        isError: false,
         recentFareContracts: action.data,
       };
   }
@@ -240,8 +240,8 @@ export const useRecentFareContracts = () => {
   );
 
   return {
-    loading: state.loading,
-    error: state.error,
+    isLoading: state.isLoading,
+    isError: state.isError,
     recentFareContracts,
     refresh: fetchRecentFareContracts,
   };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
@@ -7,13 +7,13 @@ import {
 import {InteractiveColor} from '@atb/theme/colors';
 import {ScrollView, StyleProp, View, ViewStyle} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {
-  isProductSellableInApp,
-  useFirestoreConfigurationContext,
-} from '@atb/modules/configuration';
+import {isProductSellableInApp} from '@atb/modules/configuration';
 import {useTextForLanguage} from '@atb/translations/utils';
 import {ProductAliasChip} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductAliasChip';
-import {useTicketingContext} from '@atb/modules/ticketing';
+import {
+  useGetFareProductsQuery,
+  useTicketingContext,
+} from '@atb/modules/ticketing';
 import {ContentHeading} from '@atb/components/heading';
 import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
 import {
@@ -36,7 +36,7 @@ export function ProductSelectionByAlias({
 }: Props) {
   const {t, language} = useTranslation();
   const styles = useStyles();
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {customerProfile} = useTicketingContext();
   const selectionBuilder = usePurchaseSelectionBuilder();
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -7,7 +7,6 @@ import {
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {
   PreassignedFareProduct,
-  useFirestoreConfigurationContext,
   getReferenceDataName,
   isProductSellableInApp,
 } from '@atb/modules/configuration';
@@ -17,7 +16,10 @@ import {
   RadioGroupSection,
   Section,
 } from '@atb/components/sections';
-import {useTicketingContext} from '@atb/modules/ticketing';
+import {
+  useGetFareProductsQuery,
+  useTicketingContext,
+} from '@atb/modules/ticketing';
 import {ProductDescriptionToggle} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle';
 import {usePreferencesContext} from '@atb/modules/preferences';
 import {ContentHeading} from '@atb/components/heading';
@@ -39,7 +41,7 @@ export function ProductSelectionByProducts({
   style,
 }: ProductSelectionByProductsProps) {
   const {t, language} = useTranslation();
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {customerProfile} = useTicketingContext();
   const {hideProductDescriptions} = usePreferencesContext().preferences;
   const selectionBuilder = usePurchaseSelectionBuilder();

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-product-alternatives.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-product-alternatives.ts
@@ -1,9 +1,10 @@
 import {useMemo} from 'react';
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
-import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 export const useProductAlternatives = (selection: PurchaseSelectionType) => {
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
+
   return useMemo(() => {
     const productAliasId = selection.preassignedFareProduct?.productAliasId;
     return productAliasId

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/CompactFareContracts.tsx
@@ -12,7 +12,10 @@ import React from 'react';
 import {View, ViewStyle} from 'react-native';
 import {useTimeContext} from '@atb/modules/time';
 import {ContentHeading} from '@atb/components/heading';
-import {useFareContracts} from '@atb/modules/ticketing';
+import {
+  useFareContracts,
+  useGetFareProductsQuery,
+} from '@atb/modules/ticketing';
 
 type Props = {
   onPressDetails: (fareContractId: string) => void;
@@ -35,8 +38,8 @@ export const CompactFareContracts: React.FC<Props> = ({
 
   const {t} = useTranslation();
   const {theme} = useThemeContext();
-  const {fareZones, userProfiles, preassignedFareProducts} =
-    useFirestoreConfigurationContext();
+  const {fareZones, userProfiles} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
 
   return (
     <View style={[style, itemStyle.container]}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FareContractsScreen.tsx
@@ -1,11 +1,10 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
-import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {DetailsContent} from '@atb/modules/fare-contracts';
 import {FareContractOrReservation} from '@atb/modules/fare-contracts';
 import {findReferenceDataById} from '@atb/modules/configuration';
 import {StyleSheet, Theme} from '@atb/theme';
-import {Reservation} from '@atb/modules/ticketing';
+import {Reservation, useGetFareProductsQuery} from '@atb/modules/ticketing';
 import {TravelRightDirection, FareContractType} from '@atb-as/utils';
 import {addDays} from 'date-fns';
 import React from 'react';
@@ -16,7 +15,7 @@ import {useAuthContext} from '@atb/modules/auth';
 export const Profile_FareContractsScreen = () => {
   const styles = useStyles();
 
-  const {preassignedFareProducts} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const getPreassignedFareProduct = (fcRef: string) =>
     findReferenceDataById(preassignedFareProducts, fcRef);
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -1,5 +1,9 @@
 import {StyleSheet} from '@atb/theme';
-import {useFareContracts, useTicketingContext} from '@atb/modules/ticketing';
+import {
+  useFareContracts,
+  useGetFareProductsQuery,
+  useTicketingContext,
+} from '@atb/modules/ticketing';
 import React, {useRef} from 'react';
 import {View} from 'react-native';
 import {FareContractAndReservationsList} from '@atb/modules/fare-contracts';
@@ -32,6 +36,7 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
     {availability: 'historical'},
     serverNow,
   );
+  const {refetch: refetchPreassignedFareProducts} = useGetFareProductsQuery();
 
   const styles = useStyles();
   const {t} = useTranslation();
@@ -51,6 +56,7 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
             refreshing={isRefetchingAvailableFareContracts}
             onRefresh={() => {
               refetchAvailableFareContracts();
+              refetchPreassignedFareProducts();
               analytics.logEvent('Ticketing', 'Pull to refresh tickets', {
                 reservationsCount: reservations.length,
                 availableFareContractsCount: availableFareContracts.length,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/RecentFareContracts/RecentFareContracts.tsx
@@ -53,7 +53,7 @@ export const RecentFareContracts = ({
 
   return (
     <View>
-      {loading && (
+      {loading && !memoizedRecentFareContracts.length && (
         <View
           style={{
             paddingVertical: theme.spacing.xLarge,
@@ -73,7 +73,7 @@ export const RecentFareContracts = ({
         </View>
       )}
 
-      {!loading && !!memoizedRecentFareContracts.length && (
+      {!!memoizedRecentFareContracts.length && (
         <>
           <ThemeText typography="body__secondary" style={styles.header}>
             {t(RecentFareContractsTexts.repeatPurchase.label)}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -4,7 +4,7 @@ import {AnonymousPurchaseWarning} from '@atb/stacks-hierarchy/Root_TabNavigatorS
 import {FareProducts} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/FareProducts/FareProducts';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import React from 'react';
-import {ScrollView, View} from 'react-native';
+import {RefreshControl, ScrollView, View} from 'react-native';
 import {RecentFareContracts} from './Components/RecentFareContracts/RecentFareContracts';
 import {TicketTabNavScreenProps} from '../navigation-types';
 import {UpgradeSplash} from './Components/UpgradeSplash';
@@ -25,8 +25,17 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const {must_upgrade_ticketing} = useRemoteConfigContext();
   const {authenticationType} = useAuthContext();
   const {theme} = useThemeContext();
-  const {recentFareContracts, loading} = useRecentFareContracts();
-  const {data: fareProducts} = useGetFareProductsQuery();
+  const {
+    recentFareContracts,
+    isLoading: isLoadingRecentFareContracts,
+    refresh: refetchRecentFareContracts,
+  } = useRecentFareContracts();
+  const {
+    data: fareProducts,
+    refetch: refetchPreassignedFareProducts,
+    isRefetching: isRefetchingPreassignedFareProducts,
+    isPlaceholderData,
+  } = useGetFareProductsQuery();
   const selectionBuilder = usePurchaseSelectionBuilder();
 
   const hasRecentFareContracts = !!recentFareContracts.length;
@@ -103,11 +112,25 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   };
 
   return authenticationType !== 'none' ? (
-    <ScrollView>
+    <ScrollView
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefetchingPreassignedFareProducts}
+          onRefresh={() => {
+            refetchRecentFareContracts();
+            refetchPreassignedFareProducts();
+            analytics.logEvent('Ticketing', 'Pull to refresh products', {
+              fareProductsCount: fareProducts.length,
+              isPlaceholderData,
+            });
+          }}
+        />
+      }
+    >
       <ErrorWithAccountMessage style={styles.accountWrongMessage} />
       <RecentFareContracts
         recentFareContracts={recentFareContracts}
-        loading={loading}
+        loading={isLoadingRecentFareContracts}
         onSelect={onFareContractSelect}
       />
       <View

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -31,7 +31,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
     refresh: refetchRecentFareContracts,
   } = useRecentFareContracts();
   const {
-    data: fareProducts,
+    data: preassignedFareProducts,
     refetch: refetchPreassignedFareProducts,
     isRefetching: isRefetchingPreassignedFareProducts,
     isPlaceholderData,
@@ -120,7 +120,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
             refetchRecentFareContracts();
             refetchPreassignedFareProducts();
             analytics.logEvent('Ticketing', 'Pull to refresh products', {
-              fareProductsCount: fareProducts.length,
+              fareProductsCount: preassignedFareProducts.length,
               isPlaceholderData,
             });
           }}
@@ -158,7 +158,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
         )}
 
         <FareProducts
-          fareProducts={fareProducts}
+          fareProducts={preassignedFareProducts}
           onProductSelect={onProductSelect}
         />
       </View>

--- a/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
@@ -17,6 +17,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useOperatorBenefitsForFareProduct} from '@atb/modules/mobility';
 import {MobilitySingleBenefitInfoSectionItem} from '@atb/modules/mobility';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 type Props = RootStackScreenProps<'Root_TicketInformationScreen'>;
 
@@ -25,8 +26,9 @@ export const Root_TicketInformationScreen = (props: Props) => {
   const styles = useStyle();
   const {theme} = useThemeContext();
   const themeColor = theme.color.background.accent[0];
-  const {preassignedFareProducts, fareProductTypeConfigs} =
-    useFirestoreConfigurationContext();
+  const {fareProductTypeConfigs} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
+
   const {isTipsAndInformationEnabled} = useFeatureTogglesContext();
   const {benefits} = useOperatorBenefitsForFareProduct(
     props.route.params.preassignedFareProductId,

--- a/src/utils/durations.ts
+++ b/src/utils/durations.ts
@@ -3,3 +3,4 @@ export const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 export const HALF_DAY_MS = 12 * ONE_HOUR_MS;
 export const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+export const ONE_WEEK_MS = 7 * ONE_DAY_MS;


### PR DESCRIPTION
- Uses `useGetFareProductsQuery` instead of `useFirestoreConfigurationContext` for all uses of `preassignedFareProducts`
- Persists fare products in local storage, which is cached for one week, the same as fare contracts.
- Makes pull to refresh on the active tickets and purchase tab reload preassigned fare products.
- Removes the reliance of firestore data entirely.

Note: If we want to keep the fallback to firestore data for a bit longer, 143ea65e4b6e0d2a737367ef6d4b253dd5a5ea21 can be reverted.

closes https://github.com/AtB-AS/kundevendt/issues/17568