### PR TITLE
feat: Add own action button for bottom sheet

### DIFF
--- a/src/modules/analytics/types.ts
+++ b/src/modules/analytics/types.ts
@@ -20,4 +20,5 @@ export type AnalyticsEventContext =
   | 'Trip search'
   | 'In App Review'
   | 'Bonus'
-  | 'Smart Park & Ride';
+  | 'Smart Park & Ride'
+  | 'AnnouncementSheet';

--- a/src/modules/announcements/index.ts
+++ b/src/modules/announcements/index.ts
@@ -3,4 +3,10 @@ export {
   useAnnouncementsContext,
 } from './AnnouncementsContext';
 export {ActionType} from './types';
-export type {Announcement} from './types';
+export type {
+  Announcement,
+  BottomSheetAnnouncement,
+  LinkAnnouncement,
+} from './types';
+
+export {isBottomSheetAnnouncement, isLinkAnnouncement} from './types';

--- a/src/modules/announcements/index.ts
+++ b/src/modules/announcements/index.ts
@@ -7,6 +7,8 @@ export type {
   Announcement,
   BottomSheetAnnouncement,
   LinkAnnouncement,
+  UrlActionButton,
+  BottomSheetActionButton,
 } from './types';
 
 export {isBottomSheetAnnouncement, isLinkAnnouncement} from './types';

--- a/src/modules/announcements/types.ts
+++ b/src/modules/announcements/types.ts
@@ -44,12 +44,16 @@ const UrlActionButton = z.object({
   ]),
 });
 
+export type UrlActionButton = z.infer<typeof UrlActionButton>;
+
 const BottomSheetActionButton = z.object({
   label: LanguageAndTextTypeArray.optional(),
   actionType: z.literal(ActionType.bottom_sheet),
   /** Action button for bottom sheet, only shown in bottom sheet, only used for deeplinks or external links */
   sheetPrimaryButton: UrlActionButton.optional(),
 });
