### PR TITLE
feat: app calls benefit service directly

### DIFF
--- a/src/modules/map/MapV2.tsx
+++ b/src/modules/map/MapV2.tsx
@@ -76,7 +76,7 @@ export const MapV2 = (props: MapProps) => {
     () =>
       initialLocation && initialLocation?.resultType !== 'geolocation'
         ? initialLocation.coordinates
-        : FOCUS_ORIGIN || FOCUS_ORIGIN,
+        : getCurrentCoordinatesGlobal() || FOCUS_ORIGIN,
     [initialLocation],
   );
 

--- a/src/modules/map/MapV2.tsx
+++ b/src/modules/map/MapV2.tsx
@@ -76,7 +76,7 @@ export const MapV2 = (props: MapProps) => {
     () =>
       initialLocation && initialLocation?.resultType !== 'geolocation'
         ? initialLocation.coordinates
-        : getCurrentCoordinatesGlobal() || FOCUS_ORIGIN,
+        : FOCUS_ORIGIN || FOCUS_ORIGIN,
     [initialLocation],
   );
 

--- a/src/modules/mobility/use-is-eligible-for-benefit.tsx
+++ b/src/modules/mobility/use-is-eligible-for-benefit.tsx
@@ -13,11 +13,11 @@ export const useIsEligibleForBenefit = (
     isError,
   } = useUserBenefitsQuery(!!operatorBenefit);
 
-  const userBenefitIds =
-    userBenefits?.flatMap((b) => b.benefitIds).filter(isDefined) || [];
+  const userBenefitTypes =
+    userBenefits?.flatMap((b) => b.benefit_types).filter(isDefined) || [];
 
   const isUserEligibleForBenefit =
-    operatorBenefit && userBenefitIds.includes(operatorBenefit.id);
+    operatorBenefit && userBenefitTypes.includes(operatorBenefit.id);
 
   const benefitRequiresValueCodeToUnlock =
     operatorBenefit &&

--- a/src/modules/mobility/use-operator-benefits-for-fare-product.tsx
+++ b/src/modules/mobility/use-operator-benefits-for-fare-product.tsx
@@ -30,15 +30,15 @@ export const useOperatorBenefitsForFareProduct = (
     ?.map((fareProductBenefit) => {
       const operator = mobilityOperators?.find(
         (mobilityOperator) =>
-          mobilityOperator.id === fareProductBenefit.operator,
+          mobilityOperator.id === fareProductBenefit.operator_id,
       );
       const operatorBenefits = operator?.benefits.find((mobilityBenefit) =>
-        fareProductBenefit.benefits.includes(mobilityBenefit.id),
+        fareProductBenefit.benefit_types.includes(mobilityBenefit.id),
       );
       if (!operatorBenefits) return;
       return {
         ...operatorBenefits,
-        operatorId: fareProductBenefit.operator,
+        operatorId: fareProductBenefit.operator_id,
       };
     })
     .filter(isDefined);


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/21812

Now the app calls the benefit service directly instead of indirectly through the mobility service

Should be merged after https://github.com/AtB-AS/benefit/pull/4, since it updates the format of the data returned from the endpoint