### PR TITLE
fix: Removed hardcoding of distances endpoint for NFK

### DIFF
--- a/src/api/bff/stop-places.ts
+++ b/src/api/bff/stop-places.ts
@@ -1,14 +1,13 @@
-import {client} from '@atb/api/index';
+import {client} from '@atb/api';
 import {stringifyUrl} from '@atb/api/utils';
 import qs from 'query-string';
 import {AxiosRequestConfig} from 'axios';
-import {APP_ORG, AUTHORITY} from '@env';
+import {AUTHORITY} from '@env';
 import {
   TransportMode,
   TransportSubmode,
 } from '@atb/api/types/generated/journey_planner_v3_types';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
-import {EnturOrgIDs} from '../../../types/app-orgs';
 
 export const getStopPlacesByMode = async (
   transportModes: TransportMode[],
@@ -51,12 +50,10 @@ export const getStopPlaceDistances = async (
   opts?: AxiosRequestConfig,
 ): Promise<StopPlaceFragment[]> => {
   const url = '/bff/v2/stop-places/distances';
-  const enturOrgId = EnturOrgIDs[APP_ORG];
   const query = qs.stringify({
     authorities: AUTHORITY,
     fromStopPlaceId,
     transportModes: [TransportMode.Water],
-    orgId: enturOrgId,
   });
   const result = await client.get<StopPlaceFragment[]>(
     stringifyUrl(url, query),

--- a/types/app-orgs.ts
+++ b/types/app-orgs.ts
@@ -11,10 +11,3 @@ export enum FareZoneAuthorities {
   fram = 'MOR',
   troms = 'TRO',
 }
-
-export const EnturOrgIDs: Record<AppOrgs, string> = {
-  [AppOrgs.nfk]: '18',
-  [AppOrgs.atb]: '3',
-  [AppOrgs.fram]: '71',
-  [AppOrgs.troms]: '72',
-};


### PR DESCRIPTION
Related to https://github.com/AtB-AS/kundevendt/issues/21813

We send in an Entur orgId, such that it is also usable for atb, fram and troms. 

Not sure if this should be done in the BFF instead, but as far as I could see the BFF had no concept of org so I didn't want to introduce it. I might be wrong though...