### PR TITLE
build: add maven central as gradle dependency repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,8 @@ allprojects {
     repositories {
         def netRcFile = new File('../.netrc').exists() ? new File('../.netrc') : new File('.netrc')
 
+        mavenCentral()
+
         // For more details, see the requirements setting for Kettle at https://developer.kogenta.com/docs/react-native/add-kettle#declare-repository-manually
         maven { url "https://artifacts.kogenta.com/release" }
 


### PR DESCRIPTION
Got an request from Entur to add the Maven Central repository to rely less on on Enturs artifactory. 

- Docs on repositories: https://docs.gradle.org/current/userguide/declaring_repositories.html
- Successful build with these changes: https://github.com/AtB-AS/mittatb-app/actions/runs/17794424752/job/50578774852