### PR TITLE
fix: use popTo when navigating backwards

### DIFF
--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -48,7 +48,7 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
     }
   };
   const onNavigateToMap = async (initialFilters: MapFilterType) => {
-    navigation.navigate('Root_TabNavigatorStack', {
+    navigation.popTo('Root_TabNavigatorStack', {
       screen: 'TabNav_MapStack',
       params: {
         screen: 'Map_RootScreen',

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -150,7 +150,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
       reserveMutation.data?.recurringPaymentId,
     );
     closeInAppBrowseriOS();
-    navigation.navigate('Root_TabNavigatorStack', {
+    navigation.popTo('Root_TabNavigatorStack', {
       screen: 'TabNav_TicketingStack',
       params: {
         screen: 'Ticketing_RootScreen',

--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/Root_PurchaseFareZonesSearchByTextScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/Root_PurchaseFareZonesSearchByTextScreen.tsx
@@ -88,7 +88,7 @@ export const Root_PurchaseFareZonesSearchByTextScreen: React.FC<Props> = ({
     }
     const newSelection = builder.build();
 
-    navigation.navigate('Root_PurchaseFareZonesSearchByMapScreen', {
+    navigation.popTo('Root_PurchaseFareZonesSearchByMapScreen', {
       selection: newSelection,
     });
   };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_PlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_PlaceScreen.tsx
@@ -26,7 +26,7 @@ export const Dashboard_PlaceScreen = ({navigation, route}: Props) => (
     }
     onPressClose={
       route.params.onCloseRoute
-        ? () => navigation.navigate(route.params.onCloseRoute as any)
+        ? () => navigation.popTo(route.params.onCloseRoute as any)
         : undefined
     }
   />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PlaceScreen.tsx
@@ -6,7 +6,7 @@ type Props = ProfileScreenProps<'Profile_PlaceScreen'>;
 export const Profile_PlaceScreen = ({navigation, route}: Props) => (
   <PlaceScreenComponent
     {...route.params}
-    onPressClose={() => navigation.navigate('Profile_FavoriteDeparturesScreen')}
+    onPressClose={() => navigation.popTo('Profile_FavoriteDeparturesScreen')}
     onPressQuay={(stopPlace, quayId, onlyReplaceParam) =>
       onlyReplaceParam
         ? navigation.setParams({selectedQuayId: quayId})


### PR DESCRIPTION
This fixes issues where actions that should go backwards in the stack instead added the next screen on top

- Completing a ticket purchase added a Root screen on top
- Clicking fare contract benefits adds a Root screen on top
- Picking a fare zone when searching by text navigates to a new zone map
- The close button when adding favorites departures navigates forwards

Likely caused by the react-navigation v7 upgrade: https://reactnavigation.org/docs/upgrading-from-6.x#the-navigate-method-no-longer-goes-back-use-popto-instead

Ref. slack discussion https://mittatb.slack.com/archives/C0116FMPX4Y/p1761217564887349

## Acceptance criteria

- [ ] Functionality mentioned above works as expected ☝️ 
- [ ] Should verify that navigation in obscure places in the app still works as expected.