### PR TITLE
feat: create EventStreamContext and add event log to debug menu

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,6 +41,7 @@ import {BeaconsContextProvider} from '@atb/modules/beacons';
 import {FeatureTogglesContextProvider} from '@atb/modules/feature-toggles';
 import {configureReanimatedLogger} from 'react-native-reanimated';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {EventStreamContextProvider} from './modules/event-stream/EventStreamContext';
 
 // https://rnfirebase.io/migrating-to-v22
 (globalThis as any).RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
@@ -94,45 +95,47 @@ export const App = () => {
                     <FeatureTogglesContextProvider>
                       <AuthContextProvider>
                         <TimeContextProvider>
-                          <AccessibilityContextProvider>
-                            <ThemeContextProvider>
-                              <FavoritesContextProvider>
-                                <FiltersContextProvider>
-                                  <SearchHistoryContextProvider>
-                                    <FirestoreConfigurationContextProvider>
-                                      <TicketingContextProvider>
-                                        <MobileTokenContextProvider>
-                                          <AppLanguageContextProvider>
-                                            <GeolocationContextProvider>
-                                              <MapContextProvider>
-                                                <GlobalMessagesContextProvider>
-                                                  <AnnouncementsContextProvider>
-                                                    <NotificationContextProvider>
-                                                      <BottomSheetContextProvider>
-                                                        <BottomSheetModalProvider>
-                                                          <FeedbackQuestionsContextProvider>
-                                                            <BeaconsContextProvider>
-                                                              <OnboardingContextProvider>
-                                                                <RootStack />
-                                                              </OnboardingContextProvider>
-                                                            </BeaconsContextProvider>
-                                                          </FeedbackQuestionsContextProvider>
-                                                        </BottomSheetModalProvider>
-                                                      </BottomSheetContextProvider>
-                                                    </NotificationContextProvider>
-                                                  </AnnouncementsContextProvider>
-                                                </GlobalMessagesContextProvider>
-                                              </MapContextProvider>
-                                            </GeolocationContextProvider>
-                                          </AppLanguageContextProvider>
-                                        </MobileTokenContextProvider>
-                                      </TicketingContextProvider>
-                                    </FirestoreConfigurationContextProvider>
-                                  </SearchHistoryContextProvider>
-                                </FiltersContextProvider>
-                              </FavoritesContextProvider>
-                            </ThemeContextProvider>
-                          </AccessibilityContextProvider>
+                          <EventStreamContextProvider>
+                            <AccessibilityContextProvider>
+                              <ThemeContextProvider>
+                                <FavoritesContextProvider>
+                                  <FiltersContextProvider>
+                                    <SearchHistoryContextProvider>
+                                      <FirestoreConfigurationContextProvider>
+                                        <TicketingContextProvider>
+                                          <MobileTokenContextProvider>
+                                            <AppLanguageContextProvider>
+                                              <GeolocationContextProvider>
+                                                <MapContextProvider>
+                                                  <GlobalMessagesContextProvider>
+                                                    <AnnouncementsContextProvider>
+                                                      <NotificationContextProvider>
+                                                        <BottomSheetContextProvider>
+                                                          <BottomSheetModalProvider>
+                                                            <FeedbackQuestionsContextProvider>
+                                                              <BeaconsContextProvider>
+                                                                <OnboardingContextProvider>
+                                                                  <RootStack />
+                                                                </OnboardingContextProvider>
+                                                              </BeaconsContextProvider>
+                                                            </FeedbackQuestionsContextProvider>
+                                                          </BottomSheetModalProvider>
+                                                        </BottomSheetContextProvider>
+                                                      </NotificationContextProvider>
+                                                    </AnnouncementsContextProvider>
+                                                  </GlobalMessagesContextProvider>
+                                                </MapContextProvider>
+                                              </GeolocationContextProvider>
+                                            </AppLanguageContextProvider>
+                                          </MobileTokenContextProvider>
+                                        </TicketingContextProvider>
+                                      </FirestoreConfigurationContextProvider>
+                                    </SearchHistoryContextProvider>
+                                  </FiltersContextProvider>
+                                </FavoritesContextProvider>
+                              </ThemeContextProvider>
+                            </AccessibilityContextProvider>
+                          </EventStreamContextProvider>
                         </TimeContextProvider>
                       </AuthContextProvider>
                     </FeatureTogglesContextProvider>

--- a/src/modules/event-stream/EventStreamContext.tsx
+++ b/src/modules/event-stream/EventStreamContext.tsx
@@ -1,0 +1,39 @@
+import {createContext, useContext} from 'react';
+import {useSetupEventStream} from './use-setup-event-stream';
+import {StreamEventLog} from './types';
+
+interface EventStreamContextValue {
+  eventLog: StreamEventLog;
+}
+
+export const EventStreamContext = createContext<EventStreamContextValue>({
+  eventLog: [],
+});
+
+export function useEventStreamContext() {
+  const context = useContext(EventStreamContext);
+  if (context === undefined) {
+    throw new Error(
+      'useEventStreamContext must be used within a EventStreamContextProvider',
+    );
+  }
+  return context;
+}
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const EventStreamContextProvider = ({children}: Props) => {
+  const {eventLog} = useSetupEventStream();
+
+  return (
+    <EventStreamContext.Provider
+      value={{
+        eventLog,
+      }}
+    >
+      {children}
+    </EventStreamContext.Provider>
+  );
+};

--- a/src/modules/event-stream/index.ts
+++ b/src/modules/event-stream/index.ts
@@ -1,1 +1,2 @@
 export {useSetupEventStream} from './use-setup-event-stream';
+export {EventStreamContext, useEventStreamContext} from './EventStreamContext';

--- a/src/modules/event-stream/types.ts
+++ b/src/modules/event-stream/types.ts
@@ -36,3 +36,9 @@ export const StreamEventSchema = z.discriminatedUnion('event', [
 ]);
 
 export type StreamEvent = z.infer<typeof StreamEventSchema>;
+
+export type StreamEventLog = Array<{
+  date: Date;
+  streamEvent?: StreamEvent;
+  meta?: string;
+}>;

--- a/src/modules/event-stream/use-setup-event-stream.ts
+++ b/src/modules/event-stream/use-setup-event-stream.ts
@@ -1,11 +1,11 @@
 import {useSubscription} from '@atb/api/use-subscription';
 import {useQueryClient} from '@tanstack/react-query';
-import {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 import {WS_API_BASE_URL} from '@env';
 import {getIdTokenGlobal, useAuthContext} from '../auth';
 import Bugsnag from '@bugsnag/react-native';
 import {handleStreamEvent} from './handle-stream-event';
-import {StreamEventSchema} from './types';
+import {StreamEventLog, StreamEvent, StreamEventSchema} from './types';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {jsonStringToObject} from '@atb/utils/object';
 
@@ -14,6 +14,16 @@ export const useSetupEventStream = () => {
   const {userId, isValidIdToken} = useAuthContext();
   const {isEventStreamEnabled, isEventStreamFareContractsEnabled} =
     useFeatureTogglesContext();
+
+  // Keep a list of events to use for debugging. In memory only, so this will be
+  // reset when reloading the app.
+  const [eventLog, setEventLog] = useState<StreamEventLog>([]);
+  const addToEventLog = useCallback(
+    ({streamEvent, meta}: {streamEvent?: StreamEvent; meta?: string}) => {
+      setEventLog((prev) => [{date: new Date(), streamEvent, meta}, ...prev]);
+    },
+    [],
+  );
 
   const url = `${WS_API_BASE_URL}stream/v1`;
 
@@ -32,22 +42,37 @@ export const useSetupEventStream = () => {
       Bugsnag.leaveBreadcrumb('Received event from stream', {
         data: event.data,
       });
+      addToEventLog({streamEvent});
       handleStreamEvent(streamEvent, queryClient, userId, {
         isEventStreamFareContractsEnabled,
       });
     },
-    [queryClient, isEventStreamFareContractsEnabled, userId],
+    [queryClient, isEventStreamFareContractsEnabled, userId, addToEventLog],
   );
 
-  const authenticate = useCallback((ws: WebSocket) => {
-    ws.send(`AUTH ${getIdTokenGlobal()}`);
-  }, []);
+  const onOpen = useCallback(
+    (ws: WebSocket) => {
+      addToEventLog({meta: 'OPEN'});
+      ws.send(`AUTH ${getIdTokenGlobal()}`);
+    },
+    [addToEventLog],
+  );
+
+  const onError = useCallback(
+    (event: WebSocketCloseEvent) => {
+      addToEventLog({meta: `ERROR: ${event.code} ${event.message}`});
+    },
+    [addToEventLog],
+  );
 
   useSubscription({
     url,
     // When id token is valid, we connect to the stream
     enabled: isEventStreamEnabled && isValidIdToken,
     onMessage,
-    onOpen: authenticate,
+    onOpen,
+    onError,
   });
+
+  return {eventLog};
 };

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -72,7 +72,6 @@ import {parseParamAsInt} from './utils';
 import {AnalyticsContextProvider} from '@atb/modules/analytics';
 import {Root_ParkingPhotoScreen} from './Root_ParkingPhotoScreen';
 import {Root_TripSelectionScreen} from '@atb/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen';
-import {useSetupEventStream} from '@atb/modules/event-stream';
 import {useSetupReactQueryWindowFocus} from '@atb/queries';
 import {
   Root_SmartParkAndRideAddScreen,
@@ -107,7 +106,6 @@ export const RootStack = () => {
   useBeaconsContext();
   useTestIds();
   useSetupReactQueryWindowFocus();
-  useSetupEventStream();
 
   // init Intercom user
   useRegisterIntercomUser();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -46,6 +46,8 @@ import {
   DebugTokenServerAddress,
 } from '@atb/modules/mobile-token';
 import {useMapContext} from '@atb/modules/map';
+import {useEventStreamContext} from '@atb/modules/event-stream';
+import {format} from 'date-fns';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -85,6 +87,8 @@ export const Profile_DebugInfoScreen = () => {
   } = useFeatureTogglesContext();
 
   const {resetDismissedAnnouncements} = useAnnouncementsContext();
+
+  const {eventLog} = useEventStreamContext();
 
   const {
     tokens,
@@ -341,6 +345,24 @@ export const Profile_DebugInfoScreen = () => {
                   ))}
                 </View>
               )
+            }
+          />
+        </Section>
+
+        <Section style={styles.section}>
+          <ExpandableSectionItem
+            text="Event stream log"
+            showIconText={true}
+            expandContent={
+              <View>
+                {eventLog.map((event) => (
+                  <MapEntry
+                    key={event.date.toISOString()}
+                    title={format(event.date, 'HH:mm:ss.SSS')}
+                    value={{streamEvent: event.streamEvent, meta: event.meta}}
+                  />
+                ))}
+              </View>
             }
           />
         </Section>
