### PR TITLE
fix: use innstilt instead of kansellert for trips/departures

### DIFF
--- a/src/translations/components/CancelledDeparture.ts
+++ b/src/translations/components/CancelledDeparture.ts
@@ -2,11 +2,11 @@ import {translation as _} from '../commons';
 
 const CancelledDepartureTexts = {
   message: _(
-    'Avgangen fra denne holdeplassen er kansellert.',
+    'Avgangen fra denne holdeplassen er innstilt.',
     'The departure from this stop has been cancelled.',
-    'Avgangen frå denne haldeplassen er kansellert.',
+    'Avgangen frå denne haldeplassen er innstilt.',
   ),
-  cancelled: _('Kansellert', 'Cancelled', 'Kansellert'),
+  cancelled: _('Innstilt', 'Cancelled', 'Innstilt'),
 };
 
 export default CancelledDepartureTexts;


### PR DESCRIPTION
## Description
Replaces "kansellert" with "innstilt"

The text for cancelled departures is wrong, in most of our channels (Screens on bus stops, Travel Planner Web), a cancelled departure always use "Innstilt" instead of "Kansellert".

Also, @Mariblaas shows me the marketing text and it says "Innstilt" instead of "Kansellert"