### PR TITLE
fix: Remove isDismissable on Announcement type

### DIFF
--- a/src/modules/announcements/types.ts
+++ b/src/modules/announcements/types.ts
@@ -57,7 +57,6 @@ export const Announcement = z.object({
   fullTitle: LanguageAndTextTypeArray,
   body: LanguageAndTextTypeArray,
   mainImage: Base64ImageSchema.optional(),
-  isDismissable: z.boolean().optional(),
   appPlatforms: z.array(AppPlatform).optional(),
   appVersionMin: z.string().optional(),
   appVersionMax: z.string().optional(),


### PR DESCRIPTION
We needed to either [support isDismissable](https://github.com/AtB-AS/mittatb-app/pull/5388) or remove it.
The decision with designers is to remove it, as is done in this PR.

Resolves https://github.com/AtB-AS/kundevendt/issues/21179

Acceptance criteria:
- [x] Announcements unaffected by this change