### PR TITLE
fix: snake_case instead of camelCase in remote config

### DIFF
--- a/src/modules/map/MapContext.tsx
+++ b/src/modules/map/MapContext.tsx
@@ -61,10 +61,10 @@ type Props = {
 };
 
 export const MapContextProvider = ({children}: Props) => {
-  const {mapboxApiToken} = useRemoteConfigContext();
+  const {mapbox_api_token} = useRemoteConfigContext();
   useEffect(() => {
-    MapboxGL.setAccessToken(mapboxApiToken);
-  }, [mapboxApiToken]);
+    MapboxGL.setAccessToken(mapbox_api_token);
+  }, [mapbox_api_token]);
 
   const [mapState, dispatchMapState] = useReducer(mapStateReducer, {
     bottomSheetType: MapBottomSheetType.None,

--- a/src/modules/map/components/national-stop-registry-features/use-nsr-circle-layers.ts
+++ b/src/modules/map/components/national-stop-registry-features/use-nsr-circle-layers.ts
@@ -14,14 +14,14 @@ export const useNsrCircleLayers = (
   selectedFeaturePropertyId: NsrProps['selectedFeaturePropertyId'],
 ): SymbolLayerProps[] => {
   const {theme, themeName} = useThemeContext();
-  const {mapboxNsrSourceLayerId} = useRemoteConfigContext();
+  const {mapbox_nsr_source_layer_id} = useRemoteConfigContext();
 
   return useMemo(
     () =>
       nsrCircleLayers.map((nsrCircleLayer) => {
         const {id, reachFullScaleAtZoomLevel} = nsrCircleLayer;
         const nsrLayerSourceProps = getNsrLayerSourceProps(
-          mapboxNsrSourceLayerId,
+          mapbox_nsr_source_layer_id,
           id,
         );
 
@@ -55,7 +55,7 @@ export const useNsrCircleLayers = (
         };
       }),
     [
-      mapboxNsrSourceLayerId,
+      mapbox_nsr_source_layer_id,
       selectedFeaturePropertyId,
       theme.color.transport.city.primary.background,
       themeName,

--- a/src/modules/map/components/national-stop-registry-features/use-nsr-symbol-layers.ts
+++ b/src/modules/map/components/national-stop-registry-features/use-nsr-symbol-layers.ts
@@ -16,7 +16,7 @@ export const useNsrSymbolLayers = (
   selectedFeaturePropertyId: NsrProps['selectedFeaturePropertyId'],
 ): SymbolLayerProps[] => {
   const {theme, themeName} = useThemeContext();
-  const {mapboxNsrSourceLayerId} = useRemoteConfigContext();
+  const {mapbox_nsr_source_layer_id} = useRemoteConfigContext();
 
   return useMemo(
     () =>
@@ -29,7 +29,7 @@ export const useNsrSymbolLayers = (
           reachFullScaleAtZoomLevel,
         } = nsrSymbolLayer;
         const nsrSymbolLayerSourceProps = getNsrLayerSourceProps(
-          mapboxNsrSourceLayerId,
+          mapbox_nsr_source_layer_id,
           id,
         );
 
@@ -123,7 +123,7 @@ export const useNsrSymbolLayers = (
         };
       }),
     [
-      mapboxNsrSourceLayerId,
+      mapbox_nsr_source_layer_id,
       selectedFeaturePropertyId,
       theme.color.foreground.dynamic.primary,
       theme.color.foreground.inverse.primary,

--- a/src/modules/map/hooks/use-mapbox-json-style.tsx
+++ b/src/modules/map/hooks/use-mapbox-json-style.tsx
@@ -41,7 +41,7 @@ export const useMapboxJsonStyle: (
 ) => string | undefined = (includeVehiclesAndStationsVectorSource) => {
   const {themeName} = useThemeContext();
   const {language} = useTranslation();
-  const {mapboxUserName, mapboxNsrTilesetId} = useRemoteConfigContext();
+  const {mapbox_user_name, mapbox_nsr_tileset_id} = useRemoteConfigContext();
 
   const {configurableLinks} = useFirestoreConfigurationContext();
   const mapboxSpriteUrl =
@@ -55,8 +55,8 @@ export const useMapboxJsonStyle: (
   const themedStyleWithExtendedSourcesAndSlotLayers = useMemo(() => {
     const themedStyle =
       themeName === 'dark'
-        ? getMapboxDarkStyle(mapboxUserName, mapboxNsrTilesetId)
-        : getMapboxLightStyle(mapboxUserName, mapboxNsrTilesetId);
+        ? getMapboxDarkStyle(mapbox_user_name, mapbox_nsr_tileset_id)
+        : getMapboxLightStyle(mapbox_user_name, mapbox_nsr_tileset_id);
 
     const extendedSources: StyleJsonVectorSourcesObj = {
       ...themedStyle.sources,
@@ -78,8 +78,8 @@ export const useMapboxJsonStyle: (
     };
   }, [
     themeName,
-    mapboxUserName,
-    mapboxNsrTilesetId,
+    mapbox_user_name,
+    mapbox_nsr_tileset_id,
     includeVehiclesAndStationsVectorSource,
     vehiclesAndStationsVectorSourceId,
     vehiclesAndStationsVectorSource,

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -90,10 +90,10 @@ export type RemoteConfig = {
   flex_ticket_url: string;
   live_vehicle_stale_threshold: number;
   loading_screen_delay_ms: number;
-  mapboxApiToken: string;
-  mapboxNsrSourceLayerId: string;
-  mapboxNsrTilesetId: string;
-  mapboxUserName: string;
+  mapbox_api_token: string;
+  mapbox_nsr_source_layer_id: string;
+  mapbox_nsr_tileset_id: string;
+  mapbox_user_name: string;
   minimum_app_version: string;
   must_upgrade_ticketing: boolean;
   new_favourites_info_url: string;
@@ -181,10 +181,10 @@ export const defaultRemoteConfig: RemoteConfig = {
   flex_ticket_url: '',
   live_vehicle_stale_threshold: 15,
   loading_screen_delay_ms: 200,
-  mapboxApiToken: MAPBOX_API_TOKEN,
-  mapboxNsrSourceLayerId: MAPBOX_NSR_SOURCE_LAYER_ID,
-  mapboxNsrTilesetId: MAPBOX_NSR_TILESET_ID,
-  mapboxUserName: MAPBOX_USER_NAME,
+  mapbox_api_token: MAPBOX_API_TOKEN,
+  mapbox_nsr_source_layer_id: MAPBOX_NSR_SOURCE_LAYER_ID,
+  mapbox_nsr_tileset_id: MAPBOX_NSR_TILESET_ID,
+  mapbox_user_name: MAPBOX_USER_NAME,
   minimum_app_version: '',
   must_upgrade_ticketing: false,
   new_favourites_info_url: '',
@@ -388,16 +388,18 @@ export function getConfig(): RemoteConfig {
   const loading_screen_delay_ms =
     values['loading_screen_delay_ms']?.asNumber() ??
     defaultRemoteConfig.loading_screen_delay_ms;
-  const mapboxApiToken =
-    values['mapboxApiToken']?.asString() ?? defaultRemoteConfig.mapboxApiToken;
-  const mapboxNsrSourceLayerId =
-    values['mapboxNsrSourceLayerId']?.asString() ??
-    defaultRemoteConfig.mapboxNsrSourceLayerId;
-  const mapboxNsrTilesetId =
-    values['mapboxNsrTilesetId']?.asString() ??
-    defaultRemoteConfig.mapboxNsrTilesetId;
-  const mapboxUserName =
-    values['mapboxUserName']?.asString() ?? defaultRemoteConfig.mapboxUserName;
+  const mapbox_api_token =
+    values['mapbox_api_token']?.asString() ??
+    defaultRemoteConfig.mapbox_api_token;
+  const mapbox_nsr_source_layer_id =
+    values['mapbox_nsr_source_layer_id']?.asString() ??
+    defaultRemoteConfig.mapbox_nsr_source_layer_id;
+  const mapbox_nsr_tileset_id =
+    values['mapbox_nsr_tileset_id']?.asString() ??
+    defaultRemoteConfig.mapbox_nsr_tileset_id;
+  const mapbox_user_name =
+    values['mapbox_user_name']?.asString() ??
+    defaultRemoteConfig.mapbox_user_name;
   const minimum_app_version =
     values['minimum_app_version']?.asString() ??
     defaultRemoteConfig.minimum_app_version;
@@ -505,10 +507,10 @@ export function getConfig(): RemoteConfig {
     flex_ticket_url,
     live_vehicle_stale_threshold,
     loading_screen_delay_ms,
-    mapboxApiToken,
-    mapboxNsrSourceLayerId,
-    mapboxNsrTilesetId,
-    mapboxUserName,
+    mapbox_api_token,
+    mapbox_nsr_source_layer_id,
+    mapbox_nsr_tileset_id,
+    mapbox_user_name,
     minimum_app_version,
     must_upgrade_ticketing,
     new_favourites_info_url,


### PR DESCRIPTION
Follow-up to https://github.com/AtB-AS/mittatb-app/pull/5559.
Using snake_case instead since it is used for all other remote config names.