### PR TITLE
fix: fixed stateissue with returning form onboarding

### DIFF
--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -125,7 +125,11 @@ export const MapBottomSheets = ({
             onReportParkingViolation={onReportParkingViolation}
             navigation={navigation}
             startOnboardingCallback={() => {
-              navigation.navigate('Root_ShmoOnboardingScreen');
+              navigation.navigate('Root_ShmoOnboardingScreen', {
+                assetId:
+                  mapState.feature?.properties?.id ?? mapState.assetId ?? '',
+              });
+              dispatchMapState({type: MapStateActionType.None});
             }}
             locationArrowOnPress={locationArrowOnPress}
           />

--- a/src/modules/mobility/components/ShmoActionButton.tsx
+++ b/src/modules/mobility/components/ShmoActionButton.tsx
@@ -16,10 +16,10 @@ import {PaymentMethod, savePreviousPayment} from '@atb/modules/payment';
 import {useShmoWarnings} from '@atb/modules/map';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {AgeVerificationEnum} from '../queries/use-get-age-verification-query';
-import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
 import {useHasReservationOrAvailableFareContract} from '@atb/modules/ticketing';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 
 type ShmoActionButtonProps = {
   onStartOnboarding: () => void;
@@ -44,7 +44,7 @@ export const ShmoActionButton = ({
   const styles = useStyles();
   const coordinates = getCurrentCoordinatesGlobal();
   const {warningMessage} = useShmoWarnings(vehicleId);
-  const {logEvent} = useBottomSheetContext();
+  const {logEvent} = useAnalyticsContext();
 
   const {enable_vipps_login} = useRemoteConfigContext();
   const hasReservationOrAvailableFareContract =

--- a/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoOnboardingScreen.tsx
@@ -8,17 +8,23 @@ import {PaymentScreenComponent} from '@atb/modules/mobility';
 import {ShmoRequirementEnum} from '@atb/modules/mobility';
 import {useShmoRequirements} from '@atb/modules/mobility';
 import {RootStackScreenProps} from './navigation-types';
+import {MapStateActionType, useMapContext} from '@atb/modules/map';
 
 type Props = RootStackScreenProps<'Root_ShmoOnboardingScreen'>;
 
-export const Root_ShmoOnboardingScreen = ({navigation}: Props) => {
+export const Root_ShmoOnboardingScreen = ({navigation, route}: Props) => {
   const {requirements, hasBlockers, setGivenConsent} = useShmoRequirements();
+  const {dispatchMapState} = useMapContext();
 
   useEffect(() => {
     if (!hasBlockers) {
+      dispatchMapState({
+        type: MapStateActionType.ScooterScanned,
+        assetId: route.params.assetId,
+      });
       navigation.goBack();
     }
-  }, [hasBlockers, navigation]);
+  }, [dispatchMapState, hasBlockers, navigation, route.params.assetId]);
 
   if (
     requirements.find(

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -79,6 +79,9 @@ type ScooterHelpParams = {operatorId: string} & (
   | {bookingId: string}
 );
 type Root_ScooterHelpScreenParams = ScooterHelpParams;
+type Root_ShmoOnboardingScreenParams = {
+  assetId: string;
+};
 type Root_ContactScooterOperatorScreenParams = ScooterHelpParams;
 
 type Root_ContactScooterOperatorConfirmationScreenParams = {
@@ -140,7 +143,7 @@ export type RootStackParamList = StackParams<{
   Root_ParkingViolationsQrScreen: Root_ParkingViolationsQrParams;
   Root_ParkingViolationsConfirmationScreen: Root_ParkingViolationsConfirmationParams;
   Root_ScooterHelpScreen: Root_ScooterHelpScreenParams;
-  Root_ShmoOnboardingScreen: undefined;
+  Root_ShmoOnboardingScreen: Root_ShmoOnboardingScreenParams;
   Root_ContactScooterOperatorScreen: Root_ContactScooterOperatorScreenParams;
   Root_ContactScooterOperatorConfirmationScreen: Root_ContactScooterOperatorConfirmationScreenParams;
   Root_NotificationPermissionScreen: undefined;


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/18903

When opening scootersheet and then doing onboarding, after you finish and are returning to the map/scootersheet, the scootersheet is not updated because it was just mounted on the map in the background the whole time. Now its reopening having fresh state on return