### PR TITLE
feat: created startTripBikeScreen for citybike

### DIFF
--- a/src/modules/mobility/use-vehicle.tsx
+++ b/src/modules/mobility/use-vehicle.tsx
@@ -2,7 +2,7 @@ import {useSystem} from './use-system';
 import {getRentalAppUri} from './utils';
 import {useVehicleQuery} from './queries/use-vehicle-query';
 
-export const useVehicle = (id: string) => {
+export const useVehicle = (id?: string) => {
   const {data: vehicle, isLoading, isError} = useVehicleQuery(id);
   const {appStoreUri, brandLogoUrl, operatorId, operatorName} = useSystem(
     vehicle,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_CityBikeStartTripScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_CityBikeStartTripScreen.tsx
@@ -1,0 +1,147 @@
+import React, {useEffect} from 'react';
+import {useActiveShmoBookingQuery} from '@atb/modules/mobility';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {ActivityIndicator, View} from 'react-native';
+import {ThemeText} from '@atb/components/text';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import {ONE_SECOND_MS} from '@atb/utils/durations';
+import {ShmoBookingState} from '@atb/api/types/mobility';
+import {MapTexts, useTranslation} from '@atb/translations';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MapScreenProps} from './navigation-types';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Parking} from '@atb/assets/svg/mono-icons/places';
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ThemedCityBike} from '@atb/theme/ThemedAssets';
+import {LinkSectionItem} from '@atb/components/sections';
+import {MessageInfoBox} from '@atb/components/message-info-box';
+import {Button} from '@atb/components/button';
+
+type Props = MapScreenProps<'Map_CityBikeStartTripScreen'>;
+
+export const Map_CityBikeStartTripScreen = ({navigation}: Props) => {
+  const styles = useStyle();
+  const {t} = useTranslation();
+  const {theme} = useThemeContext();
+  const focusRef = useFocusOnLoad(navigation);
+  const isFocusedAndActive = useIsFocusedAndActive();
+
+  const {
+    data: activeBooking,
+    isLoading,
+    isError,
+  } = useActiveShmoBookingQuery(isFocusedAndActive, ONE_SECOND_MS * 10);
+
+  useEffect(() => {
+    if (
+      activeBooking &&
+      activeBooking?.state !== ShmoBookingState.NOT_STARTED
+    ) {
+      navigation.goBack();
+    }
+  }, [activeBooking, navigation]);
+
+  if (isLoading) {
+    return (
+      <View style={styles.fullScreenWrapper}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={styles.fullScreenWrapper}>
+        <MessageInfoBox
+          type="error"
+          message={t(MobilityTexts.loadingBookingFailed)}
+        />
+        <Button
+          text={t(MapTexts.exitButton.a11yLabel)}
+          expanded
+          onPress={() => navigation.goBack()}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <FullScreenView
+      focusRef={focusRef}
+      headerProps={{
+        title: t(MobilityTexts.cityBike.startTripView.header),
+      }}
+    >
+      <View style={styles.container}>
+        <View style={styles.contentWrapper}>
+          <View style={styles.title}>
+            <ThemeIcon size="large" svg={Parking} />
+            <ThemeText style={theme.typography.heading__xl}>
+              {t(MobilityTexts.cityBike.location(1))}
+            </ThemeText>
+          </View>
+          <ThemedCityBike />
+          <View style={styles.content}>
+            <ThemeText style={theme.typography.heading__xl}>
+              {t(MobilityTexts.cityBike.startTripView.title)}
+            </ThemeText>
+            <ThemeText>
+              {t(MobilityTexts.cityBike.startTripView.description)}
+            </ThemeText>
+            <ThemeText>
+              {t(MobilityTexts.cityBike.startTripView.safeTrip)}
+            </ThemeText>
+          </View>
+        </View>
+        <View style={styles.supportButton}>
+          <LinkSectionItem
+            text={t(MobilityTexts.helpText)}
+            onPress={() => {
+              /* Will add when support for city bike is implemented */
+            }}
+            radius="top-bottom"
+          />
+        </View>
+      </View>
+    </FullScreenView>
+  );
+};
+const useStyle = StyleSheet.createThemeHook((theme) => {
+  return {
+    container: {
+      flex: 1,
+      paddingHorizontal: theme.spacing.xLarge,
+    },
+    contentWrapper: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 48,
+    },
+    title: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: theme.spacing.small,
+      fontSize: theme.typography.heading__xl,
+    },
+    content: {
+      alignItems: 'center',
+      flexDirection: 'column',
+      gap: theme.spacing.medium,
+    },
+
+    supportButton: {
+      width: '100%',
+      marginTop: 'auto',
+      paddingBottom: theme.spacing.xLarge,
+    },
+    fullScreenWrapper: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: theme.spacing.xLarge,
+      gap: theme.spacing.large,
+    },
+  };
+});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/TabNav_MapStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/TabNav_MapStack.tsx
@@ -7,6 +7,7 @@ import {Map_TravelDetailsMapScreen} from './Map_TravelDetailsMapScreen';
 import {Map_PlaceScreen} from './Map_PlaceScreen';
 import {MapStackParams} from './navigation-types';
 import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
