### PR TITLE
fix: refresh mobile token on window focus always

### DIFF
--- a/src/modules/mobile-token/hooks/use-get-signed-token-query.tsx
+++ b/src/modules/mobile-token/hooks/use-get-signed-token-query.tsx
@@ -33,5 +33,6 @@ export const useGetSignedTokenQuery = () => {
       }
     },
     refetchInterval: TEN_SECONDS_MS,
+    refetchOnWindowFocus: 'always',
   });
 };


### PR DESCRIPTION
This fixes an issue with stale Aztec codes when someone closes the app and reopens directly to ticketing details where the barcode is visible. This should work as `useSetupReactQueryWindowFocus` is used in root view.

NOTE: I am still unable to get the app running locally, so I haven't verified the fix my self. 😬

---

From Slack:
> The Aztec is replaced every X seconds (currently 10?). But the content it self is valid for Y seconds. When validating now we some times get error ("Ugyldig kortinnhold" in MT Buss. Essentially no travel right). I think this is might be due to that the read barcode becomes invalid when trying to be validated. For instance, if X = Y and it took 4 seconds to parse and read the barcode, you could have situations where right before the Aztec is replaced, it will be invalid when trying to validate. We've seen this error "Ugyldig kortinnhold" sporadically when testing, but unable to do stable reproductions.

Conclusion:
> This is what happens: Someone has buys a ticket. After they have bought the ticket, and have ticket details (with aztec up), they swipe out of the app. That means the timeout/interval of replacing the Aztec stops running. When they open the app again and ready to show the Barcode, the timer starts again, but doesn't refresh at once, but there is potentially 10 seconds until the new aztec code shows. This means that an OLD Aztec code is showing (if there has been over 60 sconds since they closed the app), and validation fails.

(Context: https://mittatb.slack.com/archives/C025NUF4WA0/p1756283749406079)


