### PR TITLE
fix: Use correct props for gfz message when using gfz as tiles

### DIFF
--- a/src/modules/map/hooks/use-shmo-warnings.tsx
+++ b/src/modules/map/hooks/use-shmo-warnings.tsx
@@ -93,7 +93,7 @@ export const useShmoWarnings = (
       if (code !== 'allowed') {
         const isStationParking: boolean =
           (isGeofencingZonesAsTilesEnabled
-            ? featProps?.stationParking
+            ? featProps?.station_parking
             : featProps?.geofencingZoneCustomProps?.isStationParking) ?? false;
 
         const geofencingZoneContent = getGeofencingZoneContent(

--- a/src/modules/map/hooks/use-shmo-warnings.tsx
+++ b/src/modules/map/hooks/use-shmo-warnings.tsx
@@ -18,6 +18,7 @@ import {throttle} from '@atb/utils/throttle';
 import {Coordinates} from '@atb/utils/coordinates';
 import {useOpeningHours} from './use-opening-hours';
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
+import {GeofencingZoneCode} from '@atb-as/theme';
 
 export const useShmoWarnings = (
   vehicleId: string,
@@ -83,14 +84,21 @@ export const useShmoWarnings = (
         coordinates.latitude,
       ]);
 
-      if (
-        featureToSelect?.properties?.geofencingZoneCustomProps?.code !==
-        'allowed'
-      ) {
+      const featProps = featureToSelect?.properties;
+      const code: GeofencingZoneCode =
+        (enable_geofencing_zones_as_tiles
+          ? featProps?.code
+          : featProps?.geofencingZoneCustomProps?.code) ?? 'allowed';
+
+      if (code !== 'allowed') {
+        const isStationParking: boolean =
+          (enable_geofencing_zones_as_tiles
+            ? featProps?.stationParking
+            : featProps?.geofencingZoneCustomProps?.isStationParking) ?? false;
+
         const geofencingZoneContent = getGeofencingZoneContent(
-          featureToSelect?.properties?.geofencingZoneCustomProps?.code,
-          featureToSelect?.properties?.geofencingZoneCustomProps
-            ?.isStationParking,
+          code,
+          isStationParking,
         );
         setGeofencingZoneWarning(geofencingZoneContent);
       } else {

--- a/src/modules/map/hooks/use-shmo-warnings.tsx
+++ b/src/modules/map/hooks/use-shmo-warnings.tsx
@@ -17,14 +17,14 @@ import {useVehicle} from '@atb/modules/mobility';
 import {throttle} from '@atb/utils/throttle';
 import {Coordinates} from '@atb/utils/coordinates';
 import {useOpeningHours} from './use-opening-hours';
-import {useRemoteConfigContext} from '@atb/modules/remote-config';
 import {GeofencingZoneCode} from '@atb-as/theme';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export const useShmoWarnings = (
   vehicleId: string,
   mapViewRef?: RefObject<MapView | null>,
 ) => {
-  const {enable_geofencing_zones_as_tiles} = useRemoteConfigContext();
+  const {isGeofencingZonesAsTilesEnabled} = useFeatureTogglesContext();
   const {t} = useTranslation();
   const [geofencingZoneWarning, setGeofencingZoneWarning] =
     useState<GeofencingZoneContent | null>(null);
@@ -68,7 +68,7 @@ export const useShmoWarnings = (
       );
 
       const geofencingZoneFeatures = featuresAtLocation?.filter((feature) =>
-        enable_geofencing_zones_as_tiles
+        isGeofencingZonesAsTilesEnabled
           ? isFeatureGeofencingZoneAsTiles(feature)
           : isFeatureGeofencingZone(feature) &&
             feature?.properties?.geofencingZoneCustomProps?.code,
@@ -86,13 +86,13 @@ export const useShmoWarnings = (
 
       const featProps = featureToSelect?.properties;
       const code: GeofencingZoneCode =
-        (enable_geofencing_zones_as_tiles
+        (isGeofencingZonesAsTilesEnabled
           ? featProps?.code
           : featProps?.geofencingZoneCustomProps?.code) ?? 'allowed';
 
       if (code !== 'allowed') {
         const isStationParking: boolean =
-          (enable_geofencing_zones_as_tiles
+          (isGeofencingZonesAsTilesEnabled
             ? featProps?.stationParking
             : featProps?.geofencingZoneCustomProps?.isStationParking) ?? false;
 


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->
With `enable_geofencing_zones_as_tiles` true, this message in the ActiveScooterSheet didn't work due to wrong prop lookups.
<img width="230" src="https://github.com/user-attachments/assets/60f445d3-5c6a-45af-a69f-f55a4af983b9" />

## Description
This PR uses the correct prop lookups and also respects the debug override option.

### Acceptance Criteria:
- [ ] When driving into a geofencing zone with code other than `allowed`, the message in the bottom sheet should behave the same when enable_geofencing_zones_as_tiles/isGeofencingZonesAsTilesEnabled is true as when it is false.