### PR TITLE
fix: don't persist nearest stops

### DIFF
--- a/src/screen-components/nearby-stop-places/use-nearest-stop-place-nodes-query.ts
+++ b/src/screen-components/nearby-stop-places/use-nearest-stop-place-nodes-query.ts
@@ -13,7 +13,4 @@ export const useNearestStopPlaceNodesQuery = (
     queryFn: ({signal}) => getNearestStopPlaceNodes(queryVariables, {signal}),
     staleTime: 1 * ONE_HOUR_MS,
     gcTime: 24 * ONE_HOUR_MS,
-    meta: {
-      persistInAsyncStorage: true,
-    },
   });


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/20116, follow up to https://github.com/AtB-AS/mittatb-app/pull/5627

Since the location will be unique for each app open, we skip storing the data.
