### PR TITLE
fix: text input section alignment android

### DIFF
--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -138,6 +138,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
               style,
               props.multiline && {
                 minHeight: theme.typography.body__m.lineHeight * 3,
+                textAlignVertical: 'top',
               },
             ]}
             placeholderTextColor={theme.color.foreground.dynamic.secondary}
@@ -183,7 +184,6 @@ const useInputStyle = StyleSheet.createTheme((theme) => ({
     color: theme.color.foreground.dynamic.primary,
     paddingRight: 40,
     paddingVertical: 0,
-    textAlignVertical: 'top',
     fontSize: theme.typography.body__m.fontSize,
   },
   container: {


### PR DESCRIPTION
## ✨ Description
After this PR: https://github.com/AtB-AS/kundevendt/issues/20861
This Alignment error appeared on input fields with labels on Android:
<img width="487" height="99" alt="image" src="https://github.com/user-attachments/assets/3ec54aef-93cb-4ff5-bd05-a35901f2fa49" />

## 💯  Solution
textAlignVertically top only on multiline text inputs

## 📋 Acceptance criteria

- [x] Input field with label looks correct (text center aligned) on android
- [x] Multipline input field looks correct (text top aligned) on androind