### PR TITLE
fix: Remove legacy useEffect

### DIFF
--- a/src/modules/mobility/queries/use-active-shmo-booking-query.tsx
+++ b/src/modules/mobility/queries/use-active-shmo-booking-query.tsx
@@ -14,7 +14,8 @@ export const useActiveShmoBookingQuery = (
 ) => {
   const acceptLanguage = useAcceptLanguage();
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
-  const res = useQuery({
+
+  return useQuery({
     enabled: isShmoDeepIntegrationEnabled,
     queryKey: getActiveShmoBookingQueryKey(acceptLanguage),
     queryFn: ({signal}) => getActiveShmoBooking(acceptLanguage, {signal}),
@@ -24,6 +25,4 @@ export const useActiveShmoBookingQuery = (
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: true,
   });
-
-  return res;
 };


### PR DESCRIPTION
After the state management refactor, we no longer need to sync booking data from active booking to any booking.
Also it caused a bug because it was triggered without new data.
This caused the previously active booking data to overwrite the finished one, and that caused the price to be 0.