### PR TITLE
fix: use popTo for navigation on zone confirm button

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByMapScreen.tsx
@@ -32,7 +32,7 @@ export const Root_PurchaseFareZonesSearchByMapScreen = ({
   );
 
   const onSave = () =>
-    navigation.navigate('Root_PurchaseOverviewScreen', {
+    navigation.popTo('Root_PurchaseOverviewScreen', {
       mode: 'Ticket',
       selection,
       onFocusElement: 'zones',


### PR DESCRIPTION
Same as https://github.com/AtB-AS/mittatb-app/pull/5533, but for the "Save selected zone" button.