### PR TITLE
feat(spar): make onboarding texts configurable 

### DIFF
--- a/src/modules/configuration/FirestoreConfigurationContext.tsx
+++ b/src/modules/configuration/FirestoreConfigurationContext.tsx
@@ -58,7 +58,13 @@ export const defaultVatPercent: number = 12;
 export const defaultStopSignalButtonConfig = StopSignalButtonConfig.parse({});
 
 export type AppTexts = {
-  discountInfo: LanguageAndTextType[];
+  discountInfo: LanguageAndTextType[] | undefined;
+  sparInformationDescription?: LanguageAndTextType[];
+  sparInformationPenaltyNotice?: LanguageAndTextType[];
+  sparAutomaticRegistrationDescription?: LanguageAndTextType[];
+  sparAutomaticRegistrationDescriptionLinkText?: LanguageAndTextType[];
+  sparAutomaticRegistrationDescriptionLinkUrl?: LanguageAndTextType[];
+  sparHowItWorksDescription?: LanguageAndTextType[];
 };
 
 type ConfigurationContextState = {
@@ -575,10 +581,29 @@ function getAppTextsFromSnapshot(
     Bugsnag.notify(
       `App text field "discountInfo" should conform: "LanguageAndTextType"`,
     );
-    return undefined;
   }
 
-  return {discountInfo};
+  return {
+    discountInfo,
+    sparInformationDescription: mapLanguageAndTextType(
+      appTextsRaw.get('sparInformationDescription'),
+    ),
+    sparInformationPenaltyNotice: mapLanguageAndTextType(
+      appTextsRaw.get('sparInformationPenaltyNotice'),
+    ),
+    sparAutomaticRegistrationDescription: mapLanguageAndTextType(
+      appTextsRaw.get('sparAutomaticRegistrationDescription'),
+    ),
+    sparAutomaticRegistrationDescriptionLinkText: mapLanguageAndTextType(
+      appTextsRaw.get('sparAutomaticRegistrationDescriptionLinkText'),
+    ),
+    sparAutomaticRegistrationDescriptionLinkUrl: mapLanguageAndTextType(
+      appTextsRaw.get('sparAutomaticRegistrationDescriptionLinkUrl'),
+    ),
+    sparHowItWorksDescription: mapLanguageAndTextType(
+      appTextsRaw.get('sparHowItWorksDescription'),
+    ),
+  };
 }
 
 function getConfigurableLinksFromSnapshot(

--- a/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
+++ b/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
@@ -1,5 +1,3 @@
-import {useTranslation} from '@atb/translations';
-import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import React from 'react';
 import {OnboardingScreenComponent} from '@atb/modules/onboarding';
 import {ThemedCityBike} from '@atb/theme/ThemedAssets';
@@ -8,9 +6,10 @@ import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 import {Linking} from 'react-native';
 import {sparPilotEnrollmentId} from './config';
 import {useNavigateToNextEnrollmentOnboardingScreen} from '@atb/modules/enrollment-onboarding';
+import {useSmartParkAndRideOnboardingTexts} from './useSmartParkAndRideOnboardingTexts';
 
 export const SmartParkAndRideOnboarding_AutomaticRegistrationScreen = () => {
-  const {t} = useTranslation();
+  const onboardingTexts = useSmartParkAndRideOnboardingTexts();
 
   const navigateToNextScreen = useNavigateToNextEnrollmentOnboardingScreen(
     sparPilotEnrollmentId,
@@ -20,28 +19,20 @@ export const SmartParkAndRideOnboarding_AutomaticRegistrationScreen = () => {
   return (
     <OnboardingScreenComponent
       illustration={<ThemedCityBike height={170} />}
-      title={t(SmartParkAndRideTexts.onboarding.automaticRegistration.title)}
-      description={t(
-        SmartParkAndRideTexts.onboarding.automaticRegistration.description,
-      )}
+      title={onboardingTexts.automaticRegistration.title}
+      description={onboardingTexts.automaticRegistration.description}
       descriptionLink={{
-        text: t(
-          SmartParkAndRideTexts.onboarding.automaticRegistration.descriptionLink
-            .text,
-        ),
-        a11yHint: t(
-          SmartParkAndRideTexts.onboarding.automaticRegistration.descriptionLink
-            .a11yHint,
-        ),
+        text: onboardingTexts.automaticRegistration.descriptionLinkText,
+        a11yHint: onboardingTexts.automaticRegistration.descriptionLinkText,
         onPress: () => {
-          Linking.openURL('https://www.atb.no/RanheimFabrikker'); // TODO: This link should be configurable, and updated.
+          Linking.openURL(
+            onboardingTexts.automaticRegistration.descriptionLinkUrl,
+          );
         },
       }}
       footerButton={{
         onPress: navigateToNextScreen,
-        text: t(
-          SmartParkAndRideTexts.onboarding.automaticRegistration.buttonText,
-        ),
+        text: onboardingTexts.automaticRegistration.buttonText,
         expanded: true,
         rightIcon: {svg: Confirm},
       }}

--- a/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_InformationScreen.tsx
+++ b/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_InformationScreen.tsx
@@ -1,5 +1,3 @@
-import {useTranslation} from '@atb/translations';
-import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import React from 'react';
 import {OnboardingScreenComponent} from '@atb/modules/onboarding';
 import {ThemedParkAndRide} from '@atb/theme/ThemedAssets';
@@ -7,9 +5,10 @@ import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {ThemeText} from '@atb/components/text';
 import {useNavigateToNextEnrollmentOnboardingScreen} from '@atb/modules/enrollment-onboarding';
 import {sparPilotEnrollmentId} from './config';
+import {useSmartParkAndRideOnboardingTexts} from './useSmartParkAndRideOnboardingTexts';
 
 export const SmartParkAndRideOnboarding_InformationScreen = () => {
-  const {t} = useTranslation();
+  const onboardingTexts = useSmartParkAndRideOnboardingTexts();
 
   const navigateToNextScreen = useNavigateToNextEnrollmentOnboardingScreen(
     sparPilotEnrollmentId,
@@ -19,12 +18,14 @@ export const SmartParkAndRideOnboarding_InformationScreen = () => {
   return (
     <OnboardingScreenComponent
       illustration={<ThemedParkAndRide height={170} />}
-      title={t(SmartParkAndRideTexts.onboarding.information.title)}
-      description={t(SmartParkAndRideTexts.onboarding.information.description)}
-      contentNode={<PenaltyNoticeText />}
+      title={onboardingTexts.information.title}
+      description={onboardingTexts.information.description}
+      contentNode={
+        <PenaltyNoticeText text={onboardingTexts.information.penaltyNotice} />
+      }
       footerButton={{
         onPress: navigateToNextScreen,
-        text: t(SmartParkAndRideTexts.onboarding.information.buttonText),
+        text: onboardingTexts.information.buttonText,
         expanded: true,
         rightIcon: {svg: ArrowRight},
       }}
@@ -33,11 +34,10 @@ export const SmartParkAndRideOnboarding_InformationScreen = () => {
   );
 };
 
-const PenaltyNoticeText = () => {
-  const {t} = useTranslation();
+const PenaltyNoticeText = ({text}: {text: string}) => {
   return (
     <ThemeText typography="body__primary--bold" style={{textAlign: 'center'}}>
-      {t(SmartParkAndRideTexts.onboarding.information.penaltyNotice)}
+      {text}
     </ThemeText>
   );
 };

--- a/src/modules/smart-park-and-ride/enrollment/useSmartParkAndRideOnboardingTexts.ts
+++ b/src/modules/smart-park-and-ride/enrollment/useSmartParkAndRideOnboardingTexts.ts
@@ -1,0 +1,54 @@
+import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {useTextForLanguage} from '@atb/translations/utils';
+import {useTranslation} from '@atb/translations';
+import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
+
+export interface SmartParkAndRideOnboardingTexts {
+  information: {
+    title: string;
+    description: string;
+    penaltyNotice: string;
+    buttonText: string;
+  };
+  automaticRegistration: {
+    title: string;
+    description: string;
+    descriptionLinkText: string;
+    descriptionLinkUrl: string;
+    buttonText: string;
+  };
+}
+
+export const useSmartParkAndRideOnboardingTexts =
+  (): SmartParkAndRideOnboardingTexts => {
+    const {t} = useTranslation();
+    const {appTexts} = useFirestoreConfigurationContext();
+
+    return {
+      information: {
+        title: t(SmartParkAndRideTexts.onboarding.information.title),
+        description:
+          useTextForLanguage(appTexts?.sparInformationDescription) || '',
+        penaltyNotice:
+          useTextForLanguage(appTexts?.sparInformationPenaltyNotice) || '',
+        buttonText: t(SmartParkAndRideTexts.onboarding.information.buttonText),
+      },
+      automaticRegistration: {
+        title: t(SmartParkAndRideTexts.onboarding.automaticRegistration.title),
+        description:
+          useTextForLanguage(appTexts?.sparAutomaticRegistrationDescription) ||
+          '',
+        descriptionLinkText:
+          useTextForLanguage(
+            appTexts?.sparAutomaticRegistrationDescriptionLinkText,
+          ) || '',
+        descriptionLinkUrl:
+          useTextForLanguage(
+            appTexts?.sparAutomaticRegistrationDescriptionLinkUrl,
+          ) || '',
+        buttonText: t(
+          SmartParkAndRideTexts.onboarding.automaticRegistration.buttonText,
+        ),
+      },
+    };
+  };

--- a/src/modules/smart-park-and-ride/index.tsx
+++ b/src/modules/smart-park-and-ride/index.tsx
@@ -8,6 +8,7 @@ export {LicensePlateSection} from './components/LicensePlateSection';
 export {useSearchVehicleInformationQuery} from './queries/use-search-vehicle-information-query';
 export {SmartParkAndRideOnboarding_InformationScreen} from './enrollment/SmartParkAndRideOnboarding_InformationScreen';
 export {SmartParkAndRideOnboarding_AutomaticRegistrationScreen} from './enrollment/SmartParkAndRideOnboarding_AutomaticRegistrationScreen';
+export {useSmartParkAndRideTexts} from './useSmartParkAndRideTexts';
 
 export {
   sparEnrollmentConfig,

--- a/src/modules/smart-park-and-ride/useSmartParkAndRideTexts.ts
+++ b/src/modules/smart-park-and-ride/useSmartParkAndRideTexts.ts
@@ -1,0 +1,28 @@
+import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {useTextForLanguage} from '@atb/translations/utils';
+import {useTranslation} from '@atb/translations';
+import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
+
+export interface SmartParkAndRideTexts {
+  howItWorks: {
+    heading: string;
+    title: string;
+    description: string;
+    link: string;
+  };
+}
+
+export const useSmartParkAndRideTexts = (): SmartParkAndRideTexts => {
+  const {t} = useTranslation();
+  const {appTexts} = useFirestoreConfigurationContext();
+
+  return {
+    howItWorks: {
+      heading: t(SmartParkAndRideTexts.howItWorks.heading),
+      title: t(SmartParkAndRideTexts.howItWorks.title),
+      description:
+        useTextForLanguage(appTexts?.sparHowItWorksDescription) || '',
+      link: t(SmartParkAndRideTexts.howItWorks.link),
+    },
+  };
+};

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -19,6 +19,7 @@ import {CarFill} from '@atb/assets/svg/mono-icons/transportation';
 import {
   useVehicleRegistrationsQuery,
   VehicleRegistration,
+  useSmartParkAndRideTexts,
 } from '@atb/modules/smart-park-and-ride';
 import {spellOut} from '@atb/utils/accessibility';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
@@ -123,12 +124,12 @@ type HowItWorksSectionProps = {
 };
 
 const HowItWorksSection = ({onPress}: HowItWorksSectionProps) => {
-  const {t} = useTranslation();
   const styles = useStyles();
+  const {howItWorks} = useSmartParkAndRideTexts();
 
   return (
     <>
-      <ContentHeading text={t(SmartParkAndRideTexts.howItWorks.heading)} />
+      <ContentHeading text={howItWorks.heading} />
       <Section>
         <GenericSectionItem>
           <View style={styles.horizontalContainer}>
@@ -141,18 +142,15 @@ const HowItWorksSection = ({onPress}: HowItWorksSectionProps) => {
             />
             <View style={styles.howItWorks}>
               <ThemeText typography="body__primary--bold">
-                {t(SmartParkAndRideTexts.howItWorks.title)}
+                {howItWorks.title}
               </ThemeText>
               <ThemeText typography="body__secondary" color="secondary">
-                {t(SmartParkAndRideTexts.howItWorks.description)}
+                {howItWorks.description}
               </ThemeText>
             </View>
           </View>
         </GenericSectionItem>
-        <LinkSectionItem
-          text={t(SmartParkAndRideTexts.howItWorks.link)}
-          onPress={onPress}
-        />
+        <LinkSectionItem text={howItWorks.link} onPress={onPress} />
       </Section>
     </>
   );


### PR DESCRIPTION
Moved some of the onboarding texts to Firestore so that we can update the terms in the text on the fly if it suddenly changes.

<details><summary>screenshots</summary>
<p>

<img width="627" height="197" alt="image" src="https://github.com/user-attachments/assets/53013dfa-b309-434c-ad83-cfc7d880a50e" />


</p>
</details> 

fixes https://github.com/AtB-AS/kundevendt/issues/21564