### PR TITLE
refactor: update cancel error handling in useTripsQuery

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -57,7 +57,6 @@ export function setInstallId(installId: string) {
 }
 
 export const CancelToken = axios.CancelToken;
-export const isCancel = axios.isCancel;
 
 function requestHandler(
   config: InternalAxiosRequestConfig,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,3 @@
-export {CancelToken, isCancel, client} from './client';
+export {CancelToken, client} from './client';
 export {autocomplete, reverse} from './bff/geocoder';
 export {getProfile, updateProfile, deleteProfile} from './profile';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-query.ts
@@ -1,4 +1,4 @@
-import {CancelToken, isCancel} from '@atb/api';
+import {CancelToken} from '@atb/api';
 import {tripsSearch} from '@atb/api/bff/trips';
 import {Modes} from '@atb/api/types/generated/journey_planner_v3_types';
 import {TripPattern} from '@atb/api/types/trips';
@@ -154,7 +154,7 @@ export function useTripsQuery(
             const error = e as ErrorResponse;
             setTripPatterns([]);
             setPageCursor(undefined);
-            if (!isCancel(e)) {
+            if (error.kind !== 'AXIOS_CANCEL') {
               setSearchState('search-empty-result');
               setErrorType(toAxiosErrorKind(error.kind));
               console.warn(e);


### PR DESCRIPTION
Update the error handling in the `useTripsQuery` function to improve the cancellation logic by removing the dependency on `axios.isCancel` and checking agains the error kind (`AXIOS_CANCEL`) instead. 