### PR TITLE
poc: live activities

### DIFF
--- a/docs/LiveActivitiesSetup.md
+++ b/docs/LiveActivitiesSetup.md
@@ -1,0 +1,476 @@
+# iOS Live Activities Configuration Guide
+
+This guide documents the **simplified** Live Activities implementation that integrates with the existing widget extension.
+
+## Implementation Overview
+
+This implementation uses a **simplified approach** that:
+
+- ✅ Uses the existing `departureWidget` extension (no separate Live Activities extension)
+- ✅ Integrates Live Activities into the existing widget bundle
+- ✅ Uses system default UI styling (no custom widget views complexity)
+- ✅ Supports both regular widgets and Live Activities in one extension
+
+## Prerequisites
+
+- iOS 16.2+ deployment target (for Live Activities)
+- Xcode 14.1+
+- Developer account with appropriate provisioning profiles
+
+## Required Capabilities
+
+### 1. Add Push Notifications Capability
+
+1. Open the iOS project in Xcode (`ios/atb.xcworkspace`)
+2. Select the main app target (`atb`)
+3. Go to **Signing & Capabilities** tab
+4. Click **+ Capability** and add **Push Notifications**
+
+> **Note**: Live Activities don't have a separate capability in Xcode. They use the Push Notifications capability for both local and remote Live Activities.
+
+### 2. Update Main App Info.plist
+
+Add the following to your main app's `Info.plist`:
+
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
+
+### 3. Widget Extension Configuration
+
+The existing `departureWidget` extension is updated to support Live Activities:
+
+1. Select the `departureWidget` target
+2. Go to **Signing & Capabilities**
+3. Ensure **Push Notifications** capability is added (not a separate "Live Activities" capability)
+4. Update the deployment target to iOS 16.2+
+
+### 4. Update departureWidget.entitlements
+
+The `departureWidget.entitlements` file includes:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_NAME)</string>
+	</array>
+	<key>com.apple.developer.ActivityKit.pushtostart</key>
+	<true/>
+</dict>
+</plist>
+```
+
+## Production Considerations
+
+1. **Rate Limiting**: iOS limits the number of Live Activities per app (max 8 active)
+2. **Battery Impact**: Live Activities consume battery, design accordingly
+3. **User Privacy**: Respect user preferences for Live Activities
+4. **Fallback**: Always provide fallback for unsupported devices
+5. **Date Handling**: Always use ISO strings for consistent serialization
+6. **System UI**: This implementation uses system default styling for simplicity
+
+## Key Differences from Complex Implementations
+
+This **simplified approach**:
+
+- ✅ Uses existing widget extension (no additional extension needed)
+- ✅ Uses system default UI styling (no custom SwiftUI complexity)
+- ✅ Integrates seamlessly with existing widget architecture
+- ✅ Focuses on functionality over custom appearance
+- ✅ Much easier to maintain and debug
+
+The system provides default styling for:
+
+- Dynamic Island compact/minimal views
+- Lock screen banner appearance
+- Notification-style layout
+
+## Architecture
+
+### Files Structure
+
+```
+ios/
+├── Shared/
+│   ├── RNLiveActivity.swift              # React Native bridge implementation
+│   └── LiveActivityDataStructures.swift  # Shared data types
+├── BridgeModules/
+│   └── RNLiveActivityBridge.m            # Objective-C bridge declarations
+└── departureWidget/
+    ├── DepartureWidget.swift             # Widget bundle with Live Activities
+    └── Info.plist                        # Widget extension configuration
+```
+
+### Key Components
+
+1. **RNLiveActivity.swift**: React Native bridge providing Live Activities functionality
+2. **LiveActivityDataStructures.swift**: Swift types for Live Activities attributes and content
+3. **DepartureWidget.swift**: Widget bundle that includes both regular widgets and Live Activities
+4. **RNLiveActivityBridge.m**: Objective-C bridge for React Native integration
+
+## React Native Integration
+
+### 1. TypeScript Types
+
+The TypeScript types use **ISO strings** for all dates:
+
+```typescript
+export interface DepartureLiveActivityContentState {
+  updatedAt: string; // ISO 8601 string
+  scheduledTime: string; // ISO 8601 string
+  estimatedTime?: string; // ISO 8601 string
+  realtimeStatus: 'on-time' | 'delayed' | 'cancelled' | 'no-data';
+  delay?: number;
+  platform?: string;
+}
+```
+
+### 2. Creating Live Activities
+
+```typescript
+import {useLiveActivities} from '@atb/modules/live-activities';
+
+const MyComponent = () => {
+  const {createActivity, isSupported} = useLiveActivities();
+
+  const handleCreateActivity = async () => {
+    if (!isSupported) {
+      Alert.alert('Not supported', 'Live Activities require iOS 16.2+');
+      return;
+    }
+
+    // Create scheduled time 30 minutes from now
+    const scheduledTime = new Date(Date.now() + 30 * 60 * 1000);
+
+    const activity = await createActivity({
+      attributes: {
+        id: 'departure_123',
+        type: LiveActivityType.departure,
+        title: 'Bus 3 to Lade',
+        description: 'Departure from Sentrum',
+        activityName: 'Bus Departure',
+      },
+      contentState: {
+        updatedAt: new Date().toISOString(), // ✅ ISO string
+        scheduledTime: scheduledTime.toISOString(), // ✅ ISO string
+        realtimeStatus: 'on-time',
+        delay: 0,
+        platform: 'A',
+      },
+      config: {
+        enablePushUpdates: false,
+        relevanceScore: 0.8,
+      },
+    });
+  };
+};
+```
+
+### 3. Key Date Handling Rule
+
+**Always use `.toISOString()` when passing dates from React Native to Live Activities:**
+
+```typescript
+// ✅ Correct
+scheduledTime: new Date().toISOString();
+
+// ❌ Wrong - will cause parsing errors
+scheduledTime: new Date();
+scheduledTime: Date.now();
+scheduledTime: 'some-string-format';
+```
+
+## Build Settings
+
+### Main App Target
+
+1. Set **iOS Deployment Target** to `16.2` or later
+2. Add the following to **Build Settings**:
+   - **Swift Compiler - Language**: Swift 5.7+
+   - **User-Defined**: `SUPPORTS_LIVE_ACTIVITIES = YES`
+
+### Widget Extension Target
+
+1. Set **iOS Deployment Target** to `16.2` or later
+2. Ensure **Bundle Identifier** follows pattern: `$(PRODUCT_BUNDLE_IDENTIFIER).departureWidget`
+
+## Code Integration
+
+### 1. Import the Live Activities Module
+
+In the React Native code:
+
+```typescript
+import {
+  useLiveActivities,
+  DepartureLiveActivityExample,
+  LiveActivityType,
+} from '@atb/modules/live-activities';
+```
+
+### 2. Initialize in App Component
+
+```typescript
+// In the main App component or a provider
+import {getLiveActivityService} from '@atb/modules/live-activities';
+
+const App = () => {
+  useEffect(() => {
+    const initializeLiveActivities = async () => {
+      const service = getLiveActivityService();
+      await service.initialize();
+    };
+
+    initializeLiveActivities();
+  }, []);
+
+  // ... rest of the app
+};
+```
+
+### 3. Use the Hook
+
+```typescript
+const MyDepartureScreen = () => {
+  const {createActivity, isSupported} = useLiveActivities();
+
+  const handleCreateLiveActivity = async () => {
+    if (!isSupported) {
+      Alert.alert('Not supported', 'Live Activities require iOS 16.2+');
+      return;
+    }
+
+    // Create a Live Activity
+    const activity = await createActivity({
+      attributes: {
+        id: 'departure_123',
+        type: LiveActivityType.departure,
+        title: 'Bus 3 to Lade',
+        // ... other attributes
+      },
+      contentState: {
+        scheduledTime: new Date().toISOString(),
+        // ... other content
+      },
+    });
+  };
+
+  return (
+    <View>
+      <Button title="Create Live Activity" onPress={handleCreateLiveActivity} />
+    </View>
+  );
+};
+```
+
+## Entitlements
+
+### Main App (`atb.entitlements`):
+
+```xml
+<key>com.apple.developer.usernotifications.live-activities</key>
+<true/>
+```
+
+### Widget Extension (`departureWidget.entitlements`):
+
+```xml
+<key>com.apple.developer.ActivityKit.pushtostart</key>
+<true/>
+```
+
+## Widget Implementation
+
+The `DepartureWidget.swift` file uses a **Widget Bundle** approach:
+
+```swift
+@main
+struct DepartureWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    DepartureWidget()                    // Regular widget
+    if #available(iOS 16.2, *) {
+      LiveActivityWidget()               // Live Activities widget
+    }
+  }
+}
+
+@available(iOS 16.2, *)
+struct LiveActivityWidget: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: LiveActivityAttributes.self) { context in
+      // Lock screen/banner view with system default styling
+      LiveActivityLockScreenView(context: context)
+    } dynamicIsland: { context in
+      // Dynamic Island views
+      DynamicIsland { /* ... */ }
+    }
+  }
+}
+```
+
+## Testing Live Activities
+
+### Example Usage
+
+Use the provided example component:
+
+```typescript
+import {DepartureLiveActivityDemo} from '@atb/modules/live-activities/examples';
+
+// In your app
+<DepartureLiveActivityDemo />;
+```
+
+### Debug Logs
+
+The Swift implementation includes extensive debug logging:
+
+```
+🔍 Parsing content state from dict: [...]
+🕒 Parsed scheduledTime: 2025-08-19T15:04:18.224Z -> 2025-08-19 15:04:18 +0000
+🟢 Created Live Activity: ABC123
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"🕒 Failed to parse scheduledTime"**
+
+   - **Cause**: Passing Date object instead of ISO string
+   - **Fix**: Use `.toISOString()` when creating activities
+
+2. **"Cannot find type 'LiveActivityAttributes' in scope"**
+
+   - **Cause**: Widget extension can't see shared types
+   - **Fix**: Verify `LiveActivityDataStructures.swift` is added to widget target
+
+3. **"Live Activities not supported"**
+
+   - Check iOS version (16.2+ required for simplified approach)
+   - Verify capability is added to both targets
+   - Ensure deployment target is set correctly
+
+4. **Activities appear but show "--:--" for time**
+
+   - **Cause**: `scheduledTime` is not being passed correctly
+   - **Fix**: Ensure you're passing ISO string format
+
+5. **Dynamic Island not showing**
+   - Only available on iPhone 14 Pro/Pro Max and later
+   - Check device compatibility
+   - Verify compact and minimal views are implemented
+
+### Debugging Commands
+
+```typescript
+// Check device capabilities
+const capabilities = await RNLiveActivity.getCapabilities();
+console.log('Capabilities:', capabilities);
+
+// Get debug information
+const debugInfo = await RNLiveActivity.debugLiveActivities();
+console.log('Debug Info:', debugInfo);
+
+// List active activities
+const activities = await RNLiveActivity.getAllActiveActivities();
+console.log('Active Activities:', activities);
+```
+
+```xml
+<key>com.apple.developer.usernotifications.live-activities</key>
+<true/>
+```
+
+## Testing
+
+### 1. Device Requirements
+
+- Physical device with iOS 16.2+
+- Live Activities don't work in Simulator for Dynamic Island features
+
+### 2. Test Steps
+
+1. Build and install the app
+2. Use the `DepartureLiveActivityExample` component to test
+3. Check that Live Activities appear in:
+   - Lock Screen
+   - Dynamic Island (on supported devices)
+   - Notification Center
+
+### 3. Debugging
+
+- Check Xcode console for Live Activity logs
+- Use `getAllActiveActivities()` to verify activity state
+- Monitor Activity Monitor for widget extension crashes
+
+## Push Updates
+
+### 1. APNs Configuration
+
+Live Activities support push updates. To enable:
+
+1. Configure APNs certificates in Apple Developer portal
+2. Update the notification service to send Live Activity push notifications
+3. Use the push token returned from `createActivity()`
+
+### 2. Push Payload Example
+
+```json
+{
+  "aps": {
+    "timestamp": 1234567890,
+    "event": "update",
+    "content-state": {
+      "scheduledTime": 1234567890000,
+      "estimatedTime": 1234567950000,
+      "delay": 1,
+      "realtimeStatus": "delayed"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Live Activities not supported"**
+
+   - Check iOS version (16.2+ required)
+   - Verify capability is added to both targets
+   - Ensure deployment target is set correctly
+
+2. **Widget extension crashes**
+
+   - Check widget extension logs in Xcode
+   - Verify all required frameworks are linked
+   - Ensure ActivityKit is imported in Swift files
+
+3. **Activities not appearing**
+
+   - Check device settings: Settings > Face ID & Passcode > Live Activities
+   - Verify entitlements are correctly configured
+   - Check that the widget bundle is properly configured
+
+4. **Dynamic Island not showing**
+   - Only available on iPhone 14 Pro/Pro Max and later
+   - Check device compatibility
+   - Verify compact and minimal views are implemented
+
+### Logs and Debugging
+
+Enable additional logging by adding to the app:
+
+```swift
+// In AppDelegate or SceneDelegate
+#if DEBUG
+import os.log
+let activityLogger = Logger(subsystem: "no.mittatb.app", category: "LiveActivity")
+#endif
+```

--- a/ios/BridgeModules/RNLiveActivityBridge.h
+++ b/ios/BridgeModules/RNLiveActivityBridge.h
@@ -1,0 +1,8 @@
+#ifndef RNLiveActivity_h
+#define RNLiveActivity_h
+
+// RNLiveActivity is implemented in Swift and exposed via RCT_EXTERN_MODULE
+// This header exists for consistency but the actual interface is in
+// RNLiveActivity.m
+
+#endif /* RNLiveActivity_h */

--- a/ios/BridgeModules/RNLiveActivityBridge.m
+++ b/ios/BridgeModules/RNLiveActivityBridge.m
@@ -1,0 +1,51 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE (RNLiveActivity, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(isSupported
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getCapabilities
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(requestPermissions
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(debugLiveActivities
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(createActivity
+                  : (NSDictionary *)attributes contentState
+                  : (NSDictionary *)contentState config
+                  : (NSDictionary *)config resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(updateActivity
+                  : (NSString *)activityId contentState
+                  : (NSDictionary *)contentState config
+                  : (NSDictionary *)config resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(endActivity
+                  : (NSString *)activityId dismissalPolicy
+                  : (NSString *)dismissalPolicy finalContentState
+                  : (NSDictionary *)finalContentState resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getAllActiveActivities
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+@end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3466,7 +3466,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: eb4a80f6bf578536c58a44198ec93a30f6e69218
   Intercom: d9c81b3e45e6ecd9b2db2dc188d0521a40393f56
-  intercom-react-native: 267c5e40d45cf663da091c4417b5306d8ecfe4ee
+  intercom-react-native: 6219f7c600720acd4d1ebb37c632b25806128936
   KettleKit: 607b72ed627477a08450e5e5762c21dba1f461e3
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   MapboxCommon: 68daa8291a799ba2e24050160a1eb71e090ac0ca
@@ -3474,99 +3474,99 @@ SPEC CHECKSUMS:
   MapboxMaps: 5199095d616bbf02d99f6287dbb2023e66c6987c
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 7691283dd69fed46f6653d376de6fa83aaad774c
   RCTRequired: eac044a04629288f272ee6706e31f81f3a2b4bfe
   RCTTypeSafety: cfe499e127eda6dd46e5080e12d80d0bfe667228
   React: 1f3737a983fdd26fb3d388ddbca41a26950fe929
   React-callinvoker: 5c15ac628eab5468fe0b4dc453495f4742761f00
-  React-Core: 4b90a977a5b2777fd8f4a8db7325a83431ecd2d8
-  React-CoreModules: 385bbacfa34ac9208aa24f239a5184fa7ab1cd28
-  React-cxxreact: 3e09bcdf1f86b931b5e96bf5429d7c274a0ec168
+  React-Core: e467bf49f10da6fe92d915d2311cd0fd9bfbe052
+  React-CoreModules: 0299b3c0782edd3b37c8445ba07bf18ceb73812d
+  React-cxxreact: 54e253030b3b82b05575f19a1fb0e25c049f30ba
   React-debug: 2669a88076750ff75f3ee720f5744bd6dca62505
-  React-defaultsnativemodule: a944e2883e00c189bfa6a9e7e8c8ff5b14e6b5c8
-  React-domnativemodule: 66205b6dd1f51122c1a32b6c78e4439567044bec
-  React-Fabric: 61dfae833d674bbfea1925e484d2de3c73443af5
-  React-FabricComponents: f8b808ea0c5b7f8cb994b42cca4b2850a184ba39
-  React-FabricImage: 6121ae656aa88beb74a4bcd63fda61ca40ca2d88
+  React-defaultsnativemodule: ef7b6131b1f0f044257815fd6dfa174c8958dcf4
+  React-domnativemodule: 87e13158dfffad032e92feb8a99fd04f7f022dc2
+  React-Fabric: 3ea28339acbf5da1fb1904a8e7397d670bceba7c
+  React-FabricComponents: 7a2de521b46f33c019b1f5142e677a03c4af7d8d
+  React-FabricImage: e83ffca5409a30b1db84978ca73462c9aa60b5a9
   React-featureflags: de929056b02f8e00b8ee0de4ad6f107c1f6beb82
-  React-featureflagsnativemodule: 90c317e73745c210699b79e9c65b7ae9ee36348b
-  React-graphics: 085147f596e4cede9e8a2f1c0e61f7a1730e1371
-  React-hermes: 24bfc254f1ba83182d4936641898fe963af343fb
-  React-idlecallbacksnativemodule: 4bf0846bdab21af4a7267634390c132b4c0b9ab6
-  React-ImageManager: 5465f84b7b58fb056dbec1a315bcdaee92e3a47f
-  React-jserrorhandler: 5b07e25284405ddca6465cf4ef83542a04ffbce1
-  React-jsi: ede7e8c96f997f8772871c82688cea53c1ffb148
-  React-jsiexecutor: fc9b287189ce800a92d5ab4e7291508eacaab451
-  React-jsinspector: 657e24b84532a572238ddb577885648c4b8c925e
-  React-jsitracing: d5d719177e8ac8df8289992a841b4e08e9a68fd4
-  React-logger: f9d104eace4ce03d7d5ab96802069d9905082225
-  React-Mapbuffer: 33ee28be239923f0e1db4650f859380c5640562c
-  React-microtasksnativemodule: 76f6ff854124d63547996c6228ccaa1066f434f5
-  react-native-compressor: 907ff1e3b4a942d8dc5a1f93d0ef75a0df37ca12
-  react-native-date-picker: 8a0d56cdef18f61945e6d0dfd250dc1b8e7a313e
-  react-native-device-brightness: 886cfbfb49a32b6de4ccfc1f720776dc5f381d24
-  react-native-geolocation: 27e2ec1ac037c5209c57716ad8cb0b4e61d145e7
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-in-app-review: db8bb167a5f238e7ceca5c242d6b36ce8c4404a4
-  react-native-keep-awake: f242130d32a8e312b53c4b422534fd73ff35885a
-  react-native-kettle-module: 8cff9eddef0d70da7f647ca997f5ff99d3588a20
-  react-native-pager-view: 87334b0013bb6ba27a491ddc499e2c1cb9058e3f
-  react-native-safe-area-context: 141eca0fd4e4191288dfc8b96a7c7e1c2983447a
-  react-native-slider: 7573f654cac3496c26663a55628e5e8fde3325e8
+  React-featureflagsnativemodule: 69e1147fc5b9bddd02888782aecfaca18a86246d
+  React-graphics: c9d17e172cc0a3cdebd87dcc533749e19d565681
+  React-hermes: 91baa15c07e76b0768d6e10f4dac1c080a47eef4
+  React-idlecallbacksnativemodule: eda2b6cd14ce54effadadbb7cb5405a7944efc13
+  React-ImageManager: b3a91321c7e32d0cae8bc8191013a87abac99dcf
+  React-jserrorhandler: 7ea0146a6e63c1f5b92b91b03c2722e97ebc370e
+  React-jsi: 87fa67556d7a82125bc77930bf973717fb726d14
+  React-jsiexecutor: 3a92052dd96cff1cd693fa3ef8d9738b1d05372a
+  React-jsinspector: 0254ecc3023064e092d69ff2b30f69fef3639924
+  React-jsitracing: db3be7be47007cf5bd35156efee83da71058b62a
+  React-logger: 5cad0c76d056809523289e589309012215a393b5
+  React-Mapbuffer: bfec84fd4dc022fcd29656030d0ddba0092376bd
+  React-microtasksnativemodule: bd7c624bb83ddc4f8449cadc62674e8107a2bd99
+  react-native-compressor: 81ce003efb3740b8d11287015589d52aaebf9388
+  react-native-date-picker: efc84d576cf2637a9697853e790c40f2790bd977
+  react-native-device-brightness: 1a997350d060c3df9f303b1df84a4f7c5cbeb924
+  react-native-geolocation: 72fdcaabfe4c35e9a3bb15375c9543d3daa65f6b
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-in-app-review: b3d1eed3d1596ebf6539804778272c4c65e4a400
+  react-native-keep-awake: 03b74eebe4f2bb5e8478fc8f420651a92463b6f8
+  react-native-kettle-module: bd43213d8f7d6a3838d16b387838ec3b0fa8a8a0
+  react-native-pager-view: 1b70e63833fef9845f895d5ca0bad88cb4267938
+  react-native-safe-area-context: 758e894ca5a9bd1868d2a9cfbca7326a2b6bf9dc
+  react-native-slider: d34699c23a92c851e312220d553946e4f723aa74
   React-nativeconfig: c77447a7820ac780b97f121ae6248ac07248835f
-  React-NativeModulesApple: 2d6558580b3eb08593091264bdfff3301e708d9d
-  React-perflogger: f02ee21d98773121d77993b3c1a8be445840fae3
-  React-performancetimeline: 348b294a18697f9fa0ed3229bb1eb0da448be231
+  React-NativeModulesApple: 3156840c8d3cddd5cdf9df8ff417641088ae43d3
+  React-perflogger: d1149037ac466ad2141d4ae541ca16cb73b2343b
+  React-performancetimeline: d2517e44210dd8626b450c84f323501e5e06800f
   React-RCTActionSheet: ad84d5a0bd1ad1782f0b78b280c6f329ad79a53a
-  React-RCTAnimation: 388460f7c124c76e337c6646738a83d6ea147095
-  React-RCTAppDelegate: 0d66f6fc0a501b9e34a8a16e9099411b082904b2
-  React-RCTBlob: 07cccbb74e22ce66745358799f6ab02a5bed2993
-  React-RCTFabric: 87b1c3a25f15ab78673d340d80ca2a505b2509b3
-  React-RCTImage: 8fbdae841ea1217c44f4c413bba2403134b83cd1
-  React-RCTLinking: c59bf8286ba2cc327b01bb524fb9c16446dc18bc
-  React-RCTNetwork: 2c137a0aaaed2cf4bb53aff82a2bb8c34f2fbeac
-  React-RCTSettings: 9fcd32c5b38af6421a3dd20cdd9ebf09df0a9a6d
-  React-RCTText: 5308618477fec454282809065bd121c2bd3dd5e1
-  React-RCTVibration: 7b2a186756b5c8e586e3e7948eed4432a93299c0
+  React-RCTAnimation: 64ed42bb43b33b0d861126f83048429606390903
+  React-RCTAppDelegate: 443dcfa567b73f10285f615ef442a8f7e35b48fb
+  React-RCTBlob: e74dfdbbfcd46d9d1eec3b3a0f045e655e3f7861
+  React-RCTFabric: 4e8c01c57b0b247297d73578d891bbc7707abd84
+  React-RCTImage: 1b6d8ad60f74a3cec4ee52e0ca55f1773afd03f4
+  React-RCTLinking: 88b2384d876346fbb16839a60c1d20830b2e95fe
+  React-RCTNetwork: 88aa473814e796d3a7bc6a0b51e7ae5749bdc243
+  React-RCTSettings: 0d73a1846aef87ef07c2026c186ea0d80602a130
+  React-RCTText: bfdb776f849156f895909ee999b4b5f2f9cf9a0b
+  React-RCTVibration: 81c8bbcc841ce5a7ae6e1bd2ec949b30e58d1fcf
   React-rendererconsistency: 764e4066c5ec9f80b8b18b4b117ec92c79ce4011
-  React-rendererdebug: ac19be3c50e9c370538620c4f323f5b426f47ce2
+  React-rendererdebug: 16cef9382fb58b4a48c38ac0726dc87a71091b63
   React-rncore: 75849d74ca735b2496f667635b9686594e2f6624
-  React-RuntimeApple: e4da43c529498b23f024225138da6aa2ebf481aa
-  React-RuntimeCore: 75386d1ac115277c83e63678bd200173d32ea138
+  React-RuntimeApple: 89e8bc63bc342a36af177834ba9c461e7b803d3a
+  React-RuntimeCore: 8ff5c39d3c1e977ac1b14036c7c3d0d8fcec0962
   React-runtimeexecutor: 732038d7c356ba74132f1d16253a410621d3c2c1
-  React-RuntimeHermes: 1cb35aa9baf0609e898deb0857aff72a886e2606
-  React-runtimescheduler: 96279a5332c45a79999ff5afcdc828e970abb157
+  React-RuntimeHermes: 73f481b91f5aeefc8aa68faf7cc97ec51e16fe44
+  React-runtimescheduler: 236b43000d728475d3ea5ffc112b97df6fd31b08
   React-timing: 30584b21b496cf80d332c70db3063c295f997fa3
-  React-utils: 72cb4a2db18c087d09ec80079524e1fcb27b29a0
-  ReactCodegen: 807cff999d1705af15b99363e2cc37ca9fae4761
-  ReactCommon: 043f537fa4c5366bb960a760bc626fb50c4eb84f
-  ReactNativeCameraKit: 80ee467bdc72ab04dea312eb275c0d2cd682f2db
+  React-utils: 8742420880b3d5d8f8a5d347b9d24c0b9160bc4d
+  ReactCodegen: fe2ffeda5a1ad1b6f2bb4f676ae60da296630ce4
+  ReactCommon: 885ac625dd73cd6585ca5c1ad5c09e1ce848b015
+  ReactNativeCameraKit: bc521fe3263ce4b526271801e79bdd2c3a17a3f7
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
-  RNBootSplash: 5951974a5271183d06d3279bd4b9d7d093f4e2fc
-  RNCAsyncStorage: 687bb9e85dd3d45b966662440dcfc0cd962347e6
-  RNCClipboard: d7a8903d32692b0a1e71738c3825465a9acae10e
-  RNDateTimePicker: 40ffda97d071a98a10fdca4fa97e3977102ccd14
-  RNDeviceInfo: feea80a690d2bde1fe51461cf548039258bd03f2
-  RNFBAnalytics: c26f9c7b4c748c39b3e8e323a6cf6f682e49dfe4
-  RNFBApp: 017499cd7ea340963bfac43b4fcb28d2b0b21a09
-  RNFBAuth: 97633be48cc4e539d954270a218785d2e3f9fde7
-  RNFBFirestore: 5250af3b06d1fe90b75c905d8b29d155e603d040
-  RNFBMessaging: 81f9447a3790df25c72753b446247ebeba95b182
-  RNFBRemoteConfig: 9b1a791f4861fbc4edb2174ee8d5b292a1d6369e
-  RNGestureHandler: a52601cdccc6213650ad4a9eb2911360d13f4447
-  RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
-  RNLocalize: 4f22418187ecd5ca693231093ff1d912d1b3c9bc
-  rnmapbox-maps: 1a097b7d5a29418ecf9535ebd419b686d8b538cc
-  RNPermissions: 47db57715014b92750634e0fd5c0287fa7156007
-  RNReanimated: 26cd23938ae57e108d7f3e1e05ab53b457f577ec
-  RNScreens: 16b782596e80e475b7f3ec769c9a97d789d9b0ed
-  RNSVG: 76d7cafaaa603fbbcb05aff928653e720251f483
+  RNBootSplash: 2563a5286234d9571e2fd611fde5d20f0983f1e0
+  RNCAsyncStorage: 24e389fea98b1231212f8e5de4e7d306c92f1b53
+  RNCClipboard: ee059e6006b137e369caed5eb852b4aad9f5d886
+  RNDateTimePicker: 818460dc31b0dc5ec58289003e27dd8d022fb79c
+  RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
+  RNFBAnalytics: 21de72aaf80b78bbe57c44636335a6ab207322f4
+  RNFBApp: 4e6da65e29a144d20bcb5bf264fc8e2055831bab
+  RNFBAuth: 0e317b179cef51f450531da980b927212cfb73cb
+  RNFBFirestore: 5ebbd50cd31648e656f4f01fc44c4f0807e32f4d
+  RNFBMessaging: fb5a9b0a3043d5d3e6e9fe7b27b78fcc3a0f753f
+  RNFBRemoteConfig: 2af832c678d0bf4d3a7b83dbef8b316e2b10dae3
+  RNGestureHandler: 4a7cce66468343e82d601e8f6cdc0148b18b6c6b
+  RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
+  RNLocalize: e7378161f0b6a6365407eb2377aab46cc38047d8
+  rnmapbox-maps: f08ccc7454f02131916905654d9612db262baa87
+  RNPermissions: 8f723aff8930c269b8faebf8cde4a7bcffd21b8d
+  RNReanimated: 25ec70669c387101a4c8e671fcc58cffda76da88
+  RNScreens: 4a5446dc4d922b2375df14c3a3f30bfc7719f6b1
+  RNSVG: a07e14363aa208062c6483bad24a438d5986d490
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftProtobuf: 4dbaffec76a39a8dc5da23b40af1a5dc01a4c02d
   TimeApiiOSLib: 59b914855fe3abc93d34670061450422aee2ea7b
   TokenCore: 10f20eb282693b9b6ee15e38dae3b9f1a64b372b
-  TokenStateReactNativeLib: 0bb0ca8f9116785e5e0f3e651fc82ba97772919b
+  TokenStateReactNativeLib: df19d0524b21a5ed99125434723f637a65484b51
   Turf: c9eb11a65d96af58cac523460fd40fec5061b081
   VisualCodeModeliOSLib: fde1749faebf9266352736a1260bdbed1c9a06b1
   VisualCodeViewiOSLib: 2c79d22b46584eea81e7638ac19817e9a9e6abac
@@ -3574,4 +3574,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 83953c0975b744bbaae14e23786ba97c3b778969
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/ios/Shared/LiveActivityDataStructures.swift
+++ b/ios/Shared/LiveActivityDataStructures.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+#if canImport(ActivityKit)
+  import ActivityKit
+
+  // MARK: - Live Activity Data Structures for Main App
+  // Simple data structures for Live Activities without widget extension complexity
+
+  @available(iOS 16.2, *)
+  struct LiveActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+      let status: ActivityStatus
+      let actionButton: ActionButton?
+      let scheduledTime: Date?
+      let startTime: Date?
+      let reminderTime: Date?
+      let delay: Int?
+      let customData: [String: String]
+
+      init(
+        status: ActivityStatus = .active,
+        actionButton: ActionButton? = nil,
+        scheduledTime: Date? = nil,
+        startTime: Date? = nil,
+        reminderTime: Date? = nil,
+        delay: Int? = nil,
+        customData: [String: String] = [:]
+      ) {
+        self.status = status
+        self.actionButton = actionButton
+        self.scheduledTime = scheduledTime
+        self.startTime = startTime
+        self.reminderTime = reminderTime
+        self.delay = delay
+        self.customData = customData
+      }
+    }
+
+    let title: String
+    let description: String?
+    let type: ActivityType
+    let id: String
+    let activityName: String
+    let deepLink: String?
+
+    init(
+      title: String,
+      description: String? = nil,
+      type: ActivityType,
+      id: String,
+      activityName: String,
+      deepLink: String? = nil
+    ) {
+      self.title = title
+      self.description = description
+      self.type = type
+      self.id = id
+      self.activityName = activityName
+      self.deepLink = deepLink
+    }
+  }
+
+  @available(iOS 16.2, *)
+  enum ActivityType: String, Codable, CaseIterable {
+    case departure = "departure"
+    case journey = "journey"
+    case reminder = "reminder"
+    case alert = "alert"
+  }
+
+  @available(iOS 16.2, *)
+  enum ActivityStatus: String, Codable, CaseIterable {
+    case active = "active"
+    case delayed = "delayed"
+    case cancelled = "cancelled"
+    case completed = "completed"
+  }
+
+  @available(iOS 16.2, *)
+  struct ActionButton: Codable, Hashable {
+    let title: String
+    let action: String
+
+    init(title: String, action: String) {
+      self.title = title
+      self.action = action
+    }
+  }
+
+#endif

--- a/ios/Shared/RNLiveActivity.swift
+++ b/ios/Shared/RNLiveActivity.swift
@@ -1,0 +1,648 @@
+import ActivityKit
+import Foundation
+import React
+import WidgetKit
+
+@objc(RNLiveActivity)
+class RNLiveActivity: RCTEventEmitter {
+
+    private var hasListeners = false
+    private var activeActivities: [String: Any] = [:]
+
+    override func supportedEvents() -> [String]! {
+        return ["LiveActivityEvent"]
+    }
+
+    override func startObserving() {
+        hasListeners = true
+        if #available(iOS 16.2, *) {
+            setupActivityObservers()
+        }
+    }
+
+    override func stopObserving() {
+        hasListeners = false
+    }
+
+    @objc
+    override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
+    // MARK: - Activity Dictionary Helpers
+
+    @available(iOS 16.2, *)
+    private func getTypedActivities() -> [String: Activity<LiveActivityAttributes>] {
+        return activeActivities.compactMapValues { $0 as? Activity<LiveActivityAttributes> }
+    }
+
+    @available(iOS 16.2, *)
+    private func findActivity(by id: String) -> Activity<LiveActivityAttributes>? {
+        // First check our local storage
+        if let activity = getTypedActivities()[id] {
+            #if DEBUG
+                print("🔵 Found activity in local storage: \(id)")
+            #endif
+            return activity
+        }
+
+        // If not found locally, check system activities
+        let systemActivity = Activity<LiveActivityAttributes>.activities.first { $0.id == id }
+
+        #if DEBUG
+            print("🔍 Searching for activity ID: \(id)")
+            print("🔍 Local activities: \(getTypedActivities().keys)")
+            print(
+                "🔍 System activities: \(Activity<LiveActivityAttributes>.activities.map { $0.id })")
+            if let systemActivity = systemActivity {
+                print("🟡 Found activity in system: \(id)")
+                // Re-store it locally
+                storeActivity(systemActivity, forKey: id)
+            } else {
+                print("🔴 Activity not found anywhere: \(id)")
+            }
+        #endif
+
+        return systemActivity
+    }
+
+    @available(iOS 16.2, *)
+    private func storeActivity(_ activity: Activity<LiveActivityAttributes>, forKey key: String) {
+        activeActivities[key] = activity
+    }
+
+    @available(iOS 16.2, *)
+    private func removeActivity(forKey key: String) {
+        activeActivities.removeValue(forKey: key)
+    }
+
+    // MARK: - Public Methods
+
+    @objc
+    func isSupported(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        #if canImport(ActivityKit)
+            if #available(iOS 16.2, *) {
+                let authInfo = ActivityAuthorizationInfo()
+                let isEnabled = authInfo.areActivitiesEnabled
+
+                #if DEBUG
+                    print("🔴 Live Activities Debug:")
+                    print("  - iOS version check: ✅ (16.2+)")
+                    print("  - areActivitiesEnabled: \(isEnabled)")
+                    print("  - ActivityAuthorizationInfo: \(authInfo)")
+                #endif
+
+                resolve(isEnabled)
+            } else {
+                #if DEBUG
+                    print("🔴 Live Activities: iOS version too old (need 16.2+)")
+                #endif
+                resolve(false)
+            }
+        #else
+            #if DEBUG
+                print("🔴 Live Activities: ActivityKit not available")
+            #endif
+            resolve(false)
+        #endif
+    }
+
+    @objc
+    func getCapabilities(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        #if canImport(ActivityKit)
+            if #available(iOS 16.2, *) {
+                let capabilities: [String: Any] = [
+                    "isSupported": ActivityAuthorizationInfo().areActivitiesEnabled,
+                    "supportsDynamicIsland": UIDevice.current.userInterfaceIdiom == .phone,
+                    "supportsLockScreen": true,
+                    "supportsPushUpdates": true,
+                    "maxActiveActivities": 8,  // iOS limit
+                ]
+                resolve(capabilities)
+            } else {
+                let capabilities: [String: Any] = [
+                    "isSupported": false,
+                    "supportsDynamicIsland": false,
+                    "supportsLockScreen": false,
+                    "supportsPushUpdates": false,
+                    "maxActiveActivities": 0,
+                ]
+                resolve(capabilities)
+            }
+        #else
+            let capabilities: [String: Any] = [
+                "isSupported": false,
+                "supportsDynamicIsland": false,
+                "supportsLockScreen": false,
+                "supportsPushUpdates": false,
+                "maxActiveActivities": 0,
+            ]
+            resolve(capabilities)
+        #endif
+    }
+
+    @objc
+    func requestPermissions(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        #if canImport(ActivityKit)
+            if #available(iOS 16.2, *) {
+                // Live Activities don't require explicit permission request
+                // Permission is handled automatically when creating the first activity
+                resolve(ActivityAuthorizationInfo().areActivitiesEnabled)
+            } else {
+                resolve(false)
+            }
+        #else
+            resolve(false)
+        #endif
+    }
+
+    @objc
+    func debugLiveActivities(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        var debugInfo: [String: Any] = [:]
+
+        #if canImport(ActivityKit)
+            if #available(iOS 16.2, *) {
+                let authInfo = ActivityAuthorizationInfo()
+
+                debugInfo = [
+                    "iosVersionSupported": true,
+                    "currentIOSVersion": UIDevice.current.systemVersion,
+                    "areActivitiesEnabled": authInfo.areActivitiesEnabled,
+                    "activityAuthorizationInfo": "\(authInfo)",
+                    "deviceModel": UIDevice.current.model,
+                    "deviceName": UIDevice.current.name,
+                    "userInterfaceIdiom": UIDevice.current.userInterfaceIdiom.rawValue,
+                    "isPhysicalDevice": TARGET_OS_SIMULATOR == 0,
+                    "activityKitAvailable": true,
+                ]
+            } else {
+                debugInfo = [
+                    "iosVersionSupported": false,
+                    "currentIOSVersion": UIDevice.current.systemVersion,
+                    "minimumRequired": "16.2",
+                    "activityKitAvailable": true,
+                ]
+            }
+        #else
+            debugInfo = [
+                "iosVersionSupported": false,
+                "currentIOSVersion": UIDevice.current.systemVersion,
+                "minimumRequired": "16.2",
+                "activityKitAvailable": false,
+                "error": "ActivityKit framework not available",
+            ]
+        #endif
+
+        resolve(debugInfo)
+    }
+
+    @objc
+    func createActivity(
+        _ attributes: [String: Any],
+        contentState: [String: Any],
+        config: [String: Any],
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+
+        guard #available(iOS 16.2, *) else {
+            reject("NOT_SUPPORTED", "Live Activities require iOS 16.2 or later", nil)
+            return
+        }
+
+        do {
+            let activityAttributes = try parseAttributes(from: attributes)
+            let initialContentState = try parseContentState(from: contentState)
+            let activityConfig = parseConfig(from: config)
+
+            let activityContent = ActivityContent(
+                state: initialContentState,
+                staleDate: activityConfig.staleDate
+            )
+
+            let activity = try Activity<LiveActivityAttributes>.request(
+                attributes: activityAttributes,
+                content: activityContent,
+                pushType: activityConfig.enablePushUpdates ? .token : nil
+            )
+
+            // Store the activity reference
+            storeActivity(activity, forKey: activity.id)
+
+            #if DEBUG
+                print("🟢 Created Live Activity: \(activity.id)")
+                print("🟢 Activity state: \(activity.activityState)")
+                print("🟢 Total stored activities: \(getTypedActivities().count)")
+            #endif
+
+            let result: [String: Any] = [
+                "id": activity.id,
+                "pushToken": activity.pushToken?.map { String(format: "%02x", $0) }.joined() ?? "",
+            ]
+
+            // Send creation event
+            sendEvent(type: "created", activityId: activity.id, activity: activity)
+
+            resolve(result)
+
+        } catch {
+            reject(
+                "CREATE_FAILED", "Failed to create Live Activity: \(error.localizedDescription)",
+                error)
+        }
+    }
+
+    @objc
+    func updateActivity(
+        _ activityId: String,
+        contentState: [String: Any],
+        config: [String: Any]?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+
+        guard #available(iOS 16.2, *) else {
+            reject("NOT_SUPPORTED", "Live Activities require iOS 16.2 or later", nil)
+            return
+        }
+
+        guard let activity = findActivity(by: activityId) else {
+            reject("ACTIVITY_NOT_FOUND", "Activity with ID \(activityId) not found", nil)
+            return
+        }
+
+        do {
+            let newContentState = try parseContentState(from: contentState)
+            let activityConfig = parseConfig(from: config ?? [:])
+
+            let activityContent = ActivityContent(
+                state: newContentState,
+                staleDate: activityConfig.staleDate
+            )
+
+            Task {
+                await activity.update(activityContent)
+
+                // Send update event
+                DispatchQueue.main.async {
+                    self.sendEvent(type: "updated", activityId: activityId, activity: activity)
+                }
+            }
+
+            resolve(nil)
+
+        } catch {
+            reject(
+                "UPDATE_FAILED", "Failed to update Live Activity: \(error.localizedDescription)",
+                error)
+        }
+    }
+
+    @objc
+    func endActivity(
+        _ activityId: String,
+        dismissalPolicy: String?,
+        finalContentState: [String: Any]?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+
+        guard #available(iOS 16.2, *) else {
+            reject("NOT_SUPPORTED", "Live Activities require iOS 16.2 or later", nil)
+            return
+        }
+
+        guard let activity = findActivity(by: activityId) else {
+            reject("ACTIVITY_NOT_FOUND", "Activity with ID \(activityId) not found", nil)
+            return
+        }
+
+        do {
+            let policy = parseDismissalPolicy(from: dismissalPolicy)
+
+            Task {
+                if let finalState = finalContentState {
+                    let finalContentStateObj = try self.parseContentState(from: finalState)
+                    let finalContent = ActivityContent(state: finalContentStateObj, staleDate: nil)
+                    await activity.end(finalContent, dismissalPolicy: policy)
+                } else {
+                    await activity.end(nil, dismissalPolicy: policy)
+                }
+
+                // Remove from active activities
+                DispatchQueue.main.async {
+                    self.removeActivity(forKey: activityId)
+                    self.sendEvent(type: "ended", activityId: activityId, activity: activity)
+                }
+            }
+
+            resolve(nil)
+
+        } catch {
+            reject(
+                "END_FAILED", "Failed to end Live Activity: \(error.localizedDescription)", error)
+        }
+    }
+
+    @objc
+    func getAllActiveActivities(
+        _ resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+
+        guard #available(iOS 16.2, *) else {
+            resolve([])
+            return
+        }
+
+        let activeActivitiesData = Activity<LiveActivityAttributes>.activities.map { activity in
+            return [
+                "id": activity.id,
+                "status": activityStateToString(activity.activityState),
+            ]
+        }
+
+        resolve(activeActivitiesData)
+    }
+
+    // MARK: - Private Helper Methods
+
+    @available(iOS 16.2, *)
+    private func setupActivityObservers() {
+        guard #available(iOS 16.2, *) else { return }
+
+        // Monitor all activities for state changes
+        Task {
+            for await activity in Activity<LiveActivityAttributes>.activityUpdates {
+                handleActivityStateChange(activity)
+            }
+        }
+    }
+
+    @available(iOS 16.2, *)
+    private func handleActivityStateChange(_ activity: Activity<LiveActivityAttributes>) {
+        guard hasListeners else { return }
+
+        switch activity.activityState {
+        case .active:
+            sendEvent(type: "updated", activityId: activity.id, activity: activity)
+        case .ended:
+            removeActivity(forKey: activity.id)
+            sendEvent(type: "ended", activityId: activity.id, activity: activity)
+        case .dismissed:
+            removeActivity(forKey: activity.id)
+            sendEvent(type: "dismissed", activityId: activity.id, activity: activity)
+        case .stale:
+            sendEvent(type: "updated", activityId: activity.id, activity: activity)
+        @unknown default:
+            break
+        }
+    }
+
+    @available(iOS 16.2, *)
+    private func sendEvent(
+        type: String, activityId: String, activity: Activity<LiveActivityAttributes>? = nil
+    ) {
+        guard hasListeners else { return }
+
+        var eventData: [String: Any] = [
+            "type": type,
+            "activityId": activityId,
+            "timestamp": Date().timeIntervalSince1970 * 1000,
+        ]
+
+        if let activity = activity {
+            eventData["activity"] = [
+                "id": activity.id,
+                "status": activityStateToString(activity.activityState),
+                "pushToken": activity.pushToken?.map { String(format: "%02x", $0) }.joined() ?? "",
+            ]
+        }
+
+        sendEvent(withName: "LiveActivityEvent", body: eventData)
+    }
+
+    @available(iOS 16.2, *)
+    private func parseAttributes(from dict: [String: Any]) throws -> LiveActivityAttributes {
+        #if DEBUG
+            print("🔍 Parsing attributes from dict: \(dict)")
+        #endif
+
+        guard let typeString = dict["type"] as? String,
+            let id = dict["id"] as? String,
+            let title = dict["title"] as? String,
+            let activityName = dict["activityName"] as? String
+        else {
+            #if DEBUG
+                print("🔴 Missing required attributes")
+                print("  - type: \(dict["type"] ?? "missing")")
+                print("  - id: \(dict["id"] ?? "missing")")
+                print("  - title: \(dict["title"] ?? "missing")")
+                print("  - activityName: \(dict["activityName"] ?? "missing")")
+            #endif
+            throw NSError(
+                domain: "RNLiveActivity", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Missing required attributes"])
+        }
+
+        // Convert string type to enum
+        let activityType: ActivityType
+        switch typeString.lowercased() {
+        case "departure":
+            activityType = .departure
+        case "journey":
+            activityType = .journey
+        case "reminder":
+            activityType = .reminder
+        case "alert":
+            activityType = .alert
+        default:
+            #if DEBUG
+                print("🟡 Unknown activity type '\(typeString)', defaulting to departure")
+            #endif
+            activityType = .departure  // Default fallback
+        }
+
+        #if DEBUG
+            print("🟢 Parsed attributes:")
+            print("  - type: \(activityType)")
+            print("  - id: \(id)")
+            print("  - title: \(title)")
+            print("  - description: \(dict["description"] as? String ?? "nil")")
+        #endif
+
+        return LiveActivityAttributes(
+            title: title,
+            description: dict["description"] as? String,
+            type: activityType,
+            id: id,
+            activityName: activityName,
+            deepLink: dict["deepLink"] as? String
+        )
+    }
+
+    @available(iOS 16.2, *)
+    private func parseContentState(from dict: [String: Any]) throws
+        -> LiveActivityAttributes.ContentState
+    {
+        #if DEBUG
+            print("🔍 Parsing content state from dict: \(dict)")
+        #endif
+
+        // Helper function to parse ISO 8601 dates with fractional seconds
+        func parseISODate(from string: String) -> Date? {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter.date(from: string)
+        }
+
+        // Parse status
+        let statusString = dict["status"] as? String ?? "active"
+        let status: ActivityStatus
+        switch statusString.lowercased() {
+        case "delayed":
+            status = .delayed
+        case "cancelled":
+            status = .cancelled
+        case "completed":
+            status = .completed
+        default:
+            status = .active
+        }
+
+        // Parse action button
+        var actionButton: ActionButton?
+        if let buttonDict = dict["actionButton"] as? [String: Any],
+            let title = buttonDict["title"] as? String,
+            let action = buttonDict["action"] as? String
+        {
+            actionButton = ActionButton(title: title, action: action)
+        }
+
+        // Parse times - expect ISO 8601 strings
+        var scheduledTime: Date?
+        if let dateString = dict["scheduledTime"] as? String, !dateString.isEmpty {
+            scheduledTime = parseISODate(from: dateString)
+            #if DEBUG
+                if scheduledTime != nil {
+                    print("🕒 Parsed scheduledTime: \(dateString) -> \(scheduledTime!)")
+                } else {
+                    print("🕒 Failed to parse scheduledTime: \(dateString)")
+                }
+            #endif
+        } else {
+            #if DEBUG
+                if let rawTime = dict["scheduledTime"] {
+                    print(
+                        "🕒 Invalid scheduledTime format. Expected ISO string, got: \(rawTime) (type: \(type(of: rawTime)))"
+                    )
+                } else {
+                    print("🕒 No scheduledTime provided")
+                }
+            #endif
+        }
+
+        var startTime: Date?
+        if let dateString = dict["startTime"] as? String, !dateString.isEmpty {
+            startTime = parseISODate(from: dateString)
+        }
+
+        var reminderTime: Date?
+        if let dateString = dict["reminderTime"] as? String, !dateString.isEmpty {
+            reminderTime = parseISODate(from: dateString)
+        }
+
+        // Parse delay
+        let delay = dict["delay"] as? Int
+
+        // Parse custom data (convert [String: Any] to [String: String])
+        var customData: [String: String] = [:]
+        if let customDict = dict["customData"] as? [String: Any] {
+            for (key, value) in customDict {
+                customData[key] = "\(value)"
+            }
+        }
+
+        #if DEBUG
+            print("🟢 Parsed content state:")
+            print("  - status: \(status)")
+            print("  - scheduledTime: \(scheduledTime?.description ?? "nil")")
+            print("  - delay: \(delay?.description ?? "nil")")
+            print("  - customData keys: \(customData.keys)")
+        #endif
+
+        return LiveActivityAttributes.ContentState(
+            status: status,
+            actionButton: actionButton,
+            scheduledTime: scheduledTime,
+            startTime: startTime,
+            reminderTime: reminderTime,
+            delay: delay,
+            customData: customData
+        )
+    }
+
+    private func parseConfig(from dict: [String: Any]) -> ActivityConfig {
+        let enablePushUpdates = dict["enablePushUpdates"] as? Bool ?? false
+        let relevanceScore = dict["relevanceScore"] as? Double ?? 0.5
+
+        var staleDate: Date?
+        if let staleDateTimestamp = dict["staleDate"] as? Double {
+            staleDate = Date(timeIntervalSince1970: staleDateTimestamp / 1000)
+        }
+
+        return ActivityConfig(
+            enablePushUpdates: enablePushUpdates,
+            relevanceScore: relevanceScore,
+            staleDate: staleDate
+        )
+    }
+
+    @available(iOS 16.1, *)
+    private func parseDismissalPolicy(from string: String?) -> ActivityUIDismissalPolicy {
+        switch string {
+        case "immediate":
+            return .immediate
+        case "after-date":
+            return .default
+        default:
+            return .default
+        }
+    }
+
+    @available(iOS 16.1, *)
+    private func activityStateToString(_ state: ActivityState) -> String {
+        switch state {
+        case .active:
+            return "active"
+        case .ended:
+            return "ended"
+        case .dismissed:
+            return "dismissed"
+        case .stale:
+            return "stale"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
+// MARK: - Supporting Structures
+
+struct ActivityConfig {
+    let enablePushUpdates: Bool
+    let relevanceScore: Double
+    let staleDate: Date?
+}

--- a/ios/atb.xcodeproj/project.pbxproj
+++ b/ios/atb.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		298D19472AEBC45E00065733 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 298D19492AEBC45E00065733 /* InfoPlist.strings */; };
 		385EE0D3242C0AFC002E1272 /* enforce-bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385EE0D2242C0AFC002E1272 /* enforce-bridge.swift */; };
 		38CD3270254B612600C6B978 /* AtBRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 38CD326F254B612600C6B978 /* AtBRootView.m */; };
+		468F74092E5475A80022CCB2 /* RNLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468F74082E5475A80022CCB2 /* RNLiveActivity.swift */; };
+		468F740C2E5499CA0022CCB2 /* RNLiveActivityBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 468F740B2E5499CA0022CCB2 /* RNLiveActivityBridge.m */; };
+		468F74152E54A79C0022CCB2 /* LiveActivityDataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468F74142E54A79C0022CCB2 /* LiveActivityDataStructures.swift */; };
+		468F74362E55B3630022CCB2 /* LiveActivityDataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468F74142E54A79C0022CCB2 /* LiveActivityDataStructures.swift */; };
 		500752DC29855BD100AC5A7F /* Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 500752DB29855BD100AC5A7F /* Intents.framework */; };
 		500752DF29855BD100AC5A7F /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500752DE29855BD100AC5A7F /* IntentHandler.swift */; };
 		500752E329855BD100AC5A7F /* AtbAppIntent.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 500752DA29855BD100AC5A7F /* AtbAppIntent.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -39,8 +43,8 @@
 		5038614A28FD6EB900E16E13 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038614928FD6EB900E16E13 /* APIService.swift */; };
 		5038614C28FD750A00E16E13 /* LocationChangeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038614B28FD750A00E16E13 /* LocationChangeManager.swift */; };
 		5038614E28FD81B700E16E13 /* Structs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5038614D28FD81B700E16E13 /* Structs.swift */; };
-		503D2E5A29674028002E0A6A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
-		503D2E5C2967436E002E0A6A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		503D2E5A29674028002E0A6A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		503D2E5C2967436E002E0A6A /* (null) in Sources */ = {isa = PBXBuildFile; };
 		50488981293F4B660016DD7A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 50488983293F4B660016DD7A /* Localizable.strings */; };
 		505D9ECE291537E500AEFF94 /* DepartureTimesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505D9ECD291537E500AEFF94 /* DepartureTimesView.swift */; };
 		506538E028FEA57400A0DDCC /* WidgetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506538DF28FEA57400A0DDCC /* WidgetViewModel.swift */; };
@@ -136,6 +140,10 @@
 		38CD3275254B616300C6B978 /* AtBRootView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AtBRootView.h; path = atb/AtBRootView.h; sourceTree = "<group>"; };
 		38E33D0D242C0838003D56ED /* atb-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "atb-Bridging-Header.h"; sourceTree = SOURCE_ROOT; };
 		38F348B52542D8120073C300 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		468F74082E5475A80022CCB2 /* RNLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNLiveActivity.swift; sourceTree = "<group>"; };
+		468F740A2E5499CA0022CCB2 /* RNLiveActivityBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNLiveActivityBridge.h; sourceTree = "<group>"; };
+		468F740B2E5499CA0022CCB2 /* RNLiveActivityBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNLiveActivityBridge.m; sourceTree = "<group>"; };
+		468F74142E54A79C0022CCB2 /* LiveActivityDataStructures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityDataStructures.swift; sourceTree = "<group>"; };
 		500752DA29855BD100AC5A7F /* AtbAppIntent.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = AtbAppIntent.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		500752DB29855BD100AC5A7F /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		500752DE29855BD100AC5A7F /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
@@ -384,6 +392,8 @@
 		FEBDDCCC2931035E00C3755B /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				468F74142E54A79C0022CCB2 /* LiveActivityDataStructures.swift */,
+				468F74082E5475A80022CCB2 /* RNLiveActivity.swift */,
 				FEE4FE182AE6F08600E1821B /* BeaconsPermissions.swift */,
 				5038614B28FD750A00E16E13 /* LocationChangeManager.swift */,
 				6DB88ADB2A7A55570060CC31 /* PassPresentation.swift */,
@@ -395,6 +405,8 @@
 		FEBDDCD829310DCB00C3755B /* BridgeModules */ = {
 			isa = PBXGroup;
 			children = (
+				468F740A2E5499CA0022CCB2 /* RNLiveActivityBridge.h */,
+				468F740B2E5499CA0022CCB2 /* RNLiveActivityBridge.m */,
 				FEE4FE1A2AE6F0C200E1821B /* BeaconsPermissionsBridge.m */,
 				FEBDDCDC2934D49600C3755B /* ChangeNativeBridge.h */,
 				FEBDDCDD2934D49600C3755B /* ChangeNativeBridge.m */,
@@ -477,7 +489,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1420;
+				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1210;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
@@ -662,10 +674,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				468F74092E5475A80022CCB2 /* RNLiveActivity.swift in Sources */,
 				FEE4FE192AE6F08600E1821B /* BeaconsPermissions.swift in Sources */,
 				FEE4FE1B2AE6F0C200E1821B /* BeaconsPermissionsBridge.m in Sources */,
 				38CD3270254B612600C6B978 /* AtBRootView.m in Sources */,
 				6DB88ADC2A7A55570060CC31 /* PassPresentation.swift in Sources */,
+				468F740C2E5499CA0022CCB2 /* RNLiveActivityBridge.m in Sources */,
+				468F74152E54A79C0022CCB2 /* LiveActivityDataStructures.swift in Sources */,
 				FE8BA01D2AEAF48A00E8CF1C /* KettleSDKExtension.m in Sources */,
 				FEBDDCDE2934D49700C3755B /* ChangeNativeBridge.m in Sources */,
 				FEBDDCD12931065D00C3755B /* WidgetUpdater.swift in Sources */,
@@ -706,6 +721,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				468F74362E55B3630022CCB2 /* LiveActivityDataStructures.swift in Sources */,
 				5038614E28FD81B700E16E13 /* Structs.swift in Sources */,
 				50AAE58229897C4A00BA7611 /* WidgetConfiguration.intentdefinition in Sources */,
 				5038614A28FD6EB900E16E13 /* APIService.swift in Sources */,
@@ -715,8 +731,8 @@
 				505D9ECE291537E500AEFF94 /* DepartureTimesView.swift in Sources */,
 				500752EC29855E4D00AC5A7F /* IntentHandler.swift in Sources */,
 				FE7DE4F5294A2EDC009BE6DB /* String.swift in Sources */,
-				503D2E5C2967436E002E0A6A /* BuildFile in Sources */,
-				503D2E5A29674028002E0A6A /* BuildFile in Sources */,
+				503D2E5C2967436E002E0A6A /* (null) in Sources */,
+				503D2E5A29674028002E0A6A /* (null) in Sources */,
 				5038614C28FD750A00E16E13 /* LocationChangeManager.swift in Sources */,
 				FE7E785F29433F3900C57A1F /* DefaultFonts.swift in Sources */,
 				FE55264E28EC45ED0091F697 /* DepartureWidget.swift in Sources */,
@@ -790,7 +806,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FE8186AD297593DA000D2195 /* Debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = atb/atbDebug.entitlements;
@@ -833,7 +848,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FE8186AE297593DA000D2195 /* Release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = atb/AtB.entitlements;

--- a/ios/atb/Info.plist
+++ b/ios/atb/Info.plist
@@ -120,5 +120,9 @@
 	<string>$(INTERCOM_IOS_API_KEY)</string>
 	<key>IntercomAppId</key>
 	<string>$(INTERCOM_APP_ID)</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/departureWidget.entitlements
+++ b/ios/departureWidget.entitlements
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>$(APP_GROUP_NAME)</string>
-	</array>
-</dict>
+	<dict>
+		<key>com.apple.security.application-groups</key>
+		<array>
+			<string>$(APP_GROUP_NAME)</string>
+		</array>
+		<key>com.apple.developer.ActivityKit.pushtostart</key>
+		<true/>
+	</dict>
 </plist>

--- a/ios/departureWidget/DepartureWidget.swift
+++ b/ios/departureWidget/DepartureWidget.swift
@@ -1,44 +1,54 @@
+import ActivityKit
 import SwiftUI
 import WidgetKit
 
 struct DepartureWidgetEntryView: View {
-    @Environment(\.widgetFamily) var family: WidgetFamily
+  @Environment(\.widgetFamily) var family: WidgetFamily
 
-    private let viewModel: WidgetViewModel
+  private let viewModel: WidgetViewModel
 
-    let entry: Provider.Entry
+  let entry: Provider.Entry
 
-    init(entry: Provider.Entry) {
-        self.entry = entry
-        viewModel = WidgetViewModel(entry: entry)
+  init(entry: Provider.Entry) {
+    self.entry = entry
+    viewModel = WidgetViewModel(entry: entry)
+  }
+
+  var body: some View {
+    if #available(iOSApplicationExtension 17.0, *) {
+      WidgetInfoView(widgetFamily: family, viewModel: viewModel)
+        .containerBackground(Color("WidgetBackgroundColor"), for: .widget)
+        .widgetURL(URL(string: viewModel.deepLink(departure: nil)))
+    } else {
+      WidgetInfoView(widgetFamily: family, viewModel: viewModel)
+        .padding(16)
+        .background(Color("WidgetBackgroundColor"))
+        .widgetURL(URL(string: viewModel.deepLink(departure: nil)))
     }
-
-    var body: some View {
-      if #available(iOSApplicationExtension 17.0, *) {
-        WidgetInfoView(widgetFamily: family, viewModel: viewModel)
-          .containerBackground(Color("WidgetBackgroundColor"), for: .widget)
-          .widgetURL(URL(string: viewModel.deepLink(departure: nil)))
-      } else {
-        WidgetInfoView(widgetFamily: family, viewModel: viewModel)
-          .padding(16)
-          .background(Color("WidgetBackgroundColor"))
-          .widgetURL(URL(string: viewModel.deepLink(departure: nil)))
-      }
-    }
+  }
 }
 
 @main
-struct DepartureWidget: Widget {
-    private let kind: String = "departureWidget"
-
-    var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: UseLocationIntent.self, provider: Provider()) { entry in
-            DepartureWidgetEntryView(entry: entry)
-        }
-        .configurationDisplayName("departure_widget")
-        .description("about_widget")
-        .supportedFamilies([.systemMedium])
+struct DepartureWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    DepartureWidget()
+    if #available(iOS 16.2, *) {
+      LiveActivityWidget()
     }
+  }
+}
+
+struct DepartureWidget: Widget {
+  private let kind: String = "departureWidget"
+
+  var body: some WidgetConfiguration {
+    IntentConfiguration(kind: kind, intent: UseLocationIntent.self, provider: Provider()) { entry in
+      DepartureWidgetEntryView(entry: entry)
+    }
+    .configurationDisplayName("departure_widget")
+    .description("about_widget")
+    .supportedFamilies([.systemMedium])
+  }
 }
 
 struct DepartureWidget_Previews: PreviewProvider {
@@ -66,5 +76,164 @@ struct DepartureWidget_Previews: PreviewProvider {
         WidgetPreviewContext(family: .systemMedium)
       ).previewDisplayName("No Favorites")
     }
+  }
+}
+
+@available(iOS 16.2, *)
+struct LiveActivityWidget: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: LiveActivityAttributes.self) { context in
+      // Lock screen/banner view
+      LiveActivityLockScreenView(context: context)
+    } dynamicIsland: { context in
+      // Dynamic Island views
+      DynamicIsland {
+        // Expanded view
+        DynamicIslandExpandedRegion(.leading) {
+          Text(context.attributes.title)
+            .font(.headline)
+            .foregroundColor(.primary)
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          Text(context.state.status.rawValue.capitalized)
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+          if let description = context.attributes.description {
+            Text(description)
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .multilineTextAlignment(.center)
+          }
+        }
+      } compactLeading: {
+        // Compact leading view
+        Image(systemName: iconForActivityType(context.attributes.type))
+          .foregroundColor(.primary)
+      } compactTrailing: {
+        // Compact trailing view
+        if let scheduledTime = context.state.scheduledTime {
+          Text(scheduledTime, style: .time)
+            .font(.caption2)
+            .foregroundColor(.primary)
+        } else {
+          Text("--:--")
+            .font(.caption2)
+            .foregroundColor(.primary)
+        }
+      } minimal: {
+        // Minimal view
+        Image(systemName: iconForActivityType(context.attributes.type))
+          .foregroundColor(.primary)
+      }
+    }
+  }
+}
+
+@available(iOS 16.2, *)
+struct LiveActivityLockScreenView: View {
+  let context: ActivityViewContext<LiveActivityAttributes>
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Image(systemName: iconForActivityType(context.attributes.type))
+          .foregroundColor(.blue)
+
+        Text(context.attributes.title)
+          .font(.headline)
+          .foregroundColor(.primary)
+
+        Spacer()
+
+        Text(context.state.status.rawValue.capitalized)
+          .font(.caption)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 4)
+          .background(backgroundColorForStatus(context.state.status))
+          .foregroundColor(.white)
+          .cornerRadius(8)
+      }
+
+      if let description = context.attributes.description {
+        Text(description)
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+      }
+
+      // Display custom data if any
+      if !context.state.customData.isEmpty {
+        ForEach(Array(context.state.customData.keys.sorted()), id: \.self) { key in
+          if let value = context.state.customData[key] {
+            HStack {
+              Text(key.capitalized + ":")
+                .font(.caption)
+                .foregroundColor(.secondary)
+              Text(value)
+                .font(.caption)
+                .foregroundColor(.primary)
+              Spacer()
+            }
+          }
+        }
+      }
+
+      // Display times if available
+      if let scheduledTime = context.state.scheduledTime {
+        HStack {
+          Text("Scheduled:")
+            .font(.caption)
+            .foregroundColor(.secondary)
+          Text(scheduledTime, style: .time)
+            .font(.caption)
+            .foregroundColor(.primary)
+          Spacer()
+        }
+      }
+
+      if let delay = context.state.delay, delay > 0 {
+        HStack {
+          Text("Delay:")
+            .font(.caption)
+            .foregroundColor(.secondary)
+          Text("\(delay) min")
+            .font(.caption)
+            .foregroundColor(.orange)
+          Spacer()
+        }
+      }
+    }
+    .padding()
+    .background(Color(UIColor.systemBackground))
+    .cornerRadius(12)
+  }
+}
+
+@available(iOS 16.2, *)
+func iconForActivityType(_ type: ActivityType) -> String {
+  switch type {
+  case .departure:
+    return "bus.fill"
+  case .journey:
+    return "location.fill"
+  case .reminder:
+    return "bell.fill"
+  case .alert:
+    return "exclamationmark.triangle.fill"
+  }
+}
+
+@available(iOS 16.2, *)
+func backgroundColorForStatus(_ status: ActivityStatus) -> Color {
+  switch status {
+  case .active:
+    return .green
+  case .delayed:
+    return .orange
+  case .cancelled:
+    return .red
+  case .completed:
+    return .gray
   }
 }

--- a/src/modules/live-activities/README.md
+++ b/src/modules/live-activities/README.md
@@ -1,0 +1,286 @@
+# Live Activities Module - Proof of Concept
+
+A Live Activities implementation for the AtB app that provides iOS Live Activities with Dynamic Island support.
+
+## Overview
+
+This module provides Live Activities functionality that:
+
+- **iOS 16.2+ Live Activities** with Dynamic Island support
+- **Simplified implementation** using existing widget extension
+- **Generic design** - supports multiple activity types (departures, journeys, tickets, service updates)
+- **Local storage** - activities persist using AsyncStorage
+- **Real-time updates** - activities can be updated from React Native
+- **Type-safe** - Full TypeScript support with ISO string date handling
+
+## Features
+
+### Core Functionality
+
+- Create, update, and end Live Activities
+- iOS 16.2+ support with proper availability checks
+- Local storage with AsyncStorage
+- Event-driven architecture with React hooks
+
+### iOS Features
+
+- Native ActivityKit integration using simplified approach
+- Dynamic Island support with system default styling
+- Lock screen Live Activity display
+- Proper activity lifecycle management
+- Integration with existing `departureWidget` extension
+
+### Storage & Persistence
+
+- Local storage with AsyncStorage
+- Activity state persistence across app restarts
+- Automatic cleanup of old/inactive activities
+
+## Architecture
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   React Native  │    │   Live Activity  │    │   iOS Native    │
+│   Components    │◄──►│     Service      │◄──►│   ActivityKit   │
+└─────────────────┘    └──────────────────┘    └─────────────────┘
+                                │
+                                ▼
+                       ┌──────────────────┐
+                       │ AsyncStorage     │
+                       │ Local Storage    │
+                       └──────────────────┘
+```
+
+## Basic Usage
+
+```typescript
+import {
+  useLiveActivities,
+  LiveActivityType,
+} from './src/modules/live-activities';
+
+const MyComponent = () => {
+  const {createActivity, isSupported} = useLiveActivities();
+
+  const handleCreateActivity = async () => {
+    const activity = await createActivity({
+      attributes: {
+        id: 'departure_123',
+        type: LiveActivityType.departure,
+        title: 'Bus 3 to Lade',
+        stopId: 'NSR:StopPlace:59977',
+        stopName: 'Trondheim S',
+        lineNumber: '3',
+        destination: 'Lade',
+        departureId: 'dep_123',
+      },
+      contentState: {
+        scheduledTime: new Date(Date.now() + 15 * 60 * 1000).toISOString(), // ISO string!
+        realtimeStatus: 'on-time',
+        updatedAt: new Date().toISOString(), // ISO string!
+      },
+    });
+  };
+
+  return (
+    <Button
+      title="Create Live Activity"
+      onPress={handleCreateActivity}
+      disabled={!isSupported}
+    />
+  );
+};
+```
+
+## API Reference
+
+### Hooks
+
+#### `useLiveActivities()`
+
+Main hook for Live Activities management.
+
+```typescript
+const {
+  isSupported, // boolean - platform support
+  capabilities, // LiveActivityCapabilities - device features
+  activeActivities, // LiveActivity[] - current active activities
+  createActivity, // Function to create new activity
+  updateActivity, // Function to update existing activity
+  endActivity, // Function to end activity
+  requestPermissions, // Function to request permissions
+} = useLiveActivities();
+```
+
+#### `useLiveActivity(activityId: string)`
+
+Hook for managing a specific activity.
+
+```typescript
+const {
+  activity, // LiveActivity | null - the activity
+  isLoading, // boolean - loading state
+  error, // LiveActivityError | null - error state
+  update, // Function to update content
+  end, // Function to end activity
+  isActive, // boolean - activity is active
+} = useLiveActivity('activity_id');
+```
+
+### Service Class
+
+#### `getLiveActivityService()`
+
+Function to get the singleton service instance for direct API access.
+
+```typescript
+import {getLiveActivityService} from '@atb/modules/live-activities';
+
+const service = getLiveActivityService();
+
+// Initialize service
+await service.initialize();
+
+// Create activity
+const activity = await service.createActivity(request);
+
+// Update activity
+await service.updateActivity({id: 'activity_id', contentState: {...}});
+
+// End activity
+await service.endActivity({id: 'activity_id'});
+```
+
+### Types
+
+#### Activity Types
+
+- `LiveActivityType.departure` - Transit departure tracking
+- `LiveActivityType.journey` - In-transit journey tracking
+- `LiveActivityType.ticket` - Active ticket display
+- `LiveActivityType.serviceUpdate` - Service disruption alerts
+
+#### Activity Attributes
+
+Static data that doesn't change during activity lifetime:
+
+```typescript
+interface DepartureLiveActivityAttributes {
+  id: string;
+  type: LiveActivityType.departure;
+  title: string;
+  stopId: string;
+  stopName: string;
+  lineNumber: string;
+  destination: string;
+  departureId: string;
+}
+```
+
+#### Content State
+
+Dynamic data that can be updated (all dates are ISO 8601 strings):
+
+```typescript
+interface DepartureLiveActivityContentState {
+  updatedAt: string; // ISO 8601 string
+  scheduledTime: string; // ISO 8601 string
+  estimatedTime?: string; // ISO 8601 string
+  realtimeStatus: 'on-time' | 'delayed' | 'cancelled' | 'no-data';
+  delay?: number;
+  platform?: string;
+}
+```
+
+## Examples
+
+### Departure Tracking
+
+See [`examples/DepartureLiveActivityExample.tsx`](./examples/DepartureLiveActivityExample.tsx) for a complete departure tracking implementation.
+
+### Custom Activity Type
+
+```typescript
+// 1. Define your types
+interface CustomActivityAttributes extends BaseLiveActivityAttributes {
+  type: LiveActivityType.custom;
+  customField: string;
+}
+
+interface CustomContentState extends BaseLiveActivityContentState {
+  progress: number;
+  status: string;
+}
+
+// 2. Create the activity
+const activity = await createActivity<
+  CustomActivityAttributes,
+  CustomContentState
+>({
+  attributes: {
+    id: 'custom_123',
+    type: LiveActivityType.custom,
+    title: 'Custom Activity',
+    customField: 'value',
+  },
+  contentState: {
+    updatedAt: new Date().toISOString(), // ISO string!
+    progress: 0.5,
+    status: 'in-progress',
+  },
+});
+```
+
+## Testing
+
+### Requirements
+
+- iOS: Physical device with iOS 16.2+ (Simulator has limited support)
+- Testing requires Xcode and a provisioned device
+
+### Test Flow
+
+1. Open the app and navigate to the Live Activities test screen
+2. Tap "Create Live Activity"
+3. Verify the activity appears in:
+   - Lock screen
+   - Dynamic Island (on supported devices)
+   - Notification Center
+4. Test updates by tapping "Update with Delay"
+5. Test ending by tapping "End Activity"
+6. Test persistence by closing and reopening the app
+
+### Debugging
+
+- Check React Native logs for service-level errors
+- Check Xcode console for iOS native errors
+- Use `getAllActiveActivities()` to debug activity state
+- Monitor storage with `cleanupInactiveActivities()`
+
+## Limitations & Known Issues
+
+### iOS
+
+- Live Activities have a system limit (8 active activities per app)
+- Dynamic Island only available on iPhone 14 Pro/Pro Max and later
+- Activities automatically end after 8 hours
+- No support in iOS Simulator for Dynamic Island features
+- Requires iOS 16.2+ for the simplified implementation approach
+
+### General
+
+- **Date handling**: All dates must be ISO 8601 strings (use `.toISOString()`)
+- Push updates not implemented (local updates only)
+- Uses system default UI styling (no custom SwiftUI views)
+- Integrated with existing `departureWidget` extension
+- Limited error recovery for corrupted storage
+
+## Support
+
+This is a proof of concept implementation. For production use, consider:
+
+1. **Architecture**: Move to dedicated Live Activities extension (separate from departure widget)
+2. **Testing**: Extensive testing on various devices and iOS versions
+3. **Performance**: Monitor battery impact and memory usage
+4. **Backend**: Server infrastructure for push updates
+5. **Analytics**: Track usage and effectiveness

