### PR TITLE
feat: add toggle to switch to textureview to fix Android map issues

### DIFF
--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -126,6 +126,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_show_valid_time_info',
   },
   {
+    name: 'isSurfaceViewMapEnabled',
+    remoteConfigKey: 'enable_surface_view_map',
+  },
+  {
     name: 'isTicketInformationEnabled',
     remoteConfigKey: 'enable_ticket_information',
   },

--- a/src/modules/map/hooks/use-map-view-config.ts
+++ b/src/modules/map/hooks/use-map-view-config.ts
@@ -5,6 +5,10 @@ import {useMemo} from 'react';
 const MapViewStaticConfig = {
   compassEnabled: true,
   scaleBarEnabled: false,
+  // Use TextureView instead of SurfaceView on Android to avoid
+  // black bar artifacts on some devices when switching tabs.
+  // (SurfaceView's GL surface is not properly cleaned up).
+  surfaceView: false,
   // `mapbox` (v10) Adds compass offset `compassViewMargins` is still supported but generates issues:
   // Mapbox error fireEvent failed: <rnmapbox_maps.RCTMGLEvent: 0x6000028a0fe0>
   compassPosition: {

--- a/src/modules/map/hooks/use-map-view-config.ts
+++ b/src/modules/map/hooks/use-map-view-config.ts
@@ -1,14 +1,11 @@
 import {Platform} from 'react-native';
 import {useMapboxJsonStyle} from './use-mapbox-json-style';
 import {useMemo} from 'react';
+import {useRemoteConfigContext} from '@atb/modules/remote-config';
 
 const MapViewStaticConfig = {
   compassEnabled: true,
   scaleBarEnabled: false,
-  // Use TextureView instead of SurfaceView on Android to avoid
-  // black bar artifacts on some devices when switching tabs.
-  // (SurfaceView's GL surface is not properly cleaned up).
-  surfaceView: false,
   // `mapbox` (v10) Adds compass offset `compassViewMargins` is still supported but generates issues:
   // Mapbox error fireEvent failed: <rnmapbox_maps.RCTMGLEvent: 0x6000028a0fe0>
   compassPosition: {
@@ -41,12 +38,14 @@ export const useMapViewConfig = (
     () => ({styleJSON: mapboxJsonStyle}),
     [mapboxJsonStyle],
   );
+  const {enable_surface_view_map} = useRemoteConfigContext();
 
   return useMemo(
     () => ({
       ...MapViewStaticConfig,
       ...configMap,
+      surfaceView: enable_surface_view_map,
     }),
-    [configMap],
+    [configMap, enable_surface_view_map],
   );
 };

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -123,7 +123,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_shmo_deep_integration: false,
   enable_shmo_deep_integration_citybike: false,
   enable_show_valid_time_info: true,
-  enable_surface_view_map: false,
+  enable_surface_view_map: true,
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
   enable_event_stream: false,

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -51,6 +51,7 @@ export type RemoteConfig = {
   enable_shmo_deep_integration: boolean;
   enable_shmo_deep_integration_citybike: boolean;
   enable_show_valid_time_info: boolean;
+  enable_surface_view_map: boolean;
   enable_ticket_information: boolean;
   enable_ticketing: boolean;
   enable_tips_and_information: boolean;
@@ -122,6 +123,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_shmo_deep_integration: false,
   enable_shmo_deep_integration_citybike: false,
   enable_show_valid_time_info: true,
+  enable_surface_view_map: false,
   enable_ticket_information: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
   enable_event_stream: false,
@@ -264,6 +266,9 @@ export function getConfig(): RemoteConfig {
   const enable_show_valid_time_info =
     values['enable_show_valid_time_info']?.asBoolean() ??
     defaultRemoteConfig.enable_show_valid_time_info;
+  const enable_surface_view_map =
+    values['enable_surface_view_map']?.asBoolean() ??
+    defaultRemoteConfig.enable_surface_view_map;
   const enable_ticket_information =
     values['enable_ticket_information']?.asBoolean() ??
     defaultRemoteConfig.enable_ticket_information;
@@ -380,6 +385,7 @@ export function getConfig(): RemoteConfig {
     enable_shmo_deep_integration,
     enable_shmo_deep_integration_citybike,
     enable_show_valid_time_info,
+    enable_surface_view_map,
     enable_ticket_information,
     enable_ticketing,
     enable_tips_and_information,


### PR DESCRIPTION
## Issue Reference
fixes https://github.com/AtB-AS/kundevendt/issues/23665

## Description
Adds a feature toggle to use TextureView instead of SurfaceView for MapBox implementation on Android, the `surfaceView` flag is [android only](https://rnmapbox.github.io/docs/components/MapView#surfaceview)

This will cause the MapBox rendering in Android to use a TextureView, which will have a performance impact due to how it works.

- **SurfaceView** is rendered in a separate window layer from the regular Android view hierarchy, behind the normal view, GPU renders directly there, but the tradeoff is that the app doesn't have any control over what is rendered there.

- **TextureView** is rendered in the normal Android view hierarchy, has more overhead because it needs to pass through the normal view rendering, consumes more memory, and slightly less performant.

When we show this SurfaceView, the view compositor basically made the regular app window transparent to show the SurfaceView behind. The issue that we have here is that the view compositor of some devices cannot properly re-render the app window on top of this SurfaceView.

Image generated by Claude

<img width="1440" height="1440" alt="image" src="https://github.com/user-attachments/assets/09af3c7d-b926-47e9-a35c-4fd045ba2bfb" />
