### PR TITLE
fix: Fixed bottom navbar hiding some UI elements 

### DIFF
--- a/src/components/screen-footer/FullScreenFooter.tsx
+++ b/src/components/screen-footer/FullScreenFooter.tsx
@@ -27,10 +27,10 @@ export function FullScreenFooter({
 }
 
 const useStyles = StyleSheet.createThemeHook((theme: Theme) => {
-  const {bottom} = useSafeAreaInsets();
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
   return {
     container: {
-      paddingBottom: Math.max(bottom, theme.spacing.medium),
+      paddingBottom: bottomSafeAreaInset + theme.spacing.medium,
       paddingHorizontal: theme.spacing.medium,
     },
   };

--- a/src/modules/fare-contracts/components/ActivateNowBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowBottomSheet.tsx
@@ -100,7 +100,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     container: {
       backgroundColor: theme.color.background.neutral[1].background,
       marginHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: bottom + theme.spacing.medium,
     },
     contentContainer: {
       rowGap: theme.spacing.medium,

--- a/src/modules/fare-contracts/components/ConsumeCarnetBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetBottomSheet.tsx
@@ -105,12 +105,12 @@ export const ConsumeCarnetBottomSheet = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
   return {
     container: {
       backgroundColor: theme.color.background.neutral[1].background,
       marginHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: bottomSafeAreaInset + theme.spacing.medium,
     },
     contentContainer: {
       rowGap: theme.spacing.medium,

--- a/src/modules/fare-contracts/components/RefundBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/RefundBottomSheet.tsx
@@ -103,12 +103,12 @@ export const RefundBottomSheet = ({orderId, fareProductType, state}: Props) => {
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
   return {
     container: {
       backgroundColor: theme.color.background.neutral[1].background,
       marginHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: bottomSafeAreaInset + theme.spacing.medium,
     },
     contentContainer: {
       rowGap: theme.spacing.medium,

--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -56,6 +56,7 @@ import {
 } from '@atb/modules/bonus';
 import {useFareContractLegs} from '@atb/modules/fare-contracts';
 import {LegsSummary} from '@atb/components/journey-legs-summary';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 type Props = {
   fareContract: FareContractType;
@@ -265,21 +266,24 @@ export const DetailsContent: React.FC<Props> = ({
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  globalMessages: {
-    flex: 1,
-    rowGap: theme.spacing.medium,
-  },
-  section: {
-    marginBottom: theme.spacing.large,
-  },
-  fareContractDetails: {
-    flex: 1,
-    paddingBottom: theme.spacing.large,
-    rowGap: theme.spacing.medium,
-  },
-  enlargedWhiteBarcodePaddingView: {
-    backgroundColor: '#ffffff',
-    paddingVertical: theme.spacing.xLarge * 2,
-  },
-}));
+const useStyles = StyleSheet.createThemeHook((theme) => {
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
+  return {
+    globalMessages: {
+      flex: 1,
+      rowGap: theme.spacing.medium,
+    },
+    section: {
+      marginBottom: bottomSafeAreaInset,
+    },
+    fareContractDetails: {
+      flex: 1,
+      paddingBottom: theme.spacing.large,
+      rowGap: theme.spacing.medium,
+    },
+    enlargedWhiteBarcodePaddingView: {
+      backgroundColor: '#ffffff',
+      paddingVertical: theme.spacing.xLarge * 2,
+    },
+  };
+});

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -21,6 +21,7 @@ import HarborSearchTexts from '@atb/translations/screens/subscreens/HarborSearch
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {useHarbors} from '@atb/modules/harbors';
 import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 type Props = RootStackScreenProps<'Root_PurchaseHarborSearchScreen'>;
 
@@ -131,24 +132,28 @@ export const Root_PurchaseHarborSearchScreen = ({
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  container: {
-    flex: 1,
-    backgroundColor: theme.color.background.neutral[2].background,
-  },
-  headerContainer: {
-    backgroundColor: theme.color.background.accent[0].background,
-  },
-  header: {
-    backgroundColor: theme.color.background.accent[0].background,
-  },
-  withMargin: {
-    margin: theme.spacing.medium,
-  },
-  contentBlock: {
-    marginHorizontal: theme.spacing.medium,
-  },
-  scroll: {
-    flex: 1,
-  },
-}));
+const useStyles = StyleSheet.createThemeHook((theme) => {
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
+  return {
+    container: {
+      flex: 1,
+      backgroundColor: theme.color.background.neutral[2].background,
+      paddingBottom: bottomSafeAreaInset,
+    },
+    headerContainer: {
+      backgroundColor: theme.color.background.accent[0].background,
+    },
+    header: {
+      backgroundColor: theme.color.background.accent[0].background,
+    },
+    withMargin: {
+      margin: theme.spacing.medium,
+    },
+    contentBlock: {
+      marginHorizontal: theme.spacing.medium,
+    },
+    scroll: {
+      flex: 1,
+    },
+  };
+});

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -384,7 +384,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
   return {
     header: {
       marginHorizontal: theme.spacing.medium,
@@ -392,7 +392,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     contentContainer: {
       rowGap: theme.spacing.medium,
       margin: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: bottomSafeAreaInset + theme.spacing.medium,
     },
     messages: {
       rowGap: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
@@ -59,13 +59,13 @@ export const AnnouncementSheet = ({announcement}: Props) => {
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
   return {
     container: {
       paddingHorizontal: theme.spacing.medium,
       minHeight: 350,
       gap: theme.spacing.medium,
-      paddingBottom: Math.max(bottom, theme.spacing.medium),
+      paddingBottom: bottomSafeAreaInset + theme.spacing.medium,
     },
     articleContainer: {
       gap: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
@@ -110,11 +110,11 @@ export const Root_TicketInformationScreen = (props: Props) => {
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => {
-  const {bottom} = useSafeAreaInsets();
+  const {bottom: bottomSafeAreaInset} = useSafeAreaInsets();
   return {
     container: {
       marginHorizontal: theme.spacing.medium,
-      marginBottom: Math.max(bottom, theme.spacing.medium),
+      marginBottom: bottomSafeAreaInset + theme.spacing.medium,
       rowGap: theme.spacing.small,
     },
     descriptionContainer: {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/21412

Since Android 15 the bottom navbar (onscreen/software) has changed behavior. Before 15 the area behind/"under" the navbar was not drawable area, but since 15 it is. Android calls it "edge-to-edge enforcement". 

To handle the previous situation we have a lot of `Math.max(bottomSafeAreaInset, theme.spacing.medium)` which in practice meant that for Android we used `theme.spacing.medium` while for iOS we used `bottomSafeAreaInset`. But after the change that falls down and some screens now don't have any padding any more, or UI elements are hidden behind the navbar 

<details>
<summary>Before and after images</summary>

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/fe02736a-8099-4e15-83cd-4d37ba84b7b9" /> | <img width="200" src="https://github.com/user-attachments/assets/5917fc0c-1f6a-4b4f-8af5-42518358576d" /> |
| <img width="200" src="https://github.com/user-attachments/assets/f783fb8c-1bad-4b48-83a4-d534cd6ebae0" /> | <img width="200" src="https://github.com/user-attachments/assets/ab6253ac-9d6d-427e-8d40-1c9e30ad7630" /> |


</details>

I have now changed these occurences to be `bottomSafeAreaInset + theme.spacing.medium`. This is based on an assumption that a padding/margin should be relative to a safeArea, but I suspect not everyone will agree and that not all screens are designed with this in mind. 

This is especially important for @Dahly96 since I see this pattern is used in several scooter screens. I didn't change those since I don't know how to test it, and they are not in production yet. 