### PR TITLE
fix: use popTo when selecting harbors

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -41,15 +41,14 @@ export const Root_PurchaseHarborSearchScreen = ({
     if (!selection.stopPlaces?.from) builder.fromStopPlace(selectedStopPlace);
     if (selection.stopPlaces?.from) builder.toStopPlace(selectedStopPlace);
     const newSelection = builder.build();
-    navigation.navigate({
-      name: 'Root_PurchaseOverviewScreen',
-      params: {
-        mode: 'Ticket',
+    navigation.popTo(
+      'Root_PurchaseOverviewScreen',
+      {
         selection: newSelection,
         onFocusElement: selection.stopPlaces?.from ? 'toHarbor' : 'fromHarbor',
       },
-      merge: true,
-    });
+      {merge: true},
+    );
   };
 
   const styles = useStyles();


### PR DESCRIPTION
This fixes a bug where selecting a harbor during ticket purchase didn't navigate back to the purchase overview screen, but to a new stack.


### Acceptance criteria

- [x] Selecting and navigating back when selecting harbors in ticket purchase animates from the right, and not from the bottom.