### PR TITLE
feat: updated TravelSearchFiltersBottomSheet

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
@@ -50,11 +50,6 @@ export const TravelSearchFiltersBottomSheet = ({
       filtersSelection.travelSearchPreferences ?? [],
     );
 
-  const changesMade =
-    filtersSelection.transportModes !== selectedModeOptions ||
-    filtersSelection.travelSearchPreferences !==
-      selectedTravelSearchPreferences;
-
   useEffect(() => {
     setSelectedModes(filtersSelection.transportModes);
     setSelectedTravelSearchPreferences(
@@ -77,10 +72,7 @@ export const TravelSearchFiltersBottomSheet = ({
     setFilters({
       travelSearchPreferences: selectedTravelSearchPreferences,
     });
-
-    bottomSheetModalRef?.current?.dismiss();
   }, [
-    bottomSheetModalRef,
     onSave,
     selectedModeOptions,
     selectedTravelSearchPreferences,
@@ -97,7 +89,11 @@ export const TravelSearchFiltersBottomSheet = ({
       rightIcon={Confirm}
       closeCallback={() => {
         giveFocus(onCloseFocusRef);
-        if (changesMade) {
+        if (
+          filtersSelection.transportModes !== selectedModeOptions ||
+          filtersSelection.travelSearchPreferences !==
+            selectedTravelSearchPreferences
+        ) {
           save();
         }
       }}


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/21749

* Fixed issue comment by @tormoseng in the issue linked:
   
_`"The functionality of removing a filter from the travel search results isn't updated in the filter when opening it again. See screen recording below. This works in Prod currently."`_

* Also updated the design to the new autosave functionality, where we remove the save button and save on close bottomsheet, se image bellow. Its the one to the right for this filter

<img width="600" height="663" alt="image" src="https://github.com/user-attachments/assets/5663f4e5-f2b3-4907-9aa8-f76f7a13fbd3" />
