### PR TITLE
ci: use cache by default when manually creating android builds

### DIFF
--- a/.github/workflows/build-staging-android.yml
+++ b/.github/workflows/build-staging-android.yml
@@ -6,7 +6,7 @@ on:
         description: 'Forces a new build and ignores the cache'
         required: false
         type: choice
-        default: 'true'
+        default: 'false'
         options:
           - 'true'
           - 'false'


### PR DESCRIPTION
Noticed that we force a rebuild by default when triggering staging builds for android:

<img width="364" height="357" alt="Screenshot 2025-09-23 at 16 01 01" src="https://github.com/user-attachments/assets/72b0ede6-5975-4f2c-b887-e8447484bd09" />
