### PR TITLE
refactor: remove remains of `bypassRestrictions` field

### DIFF
--- a/src/modules/mobile-token/hooks/use-toggle-token-mutation.tsx
+++ b/src/modules/mobile-token/hooks/use-toggle-token-mutation.tsx
@@ -9,15 +9,13 @@ import {useMobileTokenContext} from '../MobileTokenContext';
 
 type Args = {
   tokenId: string;
-  bypassRestrictions: boolean;
 };
 export const useToggleTokenMutation = () => {
   const queryClient = useQueryClient();
   const {userId} = useAuthContext();
   const {nativeToken, secureContainer} = useMobileTokenContext();
   return useMutation({
-    mutationFn: ({tokenId, bypassRestrictions}: Args) =>
-      tokenService.toggle(tokenId, uuid(), bypassRestrictions),
+    mutationFn: ({tokenId}: Args) => tokenService.toggle(tokenId, uuid()),
     onSuccess: (tokens) => {
       queryClient.setQueryData(
         [

--- a/src/modules/mobile-token/tokenService.ts
+++ b/src/modules/mobile-token/tokenService.ts
@@ -36,11 +36,7 @@ export type TokenService = RemoteTokenService & {
     secureContainer: string | undefined,
     traceId: string,
   ) => Promise<RemoteToken[]>;
-  toggle: (
-    tokenId: string,
-    traceId: string,
-    bypassRestrictions: boolean,
-  ) => Promise<RemoteToken[]>;
+  toggle: (tokenId: string, traceId: string) => Promise<RemoteToken[]>;
   getTokenToggleDetails: () => Promise<TokenLimitResponse>;
   postTokenStatus: (
     tokenId: string | undefined,
@@ -210,15 +206,11 @@ export const tokenService: TokenService = {
       })
       .then((res) => res.data.tokens)
       .catch(handleError),
-  toggle: async (
-    tokenId: string,
-    traceId: string,
-    bypassRestrictions: boolean,
-  ) =>
+  toggle: async (tokenId: string, traceId: string) =>
     client
       .post<ToggleResponse>(
         '/token/v1/toggle',
-        {tokenId, bypassRestrictions},
+        {tokenId},
         {
           headers: {
             [CorrelationIdHeaderName]: traceId,

--- a/src/screen-components/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
+++ b/src/screen-components/select-travel-token-screen/SelectTravelTokenScreenComponent.tsx
@@ -67,7 +67,6 @@ export const SelectTravelTokenScreenComponent = ({onAfterSave}: Props) => {
       }
       toggleMutation.mutate({
         tokenId: selectedToken.id,
-        bypassRestrictions: false,
       });
     }
   }, [selectedToken, toggleMutation, onAfterSave]);


### PR DESCRIPTION
The logic that used this was removed in #5026, and the endpoint no longer supports it.

## Acceptance criteria

- [x] Token toggling still works, and it decreases the remaining toggles as expected.