### PR TITLE
ci: fix imagemagick installation issue on macos runner

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -114,5 +114,5 @@ runs:
           rm '/usr/local/bin/pydoc3.11'
           rm '/usr/local/bin/python3.11'
           rm '/usr/local/bin/python3.11-config'
-          brew install imagemagick
+          brew install shared-mime-info imagemagick
           yarn generate-native-assets


### PR DESCRIPTION
## Description
Workaround for imagemagick installation issue on macos runner 26 https://github.com/actions/runner-images/issues/13902