### PR TITLE
fix: use Linking.openURL for contacting customer service

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
@@ -134,7 +134,9 @@ export const Profile_HelpAndContactScreen = () => {
                 rightIcon={{svg: Support}}
                 accessibilityRole="button"
                 testID="contactCustomerServiceButton"
-                onPress={async () => Linking.openURL(`tel:${contactPhoneNumber}`)}
+                onPress={async () =>
+                  Linking.openURL(`tel:${contactPhoneNumber}`)
+                }
               />
             </View>
           )}


### PR DESCRIPTION
fixes https://github.com/AtB-AS/kundevendt/issues/18945#issuecomment-3601863647

Links on the help and contact screen is called using a single function `openLink`, which now uses the `openInAppBrowser`, causing the contact customer service button to not trigger the telephone function. I changed it to Linking.openURL and now it should work correctly.