### PR TITLE
feat: Extend DebugServerOverrides to websocket connections

### DIFF
--- a/src/api/use-subscription.ts
+++ b/src/api/use-subscription.ts
@@ -31,7 +31,6 @@ export function useSubscription({
       const overriddenUrl = applyDebugServerOverride(url, {
         forWebSocket: true,
       });
-      console.log('Subscribing to WebSocket with url:', overriddenUrl);
       const ws = new WebSocket(overriddenUrl);
 
       ws.onmessage = (event) => {

--- a/src/api/use-subscription.ts
+++ b/src/api/use-subscription.ts
@@ -1,5 +1,6 @@
 import Bugsnag from '@bugsnag/react-native';
 import {MutableRefObject, useEffect, useRef} from 'react';
+import {applyDebugServerOverride} from '@atb/modules/debug';
 
 const RETRY_INTERVAL_CAP_IN_SECONDS = 10;
 
@@ -27,7 +28,11 @@ export function useSubscription({
     let retryTimeout: NodeJS.Timeout | null = null;
     let resetRetryCountTimeout: NodeJS.Timeout | null = null;
     const connect = () => {
-      const ws = new WebSocket(url);
+      const overriddenUrl = applyDebugServerOverride(url, {
+        forWebSocket: true,
+      });
+      console.log('Subscribing to WebSocket with url:', overriddenUrl);
+      const ws = new WebSocket(overriddenUrl);
 
       ws.onmessage = (event) => {
         onMessage?.(event);

--- a/src/modules/debug/DebugServerOverrides.tsx
+++ b/src/modules/debug/DebugServerOverrides.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {Alert, View} from 'react-native';
+import {Alert, Platform, View} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import {Button} from '@atb/components/button';
 import {
@@ -28,11 +28,22 @@ import type {DebugServerOverride, HeaderOverride} from './types';
 
 type OftenUsedOverride = DebugServerOverride & {label: string};
 
+// The Android emulator runs in a VM where "localhost" refers to the emulator
+// itself, not the host machine. 10.0.2.2 is Android's special alias for the
+// host loopback interface. iOS Simulator shares the host network stack, so
+// "localhost" works directly.
+const localBffHost = Platform.OS === 'android' ? '10.0.2.2' : 'localhost';
+
 const oftenUsedOverrides: OftenUsedOverride[] = [
   {
     label: 'Local BFF',
     match: RegExp('/.*/bff\/?.*/'),
-    newValue: 'http://localhost:8080/',
+    newValue: `http://${localBffHost}:8080/`,
+  },
+  {
+    label: 'Local BFF WebSocket',
+    match: RegExp('/.*(ws|stream)\/?.*/'),
+    newValue: `http://${localBffHost}:8080/`,
   },
 ];
 

--- a/src/modules/debug/debug-server-overrides-cache.ts
+++ b/src/modules/debug/debug-server-overrides-cache.ts
@@ -51,3 +51,38 @@ export function setDebugServerOverrides(
 export function getDebugServerOverrides(): DebugServerOverride[] {
   return cachedOverrides;
 }
+
+/**
+ * Apply debug server overrides to a URL. If a matching override is found, the
+ * origin (scheme+host+port) of the URL is replaced with the override's
+ * newValue while preserving the path and query string.
+ *
+ * When `forWebSocket` is true, `http://` and `https://` in the override value
+ * are converted to `ws://` and `wss://` respectively, since overrides are
+ * typically entered as HTTP URLs.
+ *
+ * Header overrides are not supported for WebSocket connections.
+ */
+export function applyDebugServerOverride(
+  url: string,
+  options?: {forWebSocket?: boolean},
+): string {
+  const overrides = getDebugServerOverrides();
+
+  for (const override of overrides) {
+    if (override.match.test(url)) {
+      let newBaseUrl = override.newValue;
+      if (options?.forWebSocket) {
+        newBaseUrl = newBaseUrl
+          .replace(/^http:\/\//, 'ws://')
+          .replace(/^https:\/\//, 'wss://');
+      }
+
+      const urlObj = new URL(url);
+      const pathAndQuery = urlObj.pathname + urlObj.search;
+      return newBaseUrl.replace(/\/+$/, '') + pathAndQuery;
+    }
+  }
+
+  return url;
+}

--- a/src/modules/debug/index.ts
+++ b/src/modules/debug/index.ts
@@ -3,5 +3,6 @@ export {
   loadDebugServerOverrides,
   getDebugServerOverrides,
   setDebugServerOverrides,
+  applyDebugServerOverride,
 } from './debug-server-overrides-cache';
 export type {DebugServerOverride, HeaderOverride} from './types';


### PR DESCRIPTION
## Description
Extend the DebugServerOverride-system introduced in [this PR](https://github.com/AtB-AS/mittatb-app/pull/5911) to also cover WebSockets connections. 

<details>
<summary>Also, added a Local BFF WebSocket entry in "Often used"</summary>
<img width="400" src="https://github.com/user-attachments/assets/6a7720cc-2999-41a5-a895-3d746b35d3c8" />
</details>

### Why?
Because I'm working on WebSockets-pooling in the BFF. Stay tuned...