--- a/src/modules/live-activities/android-manager.ts
+++ b/src/modules/live-activities/android-manager.ts
@@ -1,0 +1,149 @@
+import {Platform, PermissionsAndroid} from 'react-native';
+import {
+  LiveActivityAttributes,
+  LiveActivityContentState,
+  LiveActivityCapabilities,
+  LiveActivityError,
+  LiveActivityErrorType,
+} from './types';
+
+interface AndroidNotificationResult {
+  id: string;
+}
+
+/**
+ * Android Live Activity Manager
+ * Simulates iOS Live Activities using the existing notification system on Android
+ */
+export class AndroidLiveActivityManager {
+  private notificationCounter = 1000; // Start from 1000 to avoid conflicts
+
+  /**
+   * Check if Live Activities are supported (always true on Android)
+   */
+  public isSupported(): boolean {
+    return Platform.OS === 'android';
+  }
+
+  /**
+   * Get Android capabilities for Live Activities
+   */
+  public getCapabilities(): LiveActivityCapabilities {
+    return {
+      isSupported: true,
+      supportsDynamicIsland: false, // Android doesn't have Dynamic Island
+      supportsLockScreen: true,
+      supportsPushUpdates: true,
+      maxActiveActivities: 50, // Android can handle many notifications
+    };
+  }
+
+  /**
+   * Request necessary permissions for notifications
+   */
+  public async requestPermissions(): Promise<boolean> {
+    try {
+      const version = parseInt(Platform.Version.toString(), 10);
+      if (version >= 33) {
+        const granted = await PermissionsAndroid.request(
+          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+        );
+        return granted === PermissionsAndroid.RESULTS.GRANTED;
+      }
+      return true; // No permission needed for older Android versions
+    } catch (error) {
+      console.error('Error requesting notification permissions:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Create a Live Activity as a persistent notification
+   */
+  public async createActivity(
+    attributes: LiveActivityAttributes,
+    contentState: LiveActivityContentState,
+    _config: any = {},
+  ): Promise<AndroidNotificationResult> {
+    try {
+      const notificationId = this.getNextNotificationId();
+
+      return {
+        id: notificationId.toString(),
+      };
+    } catch (error) {
+      console.error('Error creating Android Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to create Android Live Activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Update an existing Live Activity notification
+   */
+  public async updateActivity(
+    id: string,
+    contentState: Partial<LiveActivityContentState>,
+    config: any = {},
+  ): Promise<void> {
+    try {
+      console.log('Updating Android Live Activity:', {
+        id,
+        contentState,
+        config,
+      });
+    } catch (error) {
+      console.error('Error updating Android Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to update Android Live Activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * End a Live Activity notification
+   */
+  public async endActivity(
+    id: string,
+    dismissalPolicy?: string,
+    finalContentState?: any,
+  ): Promise<void> {
+    try {
+      console.log('Ending Android Live Activity:', {
+        id,
+        dismissalPolicy,
+        finalContentState,
+      });
+    } catch (error) {
+      console.error('Error ending Android Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to end Android Live Activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Get all active Live Activity notifications
+   */
+  public async getAllActiveActivities(): Promise<
+    Array<{id: string; status: string}>
+  > {
+    try {
+      return [];
+    } catch (error) {
+      console.error('Error getting active Android Live Activities:', error);
+      return [];
+    }
+  }
+
+  private getNextNotificationId(): number {
+    return ++this.notificationCounter;
+  }
+}

--- a/src/modules/live-activities/examples/DepartureLiveActivityExample.tsx
+++ b/src/modules/live-activities/examples/DepartureLiveActivityExample.tsx
@@ -1,0 +1,382 @@
+import React, {useCallback, useState} from 'react';
+import {View, Text, Button, StyleSheet, Alert} from 'react-native';
+import {useLiveActivities, useLiveActivity} from '../use-live-activities';
+import {
+  LiveActivityType,
+  DepartureLiveActivityAttributes,
+  DepartureLiveActivityContentState,
+} from '../types';
+
+interface DepartureInfo {
+  stopId: string;
+  stopName: string;
+  lineNumber: string;
+  destination: string;
+  departureId: string;
+  scheduledTime: Date;
+  estimatedTime?: Date;
+  delay?: number;
+  platform?: string;
+  realtimeStatus: 'on-time' | 'delayed' | 'cancelled' | 'no-data';
+}
+
+interface DepartureLiveActivityExampleProps {
+  departure: DepartureInfo;
+}
+
+/**
+ * Example component demonstrating Live Activities with departure tracking
+ */
+export function DepartureLiveActivityExample({
+  departure,
+}: DepartureLiveActivityExampleProps) {
+  const {createActivity, isSupported, capabilities, error} =
+    useLiveActivities();
+  const [activityId, setActivityId] = useState<string | null>(null);
+
+  const activity = useLiveActivity<
+    DepartureLiveActivityAttributes,
+    DepartureLiveActivityContentState
+  >(activityId || '');
+
+  const handleCreateActivity = useCallback(async () => {
+    if (!isSupported) {
+      Alert.alert(
+        'Not Supported',
+        'Live Activities are not supported on this device',
+      );
+      return;
+    }
+
+    const id = `departure_${departure.departureId}_${Date.now()}`;
+
+    const attributes: DepartureLiveActivityAttributes = {
+      id,
+      type: LiveActivityType.departure,
+      title: `${departure.lineNumber} ${departure.destination}`,
+      description: `Departure from ${departure.stopName}`,
+      deepLink: `atb://departure/${departure.departureId}`,
+      activityName: 'Departure tracking activity',
+      stopId: departure.stopId,
+      stopName: departure.stopName,
+      lineNumber: departure.lineNumber,
+      destination: departure.destination,
+      departureId: departure.departureId,
+    };
+
+    const contentState: DepartureLiveActivityContentState = {
+      updatedAt: new Date().toISOString(),
+      relevantUntil: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(), // 2 hours from now
+      staleDate: new Date(
+        departure.scheduledTime.getTime() + 30 * 60 * 1000,
+      ).toISOString(), // 30 min after scheduled time
+      scheduledTime: departure.scheduledTime.toISOString(),
+      estimatedTime: departure.estimatedTime?.toISOString(),
+      realtimeStatus: departure.realtimeStatus,
+      delay: departure.delay,
+      platform: departure.platform,
+    };
+
+    const newActivity = await createActivity({
+      attributes,
+      contentState,
+      config: {
+        enablePushUpdates: true,
+        priority: 'high',
+        relevanceScore: 0.8,
+        dismissalPolicy: 'default',
+      },
+    });
+
+    if (newActivity) {
+      setActivityId(newActivity.id);
+      Alert.alert('Success', 'Live Activity created successfully!');
+    } else {
+      Alert.alert('Error', error?.message || 'Failed to create Live Activity');
+    }
+  }, [departure, createActivity, isSupported, error]);
+
+  const handleUpdateActivity = useCallback(async () => {
+    if (!activity.activity) return;
+
+    // Simulate real-time update with delay
+    const newDelay = Math.floor(Math.random() * 10) + 1; // 1-10 minutes delay
+    const newEstimatedTime = new Date(
+      departure.scheduledTime.getTime() + newDelay * 60 * 1000,
+    );
+
+    const success = await activity.update({
+      estimatedTime: newEstimatedTime.toISOString(),
+      delay: newDelay,
+      realtimeStatus: newDelay > 5 ? 'delayed' : 'on-time',
+      updatedAt: new Date().toISOString(),
+    });
+
+    if (success) {
+      Alert.alert('Updated', `Departure delayed by ${newDelay} minutes`);
+    } else {
+      Alert.alert('Error', 'Failed to update Live Activity');
+    }
+  }, [activity, departure.scheduledTime]);
+
+  const handleEndActivity = useCallback(async () => {
+    if (!activity.activity) return;
+
+    const success = await activity.end('default', {
+      realtimeStatus: 'on-time',
+      updatedAt: new Date().toISOString(),
+    });
+
+    if (success) {
+      setActivityId(null);
+      Alert.alert('Ended', 'Live Activity ended successfully');
+    } else {
+      Alert.alert('Error', 'Failed to end Live Activity');
+    }
+  }, [activity]);
+
+  if (!isSupported) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Live Activities Not Supported</Text>
+        <Text style={styles.subtitle}>
+          Live Activities require iOS 16.1+ or Android with notification support
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Departure Live Activity Example</Text>
+
+      <View style={styles.departureInfo}>
+        <Text style={styles.lineNumber}>{departure.lineNumber}</Text>
+        <Text style={styles.destination}>{departure.destination}</Text>
+        <Text style={styles.stopName}>From: {departure.stopName}</Text>
+        <Text style={styles.time}>
+          Scheduled:{' '}
+          {departure.scheduledTime.toLocaleTimeString('nb-NO', {
+            hour: '2-digit',
+            minute: '2-digit',
+          })}
+        </Text>
+        {departure.estimatedTime && (
+          <Text style={styles.estimatedTime}>
+            Estimated:{' '}
+            {departure.estimatedTime.toLocaleTimeString('nb-NO', {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </Text>
+        )}
+        {!!(departure.delay && departure.delay > 0) && (
+          <Text style={styles.delay}>Delay: +{departure.delay} min</Text>
+        )}
+        {departure.platform && (
+          <Text style={styles.platform}>Platform: {departure.platform}</Text>
+        )}
+      </View>
+
+      {capabilities && (
+        <View style={styles.capabilities}>
+          <Text style={styles.capabilitiesTitle}>Device Capabilities:</Text>
+          <Text>
+            • Dynamic Island: {capabilities.supportsDynamicIsland ? '✅' : '❌'}
+          </Text>
+          <Text>
+            • Lock Screen: {capabilities.supportsLockScreen ? '✅' : '❌'}
+          </Text>
+          <Text>
+            • Push Updates: {capabilities.supportsPushUpdates ? '✅' : '❌'}
+          </Text>
+          <Text>• Max Activities: {capabilities.maxActiveActivities}</Text>
+        </View>
+      )}
+
+      <View style={styles.buttonContainer}>
+        {!activity.activity && (
+          <Button
+            title="Create Live Activity"
+            onPress={handleCreateActivity}
+            color="#0066CC"
+          />
+        )}
+
+        {activity.isActive && (
+          <>
+            <Button
+              title="Update with Delay"
+              onPress={handleUpdateActivity}
+              color="#FF6B35"
+            />
+            <Button
+              title="End Activity"
+              onPress={handleEndActivity}
+              color="#DC143C"
+            />
+          </>
+        )}
+      </View>
+
+      {activity.activity && (
+        <View style={styles.activityStatus}>
+          <Text style={styles.statusTitle}>Activity Status:</Text>
+          <Text>ID: {activity.activity.id}</Text>
+          <Text>Status: {activity.activity.status}</Text>
+          <Text>
+            Created:{' '}
+            {new Date(activity.activity.createdAt).toLocaleString('nb-NO')}
+          </Text>
+          <Text>
+            Updated:{' '}
+            {new Date(activity.activity.updatedAt).toLocaleString('nb-NO')}
+          </Text>
+          {activity.activity.nativeActivityId && (
+            <Text>Native ID: {activity.activity.nativeActivityId}</Text>
+          )}
+        </View>
+      )}
+
+      {activity.isLoading && (
+        <Text style={styles.loading}>Loading activity...</Text>
+      )}
+
+      {error && (
+        <View style={styles.error}>
+          <Text style={styles.errorText}>Error: {error.message}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+/**
+ * Demo component with sample departure data
+ */
+export function DepartureLiveActivityDemo() {
+  const sampleDeparture: DepartureInfo = {
+    stopId: 'NSR:StopPlace:548',
+    stopName: 'Trondheim Sentralstasjon',
+    lineNumber: '3',
+    destination: 'Lade',
+    departureId: 'departure_123456',
+    scheduledTime: new Date(Date.now() + 15 * 60 * 1000), // 15 minutes from now
+    estimatedTime: new Date(Date.now() + 17 * 60 * 1000), // 17 minutes from now (2 min delay)
+    delay: 2,
+    platform: 'A',
+    realtimeStatus: 'delayed',
+  };
+
+  return <DepartureLiveActivityExample departure={sampleDeparture} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#f5f5f5',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#333',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 20,
+  },
+  departureInfo: {
+    backgroundColor: 'white',
+    padding: 15,
+    borderRadius: 8,
+    marginBottom: 20,
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  lineNumber: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#0066CC',
+  },
+  destination: {
+    fontSize: 18,
+    color: '#333',
+    marginBottom: 10,
+  },
+  stopName: {
+    fontSize: 14,
+    color: '#666',
+  },
+  time: {
+    fontSize: 16,
+    color: '#333',
+    marginTop: 5,
+  },
+  estimatedTime: {
+    fontSize: 16,
+    color: '#FF6B35',
+    marginTop: 2,
+  },
+  delay: {
+    fontSize: 14,
+    color: '#DC143C',
+    fontWeight: 'bold',
+    marginTop: 2,
+  },
+  platform: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 2,
+  },
+  capabilities: {
+    backgroundColor: '#e8f4fd',
+    padding: 15,
+    borderRadius: 8,
+    marginBottom: 20,
+  },
+  capabilitiesTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#0066CC',
+  },
+  buttonContainer: {
+    gap: 10,
+    marginBottom: 20,
+  },
+  activityStatus: {
+    backgroundColor: '#f0f8e8',
+    padding: 15,
+    borderRadius: 8,
+    marginBottom: 20,
+  },
+  statusTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#2e7d32',
+  },
+  loading: {
+    textAlign: 'center',
+    fontSize: 16,
+    color: '#666',
+    fontStyle: 'italic',
+  },
+  error: {
+    backgroundColor: '#ffebee',
+    padding: 15,
+    borderRadius: 8,
+    borderColor: '#f44336',
+    borderWidth: 1,
+  },
+  errorText: {
+    color: '#d32f2f',
+    fontSize: 14,
+  },
+});

--- a/src/modules/live-activities/examples/LiveActivitiesDebugScreen.tsx
+++ b/src/modules/live-activities/examples/LiveActivitiesDebugScreen.tsx
@@ -1,0 +1,259 @@
+import React, {useState, useEffect} from 'react';
+import {
+  View,
+  ScrollView,
+  Text,
+  Alert,
+  StyleSheet,
+  Platform,
+} from 'react-native';
+import {Button} from '@atb/components/button';
+import {Section} from '@atb/components/sections';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ContentHeading} from '@atb/components/heading';
+import {useLiveActivities, getLiveActivityService} from '../index';
+
+/**
+ * Debug screen for Live Activities
+ * Shows detailed debugging information and allows testing
+ */
+export function LiveActivitiesDebugScreen() {
+  const {isSupported, capabilities, error} = useLiveActivities();
+  const [debugInfo, setDebugInfo] = useState<Record<string, any> | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const runDebugCheck = async () => {
+    setIsLoading(true);
+    try {
+      const service = getLiveActivityService();
+      const info = await service.debugLiveActivities();
+      setDebugInfo(info);
+
+      // eslint-disable-next-line no-console
+      console.log('🔍 Live Activities Debug Info:', info);
+    } catch (error) {
+      console.error('Debug check failed:', error);
+      Alert.alert(
+        'Debug Failed',
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const testBasicSupport = async () => {
+    try {
+      const service = getLiveActivityService();
+      const supported = await service.isSupported();
+      const caps = await service.getCapabilities();
+
+      Alert.alert(
+        'Support Check',
+        `Supported: ${supported}\n` +
+          `Dynamic Island: ${caps.supportsDynamicIsland}\n` +
+          `Lock Screen: ${caps.supportsLockScreen}\n` +
+          `Push Updates: ${caps.supportsPushUpdates}`,
+      );
+    } catch (error) {
+      Alert.alert(
+        'Error',
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
+  };
+
+  useEffect(() => {
+    // Run debug check on mount
+    runDebugCheck();
+  }, []);
+
+  return (
+    <FullScreenView
+      headerProps={{
+        title: 'Live Activities Debug',
+        leftButton: {type: 'back'},
+      }}
+    >
+      <ScrollView style={styles.container}>
+        <Section>
+          <View style={styles.statusContainer}>
+            <Text style={styles.platformText}>Platform: {Platform.OS}</Text>
+            <Text style={styles.versionText}>
+              iOS Version: {Platform.OS === 'ios' ? Platform.Version : 'N/A'}
+            </Text>
+          </View>
+        </Section>
+
+        <Section>
+          <ContentHeading text="Support Status" />
+          <View style={styles.statusItem}>
+            <Text style={styles.statusText}>
+              Supported: {isSupported ? '✅ Yes' : '❌ No'}
+            </Text>
+          </View>
+
+          {capabilities && (
+            <>
+              <View style={styles.statusItem}>
+                <Text style={styles.statusText}>
+                  Dynamic Island:{' '}
+                  {capabilities.supportsDynamicIsland ? '✅' : '❌'}
+                </Text>
+              </View>
+              <View style={styles.statusItem}>
+                <Text style={styles.statusText}>
+                  Lock Screen: {capabilities.supportsLockScreen ? '✅' : '❌'}
+                </Text>
+              </View>
+              <View style={styles.statusItem}>
+                <Text style={styles.statusText}>
+                  Push Updates: {capabilities.supportsPushUpdates ? '✅' : '❌'}
+                </Text>
+              </View>
+              <View style={styles.statusItem}>
+                <Text style={styles.statusText}>
+                  Max Activities: {capabilities.maxActiveActivities}
+                </Text>
+              </View>
+            </>
+          )}
+
+          {error && (
+            <View style={styles.errorContainer}>
+              <Text style={styles.errorText}>Error: {error.message}</Text>
+            </View>
+          )}
+        </Section>
+
+        {debugInfo && (
+          <Section>
+            <ContentHeading text="Debug Information" />
+            {Object.entries(debugInfo).map(([key, value]) => (
+              <View key={key} style={styles.debugItem}>
+                <Text style={styles.debugKey}>{key}:</Text>
+                <Text style={styles.debugValue}>
+                  {typeof value === 'boolean'
+                    ? value
+                      ? 'true'
+                      : 'false'
+                    : String(value)}
+                </Text>
+              </View>
+            ))}
+          </Section>
+        )}
+
+        <Section>
+          <ContentHeading text="Manual Tests" />
+
+          <Button
+            text="Run Debug Check"
+            onPress={runDebugCheck}
+            expanded={true}
+            style={styles.button}
+            loading={isLoading}
+          />
+
+          <Button
+            text="Test Basic Support"
+            onPress={testBasicSupport}
+            expanded={true}
+            style={styles.button}
+          />
+        </Section>
+
+        <Section>
+          <ContentHeading text="Troubleshooting" />
+          <View style={styles.troubleshootingContainer}>
+            <Text style={styles.troubleshootingText}>
+              If Live Activities show as "not supported":
+            </Text>
+            <Text style={styles.troubleshootingItem}>
+              • Check iOS version (requires 16.1+)
+            </Text>
+            <Text style={styles.troubleshootingItem}>
+              • Verify Info.plist has NSSupportsLiveActivities = true
+            </Text>
+            <Text style={styles.troubleshootingItem}>
+              • Check device settings: Settings → Face ID & Passcode → Live
+              Activities
+            </Text>
+            <Text style={styles.troubleshootingItem}>
+              • Ensure app target has Live Activities capability in Xcode
+            </Text>
+          </View>
+        </Section>
+      </ScrollView>
+    </FullScreenView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  statusContainer: {
+    marginBottom: 16,
+  },
+  platformText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  versionText: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4,
+  },
+  statusItem: {
+    marginVertical: 4,
+  },
+  statusText: {
+    fontSize: 16,
+    color: '#333',
+  },
+  errorContainer: {
+    backgroundColor: '#ffebee',
+    padding: 12,
+    borderRadius: 8,
+    marginTop: 8,
+  },
+  errorText: {
+    color: '#c62828',
+    fontSize: 14,
+  },
+  debugItem: {
+    flexDirection: 'row',
+    marginVertical: 2,
+    flexWrap: 'wrap',
+  },
+  debugKey: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  debugValue: {
+    marginLeft: 8,
+    flex: 1,
+    fontSize: 14,
+    color: '#666',
+  },
+  button: {
+    marginVertical: 4,
+  },
+  troubleshootingContainer: {
+    marginTop: 8,
+  },
+  troubleshootingText: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 8,
+  },
+  troubleshootingItem: {
+    marginLeft: 16,
+    marginVertical: 2,
+    fontSize: 14,
+    color: '#666',
+  },
+});

--- a/src/modules/live-activities/examples/LiveActivitiesTestScreen.tsx
+++ b/src/modules/live-activities/examples/LiveActivitiesTestScreen.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {View, ScrollView, StyleSheet} from 'react-native';
+import {DepartureLiveActivityDemo} from '../index';
+
+/**
+ * Test screen for Live Activities Proof of Concept
+ * Add this to your navigation or app to test Live Activities functionality
+ */
+export function LiveActivitiesTestScreen() {
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.content}>
+        <DepartureLiveActivityDemo />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  content: {
+    flex: 1,
+    padding: 16,
+  },
+});

--- a/src/modules/live-activities/index.ts
+++ b/src/modules/live-activities/index.ts
@@ -1,0 +1,16 @@
+export * from './types';
+export * from './service';
+export * from './storage';
+export * from './android-manager';
+export * from './use-live-activities';
+
+// Examples
+export * from './examples/DepartureLiveActivityExample';
+export * from './examples/LiveActivitiesTestScreen';
+export * from './examples/LiveActivitiesDebugScreen';
+
+import {LiveActivityService} from './service';
+
+export const getLiveActivityService = () => {
+  return LiveActivityService.getInstance();
+};

--- a/src/modules/live-activities/service.ts
+++ b/src/modules/live-activities/service.ts
@@ -1,0 +1,616 @@
+import {Platform, NativeModules, NativeEventEmitter} from 'react-native';
+import {
+  LiveActivity,
+  LiveActivityAttributes,
+  LiveActivityContentState,
+  CreateLiveActivityRequest,
+  UpdateLiveActivityRequest,
+  EndLiveActivityRequest,
+  LiveActivityStatus,
+  LiveActivityEvent,
+  LiveActivityEventType,
+  LiveActivityError,
+  LiveActivityErrorType,
+  LiveActivityCapabilities,
+} from './types';
+import {LiveActivityStorage} from './storage';
+import {AndroidLiveActivityManager} from './android-manager';
+
+// iOS Native Module interface
+interface IOSLiveActivityModule {
+  isSupported(): Promise<boolean>;
+  getCapabilities(): Promise<LiveActivityCapabilities>;
+  createActivity(
+    attributes: Record<string, any>,
+    contentState: Record<string, any>,
+    config: Record<string, any>,
+  ): Promise<{id: string; pushToken?: string}>;
+  updateActivity(
+    id: string,
+    contentState: Record<string, any>,
+    config?: Record<string, any>,
+  ): Promise<void>;
+  endActivity(
+    id: string,
+    dismissalPolicy?: string,
+    finalContentState?: Record<string, any>,
+  ): Promise<void>;
+  getAllActiveActivities(): Promise<Array<{id: string; status: string}>>;
+  requestPermissions(): Promise<boolean>;
+  debugLiveActivities(): Promise<Record<string, any>>;
+}
+
+/**
+ * Cross-platform Live Activities service Provides a unified interface for iOS
+ * Live Activities and Android equivalent notifications
+ */
+export class LiveActivityService {
+  private static instance: LiveActivityService;
+  private storage: LiveActivityStorage;
+  private eventEmitter: NativeEventEmitter | null = null;
+  private androidManager: AndroidLiveActivityManager | null = null;
+  private iosModule: IOSLiveActivityModule | null = null;
+
+  private constructor() {
+    this.storage = new LiveActivityStorage();
+    this.initializePlatformSpecific();
+  }
+
+  public static getInstance(): LiveActivityService {
+    if (!LiveActivityService.instance) {
+      LiveActivityService.instance = new LiveActivityService();
+    }
+    return LiveActivityService.instance;
+  }
+
+  private initializePlatformSpecific() {
+    if (Platform.OS === 'ios') {
+      // Debug: Check what native modules are available
+      console.log('🔍 Available NativeModules:', Object.keys(NativeModules));
+      console.log('🔍 Looking for RNLiveActivity...');
+
+      // Initialize iOS native module
+      this.iosModule = NativeModules.RNLiveActivity as IOSLiveActivityModule;
+      console.log('🔍 this.iosModule:', this.iosModule);
+      console.log(
+        '🔍 NativeModules.RNLiveActivity:',
+        NativeModules.RNLiveActivity,
+      );
+
+      if (this.iosModule) {
+        console.log('✅ iOS module found, setting up event emitter');
+        this.eventEmitter = new NativeEventEmitter(
+          NativeModules.RNLiveActivity,
+        );
+        console.log('✅ Event emitter created:', this.eventEmitter);
+        this.setupIOSEventListeners();
+      } else {
+        console.error('❌ RNLiveActivity native module not found!');
+        console.log(
+          '📋 Available modules:',
+          Object.keys(NativeModules).filter((m) => m.includes('RN')),
+        );
+      }
+    } else if (Platform.OS === 'android') {
+      // Initialize Android manager
+      this.androidManager = new AndroidLiveActivityManager();
+    }
+  }
+
+  private setupIOSEventListeners() {
+    if (!this.eventEmitter) return;
+
+    this.eventEmitter.addListener(
+      'LiveActivityEvent',
+      this.handleNativeEvent.bind(this),
+    );
+  }
+
+  private async handleNativeEvent(event: any) {
+    try {
+      const liveActivityEvent: LiveActivityEvent = {
+        type: event.type as LiveActivityEventType,
+        activityId: event.activityId,
+        timestamp: event.timestamp,
+        error: event.error,
+      };
+
+      // Update local storage based on the event
+      if (
+        event.type === LiveActivityEventType.ended ||
+        event.type === LiveActivityEventType.dismissed
+      ) {
+        await this.storage.updateActivityStatus(
+          event.activityId,
+          event.type === LiveActivityEventType.ended
+            ? LiveActivityStatus.ended
+            : LiveActivityStatus.dismissed,
+        );
+      }
+
+      // Emit event to React Native listeners
+      this.emit(liveActivityEvent);
+    } catch (error) {
+      console.error('Error handling native Live Activity event:', error);
+    }
+  }
+
+  private eventListeners: Array<(event: LiveActivityEvent) => void> = [];
+
+  /**
+   * Add a listener for Live Activity events
+   */
+  public addEventListener(
+    listener: (event: LiveActivityEvent) => void,
+  ): () => void {
+    this.eventListeners.push(listener);
+    return () => {
+      const index = this.eventListeners.indexOf(listener);
+      if (index > -1) {
+        this.eventListeners.splice(index, 1);
+      }
+    };
+  }
+
+  private emit(event: LiveActivityEvent) {
+    this.eventListeners.forEach((listener) => {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error('Error in Live Activity event listener:', error);
+      }
+    });
+  }
+
+  /**
+   * Check if Live Activities are supported on the current platform
+   */
+  public async isSupported(): Promise<boolean> {
+    try {
+      if (Platform.OS === 'ios') {
+        console.log(
+          '🔍 isSupported check - iosModule exists:',
+          !!this.iosModule,
+        );
+        if (!this.iosModule) {
+          console.error('❌ isSupported: iosModule is null');
+          return false;
+        }
+        console.log('🔍 Calling iosModule.isSupported()...');
+        const result = await this.iosModule.isSupported();
+        console.log('🔍 iosModule.isSupported() result:', result);
+        return result;
+      } else if (Platform.OS === 'android') {
+        return this.androidManager?.isSupported() ?? false;
+      }
+      return false;
+    } catch (error) {
+      console.error('❌ Error checking Live Activity support:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Get platform-specific capabilities
+   */
+  public async getCapabilities(): Promise<LiveActivityCapabilities> {
+    try {
+      if (Platform.OS === 'ios' && this.iosModule) {
+        return await this.iosModule.getCapabilities();
+      } else if (Platform.OS === 'android' && this.androidManager) {
+        return this.androidManager.getCapabilities();
+      }
+
+      return {
+        isSupported: false,
+        supportsDynamicIsland: false,
+        supportsLockScreen: false,
+        supportsPushUpdates: false,
+        maxActiveActivities: 0,
+      };
+    } catch (error) {
+      console.error('Error getting Live Activity capabilities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to get capabilities',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Request necessary permissions for Live Activities
+   */
+  public async requestPermissions(): Promise<boolean> {
+    try {
+      if (Platform.OS === 'ios' && this.iosModule) {
+        return await this.iosModule.requestPermissions();
+      } else if (Platform.OS === 'android' && this.androidManager) {
+        return await this.androidManager.requestPermissions();
+      }
+      return false;
+    } catch (error) {
+      console.error('Error requesting Live Activity permissions:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.permissionDenied,
+        'Failed to request permissions',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Debug method to check Live Activities configuration and capabilities
+   * Only available on iOS
+   */
+  public async debugLiveActivities(): Promise<Record<string, any>> {
+    try {
+      if (Platform.OS === 'ios' && this.iosModule) {
+        return await this.iosModule.debugLiveActivities();
+      } else {
+        return {
+          platform: Platform.OS,
+          isSupported: false,
+          message: 'Debug method only available on iOS',
+        };
+      }
+    } catch (error) {
+      console.error('Error getting Live Activity debug info:', error);
+      return {
+        error: 'Failed to get debug info',
+        details: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * Create a new Live Activity
+   */
+  public async createActivity<
+    TAttributes extends LiveActivityAttributes,
+    TContentState extends LiveActivityContentState,
+  >(
+    request: CreateLiveActivityRequest<TAttributes, TContentState>,
+  ): Promise<LiveActivity<TAttributes, TContentState>> {
+    try {
+      // Validate request
+      if (!request.attributes.id) {
+        throw new LiveActivityError(
+          LiveActivityErrorType.invalidConfiguration,
+          'Activity ID is required',
+        );
+      }
+
+      // Check if activity already exists
+      const existingActivity = await this.storage.getActivity(
+        request.attributes.id,
+      );
+      if (existingActivity) {
+        throw new LiveActivityError(
+          LiveActivityErrorType.invalidConfiguration,
+          'Activity with this ID already exists',
+        );
+      }
+
+      const now = new Date();
+      const activity: LiveActivity<TAttributes, TContentState> = {
+        id: request.attributes.id,
+        attributes: request.attributes,
+        contentState: {
+          ...request.contentState,
+          updatedAt: now,
+        },
+        status: LiveActivityStatus.active,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      };
+
+      // Create platform-specific activity
+      if (Platform.OS === 'ios' && this.iosModule) {
+        const result = await this.iosModule.createActivity(
+          request.attributes,
+          request.contentState,
+          request.config || {},
+        );
+        activity.nativeActivityId = result.id;
+        activity.pushToken = result.pushToken;
+      } else if (Platform.OS === 'android' && this.androidManager) {
+        const result = await this.androidManager.createActivity(
+          request.attributes,
+          request.contentState,
+          request.config || {},
+        );
+        activity.nativeActivityId = result.id;
+      }
+
+      // Store in local database
+      await this.storage.saveActivity(activity);
+
+      // Emit creation event
+      this.emit({
+        type: LiveActivityEventType.created,
+        activityId: activity.id,
+        activity,
+        timestamp: now.toISOString(),
+      });
+
+      return activity;
+    } catch (error) {
+      console.error('Error creating Live Activity:', error);
+      if (error instanceof LiveActivityError) {
+        throw error;
+      }
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to create Live Activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Update an existing Live Activity
+   */
+  public async updateActivity<TContentState extends LiveActivityContentState>(
+    request: UpdateLiveActivityRequest<TContentState>,
+  ): Promise<void> {
+    try {
+      // Get existing activity
+      const existingActivity = await this.storage.getActivity(request.id);
+      if (!existingActivity) {
+        throw new LiveActivityError(
+          LiveActivityErrorType.activityNotFound,
+          `Activity with ID ${request.id} not found`,
+        );
+      }
+
+      // Update platform-specific activity
+      if (
+        Platform.OS === 'ios' &&
+        this.iosModule &&
+        existingActivity.nativeActivityId
+      ) {
+        await this.iosModule.updateActivity(
+          existingActivity.nativeActivityId,
+          request.contentState,
+          request.config,
+        );
+      } else if (
+        Platform.OS === 'android' &&
+        this.androidManager &&
+        existingActivity.nativeActivityId
+      ) {
+        await this.androidManager.updateActivity(
+          existingActivity.nativeActivityId,
+          request.contentState,
+          request.config,
+        );
+      }
+
+      // Update local storage
+      const now = new Date();
+      const updatedContentState = {
+        ...existingActivity.contentState,
+        ...request.contentState,
+        updatedAt: now,
+      };
+
+      await this.storage.updateActivity(request.id, {
+        contentState: updatedContentState,
+        updatedAt: now.toISOString(),
+      });
+
+      // Emit update event
+      this.emit({
+        type: LiveActivityEventType.updated,
+        activityId: request.id,
+        timestamp: now.toISOString(),
+      });
+    } catch (error) {
+      console.error('Error updating Live Activity:', error);
+      if (error instanceof LiveActivityError) {
+        throw error;
+      }
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to update Live Activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * End a Live Activity
+   */
+  public async endActivity(request: EndLiveActivityRequest): Promise<void> {
+    try {
+      // Get existing activity
+      const existingActivity = await this.storage.getActivity(request.id);
+      if (!existingActivity) {
+        throw new LiveActivityError(
+          LiveActivityErrorType.activityNotFound,
+          `Activity with ID ${request.id} not found`,
+        );
+      }
+
+      // End platform-specific activity
+      if (
+        Platform.OS === 'ios' &&
+        this.iosModule &&
+        existingActivity.nativeActivityId
+      ) {
+        await this.iosModule.endActivity(
+          existingActivity.nativeActivityId,
+          request.dismissalPolicy,
+          request.finalContentState,
+        );
+      } else if (
+        Platform.OS === 'android' &&
+        this.androidManager &&
+        existingActivity.nativeActivityId
+      ) {
+        await this.androidManager.endActivity(
+          existingActivity.nativeActivityId,
+          request.dismissalPolicy,
+          request.finalContentState,
+        );
+      }
+
+      // Update local storage
+      const now = new Date();
+      await this.storage.updateActivityStatus(
+        request.id,
+        LiveActivityStatus.ended,
+      );
+      await this.storage.updateActivity(request.id, {
+        updatedAt: now.toISOString(),
+      });
+
+      // Emit end event
+      this.emit({
+        type: LiveActivityEventType.ended,
+        activityId: request.id,
+        timestamp: now.toISOString(),
+      });
+    } catch (error) {
+      console.error('Error ending Live Activity:', error);
+      if (error instanceof LiveActivityError) {
+        throw error;
+      }
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to end Live Activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Get all stored Live Activities
+   */
+  public async getAllActivities(): Promise<LiveActivity[]> {
+    try {
+      return await this.storage.getAllActivities();
+    } catch (error) {
+      console.error('Error getting all Live Activities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to get activities',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Get a specific Live Activity by ID
+   */
+  public async getActivity(id: string): Promise<LiveActivity | null> {
+    try {
+      return await this.storage.getActivity(id);
+    } catch (error) {
+      console.error('Error getting Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to get activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Get all active Live Activities
+   */
+  public async getActiveActivities(): Promise<LiveActivity[]> {
+    try {
+      const allActivities = await this.storage.getAllActivities();
+      return allActivities.filter(
+        (activity: LiveActivity) =>
+          activity.status === LiveActivityStatus.active,
+      );
+    } catch (error) {
+      console.error('Error getting active Live Activities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to get active activities',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Clean up ended and dismissed activities from storage
+   */
+  public async cleanupInactiveActivities(): Promise<void> {
+    try {
+      await this.storage.cleanupInactiveActivities();
+    } catch (error) {
+      console.error('Error cleaning up inactive Live Activities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to cleanup activities',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Sync local storage with platform-specific active activities
+   */
+  public async syncWithNativeActivities(): Promise<void> {
+    try {
+      let nativeActivities: Array<{id: string; status: string}> = [];
+
+      if (Platform.OS === 'ios' && this.iosModule) {
+        nativeActivities = await this.iosModule.getAllActiveActivities();
+      } else if (Platform.OS === 'android' && this.androidManager) {
+        nativeActivities = await this.androidManager.getAllActiveActivities();
+      }
+
+      const localActivities = await this.storage.getAllActivities();
+
+      // Mark activities as ended if they're not active natively
+      for (const localActivity of localActivities) {
+        if (localActivity.status === LiveActivityStatus.active) {
+          const nativeActivity = nativeActivities.find(
+            (na) => na.id === localActivity.nativeActivityId,
+          );
+
+          if (!nativeActivity || nativeActivity.status !== 'active') {
+            await this.storage.updateActivityStatus(
+              localActivity.id,
+              LiveActivityStatus.ended,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error syncing with native Live Activities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to sync with native activities',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Initialize the service and restore activities from storage
+   */
+  public async initialize(): Promise<void> {
+    try {
+      await this.storage.initialize();
+
+      // Sync with native activities on startup
+      if (await this.isSupported()) {
+        await this.syncWithNativeActivities();
+      }
+    } catch (error) {
+      console.error('Error initializing Live Activity service:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.nativeError,
+        'Failed to initialize Live Activity service',
+        error as Error,
+      );
+    }
+  }
+}

--- a/src/modules/live-activities/storage.ts
+++ b/src/modules/live-activities/storage.ts
@@ -1,0 +1,441 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import firestore from '@react-native-firebase/firestore';
+import {
+  LiveActivity,
+  LiveActivityStatus,
+  LiveActivityStorageSchema,
+  LiveActivityStorageData,
+  LiveActivityError,
+  LiveActivityErrorType,
+} from './types';
+import {parseISO} from 'date-fns';
+
+const STORAGE_KEY = '@ATB_live_activities';
+const FIRESTORE_COLLECTION = 'live_activities';
+
+/**
+ * Storage manager for Live Activities
+ * Uses both AsyncStorage for local caching and Firestore for persistence across
+ * devices
+ */
+export class LiveActivityStorage {
+  private userId: string | null = null;
+
+  /**
+   * Initialize storage with user ID for Firestore operations
+   */
+  public async initialize(userId?: string): Promise<void> {
+    this.userId = userId || null;
+
+    // Clean up any corrupted local data on initialization
+    try {
+      await this.validateAndCleanLocalStorage();
+    } catch (error) {
+      console.warn('Error during storage initialization cleanup:', error);
+      // Clear local storage if validation fails
+      await AsyncStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  /**
+   * Save a Live Activity to both local and remote storage
+   */
+  public async saveActivity(activity: LiveActivity): Promise<void> {
+    try {
+      // Save to local storage
+      await this.saveToLocal(activity);
+
+      // Save to Firestore if user is authenticated
+      if (this.userId) {
+        await this.saveToFirestore(activity);
+      }
+    } catch (error) {
+      console.error('Error saving Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to save activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Get a specific Live Activity by ID
+   */
+  public async getActivity(id: string): Promise<LiveActivity | null> {
+    try {
+      const localActivity = await this.getFromLocal(id);
+      if (localActivity) {
+        return localActivity;
+      }
+
+      if (this.userId) {
+        const remoteActivity = await this.getFromFirestore(id);
+        if (remoteActivity) {
+          await this.saveToLocal(remoteActivity);
+          return remoteActivity;
+        }
+      }
+
+      return null;
+    } catch (error) {
+      console.error('Error getting Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to get activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Get all Live Activities
+   */
+  public async getAllActivities(): Promise<LiveActivity[]> {
+    try {
+      const localActivities = await this.getAllFromLocal();
+
+      if (this.userId) {
+        const remoteActivities = await this.getAllFromFirestore();
+        const mergedActivities = this.mergeActivities(
+          localActivities,
+          remoteActivities,
+        );
+
+        await this.saveAllToLocal(mergedActivities);
+        return mergedActivities;
+      }
+
+      return localActivities;
+    } catch (error) {
+      console.error('Error getting all Live Activities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to get all activities',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Update an existing Live Activity
+   */
+  public async updateActivity(
+    id: string,
+    updates: Partial<LiveActivity>,
+  ): Promise<void> {
+    try {
+      const existingActivity = await this.getActivity(id);
+      if (!existingActivity) {
+        throw new LiveActivityError(
+          LiveActivityErrorType.activityNotFound,
+          `Activity with ID ${id} not found`,
+        );
+      }
+
+      const updatedActivity: LiveActivity = {
+        ...existingActivity,
+        ...updates,
+        id,
+      };
+
+      await this.saveActivity(updatedActivity);
+    } catch (error) {
+      console.error('Error updating Live Activity:', error);
+      if (error instanceof LiveActivityError) {
+        throw error;
+      }
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to update activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Update activity status
+   */
+  public async updateActivityStatus(
+    id: string,
+    status: LiveActivityStatus,
+  ): Promise<void> {
+    try {
+      await this.updateActivity(id, {
+        status,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      console.error('Error updating Live Activity status:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a Live Activity
+   */
+  public async deleteActivity(id: string): Promise<void> {
+    try {
+      await this.deleteFromLocal(id);
+
+      if (this.userId) {
+        await this.deleteFromFirestore(id);
+      }
+    } catch (error) {
+      console.error('Error deleting Live Activity:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to delete activity',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Clean up inactive activities (ended, dismissed, expired)
+   */
+  public async cleanupInactiveActivities(): Promise<void> {
+    try {
+      const allActivities = await this.getAllActivities();
+      const now = new Date();
+      const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+      const activitiesToDelete = allActivities.filter((activity) => {
+        // Delete if ended/dismissed and older than a week
+        const isInactive =
+          activity.status === LiveActivityStatus.ended ||
+          activity.status === LiveActivityStatus.dismissed;
+        const isOld = parseISO(activity.updatedAt) < oneWeekAgo;
+
+        return isInactive && isOld;
+      });
+
+      // Delete old inactive activities
+      for (const activity of activitiesToDelete) {
+        await this.deleteActivity(activity.id);
+      }
+
+      console.log(
+        `Cleaned up ${activitiesToDelete.length} inactive Live Activities`,
+      );
+    } catch (error) {
+      console.error('Error cleaning up inactive Live Activities:', error);
+      throw new LiveActivityError(
+        LiveActivityErrorType.storageError,
+        'Failed to cleanup activities',
+        error as Error,
+      );
+    }
+  }
+
+  // Private methods for local storage
+
+  private async saveToLocal(activity: LiveActivity): Promise<void> {
+    const localActivities = await this.getAllFromLocal();
+    const existingIndex = localActivities.findIndex(
+      (a) => a.id === activity.id,
+    );
+
+    if (existingIndex >= 0) {
+      localActivities[existingIndex] = activity;
+    } else {
+      localActivities.push(activity);
+    }
+
+    await this.saveAllToLocal(localActivities);
+  }
+
+  private async getFromLocal(id: string): Promise<LiveActivity | null> {
+    const localActivities = await this.getAllFromLocal();
+    return localActivities.find((a) => a.id === id) || null;
+  }
+
+  private async getAllFromLocal(): Promise<LiveActivity[]> {
+    try {
+      const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!stored) return [];
+
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) return [];
+
+      // Validate and parse each activity
+      const validActivities: LiveActivity[] = [];
+      for (const item of parsed) {
+        try {
+          const validated = LiveActivityStorageSchema.parse(item);
+          validActivities.push(this.storageDataToActivity(validated));
+        } catch (validationError) {
+          console.warn(
+            'Invalid activity data found in local storage:',
+            validationError,
+          );
+        }
+      }
+
+      return validActivities;
+    } catch (error) {
+      console.error('Error reading from local storage:', error);
+      return [];
+    }
+  }
+
+  private async saveAllToLocal(activities: LiveActivity[]): Promise<void> {
+    const storageData = activities.map(this.activityToStorageData);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(storageData));
+  }
+
+  private async deleteFromLocal(id: string): Promise<void> {
+    const localActivities = await this.getAllFromLocal();
+    const filteredActivities = localActivities.filter((a) => a.id !== id);
+    await this.saveAllToLocal(filteredActivities);
+  }
+
+  // Private methods for Firestore
+
+  private async saveToFirestore(activity: LiveActivity): Promise<void> {
+    if (!this.userId) return;
+
+    const docRef = firestore()
+      .collection(FIRESTORE_COLLECTION)
+      .doc(`${this.userId}_${activity.id}`);
+
+    await docRef.set(this.activityToStorageData(activity), {merge: true});
+  }
+
+  private async getFromFirestore(id: string): Promise<LiveActivity | null> {
+    if (!this.userId) return null;
+
+    const docRef = firestore()
+      .collection(FIRESTORE_COLLECTION)
+      .doc(`${this.userId}_${id}`);
+
+    const doc = await docRef.get();
+    if (!doc.exists) return null;
+
+    try {
+      const data = doc.data();
+      const validated = LiveActivityStorageSchema.parse(data);
+      return this.storageDataToActivity(validated);
+    } catch (error) {
+      console.warn('Invalid activity data in Firestore:', error);
+      return null;
+    }
+  }
+
+  private async getAllFromFirestore(): Promise<LiveActivity[]> {
+    if (!this.userId) return [];
+
+    const querySnapshot = await firestore()
+      .collection(FIRESTORE_COLLECTION)
+      .where('__name__', '>=', `${this.userId}_`)
+      .where('__name__', '<', `${this.userId}_\uf8ff`)
+      .get();
+
+    const activities: LiveActivity[] = [];
+    querySnapshot.forEach((doc) => {
+      try {
+        const data = doc.data();
+        const validated = LiveActivityStorageSchema.parse(data);
+        activities.push(this.storageDataToActivity(validated));
+      } catch (error) {
+        console.warn('Invalid activity data in Firestore:', error);
+      }
+    });
+
+    return activities;
+  }
+
+  private async deleteFromFirestore(id: string): Promise<void> {
+    if (!this.userId) return;
+
+    const docRef = firestore()
+      .collection(FIRESTORE_COLLECTION)
+      .doc(`${this.userId}_${id}`);
+
+    await docRef.delete();
+  }
+
+  // Helper methods
+
+  private activityToStorageData(activity: LiveActivity): any {
+    return {
+      id: activity.id,
+      attributes: activity.attributes,
+      contentState: activity.contentState,
+      status: activity.status,
+      createdAt: activity.createdAt,
+      updatedAt: activity.updatedAt,
+      nativeActivityId: activity.nativeActivityId,
+      pushToken: activity.pushToken,
+    };
+  }
+
+  private storageDataToActivity(data: LiveActivityStorageData): LiveActivity {
+    return {
+      id: data.id,
+      attributes: data.attributes as any,
+      contentState: data.contentState as any,
+      status: data.status,
+      createdAt: data.createdAt.toISOString(),
+      updatedAt: data.updatedAt.toISOString(),
+      nativeActivityId: data.nativeActivityId,
+      pushToken: data.pushToken,
+    };
+  }
+
+  private mergeActivities(
+    localActivities: LiveActivity[],
+    remoteActivities: LiveActivity[],
+  ): LiveActivity[] {
+    const merged = new Map<string, LiveActivity>();
+
+    // Add local activities
+    localActivities.forEach((activity) => {
+      merged.set(activity.id, activity);
+    });
+
+    // Merge with remote activities, preferring the one with latest updatedAt
+    remoteActivities.forEach((remoteActivity) => {
+      const localActivity = merged.get(remoteActivity.id);
+      if (
+        !localActivity ||
+        remoteActivity.updatedAt > localActivity.updatedAt
+      ) {
+        merged.set(remoteActivity.id, remoteActivity);
+      }
+    });
+
+    return Array.from(merged.values());
+  }
+
+  private async validateAndCleanLocalStorage(): Promise<void> {
+    try {
+      const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      if (!stored) return;
+
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        await AsyncStorage.removeItem(STORAGE_KEY);
+        return;
+      }
+
+      // Validate each item and remove invalid ones
+      const validItems = [];
+      for (const item of parsed) {
+        try {
+          LiveActivityStorageSchema.parse(item);
+          validItems.push(item);
+        } catch (error) {
+          console.warn('Removing invalid activity from storage:', error);
+        }
+      }
+
+      // Save cleaned data back
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(validItems));
+    } catch (error) {
+      console.error('Error validating local storage:', error);
+      // Remove corrupted storage
+      await AsyncStorage.removeItem(STORAGE_KEY);
+    }
+  }
+}

--- a/src/modules/live-activities/types.ts
+++ b/src/modules/live-activities/types.ts
@@ -1,0 +1,291 @@
+import {z} from 'zod';
+
+/**
+ * Live Activity status types
+ */
+export enum LiveActivityStatus {
+  active = 'active',
+  ended = 'ended',
+  dismissed = 'dismissed',
+  stale = 'stale',
+}
+
+/**
+ * Live Activity types for different features in the app
+ */
+export enum LiveActivityType {
+  departure = 'departure',
+  journey = 'journey',
+  ticket = 'ticket',
+  serviceUpdate = 'serviceUpdate',
+}
+
+/**
+ * Base interface for all Live Activity attributes
+ * This contains static data that doesn't change during the activity's lifetime
+ */
+export interface BaseLiveActivityAttributes {
+  id: string;
+  type: LiveActivityType;
+  title: string;
+  description?: string;
+  deepLink?: string;
+  activityName: string; // For debugging purposes
+}
+
+/**
+ * Base interface for Live Activity content state
+ * This contains dynamic data that can be updated during the activity's lifetime
+ * All dates are ISO 8601 strings for consistent serialization
+ */
+export interface BaseLiveActivityContentState {
+  updatedAt: string; // ISO 8601 string
+  relevantUntil?: string; // ISO 8601 string
+  staleDate?: string; // ISO 8601 string
+}
+
+/**
+ * Departure-specific Live Activity attributes
+ */
+export interface DepartureLiveActivityAttributes
+  extends BaseLiveActivityAttributes {
+  type: LiveActivityType.departure;
+  stopId: string;
+  stopName: string;
+  lineNumber: string;
+  destination: string;
+  departureId: string;
+}
+
+/**
+ * Departure-specific Live Activity content state
+ * All dates are ISO 8601 strings for consistent serialization
+ */
+export interface DepartureLiveActivityContentState
+  extends BaseLiveActivityContentState {
+  scheduledTime: string; // ISO 8601 string
+  estimatedTime?: string; // ISO 8601 string
+  realtimeStatus: 'on-time' | 'delayed' | 'cancelled' | 'no-data';
+  delay?: number; // in minutes
+  platform?: string;
+  occupancy?: 'low' | 'medium' | 'high';
+}
+
+/**
+ * Journey-specific Live Activity attributes
+ */
+export interface JourneyLiveActivityAttributes
+  extends BaseLiveActivityAttributes {
+  type: LiveActivityType.journey;
+  fromStopName: string;
+  toStopName: string;
+  routeId: string;
+}
+
+/**
+ * Journey-specific Live Activity content state
+ * All dates are ISO 8601 strings for consistent serialization
+ */
+export interface JourneyLiveActivityContentState
+  extends BaseLiveActivityContentState {
+  currentProgress: number; // 0-1
+  nextStopName: string;
+  estimatedArrival: string; // ISO 8601 string
+  totalDuration: number; // in minutes
+}
+
+/**
+ * Ticket-specific Live Activity attributes
+ */
+export interface TicketLiveActivityAttributes
+  extends BaseLiveActivityAttributes {
+  type: LiveActivityType.ticket;
+  ticketId: string;
+  productName: string;
+  zoneNames: string[];
+}
+
+/**
+ * Ticket-specific Live Activity content state
+ * All dates are ISO 8601 strings for consistent serialization
+ */
+export interface TicketLiveActivityContentState
+  extends BaseLiveActivityContentState {
+  validFrom: string; // ISO 8601 string
+  validTo: string; // ISO 8601 string
+  remainingTime: number; // in minutes
+  usageStatus: 'unused' | 'active' | 'expired';
+}
+
+/**
+ * Service Update-specific Live Activity attributes
+ */
+export interface ServiceUpdateLiveActivityAttributes
+  extends BaseLiveActivityAttributes {
+  type: LiveActivityType.serviceUpdate;
+  affectedLines: string[];
+  severity: 'info' | 'warning' | 'critical';
+}
+
+/**
+ * Service Update-specific Live Activity content state
+ * All dates are ISO 8601 strings for consistent serialization
+ */
+export interface ServiceUpdateLiveActivityContentState
+  extends BaseLiveActivityContentState {
+  message: string;
+  expectedResolution?: string; // ISO 8601 string
+  status: 'ongoing' | 'resolved' | 'escalated';
+}
+
+/**
+ * Union types for type-safe handling of different activity types
+ */
+export type LiveActivityAttributes =
+  | DepartureLiveActivityAttributes
+  | JourneyLiveActivityAttributes
+  | TicketLiveActivityAttributes
+  | ServiceUpdateLiveActivityAttributes;
+
+export type LiveActivityContentState =
+  | DepartureLiveActivityContentState
+  | JourneyLiveActivityContentState
+  | TicketLiveActivityContentState
+  | ServiceUpdateLiveActivityContentState;
+
+/**
+ * Complete Live Activity data structure
+ */
+export interface LiveActivity<
+  TAttributes extends LiveActivityAttributes = LiveActivityAttributes,
+  TContentState extends LiveActivityContentState = LiveActivityContentState,
+> {
+  id: string;
+  attributes: TAttributes;
+  contentState: TContentState;
+  status: LiveActivityStatus;
+  createdAt: string; // ISO 8601 string
+  updatedAt: string; // ISO 8601 string
+  nativeActivityId?: string; // iOS ActivityKit ID or Android notification ID
+  pushToken?: string; // For push updates
+}
+
+/**
+ * Configuration for Live Activity creation
+ */
+export interface LiveActivityConfig {
+  enablePushUpdates?: boolean;
+  priority?: 'low' | 'default' | 'high';
+  relevanceScore?: number; // 0-1, higher = more prominent in Dynamic Island
+  dismissalPolicy?: 'immediate' | 'default' | 'after-date';
+  dynamicIslandContentMargins?: {
+    leading?: number;
+    trailing?: number;
+    top?: number;
+    bottom?: number;
+  };
+}
+
+/**
+ * Request to create a new Live Activity
+ */
+export interface CreateLiveActivityRequest<
+  TAttributes extends LiveActivityAttributes = LiveActivityAttributes,
+  TContentState extends LiveActivityContentState = LiveActivityContentState,
+> {
+  attributes: TAttributes;
+  contentState: TContentState;
+  config?: LiveActivityConfig;
+}
+
+/**
+ * Request to update an existing Live Activity
+ */
+export interface UpdateLiveActivityRequest<
+  TContentState extends LiveActivityContentState = LiveActivityContentState,
+> {
+  id: string;
+  contentState: Partial<TContentState>;
+  config?: Partial<LiveActivityConfig>;
+}
+
+/**
+ * Request to end a Live Activity
+ */
+export interface EndLiveActivityRequest {
+  id: string;
+  dismissalPolicy?: 'immediate' | 'default' | 'after-date';
+  finalContentState?: Partial<LiveActivityContentState>;
+}
+
+/**
+ * Live Activity event types for listeners
+ */
+export enum LiveActivityEventType {
+  created = 'created',
+  updated = 'updated',
+  ended = 'ended',
+  dismissed = 'dismissed',
+  error = 'error',
+}
+
+/**
+ * Live Activity event data
+ */
+export interface LiveActivityEvent {
+  type: LiveActivityEventType;
+  activityId: string;
+  activity?: LiveActivity;
+  error?: string;
+  timestamp: string; // ISO 8601 string
+}
+
+/**
+ * Persistent storage schema for Live Activities
+ */
+export const LiveActivityStorageSchema = z.object({
+  id: z.string(),
+  attributes: z.record(z.any()),
+  contentState: z.record(z.any()),
+  status: z.nativeEnum(LiveActivityStatus),
+  createdAt: z.string().transform((val) => new Date(val)),
+  updatedAt: z.string().transform((val) => new Date(val)),
+  nativeActivityId: z.string().optional(),
+  pushToken: z.string().optional(),
+});
+
+export type LiveActivityStorageData = z.infer<typeof LiveActivityStorageSchema>;
+
+/**
+ * Error types for Live Activities
+ */
+export enum LiveActivityErrorType {
+  notSupported = 'not_supported',
+  permissionDenied = 'permission_denied',
+  invalidConfiguration = 'invalid_configuration',
+  activityNotFound = 'activity_not_found',
+  nativeError = 'native_error',
+  storageError = 'storage_error',
+}
+
+export class LiveActivityError extends Error {
+  constructor(
+    public type: LiveActivityErrorType,
+    message: string,
+    public originalError?: Error,
+  ) {
+    super(message);
+    this.name = 'LiveActivityError';
+  }
+}
+
+/**
+ * Platform-specific Live Activity capabilities
+ */
+export interface LiveActivityCapabilities {
+  isSupported: boolean;
+  supportsDynamicIsland: boolean;
+  supportsLockScreen: boolean;
+  supportsPushUpdates: boolean;
+  maxActiveActivities: number;
+}

--- a/src/modules/live-activities/use-live-activities.tsx
+++ b/src/modules/live-activities/use-live-activities.tsx
@@ -1,0 +1,372 @@
+import {useEffect, useState, useCallback, useRef} from 'react';
+import {useAuthContext} from '@atb/modules/auth';
+import {
+  LiveActivity,
+  LiveActivityAttributes,
+  LiveActivityContentState,
+  CreateLiveActivityRequest,
+  UpdateLiveActivityRequest,
+  EndLiveActivityRequest,
+  LiveActivityEvent,
+  LiveActivityCapabilities,
+  LiveActivityError,
+  LiveActivityErrorType,
+  LiveActivityStatus,
+} from './types';
+import {LiveActivityService} from './service';
+
+/**
+ * Hook for managing Live Activities
+ * Provides a React-friendly interface to the Live Activity service
+ */
+export function useLiveActivities() {
+  const [isSupported, setIsSupported] = useState<boolean>(false);
+  const [capabilities, setCapabilities] =
+    useState<LiveActivityCapabilities | null>(null);
+  const [activeActivities, setActiveActivities] = useState<LiveActivity[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<LiveActivityError | null>(null);
+
+  const {authStatus} = useAuthContext();
+  const serviceRef = useRef<LiveActivityService | null>(null);
+  const eventListenerRef = useRef<(() => void) | null>(null);
+
+  // Initialize service
+  useEffect(() => {
+    const initializeService = async () => {
+      try {
+        setIsLoading(true);
+        serviceRef.current = LiveActivityService.getInstance();
+
+        // Initialize with user ID for storage
+        await serviceRef.current.initialize();
+
+        // Check support and capabilities
+        const supported = await serviceRef.current.isSupported();
+        const caps = await serviceRef.current.getCapabilities();
+
+        setIsSupported(supported);
+        setCapabilities(caps);
+
+        // Load active activities
+        if (supported) {
+          const activities = await serviceRef.current.getActiveActivities();
+          setActiveActivities(activities);
+        }
+
+        setError(null);
+      } catch (err) {
+        console.error('Error initializing Live Activities:', err);
+        setError(err as LiveActivityError);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    initializeService();
+  }, [authStatus]);
+
+  const handleLiveActivityEvent = useCallback((event: LiveActivityEvent) => {
+    switch (event.type) {
+      case 'created':
+      case 'updated':
+        if (event.activity) {
+          setActiveActivities((prev) => {
+            const filtered = prev.filter((a) => a.id !== event.activityId);
+            return [...filtered, event.activity!];
+          });
+        }
+        break;
+
+      case 'ended':
+      case 'dismissed':
+        setActiveActivities((prev) =>
+          prev.filter((a) => a.id !== event.activityId),
+        );
+        break;
+
+      case 'error':
+        console.error('Live Activity error:', event.error);
+        break;
+    }
+  }, []);
+
+  // Setup event listeners
+  useEffect(() => {
+    if (!serviceRef.current) return;
+
+    const removeListener = serviceRef.current.addEventListener(
+      handleLiveActivityEvent,
+    );
+    eventListenerRef.current = removeListener;
+
+    return () => {
+      if (eventListenerRef.current) {
+        eventListenerRef.current();
+      }
+    };
+  }, [handleLiveActivityEvent]);
+
+  const createActivity = useCallback(
+    async <
+      TAttributes extends LiveActivityAttributes,
+      TContentState extends LiveActivityContentState,
+    >(
+      request: CreateLiveActivityRequest<TAttributes, TContentState>,
+    ): Promise<LiveActivity<TAttributes, TContentState> | null> => {
+      if (!serviceRef.current) {
+        setError(
+          new LiveActivityError(
+            LiveActivityErrorType.notSupported,
+            'Service not initialized',
+          ),
+        );
+        return null;
+      }
+
+      try {
+        setError(null);
+        const activity = await serviceRef.current.createActivity(request);
+        return activity;
+      } catch (err) {
+        console.error('Error creating Live Activity:', err);
+        setError(err as LiveActivityError);
+        return null;
+      }
+    },
+    [],
+  );
+
+  const updateActivity = useCallback(
+    async <TContentState extends LiveActivityContentState>(
+      request: UpdateLiveActivityRequest<TContentState>,
+    ): Promise<boolean> => {
+      if (!serviceRef.current) {
+        setError(
+          new LiveActivityError(
+            LiveActivityErrorType.notSupported,
+            'Service not initialized',
+          ),
+        );
+        return false;
+      }
+
+      try {
+        setError(null);
+        await serviceRef.current.updateActivity(request);
+        return true;
+      } catch (err) {
+        console.error('Error updating Live Activity:', err);
+        setError(err as LiveActivityError);
+        return false;
+      }
+    },
+    [],
+  );
+
+  const endActivity = useCallback(
+    async (request: EndLiveActivityRequest): Promise<boolean> => {
+      if (!serviceRef.current) {
+        setError(
+          new LiveActivityError(
+            LiveActivityErrorType.notSupported,
+            'Service not initialized',
+          ),
+        );
+        return false;
+      }
+
+      try {
+        setError(null);
+        await serviceRef.current.endActivity(request);
+        return true;
+      } catch (err) {
+        console.error('Error ending Live Activity:', err);
+        setError(err as LiveActivityError);
+        return false;
+      }
+    },
+    [],
+  );
+
+  const getActivity = useCallback(
+    async (id: string): Promise<LiveActivity | null> => {
+      if (!serviceRef.current) {
+        return null;
+      }
+
+      try {
+        return await serviceRef.current.getActivity(id);
+      } catch (err) {
+        console.error('Error getting Live Activity:', err);
+        setError(err as LiveActivityError);
+        return null;
+      }
+    },
+    [],
+  );
+
+  const requestPermissions = useCallback(async (): Promise<boolean> => {
+    if (!serviceRef.current) {
+      setError(
+        new LiveActivityError(
+          LiveActivityErrorType.notSupported,
+          'Service not initialized',
+        ),
+      );
+      return false;
+    }
+
+    try {
+      setError(null);
+      return await serviceRef.current.requestPermissions();
+    } catch (err) {
+      console.error('Error requesting permissions:', err);
+      setError(err as LiveActivityError);
+      return false;
+    }
+  }, []);
+
+  const cleanupInactiveActivities = useCallback(async (): Promise<boolean> => {
+    if (!serviceRef.current) {
+      return false;
+    }
+
+    try {
+      await serviceRef.current.cleanupInactiveActivities();
+
+      // Refresh active activities list
+      const activities = await serviceRef.current.getActiveActivities();
+      setActiveActivities(activities);
+
+      return true;
+    } catch (err) {
+      console.error('Error cleaning up activities:', err);
+      setError(err as LiveActivityError);
+      return false;
+    }
+  }, []);
+
+  const syncWithNative = useCallback(async (): Promise<boolean> => {
+    if (!serviceRef.current) {
+      return false;
+    }
+
+    try {
+      await serviceRef.current.syncWithNativeActivities();
+
+      // Refresh active activities list
+      const activities = await serviceRef.current.getActiveActivities();
+      setActiveActivities(activities);
+
+      return true;
+    } catch (err) {
+      console.error('Error syncing with native:', err);
+      setError(err as LiveActivityError);
+      return false;
+    }
+  }, []);
+
+  return {
+    // State
+    isSupported,
+    capabilities,
+    activeActivities,
+    isLoading,
+    error,
+
+    // Actions
+    createActivity,
+    updateActivity,
+    endActivity,
+    getActivity,
+    requestPermissions,
+    cleanupInactiveActivities,
+    syncWithNative,
+  };
+}
+
+/**
+ * Hook for managing a specific type of Live Activity
+ */
+export function useLiveActivity<
+  TAttributes extends LiveActivityAttributes,
+  TContentState extends LiveActivityContentState,
+>(activityId: string) {
+  const [activity, setActivity] = useState<LiveActivity<
+    TAttributes,
+    TContentState
+  > | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<LiveActivityError | null>(null);
+
+  const {getActivity, updateActivity, endActivity} = useLiveActivities();
+
+  // Load activity on mount
+  useEffect(() => {
+    const loadActivity = async () => {
+      try {
+        setIsLoading(true);
+        const loadedActivity = await getActivity(activityId);
+        setActivity(loadedActivity as LiveActivity<TAttributes, TContentState>);
+        setError(null);
+      } catch (err) {
+        console.error('Error loading Live Activity:', err);
+        setError(err as LiveActivityError);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (activityId) {
+      loadActivity();
+    }
+  }, [activityId, getActivity]);
+
+  const update = useCallback(
+    async (contentState: Partial<TContentState>): Promise<boolean> => {
+      if (!activity) return false;
+
+      const success = await updateActivity({
+        id: activity.id,
+        contentState,
+      });
+
+      if (success) {
+        // Reload activity to get updated state
+        const updatedActivity = await getActivity(activityId);
+        setActivity(
+          updatedActivity as LiveActivity<TAttributes, TContentState>,
+        );
+      }
+
+      return success;
+    },
+    [activity, activityId, updateActivity, getActivity],
+  );
+
+  const end = useCallback(
+    async (
+      dismissalPolicy?: 'immediate' | 'default' | 'after-date',
+      finalContentState?: Partial<TContentState>,
+    ): Promise<boolean> => {
+      if (!activity) return false;
+
+      return await endActivity({
+        id: activity.id,
+        dismissalPolicy,
+        finalContentState,
+      });
+    },
+    [activity, endActivity],
+  );
+
+  return {
+    activity,
+    isLoading,
+    error,
+    update,
+    end,
+    isActive: activity?.status === LiveActivityStatus.active,
+  };
+}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -266,6 +266,20 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                   testID="debugButton"
                   onPress={() => navigation.navigate('Profile_DebugInfoScreen')}
                 />
+                <LinkSectionItem
+                  text="Live Activities Test"
+                  testID="liveActivitiesTestButton"
+                  onPress={() =>
+                    navigation.navigate('Profile_LiveActivitiesTestScreen')
+                  }
+                />
+                <LinkSectionItem
+                  text="Live Activities Debug"
+                  testID="liveActivitiesDebugButton"
+                  onPress={() =>
+                    navigation.navigate('Profile_LiveActivitiesDebugScreen')
+                  }
+                />
               </Section>
             </>
           )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -32,6 +32,10 @@ import {Profile_SettingsScreen} from './Profile_SettingsScreen';
 import {Profile_FavoriteScreen} from './Profile_FavoriteScreen';
 import {Profile_InformationScreen} from './Profile_InformationScreen';
 import {Profile_HelpAndContactScreen} from './Profile_HelpAndContactScreen';
+import {
+  LiveActivitiesTestScreen,
+  LiveActivitiesDebugScreen,
+} from '@atb/modules/live-activities';
 
 const Stack = createStackNavigator<ProfileStackParams>();
 
@@ -159,6 +163,14 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_InformationScreen"
         component={Profile_InformationScreen}
+      />
+      <Stack.Screen
+        name="Profile_LiveActivitiesTestScreen"
+        component={LiveActivitiesTestScreen}
+      />
+      <Stack.Screen
+        name="Profile_LiveActivitiesDebugScreen"
+        component={LiveActivitiesDebugScreen}
       />
     </Stack.Navigator>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -39,6 +39,8 @@ export type ProfileStackParams = StackParams<{
   Profile_FavoriteScreen: undefined;
   Profile_InformationScreen: undefined;
   Profile_HelpAndContactScreen: undefined;
+  Profile_LiveActivitiesTestScreen: undefined;
+  Profile_LiveActivitiesDebugScreen: undefined;
 }>;
 
 export type ProfileStackRootProps =


### PR DESCRIPTION
# Live Activities PoC Summary

## Work Completed

The Live Activities PoC adopts a simplified integration by extending the existing widget extension rather than introducing a new one. This approach delivers Live Activities capabilities (Dynamic Island, Lock Screen, real-time updates) while reducing complexity, limiting code duplication, and lowering maintenance overhead.

## Future Considerations

Next steps include creating a dedicated Live Activities widget rather than reusing the Departure widget, moving data persistence and state management into the Notification Service Extension, and delivering a polished, production-ready design. We should also decide whether users can disable Live Activities; if so, we will add an in-app setting to manage this preference.


<img width="1179" height="2603" alt="image" src="https://github.com/user-attachments/assets/5003e023-29de-4f90-927c-bb9763139842" />