+
+export type BottomSheetActionButton = z.infer<typeof BottomSheetActionButton>;
 
 const AnnouncementBase = z.object({
   id: z.string(),

--- a/src/modules/announcements/types.ts
+++ b/src/modules/announcements/types.ts
@@ -48,7 +48,7 @@ const BottomSheetActionButton = z.object({
   label: LanguageAndTextTypeArray.optional(),
   actionType: z.literal(ActionType.bottom_sheet),
   /** Action button for bottom sheet, only shown in bottom sheet, only used for deeplinks or external links */
-  sheetActionButton: UrlActionButton.optional(),
+  sheetPrimaryButton: UrlActionButton.optional(),
 });
 
 const AnnouncementBase = z.object({

--- a/src/modules/announcements/types.ts
+++ b/src/modules/announcements/types.ts
@@ -34,10 +34,7 @@ export enum ActionType {
   deeplink = 'deeplink',
   bottom_sheet = 'bottom_sheet',
 }
-const BottomSheetActionButton = z.object({
-  label: LanguageAndTextTypeArray.optional(),
-  actionType: z.literal(ActionType.bottom_sheet),
-});
+
 const UrlActionButton = z.object({
   label: LanguageAndTextTypeArray.optional(),
   url: z.string().url(),
@@ -46,23 +43,71 @@ const UrlActionButton = z.object({
     z.literal(ActionType.deeplink),
   ]),
 });
-const ActionButton = z.union([BottomSheetActionButton, UrlActionButton]);
 
-export const Announcement = z.object({
+const BottomSheetActionButton = z.object({
+  label: LanguageAndTextTypeArray.optional(),
+  actionType: z.literal(ActionType.bottom_sheet),
+  /** Action button for bottom sheet, only shown in bottom sheet, only used for deeplinks or external links */
+  sheetActionButton: UrlActionButton.optional(),
+});
+
+const AnnouncementBase = z.object({
   id: z.string(),
   active: z.boolean(),
+
+  /** Announcement card title */
   summaryTitle: LanguageAndTextTypeArray.optional(),
+  /** Announcement card summary */
   summary: LanguageAndTextTypeArray,
+  /** Announcement card image */
   summaryImage: Base64ImageSchema.optional(),
+
+  /** Announcement bottom sheet title, also used as card title if no summaryTitle is provided */
   fullTitle: LanguageAndTextTypeArray,
-  body: LanguageAndTextTypeArray,
-  mainImage: Base64ImageSchema.optional(),
+
   appPlatforms: z.array(AppPlatform).optional(),
   appVersionMin: z.string().optional(),
   appVersionMax: z.string().optional(),
   startDate: TimestampSchema.optional(),
   endDate: TimestampSchema.optional(),
   rules: z.array(Rule).optional(),
-  actionButton: ActionButton.optional(),
+  actionButton: z.union([UrlActionButton, BottomSheetActionButton]).optional(),
 });
+
+export const LinkAnnouncement = AnnouncementBase.extend({
+  actionButton: UrlActionButton,
+});
+
+export const BottomSheetAnnouncement = AnnouncementBase.extend({
+  /** Announcement bottom sheet body */
+  body: LanguageAndTextTypeArray,
+  /** Announcement bottom sheet image */
+  mainImage: Base64ImageSchema.optional(),
+
+  actionButton: BottomSheetActionButton,
+});
+
+export const Announcement = z.union([
+  AnnouncementBase,
+  LinkAnnouncement,
+  BottomSheetAnnouncement,
+]);
+
+export type LinkAnnouncement = z.infer<typeof LinkAnnouncement>;
+export type BottomSheetAnnouncement = z.infer<typeof BottomSheetAnnouncement>;
 export type Announcement = z.infer<typeof Announcement>;
+
+export function isBottomSheetAnnouncement(
+  announcement: Announcement,
+): announcement is BottomSheetAnnouncement {
+  return announcement.actionButton?.actionType === ActionType.bottom_sheet;
+}
+
+export function isLinkAnnouncement(
+  announcement: Announcement,
+): announcement is LinkAnnouncement {
+  return (
+    announcement.actionButton?.actionType === ActionType.external ||
+    announcement.actionButton?.actionType === ActionType.deeplink
+  );
+}

--- a/src/modules/announcements/types.ts
+++ b/src/modules/announcements/types.ts
@@ -88,9 +88,9 @@ export const BottomSheetAnnouncement = AnnouncementBase.extend({
 });
 
 export const Announcement = z.union([
-  AnnouncementBase,
-  LinkAnnouncement,
   BottomSheetAnnouncement,
+  LinkAnnouncement,
+  AnnouncementBase,
 ]);
 
 export type LinkAnnouncement = z.infer<typeof LinkAnnouncement>;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
@@ -107,11 +107,11 @@ export const AnnouncementSection = ({announcement, style}: Props) => {
   );
 };
 
-function AnnouncementActionButton({
+const AnnouncementActionButton = ({
   announcement,
 }: {
   announcement: BottomSheetAnnouncement | LinkAnnouncement;
-}) {
+}) => {
   const {t} = useTranslation();
   const {language} = useTranslation();
   const analytics = useAnalyticsContext();
@@ -189,7 +189,7 @@ function AnnouncementActionButton({
       />
     );
   }
-}
+};
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
   sectionItem: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback} from 'react';
-import {ActionType, BottomSheetAnnouncement} from '@atb/modules/announcements';
+import React from 'react';
+import {BottomSheetAnnouncement} from '@atb/modules/announcements';
 import {BottomSheetContainer} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {ThemeText} from '@atb/components/text';
@@ -9,7 +9,7 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {Image, Linking, View} from 'react-native';
+import {Image, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
@@ -17,33 +17,22 @@ import {
   useInAppReviewFlow,
 } from '@atb/utils/use-in-app-review';
 import {GenericSectionItem, Section} from '@atb/components/sections';
-import {useAnalyticsContext} from '@atb/modules/analytics';
-import Bugsnag from '@bugsnag/react-native';
-import {ArrowRight, ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
+import {useActionButtonProps} from './hooks';
 
 type Props = {
   announcement: BottomSheetAnnouncement;
 };
 
 export const AnnouncementSheet = ({announcement}: Props) => {
-  const {language} = useTranslation();
+  const {language, t} = useTranslation();
   const style = useStyle();
   const {requestReview} = useInAppReviewFlow();
-  const {t} = useTranslation();
-  const analytics = useAnalyticsContext();
 
-  const primaryButton = announcement.actionButton.sheetPrimaryButton;
-
-  const summaryTitle = getTextForLanguage(
-    announcement.summaryTitle ?? announcement.fullTitle,
-    language,
+  const primaryButtonProps = useActionButtonProps(
+    announcement,
+    announcement.actionButton.sheetPrimaryButton,
+    'AnnouncementSheet',
   );
-
-  const logPress = useCallback(() => {
-    analytics.logEvent('AnnouncementSheet', 'Sheet action button pressed', {
-      id: announcement.id,
-    });
-  }, [analytics, announcement.id]);
 
   return (
     <BottomSheetContainer
@@ -71,40 +60,8 @@ export const AnnouncementSheet = ({announcement}: Props) => {
             </ThemeText>
           </GenericSectionItem>
         </Section>
-        {primaryButton && (
-          <Button
-            expanded={true}
-            rightIcon={
-              primaryButton.actionType === ActionType.external
-                ? {svg: ExternalLink}
-                : {svg: ArrowRight}
-            }
-            mode="primary"
-            text={
-              getTextForLanguage(primaryButton.label, language) ??
-              t(
-                DashboardTexts.announcements.buttonAction.defaultLabel(
-                  summaryTitle,
-                ),
-              )
-            }
-            accessibilityHint={t(
-              DashboardTexts.announcements.buttonAction.a11yHint[
-                primaryButton.actionType
-              ],
-            )}
-            accessibilityRole="link"
-            onPress={async () => {
-              logPress();
-
-              const actionButtonURL = primaryButton.url;
-              try {
-                actionButtonURL && (await Linking.openURL(actionButtonURL));
-              } catch (err: any) {
-                Bugsnag.notify(err);
-              }
-            }}
-          />
+        {primaryButtonProps && (
+          <Button expanded={true} mode="primary" {...primaryButtonProps} />
         )}
       </ScrollView>
     </BottomSheetContainer>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSheet.tsx
@@ -32,7 +32,7 @@ export const AnnouncementSheet = ({announcement}: Props) => {
   const {t} = useTranslation();
   const analytics = useAnalyticsContext();
 
-  const sheetActionButton = announcement.actionButton.sheetActionButton;
+  const primaryButton = announcement.actionButton.sheetPrimaryButton;
 
   const summaryTitle = getTextForLanguage(
     announcement.summaryTitle ?? announcement.fullTitle,
@@ -71,17 +71,17 @@ export const AnnouncementSheet = ({announcement}: Props) => {
             </ThemeText>
           </GenericSectionItem>
         </Section>
-        {sheetActionButton && (
+        {primaryButton && (
           <Button
             expanded={true}
             rightIcon={
-              sheetActionButton.actionType === ActionType.external
+              primaryButton.actionType === ActionType.external
                 ? {svg: ExternalLink}
                 : {svg: ArrowRight}
             }
             mode="primary"
             text={
-              getTextForLanguage(sheetActionButton.label, language) ??
+              getTextForLanguage(primaryButton.label, language) ??
               t(
                 DashboardTexts.announcements.buttonAction.defaultLabel(
                   summaryTitle,
@@ -90,14 +90,14 @@ export const AnnouncementSheet = ({announcement}: Props) => {
             }
             accessibilityHint={t(
               DashboardTexts.announcements.buttonAction.a11yHint[
-                sheetActionButton.actionType
+                primaryButton.actionType
               ],
             )}
             accessibilityRole="link"
             onPress={async () => {
               logPress();
 
-              const actionButtonURL = sheetActionButton.url;
+              const actionButtonURL = primaryButton.url;
               try {
                 actionButtonURL && (await Linking.openURL(actionButtonURL));
               } catch (err: any) {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
@@ -52,6 +52,9 @@ export const useActionButtonProps = (
     language,
   );
 
+  const accessibilityRole: AccessibilityRole =
+    button.actionType === ActionType.bottom_sheet ? 'button' : 'link';
+
   return {
     rightIcon:
       button.actionType === ActionType.external
@@ -65,10 +68,7 @@ export const useActionButtonProps = (
         button.actionType as ActionType
       ],
     ),
-    accessibilityRole:
-      button.actionType === ActionType.bottom_sheet
-        ? ('button' as AccessibilityRole)
-        : ('link' as AccessibilityRole),
+    accessibilityRole,
     onPress: async () => {
       logPress();
       if (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
@@ -1,0 +1,95 @@
+import React from 'react';
+import {useTranslation} from '@atb/translations';
+import {getTextForLanguage} from '@atb/translations';
+import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
+import {ArrowRight} from '@atb/assets/svg/mono-icons/navigation';
+import {DashboardTexts} from '@atb/translations';
+import {AccessibilityRole} from 'react-native';
+import {Linking} from 'react-native';
+import Bugsnag from '@bugsnag/react-native';
+import {SvgProps} from 'react-native-svg';
+import {RefObject, useCallback, useRef} from 'react';
+import {useBottomSheetContext} from '@atb/components/bottom-sheet';
+import {
+  ActionType,
+  Announcement,
+  BottomSheetActionButton,
+  UrlActionButton,
+  isBottomSheetAnnouncement,
+} from '@atb/modules/announcements';
+import {AnalyticsEventContext} from '@atb/modules/analytics';
+import {useAnalyticsContext} from '@atb/modules/analytics';
+import {AnnouncementSheet} from './AnnouncementSheet';
+
+type ActionButtonProps = {
+  rightIcon: {svg: (props: SvgProps) => React.JSX.Element};
+  text: string;
+  accessibilityHint: string;
+  accessibilityRole: AccessibilityRole;
+  onPress: () => void;
+};
+
+export const useActionButtonProps = (
+  announcement: Announcement,
+  button: UrlActionButton | BottomSheetActionButton | undefined,
+  logContext: AnalyticsEventContext,
+): ActionButtonProps | undefined => {
+  const {language, t} = useTranslation();
+  const analytics = useAnalyticsContext();
+  const {open: openBottomSheet} = useBottomSheetContext();
+  const onCloseFocusRef = useRef<RefObject<any>>(null);
+
+  const logPress = useCallback(() => {
+    analytics.logEvent(logContext, 'Announcement pressed', {
+      id: announcement.id,
+    });
+  }, [analytics, logContext, announcement.id]);
+
+  if (!button) return undefined;
+
+  const summaryTitle = getTextForLanguage(
+    announcement.summaryTitle ?? announcement.fullTitle,
+    language,
+  );
+
+  return {
+    rightIcon:
+      button.actionType === ActionType.external
+        ? {svg: ExternalLink}
+        : {svg: ArrowRight},
+    text:
+      getTextForLanguage(button.label, language) ??
+      t(DashboardTexts.announcements.buttonAction.defaultLabel(summaryTitle)),
+    accessibilityHint: t(
+      DashboardTexts.announcements.buttonAction.a11yHint[
+        button.actionType as ActionType
+      ],
+    ),
+    accessibilityRole:
+      button.actionType === ActionType.bottom_sheet
+        ? ('button' as AccessibilityRole)
+        : ('link' as AccessibilityRole),
+    onPress: async () => {
+      logPress();
+      if (
+        button.actionType === ActionType.bottom_sheet &&
+        isBottomSheetAnnouncement(announcement)
+      ) {
+        openBottomSheet(
+          () => React.createElement(AnnouncementSheet, {announcement}),
+          onCloseFocusRef,
+        );
+      } else if (
+        button.actionType === ActionType.external ||
+        button.actionType === ActionType.deeplink
+      ) {
+        const actionButtonURL = button.url;
+        try {
+          actionButtonURL && (await Linking.openURL(actionButtonURL));
+        } catch (err: any) {
+          Bugsnag.notify(err);
+        }
+      }
+    },
+  };
+};


### PR DESCRIPTION
Also refactor types a bit in an effort to make it more statically typed and clearer to understand

In order to support button for carpooling bottom sheet announcement.

<img width="294" height="561" alt="image" src="https://github.com/user-attachments/assets/8cdf6e92-4f06-4811-8f56-22a264e92f93" />


<details><summary>From future design component changes</summary>
<p>

<img width="2072" height="1660" alt="image" src="https://github.com/user-attachments/assets/2dcab619-b571-4b60-891f-5e9ed4b61485" />

Named button primary to allow for a secondary button down the road, as per new guidelines for bottom sheet:
<img width="782" height="766" alt="image" src="https://github.com/user-attachments/assets/355b7496-04e7-4b2e-ba79-a599e1c06892" />

</p>
</details> 
