### PR TITLE
feat: get geofencing data from activebooking when vehicle is missing

### DIFF
--- a/src/api/bff/mobility.ts
+++ b/src/api/bff/mobility.ts
@@ -67,6 +67,7 @@ export const getVehicle = (
   id: string,
   opts?: VehicleRequestOpts,
 ): Promise<VehicleExtendedFragment | null> => {
+  if (!id || id === '') return Promise.resolve(null);
   const url = '/bff/v2/mobility/vehicle';
   const query = qs.stringify({ids: id});
   return client

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -129,6 +129,9 @@ const ShmoOperatorSchema = z.object({
 export const AssetSchema = z.object({
   id: z.string().nullish(),
   operator: ShmoOperatorSchema,
+  systemId: z.string().nullish(),
+  vehicleTypeId: z.string().nullish(),
+  vehicleCode: z.string().nullish(),
   stationId: z.string().nullish(),
   licensePlate: z.string().nullish(),
   stateOfCharge: z.number().int().nullish(),

--- a/src/modules/map/components/mobility/GeofencingZones.tsx
+++ b/src/modules/map/components/mobility/GeofencingZones.tsx
@@ -6,35 +6,40 @@ import {
   PreProcessedGeofencingZones,
   usePreProcessedGeofencingZones,
 } from '@atb/modules/map';
-import {useVehicleQuery} from '@atb/modules/mobility';
 
 import {hitboxCoveringIconOnly} from '@atb/modules/map';
-import {VehicleExtendedFragment} from '@atb/api/types/generated/fragments/vehicles';
 import {MapSlotLayerId} from '../../hooks/use-mapbox-json-style';
 
 type GeofencingZonesProps = {
-  selectedVehicleId: string;
+  systemId: string | null;
+  vehicleTypeId: string | null;
 };
-export const GeofencingZones = ({selectedVehicleId}: GeofencingZonesProps) => {
-  const {
-    data: vehicle,
-    isLoading,
-    isError,
-  } = useVehicleQuery(selectedVehicleId);
-
-  if (!vehicle || !selectedVehicleId || isLoading || isError) {
+export const GeofencingZones = ({
+  systemId,
+  vehicleTypeId,
+}: GeofencingZonesProps) => {
+  if (!systemId || !vehicleTypeId) {
     return <></>;
   }
-  return <GeofencingZonesForVehicle vehicle={vehicle} />;
+  return (
+    <GeofencingZonesForVehicle
+      systemId={systemId}
+      vehicleTypeId={vehicleTypeId}
+    />
+  );
 };
 
-type GeofencingZonesForVehicleProps = {
-  vehicle: VehicleExtendedFragment;
-};
 const GeofencingZonesForVehicle = ({
-  vehicle,
-}: GeofencingZonesForVehicleProps) => {
-  const preProcessedGeofencingZones = usePreProcessedGeofencingZones(vehicle);
+  systemId,
+  vehicleTypeId,
+}: {
+  systemId: string;
+  vehicleTypeId: string;
+}) => {
+  const preProcessedGeofencingZones = usePreProcessedGeofencingZones(
+    systemId,
+    vehicleTypeId,
+  );
 
   return (
     <>

--- a/src/modules/map/hooks/use-pre-processed-geofencing-zones.tsx
+++ b/src/modules/map/hooks/use-pre-processed-geofencing-zones.tsx
@@ -6,16 +6,13 @@ import {
 } from '@atb/modules/map';
 
 import {useMemo} from 'react';
-import {VehicleExtendedFragment} from '@atb/api/types/generated/fragments/vehicles';
 import {useGeofencingZonesQuery} from '@atb/modules/mobility';
 import {useThemeContext} from '@atb/theme';
 
 export const usePreProcessedGeofencingZones = (
-  vehicle: VehicleExtendedFragment,
+  systemId: string,
+  vehicleTypeId: string,
 ) => {
-  const systemId = vehicle?.system.id;
-  const vehicleTypeId = vehicle?.vehicleType.id;
-
   const {theme} = useThemeContext();
 
   const {

--- a/src/modules/map/hooks/use-shmo-warnings.tsx
+++ b/src/modules/map/hooks/use-shmo-warnings.tsx
@@ -40,7 +40,7 @@ export const useShmoWarnings = (
       return t(ShmoWarnings.scooterDisabled);
     }
 
-    if (!isOpen) {
+    if (!isOpen && vehicle) {
       return t(
         ShmoWarnings.scooterClosed(
           openingTime?.toLocaleTimeString([], timeFormatOptions),
@@ -50,7 +50,7 @@ export const useShmoWarnings = (
     }
 
     return null;
-  }, [vehicle?.isDisabled, isOpen, t, openingTime, closingTime]);
+  }, [vehicle, isOpen, t, openingTime, closingTime]);
 
   const throttledCallback = useRef(
     throttle(async (coordinates: Coordinates) => {


### PR DESCRIPTION
Closes http://github.com/AtB-AS/kundevendt/issues/20834

 Geofencing zones only used vehicle before, from selected vehicle, but after app restart we only have active booking as reference, so i made geofencing zones use both