### PR TITLE
feat(aztec): remote configurable aztec code dimensions

### DIFF
--- a/src/modules/fare-contracts/details/Barcode.tsx
+++ b/src/modules/fare-contracts/details/Barcode.tsx
@@ -86,6 +86,7 @@ function useScreenBrightnessIncrease() {
  */
 const MobileTokenAztec = ({fc}: {fc: FareContractType}) => {
   const styles = useStyles();
+  const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
   const {t} = useTranslation();
   const {data: signedToken} = useGetSignedTokenQuery();
   const [aztecCodeError, setAztecCodeError] = useState(false);
@@ -108,7 +109,10 @@ const MobileTokenAztec = ({fc}: {fc: FareContractType}) => {
 
   return (
     <View
-      style={styles.aztecCode}
+      style={[
+        styles.aztecCode,
+        {padding: aztec_code_padding, maxHeight: aztec_code_max_height},
+      ]}
       accessible={true}
       accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
       testID="mobileTokenBarcode"
@@ -180,6 +184,7 @@ const LoadingBarcode = () => {
 
 const StaticAztec = ({fc}: {fc: FareContractType}) => {
   const styles = useStyles();
+  const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
   const {t} = useTranslation();
   const [aztecXml, setAztecXml] = useState<string>();
   const onCloseFocusRef = useRef<RefObject<any>>(null);
@@ -197,7 +202,12 @@ const StaticAztec = ({fc}: {fc: FareContractType}) => {
   if (!aztecXml) return null;
 
   return (
-    <View style={styles.aztecCode}>
+    <View
+      style={[
+        styles.aztecCode,
+        {padding: aztec_code_padding, maxHeight: aztec_code_max_height},
+      ]}
+    >
       <PressableOpacity
         onPress={onOpenBarcodePress}
         accessibilityRole="button"
@@ -215,6 +225,7 @@ const StaticAztec = ({fc}: {fc: FareContractType}) => {
 
 const StaticQrCode = ({fc}: {fc: FareContractType}) => {
   const styles = useStyles();
+  const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
   const {t} = useTranslation();
   const [qrCodeSvg, setQrCodeSvg] = useState<string>();
   const onCloseFocusRef = useRef<RefObject<any>>(null);
@@ -233,7 +244,12 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
 
   return (
     <View
-      style={[styles.aztecCode, styles.staticQrCode, styles.staticQrCodeSmall]}
+      style={[
+        styles.aztecCode,
+        {padding: aztec_code_padding, maxHeight: aztec_code_max_height},
+        styles.staticQrCode,
+        styles.staticQrCodeSmall,
+      ]}
     >
       <PressableOpacity
         onPress={onOpenBarcodePress}
@@ -250,38 +266,33 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
   );
 };
 
-const useStyles = () => {
-  // Some code readers are sensitive to size and padding. Configurable parameters allow quick response to reading issues.
-  const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
-  return StyleSheet.createThemeHook(() => ({
-    aztecCode: {
-      width: '100%',
-      aspectRatio: 1,
-      padding: aztec_code_padding,
-      backgroundColor: '#FFFFFF',
-      maxHeight: aztec_code_max_height,
-    },
-    staticBottomContainer: {
-      flex: 1,
-      backgroundColor: '#ffffff',
-    },
-    staticQrCode: {
-      padding: 0,
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      maxWidth: 250,
-    },
-    staticQrCodeSmall: {
-      maxWidth: 125,
-    },
-  }))();
-};
+const useStyles = StyleSheet.createThemeHook(() => ({
+  aztecCode: {
+    width: '100%',
+    aspectRatio: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  staticBottomContainer: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  staticQrCode: {
+    padding: 0,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    maxWidth: 250,
+  },
+  staticQrCodeSmall: {
+    maxWidth: 125,
+  },
+}));
 
 function useStaticBarcodeBottomSheet(
   qrCodeSvg: string | undefined,
   onCloseFocusRef: RefObject<any>,
 ) {
   const styles = useStyles();
+  const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
   const {t} = useTranslation();
 
   const {
@@ -299,7 +310,13 @@ function useStaticBarcodeBottomSheet(
           fullHeight
         >
           <View style={styles.staticBottomContainer}>
-            <View style={[styles.aztecCode, styles.staticQrCode]}>
+            <View
+              style={[
+                styles.aztecCode,
+                {padding: aztec_code_padding, maxHeight: aztec_code_max_height},
+                styles.staticQrCode,
+              ]}
+            >
               <PressableOpacity
                 ref={onOpenFocusRef}
                 onPress={closeBottomSheet}

--- a/src/modules/fare-contracts/details/Barcode.tsx
+++ b/src/modules/fare-contracts/details/Barcode.tsx
@@ -19,6 +19,7 @@ import {PressableOpacity} from '@atb/components/pressable-opacity';
 import {SvgXml} from 'react-native-svg';
 import {GenericSectionItem} from '@atb/components/sections';
 import {useGetSignedTokenQuery} from '@atb/modules/mobile-token';
+import {useRemoteConfigContext} from '@atb/modules/remote-config';
 
 type Props = {
   validityStatus: ValidityStatus;
@@ -249,28 +250,34 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  aztecCode: {
-    width: '100%',
-    aspectRatio: 1,
-    padding: theme.spacing.large,
-    backgroundColor: '#FFFFFF',
-    maxHeight: 275,
-  },
-  staticBottomContainer: {
-    flex: 1,
-    backgroundColor: '#ffffff',
-  },
-  staticQrCode: {
-    padding: 0,
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    maxWidth: 250,
-  },
-  staticQrCodeSmall: {
-    maxWidth: 125,
-  },
-}));
+const useStyles = () => {
+  const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
+  return StyleSheet.createThemeHook((theme) => ({
+    aztecCode: {
+      width: '100%',
+      aspectRatio: 1,
+      padding:
+        aztec_code_padding == Number.MIN_SAFE_INTEGER
+          ? theme.spacing.large
+          : aztec_code_padding,
+      backgroundColor: '#FFFFFF',
+      maxHeight: aztec_code_max_height,
+    },
+    staticBottomContainer: {
+      flex: 1,
+      backgroundColor: '#ffffff',
+    },
+    staticQrCode: {
+      padding: 0,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      maxWidth: 250,
+    },
+    staticQrCodeSmall: {
+      maxWidth: 125,
+    },
+  }))();
+};
 
 function useStaticBarcodeBottomSheet(
   qrCodeSvg: string | undefined,

--- a/src/modules/fare-contracts/details/Barcode.tsx
+++ b/src/modules/fare-contracts/details/Barcode.tsx
@@ -251,6 +251,7 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
 };
 
 const useStyles = () => {
+  // Some code readers are sensitive to size and padding. Configurable parameters allow quick response to reading issues.
   const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
   return StyleSheet.createThemeHook(() => ({
     aztecCode: {

--- a/src/modules/fare-contracts/details/Barcode.tsx
+++ b/src/modules/fare-contracts/details/Barcode.tsx
@@ -252,14 +252,11 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
 
 const useStyles = () => {
   const {aztec_code_max_height, aztec_code_padding} = useRemoteConfigContext();
-  return StyleSheet.createThemeHook((theme) => ({
+  return StyleSheet.createThemeHook(() => ({
     aztecCode: {
       width: '100%',
       aspectRatio: 1,
-      padding:
-        aztec_code_padding == Number.MIN_SAFE_INTEGER
-          ? theme.spacing.large
-          : aztec_code_padding,
+      padding: aztec_code_padding,
       backgroundColor: '#FFFFFF',
       maxHeight: aztec_code_max_height,
     },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -2,7 +2,15 @@ import remoteConfig from '@react-native-firebase/remote-config';
 import {ENABLE_TICKETING, PRIVACY_POLICY_URL, CUSTOMER_SERVICE_URL} from '@env';
 
 export type RemoteConfig = {
+  /**
+   * Some code readers are sensitive to code size.
+   * Configurable parameter allows quick response to reading issues.
+   */
   aztec_code_padding: number;
+  /**
+   * Some code readers are sensitive to padding around code.
+   * Configurable parameter allows quick response to reading issues.
+   */
   aztec_code_max_height: number;
   customer_feedback_url: string;
   customer_service_url: string;

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -1,5 +1,6 @@
 import remoteConfig from '@react-native-firebase/remote-config';
 import {ENABLE_TICKETING, PRIVACY_POLICY_URL, CUSTOMER_SERVICE_URL} from '@env';
+import {themes} from '@atb/theme';
 
 export type RemoteConfig = {
   aztec_code_padding: number;
@@ -85,7 +86,7 @@ export type RemoteConfig = {
 
 export const defaultRemoteConfig: RemoteConfig = {
   aztec_code_max_height: 275,
-  aztec_code_padding: Number.MIN_SAFE_INTEGER, // default will be read from theme
+  aztec_code_padding: themes['light'].spacing.large,
   customer_feedback_url: '',
   customer_service_url: CUSTOMER_SERVICE_URL,
   default_map_filter: JSON.stringify({

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -2,6 +2,8 @@ import remoteConfig from '@react-native-firebase/remote-config';
 import {ENABLE_TICKETING, PRIVACY_POLICY_URL, CUSTOMER_SERVICE_URL} from '@env';
 
 export type RemoteConfig = {
+  aztec_code_padding: number;
+  aztec_code_max_height: number;
   customer_feedback_url: string;
   customer_service_url: string;
   default_map_filter: string;
@@ -82,6 +84,8 @@ export type RemoteConfig = {
 };
 
 export const defaultRemoteConfig: RemoteConfig = {
+  aztec_code_max_height: 275,
+  aztec_code_padding: Number.MIN_SAFE_INTEGER, // default will be read from theme
   customer_feedback_url: '',
   customer_service_url: CUSTOMER_SERVICE_URL,
   default_map_filter: JSON.stringify({
@@ -167,6 +171,12 @@ export type RemoteConfigKeys = keyof RemoteConfig;
 export function getConfig(): RemoteConfig {
   const values = remoteConfig().getAll();
 
+  const aztec_code_max_height =
+    values['aztec_code_max_height']?.asNumber() ??
+    defaultRemoteConfig.aztec_code_max_height;
+  const aztec_code_padding =
+    values['aztec_code_padding']?.asNumber() ??
+    defaultRemoteConfig.aztec_code_padding;
   const customer_feedback_url =
     values['customer_feedback_url']?.asString() ??
     defaultRemoteConfig.customer_feedback_url;
@@ -374,6 +384,8 @@ export function getConfig(): RemoteConfig {
     defaultRemoteConfig.vehicles_poll_interval;
 
   return {
+    aztec_code_max_height,
+    aztec_code_padding,
     customer_feedback_url,
     customer_service_url,
     default_map_filter,

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -1,6 +1,5 @@
 import remoteConfig from '@react-native-firebase/remote-config';
 import {ENABLE_TICKETING, PRIVACY_POLICY_URL, CUSTOMER_SERVICE_URL} from '@env';
-import {themes} from '@atb/theme';
 
 export type RemoteConfig = {
   aztec_code_padding: number;
@@ -86,7 +85,7 @@ export type RemoteConfig = {
 
 export const defaultRemoteConfig: RemoteConfig = {
   aztec_code_max_height: 275,
-  aztec_code_padding: themes['light'].spacing.large,
+  aztec_code_padding: 20,
   customer_feedback_url: '',
   customer_service_url: CUSTOMER_SERVICE_URL,
   default_map_filter: JSON.stringify({


### PR DESCRIPTION
For the FRAM Aztec rollout, we'd like to be able to tweak dimensions via remote config.

Defined `aztec_code_max_height` and `aztec_code_padding` for this. The current values have been preserved as defaults. 

~~The default setup using `themes['light'].spacing.large` doesn't seem ideal, so open to other approaches!~~

Initial proposal (first commit):
> Since the padding default is retrieved from `theme`, we can't give a proper default from the start (`RemoteConfigContextProvider` is not wrapped by `ThemeContextProvider`). Also, remote config only supports `string | number | boolean` defaults. I chose to use `Number.MIN_SAFE_INTEGER` as a `undefined`/`null` alternative. `NaN` would make more sense, but causes errors in React Native. Also, `Number.MIN_SAFE_INTEGER` will have the safe effect as `0`, so it's safe even if you forget to check the value. Open to other solutions 🤗 