### PR TITLE
fix: Removed flexDiscountInfo when not relevant. Also added more type safety

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -14,7 +14,10 @@ import {StartTimeSelection} from './components/StartTimeSelection';
 import {Summary} from './components/Summary';
 import {TravellerSelection} from './components/TravellerSelection';
 import {type OfferError, useOfferState} from './use-offer-state';
-import {RootStackScreenProps} from '@atb/stacks-hierarchy';
+import {
+  type RootStackParamList,
+  RootStackScreenProps,
+} from '@atb/stacks-hierarchy';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {FromToSelection} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FromToSelection';
 import {
@@ -96,9 +99,9 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   );
 
   const handleTicketInfoButtonPress = () => {
-    const parameters = {
-      fareProductTypeConfigType: selection.fareProductTypeConfig.type,
+    const parameters: RootStackParamList['Root_TicketInformationScreen'] = {
       selection,
+      shouldShowFlexTicketDiscountInfo: true,
     };
     analytics.logEvent(
       'Ticketing',

--- a/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
@@ -102,7 +102,11 @@ export const Root_TicketInformationScreen = (props: Props) => {
             </Section>
           </>
         )}
-        <FlexTicketDiscountInfo userProfiles={userProfilesWithCountAndOffer} />
+        {props.route.params.shouldShowFlexTicketDiscountInfo && (
+          <FlexTicketDiscountInfo
+            userProfiles={userProfilesWithCountAndOffer}
+          />
+        )}
         {isTipsAndInformationEnabled && (
           <>
             <ContentHeading

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -43,6 +43,7 @@ type FareContractDetailsRouteParams = {
 
 type TicketInformationScreenParams = {
   selection?: PurchaseSelectionType;
+  shouldShowFlexTicketDiscountInfo?: boolean;
 };
 
 export type Root_LoginOptionsScreenParams = {


### PR DESCRIPTION
Fixes comment from https://github.com/AtB-AS/kundevendt/issues/21851#issuecomment-3467238697

Now the flexDiscountInfo is only shown when the `shouldShowFlexDiscountInfo` flag is set, which is only set when navigating from `PurchaseOverviewScreen`. That is correct since the flexDiscountInfo is only relevant when using an offer for purchasing a new ticket. 