### PR TITLE
feat: Add TOKEN_ACTION_IDENTIFICATION to QR-code for carpool

### DIFF
--- a/src/modules/mobile-token/mobileTokenClient.ts
+++ b/src/modules/mobile-token/mobileTokenClient.ts
@@ -72,7 +72,10 @@ export const mobileTokenClient = {
       CONTEXT_ID,
       token.tokenId,
       [],
-      tokenActions ?? [TokenAction.TOKEN_ACTION_TICKET_INSPECTION],
+      tokenActions ?? [
+        TokenAction.TOKEN_ACTION_TICKET_INSPECTION,
+        TokenAction.TOKEN_ACTION_IDENTIFICATION,
+      ],
       false,
     ),
   clear: () => abtClient.clearToken(CONTEXT_ID),


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/team-platform/issues/939

Long story short; not allowed to identify customer by QR-code if this action is not encoded into the token.

📦 Test staging build ID: 1761638989

## Test input
- [x] Inspection of QR-code still works in inspection app