### PR TITLE
feat: Map tile preloader

### DIFF
--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -66,6 +66,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_map_pitch',
   },
   {
+    name: 'isMapTilePreloadingEnabled',
+    remoteConfigKey: 'enable_map_tile_preloading',
+  },
+  {
     name: 'isNonTransitTripSearchEnabled',
     remoteConfigKey: 'enable_non_transit_trip_search',
   },

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -11,6 +11,7 @@ import {
   Viewport,
   Camera,
   MapView,
+  MapState,
 } from '@rnmapbox/maps';
 
 import {Feature} from 'geojson';
@@ -56,7 +57,11 @@ import {useMapContext} from '@atb/modules/map';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
 import {OnPressEvent} from 'node_modules/@rnmapbox/maps/src/types/OnPressEvent';
-import {VehiclesAndStations} from './components/mobility/VehiclesAndStations';
+import {
+  StationsWithClusters,
+  VehiclesAndStations,
+  VehiclesWithClusters,
+} from './components/mobility/VehiclesAndStations';
 import {SelectedFeatureIcon} from './components/SelectedFeatureIcon';
 import {ShmoBookingState} from '@atb/api/types/mobility';
 import {useStablePreviousValue} from '@atb/utils/use-stable-previous-value';
@@ -68,8 +73,9 @@ import {ShmoTesting} from './components/mobility/ShmoTesting';
 import {usePreferencesContext} from '../preferences';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {GeofencingZonesAsTiles} from './components/mobility/GeofencingZonesAsTiles';
+import {MapTilePreloader} from './components/MapTilePreloader';
 
