### PR TITLE
fix: Use cacheTime 1 hour for geofencing zones

### DIFF
--- a/src/modules/mobility/queries/use-geofencing-zones.tsx
+++ b/src/modules/mobility/queries/use-geofencing-zones.tsx
@@ -1,12 +1,12 @@
 import {useQuery} from '@tanstack/react-query';
 import {getGeofencingZones} from '@atb/api/bff/mobility';
-import {HALF_DAY_MS} from '@atb/utils/durations';
+import {ONE_HOUR_MS} from '@atb/utils/durations';
 
 export const useGeofencingZonesQuery = (systemId: string) => {
   return useQuery({
     queryKey: ['getGeofencingZones', systemId],
     queryFn: ({signal}) => getGeofencingZones([systemId], {signal}),
-    staleTime: HALF_DAY_MS,
-    cacheTime: HALF_DAY_MS,
+    staleTime: ONE_HOUR_MS,
+    cacheTime: ONE_HOUR_MS,
   });
 };


### PR DESCRIPTION
Geofencing zone data has been observed to be changed by operators more often than expected.
E.g. by adding slow zones in the morning and evening if there is a chance of frost.

Due to the bug discovered and fixed in https://github.com/AtB-AS/mittatb-app/pull/5348, it turns out we used to have a cache time of only 12 minutes. After the fix it is 12 hours, but now setting it to 1 hour instead.