### PR TITLE
refactor: rename `onError` subscription event to `onClose`

### DIFF
--- a/src/api/bff/vehicles.ts
+++ b/src/api/bff/vehicles.ts
@@ -74,7 +74,7 @@ export const useLiveVehicleSubscription = ({
     [setLiveVehicle, setIsConnected],
   );
 
-  const onErrorHandler = useCallback(
+  const onCloseHandler = useCallback(
     () => setIsConnected(true),
     [setIsConnected],
   );
@@ -82,7 +82,7 @@ export const useLiveVehicleSubscription = ({
   useSubscription({
     url: serviceJourneyId ? url : null,
     onMessage: onMessageHandler,
-    onError: onErrorHandler,
+    onClose: onCloseHandler,
     enabled,
   });
 

--- a/src/api/use-subscription.ts
+++ b/src/api/use-subscription.ts
@@ -5,7 +5,7 @@ const RETRY_INTERVAL_CAP_IN_SECONDS = 10;
 
 export type SubscriptionProps = {
   onMessage?: (event: WebSocketMessageEvent) => void;
-  onError?: (event: WebSocketCloseEvent) => void;
+  onClose?: (event: WebSocketCloseEvent) => void;
   onOpen?: (ws: WebSocket) => void;
   url: string | null;
   enabled: boolean;
@@ -14,7 +14,7 @@ export type SubscriptionProps = {
 export function useSubscription({
   url,
   onMessage,
-  onError,
+  onClose,
   onOpen,
   enabled,
 }: SubscriptionProps) {
@@ -55,7 +55,7 @@ export function useSubscription({
           );
         }
         retryTimeout = retryWithCappedBackoff(retryCount, connect);
-        onError?.(event);
+        onClose?.(event);
       };
 
       ws.onopen = () => {
@@ -84,7 +84,7 @@ export function useSubscription({
       }
       webSocket.current = null;
     };
-  }, [url, enabled, onMessage, onError, onOpen]);
+  }, [url, enabled, onMessage, onClose, onOpen]);
 }
 
 /**

--- a/src/modules/event-stream/use-setup-event-stream.ts
+++ b/src/modules/event-stream/use-setup-event-stream.ts
@@ -58,9 +58,9 @@ export const useSetupEventStream = () => {
     [addToEventLog],
   );
 
-  const onError = useCallback(
+  const onClose = useCallback(
     (event: WebSocketCloseEvent) => {
-      addToEventLog({meta: `ERROR: ${event.code} ${event.message}`});
+      addToEventLog({meta: `CLOSE: ${event.code} ${event.message}`});
     },
     [addToEventLog],
   );
@@ -71,7 +71,7 @@ export const useSetupEventStream = () => {
     enabled: isEventStreamEnabled && isValidIdToken,
     onMessage,
     onOpen,
-    onError,
+    onClose,
   });
 
   return {eventLog};


### PR DESCRIPTION
Follow up to https://github.com/AtB-AS/mittatb-app/pull/5532

"onError" is a bit misleading, since common close events will trigger the callback.