### PR TITLE
fix: avoid using selection builder for ticket information

### DIFF
--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -17,7 +17,6 @@ import {MapFilterType} from '@atb/modules/map';
 import {useAuthContext} from '@atb/modules/auth';
 import {ErrorBoundary} from '@atb/screen-components/error-boundary';
 import {hasShmoBookingId} from '@atb/modules/fare-contracts';
-import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
 
 type Props = RootStackScreenProps<'Root_FareContractDetailsScreen'>;
 
@@ -32,7 +31,6 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
   const {fareContract, preassignedFareProduct} = useTicketInfo(
     route.params.fareContractId,
   );
-  const purchaseSelectionBuilder = usePurchaseSelectionBuilder();
 
   const isSentFareContract =
     fareContract?.customerAccountId !== fareContract?.purchasedBy &&
@@ -42,16 +40,11 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
 
   const navigateToTicketInfoScreen = () => {
     if (preassignedFareProduct) {
-      const selection = purchaseSelectionBuilder
-        .forType(preassignedFareProduct?.type)
-        .product(preassignedFareProduct)
-        .build();
-
       analytics.logEvent('Ticketing', 'Ticket information button clicked', {
-        selection,
+        fareProductTypeConfigType: preassignedFareProduct.type,
       });
       navigation.navigate('Root_TicketInformationScreen', {
-        selection,
+        preassignedFareProductId: preassignedFareProduct.id,
       });
     }
   };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -100,8 +100,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
 
   const handleTicketInfoButtonPress = () => {
     const parameters: RootStackParamList['Root_TicketInformationScreen'] = {
-      selection,
-      shouldShowFlexTicketDiscountInfo: true,
+      preassignedFareProductId: preassignedFareProduct.id,
+      userProfilesWithCountAndOffer: userProfilesWithCountAndOffer,
     };
     analytics.logEvent(
       'Ticketing',

--- a/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
@@ -20,36 +20,30 @@ import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 import {FlexTicketDiscountInfo} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo';
 import React from 'react';
-import {useParamAsState} from '@atb/utils/use-param-as-state';
-import {useOfferState} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state';
-import {useProductAlternatives} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-product-alternatives';
 
 type Props = RootStackScreenProps<'Root_TicketInformationScreen'>;
 
-export const Root_TicketInformationScreen = (props: Props) => {
+export const Root_TicketInformationScreen = ({route}: Props) => {
+  const {preassignedFareProductId, userProfilesWithCountAndOffer} =
+    route.params;
+
   const {t, language} = useTranslation();
   const styles = useStyle();
   const {theme} = useThemeContext();
   const themeColor = theme.color.background.accent[0];
   const {fareProductTypeConfigs} = useFirestoreConfigurationContext();
   const {data: preassignedFareProducts} = useGetFareProductsQuery();
-  const [selection] = useParamAsState(props.route.params.selection);
-  const preassignedFareProductAlternatives = useProductAlternatives(selection);
-  const {userProfilesWithCountAndOffer} = useOfferState(
-    preassignedFareProductAlternatives,
-    selection,
-  );
 
   const {isTipsAndInformationEnabled} = useFeatureTogglesContext();
   const {benefits} = useOperatorBenefitsForFareProduct(
-    selection?.preassignedFareProduct.id,
+    preassignedFareProductId,
   );
 
-  const fareProductTypeConfig = fareProductTypeConfigs.find(
-    (f) => f.type === selection?.fareProductTypeConfig.type,
-  );
   const preassignedFareProduct = preassignedFareProducts.find(
-    (p) => p.id === selection?.preassignedFareProduct.id,
+    (p) => p.id === preassignedFareProductId,
+  );
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (f) => f.type === preassignedFareProduct?.type,
   );
 
   return (
@@ -102,7 +96,7 @@ export const Root_TicketInformationScreen = (props: Props) => {
             </Section>
           </>
         )}
-        {props.route.params.shouldShowFlexTicketDiscountInfo && (
+        {userProfilesWithCountAndOffer && (
           <FlexTicketDiscountInfo
             userProfiles={userProfilesWithCountAndOffer}
           />

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -16,6 +16,7 @@ import {Root_ChooseTicketRecipientScreenParams} from '@atb/stacks-hierarchy/Root
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import {Root_SmartParkAndRideEditScreenParams} from '@atb/stacks-hierarchy/Root_SmartParkAndRide/navigation-types';
 import {Root_OnboardingCarouselStackParams} from './Root_OnboardingCarouselStack';
+import {UserProfileWithCountAndOffer} from './Root_PurchaseOverviewScreen/use-offer-state';
 
 export type Root_AddEditFavoritePlaceScreenParams = {
   editItem?: StoredLocationFavorite;
@@ -42,8 +43,8 @@ type FareContractDetailsRouteParams = {
 };
 
 type TicketInformationScreenParams = {
-  selection?: PurchaseSelectionType;
-  shouldShowFlexTicketDiscountInfo?: boolean;
+  preassignedFareProductId: string | undefined;
+  userProfilesWithCountAndOffer?: UserProfileWithCountAndOffer[];
 };
 
 export type Root_LoginOptionsScreenParams = {


### PR DESCRIPTION
This fixes a bug where non-sellable products like the school ticket didn't work for the ticket information screen, since the selection builder breaks when there is no sellable products of a given type. Introduced in #5517.

Instead we now provide userProfilesWithCountAndOffer directly, which isn't defined outside the purchase flow.

Also cleans up the props used for the ticket information screen.