### PR TITLE
fix: added geofencing check for activeBooking status

### DIFF
--- a/src/modules/map/MapV2.tsx
+++ b/src/modules/map/MapV2.tsx
@@ -138,7 +138,9 @@ export const MapV2 = (props: MapProps) => {
 
   const showGeofencingZones =
     isGeofencingZonesEnabled &&
-    (selectedFeatureIsAVehicle || activeShmoBooking?.bookingId !== undefined);
+    (selectedFeatureIsAVehicle ||
+      (activeShmoBooking?.bookingId !== undefined &&
+        activeShmoBooking.state === ShmoBookingState.IN_USE));
 
   const showScanButton =
     isShmoDeepIntegrationEnabled &&


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/20834

fixed geofencing zones not showing after ended trip