### PR TITLE
fix(spar): update max length of license plate input

### DIFF
--- a/src/modules/smart-park-and-ride/components/LicensePlateSection.tsx
+++ b/src/modules/smart-park-and-ride/components/LicensePlateSection.tsx
@@ -58,7 +58,7 @@ export const LicensePlateSection = ({
           value={value}
           autoCapitalize="characters"
           inlineLabel={false}
-          maxLength={9}
+          maxLength={14}
           {...textInputSectionItemProps}
         />
       </Section>


### PR DESCRIPTION
Increase the maximum length for license plate input from 9 to 14 characters to accommodate longer license plate formats.

partly fixes https://github.com/AtB-AS/kundevendt/issues/21101