### PR TITLE
fix: useNavigateToNestedProfileScreen navigates correctly

### DIFF
--- a/src/utils/use-navigate-to-nested-profile-screen.ts
+++ b/src/utils/use-navigate-to-nested-profile-screen.ts
@@ -20,20 +20,23 @@ export const useNavigateToNestedProfileScreen = <
 
   return useCallback(() => {
     navigation.navigate('Root_TabNavigatorStack', {
-      screen: 'TabNav_ProfileStack',
-      params: {
-        screen: 'Profile_RootScreen',
+      state: {
+        routes: [
+          {
+            name: 'TabNav_ProfileStack',
+            state: {
+              routes: [
+                {name: 'Profile_RootScreen'},
+                {
+                  name: screenName,
+                  params:
+                    screenParams as NavigatorScreenParams<ProfileStackParams>,
+                },
+              ],
+            },
+          },
+        ],
       },
     });
-
-    requestAnimationFrame(() =>
-      navigation.navigate('Root_TabNavigatorStack', {
-        screen: 'TabNav_ProfileStack',
-        params: {
-          screen: screenName,
-          params: screenParams,
-        } as NavigatorScreenParams<ProfileStackParams>,
-      }),
-    );
   }, [navigation, screenName, screenParams]);
 };


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/22157

fixes navigation in useNavigateToNestedProfileScreen

Now back-button on screen you navigate to works AND visually you navigate straight to the screen