### PR TITLE
fix: updating enrollment text to say with users

### DIFF
--- a/src/translations/screens/subscreens/Enrollment.ts
+++ b/src/translations/screens/subscreens/Enrollment.ts
@@ -2,9 +2,9 @@ import {translation as _} from '../../commons';
 const EnrollmentTexts = {
   header: _('Nye konsepter', 'New concepts', 'Nye konsept'),
   info: _(
-    'Vi tester ny funksjonalitet i appen på utvalgte brukere. Har du fått en kode for å bli med? Skriv den inn her.',
-    'We are trying out new features in the app on a select group of users. Have you received a code to join? Enter it here.',
-    'Me testar ny funksjonalitet i appen på utvalde brukarar. Har du fått ein kode for å bli med? Skriv den inn her.',
+    'Vi tester ny funksjonalitet i appen med utvalgte brukere. Har du fått en kode for å bli med? Skriv den inn her.',
+    'We are trying out new features in the app with a selected group of users. Have you received a code to join? Enter it here.',
+    'Me testar ny funksjonalitet i appen med utvalde brukarar. Har du fått ein kode for å bli med? Skriv den inn her.',
   ),
   success: _('Du er inne!', 'You are in!', 'Du er inne!'),
   label: _('Kode', 'Code', 'Kode'),


### PR DESCRIPTION
closes https://github.com/AtB-AS/mittatb-app/pull/5380

<img width="200" alt="image" src="https://github.com/user-attachments/assets/08f184f1-62d4-4564-bd13-bf39c9aac1cd" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/d48f5a62-e773-4eea-b51b-434f0fe5ed7a" />


resolves [discussion](https://github.com/AtB-AS/mittatb-app/pull/5380#issuecomment-3204789905) with @hanne-at-atb & @hannahATB 