### PR TITLE
fix: small polygons polylabel issue

### DIFF
--- a/src/modules/map/geofencing-zone-utils.ts
+++ b/src/modules/map/geofencing-zone-utils.ts
@@ -116,6 +116,7 @@ export function getIconFeatureCollections(
           // No icon for large polygons, long processing time and not useful
           return;
         }
+        let iconCoordinate: number[] | undefined;
         if (polygon.length === 1 && polygon[0].length <= 7) {
           // For polygons with few points, use centroid as icon position to avoid issues with polylabel
           const polyFeature: GeoJsonFeature<GeoJsonPolygon> = {
@@ -127,23 +128,19 @@ export function getIconFeatureCollections(
             },
           };
           const polygonCentroid = centroid(polyFeature);
-
-          if (feature.properties) {
-            polygonCentroid.properties = feature.properties;
-            iconFeatures.push(polygonCentroid as PointFeature);
-          }
+          iconCoordinate = polygonCentroid.geometry.coordinates;
         } else {
-          const iconCoordinate = polylabel(polygon, 0.0001);
-          if (iconCoordinate && feature.properties) {
-            iconFeatures.push({
-              type: 'Feature',
-              properties: feature.properties,
-              geometry: {
-                type: 'Point',
-                coordinates: iconCoordinate,
-              },
-            });
-          }
+          iconCoordinate = polylabel(polygon, 0.0001);
+        }
+        if (iconCoordinate && feature.properties) {
+          iconFeatures.push({
+            type: 'Feature',
+            properties: feature.properties,
+            geometry: {
+              type: 'Point',
+              coordinates: iconCoordinate,
+            },
+          });
         }
       });
     });


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/18745

@HanneLH pointed out issue with placement of icons on small zones here: https://github.com/AtB-AS/kundevendt/issues/18745#issuecomment-3574100613

This is resolved in this PR by using centroid to calculate position for polygons with less than 7 points.

They now look better, like this:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/30749fbd-6e86-4151-a893-2abe189d7c2c" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/16d17129-d272-45a0-93b4-67abb7c53f0a" />
