### PR TITLE
fix: use correct border radius for small `CounterIconBox`es

### DIFF
--- a/src/components/icon-box/CounterIconBox.tsx
+++ b/src/components/icon-box/CounterIconBox.tsx
@@ -4,6 +4,7 @@ import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {TextNames} from '@atb/theme/colors';
 import {useFontScale} from '@atb/utils/use-font-scale';
+import {getIconBoxBorderRadius} from './utils';
 
 const getTransportColor = (theme: Theme) => theme.color.transport.other;
 
@@ -35,6 +36,7 @@ export const CounterIconBox = ({
         {
           padding:
             spacing === 'compact' ? theme.spacing.xSmall : theme.spacing.small,
+          borderRadius: getIconBoxBorderRadius(size, theme),
         },
       ]}
       importantForAccessibility="no-hide-descendants"
@@ -59,6 +61,5 @@ export const CounterIconBox = ({
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   counterContainer: {
     backgroundColor: getTransportColor(theme).primary.background,
-    borderRadius: theme.border.radius.regular,
   },
 }));

--- a/src/components/icon-box/TransportationIconBox.tsx
+++ b/src/components/icon-box/TransportationIconBox.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {StyleProp, View, ViewStyle} from 'react-native';
 
-import {StyleSheet, Theme} from '@atb/theme';
+import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {useTransportColor} from '@atb/utils/use-transport-color';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemeText} from '@atb/components/text';
-import {getTransportModeSvg} from './utils';
+import {getIconBoxBorderRadius, getTransportModeSvg} from './utils';
 import {AnyMode, AnySubMode} from '@atb/components/icon-box';
 
 export type TransportationIconBoxProps = {
@@ -41,6 +41,7 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
     : transportationColor.background;
   const {svg} = getTransportModeSvg(mode, subMode);
   const styles = useStyles();
+  const {theme} = useThemeContext();
 
   const lineNumberElement = lineNumber ? (
     <ThemeText
@@ -58,12 +59,10 @@ export const TransportationIconBox: React.FC<TransportationIconBoxProps> = ({
       style={[
         styles.transportationIconBox,
         type === 'standard' && styles.standardTransportationIconBox,
-        size === 'large' || size === 'normal'
-          ? styles.regularBorderRadius
-          : styles.smallBorderRadius,
         style,
         {
           backgroundColor,
+          borderRadius: getIconBoxBorderRadius(size, theme),
         },
       ]}
     >
@@ -84,12 +83,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     display: 'flex',
     flexDirection: 'row',
     padding: theme.spacing.xSmall,
-  },
-  smallBorderRadius: {
-    borderRadius: theme.border.radius.small,
-  },
-  regularBorderRadius: {
-    borderRadius: theme.border.radius.regular,
   },
   standardTransportationIconBox: {
     padding: theme.spacing.small,

--- a/src/components/icon-box/utils.ts
+++ b/src/components/icon-box/utils.ts
@@ -91,3 +91,18 @@ export const getGeofencingZoneCodeIconColor = (
       return theme.color.geofencingZone.noParking.color;
   }
 };
+
+export const getIconBoxBorderRadius = (
+  size: keyof Theme['icon']['size'],
+  theme: Theme,
+): number => {
+  switch (size) {
+    case 'xSmall':
+    case 'small':
+      return theme.border.radius.small;
+    case 'normal':
+    case 'large':
+    default:
+      return theme.border.radius.regular;
+  }
+};


### PR DESCRIPTION
Fixes an issue where the wrong border radius was applied to CounterIconBox. Introduced in #5511.

## Before / after

Slight change on the "+2" border radius:

<div>
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-13 at 11 03 17" src="https://github.com/user-attachments/assets/f2057103-a6fa-449b-a316-ec69017ea977" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-13 at 11 03 04" src="https://github.com/user-attachments/assets/d933263e-dc2d-4e0e-864e-d4c638022dfc" />
</div>

## Acceptance criteria

- [x] Make sure consistent border radius is applied between the "counter" boxes and regular transportation icons
	- Travel search
	- Ticket information (youth ticket / school ticket)