### PR TITLE
fix: add visibility override to BrandingImage for bonus pages

### DIFF
--- a/src/modules/bonus/enrollment/BonusOnboarding_Download.tsx
+++ b/src/modules/bonus/enrollment/BonusOnboarding_Download.tsx
@@ -74,6 +74,7 @@ export const DownloadButtons = () => {
               logoUrl={findOperatorBrandImageUrl(operatorId, mobilityOperators)}
               logoSize={50}
               style={styles.logo}
+              alwaysVisibleEnabled={true}
             />
             <ThemeText
               style={styles.operatorText}

--- a/src/modules/mobility/components/BrandingImage.tsx
+++ b/src/modules/mobility/components/BrandingImage.tsx
@@ -11,6 +11,7 @@ type BrandingImageProps = {
   fallback?: JSX.Element;
   style?: StyleProp<ViewStyle>;
   logoSize?: number;
+  alwaysVisibleEnabled?: boolean;
 };
 
 export const BrandingImage = ({
@@ -18,6 +19,7 @@ export const BrandingImage = ({
   fallback,
   style,
   logoSize = DEFAULT_LOGO_SIZE,
+  alwaysVisibleEnabled = false,
 }: BrandingImageProps) => {
   const styles = useSheetStyle();
   const {enable_vehicle_operator_logo} = useRemoteConfigContext();
@@ -25,7 +27,7 @@ export const BrandingImage = ({
 
   return (
     <View style={style}>
-      {logoUrl && enable_vehicle_operator_logo ? (
+      {logoUrl && (enable_vehicle_operator_logo || alwaysVisibleEnabled) ? (
         isSvg(logoUrl) ? (
           <SvgCssUri
             style={styles.logo}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -110,6 +110,7 @@ export const Profile_BonusScreen = () => {
                         mobilityOperators,
                       )}
                       logoSize={theme.typography['heading--big'].fontSize}
+                      alwaysVisibleEnabled={true}
                       style={styles.logo}
                     />
                   }


### PR DESCRIPTION
There is currently an `enable_vehicle_operator_logo` remote config value that should be used to determine whether logos are visible in general.

However the logos in bonus should always be visible, therefor I created an override field in BrandingImage for such occasions.

I am open to better suggestions for what the field should be called. 
Another option is to get the `enable_vehicle_operator_logo` outside this component where relevant.
Very open to input on what is best here 😇 