### PR TITLE
fix: Added safeAreaInsets in SelectTravelTokenScreenComponent

### DIFF
--- a/src/screen-components/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/screen-components/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -21,6 +21,7 @@ import {TokenToggleInfo} from './TokenToggleInfo';
 import {useTokenToggleDetailsQuery} from '@atb/modules/mobile-token';
 import {useOnboardingContext} from '@atb/modules/onboarding';
 import {ContentHeading} from '@atb/components/heading';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 type Props = {onAfterSave: () => void};
 
@@ -191,17 +192,21 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme: Theme) => ({
-  container: {
-    backgroundColor: theme.color.background.accent[0].background,
-    flex: 1,
-  },
-  scrollView: {
-    padding: theme.spacing.medium,
-    gap: theme.spacing.medium,
-  },
-  radioArea: {
-    flexDirection: 'row',
-    gap: theme.spacing.medium,
-  },
-}));
+const useStyles = StyleSheet.createThemeHook((theme: Theme) => {
+  const {bottom: safeAreaBottomInset} = useSafeAreaInsets();
+  return {
+    container: {
+      backgroundColor: theme.color.background.accent[0].background,
+      flex: 1,
+      marginBottom: safeAreaBottomInset,
+    },
+    scrollView: {
+      padding: theme.spacing.medium,
+      gap: theme.spacing.medium,
+    },
+    radioArea: {
+      flexDirection: 'row',
+      gap: theme.spacing.medium,
+    },
+  };
+});

--- a/src/screen-components/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/screen-components/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -198,7 +198,7 @@ const useStyles = StyleSheet.createThemeHook((theme: Theme) => {
     container: {
       backgroundColor: theme.color.background.accent[0].background,
       flex: 1,
-      marginBottom: safeAreaBottomInset,
+      paddingBottom: safeAreaBottomInset,
     },
     scrollView: {
       padding: theme.spacing.medium,


### PR DESCRIPTION
Small issue found by @hanne-at-atb . Missing SafeAreaInsets on SelectTravelTokenScreenComponent. 
<details>
<summary>Before</summary>
<img width="464" height="965" alt="Skjermbilde 2025-07-31 kl  14 49 58" src="https://github.com/user-attachments/assets/8cc1009e-2e5e-430c-a2cd-e448010bf0ae" />
</details>
<details>
<summary>After</summary>
<img width="477" height="965" alt="Skjermbilde 2025-07-31 kl  14 52 04" src="https://github.com/user-attachments/assets/d63ceb3e-b870-4163-b584-ccb089cd6e2a" /></details>


