### PR TITLE
fix: moved delete age verification to always run on delete profile

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DeleteProfileScreen.tsx
@@ -33,9 +33,9 @@ export const Profile_DeleteProfileScreen = () => {
     useDeleteAgeVerificationMutation();
 
   const handleDeleteProfile = async () => {
+    await deleteAgeVerification();
     const isProfileDeleted = await deleteProfile();
     if (isProfileDeleted) {
-      await deleteAgeVerification();
       await deleteCollectedData();
       await signOut();
     } else {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/21145

If deleteprofile call to profile service fails the call to delete ageVerification dont run, so i moved the call to always run on delete profile button click