### PR TITLE
feat: add progressBetweenStops debug toggle

### DIFF
--- a/src/api/types/generated/ServiceJourneyVehiclesQuery.ts
+++ b/src/api/types/generated/ServiceJourneyVehiclesQuery.ts
@@ -8,5 +8,7 @@ export type GetServiceJourneyVehicleQuery = {
     vehicleStatus?: Types.VehicleStatusEnumeration;
     location?: {latitude: number; longitude: number};
     serviceJourney?: {id: string};
+    progressBetweenStops?: {percentage?: number; linkDistance?: number};
+    monitoredCall?: {stopPointRef?: string; vehicleAtStop?: boolean};
   }>;
 };

--- a/src/modules/preferences/types.ts
+++ b/src/modules/preferences/types.ts
@@ -28,6 +28,7 @@ export type UserPreferences = {
   // not the entire accessibility settings
   journeyAidEnabled?: boolean;
   debugPredictionInaccurate?: boolean;
+  debugShowProgressBetweenStops?: boolean;
 };
 
 export type PreferenceItem = keyof UserPreferences;

--- a/src/screen-components/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
+++ b/src/screen-components/travel-details-map-screen/TravelDetailsMapScreenComponent.tsx
@@ -39,6 +39,10 @@ import {
   RegionPayload,
 } from '@rnmapbox/maps/lib/typescript/src/components/MapView';
 import {ServiceJourneyPolyline} from '@atb/api/types/serviceJourney';
+import {ThemeText} from '@atb/components/text';
+import {debugProgressBetweenStopsText} from '../travel-details-screens/utils';
+import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
+import {usePreferencesContext} from '@atb/modules/preferences';
 
 export type TravelDetailsMapScreenParams = {
   serviceJourneyPolylines: ServiceJourneyPolyline[];
@@ -48,6 +52,7 @@ export type TravelDetailsMapScreenParams = {
   mode?: AnyMode;
   subMode?: AnySubMode;
   mapFilter?: MapFilterType;
+  estimatedCalls?: Array<EstimatedCallWithQuayFragment>;
 };
 
 type Props = TravelDetailsMapScreenParams & {
@@ -66,12 +71,16 @@ export const TravelDetailsMapScreenComponent = ({
   onPressBack,
   mode,
   subMode,
+  estimatedCalls,
 }: Props) => {
   const mapCameraRef = useRef<MapboxGL.Camera>(null);
   const mapViewRef = useRef<MapboxGL.MapView>(null);
   const {location: geolocation} = useGeolocationContext();
   const isFocusedAndActive = useIsFocusedAndActive();
   const [loadedMap, setLoadedMap] = useState(false);
+  const {
+    preferences: {debugShowProgressBetweenStops},
+  } = usePreferencesContext();
 
   const mapViewConfig = useMapViewConfig();
 
@@ -218,6 +227,11 @@ export const TravelDetailsMapScreenComponent = ({
           }}
         />
       </View>
+      {debugShowProgressBetweenStops && liveVehicle && (
+        <ThemeText style={{color: 'white', backgroundColor: 'black'}}>
+          {debugProgressBetweenStopsText(liveVehicle, estimatedCalls)}
+        </ThemeText>
+      )}
     </View>
   );
 };

--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -64,6 +64,7 @@ import {
   getLineAndTimeA11yLabel,
   getNoticesForServiceJourney,
   getShouldShowLiveVehicle,
+  debugProgressBetweenStopsText,
 } from './utils';
 import {BookingOptions} from './components/BookingOptions';
 import {BookingInfoBox} from './components/BookingInfoBox';
@@ -157,7 +158,10 @@ export const DepartureDetailsScreenComponent = ({
   const screenReaderEnabled = useIsScreenReaderEnabled();
 
   const {
-    preferences: {journeyAidEnabled: travelAidPreferenceEnabled},
+    preferences: {
+      journeyAidEnabled: travelAidPreferenceEnabled,
+      debugShowProgressBetweenStops,
+    },
   } = usePreferencesContext();
   const shouldShowTravelAid =
     travelAidPreferenceEnabled &&
@@ -252,6 +256,7 @@ export const DepartureDetailsScreenComponent = ({
       vehicleWithPosition: vehiclePosition,
       mode: serviceJourney?.transportMode,
       subMode: serviceJourney?.transportSubmode,
+      estimatedCalls: serviceJourney?.estimatedCalls,
     });
   };
 
@@ -335,6 +340,14 @@ export const DepartureDetailsScreenComponent = ({
               <View style={styles.headerSubSection}>
                 <LastPassedStop realtimeText={realtimeText} />
               </View>
+            )}
+            {debugShowProgressBetweenStops && vehiclePosition && (
+              <ThemeText typography="body__s">
+                {debugProgressBetweenStopsText(
+                  vehiclePosition,
+                  serviceJourney?.estimatedCalls,
+                )}
+              </ThemeText>
             )}
           </View>
         )}

