### PR TITLE
feat: update announcements styling

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
@@ -82,7 +82,7 @@ export const AnnouncementSection = ({announcement, style}: Props) => {
                 role="button"
                 hitSlop={insets.all(theme.spacing.medium)}
                 accessibilityHint={t(
-                  DashboardTexts.announcemens.announcement.closeA11yHint,
+                  DashboardTexts.announcements.announcement.closeA11yHint,
                 )}
                 onPress={() => handleDismiss()}
                 testID="closeAnnouncement"
@@ -101,7 +101,7 @@ export const AnnouncementSection = ({announcement, style}: Props) => {
           text={
             getTextForLanguage(announcement.actionButton.label, language) ??
             t(
-              DashboardTexts.announcemens.buttonAction.defaultLabel(
+              DashboardTexts.announcements.buttonAction.defaultLabel(
                 summaryTitle,
               ),
             )
@@ -114,7 +114,7 @@ export const AnnouncementSection = ({announcement, style}: Props) => {
           }
           accessibility={{
             accessibilityHint: t(
-              DashboardTexts.announcemens.buttonAction.a11yHint[
+              DashboardTexts.announcements.buttonAction.a11yHint[
                 announcement.actionButton.actionType
               ],
             ),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
@@ -29,7 +29,7 @@ export const AnnouncementSheet = ({announcement}: Props) => {
 
   return (
     <BottomSheetContainer
-      title={t(DashboardTexts.announcemens.header)}
+      title={t(DashboardTexts.announcements.header)}
       onClose={() => {
         requestReview(InAppReviewContext.Announcement);
       }}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
@@ -3,7 +3,11 @@ import {Announcement} from '@atb/modules/announcements';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
-import {getTextForLanguage, useTranslation} from '@atb/translations';
+import {
+  DashboardTexts,
+  getTextForLanguage,
+  useTranslation,
+} from '@atb/translations';
 import {Image, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -21,15 +25,16 @@ export const AnnouncementSheet = ({announcement}: Props) => {
   const {language} = useTranslation();
   const style = useStyle();
   const {requestReview} = useInAppReviewFlow();
+  const {t} = useTranslation();
 
   return (
     <BottomSheetContainer
-      title={getTextForLanguage(announcement.fullTitle, language)}
+      title={t(DashboardTexts.announcemens.header)}
       onClose={() => {
         requestReview(InAppReviewContext.Announcement);
       }}
     >
-      <ScrollView style={style.container}>
+      <ScrollView contentContainerStyle={style.container}>
         {announcement.mainImage && (
           <View style={style.imageContainer}>
             <Image
@@ -39,7 +44,10 @@ export const AnnouncementSheet = ({announcement}: Props) => {
           </View>
         )}
         <Section>
-          <GenericSectionItem>
+          <GenericSectionItem type="spacious" style={style.articleContainer}>
+            <ThemeText typography="heading--big">
+              {getTextForLanguage(announcement.fullTitle, language)}
+            </ThemeText>
             <ThemeText isMarkdown={true}>
               {getTextForLanguage(announcement.body, language)}
             </ThemeText>
@@ -55,13 +63,16 @@ const useStyle = StyleSheet.createThemeHook((theme) => {
   return {
     container: {
       paddingHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
       minHeight: 350,
+      gap: theme.spacing.medium,
+      paddingBottom: Math.max(bottom, theme.spacing.medium),
+    },
+    articleContainer: {
+      gap: theme.spacing.medium,
     },
     imageContainer: {
       width: '100%',
       maxHeight: 150,
-      marginBottom: theme.spacing.medium,
       borderRadius: theme.border.radius.regular,
       overflow: 'hidden',
     },

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
@@ -11,6 +11,7 @@ import {
   InAppReviewContext,
   useInAppReviewFlow,
 } from '@atb/utils/use-in-app-review';
+import {GenericSectionItem, Section} from '@atb/components/sections';
 
 type Props = {
   announcement: Announcement;
@@ -37,9 +38,13 @@ export const AnnouncementSheet = ({announcement}: Props) => {
             />
           </View>
         )}
-        <ThemeText isMarkdown={true}>
-          {getTextForLanguage(announcement.body, language)}
-        </ThemeText>
+        <Section>
+          <GenericSectionItem>
+            <ThemeText isMarkdown={true}>
+              {getTextForLanguage(announcement.body, language)}
+            </ThemeText>
+          </GenericSectionItem>
+        </Section>
       </ScrollView>
     </BottomSheetContainer>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -60,7 +60,7 @@ export const Announcements = ({style}: Props) => {
       <View style={styles.headerWrapper}>
         <ContentHeading
           color={theme.color.background.accent[0]}
-          text={t(DashboardTexts.announcemens.header)}
+          text={t(DashboardTexts.announcements.header)}
         />
       </View>
       <ScrollView

--- a/src/translations/screens/Dashboard.ts
+++ b/src/translations/screens/Dashboard.ts
@@ -8,7 +8,7 @@ const DashboardTexts = {
     },
   },
   buyButton: _('Kjøp billetter', 'Buy tickets', 'Kjøp billettar'),
-  announcemens: {
+  announcements: {
     header: _('Aktuelt', 'Latest', 'Aktuelt'),
     button: {
       accessibility: _(

--- a/src/translations/screens/Dashboard.ts
+++ b/src/translations/screens/Dashboard.ts
@@ -9,7 +9,7 @@ const DashboardTexts = {
   },
   buyButton: _('Kjøp billetter', 'Buy tickets', 'Kjøp billettar'),
   announcemens: {
-    header: _('Aktuelt', 'Announcements', 'Aktuelt'),
+    header: _('Aktuelt', 'Latest', 'Aktuelt'),
     button: {
       accessibility: _(
         'Aktiver for å lese mer',


### PR DESCRIPTION
<img width="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-08 at 10 51 35" src="https://github.com/user-attachments/assets/f904c980-50da-447a-a6ed-38683c54d5b4" />


### Acceptance critera

- [ ] New name for announcements in english: "Latest"
- [ ] New design for announcements in bottom sheet, title is now part of the article body, and not in the bottom sheet header