### PR TITLE
feat: enable compact travel details map for screen reader users

### DIFF
--- a/src/screen-components/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/screen-components/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -1,8 +1,6 @@
 import {MapCameraConfig, MapLeg, useMapViewConfig} from '@atb/modules/map';
-
 import {StyleSheet} from '@atb/theme';
 import {MapTexts, useTranslation} from '@atb/translations';
-import {useDisableMapCheck} from '@atb/utils/use-disable-map-check';
 import MapboxGL from '@rnmapbox/maps';
 import {Position} from 'geojson';
 import React, {useEffect, useMemo, useRef} from 'react';
@@ -31,7 +29,6 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
   buttonText,
   onExpand,
 }) => {
-  const disableMap = useDisableMapCheck();
   const {t} = useTranslation();
   const cameraRef = useRef<MapboxGL.Camera>(null);
 
@@ -57,10 +54,6 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
   }, [bounds]);
 
   const styles = useStyles();
-
-  if (disableMap) {
-    return null;
-  }
 
   return (
     <View>


### PR DESCRIPTION
Enables the compact travel details map for screen reader users. Already tested in https://github.com/AtB-AS/kundevendt/issues/21489#issuecomment-3269644306

closes https://github.com/AtB-AS/kundevendt/issues/21489