### PR TITLE
fix: identity as in-app default

### DIFF
--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -109,7 +109,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   disable_travelcard: false,
   enable_activate_ticket_now: false,
   enable_auto_sale: false,
-  enable_backend_sms_auth: false,
+  enable_backend_sms_auth: true,
   enable_beacons: false,
   enable_bonus_program: false,
   enable_car_sharing_in_map: false,


### PR DESCRIPTION
To avoid using CloudOTP if Remote Config is not loaded, we should change the in-app default for `enable_backend_sms_auth`.

Ref [Slack](https://mittatb.slack.com/archives/C0116FMPX4Y/p1758627230059539).

### Acceptance criteria
- [x] Log in with SMS should work as before when RemConf is loaded correctly
- [x] Log in with SMS should work as before when RemConf is NOT loaded correctly

### Test input
- [x] The identity service should be used independent of RemConf is loaded correctly or not. Check with proxy (stop requests to remote config).