### PR TITLE
fix: Removed slim border on FC details

### DIFF
--- a/src/modules/fare-contracts/sections/FareContractHeaderSectionItem.tsx
+++ b/src/modules/fare-contracts/sections/FareContractHeaderSectionItem.tsx
@@ -49,7 +49,7 @@ export const FareContractHeaderSectionItem = ({
     onBehalfOfAccounts?.find((a) => a.phoneNumber === phoneNumber)?.name;
 
   return (
-    <View style={[topContainer, {paddingVertical: 0}]}>
+    <View style={[topContainer, styles.sectionItemOverrides]}>
       <WithValidityLine fc={fc}>
         <ProductName fc={fc} />
         <ValidityTime fc={fc} />
@@ -78,6 +78,10 @@ export const FareContractHeaderSectionItem = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
+  sectionItemOverrides: {
+    borderWidth: 0,
+    paddingVertical: 0,
+  },
   fareContractDetails: {
     flex: 1,
     paddingBottom: theme.spacing.large,


### PR DESCRIPTION
Follow up to https://github.com/AtB-AS/mittatb-app/pull/5335

Removes the small border in details-view as well. 

Screenshot now: 
<img width="1206" height="2622" alt="simulator_screenshot_9E4C9E9F-5223-4C65-810D-04BB81C7B90D" src="https://github.com/user-attachments/assets/8014f511-8d14-44c7-a2cf-7776f10d36b3" />
