### PR TITLE
fix: revert a11y role change for radio buttons

### DIFF
--- a/src/components/sections/items/RadioSectionItem.tsx
+++ b/src/components/sections/items/RadioSectionItem.tsx
@@ -77,7 +77,10 @@ export function RadioSectionItem({
         }}
         style={styles.mainContent}
         testID={testID}
-        accessibilityRole="radio"
+        // There is a bug in React Native where `accessibilityRole="radio"`
+        // doesn't work consistently with VoiceOver. Using "button" until it's
+        // fixed: https://github.com/facebook/react-native/issues/43266
+        accessibilityRole="button"
         accessibilityState={{selected: !!selected}}
         accessibilityLabel={a11yLabel}
         accessibilityHint={accessibilityHint}


### PR DESCRIPTION
It seems accessibilityRole radio isn't fixed, rather it's flaky, and only works sometimes on iOS.

fixes https://github.com/AtB-AS/kundevendt/issues/19430#issuecomment-3370449680