### PR TITLE
feat: update appearance settings page

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -35,7 +35,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   children,
   ...props
 }) => {
-  const {theme, useAndroidSystemFont} = useThemeContext();
+  const {theme, androidSystemFont} = useThemeContext();
   const textColor = useColor(color, type);
 
   const typeStyle = {
@@ -45,7 +45,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
 
   let textStyle: TextStyle = typeStyle;
 
-  if (Platform.OS === 'android' && !useAndroidSystemFont) {
+  if (Platform.OS === 'android' && !androidSystemFont) {
     textStyle = {
       ...typeStyle,
       fontFamily:

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_AppearanceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_AppearanceScreen.tsx
@@ -1,19 +1,22 @@
-import {Section, ToggleSectionItem} from '@atb/components/sections';
+import {
+  RadioGroupSection,
+  Section,
+  ToggleSectionItem,
+} from '@atb/components/sections';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {AppearanceSettingsTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {Platform, View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
-import {ScreenHeading} from '@atb/components/heading';
+import {ContentHeading, ScreenHeading} from '@atb/components/heading';
+import {AppearanceSelection} from '@atb/theme/ThemeContext';
 
 export const Profile_AppearanceScreen = () => {
   const {
-    storedColorScheme,
-    overrideSystemAppearance,
-    updateThemePreference,
-    overrideOSThemePreference,
-    useAndroidSystemFont,
-    updateAndroidFontOverride,
+    appearanceSelection,
+    setAppearanceSelection,
+    androidSystemFont,
+    setAndroidSystemFont,
   } = useThemeContext();
   const {t} = useTranslation();
   const styles = useStyles();
@@ -31,32 +34,41 @@ export const Profile_AppearanceScreen = () => {
         />
       )}
     >
-      <View>
-        <Section style={styles.section}>
-          <ToggleSectionItem
-            text={t(AppearanceSettingsTexts.actions.usePhoneTheme)}
-            value={!overrideSystemAppearance}
-            onValueChange={(checked) => overrideOSThemePreference(!checked)}
-          />
-
-          {overrideSystemAppearance && (
-            <ToggleSectionItem
-              text={t(AppearanceSettingsTexts.actions.darkMode)}
-              value={storedColorScheme === 'dark'}
-              onValueChange={(checked) =>
-                updateThemePreference(checked ? 'dark' : 'light')
+      <View style={styles.container}>
+        <ContentHeading text={t(AppearanceSettingsTexts.theme.heading)} />
+        <Section>
+          <RadioGroupSection<AppearanceSelection>
+            items={[
+              AppearanceSelection.SYSTEM,
+              AppearanceSelection.LIGHT,
+              AppearanceSelection.DARK,
+            ]}
+            itemToText={(item) => {
+              switch (item) {
+                case AppearanceSelection.SYSTEM:
+                  return t(AppearanceSettingsTexts.theme.system);
+                case AppearanceSelection.LIGHT:
+                  return t(AppearanceSettingsTexts.theme.light);
+                case AppearanceSelection.DARK:
+                  return t(AppearanceSettingsTexts.theme.dark);
               }
-            />
-          )}
+            }}
+            selected={appearanceSelection}
+            keyExtractor={(item) => item}
+            onSelect={(selection) => setAppearanceSelection(selection)}
+          />
         </Section>
         {Platform.OS === 'android' && (
-          <Section style={styles.section}>
-            <ToggleSectionItem
-              text={t(AppearanceSettingsTexts.actions.useSystemFont)}
-              value={useAndroidSystemFont}
-              onValueChange={(checked) => updateAndroidFontOverride(checked)}
-            />
-          </Section>
+          <>
+            <ContentHeading text={t(AppearanceSettingsTexts.font.heading)} />
+            <Section>
+              <ToggleSectionItem
+                text={t(AppearanceSettingsTexts.font.toggle)}
+                value={androidSystemFont}
+                onValueChange={(checked) => setAndroidSystemFont(checked)}
+              />
+            </Section>
+          </>
         )}
       </View>
     </FullScreenView>
@@ -64,9 +76,8 @@ export const Profile_AppearanceScreen = () => {
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  section: {
-    marginHorizontal: theme.spacing.medium,
-    marginBottom: theme.spacing.small,
-    marginTop: theme.spacing.large,
+  container: {
+    gap: theme.spacing.small,
+    margin: theme.spacing.medium,
   },
 }));

--- a/src/translations/screens/subscreens/AppearanceSettings.ts
+++ b/src/translations/screens/subscreens/AppearanceSettings.ts
@@ -4,7 +4,7 @@ const AppearanceSettingsTexts = {
     title: _('Utseende', 'Appearance', 'Utsjånad'),
   },
   theme: {
-    heading: _('Fargetema', 'Color scheme', 'Fargetema'),
+    heading: _('Fargetema', 'Theme', 'Fargetema'),
     system: _('Automatisk', 'Automatic', 'Automatisk'),
     light: _('Lyst', 'Light', 'Lyst'),
     dark: _('Mørkt', 'Dark', 'Mørkt'),

--- a/src/translations/screens/subscreens/AppearanceSettings.ts
+++ b/src/translations/screens/subscreens/AppearanceSettings.ts
@@ -3,14 +3,15 @@ const AppearanceSettingsTexts = {
   header: {
     title: _('Utseende', 'Appearance', 'Utsjånad'),
   },
-  actions: {
-    usePhoneTheme: _(
-      'Bruk fargetema fra telefonen',
-      "Use my phone's colour theme",
-      'Nytt fargetema frå mobilen min',
-    ),
-    darkMode: _('Mørk modus', 'Dark mode', 'Mørk modus'),
-    useSystemFont: _(
+  theme: {
+    heading: _('Fargetema', 'Color scheme', 'Fargetema'),
+    system: _('Automatisk', 'Automatic', 'Automatisk'),
+    light: _('Lyst', 'Light', 'Lyst'),
+    dark: _('Mørkt', 'Dark', 'Mørkt'),
+  },
+  font: {
+    heading: _('Skrifttype', 'Font', 'Skrifttype'),
+    toggle: _(
       'Bruk telefonens skrifttype',
       "Use my phone's font",
       'Nytt telefonens skrifttype',


### PR DESCRIPTION
As a suggestion from _markhor shaving hours_, it was proposed to change the two toggles on the appearance settings screen to three radio buttons instead. While working on this, I found the ThemeContext quite hard to understand, so I renamed some fields, and refactored it quite a bit to fit the new kind of selection 🤓

## Before / after 

<div>
<img width="300" alt="Screenshot_1757418366" src="https://github.com/user-attachments/assets/85d05b2d-bd6e-418a-9e60-b0e8f00a99b1" />
<img width="300" alt="Screenshot_1757417856" src="https://github.com/user-attachments/assets/7f312092-cfd2-469c-92bf-064913cf2138" />
</div>

## Acceptance criteria

- [ ] Color scheme selection works as you'd expect
- [ ] Android system font selection works like before
- [ ] Screen reader