@@ -688,6 +710,7 @@ function MapEntry({title, value}: {title: string; value: any}) {
   const isLongString =
     !!value && typeof value === 'string' && value.length > 300;
   const [isExpanded, setIsExpanded] = useState<boolean>(!isLongString);
+  if (value === undefined) return null;
 
   if (!!value && typeof value === 'object') {
     return (
@@ -752,7 +775,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   objectEntry: {
     flexDirection: 'column',
-    marginVertical: 12,
+    marginVertical: 8,
     borderLeftColor: theme.color.foreground.dynamic.secondary,
     borderLeftWidth: 1,
     paddingLeft: 4,


### PR DESCRIPTION
As part of https://github.com/AtB-AS/kundevendt/issues/21648, and towards making it easier to debug the event stream, this adds a event stream log section to the debug menu. To achieve this, we needed an EventStreamContext to make state from the event stream available to the rest of the app. This context will likely be useful in the future, when events contain data that are used for other tasks than invalidating queries.

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-23 at 15 38 00" src="https://github.com/user-attachments/assets/33b07429-3638-4e98-a069-7113a074f205" />

## Acceptance criteria

- [x] Fare contract events are shown when purchasing a ticket
- [x] Open events are shown in the log on app open or after disconnects.
- [x] Errors shows in the log on disconnects