### PR TITLE
feat: use legal age from firestore

### DIFF
--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -82,14 +82,9 @@ export const getOrCreateVippsUserCustomToken = async (
 };
 
 export const getAgeVerification = (
-  legalAge: number | undefined,
+  legalAge: number,
   opts?: AxiosRequestConfig,
 ): Promise<AgeVerificationEnum> => {
-  if (legalAge === undefined) {
-    //all users are of legal age if no age limit is set
-    return Promise.resolve(AgeVerificationEnum.LegalAge);
-  }
-
   const url = '/identity/v1/vipps/age-verification';
   const query = qs.stringify({legalAge});
 

--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -82,9 +82,14 @@ export const getOrCreateVippsUserCustomToken = async (
 };
 
 export const getAgeVerification = (
-  legalAge: number,
+  legalAge: number | undefined,
   opts?: AxiosRequestConfig,
 ): Promise<AgeVerificationEnum> => {
+  if (legalAge === undefined) {
+    //all users are of legal age if no age limit is set
+    return Promise.resolve(AgeVerificationEnum.LegalAge);
+  }
+
   const url = '/identity/v1/vipps/age-verification';
   const query = qs.stringify({legalAge});
 

--- a/src/modules/mobility/components/ShmoActionButton.tsx
+++ b/src/modules/mobility/components/ShmoActionButton.tsx
@@ -34,7 +34,8 @@ export const ShmoActionButton = ({
   paymentMethod,
 }: ShmoActionButtonProps) => {
   const {authenticationType, userId} = useAuthContext();
-  const {hasBlockers, numberOfBlockers} = useShmoRequirements();
+  const {hasBlockers, numberOfBlockers, ageVerification, operatorAgeLimit} =
+    useShmoRequirements(operatorId);
   const {t} = useTranslation();
   const {theme} = useThemeContext();
   const styles = useStyles();
@@ -48,8 +49,6 @@ export const ShmoActionButton = ({
     isError: initShmoOneStopBookingIsError,
     error: initShmoOneStopBookingError,
   } = useInitShmoOneStopBookingMutation();
-
-  const {ageVerification, legalAge} = useShmoRequirements();
 
   const initShmoBooking = useCallback(async () => {
     const initReqBody: InitShmoOneStopBookingRequestBody = {
@@ -123,12 +122,15 @@ export const ShmoActionButton = ({
           )}
         />
       )}
-      {ageVerification === AgeVerificationEnum.UnderAge && (
-        <MessageInfoBox
-          type="warning"
-          message={t(MobilityTexts.shmoRequirements.underAgeWarning(legalAge))}
-        />
-      )}
+      {ageVerification === AgeVerificationEnum.UnderAge &&
+        operatorAgeLimit !== undefined && (
+          <MessageInfoBox
+            type="warning"
+            message={t(
+              MobilityTexts.shmoRequirements.underAgeWarning(operatorAgeLimit),
+            )}
+          />
+        )}
       <Button
         mode="primary"
         active={false}

--- a/src/modules/mobility/components/ShmoActionButton.tsx
+++ b/src/modules/mobility/components/ShmoActionButton.tsx
@@ -122,15 +122,14 @@ export const ShmoActionButton = ({
           )}
         />
       )}
-      {ageVerification === AgeVerificationEnum.UnderAge &&
-        operatorAgeLimit !== undefined && (
-          <MessageInfoBox
-            type="warning"
-            message={t(
-              MobilityTexts.shmoRequirements.underAgeWarning(operatorAgeLimit),
-            )}
-          />
-        )}
+      {ageVerification === AgeVerificationEnum.UnderAge && (
+        <MessageInfoBox
+          type="warning"
+          message={t(
+            MobilityTexts.shmoRequirements.underAgeWarning(operatorAgeLimit),
+          )}
+        />
+      )}
       <Button
         mode="primary"
         active={false}

--- a/src/modules/mobility/components/onboarding/AgeVerificationScreenComponent.tsx
+++ b/src/modules/mobility/components/onboarding/AgeVerificationScreenComponent.tsx
@@ -14,13 +14,7 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {StyleSheet} from '@atb/theme';
 import {useInitAgeVerificationMutation} from '../../index';
 
-export type AgeVerificationScreenComponentProps = {
-  legalAge: number;
-};
-
-export const AgeVerificationScreenComponent = ({
-  legalAge,
-}: AgeVerificationScreenComponentProps) => {
+export const AgeVerificationScreenComponent = () => {
   const {t} = useTranslation();
   const appStatus = useAppStateStatus();
   const [error, setError] = useState<VippsSignInErrorCode>();
@@ -30,7 +24,7 @@ export const AgeVerificationScreenComponent = ({
     mutateAsync: completeAgeVerification,
     isLoading: isCompleting,
     error: completeError,
-  } = useCompleteAgeVerificationMutation(legalAge);
+  } = useCompleteAgeVerificationMutation();
 
   const {
     mutateAsync: initAgeVerification,

--- a/src/modules/mobility/components/sheets/ScooterSheet.tsx
+++ b/src/modules/mobility/components/sheets/ScooterSheet.tsx
@@ -74,7 +74,9 @@ export const ScooterSheet = ({
     (e) => e.id === operatorId,
   )?.isDeepIntegrationEnabled;
 
-  const {isLoading: shmoReqIsLoading, hasBlockers} = useShmoRequirements();
+  const {isLoading: shmoReqIsLoading, hasBlockers} =
+    useShmoRequirements(operatorId);
+
   const {operatorBenefit} = useOperatorBenefit(operatorId);
   const selectedPaymentMethod = useSelectedShmoPaymentMethod();
 

--- a/src/modules/mobility/index.ts
+++ b/src/modules/mobility/index.ts
@@ -55,7 +55,7 @@ export {
   isVehiclesClusteredFeature,
 } from './utils';
 export {
-  type AgeVerificationEnum,
+  AgeVerificationEnum,
   useGetAgeVerificationQuery,
 } from './queries/use-get-age-verification-query';
 export {useGetBirthdateQuery} from './queries/use-get-birthdate-query';

--- a/src/modules/mobility/queries/use-complete-age-verification-mutation.tsx
+++ b/src/modules/mobility/queries/use-complete-age-verification-mutation.tsx
@@ -10,6 +10,7 @@ export const useCompleteAgeVerificationMutation = () => {
       completeAgeVerification(authorizationCode),
 
     onSuccess: () => {
+      //invalidate all age verification queries
       queryClient.invalidateQueries({
         queryKey: [ageVerificationQueryKeyString],
       });

--- a/src/modules/mobility/queries/use-complete-age-verification-mutation.tsx
+++ b/src/modules/mobility/queries/use-complete-age-verification-mutation.tsx
@@ -1,8 +1,8 @@
 import {completeAgeVerification} from '@atb/api/identity';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {getAgeVerificationQueryKey} from './use-get-age-verification-query';
+import {ageVerificationQueryKeyString} from './use-get-age-verification-query';
 
-export const useCompleteAgeVerificationMutation = (legalAge: number) => {
+export const useCompleteAgeVerificationMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -10,7 +10,9 @@ export const useCompleteAgeVerificationMutation = (legalAge: number) => {
       completeAgeVerification(authorizationCode),
 
     onSuccess: () => {
-      queryClient.invalidateQueries(getAgeVerificationQueryKey(legalAge));
+      queryClient.invalidateQueries({
+        queryKey: [ageVerificationQueryKeyString],
+      });
     },
   });
 };

--- a/src/modules/mobility/queries/use-get-age-verification-query.tsx
+++ b/src/modules/mobility/queries/use-get-age-verification-query.tsx
@@ -11,12 +11,12 @@ export enum AgeVerificationEnum {
 
 export const ageVerificationQueryKeyString = 'getAgeVerification';
 
-export const getAgeVerificationQueryKey = (legalAge: number | undefined) => [
+export const getAgeVerificationQueryKey = (legalAge: number) => [
   ageVerificationQueryKeyString,
   legalAge,
 ];
 
-export const useGetAgeVerificationQuery = (legalAge: number | undefined) => {
+export const useGetAgeVerificationQuery = (legalAge: number) => {
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
   return useQuery({
     enabled: isShmoDeepIntegrationEnabled,

--- a/src/modules/mobility/queries/use-get-age-verification-query.tsx
+++ b/src/modules/mobility/queries/use-get-age-verification-query.tsx
@@ -9,8 +9,10 @@ export enum AgeVerificationEnum {
   NotVerified = 'notVerified',
 }
 
+export const ageVerificationQueryKeyString = 'getAgeVerification';
+
 export const getAgeVerificationQueryKey = (legalAge: number | undefined) => [
-  'getAgeVerification',
+  ageVerificationQueryKeyString,
   legalAge,
 ];
 

--- a/src/modules/mobility/queries/use-get-age-verification-query.tsx
+++ b/src/modules/mobility/queries/use-get-age-verification-query.tsx
@@ -9,12 +9,12 @@ export enum AgeVerificationEnum {
   NotVerified = 'notVerified',
 }
 
-export const getAgeVerificationQueryKey = (legalAge: number) => [
+export const getAgeVerificationQueryKey = (legalAge: number | undefined) => [
   'getAgeVerification',
   legalAge,
 ];
 
-export const useGetAgeVerificationQuery = (legalAge: number) => {
+export const useGetAgeVerificationQuery = (legalAge: number | undefined) => {
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
   return useQuery({
     enabled: isShmoDeepIntegrationEnabled,

--- a/src/modules/mobility/use-shmo-requirements.tsx
+++ b/src/modules/mobility/use-shmo-requirements.tsx
@@ -14,7 +14,7 @@ export const useShmoRequirements = (operatorId: string | undefined) => {
   const {mobilityOperators} = useOperators();
 
   const operator = mobilityOperators?.find((op) => op.id === operatorId);
-  const operatorAgeLimit = operator?.ageLimit;
+  const operatorAgeLimit = operator?.ageLimit ?? 0;
 
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
 

--- a/src/modules/mobility/use-shmo-requirements.tsx
+++ b/src/modules/mobility/use-shmo-requirements.tsx
@@ -8,9 +8,14 @@ import {
   useGetAgeVerificationQuery,
 } from './queries/use-get-age-verification-query';
 import {useFeatureTogglesContext} from '../feature-toggles';
+import {useOperators} from './use-operators';
 
-export const useShmoRequirements = () => {
-  const USER_AGE_LIMIT = 18; // Define the age limit for verification
+export const useShmoRequirements = (operatorId: string | undefined) => {
+  const {mobilityOperators} = useOperators();
+
+  const operator = mobilityOperators?.find((op) => op.id === operatorId);
+  const operatorAgeLimit = operator?.ageLimit;
+
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
 
   const {preciseLocationIsAvailable} = useGeolocationContext();
@@ -24,7 +29,7 @@ export const useShmoRequirements = () => {
   );
 
   const {data: ageVerification, isLoading: ageVerifiedLoading} =
-    useGetAgeVerificationQuery(USER_AGE_LIMIT);
+    useGetAgeVerificationQuery(operatorAgeLimit);
 
   const requirements: ShmoRequirementType[] = [
     {
@@ -59,7 +64,7 @@ export const useShmoRequirements = () => {
     numberOfBlockers,
     setGivenConsent,
     isLoading,
-    legalAge: USER_AGE_LIMIT,
+    operatorAgeLimit,
     ageVerification,
   };
 };

--- a/src/modules/mobility/use-shmo-requirements.tsx
+++ b/src/modules/mobility/use-shmo-requirements.tsx
@@ -10,7 +10,7 @@ import {
 import {useFeatureTogglesContext} from '../feature-toggles';
 import {useOperators} from './use-operators';
 
-export const useShmoRequirements = (operatorId: string | undefined) => {
+export const useShmoRequirements = (operatorId?: string) => {
   const {mobilityOperators} = useOperators();
 
   const operator = mobilityOperators?.find((op) => op.id === operatorId);

--- a/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
@@ -12,8 +12,7 @@ import {RootStackScreenProps} from './navigation-types';
 type Props = RootStackScreenProps<'Root_ShmoOnboardingScreen'>;
 
 export const Root_ShmoOnboardingScreen = ({navigation}: Props) => {
-  const {requirements, hasBlockers, setGivenConsent} =
-    useShmoRequirements(undefined);
+  const {requirements, hasBlockers, setGivenConsent} = useShmoRequirements();
 
   useEffect(() => {
     if (!hasBlockers) {

--- a/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
@@ -12,7 +12,7 @@ import {RootStackScreenProps} from './navigation-types';
 type Props = RootStackScreenProps<'Root_ShmoOnboardingScreen'>;
 
 export const Root_ShmoOnboardingScreen = ({navigation}: Props) => {
-  const {requirements, hasBlockers, setGivenConsent, legalAge} =
+  const {requirements, hasBlockers, setGivenConsent} =
     useShmoRequirements(undefined);
 
   useEffect(() => {
@@ -26,7 +26,7 @@ export const Root_ShmoOnboardingScreen = ({navigation}: Props) => {
       (e) => e.requirementCode === ShmoRequirementEnum.AGE_VERIFICATION,
     )?.isBlocking
   ) {
-    return <AgeVerificationScreenComponent legalAge={legalAge} />;
+    return <AgeVerificationScreenComponent />;
   }
 
   if (

--- a/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
@@ -13,7 +13,7 @@ type Props = RootStackScreenProps<'Root_ShmoOnboardingScreen'>;
 
 export const Root_ShmoOnboardingScreen = ({navigation}: Props) => {
   const {requirements, hasBlockers, setGivenConsent, legalAge} =
-    useShmoRequirements();
+    useShmoRequirements(undefined);
 
   useEffect(() => {
     if (!hasBlockers) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,9 +21,9 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@atb-as/config-specs@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-7.2.0.tgz#3c2ad47dec279ff71d2f5cc5c1a1d8b0b10985c3"
-  integrity sha512-CiCFqiRnArUcj6xigfFfqeHLtR3rgpKHiiuFfOCeJhtVPsQFdYvYKEfXi/xtJGxhZba3R0vZNIe09GUEeWq+Eg==
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@atb-as/config-specs/-/config-specs-7.3.0.tgz#29666607fae6e5313594b24885e9adfa902f6ace"
+  integrity sha512-cBKzi6aRj+oJkLI3F39DY2vE3zCfPFjZdxfzKLN7UfF2JBQFVRu8CXet+IudiZkZnz50zwYlpZpGfbIZRPxDUA==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/21511

Uses legal age per operator from firestore.
If no value is set for operator in firestore, the legal age is assumed to be 0.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/dcf910ae-1169-4578-a754-a2c5c1ad6414" />
