### PR TITLE
fix: Show recent ticket with bikes (not standalone)

### DIFF
--- a/src/modules/fare-contracts/index.ts
+++ b/src/modules/fare-contracts/index.ts
@@ -9,6 +9,7 @@ export {
   getTravellersIcon,
   getTravellersText,
 } from './utils';
+export {getBaggageProducts} from './get-baggage-products';
 export type {UserProfileWithCount, BaggageProductWithCount} from './types';
 export {FareContractOrReservation} from './FareContractOrReservation';
 export {

--- a/src/recent-fare-contracts/RecentFareContract.tsx
+++ b/src/recent-fare-contracts/RecentFareContract.tsx
@@ -44,6 +44,7 @@ export const RecentFareContract = ({
     fromFareZone,
     toFareZone,
     userProfilesWithCount,
+    baggageProductsWithCount,
     pointToPointValidity,
     direction,
   } = recentFareContract;
@@ -65,9 +66,16 @@ export const RecentFareContract = ({
 
   const productName = getReferenceDataName(preassignedFareProduct, language);
 
-  const travellersText = getTravellersText(userProfilesWithCount, [], language);
+  const travellersText = getTravellersText(
+    userProfilesWithCount,
+    baggageProductsWithCount,
+    language,
+  );
 
-  const travellersIcon = getTravellersIcon(userProfilesWithCount, []);
+  const travellersIcon = getTravellersIcon(
+    userProfilesWithCount,
+    baggageProductsWithCount,
+  );
 
   if (!fareProductTypeConfig) return null;
   const returnAccessibilityLabel = () => {

--- a/src/recent-fare-contracts/types.ts
+++ b/src/recent-fare-contracts/types.ts
@@ -2,9 +2,11 @@ import {
   PointToPointValidity,
   PreassignedFareProduct,
   FareZone,
+  BaggageProduct,
 } from '@atb/modules/configuration';
 import {UserProfileWithCount} from '@atb/modules/fare-contracts';
 import {TravelRightDirection} from '@atb-as/utils';
+import {UniqueWithCount} from '@atb/utils/unique-with-count';
 
 export type RecentFareContractType = {
   /**
@@ -18,4 +20,5 @@ export type RecentFareContractType = {
   direction?: TravelRightDirection;
   pointToPointValidity?: PointToPointValidity;
   userProfilesWithCount: UserProfileWithCount[];
+  baggageProductsWithCount: UniqueWithCount<BaggageProduct>[];
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -100,6 +100,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
       .forType(fareProductTypeConfig.type)
       .product(rfc.preassignedFareProduct)
       .userProfiles(rfc.userProfilesWithCount)
+      .baggageProducts(rfc.baggageProductsWithCount)
       .fromStopPlace(mapPlace(rfc.pointToPointValidity?.fromPlace))
       .toStopPlace(mapPlace(rfc.pointToPointValidity?.toPlace));
     if (rfc.fromFareZone) builder.fromZone(mapZone(rfc.fromFareZone));


### PR DESCRIPTION
Followup on https://github.com/AtB-AS/kundevendt/issues/4282#issuecomment-3588455967

Fixes so bicycles shows up on recent tickets if bought alongside a single ticket. Standalone bike-tickets are not shown, since they are not a "sellable" fare product in the app. We could hack it so it is hardcoded to use single ticket in that case, but we've decided to not support it for now. CC @Sebstorvik @tormoseng 

<img width="481" height="910" alt="image" src="https://github.com/user-attachments/assets/dd930321-7593-4737-8e3e-3a50e316ab1f" />