### PR TITLE
feat: attempt to improve performance on fare contract list

### DIFF
--- a/src/modules/fare-contracts/FareContractAndReservationsList.tsx
+++ b/src/modules/fare-contracts/FareContractAndReservationsList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {FareContractOrReservation} from './FareContractOrReservation';
 import {Reservation} from '@atb/modules/ticketing';
 import {useAnalyticsContext} from '@atb/modules/analytics';
@@ -14,6 +14,7 @@ type Props = {
   reservations: Reservation[];
   fareContracts: FareContractType[];
   now: number;
+  isFocused?: boolean;
   onPressFareContract: (orderId: string) => void;
   onNavigateToBonusScreen: () => void;
   onNavigateToPurchaseFlow: (newSelection: PurchaseSelectionType) => void;
@@ -27,6 +28,7 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   fareContracts,
   reservations,
   now,
+  isFocused,
   onPressFareContract,
   onNavigateToBonusScreen,
   onNavigateToPurchaseFlow,
@@ -35,10 +37,19 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
   const styles = useStyles();
   const analytics = useAnalyticsContext();
 
-  const fcAndReservations = getSortedFareContractsAndReservations(
-    fareContracts,
-    reservations,
-    now,
+  // Memoize to only recompute when the list actually changes
+  const fcAndReservations = useMemo(
+    () =>
+      getSortedFareContractsAndReservations(fareContracts, reservations, now),
+    [fareContracts, reservations, now],
+  );
+
+  const handlePressFareContract = useCallback(
+    (id: string) => {
+      analytics.logEvent('Ticketing', 'Ticket details clicked');
+      onPressFareContract(id);
+    },
+    [analytics, onPressFareContract],
   );
 
   return (
@@ -49,14 +60,8 @@ export const FareContractAndReservationsList: React.FC<Props> = ({
       {fcAndReservations?.map((fcOrReservation, index) => (
         <FareContractOrReservation
           now={now}
-          onPressFareContract={() => {
-            // Reservations don't have `id`, but also don't show the link to
-            // ticket details.
-            if ('id' in fcOrReservation) {
-              analytics.logEvent('Ticketing', 'Ticket details clicked');
-              onPressFareContract(fcOrReservation.id);
-            }
-          }}
+          isFocused={isFocused}
+          onPressFareContract={handlePressFareContract}
           onNavigateToBonusScreen={onNavigateToBonusScreen}
           onNavigateToPurchaseFlow={onNavigateToPurchaseFlow}
           key={

--- a/src/modules/fare-contracts/FareContractOrReservation.tsx
+++ b/src/modules/fare-contracts/FareContractOrReservation.tsx
@@ -6,51 +6,95 @@ import {TicketingTexts, useTranslation} from '@atb/translations';
 import {ErrorBoundary} from '@atb/screen-components/error-boundary';
 import {FareContractView} from './FareContractView';
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
+import {getValidityStatus} from './utils';
 
-export function FareContractOrReservation({
-  fcOrReservation,
-  onPressFareContract,
-  onNavigateToBonusScreen,
-  onNavigateToPurchaseFlow,
-  now,
-  index,
-  isStatic,
-}: {
+type Props = {
   fcOrReservation: FareContractType | Reservation;
-  onPressFareContract: () => void;
+  onPressFareContract: (id: string) => void;
   onNavigateToBonusScreen: () => void;
   onNavigateToPurchaseFlow?: (newSelection: PurchaseSelectionType) => void;
   now: number;
   index: number;
   isStatic?: boolean;
-}) {
-  const {t} = useTranslation();
+  isFocused?: boolean;
+};
 
-  if ('transactionId' in fcOrReservation) {
-    return (
-      <PurchaseReservation
-        key={fcOrReservation.orderId}
-        reservation={fcOrReservation}
-        now={now}
-      />
-    );
-  } else {
-    return (
-      <ErrorBoundary
-        message={t(
-          TicketingTexts.scrollView.errorLoadingTicket(fcOrReservation.orderId),
-        )}
-      >
-        <FareContractView
-          now={now}
-          fareContract={fcOrReservation}
-          isStatic={isStatic}
-          onPressDetails={onPressFareContract}
-          onNavigateToBonusScreen={onNavigateToBonusScreen}
-          onNavigateToPurchaseFlow={onNavigateToPurchaseFlow}
-          testID={'ticket' + index}
-        />
-      </ErrorBoundary>
-    );
-  }
+function arePropsEqual(prevProps: Props, nextProps: Props): boolean {
+  // Check all props except `now` for shallow equality
+  if (prevProps.fcOrReservation !== nextProps.fcOrReservation) return false;
+  if (prevProps.onPressFareContract !== nextProps.onPressFareContract)
+    return false;
+  if (prevProps.onNavigateToBonusScreen !== nextProps.onNavigateToBonusScreen)
+    return false;
+  if (prevProps.onNavigateToPurchaseFlow !== nextProps.onNavigateToPurchaseFlow)
+    return false;
+  if (prevProps.index !== nextProps.index) return false;
+  if (prevProps.isStatic !== nextProps.isStatic) return false;
+  if (prevProps.isFocused !== nextProps.isFocused) return false;
+
+  // If `now` hasn't changed, everything is equal
+  if (prevProps.now === nextProps.now) return true;
+
+  // `now` changed. Decide if it matters for this item.
+  const item = nextProps.fcOrReservation;
+
+  // Reservations don't use `now` for display — their status depends on
+  // paymentStatus, not time.
+  if ('transactionId' in item) return true;
+
+  // For fare contracts: only re-render if the validity status actually
+  // changed (a boundary was crossed, e.g. upcoming → valid). The countdown
+  // text in ValidityTime updates itself via its own per-second timer, so the
+  // parent tree does not need to re-render for that.
+  const prevStatus = getValidityStatus(prevProps.now, item);
+  const nextStatus = getValidityStatus(nextProps.now, item);
+
+  return prevStatus === nextStatus;
 }
+
+export const FareContractOrReservation = React.memo(
+  function FareContractOrReservation({
+    fcOrReservation,
+    onPressFareContract,
+    onNavigateToBonusScreen,
+    onNavigateToPurchaseFlow,
+    now,
+    index,
+    isStatic,
+    isFocused,
+  }: Props) {
+    const {t} = useTranslation();
+
+    if ('transactionId' in fcOrReservation) {
+      return (
+        <PurchaseReservation
+          key={fcOrReservation.orderId}
+          reservation={fcOrReservation}
+          now={now}
+        />
+      );
+    } else {
+      return (
+        <ErrorBoundary
+          message={t(
+            TicketingTexts.scrollView.errorLoadingTicket(
+              fcOrReservation.orderId,
+            ),
+          )}
+        >
+          <FareContractView
+            now={now}
+            fareContract={fcOrReservation}
+            isStatic={isStatic}
+            isFocused={isFocused}
+            onPressDetails={() => onPressFareContract(fcOrReservation.id)}
+            onNavigateToBonusScreen={onNavigateToBonusScreen}
+            onNavigateToPurchaseFlow={onNavigateToPurchaseFlow}
+            testID={'ticket' + index}
+          />
+        </ErrorBoundary>
+      );
+    }
+  },
+  arePropsEqual,
+);

--- a/src/modules/fare-contracts/FareContractView.tsx
+++ b/src/modules/fare-contracts/FareContractView.tsx
@@ -41,6 +41,7 @@ type Props = {
   now: number;
   fareContract: FareContractType;
   isStatic?: boolean;
+  isFocused?: boolean;
   onPressDetails?: () => void;
   onNavigateToBonusScreen: () => void;
   onNavigateToPurchaseFlow?: (
@@ -53,6 +54,7 @@ export const FareContractView: React.FC<Props> = ({
   now,
   fareContract,
   isStatic,
+  isFocused,
   onPressDetails,
   onNavigateToBonusScreen,
   onNavigateToPurchaseFlow,
@@ -112,7 +114,7 @@ export const FareContractView: React.FC<Props> = ({
         />
       ) : (
         <GenericSectionItem style={styles.header}>
-          <WithValidityLine fc={fareContract} now={now}>
+          <WithValidityLine fc={fareContract} now={now} animate={isFocused}>
             <ProductName fc={fareContract} />
             <ValidityTime fc={fareContract} now={now} />
             <Description fc={fareContract} />

--- a/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -1,6 +1,6 @@
 import {TicketValid} from '@atb/assets/svg/mono-icons/ticketing';
 import {FareContractTexts, useTranslation} from '@atb/translations';
-import React, {useRef} from 'react';
+import React, {useRef, useState} from 'react';
 import {ActivateNowBottomSheet} from './ActivateNowBottomSheet';
 import {useThemeContext} from '@atb/theme';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
@@ -25,9 +25,14 @@ export function ActivateNowSectionItem({
   const {theme} = useThemeContext();
   const onCloseFocusRef = useRef<View | null>(null);
   const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const [hasBeenPresented, setHasBeenPresented] = useState(false);
 
   const onPress = () => {
-    bottomSheetModalRef.current?.present();
+    setHasBeenPresented(true);
+    // Present after the bottom sheet mounts on next render
+    requestAnimationFrame(() => {
+      bottomSheetModalRef.current?.present();
+    });
   };
 
   return (
@@ -43,12 +48,14 @@ export function ActivateNowSectionItem({
         ref={onCloseFocusRef}
         style={{width: '100%'}} // Without this the GenericSectionItem squishes the button
       />
-      <ActivateNowBottomSheet
-        fareContractId={fareContractId}
-        fareProductType={fareProductType}
-        bottomSheetModalRef={bottomSheetModalRef}
-        onCloseFocusRef={onCloseFocusRef}
-      />
+      {hasBeenPresented && (
+        <ActivateNowBottomSheet
+          fareContractId={fareContractId}
+          fareProductType={fareProductType}
+          bottomSheetModalRef={bottomSheetModalRef}
+          onCloseFocusRef={onCloseFocusRef}
+        />
+      )}
     </GenericSectionItem>
   );
 }

--- a/src/modules/fare-contracts/components/ConsumeCarnetSectionitem.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetSectionitem.tsx
@@ -1,7 +1,7 @@
 import {TicketValid} from '@atb/assets/svg/mono-icons/ticketing';
 import {useThemeContext} from '@atb/theme';
 import {FareContractTexts, useTranslation} from '@atb/translations';
-import React, {useRef} from 'react';
+import React, {useRef, useState} from 'react';
 import {ConsumeCarnetBottomSheet} from './ConsumeCarnetBottomSheet';
 import {View} from 'react-native';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
@@ -26,9 +26,14 @@ export function ConsumeCarnetSectionitem({
   const interactiveColor = theme.color.interactive[0];
   const onCloseFocusRef = useRef<View | null>(null);
   const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const [hasBeenPresented, setHasBeenPresented] = useState(false);
 
   const onPress = () => {
-    bottomSheetModalRef.current?.present();
+    setHasBeenPresented(true);
+    // Present after the bottom sheet mounts on next render
+    requestAnimationFrame(() => {
+      bottomSheetModalRef.current?.present();
+    });
   };
 
   return (
@@ -42,12 +47,14 @@ export function ConsumeCarnetSectionitem({
         expanded={true}
         style={{width: '100%'}} // Without this the GenericSectionItem squishes the button
       />
-      <ConsumeCarnetBottomSheet
-        fareContractId={fareContractId}
-        fareProductType={fareProductType}
-        bottomSheetModalRef={bottomSheetModalRef}
-        onCloseFocusRef={onCloseFocusRef}
-      />
+      {hasBeenPresented && (
+        <ConsumeCarnetBottomSheet
+          fareContractId={fareContractId}
+          fareProductType={fareProductType}
+          bottomSheetModalRef={bottomSheetModalRef}
+          onCloseFocusRef={onCloseFocusRef}
+        />
+      )}
     </GenericSectionItem>
   );
 }

--- a/src/modules/fare-contracts/components/ValidityTime.tsx
+++ b/src/modules/fare-contracts/components/ValidityTime.tsx
@@ -15,17 +15,24 @@ import {fareContractValidityUnits} from '../fare-contract-validity-units';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
 import {useAuthContext} from '@atb/modules/auth';
 import type {FareContractType} from '@atb-as/utils';
+import {useTimeContext} from '@atb/modules/time';
+import {ONE_SECOND_MS} from '@atb/utils/durations';
 
 type Props = {
   fc: FareContractType;
   now: number;
 };
 
-export const ValidityTime = ({fc, now}: Props) => {
+export const ValidityTime = ({fc, now: parentNow}: Props) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
   const {isInspectable} = useMobileTokenContext();
   const {abtCustomerId: currentUserId} = useAuthContext();
+
+  // Use own per-second timer for the countdown display, so the parent tree
+  // does not need to re-render every second just for this text to update.
+  const {serverNow: localNow} = useTimeContext(ONE_SECOND_MS);
+  const now = localNow ?? parentNow;
 
   const {validityStatus, validFrom, validTo} = getFareContractInfo(
     now,

--- a/src/modules/fare-contracts/components/WithValidityLine.tsx
+++ b/src/modules/fare-contracts/components/WithValidityLine.tsx
@@ -15,6 +15,7 @@ type Props = PropsWithChildren<
   (
     | {
         fc: FareContractType;
+        animate?: boolean;
       }
     | ({reservation: Reservation} & {enabledLine?: boolean})
   ) & {now: number}
@@ -55,6 +56,7 @@ export const WithValidityLine = (props: Props) => {
         <ValidityLine
           status={validityStatus}
           fareProductType={preassignedFareProduct?.type}
+          animate={props.animate}
         />
         {!!props.children ? (
           <View style={styles.content}>{props.children}</View>

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -1,7 +1,7 @@
 import {useTicketingContext} from '@atb/modules/ticketing';
 import {FareContractType} from '@atb-as/utils';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {getFareContracts} from '@atb/modules/ticketing';
 import {useAuthContext} from '@atb/modules/auth';
 import {getAvailabilityStatus, AvailabilityStatus} from '@atb-as/utils';
@@ -59,11 +59,25 @@ export const useFareContracts = (
     });
   };
 
-  const filteredFareContracts = getFilterdFareContracts(
-    fareContracts,
-    availabilityStatus,
-    now,
-  );
+  // Stabilize the array reference so downstream components only re-render
+  // when the actual set of fare contracts changes (by id), not every second
+  // when `now` ticks and .filter() returns a new array with the same items.
+  const prevRef = useRef<FareContractType[]>([]);
+  const filteredFareContracts = useMemo(() => {
+    const next = getFilterdFareContracts(
+      fareContracts,
+      availabilityStatus,
+      now,
+    );
+    if (
+      next.length === prevRef.current.length &&
+      next.every((fc, i) => fc.id === prevRef.current[i]?.id)
+    ) {
+      return prevRef.current;
+    }
+    prevRef.current = next;
+    return next;
+  }, [fareContracts, availabilityStatus, now]);
 
   return {fareContracts: filteredFareContracts, refetch, isRefetching};
 };

--- a/src/screen-components/purchase-history/PurchaseHistoryScreenComponent.tsx
+++ b/src/screen-components/purchase-history/PurchaseHistoryScreenComponent.tsx
@@ -60,22 +60,25 @@ export const PurchaseHistoryScreenComponent = ({
     [fareContractsToShow, reservationsToShow],
   );
 
+  const handlePressFareContract = useCallback(
+    (id: string) => {
+      analytics.logEvent('Ticketing', 'Ticket details clicked');
+      onPressFareContract(id);
+    },
+    [analytics, onPressFareContract],
+  );
+
   const renderItem = useCallback(
     ({item, index}: {item: Reservation | FareContractType; index: number}) => (
       <FareContractOrReservation
         onNavigateToBonusScreen={onNavigateToBonusScreen}
         now={serverNow}
-        onPressFareContract={() => {
-          if ('id' in item) {
-            analytics.logEvent('Ticketing', 'Ticket details clicked');
-            onPressFareContract(item.id);
-          }
-        }}
+        onPressFareContract={handlePressFareContract}
         fcOrReservation={item}
         index={index}
       />
     ),
-    [analytics, onNavigateToBonusScreen, onPressFareContract, serverNow],
+    [handlePressFareContract, onNavigateToBonusScreen, serverNow],
   );
 
   return (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -67,6 +67,16 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
     [navigation],
   );
 
+  const navigateToFareContractDetails = useCallback(
+    (fareContractId: string) => {
+      navigation.navigate('Root_FareContractDetailsScreen', {
+        fareContractId,
+        transitionOverride: 'slide-from-right',
+      });
+    },
+    [navigation],
+  );
+
   return (
     <View style={styles.container}>
       <AnimatedGestureHandlerScrollView
@@ -100,14 +110,10 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           reservations={reservations}
           fareContracts={availableFareContracts}
           now={serverNow}
+          isFocused={isFocused}
           onNavigateToBonusScreen={navigateToBonusScreen}
           onNavigateToPurchaseFlow={navigateToBookingPurchaseFlow}
-          onPressFareContract={(fareContractId) =>
-            navigation.navigate('Root_FareContractDetailsScreen', {
-              fareContractId,
-              transitionOverride: 'slide-from-right',
-            })
-          }
+          onPressFareContract={navigateToFareContractDetails}
           emptyStateConfig={{
             title: t(
               TicketingTexts.availableFareProductsAndReservationsTab


### PR DESCRIPTION
## Description
Generally tries to reduce the rendering that happens on the fare contract list screen. Since it is PACKED with a lot of stuff.

- stabilize array reference for `filteredFareContracts` to prevent unnecessary rendering of the component tree.
- memoize `FareContractOrReservation` so that re-render only happens if the validity status changes.
- use internal time for `validityTime`, so instead of using parent-inherited `now` time, uses it's own time to render the changes, decoupling the re-render with the parent.
- stabilize callback props: some of the inline arrow functions can't be memoized properly so these are wrapped in `useCallback`
- memoize `getSortedFareContractsAndReservations` so it doesn't get re-sorted on every render.
- lazy-mount bottom sheets, only mount the bottom sheet when the user taps on the activate now button.
- validity line animation is now paused when not on focus.

Feel free to point out unnecessary optimization or overkills, I'm just trying to find a way to improve performance on the simulator, since it is so laggy on the ticket screen. On real device, no lags are observed on iPhone 7, iPhone 11 Pro, and Google Pixel 8


![please-work-please](https://github.com/user-attachments/assets/4b080de6-9da1-4f4f-a4d9-873a3658d981)
