### PR TITLE
fix(spar): set stale time of vehicle registrations query

### DIFF
--- a/src/modules/smart-park-and-ride/queries/use-get-vehicle-registrations-query.ts
+++ b/src/modules/smart-park-and-ride/queries/use-get-vehicle-registrations-query.ts
@@ -2,6 +2,7 @@ import {useAuthContext} from '@atb/modules/auth';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {useQuery} from '@tanstack/react-query';
 import {getVehicleRegistrations} from '../api/api';
+import {ONE_HOUR_MS} from '@atb/utils/durations';
 
 export const getVehicleRegistrationsQueryKey = (userId: string | undefined) => {
   return ['getVehicleRegistrations', userId];
@@ -15,6 +16,8 @@ export const useVehicleRegistrationsQuery = (disabled: boolean = false) => {
     queryKey: getVehicleRegistrationsQueryKey(userId),
     queryFn: getVehicleRegistrations,
     retry: 3,
+    cacheTime: ONE_HOUR_MS,
+    staleTime: ONE_HOUR_MS,
     enabled: isSmartParkAndRideEnabled && !disabled,
   });
 };


### PR DESCRIPTION
The RefreshControl's refreshing state was showing every time the screen was entered. This was fixed by setting the stale time of the query so that the refetching does not occur each time. The data is updated when manually refetching or when the query is invalidated.