### PR TITLE
refactor: Remove old  android font weight fix and related logic

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -35,7 +35,7 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   children,
   ...props
 }) => {
-  const {theme, androidSystemFont} = useThemeContext();
+  const {theme} = useThemeContext();
   const textColor = useColor(color, type);
 
   const typeStyle = {
@@ -45,14 +45,6 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
 
   let textStyle: TextStyle = typeStyle;
 
-  if (Platform.OS === 'android' && !androidSystemFont) {
-    textStyle = {
-      ...typeStyle,
-      fontFamily:
-        typeStyle.fontWeight === 'bold' ? 'Roboto-Bold' : 'Roboto-Regular',
-      fontWeight: 'normal',
-    };
-  }
   // Set specific letter spacing for android phones, as 0.4 leads to errors on newer pixel phones
   // https://github.com/facebook/react-native/issues/35039
   if (

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -42,23 +42,8 @@ const appOrgToThemeVariant = (appOrg: AppOrgs): ThemeVariant => {
 
 const mainThemes = createThemesFor(appOrgToThemeVariant(APP_ORG));
 
-// Override semibold with bold to avoid Android Roboto bold bug.
-// See https://github.com/facebook/react-native/issues/25696
-const fontWeightFix = {
-  fontWeight: Platform.select({
-    android: 'bold',
-    default: '600',
-  }) as 'bold' | '600',
-};
-
 const androidOrIos = Platform.OS === 'android' ? 'android' : 'ios';
-export const textTypeStyles = createTextTypeStyles(androidOrIos, {
-  'body__primary--bold': fontWeightFix,
-  'body__secondary--bold': fontWeightFix,
-  heading__component: fontWeightFix,
-  heading__paragraph: fontWeightFix,
-  heading__title: fontWeightFix,
-});
+export const textTypeStyles = createTextTypeStyles(androidOrIos);
 
 const tripLegDetail = {
   labelWidth: 80,


### PR DESCRIPTION
Eliminate outdated logic related to font weight adjustments for Android, simplifying the text styling process.