### PR TITLE
fix(spar): add missing case for error message

### DIFF
--- a/src/screen-components/smart-park-and-ride/Root_SmartParkAndRideAddScreenComponent.tsx
+++ b/src/screen-components/smart-park-and-ride/Root_SmartParkAndRideAddScreenComponent.tsx
@@ -192,6 +192,8 @@ function getErrorMessageTranslation(
       return t(SmartParkAndRideTexts.errors.invalidLicensePlate);
     case 'VEHICLE_REGISTRATION_ALREADY_EXISTS':
       return t(SmartParkAndRideTexts.errors.vehicleAlreadyAdded);
+    case 'MAXIMUM_NUMBER_OF_VEHICLE_REGISTRATIONS_REACHED':
+      return t(SmartParkAndRideTexts.errors.maximumNumberOfVehiclesReached);
     default:
       return t(SmartParkAndRideTexts.errors.unknown);
   }

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -132,6 +132,11 @@ const SmartParkAndRideTexts = {
       'This vehicle has already been added.',
       'Dette køyretøyet er allereie lagt til.',
     ),
+    maximumNumberOfVehiclesReached: _(
+      'Du kan ikke legge til flere kjøretøy. Du kan legge til maks to kjøretøy.',
+      'You cannot add more vehicles. You can add a maximum of two vehicles.',
+      'Du kan ikkje leggje til fleire køyretøy. Du kan leggje til maks to køyretøy.',
+    ),
     unknown: _(
       'Noe gikk galt. Prøv igjen.',
       'Something went wrong. Please try again.',


### PR DESCRIPTION
Add missing case to show the error message for when the maximum number of vehicle registrations is reached.

https://github.com/AtB-AS/kundevendt/issues/21089