-const DEFAULT_ZOOM_LEVEL = 14.5;
+export const DEFAULT_ZOOM_LEVEL = 14.5;
 
 export const Map = (props: MapProps) => {
   const {
@@ -92,6 +98,7 @@ export const Map = (props: MapProps) => {
   const {getCurrentCoordinates} = useGeolocationContext();
   const mapCameraRef = useRef<Camera>(null);
   const mapViewRef = useRef<MapView>(null);
+  const mapStateRef = useRef<MapState | null>(null);
   const [initMapLoaded, setInitMapLoaded] = useState(false);
   const {bottomSheetMapRef} = useBottomSheetContext();
   const onPressStartRef = useRef<boolean>(false);
@@ -120,6 +127,7 @@ export const Map = (props: MapProps) => {
     isGeofencingZonesEnabled,
     isGeofencingZonesAsTilesEnabled,
     isMapPitchEnabled,
+    isMapTilePreloadingEnabled,
   } = useFeatureTogglesContext();
 
   const {getGeofencingZoneContent} = useGeofencingZoneContent();
@@ -387,6 +395,7 @@ export const Map = (props: MapProps) => {
             onPressStartRef.current = true;
           }}
           onCameraChanged={(state) => {
+            mapStateRef.current = {...state};
             // If a collapse is pending and the camera moves, collapse immediately
             if (onPressStartRef.current && state.gestures.isGestureActive) {
               onPressStartRef.current = false;
@@ -510,6 +519,27 @@ export const Map = (props: MapProps) => {
         navigateToPaymentMethods={navigateToPaymentMethods}
         locationArrowOnPress={locationArrowOnPress}
       />
+      {isMapTilePreloadingEnabled && (
+        <MapTilePreloader
+          startingCoordinates={startingCoordinates}
+          tabBarHeight={tabBarHeight}
+          ref={mapStateRef}
+        >
+          {!!showVehicles && (
+            <VehiclesWithClusters
+              selectedFeatureId={undefined}
+              hideSymbols={true}
+            />
+          )}
+          {!!showStations && (
+            <StationsWithClusters
+              selectedFeatureId={undefined}
+              showNonVirtualStations={true}
+              hideSymbols={true}
+            />
+          )}
+        </MapTilePreloader>
+      )}
     </View>
   );
 };

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -384,6 +384,7 @@ export const Map = (props: MapProps) => {
     <View style={{flex: 1}}>
       <View style={{flex: 1}}>
         <MapView
+          id="mainMap"
           ref={mapViewRef}
           style={{
             flex: 1,

--- a/src/modules/map/components/MapTilePreloader.tsx
+++ b/src/modules/map/components/MapTilePreloader.tsx
@@ -1,0 +1,124 @@
+import {Camera, MapState, MapView} from '@rnmapbox/maps';
+import {Dimensions} from 'react-native';
+import {useMapViewConfig} from '../hooks/use-map-view-config';
+import {ForwardedRef, forwardRef, useRef} from 'react';
+import {DEFAULT_ZOOM_LEVEL} from '../Map';
+import {MapCameraConfig} from '../MapConfig';
+import {Coordinates} from '@atb/utils/coordinates';
+import {useInterval} from '@atb/utils/use-interval';
+import {Position} from 'geojson';
+import distance from '@turf/distance';
+
+type MapTilePreloaderProps = {
+  startingCoordinates?: Coordinates;
+  tabBarHeight: number;
+  children?: React.ReactNode;
+};
+
+/**
+ * The purpose of this component is to preload vector tiles.
+ * This helps prevent flickering and missed in-transitions when zooming in.
+ * Unfortunately rnmapbox does not have native functionality/props for this.
+ *
+ * Achieved with a parallell map not shown on the screen,
+ * which zooms to the next zoom level in order to preload that area with that zoom level.
+ * For the sake of performance, no symbols should be drawn on this map.
+ *
+ * Currently
+ * - only preloads based on zoom, but can in theory be used to preload e.g. flying/driving paths too.
+ * - pitch and padding ignored for viewport.
+ */
+export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
+  (
+    {startingCoordinates, tabBarHeight, children}: MapTilePreloaderProps,
+    /** Should be set like this: onCameraChanged={(state) => {mapStateRef.current = state;}} */
+    mapStateRef: ForwardedRef<MapState>,
+  ) => {
+    const mapCameraOffscreenRef = useRef<Camera>(null);
+
+    const mapViewConfig = useMapViewConfig({
+      includeVehiclesAndStationsVectorSource: true,
+      includeBasemapStyle: true,
+    });
+
+    const previousZoomRef = useRef<number>(0);
+    const previousCenterRef = useRef<Position>([0, 0]);
+    const previousUpdateTimeRef = useRef<number>(new Date().getTime());
+    useInterval(
+      () => {
+        if (mapStateRef && 'current' in mapStateRef && mapStateRef.current) {
+          const {zoom, center} = mapStateRef.current.properties;
+
+          const metersMoved = distance(center, previousCenterRef.current, {
+            units: 'meters',
+          });
+
+          const now = new Date().getTime();
+          const secondsSinceLastUpdate =
+            (now - previousUpdateTimeRef.current) / 1000;
+
+          if (
+            zoom !== previousZoomRef.current ||
+            metersMoved > 75 || // ignore small movements (may also want to adjust this threshold based on zoom)
+            secondsSinceLastUpdate > 5
+          ) {
+            const isZoomingOut = zoom < previousZoomRef.current;
+
+            mapCameraOffscreenRef.current?.setCamera({
+              centerCoordinate: center,
+              zoomLevel: zoom + (isZoomingOut ? -1 : 1), // preloading the next zoom level when zooming in or moving around
+              animationMode: 'none',
+              animationDuration: 0,
+            });
+
+            previousZoomRef.current = zoom;
+            previousCenterRef.current = center;
+            previousUpdateTimeRef.current = now;
+          }
+        }
+      },
+      [mapStateRef],
+      100, // Refresh rate. Might be lower for slow devices. No need for very short interval, this is "just for preloading behind the scenes".
+    );
+
+    const {width, height} = Dimensions.get('window');
+    return (
+      <MapView
+        surfaceView={false} // android won't render more than 1 map with surfaceView
+        style={{
+          pointerEvents: 'none',
+          position: 'absolute',
+          top: -(height - tabBarHeight) - 100,
+          left: -width - 100,
+          height: height - tabBarHeight,
+          width: width,
+          opacity: 0,
+          // useful for development/inspection:
+          // top: 0,
+          // bottom: 0,
+          // height: (height - tabBarHeight) / 2,
+          // width: width / 2,
+          // opacity: 1,
+          // borderWidth: 1,
+        }}
+        pitchEnabled={false}
+        {...mapViewConfig}
+        attributionEnabled={false}
+        compassEnabled={false}
+        logoEnabled={false}
+      >
+        <Camera
+          ref={mapCameraOffscreenRef}
+          zoomLevel={DEFAULT_ZOOM_LEVEL}
+          centerCoordinate={
+            startingCoordinates
+              ? [startingCoordinates.longitude, startingCoordinates.latitude]
+              : [0, 0]
+          }
+          {...MapCameraConfig}
+        />
+        {children}
+      </MapView>
+    );
+  },
+);

--- a/src/modules/map/components/MapTilePreloader.tsx
+++ b/src/modules/map/components/MapTilePreloader.tsx
@@ -84,6 +84,7 @@ export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
     const {width, height} = Dimensions.get('window');
     return (
       <MapView
+        id="preloaderOnlyMap"
         surfaceView={false} // android won't render more than 1 map with surfaceView
         style={{
           pointerEvents: 'none',
@@ -92,6 +93,9 @@ export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
           left: -width - 100,
           height: height - tabBarHeight,
           width: width,
+          transform: [
+            {scale: 0.01}, // Shrinks the visual output to a sub-pixel
+          ],
           opacity: 0,
           // useful for development/inspection:
           // top: 0,

--- a/src/modules/map/components/MapTilePreloader.tsx
+++ b/src/modules/map/components/MapTilePreloader.tsx
@@ -94,7 +94,7 @@ export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
           height: height - tabBarHeight,
           width: width,
           transform: [
-            {scale: 0.01}, // Shrinks the visual output to a sub-pixel
+            {scale: 0.01}, // minimize rendering work, preloading is the only purpose
           ],
           opacity: 0,
           // useful for development/inspection:

--- a/src/modules/map/components/MapTilePreloader.tsx
+++ b/src/modules/map/components/MapTilePreloader.tsx
@@ -1,5 +1,5 @@
 import {Camera, MapState, MapView} from '@rnmapbox/maps';
-import {Dimensions} from 'react-native';
+import {useWindowDimensions} from 'react-native';
 import {useMapViewConfig} from '../hooks/use-map-view-config';
 import {ForwardedRef, forwardRef, useRef} from 'react';
 import {DEFAULT_ZOOM_LEVEL} from '../Map';
@@ -81,7 +81,8 @@ export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
       100, // Refresh rate. Might be lower for slow devices. No need for very short interval, this is "just for preloading behind the scenes".
     );
 
-    const {width, height} = Dimensions.get('window');
+    const {width, height} = useWindowDimensions();
+
     return (
       <MapView
         id="preloaderOnlyMap"

--- a/src/modules/map/components/mobility/VehiclesAndStations.tsx
+++ b/src/modules/map/components/mobility/VehiclesAndStations.tsx
@@ -31,7 +31,8 @@ const vehiclesAndStationsVectorSourceId =
 
 export const VehiclesWithClusters = ({
   selectedFeatureId,
-}: SelectedFeatureIdProp) => {
+  hideSymbols = false,
+}: SelectedFeatureIdProp & {hideSymbols?: boolean}) => {
   const minZoomLevel = 14;
   const {isSelected, iconStyle, textStyle} = useMapSymbolStyles({
     selectedFeaturePropertyId: selectedFeatureId,
@@ -39,9 +40,12 @@ export const VehiclesWithClusters = ({
     reachFullScaleAtZoomLevel: minZoomLevel + scaleTransitionZoomRange + 0.3,
   });
 
-  const filter: FilterExpression = useMemo(
-    () => ['all', ['!', isSelected], hideItemsInTheDistanceFilter],
-    [isSelected],
+  const filter: {filter: FilterExpression} | undefined = useMemo(
+    () =>
+      hideSymbols
+        ? undefined
+        : {filter: ['all', ['!', isSelected], hideItemsInTheDistanceFilter]},
+    [isSelected, hideSymbols],
   );
 
   const style = useMemo(
@@ -54,13 +58,15 @@ export const VehiclesWithClusters = ({
 
   return (
     <MapboxGL.SymbolLayer
-      id="vehicles-clustered-symbol-layer"
+      id={`vehicles-clustered-symbol-layer-${
+        hideSymbols ? 'hidden' : 'visible'
+      }`}
       sourceID={vehiclesAndStationsVectorSourceId}
       sourceLayerID="combined_layer"
       minZoomLevel={minZoomLevel}
       aboveLayerID={MapSlotLayerId.Vehicles}
-      filter={filter}
-      style={style}
+      style={hideSymbols ? {} : style}
+      {...filter}
     />
   );
 };
@@ -68,8 +74,10 @@ export const VehiclesWithClusters = ({
 export const StationsWithClusters = ({
   selectedFeatureId,
   showNonVirtualStations,
+  hideSymbols = false,
 }: SelectedFeatureIdProp & {
   showNonVirtualStations: boolean;
+  hideSymbols?: boolean;
 }) => {
   const showVirtualStations = false; // not supported yet. Also – consider using a virtualStationsFilter prop instead
   const minZoomLevel = 14;
@@ -83,41 +91,46 @@ export const StationsWithClusters = ({
   const showCityBikes = mapFilter?.mobility.BICYCLE?.showAll ?? false;
   const showSharedCars = mapFilter?.mobility.CAR?.showAll ?? false;
 
-  const filter: FilterExpression = useMemo(() => {
+  const filter: {filter: FilterExpression} | undefined = useMemo(() => {
     const isVirtualStation: Expression = ['get', 'is_virtual_station'];
     const vehicle_type_form_factor: Expression = [
       'get',
       'vehicle_type_form_factor',
     ];
-    return [
-      'all',
-      ['!', isSelected],
-      [
-        'any',
-        ['==', isVirtualStation, showVirtualStations],
-        ['!=', isVirtualStation, showNonVirtualStations],
-      ],
-      [
-        'any',
-        [
-          'all',
-          ['==', vehicle_type_form_factor, 'BICYCLE'],
-          ['!', !showCityBikes],
-        ],
-        [
-          'all',
-          ['==', vehicle_type_form_factor, 'CAR'],
-          ['!', !showSharedCars],
-        ],
-      ],
-      hideItemsInTheDistanceFilter,
-    ];
+    return hideSymbols
+      ? undefined
+      : {
+          filter: [
+            'all',
+            ['!', isSelected],
+            [
+              'any',
+              ['==', isVirtualStation, showVirtualStations],
+              ['!=', isVirtualStation, showNonVirtualStations],
+            ],
+            [
+              'any',
+              [
+                'all',
+                ['==', vehicle_type_form_factor, 'BICYCLE'],
+                ['!', !showCityBikes],
+              ],
+              [
+                'all',
+                ['==', vehicle_type_form_factor, 'CAR'],
+                ['!', !showSharedCars],
+              ],
+            ],
+            hideItemsInTheDistanceFilter,
+          ],
+        };
   }, [
     isSelected,
     showVirtualStations,
     showNonVirtualStations,
     showCityBikes,
     showSharedCars,
+    hideSymbols,
   ]);
 
   const style = useMemo(
@@ -131,13 +144,15 @@ export const StationsWithClusters = ({
 
   return (
     <MapboxGL.SymbolLayer
-      id="stations-symbol-layer"
+      id={`stations-clustered-symbol-layer-${
+        hideSymbols ? 'hidden' : 'visible'
+      }`}
       sourceID={vehiclesAndStationsVectorSourceId}
       sourceLayerID="combined_stations_layer"
       minZoomLevel={minZoomLevel}
       aboveLayerID={MapSlotLayerId.Stations}
-      filter={filter}
-      style={style}
+      style={hideSymbols ? {} : style}
+      {...filter}
     />
   );
 };

--- a/src/modules/map/hooks/use-map-view-config.ts
+++ b/src/modules/map/hooks/use-map-view-config.ts
@@ -20,6 +20,7 @@ const MapViewStaticConfig = {
 type MapViewConfigOptions = {
   includeVehiclesAndStationsVectorSource?: boolean;
   shouldShowGeofencingZonesLayers?: boolean;
+  includeBasemapStyle?: boolean;
 };
 
 export const useMapViewConfig = (
@@ -28,10 +29,12 @@ export const useMapViewConfig = (
   const {
     includeVehiclesAndStationsVectorSource = false,
     shouldShowGeofencingZonesLayers = false,
+    includeBasemapStyle = true,
   } = mapViewConfigOptions || {};
   const mapboxJsonStyle = useMapboxJsonStyle(
     includeVehiclesAndStationsVectorSource,
     shouldShowGeofencingZonesLayers,
+    includeBasemapStyle,
   );
   const configMap = useMemo(
     () => ({styleJSON: mapboxJsonStyle}),

--- a/src/modules/map/hooks/use-mapbox-json-style.tsx
+++ b/src/modules/map/hooks/use-mapbox-json-style.tsx
@@ -35,9 +35,11 @@ const slotLayers = slotLayerIds.map((slotLayerId) => ({
 export const useMapboxJsonStyle: (
   includeVehiclesAndStationsVectorSource: boolean,
   shouldShowGeofencingZonesLayers: boolean,
+  includeBasemapStyle: boolean,
 ) => string | undefined = (
   includeVehiclesAndStationsVectorSource,
   shouldShowGeofencingZonesLayers,
+  includeBasemapStyle,
 ) => {
   const {themeName} = useThemeContext();
   const {mapbox_user_name, mapbox_nsr_tileset_id} = useRemoteConfigContext();
@@ -113,30 +115,32 @@ export const useMapboxJsonStyle: (
         ...themedStyleWithExtendedSourcesAndSlotLayers,
         sprite: (mapboxSpriteUrl ?? '') + themeName,
         projection: {name: 'mercator'}, // Using 'globe' instead looks pretty cool, but there is an initial frame flicker with zoom 0. Might be possible to fix somehow.
-        imports: isMap3dEnabled
-          ? [
-              {
-                id: 'basemap',
-                // url must be absolute for this to work
-                url: `https://api.mapbox.com/styles/v1/mapbox/standard?access_token=${MAPBOX_API_TOKEN}`,
-                config: {
-                  lightPreset: themeName === 'dark' ? 'night' : 'day',
-                  showPlaceLabels: true,
-                  showPointOfInterestLabels: false,
-                  showTransitLabels: false,
-                  showPedestrianRoads: true,
-                  showRoadLabels: false,
+        imports:
+          isMap3dEnabled && includeBasemapStyle
+            ? [
+                {
+                  id: 'basemap',
+                  // url must be absolute for this to work
+                  url: `https://api.mapbox.com/styles/v1/mapbox/standard?access_token=${MAPBOX_API_TOKEN}`,
+                  config: {
+                    lightPreset: themeName === 'dark' ? 'night' : 'day',
+                    showPlaceLabels: true,
+                    showPointOfInterestLabels: false,
+                    showTransitLabels: false,
+                    showPedestrianRoads: true,
+                    showRoadLabels: false,
+                  },
+                  'color-theme': colorTheme,
                 },
-                'color-theme': colorTheme,
-              },
-            ]
-          : [],
+              ]
+            : [],
       }),
     [
       themedStyleWithExtendedSourcesAndSlotLayers,
       mapboxSpriteUrl,
       themeName,
       isMap3dEnabled,
+      includeBasemapStyle,
     ],
   );
 

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -35,6 +35,7 @@ export type RemoteConfig = {
   enable_loading_screen: boolean;
   enable_map_3d: boolean;
   enable_map_pitch: boolean;
+  enable_map_tile_preloading: boolean;
   enable_non_transit_trip_search: boolean;
   enable_nynorsk: boolean;
   enable_new_token_barcode: boolean;
@@ -106,6 +107,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_loading_screen: true,
   enable_map_3d: true,
   enable_map_pitch: false,
+  enable_map_tile_preloading: false,
   enable_non_transit_trip_search: true,
   enable_new_token_barcode: false,
   enable_new_token_barcode_base64: false,
@@ -219,6 +221,9 @@ export function getConfig(): RemoteConfig {
   const enable_map_pitch =
     values['enable_map_pitch']?.asBoolean() ??
     defaultRemoteConfig.enable_map_pitch;
+  const enable_map_tile_preloading =
+    values['enable_map_tile_preloading']?.asBoolean() ??
+    defaultRemoteConfig.enable_map_tile_preloading;
   const enable_non_transit_trip_search =
     values['enable_non_transit_trip_search']?.asBoolean() ??
     defaultRemoteConfig.enable_non_transit_trip_search;
@@ -364,6 +369,7 @@ export function getConfig(): RemoteConfig {
     enable_loading_screen,
     enable_map_3d,
     enable_map_pitch,
+    enable_map_tile_preloading,
     enable_non_transit_trip_search,
     enable_new_token_barcode,
     enable_new_token_barcode_base64,


### PR DESCRIPTION
Preloading tiles at the next zoom level makes the map experience smoother, mostly due to improved in-transitions.
This is relevant for 3d buildings after https://github.com/AtB-AS/mittatb-app/pull/5230, and was originally made as part of https://github.com/AtB-AS/mittatb-app/pull/5321 to allow for better zoom transitions for vehicles and stations. Splitting it up into 2 PRs, starting with just this one for preloading (part 2: https://github.com/AtB-AS/mittatb-app/pull/5973/changes/091a371d25dfcc39b7e64f63340250b4204d7d49).

Added behind a new feature flag in remote config: `enable_map_tile_preloading`

Mapbox does not have a built in solution for tile preloading, so it has been solved with a second invisible map that zooms further than the main map, which triggers requests and populates the cache. The preloading map is not just invisible, but also just a couple of pixels large and without symbols, in order to minimize rendering work. Also, the Camera is only updated at strategic times, either when you have started zooming or move some distance. So the component rarely re-renders unless you are actually zooming and need it.

Preloading _slightly_ increases number of tile requests and may have a performance impact on some devices, which should be tested.

Staging builds that can be tested:
[iOS](https://github.com/AtB-AS/mittatb-app/actions/runs/24310680717)
[Android](https://github.com/AtB-AS/mittatb-app/actions/workflows/build-staging-android.yml)

**Acceptance Criteria:**
- [x] Overall map experience should be better, not worse.
- [ ] Smoother in-transitions for buildings. (Note -> when zooming fast, data may still not load early enough for the in-transition. This is expected.)
- [ ] Faster loading of vehicles and stations data on the next zoom level (this may be difficult to tell from just this PR, but is required for part 2 of https://github.com/AtB-AS/mittatb-app/pull/5321, where it will matter a lot).
- [x] Not too many tile requests.