### PR TITLE
feat: always black border on camera screen

### DIFF
--- a/src/components/PhotoCapture/PhotoCapture.tsx
+++ b/src/components/PhotoCapture/PhotoCapture.tsx
@@ -51,6 +51,7 @@ export const PhotoCapture = ({
 
   return (
     <ScreenContainer
+      overrideThemeName="dark"
       leftHeaderButton={{type: 'back', withIcon: true}}
       title={title}
       secondaryText={secondaryText}

--- a/src/components/PhotoCapture/ScreenContainer.tsx
+++ b/src/components/PhotoCapture/ScreenContainer.tsx
@@ -1,7 +1,7 @@
 import {LeftButtonProps, RightButtonProps} from '@atb/components/screen-header';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ThemeText} from '@atb/components/text';
-import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
+import {StyleSheet, useThemeContext, themes, Themes} from '@atb/theme';
 import {PropsWithChildren, ReactNode} from 'react';
 import {View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -9,9 +9,11 @@ import {Processing} from '@atb/components/loading';
 import {dictionary, useTranslation} from '@atb/translations';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
-export const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
+export const getThemeColor = (themeName: keyof Themes) =>
+  themes[themeName]?.color?.background?.accent?.[0];
 
 type Props = PropsWithChildren<{
+  overrideThemeName?: keyof Themes;
   title?: string;
   titleA11yLabel?: string;
   secondaryText?: string;
@@ -22,8 +24,9 @@ type Props = PropsWithChildren<{
 }>;
 
 export const ScreenContainer = (props: Props) => {
-  const {theme} = useThemeContext();
-  const themeColor = getThemeColor(theme);
+  const {themeName: contextThemeName} = useThemeContext();
+  const themeName = props.overrideThemeName ?? contextThemeName;
+  const themeColor = getThemeColor(themeName);
 
   return (
     <FullScreenView
@@ -51,10 +54,17 @@ const LoadingBody = () => {
   );
 };
 
-const ContentBody = ({title, secondaryText, buttons, children}: Props) => {
+const ContentBody = ({
+  overrideThemeName,
+  title,
+  secondaryText,
+  buttons,
+  children,
+}: Props) => {
   const style = useStyles();
-  const {theme} = useThemeContext();
-  const themeColor = getThemeColor(theme);
+  const {themeName: contextThemeName} = useThemeContext();
+  const themeName = overrideThemeName ?? contextThemeName;
+  const themeColor = getThemeColor(themeName);
   const focusRef = useFocusOnLoad();
   return (
     <>

--- a/src/stacks-hierarchy/Root_ScanQrCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScanQrCodeScreen.tsx
@@ -134,6 +134,7 @@ export const Root_ScanQrCodeScreen: React.FC<Props> = ({navigation}) => {
 
   return (
     <ScreenContainer
+      overrideThemeName="dark"
       title={t(ParkingViolationTexts.qr.title)}
       leftHeaderButton={
         getAssetFromQrCodeIsLoading

--- a/src/stacks-hierarchy/Root_ScooterHelp/Root_ParkingViolationsQrScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/Root_ParkingViolationsQrScreen.tsx
@@ -1,7 +1,7 @@
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {Camera} from '@atb/components/camera';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {ParkingViolationTexts} from '@atb/translations/screens/ParkingViolations';
 import {RefObject, useEffect, useMemo, useRef, useState} from 'react';
@@ -31,8 +31,7 @@ export const Root_ParkingViolationsQrScreen = ({
 }: QrScreenProps) => {
   const {t} = useTranslation();
   const style = useStyles();
-  const {theme} = useThemeContext();
-  const themeColor = getThemeColor(theme);
+  const themeColor = getThemeColor('dark');
   const isFocused = useIsFocusedAndActive();
   const [capturedQr, setCapturedQr] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
@@ -161,6 +160,7 @@ export const Root_ParkingViolationsQrScreen = ({
 
   return (
     <ScreenContainer
+      overrideThemeName="dark"
       title={t(ParkingViolationTexts.qr.title)}
       secondaryText={t(ParkingViolationTexts.qr.instructions)}
       leftHeaderButton={isLoading ? undefined : {type: 'back', withIcon: true}}

--- a/src/translations/screens/ParkingViolations.ts
+++ b/src/translations/screens/ParkingViolations.ts
@@ -36,14 +36,14 @@ export const ParkingViolationTexts = {
   },
   photo: {
     title: _(
-      'Ta bilde av sykkelen',
-      'Take a photo of the bike',
-      'Ta bilete av sykkelen',
+      'Ta bilde av elsparkesykkelen',
+      'Take a photo of the e-scooter',
+      'Ta bilete av elsparkesykkelen',
     ),
     instruction: _(
-      'Hold ca. 5 meter avstand. Unngå folk i bildet.',
+      'Hold ca. 5 meter avstand. Unngå folk i bildet',
       'Stand approximately 5 meters away. Avoid people in the frame',
-      '"Hald ein avstand på omtrent 5 meter. Unngå folk i biletet',
+      'Hald ein avstand på ca. 5 meter. Unngå folk i biletet',
     ),
   },
   imageConfirmation: {

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -49,14 +49,14 @@ export const MobilityTexts = {
   },
   photo: {
     header: _(
-      'Ta bilde av el-sparkesykkelen',
-      'Take a photo of the escooter',
-      'Ta eit bilde av el-sparkesykkelen',
+      'Ta bilde av elsparkesykkelen',
+      'Take a photo of the e-scooter',
+      'Ta bilete av elsparkesykkelen',
     ),
     subHeader: _(
       'Hold ca. 5 meter avstand. Unngå folk i bildet',
-      'Keep a distence of 5 meters. Avoid capturing people in the photo',
-      'Hold ca. 5 meter avstand. Unngå folk i bildet',
+      'Stand approximately 5 meters away. Avoid people in the frame',
+      'Hald ein avstand på ca. 5 meter. Unngå folk i biletet',
     ),
   },
   shmoRequirements: {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/21308

Adds `overrideThemeName` prop to `ScreenContainer` which is used for Camera screens so they are always dark

Also: updates the texts for taking photos of e-scooters, as they were defined _almost_ the same in two places.
- Considered just making them the same. Opted against it since you _could_ want to add something specific about parking or invalid parking in the future


| camera screens before | camera screens after |
|------------------------|-----------------------|
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/04712aa3-1467-4de9-8990-7ceb505f9548" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/84fa54cc-263e-409a-9550-9289dc1e3427" />