### PR TITLE
fix: ValidityLine without LinearGradient and using Reanimated instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "react-native-in-app-review": "4.4.2",
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-kettle-module": "2.0.0",
-    "react-native-linear-gradient": "^2.8.3",
     "react-native-localize": "^3.2.1",
     "react-native-pager-view": "^6.3.3",
     "react-native-permissions": "^5.4.2",

--- a/src/components/line-with-vertical-bars/LineWithVerticalBars.tsx
+++ b/src/components/line-with-vertical-bars/LineWithVerticalBars.tsx
@@ -8,10 +8,9 @@ import {
   Dimensions,
   View,
 } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
 
 const SPACE_BETWEEN_VERTICAL_LINES = 72;
-const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
+const AnimatedVerticalLineSegment = Animated.createAnimatedComponent(View);
 
 export const LineWithVerticalBars = ({
   backgroundColor,
@@ -92,11 +91,13 @@ const VerticalLine = ({
   index: number;
   color: string;
 }) => {
+  const styles = useStyles();
   return (
-    <AnimatedLinearGradient
+    <AnimatedVerticalLineSegment
       style={[
-        useStyles().verticalLine,
+        styles.verticalLine,
         {
+          backgroundColor: color,
           left: index * SPACE_BETWEEN_VERTICAL_LINES - 10,
           transform: [
             {
@@ -105,13 +106,12 @@ const VerticalLine = ({
                 outputRange: [SPACE_BETWEEN_VERTICAL_LINES, 0],
               }),
             },
+            {
+              skewX: '150deg',
+            },
           ],
         },
       ]}
-      useAngle={true}
-      angle={120}
-      locations={[0.25, 0.25, 0.75, 0.75]}
-      colors={['transparent', color, color, 'transparent']}
       pointerEvents="none"
     />
   );
@@ -131,7 +131,7 @@ const useStyles = StyleSheet.createThemeHook(() => ({
   verticalLine: {
     position: 'absolute',
     bottom: 0,
-    width: 20,
+    width: 13,
     height: '100%',
   },
 }));

--- a/src/components/line-with-vertical-bars/LineWithVerticalBars.tsx
+++ b/src/components/line-with-vertical-bars/LineWithVerticalBars.tsx
@@ -1,11 +1,6 @@
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {useEffect} from 'react';
-import {
-  StyleProp,
-  ViewStyle,
-  Dimensions,
-  View,
-} from 'react-native';
+import {StyleProp, ViewStyle, Dimensions, View} from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10405,11 +10405,6 @@ react-native-kettle-module@2.0.0:
   resolved "https://registry.yarnpkg.com/react-native-kettle-module/-/react-native-kettle-module-2.0.0.tgz#b85ef8924300d37650346b9c2bedd97eb660387b"
   integrity sha512-YnQlmRhok23rU1/4GCIgyjKaFVnucCCUok83vdjz3yrTQy9IOfObO/bBwrPlA6bpTWfNLQuH5gHTsSB4UMwXfg==
 
-react-native-linear-gradient@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz#9a116649f86d74747304ee13db325e20b21e564f"
-  integrity sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==
-
 react-native-localize@^3.2.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-3.5.2.tgz#7fcf3e1086ff3c6389359ffed28f6d0947d076f4"


### PR DESCRIPTION
Sort of a "response" to myself in this PR: https://github.com/AtB-AS/mittatb-app/pull/5710

We don't use any linear gradient colors here, actually. And `ValidityLine` is the only place where `react-native-linear-gradient` is in use. So I thought, how difficult is it to do this with just a `View`? Answer is: pretty easy to do a prototype of at least.

So interesting to see if this works well across devices, if so we could remove a library, which I look at as a 🎉 

Also refactoring it to use Reanimated instead, so a deadlock with navigation does not occur, ref: https://app.bugsnag.com/atb-as/mittatb/errors/6968cbe74ef4ae6af7de9452?filters%5Bapp.release_stage%5D=staging&filters%5Bevent.since%5D=1h

Also see https://github.com/facebook/react-native/issues/53128#issuecomment-3766913922

## Here is this PR (just a skewed View)
https://github.com/user-attachments/assets/8568ace5-5500-4986-9b48-0ce3514844d9

## Here is with LinearGradient (old way)
https://github.com/user-attachments/assets/f06dd9c9-398e-436d-a25f-7a0345b33849 