### PR TITLE
feat: log all PressableOpacity onPress events to posthog

### DIFF
--- a/src/components/pressable-opacity/PressableOpacity.tsx
+++ b/src/components/pressable-opacity/PressableOpacity.tsx
@@ -1,5 +1,6 @@
 import {Pressable, PressableProps, StyleProp, ViewStyle} from 'react-native';
 import React, {forwardRef} from 'react';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 
 export type PressableOpacityProps = {
   style?: StyleProp<ViewStyle>;
@@ -7,11 +8,18 @@ export type PressableOpacityProps = {
 
 export const PressableOpacity = forwardRef<any, PressableOpacityProps>(
   ({style, ...pressableProps}: PressableOpacityProps, focusRef) => {
+    const {logEvent} = useAnalyticsContext();
     return (
       <Pressable
         ref={focusRef}
         style={({pressed}) => [{opacity: pressed ? 0.2 : 1}, style]}
         {...pressableProps}
+        onPress={(e) => {
+          pressableProps.onPress?.(e);
+          if (pressableProps.testID) {
+            logEvent('OnPress event', pressableProps.testID);
+          }
+        }}
       >
         {pressableProps?.children}
       </Pressable>

--- a/src/modules/analytics/types.ts
+++ b/src/modules/analytics/types.ts
@@ -10,6 +10,7 @@ export type AnalyticsEventContext =
   | 'Map'
   | 'Mobility'
   | 'Onboarding'
+  | 'OnPress event'
   | 'Parking violations'
   | 'Profile'
   | 'Receipt'

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -54,7 +54,7 @@ export function StartTimeSelection({
             ),
           )}
           accessibilityHint={t(PurchaseOverviewTexts.startTime.a11yLaterHint)}
-          testID="selectZonesButton"
+          testID="startTimeButton"
         >
           <View style={styles.sectionContent}>
             <ThemeText typography="body__primary--bold">


### PR DESCRIPTION
As an easy way to make more user interactions available to PostHog, I propose logging all `onPress` events in PressableOpacity that have a `testID`. 

- The PressableOpacity component is used by _most_ "press" interactions in the app. 
- The most important flows in the app should already be covered by tests, which means testIDs are set, but if we're missing parts of user flows, we can simply add more testIDs.
- We'll hopefully get some value out of using testIDs as event names without building another layer of identifiers of interactions in the app.

closes https://github.com/AtB-AS/kundevendt/issues/17343