### PR TITLE
fix: update contact link to use full URL and change translation text for link

### DIFF
--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
@@ -169,7 +169,7 @@ const ContactInfoContent = () => {
         </GenericSectionItem>
         <GenericSectionItem>
           <PressableOpacity
-            onPress={async () => Linking.openURL(`atb.no/kontakt`)}
+            onPress={async () => Linking.openURL('https://atb.no/kontakt')}
             accessibilityRole="link"
             style={style.linkItem}
           >

--- a/src/translations/screens/subscreens/SmartParkAndRide.ts
+++ b/src/translations/screens/subscreens/SmartParkAndRide.ts
@@ -21,7 +21,7 @@ const SmartParkAndRideTexts = {
       'With a valid ticket from AtB, you can park for free at Ranheim Fabrikker for 48 hours.',
       'Med gyldig billett frå AtB kan du stå gratis på Ranheim Fabrikker i 48 timar.',
     ),
-    link: _('Sånn funker det', 'How it works', 'Slik fungerer det'),
+    link: _('Les mer', 'Read more', 'Les meir'),
   },
   add: {
     header: {


### PR DESCRIPTION
Adds `https` to the URL for it to open properly.

Updates translation of button in how it works section.