### PR TITLE
feat: create multiline input and use for Shmo feedback

### DIFF
--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -133,7 +133,13 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
         >
           <InternalTextInput
             ref={combinedRef}
-            style={[styles.input, style]}
+            style={[
+              styles.input,
+              style,
+              props.multiline && {
+                minHeight: theme.typography.body__primary.lineHeight * 3,
+              },
+            ]}
             placeholderTextColor={theme.color.foreground.dynamic.secondary}
             onFocus={onFocusEvent}
             onBlur={onBlurEvent}

--- a/src/stacks-hierarchy/Root_ScooterHelp/Root_ContactScooterOperatorScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScooterHelp/Root_ContactScooterOperatorScreen.tsx
@@ -123,6 +123,8 @@ export const Root_ContactScooterOperatorScreen = ({
                 label={t(ContactScooterOperatorTexts.comment.label)}
                 placeholder={t(ContactScooterOperatorTexts.comment.placeholder)}
                 inlineLabel={false}
+                multiline={true}
+                scrollEnabled={false}
                 autoCapitalize="sentences"
                 errorText={
                   !isCommentValid && showError


### PR DESCRIPTION
Closes: https://github.com/AtB-AS/kundevendt/issues/20861

The issue included to 'Create a custom textfield component for the app', however this is already supported in React InternalTextInput, so all I did was add design to indicate that a input field is multiline.

Multiline input field is used on ContactScooterOperatorScreen, as seen here:

<img width="200" src="https://github.com/user-attachments/assets/d751e543-7280-4ed4-9fc6-4247c0f080a4" />
<img width="200" src="https://github.com/user-attachments/assets/23e18933-e64e-488e-b826-e0a128631f10" />
<img width="200" src="https://github.com/user-attachments/assets/c97ae085-9219-48b6-bab8-e77a307ce6ca" />
