### PR TITLE
fix: fetch server time even when traveling back in time

### DIFF
--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -13,6 +13,13 @@ import {DateResponse, DateResponseSchema} from './types/mobility';
 
 export const VIPPS_CALLBACK_URL = `${APP_SCHEME}://auth/vipps`;
 
+export const getServerTime = async () => {
+  const response = await client.get('/identity/v1/time', {
+    authWithIdToken: false,
+  });
+  return response.data;
+};
+
 export const authenticateWithSms = async (
   phoneNumber: string,
   language: Language,

--- a/src/modules/time/TimeContext.tsx
+++ b/src/modules/time/TimeContext.tsx
@@ -1,11 +1,12 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+import {z} from 'zod';
 import {useInterval} from '@atb/utils/use-interval';
-import {mobileTokenClient} from '@atb/modules/mobile-token';
-import React, {createContext, useContext, useState} from 'react';
-import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {useServerTimeQuery} from './use-server-time-query';
+import {useFeatureTogglesContext} from '../feature-toggles';
 
 type TimeContextState = {
   /**
-   * The current time in milliseconds, updated every 2.5 seconds. This is based
+   * The current time in milliseconds, updated every second. This is based
    * on server time when possible, and can be safely used for checking the
    * validity of fare contracts.
    */
@@ -14,35 +15,41 @@ type TimeContextState = {
 
 const TimeContext = createContext<TimeContextState | undefined>(undefined);
 
-// The number of milliseconds the device time is ahead of server time.
-let serverDiff = 0;
+/**
+ * The number of milliseconds the device time is ahead of server time.
+ */
+let serverTimeOffsetGlobal = 0;
 
 /**
- * Returns the current time in milliseconds.
+ * Returns the current UNIX time in milliseconds.
  */
-export const getServerNow = () => Date.now() - serverDiff;
+export const getServerNowGlobal = () => Date.now() - serverTimeOffsetGlobal;
 
 type Props = {
   children: React.ReactNode;
 };
 
+/** https://github.com/AtB-AS/identity/blob/main/identity-service/src/handlers/identity/mod.rs#L53 */
+const TimeResult = z.object({
+  timestamp: z.string(),
+  timestampMs: z.number(),
+});
+
 export const TimeContextProvider = ({children}: Props) => {
   const [serverNow, setServerNow] = useState(Date.now());
   const {isServerTimeEnabled} = useFeatureTogglesContext();
 
+  const {data} = useServerTimeQuery(isServerTimeEnabled);
+  useEffect(() => {
+    const timeData = TimeResult.safeParse(data).data;
+    if (timeData?.timestampMs) {
+      serverTimeOffsetGlobal = timeData.timestampMs - Date.now();
+    }
+  }, [data]);
+
   useInterval(
-    () => {
-      if (isServerTimeEnabled) {
-        mobileTokenClient.currentTimeMillis().then((ms) => {
-          serverDiff = Date.now() - ms;
-          setServerNow(ms);
-        });
-      } else {
-        serverDiff = 0;
-        setServerNow(Date.now());
-      }
-    },
-    [isServerTimeEnabled],
+    () => setServerNow(Date.now() - serverTimeOffsetGlobal),
+    [],
     1000,
     false,
     true,

--- a/src/modules/time/index.ts
+++ b/src/modules/time/index.ts
@@ -1,1 +1,5 @@
-export {TimeContextProvider, useTimeContext, getServerNow} from './TimeContext';
+export {
+  TimeContextProvider,
+  useTimeContext,
+  getServerNowGlobal,
+} from './TimeContext';

--- a/src/modules/time/use-server-time-query.ts
+++ b/src/modules/time/use-server-time-query.ts
@@ -8,6 +8,6 @@ export const useServerTimeQuery = (enabled: boolean) =>
     queryFn: () => getServerTime(),
     refetchInterval: ONE_MINUTE_MS,
     refetchOnReconnect: true,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: 'always',
     enabled,
   });

--- a/src/modules/time/use-server-time-query.ts
+++ b/src/modules/time/use-server-time-query.ts
@@ -1,0 +1,13 @@
+import {useQuery} from '@tanstack/react-query';
+import {ONE_MINUTE_MS} from '@atb/utils/durations';
+import {getServerTime} from '@atb/api/identity';
+
+export const useServerTimeQuery = (enabled: boolean) =>
+  useQuery({
+    queryKey: ['getServerTime'],
+    queryFn: () => getServerTime(),
+    refetchInterval: ONE_MINUTE_MS,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    enabled,
+  });

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -1,7 +1,7 @@
 import {FullScreenHeader} from '@atb/components/screen-header';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {Alert, Linking, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -111,6 +111,7 @@ export const Profile_DebugInfoScreen = () => {
     },
   } = useMobileTokenContext();
   const {serverNow} = useTimeContext();
+  const serverTimeOffset = useMemo(() => Date.now() - serverNow, [serverNow]);
 
   const {
     fcmToken,
@@ -175,6 +176,9 @@ export const Profile_DebugInfoScreen = () => {
           />
         </Section>
         <Section style={styles.section}>
+          <GenericSectionItem>
+            <ThemeText>{`Device is ${serverTimeOffset}ms ahead of server time`}</ThemeText>
+          </GenericSectionItem>
           <LinkSectionItem
             text="Reset shareTravelHabits session counter"
             onPress={() => storage.set(shareTravelHabitsSessionCountKey, '0')}


### PR DESCRIPTION
This re-applies changes from https://github.com/AtB-AS/mittatb-app/pull/5342, and applies a fix so that we always fetch server time after the user manually sets device time in settings. I'll try to summarize my findings.

The issue with the previous PR seems to be when the device time is set back in time, e.g. from 12:00 to 10:00. In this case, the useServerTimeQuery will fetch server time only when the clock gets back to 12:01. Finding the root cause of this was a bit of a journey, but it boils down to two issues with the react query setup:

## 1. `refetchOnWindowFocus: true`

This should cause the app to reload server time whenever the app gets focus. So if the user exits the app to change their device time, it should refresh at once when they return to the app. However, from the [docs](https://tanstack.com/query/v4/docs/framework/react/reference/useQuery):

> refetchOnWindowFocus
> - If set to `true`, the query will refetch on window focus if the data is stale.

and 

> staleTime
> - Defaults to `0`

When the device time is set back in time the data isn't stale yet, since "two hours in the past" is less than `0` 🤷 Setting `refetchOnWindowFocus: "always"` should fix this, and refetch server time even when not stale. 8c0372ce1b3e23d826f3a0dfcccb5b66d425be93

## 2. `refetchInterval: ONE_MINUTE_MS`

However, `refetchOnWindowFocus` wasn't the only mechanism that should have caused updates 🙈 There should have been a refetch every minute, regardless of device time.

Initially, I thought this was a bug in react query. It's not! [Internally react query uses a plain old `setInterval`](https://github.com/TanStack/query/blob/a1b1279be3befc37a9d4fbb2fa79826bfb0955a4/packages/query-core/src/queryObserver.ts#L397). This is not _supposed_ to be affected by device time, and in a browser it's not. In React Native, however, it is.

**This means the issue we're seeing with server time applies to every `setInterval` in the app.** So if we have other functionality that rely on it, it might also break when device time is set back in time. Might be something to look into, but our `useInterval` hook uses `setTimeout`, which might work better.

---

Anyway, thanks for reading my rant 💛

TL;DR: I changed `true` to `"always"`. That's it.