+import {Map_CityBikeStartTripScreen} from './Map_CityBikeStartTripScreen';
 
 const Stack = createStackNavigator<MapStackParams>();
 
@@ -31,6 +32,10 @@ export const TabNav_MapStack = () => {
       <Stack.Screen
         name="Map_TravelAidScreen"
         component={Map_TravelAidScreen}
+      />
+      <Stack.Screen
+        name="Map_CityBikeStartTripScreen"
+        component={Map_CityBikeStartTripScreen}
       />
     </Stack.Navigator>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/navigation-types.ts
@@ -14,6 +14,7 @@ export type MapStackParams = StackParams<{
   Map_DepartureDetailsScreen: DepartureDetailsScreenParams;
   Map_TravelDetailsMapScreen: TravelDetailsMapScreenParams;
   Map_TravelAidScreen: TravelAidScreenParams;
+  Map_CityBikeStartTripScreen: undefined;
 }>;
 
 type RootMapScreenProps = TabNavigatorScreenProps<'TabNav_MapStack'>;

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -29,6 +29,16 @@ export const MobilityTexts = {
         return _('Annet', 'Other', 'Anna');
     }
   },
+  cityBike: {
+    location:(position:number) => _(`Plass ${position}`, `Dock ${position}`, `Plass ${position}`),
+    startTripView: {
+      title: _('Trykk på knappen på styret', 'Press the button on the handlebar', 'Trykk på knappen på styret'),
+      description: _('Når knappen lyser grønt og sykkelen lager lyd kan du ta den ut av stativet og sykle av sted.', 'When the button lights up green and the bike makes a sound, you can take it out of the dock and start riding.', 'Når knappen lyser grønt og sykkelen lagar lyd kan du ta den ut av stativet og sykle av stad.'),
+      safeTrip: _('God tur!', 'Have a nice trip!', 'God tur!'),
+      header: _('Start tur', 'Start trip', 'Start tur'),
+    }
+  },
+  loadingBookingFailed: _('Ops! Vi kunne ikke hente informasjon om turen', "Ops! We couldn't fetch the trip information", 'Ops! Vi kunne ikkje hente informasjon om turen'),
   finishing: {
     button: _('Ta bilde', 'Take a photo', 'Ta eit bilde'),
     header: _(

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -30,15 +30,28 @@ export const MobilityTexts = {
     }
   },
   cityBike: {
-    location:(position:number) => _(`Plass ${position}`, `Dock ${position}`, `Plass ${position}`),
+    location: (position: number) =>
+      _(`Plass ${position}`, `Dock ${position}`, `Plass ${position}`),
     startTripView: {
-      title: _('Trykk på knappen på styret', 'Press the button on the handlebar', 'Trykk på knappen på styret'),
-      description: _('Når knappen lyser grønt og sykkelen lager lyd kan du ta den ut av stativet og sykle av sted.', 'When the button lights up green and the bike makes a sound, you can take it out of the dock and start riding.', 'Når knappen lyser grønt og sykkelen lagar lyd kan du ta den ut av stativet og sykle av stad.'),
+      title: _(
+        'Trykk på knappen på styret',
+        'Press the button on the handlebar',
+        'Trykk på knappen på styret',
+      ),
+      description: _(
+        'Når knappen lyser grønt og sykkelen lager lyd kan du ta den ut av stativet og sykle av sted.',
+        'When the button lights up green and the bike makes a sound, you can take it out of the dock and start riding.',
+        'Når knappen lyser grønt og sykkelen lagar lyd kan du ta den ut av stativet og sykle av stad.',
+      ),
       safeTrip: _('God tur!', 'Have a nice trip!', 'God tur!'),
       header: _('Start tur', 'Start trip', 'Start tur'),
-    }
+    },
   },
-  loadingBookingFailed: _('Ops! Vi kunne ikke hente informasjon om turen', "Ops! We couldn't fetch the trip information", 'Ops! Vi kunne ikkje hente informasjon om turen'),
+  loadingBookingFailed: _(
+    'Ops! Vi kunne ikke hente informasjon om turen',
+    "Ops! We couldn't fetch the trip information",
+    'Ops! Vi kunne ikkje hente informasjon om turen',
+  ),
   finishing: {
     button: _('Ta bilde', 'Take a photo', 'Ta eit bilde'),
     header: _(


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/22834

The waiting screen after starting a trip and the bike being used by the user

<img width="250" alt="image" src="https://github.com/user-attachments/assets/7ef61a5d-1aef-4903-aab0-e5249e4bba5a" />

From implementation:

<img width="250" alt="image" src="https://github.com/user-attachments/assets/08b806f9-03eb-4b66-abac-83ef3342e4b4" />


Using the general header from FullScreenView comp. So the color is a bit off and will be fixed in another header issue: https://github.com/AtB-AS/kundevendt/issues/22686