### PR TITLE
chore: ignore "Open debugger to view warnings" LogBox warning

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,11 @@ MapboxGL.setAccessToken(MAPBOX_API_TOKEN);
 
 trackAppState();
 
-LogBox.ignoreLogs(['new NativeEventEmitter', 'Could not find Fiber with id']);
+LogBox.ignoreLogs([
+  'new NativeEventEmitter',
+  'Could not find Fiber with id',
+  'Open debugger to view warnings.',
+]);
 
 if (Platform.OS === 'android') {
   // Default seems to be True in later React Native versions,


### PR DESCRIPTION
Permanently gets rid of this warning:

<img width="592" height="127" alt="Screenshot 2025-10-22 at 13 51 30" src="https://github.com/user-attachments/assets/1509a457-5ba5-43fc-807c-0b1b245a40e0" />
