### PR TITLE
feat: add service disruption link to profile information screen

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_InformationScreen.tsx
@@ -11,12 +11,14 @@ import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {useRemoteConfigContext} from '@atb/modules/remote-config';
 
 export const Profile_InformationScreen = () => {
   const style = useStyle();
   const {t, language} = useTranslation();
 
   const {configurableLinks} = useFirestoreConfigurationContext();
+  const {service_disruption_url} = useRemoteConfigContext();
   const ticketingInfo = configurableLinks?.ticketingInfo;
   const termsInfo = configurableLinks?.termsInfo;
   const inspectionInfo = configurableLinks?.inspectionInfo;
@@ -47,6 +49,24 @@ export const Profile_InformationScreen = () => {
         style={style.contentContainer}
       >
         <Section>
+          {service_disruption_url && (
+            <LinkSectionItem
+              rightIcon={{svg: ExternalLink}}
+              text={t(
+                ProfileTexts.sections.information.linkSectionItems
+                  .serviceDisruptions.label,
+              )}
+              testID="serviceDisruptionsButton"
+              onPress={() => Linking.openURL(service_disruption_url)}
+              accessibility={{
+                accessibilityHint: t(
+                  ProfileTexts.sections.information.linkSectionItems
+                    .serviceDisruptions.a11yLabel,
+                ),
+                accessibilityRole: 'link',
+              }}
+            />
+          )}
           {ticketingInfoUrl && (
             <LinkSectionItem
               rightIcon={{svg: ExternalLink}}

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -378,6 +378,14 @@ const ProfileTexts = {
             'Tilgjengelegheitserklæring, åpner side i nettlesar',
           ),
         },
+        serviceDisruptions: {
+          label: _('Driftsmeldinger', 'Service disruptions', 'Driftsmeldingar'),
+          a11yLabel: _(
+            'Driftsmeldinger, åpner side i nettleser',
+            'Service disruptions, opens page in browser',
+            'Driftsmeldingar, opnar side i nettlesar',
+          ),
+        },
       },
     },
     contact: {


### PR DESCRIPTION
After a meeting with FRAM, we decided to include a link to service disruptions on Profile.

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-21 at 14 28 31" src="https://github.com/user-attachments/assets/f13efffd-dce5-41e4-9781-3e80363fbf04" />

### Acceptance criteria

- [ ] Link to service disruptions is added to Profile > Information
- [ ] Screen reader
- [ ] Configurable in remote config, `service_disruption_url` (same as before)