### PR TITLE
feat: Support isDismissable

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
@@ -27,6 +27,7 @@ import {useAnalyticsContext} from '@atb/modules/analytics';
 import Bugsnag from '@bugsnag/react-native';
 import {RefObject, useRef} from 'react';
 import {ArrowRight, ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
+import {isDefined} from '@atb/utils/presence';
 
 type Props = {
   announcement: Announcement;
@@ -77,18 +78,20 @@ export const AnnouncementSection = ({announcement, style}: Props) => {
               >
                 {summaryTitle}
               </ThemeText>
-              <PressableOpacity
-                style={styles.close}
-                role="button"
-                hitSlop={insets.all(theme.spacing.medium)}
-                accessibilityHint={t(
-                  DashboardTexts.announcemens.announcement.closeA11yHint,
-                )}
-                onPress={() => handleDismiss()}
-                testID="closeAnnouncement"
-              >
-                <ThemeIcon svg={Close} />
-              </PressableOpacity>
+              {!(announcement.isDismissable === false) && (
+                <PressableOpacity
+                  style={styles.close}
+                  role="button"
+                  hitSlop={insets.all(theme.spacing.medium)}
+                  accessibilityHint={t(
+                    DashboardTexts.announcemens.announcement.closeA11yHint,
+                  )}
+                  onPress={() => handleDismiss()}
+                  testID="closeAnnouncement"
+                >
+                  <ThemeIcon svg={Close} />
+                </PressableOpacity>
+              )}
             </View>
             <ThemeText style={styles.summary}>
               {getTextForLanguage(announcement.summary, language)}


### PR DESCRIPTION
isDismissable was included in the Announcement type, but not respected.
Now the close x button is hidden if isDismissable is true.

| isDismissable=true or not set, x shows | isDismissable=false, x hidden |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/10119528-0695-43f8-91aa-aba1fd78712e" /> | <img width="200" src="https://github.com/user-attachments/assets/296c7228-05b6-482c-b7a8-d43db51b784c" /> |

Resolves https://github.com/AtB-AS/kundevendt/issues/21179