### PR TITLE
fix: Bump design system to 18.3.1 to fix swapped icons and colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^7.1.0",
-    "@atb-as/generate-assets": "^18.3.0",
+    "@atb-as/generate-assets": "^18.3.1",
     "@atb-as/theme": "^14.1.0",
     "@atb-as/utils": "^3.5.0",
     "@bugsnag/react-native": "^7.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     zod "^3.24.4"
     zod-to-json-schema "^3.24.5"
 
-"@atb-as/generate-assets@^18.3.0":
-  version "18.3.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-18.3.0.tgz#51f3ce97090181f6a0fac8e2a23fde968aa82e69"
-  integrity sha512-lEqjjG2mm1Ab9Jd9XjH6sRFCKofwUkofqIu0x1BqbqQ5sm9vgIzzeTY84bh2wsKutEl7XZ++XXgMcJm/ozUxgA==
+"@atb-as/generate-assets@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-18.3.1.tgz#b962faa62493937889b2a822d9d1bddd9911f80c"
+  integrity sha512-Rmp7wJVk0H10hSIZysrfReRbV1GSjve8rWJr2CZQ+k/haLrXbgiIBm3V3aLJNlVBqRpspGrh87YwXH8F0l+Mvw==
   dependencies:
     "@atb-as/theme" "14.0.1"
     commander "^9.4.0"


### PR DESCRIPTION
Fixes another issue found while testing https://github.com/AtB-AS/kundevendt/issues/20064

Now looks like this: 

<details>
<summary>Screenshots</summary>
<img width="240" height="510" alt="simulator_screenshot_5C0EB011-98AA-41E3-93D3-C956078C17C2" src="https://github.com/user-attachments/assets/9e1d1372-113e-4fd0-b215-c8440ddc6154" />
<img width="240" height="510" alt="simulator_screenshot_D9305B1E-082C-47E9-A1CF-93351AE7131C" src="https://github.com/user-attachments/assets/e195a312-31b8-4e9f-a287-6cd2748f981f" />

</details>

