### PR TITLE
fix: Prevented booking flow to proceed without selecting fromTo

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -39,6 +39,7 @@ import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from './utils';
 import {useOnBehalfOf} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-on-behalf-of';
 import {useBookingTrips} from '@atb/modules/booking';
+import {isValidSelection} from '@atb/modules/booking/utils';
 
 type PurchaseOverviewError = OfferError | {type: 'booking-error'};
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
@@ -134,7 +135,10 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       selection.userProfilesWithCount.some((u) => u.count) &&
       userProfilesWithCountAndOffer.some((u) => u.count);
 
-    return hasOffer || (isBookingRequired && !isBookingError);
+    return (
+      hasOffer ||
+      (isBookingRequired && !isBookingError && isValidSelection(selection))
+    );
   })();
 
   const error: PurchaseOverviewError | undefined = (() => {
@@ -340,10 +344,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
           )}
 
           <Summary
-            selection={selection}
             isLoading={isBookingRequired ? false : isSearchingOffer}
             isFree={isFree}
-            isError={!!error || !canProceed}
+            isDisabled={!!error || !canProceed}
             originalPrice={originalPrice}
             price={isBookingRequired ? undefined : totalPrice}
             summaryButtonText={summaryButtonText()}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Summary.tsx
@@ -6,27 +6,24 @@ import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
 import {formatNumberToString} from '@atb/utils/numbers';
 import React from 'react';
 import {ActivityIndicator, StyleProp, View, ViewStyle} from 'react-native';
-import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 
 type Props = {
-  selection: PurchaseSelectionType;
   price?: number;
   originalPrice: number;
   isFree: boolean;
   isLoading: boolean;
-  isError: boolean;
+  isDisabled: boolean;
   summaryButtonText: string;
   onPressBuy: () => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function Summary({
-  selection,
   price,
   originalPrice,
   isFree,
   isLoading,
-  isError,
+  isDisabled,
   summaryButtonText,
   onPressBuy,
   style,
@@ -39,7 +36,6 @@ export function Summary({
     ? formatNumberToString(price, language)
     : undefined;
   const formattedOriginalPrice = formatNumberToString(originalPrice, language);
-  const hasSelection = selection.userProfilesWithCount.some((u) => u.count);
 
   const toPaymentFunction = () => {
     onPressBuy();
@@ -76,7 +72,7 @@ export function Summary({
         expanded={true}
         interactiveColor={theme.color.interactive[0]}
         text={summaryButtonText}
-        disabled={isLoading || !hasSelection || isFree || isError}
+        disabled={isDisabled || isLoading || isFree}
         onPress={toPaymentFunction}
         rightIcon={{svg: ArrowRight}}
         testID="goToPaymentButton"


### PR DESCRIPTION
It was possible to proceed in the booking flow without selecting from and to-places. This is prevented now. 

Also uncovered that we passed `selection` to the `Summary`-component, which was not necessary since the same logic was covered outside of the component. This also leads to better separation of concerns and less coupling of components. Finally, this lead to a renaming of the `isError` prop of `summary` to `isDisabled` since that is functionally what it does now. 