### PR TITLE
fix: update live pricing when reconnecting or gaining focus

### DIFF
--- a/src/modules/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/modules/mobility/queries/use-active-shmo-booking-query.tsx
@@ -24,6 +24,8 @@ export const useActiveShmoBookingQuery = (
     staleTime: ONE_MINUTE_MS,
     cacheTime: ONE_MINUTE_MS,
     refetchInterval,
+    refetchOnWindowFocus: 'always',
+    refetchOnReconnect: true,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/21087

When the phone is locked when on a trip, it does not get updates about the live pricing. If a user ends the trip after picking up the phone, they might have a stale price, so the jump from that stale price the one in the receipt summary might be a big jump to the user. So we try to keep the live pricing (and active booking) as updated as possible with this fix.