### PR TITLE
feat: Added feature-toggle and fetch function for distances-API

### DIFF
--- a/src/api/bff/stop-places.ts
+++ b/src/api/bff/stop-places.ts
@@ -44,3 +44,21 @@ export const getStopPlaceConnections = async (
 
   return result.data;
 };
+
+export const getStopPlaceDistances = async (
+  fromStopPlaceId: string,
+  opts?: AxiosRequestConfig,
+): Promise<StopPlaceFragment[]> => {
+  const url = '/bff/v2/stop-places/distances';
+  const query = qs.stringify({
+    authorities: AUTHORITY,
+    fromStopPlaceId,
+    transportModes: [TransportMode.Water],
+  });
+  const result = await client.get<StopPlaceFragment[]>(
+    stringifyUrl(url, query),
+    opts,
+  );
+
+  return result.data;
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -55,6 +55,12 @@ export function createClient(baseUrl: string | undefined) {
   client.interceptors.request.use(requestIdTokenHandler);
   client.interceptors.response.use(undefined, responseIdTokenHandler);
   client.interceptors.response.use(undefined, responseErrorHandler);
+  client.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+    if (config.url?.startsWith('/bff/')) {
+      config.baseURL = 'http://localhost:8080/';
+    }
+    return config;
+  });
   return client;
 }
 

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -161,6 +161,10 @@ export const toggleSpecifications = [
     name: 'isSmartParkAndRideEnabled',
     remoteConfigKey: 'enable_smart_park_and_ride',
   },
+  {
+    name: 'isHarborDistancesApiEnabled',
+    remoteConfigKey: 'enable_harbor_distances_api',
+  },
 ] as const satisfies readonly FeatureToggleSpecification[];
 
 /**

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -68,6 +68,7 @@ export type RemoteConfig = {
   enable_in_app_review: boolean;
   enable_in_app_review_for_announcements: boolean;
   enable_smart_park_and_ride: boolean;
+  enable_harbor_distances_api: boolean;
   favourite_departures_poll_interval: number;
   feedback_questions: string;
   fetch_id_token_retry_count: number;
@@ -151,6 +152,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_in_app_review: false,
   enable_in_app_review_for_announcements: false,
   enable_smart_park_and_ride: false,
+  enable_harbor_distances_api: false,
   favourite_departures_poll_interval: 30000,
   feedback_questions: '',
   fetch_id_token_retry_count: 3,
@@ -328,6 +330,9 @@ export function getConfig(): RemoteConfig {
   const enable_smart_park_and_ride =
     values['enable_smart_park_and_ride']?.asBoolean() ??
     defaultRemoteConfig.enable_smart_park_and_ride;
+  const enable_harbor_distances_api =
+    values['enable_harbor_distances_api']?.asBoolean() ??
+    defaultRemoteConfig.enable_harbor_distances_api;
   const favourite_departures_poll_interval =
     values['favourite_departures_poll_interval']?.asNumber() ??
     defaultRemoteConfig.favourite_departures_poll_interval;
@@ -445,6 +450,7 @@ export function getConfig(): RemoteConfig {
     enable_in_app_review,
     enable_in_app_review_for_announcements,
     enable_smart_park_and_ride,
+    enable_harbor_distances_api,
     favourite_departures_poll_interval,
     feedback_questions,
     fetch_id_token_retry_count,

--- a/src/queries/use-connections-query.ts
+++ b/src/queries/use-connections-query.ts
@@ -1,14 +1,21 @@
 import {useQuery} from '@tanstack/react-query';
-import {getStopPlaceConnections} from '@atb/api/bff/stop-places';
+import {
+  getStopPlaceConnections,
+  getStopPlaceDistances,
+} from '@atb/api/bff/stop-places';
 
 import {ONE_HOUR_MS} from '@atb/utils/durations';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export const useConnectionsQuery = (fromHarborId?: string) => {
+  const {isHarborDistancesApiEnabled} = useFeatureTogglesContext();
+  const queryFn = isHarborDistancesApiEnabled
+    ? getStopPlaceDistances
+    : getStopPlaceConnections;
   return useQuery({
     queryKey: ['connections', {connectionFrom: fromHarborId}],
     enabled: !!fromHarborId,
-    queryFn: () =>
-      !!fromHarborId ? getStopPlaceConnections(fromHarborId) : [],
+    queryFn: () => (!!fromHarborId ? queryFn(fromHarborId) : []),
     staleTime: ONE_HOUR_MS,
     cacheTime: ONE_HOUR_MS,
   });


### PR DESCRIPTION
App-part of [this BFF-PR](https://github.com/AtB-AS/atb-bff/pull/410). 

Short summary: if the feature toggle is enabled, it uses the Entur Distances API to find reachable harbors (single- or multi-leg) from a selected harbour. 