### PR TITLE
feat(spar): add new illustrations for Smart Park and Ride 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^7.2.0",
-    "@atb-as/generate-assets": "^18.3.1",
+    "@atb-as/generate-assets": "^18.4.0",
     "@atb-as/theme": "^14.1.0",
     "@atb-as/utils": "^4.3.0",
     "@bugsnag/react-native": "^7.25.0",

--- a/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
+++ b/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
@@ -2,7 +2,7 @@ import {useTranslation} from '@atb/translations';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import React from 'react';
 import {OnboardingScreenComponent} from '@atb/modules/onboarding';
-import {ThemedCityBike} from '@atb/theme/ThemedAssets';
+import {ThemedCarRegister} from '@atb/theme/ThemedAssets';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 
 import {Linking} from 'react-native';
@@ -19,7 +19,7 @@ export const SmartParkAndRideOnboarding_AutomaticRegistrationScreen = () => {
 
   return (
     <OnboardingScreenComponent
-      illustration={<ThemedCityBike height={170} />}
+      illustration={<ThemedCarRegister height={170} />}
       title={t(SmartParkAndRideTexts.onboarding.automaticRegistration.title)}
       description={t(
         SmartParkAndRideTexts.onboarding.automaticRegistration.description,

--- a/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_InformationScreen.tsx
+++ b/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_InformationScreen.tsx
@@ -2,7 +2,7 @@ import {useTranslation} from '@atb/translations';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import React from 'react';
 import {OnboardingScreenComponent} from '@atb/modules/onboarding';
-import {ThemedCarValidTicket, ThemedParkAndRide} from '@atb/theme/ThemedAssets';
+import {ThemedCarValidTicket} from '@atb/theme/ThemedAssets';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {ThemeText} from '@atb/components/text';
 import {useNavigateToNextEnrollmentOnboardingScreen} from '@atb/modules/enrollment-onboarding';

--- a/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_InformationScreen.tsx
+++ b/src/modules/smart-park-and-ride/enrollment/SmartParkAndRideOnboarding_InformationScreen.tsx
@@ -2,7 +2,7 @@ import {useTranslation} from '@atb/translations';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import React from 'react';
 import {OnboardingScreenComponent} from '@atb/modules/onboarding';
-import {ThemedParkAndRide} from '@atb/theme/ThemedAssets';
+import {ThemedCarValidTicket, ThemedParkAndRide} from '@atb/theme/ThemedAssets';
 import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
 import {ThemeText} from '@atb/components/text';
 import {useNavigateToNextEnrollmentOnboardingScreen} from '@atb/modules/enrollment-onboarding';
@@ -18,7 +18,7 @@ export const SmartParkAndRideOnboarding_InformationScreen = () => {
 
   return (
     <OnboardingScreenComponent
-      illustration={<ThemedParkAndRide height={170} />}
+      illustration={<ThemedCarValidTicket height={170} />}
       title={t(SmartParkAndRideTexts.onboarding.information.title)}
       description={t(SmartParkAndRideTexts.onboarding.information.description)}
       contentNode={<PenaltyNoticeText />}

--- a/src/screen-components/smart-park-and-ride/Root_SmartParkAndRideAddScreenComponent.tsx
+++ b/src/screen-components/smart-park-and-ride/Root_SmartParkAndRideAddScreenComponent.tsx
@@ -6,7 +6,7 @@ import {ThemeText} from '@atb/components/text';
 import {useAddVehicleRegistrationMutation} from '@atb/modules/smart-park-and-ride';
 import {LicensePlateSection} from '@atb/modules/smart-park-and-ride';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {ThemedBundlingCarSharing} from '@atb/theme/ThemedAssets';
+import {ThemedCarFront, ThemedCarValidTicket} from '@atb/theme/ThemedAssets';
 import {TranslateFunction, useTranslation} from '@atb/translations';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import {useState} from 'react';
@@ -47,7 +47,7 @@ export const Root_SmartParkAndRideAddScreenComponent = ({
   const contentNode = (
     <View style={styles.container}>
       <View style={styles.content}>
-        <ThemedBundlingCarSharing style={styles.illustration} width={150} />
+        <ThemedCarFront style={styles.illustration} width={170} />
         <View ref={focusRef} accessible={true} accessibilityRole="header">
           <ThemeText typography="body__primary--big--bold">
             {t(SmartParkAndRideTexts.add.content.title)}

--- a/src/screen-components/smart-park-and-ride/Root_SmartParkAndRideAddScreenComponent.tsx
+++ b/src/screen-components/smart-park-and-ride/Root_SmartParkAndRideAddScreenComponent.tsx
@@ -6,7 +6,7 @@ import {ThemeText} from '@atb/components/text';
 import {useAddVehicleRegistrationMutation} from '@atb/modules/smart-park-and-ride';
 import {LicensePlateSection} from '@atb/modules/smart-park-and-ride';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {ThemedCarFront, ThemedCarValidTicket} from '@atb/theme/ThemedAssets';
+import {ThemedCarFront} from '@atb/theme/ThemedAssets';
 import {TranslateFunction, useTranslation} from '@atb/translations';
 import SmartParkAndRideTexts from '@atb/translations/screens/subscreens/SmartParkAndRide';
 import {useState} from 'react';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -22,7 +22,7 @@ import {
 } from '@atb/modules/smart-park-and-ride';
 import {spellOut} from '@atb/utils/accessibility';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
-import {ThemedBundlingCarSharing} from '@atb/theme/ThemedAssets';
+import {ThemedCarRegister} from '@atb/theme/ThemedAssets';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useAuthContext} from '@atb/modules/auth';
 
@@ -142,9 +142,9 @@ const HowItWorksSection = ({onPress}: HowItWorksSectionProps) => {
       <Section>
         <GenericSectionItem>
           <View style={styles.horizontalContainer}>
-            <ThemedBundlingCarSharing
-              height={61}
-              width={61}
+            <ThemedCarRegister
+              height={63}
+              width={63}
               style={{
                 alignSelf: 'flex-start',
               }}

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -71,6 +71,16 @@ import {
   BonusTransaction as BonusTransactionDark,
   BonusTrashCan as BonusTrashCanDark,
 } from '@atb/assets/svg/color/images/bonus/dark';
+import {
+  CarFront as CarFrontLight,
+  CarRegister as CarRegisterLight,
+  CarValidTicket as CarValidTicketLight,
+} from '@atb/assets/svg/color/images/smart-park-and-ride/light';
+import {
+  CarFront as CarFrontDark,
+  CarRegister as CarRegisterDark,
+  CarValidTicket as CarValidTicketDark,
+} from '@atb/assets/svg/color/images/smart-park-and-ride/dark';
 import {useThemeContext} from '@atb/theme/ThemeContext';
 import {SvgProps} from 'react-native-svg';
 
@@ -171,4 +181,13 @@ export const ThemedProfileCardLoggedIn = getThemedAsset(
 export const ThemedProfileCardLoggedOut = getThemedAsset(
   ProfileCardLoggedOutLight,
   ProfileCardLoggedOutDark,
+);
+export const ThemedCarFront = getThemedAsset(CarFrontLight, CarFrontDark);
+export const ThemedCarRegister = getThemedAsset(
+  CarRegisterLight,
+  CarRegisterDark,
+);
+export const ThemedCarValidTicket = getThemedAsset(
+  CarValidTicketLight,
+  CarValidTicketDark,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     zod "^3.24.4"
     zod-to-json-schema "^3.24.5"
 
-"@atb-as/generate-assets@^18.3.1":
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-18.3.1.tgz#b962faa62493937889b2a822d9d1bddd9911f80c"
-  integrity sha512-Rmp7wJVk0H10hSIZysrfReRbV1GSjve8rWJr2CZQ+k/haLrXbgiIBm3V3aLJNlVBqRpspGrh87YwXH8F0l+Mvw==
+"@atb-as/generate-assets@^18.4.0":
+  version "18.4.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/generate-assets/-/generate-assets-18.4.0.tgz#d1a5870bc897e45e9895dd6e6d3079ec9dd179fe"
+  integrity sha512-YDzpPC4Ack7joyPNBzpR6eye2PuyCfwazTt5ptGO9NS/mp0lgSW52Yf2FLa4aDVMYcC6N8iHj/ymQfKXIWPjcQ==
   dependencies:
     "@atb-as/theme" "14.0.1"
     commander "^9.4.0"


### PR DESCRIPTION
Introduce new themed car illustrations for the Smart Park and Ride onboarding screens and update the dependency for asset generation.


<details><summary>Screenshots</summary>
<p>

|Before|After|
|---|---|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/1eb24ead-23ea-4714-a112-97c537858448" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/643b45fd-6ace-48b9-a2d4-93143cd2c2a2" />|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/cf5df15f-3598-4722-9091-0a7b3319b5e6" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/86aa2a15-a934-43ac-b614-ddad71ee991a" />|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/01704ebd-1234-429d-9255-4e3909d8c713" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fee0a798-af11-4348-911f-6a2861fea853" />|
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/2e6315a8-da24-432b-a64f-b332ac99ad12" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c7a28272-3d54-4ce9-b005-07e6d25bebc1" />|


</p>
</details> 


closes https://github.com/AtB-AS/kundevendt/issues/21455