### PR TITLE
fix: alwaysPaintOnEntireScreenToAvoidFlicker

### DIFF
--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -33,29 +33,36 @@ export function AnimatedBottomSheet({
     [animatedOffset, bottomOffset, windowHeight],
   );
   return (
-    <View
-      style={{
-        position: 'absolute',
-        bottom: bottomOffset,
-        left: 0,
-        right: 0,
-        height: windowHeight,
-        overflow: 'hidden',
-        pointerEvents: 'box-none',
-      }}
-    >
-      <Animated.View
+    <>
+      <View
+        style={styles.alwaysPaintOnEntireScreenToAvoidFlicker}
+        pointerEvents="box-none"
+      />
+
+      <View
         style={{
-          ...styles.bottomSheet,
-          transform: [{translateY}],
-          maxHeight: windowHeight,
-          ...shadows,
+          position: 'absolute',
+          bottom: bottomOffset,
+          left: 0,
+          right: 0,
+          height: windowHeight,
+          overflow: 'hidden',
+          pointerEvents: 'box-none',
         }}
-        onLayout={onLayout}
       >
-        {children}
-      </Animated.View>
-    </View>
+        <Animated.View
+          style={{
+            ...styles.bottomSheet,
+            transform: [{translateY}],
+            maxHeight: windowHeight,
+            ...shadows,
+          }}
+          onLayout={onLayout}
+        >
+          {children}
+        </Animated.View>
+      </View>
+    </>
   );
 }
 
@@ -67,5 +74,14 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     bottom: 0,
     borderTopLeftRadius: theme.border.radius.large,
     borderTopRightRadius: theme.border.radius.large,
+  },
+  alwaysPaintOnEntireScreenToAvoidFlicker: {
+    opacity: 0,
+    backgroundColor: 'white',
+    position: 'absolute',
+    bottom: 0,
+    top: 0,
+    left: 0,
+    right: 0,
   },
 }));

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -34,6 +34,10 @@ export function AnimatedBottomSheet({
   );
   return (
     <>
+      {/** On Android 15 and later, a black bar was observed at the top
+       * when navigating away from the map only after having opened a bottom sheet.
+       * The core issue is likely related to the Animated.View below.
+       * The fix is to add a view that ensures the whole screen is always painted on. */}
       <View style={styles.alwaysPaintOnEntireScreenToAvoidFlicker} />
 
       <View

--- a/src/components/bottom-sheet/AnimatedBottomSheet.tsx
+++ b/src/components/bottom-sheet/AnimatedBottomSheet.tsx
@@ -34,20 +34,13 @@ export function AnimatedBottomSheet({
   );
   return (
     <>
-      <View
-        style={styles.alwaysPaintOnEntireScreenToAvoidFlicker}
-        pointerEvents="box-none"
-      />
+      <View style={styles.alwaysPaintOnEntireScreenToAvoidFlicker} />
 
       <View
         style={{
-          position: 'absolute',
+          ...styles.bottomSheetContainer,
           bottom: bottomOffset,
-          left: 0,
-          right: 0,
           height: windowHeight,
-          overflow: 'hidden',
-          pointerEvents: 'box-none',
         }}
       >
         <Animated.View
@@ -67,6 +60,23 @@ export function AnimatedBottomSheet({
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
+  alwaysPaintOnEntireScreenToAvoidFlicker: {
+    position: 'absolute',
+    bottom: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    opacity: 0,
+    backgroundColor: 'white',
+    pointerEvents: 'box-none',
+  },
+  bottomSheetContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    overflow: 'hidden',
+    pointerEvents: 'box-none',
+  },
   bottomSheet: {
     backgroundColor: getThemeColor(theme).background,
     width: '100%',
@@ -74,14 +84,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     bottom: 0,
     borderTopLeftRadius: theme.border.radius.large,
     borderTopRightRadius: theme.border.radius.large,
-  },
-  alwaysPaintOnEntireScreenToAvoidFlicker: {
-    opacity: 0,
-    backgroundColor: 'white',
-    position: 'absolute',
-    bottom: 0,
-    top: 0,
-    left: 0,
-    right: 0,
   },
 }));


### PR DESCRIPTION
Fixes https://github.com/AtB-AS/kundevendt/issues/21415

The black status bar on the top should be gone after this change.
The fix is to always paint something (even though invisible) everywhere on the screen, which wasn't necessarily the case with the existing AnimatedBottomSheet.

The first video in the issue may not be fixed though, but likely will be in https://github.com/AtB-AS/kundevendt/issues/18903.

Specifically targets fixing this problem:
<video width="250" src="https://github.com/user-attachments/assets/7971bb03-df21-4f4f-9217-ffb14b2ccc48" />