### PR TITLE
chore: bump kettle to v1.4.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1478,7 +1478,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - KettleKit (1.5.1)
+  - KettleKit (1.5.5)
   - leveldb-library (1.22.6)
   - MapboxCommon (24.13.5):
     - Turf (= 4.0.0)
@@ -3274,14 +3274,14 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.3.1):
     - React-Core
-  - react-native-kettle-module (1.4.2):
+  - react-native-kettle-module (1.4.3):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - KettleKit (= 1.5.1)
+    - KettleKit (= 1.5.5)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -4620,7 +4620,7 @@ SPEC CHECKSUMS:
   hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
   Intercom: 6922723f79e2a2fb2e48b35837b56785214cf526
   intercom-react-native: e5639fa95d55e944c5687e8b9e633fedf943354f
-  KettleKit: a35575997fe055d1f2a8f41ecb98e566a8034a3f
+  KettleKit: 7888fa1cea3f55f4dbe2a5ad4ad150871a72b2d7
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   MapboxCommon: f38b69d24b1bb648629f001a6160bfaa3d8dd2b4
   MapboxCoreMaps: 90c838346286fc2136450443bfeb88194815d39b
@@ -4667,7 +4667,7 @@ SPEC CHECKSUMS:
   react-native-image-resizer: 24c5d06fae2176dc0caed4b6396e02befb44064a
   react-native-in-app-review: 1516ba69d60d58053b7eb3aaaf8d2a5a74af8b57
   react-native-keep-awake: 03b74eebe4f2bb5e8478fc8f420651a92463b6f8
-  react-native-kettle-module: fb6214c9133a4711e955f04ea6057106eb935548
+  react-native-kettle-module: cf33f72c4375417fb8e5645aa28f66ad2c363efa
   react-native-pager-view: 3d6161515c4f121854b8c82278007892ddb77b5d
   react-native-safe-area-context: 2243039f43d10cb1ea30ec5ac57fc6d1448413f4
   react-native-slider: 1603d9b8db9f5fa29d27f6f89be8e90c612c1311

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-in-app-review": "4.4.2",
     "react-native-inappbrowser-reborn": "^3.7.0",
-    "react-native-kettle-module": "1.4.2",
+    "react-native-kettle-module": "1.4.3",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-localize": "^3.2.1",
     "react-native-pager-view": "^6.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10310,10 +10310,10 @@ react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
-react-native-kettle-module@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-kettle-module/-/react-native-kettle-module-1.4.2.tgz#79bc89ba7a459e235c90c3ba95d05a29abc4058c"
-  integrity sha512-WdekwA0rA6gwf0DQBEsPMKn43FeghjiQbTveSaguR8NwHXAl/BRDgqOR0NdgkZxq20vHPEuYhB/UniEAwTnWfA==
+react-native-kettle-module@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/react-native-kettle-module/-/react-native-kettle-module-1.4.3.tgz#ff373ab758c7d934bb185913a2a643bb7498c93d"
+  integrity sha512-j5xfzyFOhf4Nl9FMDP3gEi35jzi8Qtxc2YciuhWrgy6rxQ/S82E/nJQNH4qNuWUc9EmEvLCWiFjFL0Djof2qcA==
 
 react-native-linear-gradient@^2.8.3:
   version "2.8.3"


### PR DESCRIPTION
Upgrades kettle to fix a crash on iOS.

Ref. slack threads: https://mittatb.slack.com/archives/C0116FMPX4Y/p1759822300580869 and https://mittatb.slack.com/archives/C05F7HYFCJV/p1759824792120689
