### PR TITLE
feat: Snap coordinates to grid for nearest stop place nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@turf/difference": "^7.1.0",
     "@turf/distance": "^7.1.0",
     "@turf/helpers": "^7.1.0",
+    "@turf/projection": "^7.3.1",
     "@types/polylabel": "^1.1.3",
     "axios": "^1.12.2",
     "axios-better-stacktrace": "^2.1.7",

--- a/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -66,6 +66,7 @@ export const NearbyStopPlacesScreenComponent = ({
         count: 10,
         distance: 3000,
       },
+      100,
     );
 
   // Update geolocation on screen focus if no other location is selected

--- a/src/screen-components/nearby-stop-places/use-nearest-stop-place-nodes-query.ts
+++ b/src/screen-components/nearby-stop-places/use-nearest-stop-place-nodes-query.ts
@@ -3,17 +3,45 @@ import qs from 'query-string';
 import {ONE_HOUR_MS} from '@atb/utils/durations';
 import {getNearestStopPlaceNodes} from '@atb/api/bff/departures';
 import {NearestStopPlacesQueryVariables} from '@atb/api/types/generated/NearestStopPlacesQuery';
+import {snapCoordinatesToGrid} from '@atb/utils/snap-coordinates-to-grid';
 
+/**
+ * @param queryVariables - The query variables, including latitude and longitude.
+ * @param snapCellSizeMeters
+ * * To avoid unnecessary calls from small location changes, the coordinates are snapped to a grid.
+ * snapCellSizeMeters is the size in meters for each cell, and coordinates are snapped to the center of each cell.
+ * @returns Query result from React Query for nearest stop place nodes.
+ */
 export const useNearestStopPlaceNodesQuery = (
   queryVariables?: NearestStopPlacesQueryVariables,
-) =>
-  useQuery({
+  snapCellSizeMeters: number = 100,
+) => {
+  const snappedCoordinates = snapCoordinatesToGrid(
+    {
+      latitude: queryVariables?.latitude ?? 0,
+      longitude: queryVariables?.longitude ?? 0,
+    },
+    snapCellSizeMeters,
+  );
+  const snappedQueryVariables: NearestStopPlacesQueryVariables | undefined =
+    queryVariables &&
+      snappedCoordinates && {
+        ...queryVariables,
+        ...snappedCoordinates,
+      };
+
+  return useQuery({
     enabled: !!queryVariables,
-    queryKey: ['getNearestStopPlaceNodes', qs.stringify(queryVariables ?? {})],
-    queryFn: ({signal}) => getNearestStopPlaceNodes(queryVariables, {signal}),
+    queryKey: [
+      'getNearestStopPlaceNodes',
+      qs.stringify(snappedQueryVariables ?? {}),
+    ],
+    queryFn: ({signal}) =>
+      getNearestStopPlaceNodes(snappedQueryVariables, {signal}),
     staleTime: 1 * ONE_HOUR_MS,
     gcTime: 24 * ONE_HOUR_MS,
     meta: {
       persistInAsyncStorage: true,
     },
   });
+};

--- a/src/utils/snap-coordinates-to-grid.ts
+++ b/src/utils/snap-coordinates-to-grid.ts
@@ -1,0 +1,42 @@
+import {Coordinates} from '@atb/utils/coordinates';
+import {point} from '@turf/helpers';
+import {toMercator, toWgs84} from '@turf/projection';
+
+/**
+ * Snaps a geographic coordinate to the center of the nearest grid cell of a given size (in meters).
+ *
+ * Converts the coordinate to Web Mercator, snaps it to the grid, and converts it back to WGS84.
+ *
+ * @param coordinates - The geographic coordinates to snap (latitude, longitude).
+ * @param cellSizeMeters - The size of each grid cell in meters.
+ * @returns The snapped geographic coordinates (latitude, longitude).
+ */
+export function snapCoordinatesToGrid(
+  coordinates: Coordinates,
+  cellSizeMeters: number,
+): Coordinates {
+  const {latitude, longitude} = coordinates;
+
+  // Convert to Web Mercator (units in meters)
+  const mercator = toMercator(point([longitude, latitude]));
+  const [x, y] = mercator.geometry.coordinates;
+
+  // Snap to grid (to center of the cell)
+  const snappedX = (Math.floor(x / cellSizeMeters) + 0.5) * cellSizeMeters;
+  const snappedY = (Math.floor(y / cellSizeMeters) + 0.5) * cellSizeMeters;
+
+  // Convert back to WGS84
+  const snapped = toWgs84(point([snappedX, snappedY]));
+  const [snappedLng, snappedLat] = snapped.geometry.coordinates;
+
+  // turf projections are not exact, so must be rounded to avoid "random noise"
+  return {
+    latitude: round(snappedLat, 10),
+    longitude: round(snappedLng, 10),
+  };
+}
+
+function round(n: number, decimals = 10) {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3885,6 +3885,15 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
+"@turf/clone@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-7.3.1.tgz#beed14b581937060095e742c248029076b787f1f"
+  integrity sha512-r7xDOfw9ohA7PhZW+8X9RMsO4szB4YqkhEROaELJyLtQ1bo8VNFtndpZdE6YHQpD7Pjlvlb6i99q8w1QLisEPg==
+  dependencies:
+    "@turf/helpers" "7.3.1"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
 "@turf/clone@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-7.2.0.tgz#1dbf6e2f82ba2f9da45285fb870aa40662ccc55f"
@@ -3935,6 +3944,14 @@
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
   integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/helpers@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.3.1.tgz#2f0e666ecdefbf75d0df1b94ea1f5ccc6e4abc5b"
+  integrity sha512-zkL34JVhi5XhsuMEO0MUTIIFEJ8yiW1InMu4hu/oRqamlY4mMoZql0viEmH6Dafh/p+zOl8OYvMJ3Vm3rFshgg==
+  dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
 
 "@turf/helpers@^7.1.0", "@turf/helpers@^7.2.0":
   version "7.2.0"
@@ -4003,6 +4020,14 @@
   dependencies:
     "@turf/helpers" "^6.5.0"
 
+"@turf/meta@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.3.1.tgz#af2076f6388ea87585190c99b8530cbb05e38944"
+  integrity sha512-NWsfOE5RVtWpLQNkfOF/RrYvLRPwwruxhZUV0UFIzHqfiRJ50aO9Y6uLY4bwCUe2TumLJQSR4yaoA72Rmr2mnQ==
+  dependencies:
+    "@turf/helpers" "7.3.1"
+    "@types/geojson" "^7946.0.10"
+
 "@turf/meta@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.2.0.tgz#6a6b1918890b4d9d2b5ff10b3ad47e2fd7470912"
@@ -4032,6 +4057,17 @@
     "@turf/clone" "^7.2.0"
     "@turf/helpers" "^7.2.0"
     "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/projection@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-7.3.1.tgz#efaeaadba43af2784deada8ff2febdb50258148f"
+  integrity sha512-nDM3LG2j37B1tCpF4xL4rUBrQJcG585IRyDIxL2QEvP1LLv6dcm4fodw70HcGAj05Ux8bJr7IOXQXnobOJrlRA==
+  dependencies:
+    "@turf/clone" "7.3.1"
+    "@turf/helpers" "7.3.1"
+    "@turf/meta" "7.3.1"
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/20116, follow up to https://github.com/AtB-AS/mittatb-app/pull/5627

In order to increase the cache hit both from local storage and on the server, snap coordinates to a grid for nearest stop place nodes.