### PR TITLE
fix: add a11y hint for tab activation on iOS

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/Ticketing_TicketTabNavStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/Ticketing_TicketTabNavStack.tsx
@@ -119,7 +119,7 @@ export const Ticketing_TicketTabNavStack = () => {
           component={TicketTabNav_PurchaseTabScreen}
           options={{
             tabBarLabel: t(TicketingTexts.purchaseTab.label),
-            tabBarAccessibilityLabel: t(TicketingTexts.purchaseTab.a11yLabel),
+            tabBarAccessibilityLabel: t(TicketingTexts.a11yHint),
             tabBarButtonTestID: 'purchaseTab',
           }}
         />
@@ -130,6 +130,7 @@ export const Ticketing_TicketTabNavStack = () => {
             tabBarLabel: t(
               TicketingTexts.availableFareProductsAndReservationsTab.label,
             ),
+            tabBarAccessibilityLabel: t(TicketingTexts.a11yHint),
             tabBarButtonTestID: 'activeTicketsTab',
           }}
         />
@@ -198,7 +199,7 @@ const TabBar: React.FC<
               interactiveColor={theme.theme.color.interactive[2]}
               accessibilityRole="tab"
               accessibilityState={isFocused ? {selected: true} : {}}
-              accessibilityLabel={options.tabBarAccessibilityLabel}
+              accessibilityHint={options.tabBarAccessibilityLabel}
               testID={options.tabBarButtonTestID}
               style={styles.button}
             />

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -6,6 +6,11 @@ const TicketingTexts = {
   header: {
     title: _('Billetter', 'Tickets', 'Billettar'),
   },
+  a11yHint: _(
+    'Aktivér for å velge denne fanen.',
+    'Activate to select this tab.',
+    'Aktiver for å velje denne fana.',
+  ),
   purchaseTab: {
     label: _('Kjøp billett', 'Buy ticket', 'Kjøp billett'),
     a11yLabel: _('Kjøp billetter', 'Buy tickets', 'Kjøp billettar'),


### PR DESCRIPTION
## Issue Reference
Follow up https://github.com/AtB-AS/kundevendt/issues/22686

## Description
Adds accessibility hint to tab bar on ticketing screen, this is kind of hack-ish, since RN on iOS does not recognize `accessibilityRole="tab"`, so until they fix it, this workaround should do it.  

iOS VoiceOver will now say: "{label}, activate to select this tab"
Android TalkBack will say:  "{label}, tab, activate to select this tab, double tap to activate"

Label text will follow the selected app language, screen reader follows the device language