### PR TITLE
fix: array index was used as `now` when filtering departures

### DIFF
--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -49,7 +49,9 @@ export function updateStopsWithRealtime(
 
 function filterOutOutdatedDepartures(quayGroup: QuayGroup) {
   const newDepartureGroups = quayGroup.group.map(function (group) {
-    const newDepartures = group.departures.filter(isValidDeparture);
+    const newDepartures = group.departures.filter((departure) =>
+      isValidDeparture(departure),
+    );
     // Optimization to avoid having to sort list to often.
     // If after filtering it has the same length it means we could
     // just use the previous departure list.
@@ -148,12 +150,8 @@ export function hasNoDeparturesOnGroup(group: DepartureGroup) {
   );
 }
 
-export function isValidDeparture(departure: DepartureTime, now?: number) {
-  return !isNumberOfMinutesInThePast(
-    departure.time,
-    HIDE_AFTER_NUM_MINUTES,
-    now,
-  );
+export function isValidDeparture(departure: DepartureTime) {
+  return !isNumberOfMinutesInThePast(departure.time, HIDE_AFTER_NUM_MINUTES);
 }
 
 export function isValidDepartureTime(time: string, now?: number) {


### PR DESCRIPTION
Since `isValidDeparture` takes two params, calling `filter(isValidDeparture)` caused two params to be passed to `isValidDeparture`: departure (as expected) and an index. 

In practice, this meant we were running

```ts
.filter((departure, i) => isValidDeparture(departure, i))
```

When now was set to 0, 1, 2 etc., this was interpreted as seconds since Jan 1st 1970. So in practice, departures was never more than one minute in the past, because it seemed they were 56 years in the future.

This caused departures to stay as "now" for 5 minutes on the front page (until we call for a full refresh) instead of being filtered out.

### Acceptance criteria

- [ ] On the front page, departures are removed 1 minute after passing the stop