### PR TITLE
Reduce maxzoom for tile requests

### DIFF
--- a/src/modules/map/components/mobility/VehiclesAndStations.tsx
+++ b/src/modules/map/components/mobility/VehiclesAndStations.tsx
@@ -196,7 +196,7 @@ export const useVehiclesAndStationsVectorSource: () => {
         type: 'vector',
         tiles: [tileUrlTemplate || ''],
         minzoom: 14,
-        maxzoom: 19,
+        maxzoom: 17,
         volatile: true,
       },
     }),


### PR DESCRIPTION
After https://github.com/AtB-AS/map/pull/11 which is now in prod, nothing is clustered beyond zoom level 16.
This sets max zoom to 17, so that the deepest zoom level of tiles requested, is the one where there are no clusters.
This reduces the number of requests sent to the server a little.

Acceptance criteria:
- [x] Tile requests for zoom levels 18 and 19 are no longer sent