### PR TITLE
fix: voiceover for 0 points says 0 instead of unknown

### DIFF
--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -12,9 +12,9 @@ const BonusProgramTexts = {
 
   yourBonusBalanceA11yLabel: (bonusBalance: number | null) => {
     return _(
-      `Du har ${bonusBalance ?? 'ukjent antall'} bonuspoeng`,
-      `You have ${bonusBalance ?? 'unknown number of'} bonus points`,
-      `Du har ${bonusBalance ?? 'ukjent mengde'} bonuspoeng`,
+      `Du har ${bonusBalance == null ? 'ukjent antall' : bonusBalance} poeng`,
+      `You have ${bonusBalance == null ? 'unknown number of' : bonusBalance} points`,
+      `Du har ${bonusBalance == null ? 'ukjent mengde' : bonusBalance} poeng`,
     );
   },
 


### PR DESCRIPTION
## Description
Fixes voiceover for when the user has 0 points

## Acceptance Criteria

- [x] When user has 0 points, voiceover says 0 points