### PR TITLE
feat: Point stars color

### DIFF
--- a/src/modules/bonus/components/BonusPriceTag.tsx
+++ b/src/modules/bonus/components/BonusPriceTag.tsx
@@ -1,5 +1,5 @@
 import React, {ComponentProps} from 'react';
-import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+import {BonusStarFill} from './BonusStarFill';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet} from '@atb/theme';
@@ -20,7 +20,7 @@ export const BonusPriceTag = ({amount, ...props}: Props) => {
       accessibilityLabel={t(BonusProgramTexts.costA11yLabel(amount))}
     >
       <ThemeText>{amount}</ThemeText>
-      <ThemeIcon svg={StarFill} size="small" />
+      <ThemeIcon svg={BonusStarFill} size="small" />
     </View>
   );
 };

--- a/src/modules/bonus/components/BonusStarFill.tsx
+++ b/src/modules/bonus/components/BonusStarFill.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {SvgProps} from 'react-native-svg';
+import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+import {useThemeContext} from '@atb/theme';
+
+export const BonusStarFill = (props: SvgProps) => {
+  const {theme} = useThemeContext();
+  return (
+    <StarFill {...props} fill={theme.color.interactive[0].default.background} />
+  );
+};

--- a/src/modules/bonus/components/EarnedBonusPointsSectionItem.tsx
+++ b/src/modules/bonus/components/EarnedBonusPointsSectionItem.tsx
@@ -1,7 +1,7 @@
 import {BonusProgramTexts, useTranslation} from '@atb/translations';
 import React from 'react';
 import {LinkSectionItem, SectionItemProps} from '@atb/components/sections';
-import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+import {BonusStarFill} from './BonusStarFill';
 
 type Props = SectionItemProps<{
   amount: number;
@@ -19,7 +19,7 @@ export const EarnedBonusPointsSectionItem = ({
     <LinkSectionItem
       {...props}
       isMarkdown={true}
-      leftIcon={{svg: StarFill}}
+      leftIcon={{svg: BonusStarFill}}
       text={t(BonusProgramTexts.fareContract.youEarned(amount))}
       accessibility={{
         accessibilityLabel: t(

--- a/src/modules/bonus/components/UserBonusBalanceContent.tsx
+++ b/src/modules/bonus/components/UserBonusBalanceContent.tsx
@@ -5,7 +5,7 @@ import {useBonusBalanceQuery} from '../queries';
 import {View} from 'react-native';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {UserBonusBalance} from './UserBonusBalance';
-import {StarFill} from '@atb/assets/svg/mono-icons/bonus';
+import {BonusStarFill} from './BonusStarFill';
 import {ThemeText} from '@atb/components/text';
 import {ThemedBonusBagHug} from '@atb/theme/ThemedAssets';
 
@@ -32,7 +32,7 @@ export function UserBonusBalanceContent(): React.JSX.Element {
         <View style={styles.currentBalanceDisplay}>
           <ThemeIcon
             color={theme.color.foreground.dynamic.primary}
-            svg={StarFill}
+            svg={BonusStarFill}
             size="large"
           />
           <UserBonusBalance


### PR DESCRIPTION
## Description
Adds color to all Point star icons in app

<img width="180" alt="image" src="https://github.com/user-attachments/assets/29c523d5-f716-43bd-89d0-d15760d0a40c" /> <img width="180" alt="image" src="https://github.com/user-attachments/assets/00398779-0571-4f9a-aa3a-40775131eca0" /> <img width="180"  alt="image" src="https://github.com/user-attachments/assets/782162cf-2733-4dcc-a5a2-c87e99d1dee8" /> <img width="180"  alt="image" src="https://github.com/user-attachments/assets/a0ef77e8-3201-4ef9-b2a1-09e5317b3c20" />

## Acceptance criteria
- [x] All Point star icons are now teal colored (color: interactive 0 default)
  - [x] On 'Travel' Screen for enrollment members
  - [x] On bought single Tickets for enrollment members
  - [x] On Points screen (under Profile)
