### PR TITLE
refactor: clean up location handling in NearbyStopPlaces

### DIFF
--- a/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -229,6 +229,8 @@ const Header = React.memo(function Header({
       setLocation({...geolocation, resultType: 'geolocation'});
     } else {
       requestLocationPermission(false);
+      // The screen should detect when geolocation is available, so no need to
+      // manually call setLocation.
     }
   };
 


### PR DESCRIPTION
I found the location setting functions in NearbyStopPlaces a bit confusing, so cleaned it up a bit.

### Acceptance criteria

- [x] Setting location / geolocation in the departures tab works as before