### PR TITLE
feat: Move save trips out of experimental features

### DIFF
--- a/src/modules/experimental-store-trip-patterns/SaveTripPatternButtonComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/SaveTripPatternButtonComponent.tsx
@@ -6,7 +6,7 @@ import {useStoredTripPatterns} from './StoredTripPatternsContext';
 import {Button} from '@atb/components/button';
 import {Save, SaveFill} from '@atb/assets/svg/mono-icons/actions';
 import analytics from '@react-native-firebase/analytics';
-import {wrapWithExperimentalFeatureToggledComponent} from '@atb/modules/experimental';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {getTripPatternAnalytics} from '@atb/screen-components/travel-details-screens';
@@ -17,102 +17,100 @@ type SaveTripPatternButtonComponentProps = {
   now: number;
 };
 
-export const SaveTripPatternButtonComponent =
-  wrapWithExperimentalFeatureToggledComponent<SaveTripPatternButtonComponentProps>(
-    'render-nothing-if-disabled',
-    ({tripPattern, now}) => {
-      const {
-        addTripPattern,
-        removeTripPattern,
-        isTripPatternStored,
-        canAddTripPattern,
-      } = useStoredTripPatterns();
-      const {t} = useTranslation();
-      const {theme} = useThemeContext();
-      const posthogAnalytics = useAnalyticsContext();
-      const {fareZones} = useFirestoreConfigurationContext();
+export const SaveTripPatternButtonComponent: React.FC<
+  SaveTripPatternButtonComponentProps
+> = ({tripPattern, now}) => {
+  const {isSaveTripsEnabled} = useFeatureTogglesContext();
+  const {
+    addTripPattern,
+    removeTripPattern,
+    isTripPatternStored,
+    canAddTripPattern,
+  } = useStoredTripPatterns();
+  const {t} = useTranslation();
+  const {theme} = useThemeContext();
+  const posthogAnalytics = useAnalyticsContext();
+  const {fareZones} = useFirestoreConfigurationContext();
 
-      const canAdd = useMemo(() => {
-        return canAddTripPattern(tripPattern);
-      }, [tripPattern, canAddTripPattern]);
+  const canAdd = useMemo(() => {
+    return canAddTripPattern(tripPattern);
+  }, [tripPattern, canAddTripPattern]);
 
-      const isStored = useMemo(() => {
-        if (!canAdd) {
-          return false;
-        }
+  const isStored = useMemo(() => {
+    if (!canAdd) {
+      return false;
+    }
 
-        return isTripPatternStored(tripPattern);
-      }, [tripPattern, isTripPatternStored, canAdd]);
+    return isTripPatternStored(tripPattern);
+  }, [tripPattern, isTripPatternStored, canAdd]);
 
-      if (!canAdd) {
-        return null;
+  if (!isSaveTripsEnabled || !canAdd) {
+    return null;
+  }
+
+  return (
+    <Button
+      accessibilityHint={
+        isStored
+          ? t(SaveTripPatternButtonComponentTexts.removeTrip.a11yHint)
+          : t(SaveTripPatternButtonComponentTexts.saveTrip.a11yHint)
       }
-
-      return (
-        <Button
-          accessibilityHint={
-            isStored
-              ? t(SaveTripPatternButtonComponentTexts.removeTrip.a11yHint)
-              : t(SaveTripPatternButtonComponentTexts.saveTrip.a11yHint)
-          }
-          onPress={() => {
-            if (isStored) {
-              analytics().logEvent('click_trip_remove_button');
-              posthogAnalytics.logEvent(
-                'Trip details',
-                'Trip removed',
-                getTripPatternAnalytics(tripPattern, fareZones, now),
-              );
-              removeTripPattern(tripPattern);
-              setTimeout(
-                () =>
-                  AccessibilityInfo.announceForAccessibility(
-                    t(
-                      SaveTripPatternButtonComponentTexts.removeTrip
-                        .a11yAnnouncement,
-                    ),
-                  ),
-                100,
-              );
-            } else {
-              analytics().logEvent('click_trip_save_button');
-              posthogAnalytics.logEvent(
-                'Trip details',
-                'Trip saved',
-                getTripPatternAnalytics(tripPattern, fareZones, now),
-              );
-              addTripPattern(tripPattern);
-              setTimeout(
-                () =>
-                  AccessibilityInfo.announceForAccessibility(
-                    t(
-                      SaveTripPatternButtonComponentTexts.saveTrip
-                        .a11yAnnouncement,
-                    ),
-                  ),
-                100,
-              );
-            }
-          }}
-          text={
-            isStored
-              ? t(SaveTripPatternButtonComponentTexts.removeTrip.text)
-              : t(SaveTripPatternButtonComponentTexts.saveTrip.text)
-          }
-          leftIcon={isStored ? {svg: SaveFill} : {svg: Save}}
-          expanded={true}
-          accessibilityRole="button"
-          accessible={true}
-          mode="secondary"
-          backgroundColor={
-            isStored
-              ? theme.color.interactive[0].active
-              : theme.color.background.neutral[0]
-          }
-        />
-      );
-    },
+      onPress={() => {
+        if (isStored) {
+          analytics().logEvent('click_trip_remove_button');
+          posthogAnalytics.logEvent(
+            'Trip details',
+            'Trip removed',
+            getTripPatternAnalytics(tripPattern, fareZones, now),
+          );
+          removeTripPattern(tripPattern);
+          setTimeout(
+            () =>
+              AccessibilityInfo.announceForAccessibility(
+                t(
+                  SaveTripPatternButtonComponentTexts.removeTrip
+                    .a11yAnnouncement,
+                ),
+              ),
+            100,
+          );
+        } else {
+          analytics().logEvent('click_trip_save_button');
+          posthogAnalytics.logEvent(
+            'Trip details',
+            'Trip saved',
+            getTripPatternAnalytics(tripPattern, fareZones, now),
+          );
+          addTripPattern(tripPattern);
+          setTimeout(
+            () =>
+              AccessibilityInfo.announceForAccessibility(
+                t(
+                  SaveTripPatternButtonComponentTexts.saveTrip.a11yAnnouncement,
+                ),
+              ),
+            100,
+          );
+        }
+      }}
+      text={
+        isStored
+          ? t(SaveTripPatternButtonComponentTexts.removeTrip.text)
+          : t(SaveTripPatternButtonComponentTexts.saveTrip.text)
+      }
+      leftIcon={isStored ? {svg: SaveFill} : {svg: Save}}
+      expanded={true}
+      accessibilityRole="button"
+      accessible={true}
+      mode="secondary"
+      backgroundColor={
+        isStored
+          ? theme.color.interactive[0].active
+          : theme.color.background.neutral[0]
+      }
+    />
   );
+};
 
 const SaveTripPatternButtonComponentTexts = {
   saveTrip: {

--- a/src/modules/experimental-store-trip-patterns/SaveableTripSearchResultRow.tsx
+++ b/src/modules/experimental-store-trip-patterns/SaveableTripSearchResultRow.tsx
@@ -1,9 +1,6 @@
 import React, {useCallback, useMemo} from 'react';
 import {useStoredTripPatterns} from './StoredTripPatternsContext';
-import {
-  useIsExperimentalEnabled,
-  wrapWithExperimentalFeatureToggledComponent,
-} from '@atb/modules/experimental';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {RightActionKind, SwipeableResultRow} from './SwipeableResultRow';
 import {getTripPatternKey} from '../trip-patterns/utils';
 import {TripPattern} from '@atb/api/types/trips';
@@ -14,81 +11,80 @@ import {getTripPatternAnalytics} from '@atb/screen-components/travel-details-scr
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {useTimeContext} from '../time';
 
-export const SaveableTripSearchResultRow =
-  wrapWithExperimentalFeatureToggledComponent<
-    React.PropsWithChildren<{
-      tripPattern: TripPattern;
-    }>
-  >('render-children-if-disabled', ({children, tripPattern}) => {
-    const isExperimentalEnabled = useIsExperimentalEnabled();
-    const {tripPatterns, addTripPattern, removeTripPattern, canAddTripPattern} =
-      useStoredTripPatterns();
-    const {fareZones} = useFirestoreConfigurationContext();
-    const analytics = useAnalyticsContext();
-    const {serverNow} = useTimeContext(30000);
+export const SaveableTripSearchResultRow: React.FC<
+  React.PropsWithChildren<{
+    tripPattern: TripPattern;
+  }>
+> = ({children, tripPattern}) => {
+  const {isSaveTripsEnabled} = useFeatureTogglesContext();
+  const {tripPatterns, addTripPattern, removeTripPattern, canAddTripPattern} =
+    useStoredTripPatterns();
+  const {fareZones} = useFirestoreConfigurationContext();
+  const analytics = useAnalyticsContext();
+  const {serverNow} = useTimeContext(30000);
 
-    const canAdd = useMemo(() => {
-      return canAddTripPattern(tripPattern);
-    }, [tripPattern, canAddTripPattern]);
+  const canAdd = useMemo(() => {
+    return canAddTripPattern(tripPattern);
+  }, [tripPattern, canAddTripPattern]);
 
-    const isStored = useMemo(
-      () =>
-        canAdd &&
-        tripPatterns.some((tp) => tp.key === getTripPatternKey(tripPattern)),
-      [tripPattern, tripPatterns, canAdd],
-    );
+  const isStored = useMemo(
+    () =>
+      canAdd &&
+      tripPatterns.some((tp) => tp.key === getTripPatternKey(tripPattern)),
+    [tripPattern, tripPatterns, canAdd],
+  );
 
-    const rightActionKind = useMemo<RightActionKind>(
-      () => (isStored ? 'delete' : 'save'),
-      [isStored],
-    );
+  const rightActionKind = useMemo<RightActionKind>(
+    () => (isStored ? 'delete' : 'save'),
+    [isStored],
+  );
 
-    const onRightAction = useCallback(
-      (actionKind: RightActionKind, closeSwipeable: () => void) => {
-        closeSwipeable();
-        if (actionKind === 'delete') {
-          analytics.logEvent(
-            'Trip search',
-            'Trip removed',
-            getTripPatternAnalytics(tripPattern, fareZones, serverNow),
-          );
-          removeTripPattern(tripPattern);
-        } else {
-          analytics.logEvent(
-            'Trip search',
-            'Trip saved',
-            getTripPatternAnalytics(tripPattern, fareZones, serverNow),
-          );
-          addTripPattern(tripPattern);
-        }
-      },
-      [
-        tripPattern,
-        addTripPattern,
-        removeTripPattern,
-        analytics,
-        fareZones,
-        serverNow,
-      ],
-    );
+  const onRightAction = useCallback(
+    (actionKind: RightActionKind, closeSwipeable: () => void) => {
+      closeSwipeable();
+      if (actionKind === 'delete') {
+        analytics.logEvent(
+          'Trip search',
+          'Trip removed',
+          getTripPatternAnalytics(tripPattern, fareZones, serverNow),
+        );
+        removeTripPattern(tripPattern);
+      } else {
+        analytics.logEvent(
+          'Trip search',
+          'Trip saved',
+          getTripPatternAnalytics(tripPattern, fareZones, serverNow),
+        );
+        addTripPattern(tripPattern);
+      }
+    },
+    [
+      tripPattern,
+      addTripPattern,
+      removeTripPattern,
+      analytics,
+      fareZones,
+      serverNow,
+    ],
+  );
 
-    if (!isExperimentalEnabled || !canAdd) {
-      return children;
-    }
+  if (!isSaveTripsEnabled || !canAdd) {
+    return children;
+  }
 
-    return (
-      <SwipeableResultRow
-        onRightAction={onRightAction}
-        rightActionKind={rightActionKind}
-      >
-        {children}
-        {isStored && (
-          <ThemeIcon
-            svg={SaveFill}
-            color="secondary"
-            style={{position: 'absolute', right: 20, top: 2}}
-          />
-        )}
-      </SwipeableResultRow>
-    );
-  });
+  return (
+    <SwipeableResultRow
+      onRightAction={onRightAction}
+      rightActionKind={rightActionKind}
+    >
+      {children}
+      {isStored && (
+        <ThemeIcon
+          svg={SaveFill}
+          color="secondary"
+          style={{position: 'absolute', right: 20, top: 2}}
+        />
+      )}
+    </SwipeableResultRow>
+  );
+};

--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsContext.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsContext.tsx
@@ -8,7 +8,6 @@ import React, {
 import {StoredTripPattern, storedTripPatterns} from './storage';
 import {TripPattern} from '@atb/api/types/trips';
 import {getTripPatternKey} from '../trip-patterns/utils';
-import {wrapWithExperimentalFeatureToggledComponent} from '@atb/modules/experimental';
 import {ONE_MINUTE_MS} from '@atb/utils/durations';
 import {useTimeContext} from '@atb/modules/time';
 
@@ -24,87 +23,79 @@ const StoredTripPatternsContext = createContext<
   StoredTripPatternsContextState | undefined
 >(undefined);
 
-export const StoredTripPatternsContextProvider =
-  wrapWithExperimentalFeatureToggledComponent<React.PropsWithChildren>(
-    'render-children-if-disabled',
-    ({children}) => {
-      const [tripPatterns, setTripPatternsState] = useState<
-        StoredTripPattern[]
-      >([]);
-      const {serverNow} = useTimeContext(ONE_MINUTE_MS);
+export const StoredTripPatternsContextProvider: React.FC<
+  React.PropsWithChildren
+> = ({children}) => {
+  const [tripPatterns, setTripPatternsState] = useState<StoredTripPattern[]>(
+    [],
+  );
+  const {serverNow} = useTimeContext(ONE_MINUTE_MS);
 
-      const populateTripPatterns = useCallback(async () => {
-        const tripPatterns = await storedTripPatterns.getTripPatterns();
-        setTripPatternsState(tripPatterns ?? []);
-      }, []);
+  const populateTripPatterns = useCallback(async () => {
+    const tripPatterns = await storedTripPatterns.getTripPatterns();
+    setTripPatternsState(tripPatterns ?? []);
+  }, []);
 
-      useEffect(() => {
-        populateTripPatterns();
-      }, [populateTripPatterns]);
+  useEffect(() => {
+    populateTripPatterns();
+  }, [populateTripPatterns]);
 
-      const addTripPattern = useCallback(async (tripPattern: TripPattern) => {
-        const newTripPatterns =
-          await storedTripPatterns.addTripPattern(tripPattern);
-        setTripPatternsState(newTripPatterns);
-      }, []);
+  const addTripPattern = useCallback(async (tripPattern: TripPattern) => {
+    const newTripPatterns =
+      await storedTripPatterns.addTripPattern(tripPattern);
+    setTripPatternsState(newTripPatterns);
+  }, []);
 
-      const removeTripPattern = useCallback(
-        async (tripPattern: TripPattern) => {
-          const newTripPatterns =
-            await storedTripPatterns.removeTripPattern(tripPattern);
-          setTripPatternsState(newTripPatterns);
-        },
-        [],
-      );
+  const removeTripPattern = useCallback(async (tripPattern: TripPattern) => {
+    const newTripPatterns =
+      await storedTripPatterns.removeTripPattern(tripPattern);
+    setTripPatternsState(newTripPatterns);
+  }, []);
 
-      const updateTripPattern = useCallback(
-        async (tripPattern: TripPattern) => {
-          const newTripPatterns =
-            await storedTripPatterns.updateTripPattern(tripPattern);
-          setTripPatternsState(newTripPatterns);
-        },
-        [],
-      );
+  const updateTripPattern = useCallback(async (tripPattern: TripPattern) => {
+    const newTripPatterns =
+      await storedTripPatterns.updateTripPattern(tripPattern);
+    setTripPatternsState(newTripPatterns);
+  }, []);
 
-      const isTripPatternStored = useCallback(
-        (tripPattern: TripPattern) => {
-          return tripPatterns.some(
-            (tp) => tp.key === getTripPatternKey(tripPattern),
-          );
-        },
-        [tripPatterns],
-      );
-
-      const canAddTripPattern = useCallback((tripPattern: TripPattern) => {
-        return tripPattern && tripPattern.legs.filter((l) => l.id).length > 0;
-      }, []);
-
-      const removeTripPatternsOlderThan = useCallback(async (date: Date) => {
-        const newTripPatterns =
-          await storedTripPatterns.removeTripPatternsOlderThan(date);
-        setTripPatternsState(newTripPatterns);
-      }, []);
-
-      useEffect(() => {
-        removeTripPatternsOlderThan(new Date(serverNow));
-      }, [serverNow, removeTripPatternsOlderThan]);
-
-      const contextValue: StoredTripPatternsContextState = {
-        tripPatterns,
-        addTripPattern,
-        removeTripPattern,
-        updateTripPattern,
-        isTripPatternStored,
-        canAddTripPattern,
-      };
-
-      return (
-        <StoredTripPatternsContext.Provider value={contextValue}>
-          {children}
-        </StoredTripPatternsContext.Provider>
+  const isTripPatternStored = useCallback(
+    (tripPattern: TripPattern) => {
+      return tripPatterns.some(
+        (tp) => tp.key === getTripPatternKey(tripPattern),
       );
     },
+    [tripPatterns],
   );
+
+  const canAddTripPattern = useCallback((tripPattern: TripPattern) => {
+    return tripPattern && tripPattern.legs.filter((l) => l.id).length > 0;
+  }, []);
+
+  const removeTripPatternsOlderThan = useCallback(async (date: Date) => {
+    const newTripPatterns =
+      await storedTripPatterns.removeTripPatternsOlderThan(date);
+    setTripPatternsState(newTripPatterns);
+  }, []);
+
+  useEffect(() => {
+    removeTripPatternsOlderThan(new Date(serverNow));
+  }, [serverNow, removeTripPatternsOlderThan]);
+
+  const contextValue: StoredTripPatternsContextState = {
+    tripPatterns,
+    addTripPattern,
+    removeTripPattern,
+    updateTripPattern,
+    isTripPatternStored,
+    canAddTripPattern,
+  };
+
+  return (
+    <StoredTripPatternsContext.Provider value={contextValue}>
+      {children}
+    </StoredTripPatternsContext.Provider>
+  );
+};
 
 export function useStoredTripPatterns() {
   const context = useContext(StoredTripPatternsContext);

--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
@@ -13,92 +13,88 @@ import {ContentHeading} from '@atb/components/heading';
 import {translation as _, useTranslation} from '@atb/translations';
 import {TravelCard} from '@atb/screen-components/travel-card';
 import {useStoredTripPatterns} from './StoredTripPatternsContext';
-import {wrapWithExperimentalFeatureToggledComponent} from '@atb/modules/experimental';
 import {RightActionKind, SwipeableResultRow} from './SwipeableResultRow';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {getTripPatternAnalytics} from '@atb/screen-components/travel-details-screens';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {useTimeContext} from '../time';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 type Props = {
   onDetailsPressed(tripPattern: TripPattern): void;
   isFocused: boolean;
 };
 
-export const StoredTripPatternsDashboardComponent =
-  wrapWithExperimentalFeatureToggledComponent<Props>(
-    'render-nothing-if-disabled',
-    ({onDetailsPressed, isFocused}) => {
-      const styles = useThemeStyles();
-      const {t} = useTranslation();
-      const {fareZones} = useFirestoreConfigurationContext();
-      const analytics = useAnalyticsContext();
-      const {serverNow} = useTimeContext(30000);
+export const StoredTripPatternsDashboardComponent: React.FC<Props> = ({
+  onDetailsPressed,
+  isFocused,
+}) => {
+  const {isSaveTripsEnabled} = useFeatureTogglesContext();
+  const styles = useThemeStyles();
+  const {t} = useTranslation();
+  const {fareZones} = useFirestoreConfigurationContext();
+  const analytics = useAnalyticsContext();
+  const {serverNow} = useTimeContext(30000);
 
-      const {tripPatterns, updateTripPattern, removeTripPattern} =
-        useStoredTripPatterns();
+  const {tripPatterns, updateTripPattern, removeTripPattern} =
+    useStoredTripPatterns();
 
-      const setTripPatternToRemove = useCallback(
-        (tripPattern: TripPattern, cancelRemove: () => void) => {
-          Alert.alert(
-            t(RemoveStoredTripPatternAlertTexts.header.text),
-            undefined,
-            [
-              {
-                text: t(RemoveStoredTripPatternAlertTexts.cancelButton.text),
-                style: 'cancel',
-                onPress: cancelRemove,
-              },
-              {
-                text: t(RemoveStoredTripPatternAlertTexts.removeButton.text),
-                style: 'destructive',
-                onPress: () => {
-                  analytics.logEvent(
-                    'Dashboard',
-                    'Trip removed',
-                    getTripPatternAnalytics(tripPattern, fareZones, serverNow),
-                  );
-                  removeTripPattern(tripPattern);
-                },
-              },
-            ],
-          );
+  const setTripPatternToRemove = useCallback(
+    (tripPattern: TripPattern, cancelRemove: () => void) => {
+      Alert.alert(t(RemoveStoredTripPatternAlertTexts.header.text), undefined, [
+        {
+          text: t(RemoveStoredTripPatternAlertTexts.cancelButton.text),
+          style: 'cancel',
+          onPress: cancelRemove,
         },
-        [removeTripPattern, t, analytics, fareZones, serverNow],
-      );
-
-      if (!tripPatterns.length) {
-        return null;
-      }
-
-      return (
-        <View testID="storedTripPatternsContentView">
-          <ContentHeading
-            style={styles.contentHeading}
-            text={t(StoredTripPatternsDashboardComponentTexts.header)}
-          />
-          {tripPatterns.map((tripPattern, i) => (
-            <Animated.View
-              key={tripPattern.key}
-              exiting={ZoomOut.easing(Easing.inOut(Easing.ease))}
-              layout={LinearTransition} // https://github.com/software-mansion/react-native-reanimated/discussions/5857#discussioncomment-9992457
-              style={{zIndex: 999}} // This is to make the animation appear above content which is not animating
-            >
-              <StoredTripPatternRow
-                tripPattern={tripPattern}
-                onDetailsPressed={onDetailsPressed}
-                resultIndex={i}
-                length={tripPatterns.length}
-                updateTripPattern={updateTripPattern}
-                setTripPatternToRemove={setTripPatternToRemove}
-                isFocused={isFocused}
-              />
-            </Animated.View>
-          ))}
-        </View>
-      );
+        {
+          text: t(RemoveStoredTripPatternAlertTexts.removeButton.text),
+          style: 'destructive',
+          onPress: () => {
+            analytics.logEvent(
+              'Dashboard',
+              'Trip removed',
+              getTripPatternAnalytics(tripPattern, fareZones, serverNow),
+            );
+            removeTripPattern(tripPattern);
+          },
+        },
+      ]);
     },
+    [removeTripPattern, t, analytics, fareZones, serverNow],
   );
+
+  if (!isSaveTripsEnabled || !tripPatterns.length) {
+    return null;
+  }
+
+  return (
+    <View testID="storedTripPatternsContentView">
+      <ContentHeading
+        style={styles.contentHeading}
+        text={t(StoredTripPatternsDashboardComponentTexts.header)}
+      />
+      {tripPatterns.map((tripPattern, i) => (
+        <Animated.View
+          key={tripPattern.key}
+          exiting={ZoomOut.easing(Easing.inOut(Easing.ease))}
+          layout={LinearTransition}
+          style={{zIndex: 999}}
+        >
+          <StoredTripPatternRow
+            tripPattern={tripPattern}
+            onDetailsPressed={onDetailsPressed}
+            resultIndex={i}
+            length={tripPatterns.length}
+            updateTripPattern={updateTripPattern}
+            setTripPatternToRemove={setTripPatternToRemove}
+            isFocused={isFocused}
+          />
+        </Animated.View>
+      ))}
+    </View>
+  );
+};
 
 const StoredTripPatternRow: React.FC<{
   tripPattern: TripPattern;

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -106,6 +106,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_refunds',
   },
   {
+    name: 'isSaveTripsEnabled',
+    remoteConfigKey: 'enable_save_trips',
+  },
+  {
     name: 'isServerTimeEnabled',
     remoteConfigKey: 'enable_server_time',
   },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -46,6 +46,7 @@ export type RemoteConfig = {
   enable_posthog: boolean;
   enable_push_notifications: boolean;
   enable_refunds: boolean;
+  enable_save_trips: boolean;
   enable_server_time: boolean;
   enable_shmo_deep_integration: boolean;
   enable_shmo_deep_integration_citybike: boolean;
@@ -116,6 +117,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_posthog: false,
   enable_push_notifications: false,
   enable_refunds: true,
+  enable_save_trips: false,
   enable_server_time: true,
   enable_shmo_deep_integration: false,
   enable_shmo_deep_integration_citybike: false,
@@ -247,6 +249,9 @@ export function getConfig(): RemoteConfig {
     defaultRemoteConfig.enable_push_notifications;
   const enable_refunds =
     values['enable_refunds']?.asBoolean() ?? defaultRemoteConfig.enable_refunds;
+  const enable_save_trips =
+    values['enable_save_trips']?.asBoolean() ??
+    defaultRemoteConfig.enable_save_trips;
   const enable_server_time =
     values['enable_server_time']?.asBoolean() ??
     defaultRemoteConfig.enable_server_time;
@@ -370,6 +375,7 @@ export function getConfig(): RemoteConfig {
     enable_posthog,
     enable_push_notifications,
     enable_refunds,
+    enable_save_trips,
     enable_server_time,
     enable_shmo_deep_integration,
     enable_shmo_deep_integration_citybike,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/23635

## Summary

- Added `enable_save_trips` remote config parameter with a corresponding `isSaveTripsEnabled` feature toggle, replacing the experimental features gate. This makes save trips controllable via Firebase Remote Config and overridable in the debug menu.
- Made `StoredTripPatternsContextProvider` unconditional — it always renders, so `useStoredTripPatterns()` never throws regardless of toggle state.
- Replaced `wrapWithExperimentalFeatureToggledComponent` in `StoredTripPatternsDashboardComponent`, `SaveableTripSearchResultRow`, and `SaveTripPatternButtonComponent` with direct `isSaveTripsEnabled` checks.
- Removed redundant `useIsExperimentalEnabled()` check in `SaveableTripSearchResultRow`.

## Test plan

- [ ] Verify save trips UI is hidden when `enable_save_trips` is `false` (default): no saved trips on dashboard, no swipe-to-save in search results, no save button in trip details
- [ ] Verify save trips UI is visible when `enable_save_trips` is `true`: saved trips section on dashboard, swipe-to-save on search results, save button in trip details
- [ ] Verify the toggle is overridable from the debug menu
- [ ] Verify saving/removing trips works correctly when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)