### PR TITLE
fix: read out consumption info message with VoiceOver

### DIFF
--- a/src/modules/fare-contracts/carnet/CarnetFooter.tsx
+++ b/src/modules/fare-contracts/carnet/CarnetFooter.tsx
@@ -56,16 +56,15 @@ export const CarnetFooter: React.FC<Props> = ({
     );
 
   return (
-    <View
-      style={styles.container}
-      accessible={true}
-      accessibilityLabel={t(
-        FareContractTexts.carnet.numberOfUsedAccessesRemaining(
-          accessesRemaining,
-        ),
-      )}
-    >
-      <View>
+    <View style={styles.container}>
+      <View
+        accessible={true}
+        accessibilityLabel={t(
+          FareContractTexts.carnet.numberOfUsedAccessesRemaining(
+            accessesRemaining,
+          ),
+        )}
+      >
         <ThemeText typography="body__secondary">
           {t(
             FareContractTexts.carnet.numberOfUsedAccessesRemaining(


### PR DESCRIPTION
This makes the summary text of carnet footer accessible instead of the entire container, which makes the info message selectable with VoiceOver.

fixes https://github.com/AtB-AS/kundevendt/issues/19629#issuecomment-3442514559