### PR TITLE
fix: Harbors overrides not working

### DIFF
--- a/src/modules/harbors/use-harbors.tsx
+++ b/src/modules/harbors/use-harbors.tsx
@@ -10,9 +10,9 @@ import _ from 'lodash';
 import {StopPlaceFragmentWithIsFree} from './types';
 
 export const useHarbors = ({
-                             fromHarborId,
-                             transportModes,
-                           }: {
+  fromHarborId,
+  transportModes,
+}: {
   fromHarborId?: string;
   transportModes?: ProductTypeTransportModes[];
 } = {}) => {
@@ -27,6 +27,20 @@ export const useHarbors = ({
   const isSuccess = fromHarborId
     ? connectionsQuery.isSuccess
     : harborsQuery.isSuccess;
+  const refetch = fromHarborId
+    ? () =>
+        Promise.all([
+          connectionsQuery.refetch(),
+          allHarborsQuery.refetch(),
+          harborsQuery.refetch(),
+        ]).then(([connectionsQuery, allHarborsQuery]) =>
+          applyOverrides(
+            allHarborsQuery.data,
+            connectionsQuery.data,
+            overrides,
+          ),
+        )
+    : harborsQuery.refetch;
 
   const data: StopPlaceFragmentWithIsFree[] = fromHarborId
     ? applyOverrides(allHarborsQuery.data, connectionsQuery.data, overrides)
@@ -38,6 +52,7 @@ export const useHarbors = ({
     isError,
     error,
     data,
+    refetch,
   };
 };
 

--- a/src/modules/harbors/use-harbors.tsx
+++ b/src/modules/harbors/use-harbors.tsx
@@ -10,12 +10,13 @@ import _ from 'lodash';
 import {StopPlaceFragmentWithIsFree} from './types';
 
 export const useHarbors = ({
-  fromHarborId,
-  transportModes,
-}: {
+                             fromHarborId,
+                             transportModes,
+                           }: {
   fromHarborId?: string;
   transportModes?: ProductTypeTransportModes[];
 } = {}) => {
+  const allHarborsQuery = useHarborsQuery({transportModes});
   const harborsQuery = useHarborsQuery({fromHarborId, transportModes});
   const connectionsQuery = useHarborsQuery({fromHarborId, transportModes});
   const overrides = useHarborConnectionOverrides(fromHarborId);
@@ -26,16 +27,9 @@ export const useHarbors = ({
   const isSuccess = fromHarborId
     ? connectionsQuery.isSuccess
     : harborsQuery.isSuccess;
-  const refetch = fromHarborId
-    ? () =>
-        Promise.all([connectionsQuery.refetch(), harborsQuery.refetch()]).then(
-          ([connectionsQuery, harborsQuery]) =>
-            applyOverrides(harborsQuery.data, connectionsQuery.data, overrides),
-        )
-    : harborsQuery.refetch;
 
   const data: StopPlaceFragmentWithIsFree[] = fromHarborId
-    ? applyOverrides(harborsQuery.data, connectionsQuery.data, overrides)
+    ? applyOverrides(allHarborsQuery.data, connectionsQuery.data, overrides)
     : harborsQuery.data ?? [];
 
   return {
@@ -44,7 +38,6 @@ export const useHarbors = ({
     isError,
     error,
     data,
-    refetch,
   };
 };
 


### PR DESCRIPTION
This one took some time to figure out, but I will try to explain clearly here. 

@HanneLH added some harborConnection overrides in [this commit](https://github.com/AtB-AS/firestore-configuration/commit/2d0441a82072653c62ef36753254d7100fd026f3). I.e. Sula _(NSR:StopPlace:42924)_ --> Gjæsingen _(NSR:StopPlace:44074)_ was added there. But when we went to buy an express boat ticket in the app it still looked like this:

<details>
<summary>Screenshots before</summary>

| PurchaseSummaryScreen | PurchaseHarborSearchScreen |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/222f05bd-cba9-4733-a618-718908543eb3" /> | <img width="200" src="https://github.com/user-attachments/assets/92c03117-10b4-4d32-b094-5196864850b2" /> |
</details>

The reason that they did not appear is that the `overrides` from `harborConnectionOverrides` in `firestore-configuration` were just IDs, and these IDs were then used to look up the actual harbor in the [applyOverrides](https://github.com/AtB-AS/mittatb-app/blob/e421a9a69cdd5c83b162c3c3302b79cbe4c2adb1/src/modules/harbors/use-harbors.tsx#L51) function. But when you have selected a `fromHarborId` the `{ data } = useHarborsQuery({fromHarborId})` gets refetched with only the harbors that are reachable from `fromHarborId`, and then the `applyOverrides` have no overlap between the overrides and the reachable harbors from `fromHarborId` which means that the [union](https://github.com/AtB-AS/mittatb-app/blob/e421a9a69cdd5c83b162c3c3302b79cbe4c2adb1/src/modules/harbors/use-harbors.tsx#L63) is empty. 

Long story short: we need to use `allHarbors` when we are mapping overrides, and not just the reachable harbors. Its not perfect using the `useHarborsQuery` twice, but React Query will cache the result so it will actually only be one result. 


<details>
<summary>Screenshots after</summary>

| PurchaseSummaryScreen | PurchaseHarborSearchScreen |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/a8965242-ba46-4c79-b16d-1727bfbfb238" /> | <img width="200" src="https://github.com/user-attachments/assets/103d9c03-a18d-45d5-9708-b8da10dc00df" /> |
</details>