--- a/src/screen-components/travel-details-screens/use-get-service-journey-vehicles.ts
+++ b/src/screen-components/travel-details-screens/use-get-service-journey-vehicles.ts
@@ -1,4 +1,5 @@
 import {getServiceJourneyVehicles} from '@atb/api/bff/vehicles';
+import {usePreferencesContext} from '@atb/modules/preferences';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {useQuery} from '@tanstack/react-query';
 
@@ -6,12 +7,16 @@ export const useGetServiceJourneyVehiclesQuery = (
   serviceJourneyIds: string[],
   enabled: boolean = true,
 ) => {
+  const {
+    preferences: {debugShowProgressBetweenStops},
+  } = usePreferencesContext();
+
   const isFocusedAndActive = useIsFocusedAndActive();
   return useQuery({
     enabled: enabled && isFocusedAndActive,
     queryKey: ['serviceJourneyVehicles', ...serviceJourneyIds],
     queryFn: () => getServiceJourneyVehicles(serviceJourneyIds),
-    refetchInterval: 20000,
+    refetchInterval: debugShowProgressBetweenStops ? 2000 : 20000,
     initialData: [],
   });
 };

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -26,6 +26,7 @@ import {BookingStatus, TripPatternBookingStatus} from './types';
 import {Statuses} from '@atb/theme';
 import {isDefined} from '@atb/utils/presence';
 import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
+import {VehicleWithPosition} from '@atb/api/types/vehicles';
 
 export const getNoticesForLeg = (leg: Leg) =>
   filterNotices([
@@ -491,4 +492,21 @@ export function isFreeLeg(leg: Leg) {
     leg.transportSubmode === TransportSubmode.LocalCarFerry ||
     leg.transportSubmode === TransportSubmode.LocalPassengerFerry
   );
+}
+
+export function debugProgressBetweenStopsText(
+  vehiclePosition: VehicleWithPosition,
+  estimatedCalls?: Array<EstimatedCallWithQuayFragment>,
+): string {
+  const stopPointRefName =
+    estimatedCalls?.find(
+      (ec) => ec.quay.id === vehiclePosition?.monitoredCall?.stopPointRef,
+    )?.quay.name ?? vehiclePosition.monitoredCall?.stopPointRef;
+
+  const percent = `${vehiclePosition.progressBetweenStops?.percentage?.toFixed(0)}%`;
+  const distance = `${vehiclePosition.progressBetweenStops?.linkDistance}m`;
+  const atStop = vehiclePosition.monitoredCall?.vehicleAtStop
+    ? ' (at stop)'
+    : '';
+  return `${percent} of ${distance} until ${stopPointRefName}${atStop}`;
 }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -153,8 +153,12 @@ export const Profile_DebugInfoScreen = () => {
   }
 
   const {setPreference, preferences} = usePreferencesContext();
-  const {showTestIds, debugShowSeconds, debugPredictionInaccurate} =
-    preferences;
+  const {
+    showTestIds,
+    debugShowSeconds,
+    debugPredictionInaccurate,
+    debugShowProgressBetweenStops,
+  } = preferences;
 
   return (
     <View style={styles.container}>
@@ -200,6 +204,13 @@ export const Profile_DebugInfoScreen = () => {
             value={debugShowSeconds}
             onValueChange={(debugShowSeconds) => {
               setPreference({debugShowSeconds});
+            }}
+          />
+          <ToggleSectionItem
+            text="Display percentage between stops in departure details"
+            value={debugShowProgressBetweenStops}
+            onValueChange={(debugShowProgressBetweenStops) => {
+              setPreference({debugShowProgressBetweenStops});
             }}
           />
           <ToggleSectionItem


### PR DESCRIPTION
As part of https://github.com/AtB-AS/kundevendt/issues/22219, it was suggested to add a debug toggle to show data from the `progressBetweenStops` field in the vehicle service. This adds that toggle and info on departure details and for bus in map.

Depends on BFF change: https://github.com/AtB-AS/atb-bff/pull/418

<img width="250" alt="simulator_screenshot_5A700206-6C6A-4EC6-B592-8D27D1D18E51" src="https://github.com/user-attachments/assets/ba661f1a-7ea6-439d-a74c-daad33ea325b" />
<img width="250" alt="simulator_screenshot_CC9445DD-527E-4B68-83FE-FAE0520A7C2F" src="https://github.com/user-attachments/assets/123e984c-8022-4252-964a-931a6f37fa7c" />
<img width="250" alt="simulator_screenshot_FECD6166-4987-4E5C-9FCA-0867BC926385" src="https://github.com/user-attachments/assets/5468f477-2116-4fea-96f4-c0cb79c00d13" />

closes https://github.com/AtB-AS/kundevendt/issues/22219