### PR TITLE
feat: show cancelled departures

### DIFF
--- a/src/api/bff/trips.ts
+++ b/src/api/bff/trips.ts
@@ -37,6 +37,7 @@ function cleanQuery(query: TripsQueryVariables) {
     walkReluctance: query.walkReluctance,
     walkSpeed: query.walkSpeed,
     modes: query.modes,
+    includeCancellations: query.includeCancellations,
   };
   return cleanQuery;
 }

--- a/src/api/types/generated/TripsQuery.ts
+++ b/src/api/types/generated/TripsQuery.ts
@@ -14,6 +14,7 @@ export type TripsQueryVariables = Types.Exact<{
   walkReluctance?: Types.Maybe<Types.Scalars['Float']['input']>;
   walkSpeed?: Types.Maybe<Types.Scalars['Float']['input']>;
   modes?: Types.Modes;
+  includeCancellations: Types.Scalars['Boolean']['input'];
 }>;
 
 export type TripsQuery = {
@@ -28,6 +29,7 @@ export type NonTransitTripsQueryVariables = Omit<
   | 'walkReluctance'
   | 'numTripPatterns'
   | 'modes'
+  | 'includeCancellations'
 > & {
   directModes: StreetMode[];
 };

--- a/src/api/types/generated/fragments/trips.ts
+++ b/src/api/types/generated/fragments/trips.ts
@@ -38,10 +38,12 @@ export type TripPatternFragment = {
       destinationDisplay?: {frontText?: string; via?: Array<string>};
       quay: {publicCode?: string; name: string};
       notices: Array<NoticeFragment>;
+      cancellation: boolean;
     };
     toEstimatedCall?: {
       stopPositionInPattern: number;
       notices: Array<NoticeFragment>;
+      cancellation: boolean;
     };
     situations: Array<SituationFragment>;
     fromPlace: {
@@ -110,6 +112,7 @@ export type TripPatternFragment = {
       expectedDepartureTime: any;
       predictionInaccurate: boolean;
       quay: {name: string};
+      cancellation: boolean;
     }>;
     bookingArrangements?: BookingArrangementFragment;
     datedServiceJourney?: {

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -122,6 +122,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_shmo_deep_integration_citybike',
   },
   {
+    name: 'isShowCancelledDeparturesEnabled',
+    remoteConfigKey: 'enable_show_cancelled_departures',
+  },
+  {
     name: 'isShowValidTimeInfoEnabled',
     remoteConfigKey: 'enable_show_valid_time_info',
   },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -50,6 +50,7 @@ export type RemoteConfig = {
   enable_server_time: boolean;
   enable_shmo_deep_integration: boolean;
   enable_shmo_deep_integration_citybike: boolean;
+  enable_show_cancelled_departures: boolean;
   enable_show_valid_time_info: boolean;
   enable_ticket_information: boolean;
   enable_ticketing: boolean;
@@ -121,6 +122,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_server_time: true,
   enable_shmo_deep_integration: false,
   enable_shmo_deep_integration_citybike: false,
+  enable_show_cancelled_departures: false,
   enable_show_valid_time_info: true,
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
@@ -261,6 +263,9 @@ export function getConfig(): RemoteConfig {
   const enable_shmo_deep_integration_citybike =
     values['enable_shmo_deep_integration_citybike']?.asBoolean() ??
     defaultRemoteConfig.enable_shmo_deep_integration_citybike;
+  const enable_show_cancelled_departures =
+    values['enable_show_cancelled_departures']?.asBoolean() ??
+    defaultRemoteConfig.enable_show_cancelled_departures;
   const enable_show_valid_time_info =
     values['enable_show_valid_time_info']?.asBoolean() ??
     defaultRemoteConfig.enable_show_valid_time_info;
@@ -379,6 +384,7 @@ export function getConfig(): RemoteConfig {
     enable_server_time,
     enable_shmo_deep_integration,
     enable_shmo_deep_integration_citybike,
+    enable_show_cancelled_departures,
     enable_show_valid_time_info,
     enable_ticket_information,
     enable_ticketing,

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -60,6 +60,7 @@ import {AUTHORITY} from '@env';
 import {AuthorityFragment} from '@atb/api/types/generated/fragments/authority';
 import {getRealtimeState, type TimeValues} from '@atb/utils/realtime';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {CancelledDepartureMessage} from './CancelledDepartureMessage';
 
 type TripSectionProps = {
   isLast?: boolean;
@@ -256,6 +257,11 @@ export const TripSection: React.FC<TripSectionProps> = ({
                 {t(TripDetailsTexts.flexibleTransport.onDemandTransportLabel)}
               </ThemeText>
             )}
+          </TripRow>
+        )}
+        {leg.fromEstimatedCall?.cancellation && (
+          <TripRow>
+            <CancelledDepartureMessage />
           </TripRow>
         )}
         {leg.situations.map((situation) => (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -105,8 +105,10 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const timePickerBottomSheetModalRef = useRef<BottomSheetModal | null>(null);
   const timePickerCloseRef = useRef<View | null>(null);
 
-  const {isFlexibleTransportEnabled: isFlexibleTransportEnabledInRemoteConfig} =
-    useFeatureTogglesContext();
+  const {
+    isFlexibleTransportEnabled: isFlexibleTransportEnabledInRemoteConfig,
+    isShowCancelledDeparturesEnabled,
+  } = useFeatureTogglesContext();
 
   const {location} = useGeolocationContext();
 
@@ -142,8 +144,16 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
       searchTime: sanitizedSearchTime,
       arriveBy,
       travelSearchFiltersSelection: filtersState.filtersSelection,
+      includeCancellations: isShowCancelledDeparturesEnabled,
     }),
-    [from, to, sanitizedSearchTime, arriveBy, filtersState.filtersSelection],
+    [
+      from,
+      to,
+      sanitizedSearchTime,
+      arriveBy,
+      filtersState.filtersSelection,
+      isShowCancelledDeparturesEnabled,
+    ],
   );
 
   const {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -4,7 +4,12 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import {CounterIconBox, TransportationIconBox} from '@atb/components/icon-box';
 import {SituationOrNoticeIcon} from '@atb/modules/situations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {dictionary, TripSearchTexts, useTranslation} from '@atb/translations';
+import {
+  CancelledDepartureTexts,
+  dictionary,
+  TripSearchTexts,
+  useTranslation,
+} from '@atb/translations';
 import {screenReaderHidden} from '@atb/utils/accessibility';
 import {flatMap} from '@atb/utils/array';
 import {
@@ -40,6 +45,7 @@ import {significantWaitTime} from '@atb/modules/trip-patterns';
 import {Destination} from '@atb/assets/svg/mono-icons/places';
 import {useFontScale} from '@atb/utils/use-font-scale';
 import {isSignificantDifference} from '../utils';
+import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
 
 type ResultItemState = 'enabled' | 'dimmed' | 'disabled';
 
@@ -51,6 +57,7 @@ type ResultItemProps = {
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
 }> = ({tripPattern}) => {
+  const {themeName} = useThemeContext();
   const styles = useThemeStyles();
   const {t, language} = useTranslation();
   let start = tripPattern.legs[0];
@@ -61,11 +68,36 @@ const ResultItemHeader: React.FC<{
   } else if (tripPattern.legs[0].mode !== 'foot') {
     startName = getQuayName(start.fromPlace.quay);
   }
+
+  const isCancelled = tripPattern.legs.some(
+    (leg) => leg.fromEstimatedCall?.cancellation,
+  );
+
+  const cancelledText = t(CancelledDepartureTexts.cancelled);
   const startLegIsFlexibleTransport = isLineFlexibleTransport(start.line);
   const publicCode = start.fromPlace.quay?.publicCode || start.line?.publicCode;
 
   const durationText = secondsToDurationShort(tripPattern.duration, language);
   const transportName = t(getTranslatedModeName(start.mode));
+
+  const routeName = startName
+    ? t(
+        TripSearchTexts.results.resultItem.header.title(
+          transportName,
+          startName,
+        ),
+      )
+    : startLegIsFlexibleTransport && publicCode
+      ? t(
+          TripSearchTexts.results.resultItem.header.flexTransportTitle(
+            publicCode,
+          ),
+        )
+      : transportName;
+
+  const displayName = isCancelled
+    ? `${routeName} - ${cancelledText}`
+    : routeName;
 
   return (
     <View style={styles.resultHeader}>
@@ -74,20 +106,7 @@ const ResultItemHeader: React.FC<{
         typography="body__s__strong"
         testID="resultDeparturePlace"
       >
-        {startName
-          ? t(
-              TripSearchTexts.results.resultItem.header.title(
-                transportName,
-                startName,
-              ),
-            )
-          : startLegIsFlexibleTransport && publicCode
-            ? t(
-                TripSearchTexts.results.resultItem.header.flexTransportTitle(
-                  publicCode,
-                ),
-              )
-            : transportName}
+        {displayName}
       </ThemeText>
       <View style={styles.durationContainer}>
         <AccessibleText
@@ -102,14 +121,23 @@ const ResultItemHeader: React.FC<{
 
       <RailReplacementBusMessage tripPattern={tripPattern} />
 
-      <SituationOrNoticeIcon
-        situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
-        notices={flatMap(tripPattern.legs, getNoticesForLeg)}
-        accessibilityLabel={t(
-          TripSearchTexts.results.resultItem.hasSituationsTip,
-        )}
-        style={styles.warningIcon}
-      />
+      {!isCancelled && (
+        <SituationOrNoticeIcon
+          situations={flatMap(tripPattern.legs, (leg) => leg.situations)}
+          notices={flatMap(tripPattern.legs, getNoticesForLeg)}
+          accessibilityLabel={t(
+            TripSearchTexts.results.resultItem.hasSituationsTip,
+          )}
+          style={styles.warningIcon}
+        />
+      )}
+
+      {isCancelled && (
+        <ThemeIcon
+          style={styles.warningIcon}
+          svg={statusTypeToIcon('error', true, themeName)}
+        />
+      )}
     </View>
   );
 };
@@ -176,6 +204,10 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
     return leg.mode === 'foot' && index !== 0;
   };
 
+  const isCancelled = tripPattern.legs.some(
+    (leg) => leg.fromEstimatedCall?.cancellation,
+  );
+
   return (
     <Animated.View
       entering={FadeIn}
@@ -219,7 +251,9 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                     <View style={styles.departureTimes}>
                       {staySeated(i) || isIntermediateFootLeg(leg, i) ? null : (
                         <ThemeText
-                          typography="body__xs"
+                          typography={
+                            isCancelled ? 'body__xs__strike' : 'body__xs'
+                          }
                           color="primary"
                           testID={'schTime' + i}
                         >
@@ -264,7 +298,11 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
         <View>
           <DestinationIcon style={styles.iconContainer} />
           <View style={styles.departureTimes}>
-            <ThemeText typography="body__xs" color="primary" testID="endTime">
+            <ThemeText
+              typography={isCancelled ? 'body__xs__strike' : 'body__xs'}
+              color="primary"
+              testID="endTime"
+            >
               {(lastLegIsFlexible ? t(dictionary.missingRealTimePrefix) : '') +
                 formatToClock(tripPattern.expectedEndTime, language, 'ceil')}
             </ThemeText>
@@ -289,6 +327,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     flexGrow: 1,
+  },
+  icon: {
+    marginRight: theme.spacing.small,
   },
   rightLegLine: {
     marginRight: theme.spacing.xSmall,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -56,7 +56,8 @@ type ResultItemProps = {
 
 const ResultItemHeader: React.FC<{
   tripPattern: TripPattern;
-}> = ({tripPattern}) => {
+  isCancelled: boolean;
+}> = ({tripPattern, isCancelled}) => {
   const {themeName} = useThemeContext();
   const styles = useThemeStyles();
   const {t, language} = useTranslation();
@@ -68,10 +69,6 @@ const ResultItemHeader: React.FC<{
   } else if (tripPattern.legs[0].mode !== 'foot') {
     startName = getQuayName(start.fromPlace.quay);
   }
-
-  const isCancelled = tripPattern.legs.some(
-    (leg) => leg.fromEstimatedCall?.cancellation,
-  );
 
   const cancelledText = t(CancelledDepartureTexts.cancelled);
   const startLegIsFlexibleTransport = isLineFlexibleTransport(start.line);
@@ -136,6 +133,7 @@ const ResultItemHeader: React.FC<{
         <ThemeIcon
           style={styles.warningIcon}
           svg={statusTypeToIcon('error', true, themeName)}
+          accessibilityLabel={cancelledText}
         />
       )}
     </View>
@@ -215,7 +213,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
       {...props}
       accessible={false}
     >
-      <ResultItemHeader tripPattern={tripPattern} />
+      <ResultItemHeader tripPattern={tripPattern} isCancelled={isCancelled} />
       <View style={styles.detailsContainer} {...screenReaderHidden}>
         <View
           style={styles.flexRow}
@@ -327,9 +325,6 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     flexGrow: 1,
-  },
-  icon: {
-    marginRight: theme.spacing.small,
   },
   rightLegLine: {
     marginRight: theme.spacing.xSmall,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow.tsx
@@ -247,12 +247,11 @@ const tripSummary = (
     passedTripText,
     startText,
     modeAndNumberText,
-    realTimeText,
   ];
 
   const detailTexts = isCancelled
     ? [cancelledText]
-    : [numberOfFootLegsText, walkDistanceText, traveltimesText];
+    : [realTimeText, numberOfFootLegsText, walkDistanceText, traveltimesText];
 
   return [...commonTexts, ...detailTexts]
     .filter((text) => text !== undefined)

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow.tsx
@@ -50,6 +50,9 @@ export const ResultRow: React.FC<ResultRowProps> = ({
     isInThePast(tripPattern.legs[0].expectedStartTime) &&
     searchTime?.option !== 'now';
 
+  const isCancelled =
+    tripPattern.legs[0].fromEstimatedCall?.cancellation ?? false;
+
   return (
     <Section style={styles.container}>
       <GenericClickableSectionItem
@@ -59,6 +62,7 @@ export const ResultRow: React.FC<ResultRowProps> = ({
           language,
           isInPast,
           resultNumber,
+          isCancelled,
         )}
         accessibilityHint={t(
           TripSearchTexts.results.resultItem.footer.detailsHint,
@@ -103,6 +107,7 @@ const tripSummary = (
   language: Language,
   isInPast: boolean,
   listPosition: number,
+  isCancelled: boolean,
 ) => {
   const distance = Math.round(tripPattern.legs[0].distance);
   let humanizedDistance;
@@ -138,6 +143,9 @@ const tripSummary = (
       );
     }
   }
+
+  const cancelledText =
+    isCancelled && t(TripSearchTexts.results.resultItem.tripCancelled);
 
   const nonFootLegs = tripPattern.legs.filter((l) => l.mode !== 'foot') ?? [];
   const firstLeg = nonFootLegs.length > 0 ? nonFootLegs[0] : undefined;
@@ -233,17 +241,20 @@ const tripSummary = (
   const tripPatternBookingStatus = getTripPatternBookingStatus(tripPattern);
   const bookingText = getTripPatternBookingText(tripPatternBookingStatus, t);
 
-  const texts = [
+  const commonTexts = [
     resultNumberText,
     bookingText,
     passedTripText,
     startText,
     modeAndNumberText,
     realTimeText,
-    numberOfFootLegsText,
-    walkDistanceText,
-    traveltimesText,
-  ].filter((text) => text !== undefined);
+  ];
 
-  return texts.join(screenReaderPause);
+  const detailTexts = isCancelled
+    ? [cancelledText]
+    : [numberOfFootLegsText, walkDistanceText, traveltimesText];
+
+  return [...commonTexts, ...detailTexts]
+    .filter((text) => text !== undefined)
+    .join(screenReaderPause);
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
@@ -64,6 +64,7 @@ export function createTripsQuery(
     arriveBy,
     travelSearchFiltersSelection,
     journeySearchModes,
+    includeCancellations,
   } = tripsInfiniteQueryProps;
 
   const from = {
@@ -82,6 +83,7 @@ export function createTripsQuery(
     when: searchTime?.date,
     arriveBy,
     modes: journeySearchModes,
+    includeCancellations: includeCancellations,
   };
 
   if (travelSearchFiltersSelection?.transportModes) {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
@@ -83,7 +83,7 @@ export function createTripsQuery(
     when: searchTime?.date,
     arriveBy,
     modes: journeySearchModes,
-    includeCancellations: includeCancellations,
+    includeCancellations,
   };
 
   if (travelSearchFiltersSelection?.transportModes) {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips.ts
@@ -26,6 +26,7 @@ export type TripsProps = {
   arriveBy: boolean;
   searchTime: TripSearchTime;
   travelSearchFiltersSelection?: TravelSearchFiltersSelectionType;
+  includeCancellations: boolean;
 };
 
 /**

--- a/src/translations/screens/TripSearch.ts
+++ b/src/translations/screens/TripSearch.ts
@@ -219,6 +219,7 @@ const TripSearchTexts = {
             `Frå klokka ${startTime}, til klokka ${endTime}`,
           ),
       },
+      tripCancelled: _('Reisen innstilt', 'Trip cancelled', 'Reisa innstilt'),
       hasSituationsTip: _(
         'Denne reisen har driftsmeldinger. Se detaljer for mer info',
         'There are service messages affecting your journey. See details for more info ',


### PR DESCRIPTION
## Issue Reference
Solves https://github.com/AtB-AS/kundevendt/issues/22806

## Description
Adds feature toggle for showing cancelled departures like in TPW, trips with cancelled departures will now show on the trip result list. This is mainly used where a departure from a specific stop is cancelled. In AtB, currently we can check this behavior on trips starting from "Astronomvegen" (all departures) or "Sluppenvegen" (with line 15).

- Added feature toggle in remote config: "enable_show_cancelled_departures"
- Updated the trips query to use this new flag.
- exposed `cancelled` status on `estimatedCalls` to determine if a stop has cancelled departures.
- Updated the UI to show if a trip is cancelled.

Also relevant changes on BFF: 
- https://github.com/AtB-AS/atb-bff/pull/434
- https://github.com/AtB-AS/atb-bff/pull/435
- https://github.com/AtB-AS/atb-bff/pull/439

~~Note that the "kansellert" will be updated to "innstilt" after this PR is merged: https://github.com/AtB-AS/mittatb-app/pull/5957~~

Also UI will be updated once the rounded transportation icon is implemented in issue: https://github.com/AtB-AS/kundevendt/issues/23634

<img width="350" alt="trip result screenshot" src="https://github.com/user-attachments/assets/49260d65-2f83-4430-9ca6-cee736cb66d7" />
<img width="350" alt="trip details" src="https://github.com/user-attachments/assets/641625a5-bcb4-4930-bb49-c02d32e03324" />
