### PR TITLE
fix: Minimize icons during shmo trip

### DIFF
--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -415,6 +415,12 @@ export const Map = (props: MapProps) => {
                 ? (mapPropertiesRef.current?.zoom ?? DEFAULT_ZOOM_LEVEL)
                 : undefined
             }
+            pitch={
+              isMapPitchEnabled &&
+              activeShmoBooking?.state === ShmoBookingState.IN_USE
+                ? 60
+                : 0
+            }
             centerCoordinate={
               !initMapLoaded ? mapPropertiesRef.current?.center : undefined
             }

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -141,6 +141,8 @@ export const Map = (props: MapProps) => {
     selectedFeatureIsAVehicle ? selectedFeature?.properties?.id : undefined,
   );
 
+  const activeFeatureId =
+    activeShmoBooking?.asset.id ?? selectedFeature?.properties?.id;
   const systemId =
     vehicle?.system.id ?? activeShmoBooking?.asset.systemId ?? null;
   const vehicleTypeId =
@@ -451,7 +453,7 @@ export const Map = (props: MapProps) => {
             ))}
 
           <NationalStopRegistryFeatures
-            selectedFeaturePropertyId={selectedFeature?.properties?.id}
+            selectedFeaturePropertyId={activeFeatureId}
             onMapItemClick={onMapItemClick}
           />
 
@@ -463,7 +465,7 @@ export const Map = (props: MapProps) => {
 
           {!!shouldShowVehiclesAndStations && (
             <VehiclesAndStations
-              selectedFeatureId={selectedFeature?.properties?.id}
+              selectedFeatureId={activeFeatureId}
               onPress={onMapItemClick}
               showVehicles={showVehicles}
               showStations={showStations}


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/21268

At some point icons stopped being minimized during a shmo trip.
This fixes that, and includes a slight pitch of the map as well when driving.
<img width="250" src="https://github.com/user-attachments/assets/61c186b1-8e40-49d6-805f-3ac06a13d3fd" />

