### PR TITLE
fix: Remove error logging

### DIFF
--- a/src/modules/onboarding/onboarding-carousel/use-onboarding-carousel-navigation.ts
+++ b/src/modules/onboarding/onboarding-carousel/use-onboarding-carousel-navigation.ts
@@ -44,8 +44,7 @@ const useCloseOnboardingCarousel = (configId: OnboardingCarouselConfigId) => {
     if (comingFromOnboardingSectionId) {
       continueFromOnboardingSection(comingFromOnboardingSectionId);
     } else {
-      // should never happen
-      console.error('UNKNOWN ONBOARDING SECTION');
+      // onboarding carousel entered manually, not through config
       navigation.getParent()?.goBack();
     }
   }, [


### PR DESCRIPTION
Minor follow-up to https://github.com/AtB-AS/mittatb-app/pull/5600
When the onboarding carousel is navigated to manually, it is correct to navigate back, not unexpected.
This just removes the local error log and updates the comment, no functionality change.

_No re-test needed after this_