### PR TITLE
fix: Complete onboarding section when closing carousel

### DIFF
--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_AutomaticRegistrationScreen.tsx
@@ -37,7 +37,7 @@ export const SmartParkAndRideOnboarding_AutomaticRegistrationScreen = () => {
         },
         rightButton: {
           type: 'close',
-          onPress: () => closeOnboardingCarousel('smartParkAndRide'),
+          onPress: closeOnboardingCarousel,
         },
       }}
       title={t(SmartParkAndRideTexts.onboarding.automaticRegistration.title)}

--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
@@ -41,7 +41,7 @@ export const SmartParkAndRideOnboarding_ContactInfoScreen = () => {
         },
         rightButton: {
           type: 'close',
-          onPress: () => closeOnboardingCarousel('smartParkAndRide'),
+          onPress: closeOnboardingCarousel,
         },
       }}
       title={t(SmartParkAndRideTexts.onboarding.contactInfo.title)}

--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_InformationScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_InformationScreen.tsx
@@ -24,7 +24,7 @@ export const SmartParkAndRideOnboarding_InformationScreen = () => {
       headerProps={{
         rightButton: {
           type: 'close',
-          onPress: () => closeOnboardingCarousel('smartParkAndRide'),
+          onPress: closeOnboardingCarousel,
         },
       }}
       title={t(SmartParkAndRideTexts.onboarding.information.title)}


### PR DESCRIPTION
Fixes a bug where the onboarding for SPAR went in a loop.
The problem was that the onboarding section flag was not updated.

Acceptance Criteria:
- [x] The SPAR onboarding should appear the first time entering the "Innfartsparkering" screen
- [x] The SPAR onboarding should not show again after completion
   - [x] By closing in the top right corner
   - [x] By clicking the done button
- [x] Re-test: Bonus pilot onboarding