### PR TITLE
feat: add cancel button to consume and activate fc bottom sheet

### DIFF
--- a/src/modules/fare-contracts/FareContractView.tsx
+++ b/src/modules/fare-contracts/FareContractView.tsx
@@ -124,7 +124,17 @@ export const FareContractView: React.FC<Props> = ({
           <LegsSummary legs={legs} compact={true} />
         </GenericSectionItem>
       )}
-
+      {!isStatic && (
+        <LinkSectionItem
+          text={t(
+            validityStatus === 'valid' && isInspectable
+              ? FareContractTexts.detailsLink.valid
+              : FareContractTexts.detailsLink.notValid,
+          )}
+          onPress={onPressDetails}
+          testID={testID + 'Details'}
+        />
+      )}
       {isActivateTicketNowEnabled &&
         isCanBeActivatedNowFareContract(
           fareContract,
@@ -137,17 +147,6 @@ export const FareContractView: React.FC<Props> = ({
             fareProductType={preassignedFareProduct?.type}
           />
         )}
-      {!isStatic && (
-        <LinkSectionItem
-          text={t(
-            validityStatus === 'valid' && isInspectable
-              ? FareContractTexts.detailsLink.valid
-              : FareContractTexts.detailsLink.notValid,
-          )}
-          onPress={onPressDetails}
-          testID={testID + 'Details'}
-        />
-      )}
       {isCanBeConsumedNowFareContract(fareContract, now, currentUserId) && (
         <ConsumeCarnetSectionItem
           fareContractId={fareContract.id}

--- a/src/modules/fare-contracts/components/ActivateNowBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowBottomSheet.tsx
@@ -8,9 +8,9 @@ import {Button} from '@atb/components/button';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {activateFareContractNow} from '@atb/modules/ticketing';
-import {FareContractTexts, useTranslation} from '@atb/translations';
+import {dictionary, FareContractTexts, useTranslation} from '@atb/translations';
 import Bugsnag from '@bugsnag/react-native';
 import React, {useState} from 'react';
 import {ScrollView} from 'react-native-gesture-handler';
@@ -30,6 +30,7 @@ export const ActivateNowBottomSheet = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<boolean>(false);
   const {close} = useBottomSheetContext();
+  const {theme} = useThemeContext();
 
   const {logEvent} = useBottomSheetContext();
 
@@ -80,6 +81,13 @@ export const ActivateNowBottomSheet = ({
           text={t(FareContractTexts.activateNow.confirm)}
           rightIcon={{svg: Confirm}}
           loading={isLoading}
+        />
+        <Button
+          expanded={true}
+          mode="secondary"
+          onPress={close}
+          text={t(dictionary.cancel)}
+          backgroundColor={theme.color.background.neutral[1]}
         />
       </ScrollView>
     </BottomSheetContainer>

--- a/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -4,6 +4,7 @@ import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {RefObject, useRef} from 'react';
 import {ActivateNowBottomSheet} from './ActivateNowBottomSheet';
+import {useThemeContext} from '@atb/theme';
 
 type ActivateNowSectionItemProps = SectionItemProps<{
   fareContractId: string;
@@ -16,6 +17,7 @@ export function ActivateNowSectionItem({
   ...sectionProps
 }: ActivateNowSectionItemProps): JSX.Element {
   const {t} = useTranslation();
+  const {theme} = useThemeContext();
   const {open} = useBottomSheetContext();
   const onCloseFocusRef = useRef<RefObject<any>>(null);
 
@@ -35,7 +37,8 @@ export function ActivateNowSectionItem({
     <LinkSectionItem
       text={t(FareContractTexts.activateNow.startNow)}
       onPress={onPress}
-      rightIcon={{svg: TicketValid}}
+      interactiveColor={theme.color.interactive[0]}
+      rightIcon={{svg: TicketValid, color: theme.color.interactive[0].default}}
       ref={onCloseFocusRef}
       {...sectionProps}
     />

--- a/src/modules/fare-contracts/components/ConsumeCarnetBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetBottomSheet.tsx
@@ -8,9 +8,9 @@ import {Button} from '@atb/components/button';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {consumeCarnet} from '@atb/modules/ticketing';
-import {FareContractTexts, useTranslation} from '@atb/translations';
+import {dictionary, FareContractTexts, useTranslation} from '@atb/translations';
 import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
 import React, {useState} from 'react';
 import {ScrollView} from 'react-native-gesture-handler';
@@ -32,6 +32,7 @@ export const ConsumeCarnetBottomSheet = ({
   const [isSchoolError, setSchoolError] = useState<boolean>(false);
   const {close} = useBottomSheetContext();
   const {logEvent} = useBottomSheetContext();
+  const {theme} = useThemeContext();
 
   const onConsume = async () => {
     setIsLoading(true);
@@ -90,6 +91,13 @@ export const ConsumeCarnetBottomSheet = ({
           text={t(FareContractTexts.carnet.activateCarnet)}
           rightIcon={{svg: Confirm}}
           loading={isLoading}
+        />
+        <Button
+          expanded={true}
+          mode="secondary"
+          onPress={close}
+          text={t(dictionary.cancel)}
+          backgroundColor={theme.color.background.neutral[1]}
         />
       </ScrollView>
     </BottomSheetContainer>

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -198,16 +198,16 @@ const FareContractTexts = {
   activateNow: {
     startNow: _('Start billett nå', 'Start ticket now', 'Start billett no'),
     bottomSheetTitle: _(
-      'Vil du starte billetten?',
-      'Do you want to start the ticket?',
-      'Vil du starte billetten?',
+      'Start billett før planlagt tid?',
+      'Start ticket before scheduled time?',
+      'Start billett før planlagt tid?',
     ),
     bottomSheetDescription: _(
-      'Billetten starter med en gang du bekrefter. Dette valget kan ikke angres.',
-      'The ticket will start as soon as you confirm. This choice cannot be undone.',
-      'Billetten startar med ein gong du bekreftar. Dette valet kan ikkje gjerast om på.',
+      'Dette valget kan ikke angres. Billetten starter med en gang.',
+      'This action cannot be undone. The ticket will start immediately.',
+      'Dette valet kan ikkje angrast. Billetten startar med ein gong.',
     ),
-    confirm: _('Bekreft og start', 'Confirm and start', 'Bekreft og start'),
+    confirm: _('Start billett', 'Start ticket', 'Start billett'),
     genericError: _(
       'En feil har oppstått under aktivering av billetten. Vennligst prøv igjen.',
       'An error occurred while activating the ticket. Please try again.',


### PR DESCRIPTION
Task from markhor shaving hours: Updates design of activate single ticket to try to reduce the amount of tickets activated by mistake.

- Adds interactive color to "Start ticket now" button, and moves it below the details button.
- Adds cancel button to activate and consume bottom sheet.

https://github.com/user-attachments/assets/dfdd65e1-1e98-4187-b3ce-839d86b57633

## Acceptance criteria

- [ ] New cancel button for activating carnet and starting ticket early closes the bottom sheet without completing the activation/consumption.

## Test input

- [ ] Screen reader
- [ ] 200% zoom