### PR TITLE
fix: Center travellers text if no description

### DIFF
--- a/src/components/sections/items/CounterSectionItem.tsx
+++ b/src/components/sections/items/CounterSectionItem.tsx
@@ -48,7 +48,6 @@ export function CounterSectionItem({
 
   return (
     <View style={[topContainer, counterStyles.countContainer]} testID={testID}>
-      {illustration && <ThemeIcon svg={illustration} />}
       <View
         style={[
           style.spaceBetween,
@@ -58,7 +57,10 @@ export function CounterSectionItem({
         accessible={true}
         accessibilityLabel={`${count} ${text}, ${subtext || ''}`}
       >
-        <ThemeText>{text}</ThemeText>
+        <View style={counterStyles.infoTextContainer}>
+          {illustration && <ThemeIcon svg={illustration} />}
+          <ThemeText>{text}</ThemeText>
+        </View>
         {subtext && (
           <ThemeText
             typography="body__s"
@@ -146,6 +148,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     infoContainer: {
       flexDirection: 'column',
       alignItems: 'flex-start',
+      justifyContent: 'center',
       marginRight: theme.spacing.medium,
     },
     infoSubtext: {
@@ -176,6 +179,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
     addCount: {
       marginLeft: theme.spacing.xLarge,
+    },
+    infoTextContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.small,
     },
   };
 });


### PR DESCRIPTION
Fixes: https://github.com/AtB-AS/kundevendt/issues/4282#issuecomment-3606465390

Also move description (if exists) to be under both icon and name of traveller. CC. @tormoseng @Mariblaas 

| With description | Without description |
|--------|--------|
| <img width="657" height="1261" alt="image" src="https://github.com/user-attachments/assets/22ecb143-13d5-40e2-82d4-391626da7879" /> | <img width="657" height="1261" alt="image" src="https://github.com/user-attachments/assets/aea8a3a5-686b-46cc-ab92-55d61358c075" /> |