### PR TITLE
fix: improve handling of passed departure favorites

### DIFF
--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -50,12 +50,14 @@ export type LineItemProps = SectionItemProps<{
   group: DepartureGroup;
   searchDate: string;
   onPressDeparture: QuaySectionProps['onPressDeparture'];
+  now: number;
 }>;
 export function LineItem({
   group,
   searchDate,
   testID,
   onPressDeparture,
+  now,
   ...props
 }: LineItemProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
@@ -63,7 +65,7 @@ export function LineItem({
   const styles = useItemStyles();
   const {t, language} = useTranslation();
 
-  if (hasNoDeparturesOnGroup(group)) {
+  if (hasNoDeparturesOnGroup(group, now)) {
     return null;
   }
 
@@ -81,7 +83,7 @@ export function LineItem({
   }));
 
   // we know we have a departure as we've checked hasNoDeparturesOnGroup
-  const nextValids = group.departures.filter(isValidDeparture);
+  const nextValids = group.departures.filter((d) => isValidDeparture(d, now));
 
   return (
     <View style={[topContainer, {paddingVertical: 0, paddingHorizontal: 0}]}>
@@ -128,6 +130,7 @@ export function LineItem({
             onPress={() => onPressDeparture(items, i)}
             searchDate={searchDate}
             testID={'depTime' + i}
+            now={now}
           />
         ))}
       </ScrollView>
@@ -223,6 +226,7 @@ type DepartureTimeItemProps = {
   departure: DepartureTime;
   onPress(departure: DepartureTime): void;
   searchDate: string;
+  now: number;
   testID?: string;
 };
 function DepartureTimeItem({
@@ -230,6 +234,7 @@ function DepartureTimeItem({
   onPress,
   searchDate,
   testID,
+  now,
 }: DepartureTimeItemProps) {
   const styles = useItemStyles();
   const {t, language} = useTranslation();
@@ -243,7 +248,7 @@ function DepartureTimeItem({
         : RealtimeLight
       : undefined;
 
-  if (!isValidDeparture(departure)) {
+  if (!isValidDeparture(departure, now)) {
     return null;
   }
   return (

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -27,6 +27,7 @@ export type QuaySectionProps = {
     items: ServiceJourneyDeparture[],
     activeIndex: number,
   ) => void;
+  now: number;
 };
 
 export const QuaySection = React.memo(function QuaySection({
@@ -36,6 +37,7 @@ export const QuaySection = React.memo(function QuaySection({
   searchDate,
   testID,
   onPressDeparture,
+  now,
 }: QuaySectionProps) {
   const [limit, setLimit] = useState(LIMIT_SIZE);
   const {t} = useTranslation();
@@ -46,9 +48,9 @@ export const QuaySection = React.memo(function QuaySection({
   }, [quayGroup.quay.id]);
 
   const sorted = useMemo(
-    () => sortAndLimit(quayGroup, limit),
+    () => sortAndLimit(quayGroup, limit, now),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [quayGroup, limit, lastUpdated],
+    [quayGroup, limit, lastUpdated, now],
   );
 
   if (!sorted) {
@@ -77,6 +79,7 @@ export const QuaySection = React.memo(function QuaySection({
             searchDate={searchDate}
             testID={'lineItem' + i}
             onPressDeparture={onPressDeparture}
+            now={now}
           />
         ))}
       </Section>
@@ -85,13 +88,13 @@ export const QuaySection = React.memo(function QuaySection({
   );
 });
 
-function sortAndLimit(quayGroup: QuayGroup, limit: number) {
-  if (hasNoGroupsWithDepartures([quayGroup])) {
+function sortAndLimit(quayGroup: QuayGroup, limit: number, now: number) {
+  if (hasNoGroupsWithDepartures([quayGroup], now)) {
     return null;
   }
   const sorted = sortBy(
     quayGroup.group,
-    (v) => v.departures.find(isValidDeparture)?.time,
+    (v) => v.departures.find((d) => isValidDeparture(d, now))?.time,
   ).slice(0, limit);
   return sorted;
 }

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -19,7 +19,6 @@ const LIMIT_SIZE = 5;
 export type QuaySectionProps = {
   quayGroup: QuayGroup;
   locationOrStopPlace?: Location | StopPlace;
-  lastUpdated?: Date;
   hidden?: Date;
   searchDate: string;
   testID?: string;
@@ -33,7 +32,6 @@ export type QuaySectionProps = {
 export const QuaySection = React.memo(function QuaySection({
   quayGroup,
   locationOrStopPlace,
-  lastUpdated,
   searchDate,
   testID,
   onPressDeparture,
@@ -49,8 +47,7 @@ export const QuaySection = React.memo(function QuaySection({
 
   const sorted = useMemo(
     () => sortAndLimit(quayGroup, limit, now),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [quayGroup, limit, lastUpdated, now],
+    [quayGroup, limit, now],
   );
 
   if (!sorted) {

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -50,7 +50,7 @@ export function updateStopsWithRealtime(
 function filterOutOutdatedDepartures(quayGroup: QuayGroup) {
   const newDepartureGroups = quayGroup.group.map(function (group) {
     const newDepartures = group.departures.filter((departure) =>
-      isValidDeparture(departure),
+      isValidDeparture(departure, Date.now()),
     );
     // Optimization to avoid having to sort list to often.
     // If after filtering it has the same length it means we could
@@ -140,18 +140,27 @@ export function getDeparturesAugmentedWithRealtimeData(
     });
 }
 
-export function hasNoGroupsWithDepartures(departures: QuayGroup[]) {
-  return departures.every((q) => q.group.every(hasNoDeparturesOnGroup));
+export function hasNoGroupsWithDepartures(
+  departures: QuayGroup[],
+  now: number,
+) {
+  return departures.every((q) =>
+    q.group.every((group) => hasNoDeparturesOnGroup(group, now)),
+  );
 }
-export function hasNoDeparturesOnGroup(group: DepartureGroup) {
+export function hasNoDeparturesOnGroup(group: DepartureGroup, now: number) {
   return (
     group.departures.length === 0 ||
-    group.departures.every((d) => !isValidDeparture(d))
+    group.departures.every((d) => !isValidDeparture(d, now))
   );
 }
 
-export function isValidDeparture(departure: DepartureTime) {
-  return !isNumberOfMinutesInThePast(departure.time, HIDE_AFTER_NUM_MINUTES);
+export function isValidDeparture(departure: DepartureTime, now: number) {
+  return !isNumberOfMinutesInThePast(
+    departure.time,
+    HIDE_AFTER_NUM_MINUTES,
+    now,
+  );
 }
 
 export function isValidDepartureTime(time: string, now?: number) {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -30,6 +30,8 @@ import {ContentHeading} from '@atb/components/heading';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {Loading} from '@atb/components/loading';
+import {useNow} from '@atb/utils/use-now';
+import {ONE_SECOND_MS} from '@atb/utils/durations';
 
 type Props = {
   onEditFavouriteDeparture: () => void;
@@ -47,6 +49,8 @@ export const DeparturesWidget = ({
   const styles = useStyles();
   const {t} = useTranslation();
   const {theme} = useThemeContext();
+  const now = useNow(10 * ONE_SECOND_MS);
+
   const themeColor = theme.color.background.neutral[1];
   const {favoriteDepartures} = useFavoritesContext();
   const {location} = useGeolocationContext();
@@ -114,6 +118,7 @@ export const DeparturesWidget = ({
               locationOrStopPlace={location || undefined}
               onPressDeparture={onPressDeparture}
               testID="stopPlace"
+              now={now}
             />
           ))}
         </View>

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -502,3 +502,23 @@ describe('isNumberOfMinutesInThePast', () => {
     expect(isNumberOfMinutesInThePast(pastDate, 1, now.valueOf())).toBe(false);
   });
 });
+
+describe('minutesBetween', () => {
+  test('calculates minutes between two dates correctly', () => {
+    const start = new Date('2024-09-01T12:00:00Z');
+    const end = new Date('2024-09-01T12:30:00Z');
+    expect(minutesBetween(start, end)).toBe(30);
+  });
+
+  test('rounds down', () => {
+    const start = new Date('2024-09-01T12:00:00Z');
+    const end = new Date('2024-09-01T12:30:59Z');
+    expect(minutesBetween(start, end)).toBe(30);
+  });
+
+  test('handles seconds', () => {
+    const start = new Date('2024-09-01T12:00:20Z');
+    const end = new Date('2024-09-01T12:30:19Z');
+    expect(minutesBetween(start, end)).toBe(29);
+  });
+});

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -13,6 +13,8 @@ import {
   isBefore,
   isBetween,
   isEqualOrAfter,
+  isNumberOfMinutesInThePast,
+  minutesBetween,
   secondsToDuration,
 } from '../date'; // Adjust the path if needed
 
@@ -466,5 +468,37 @@ describe('secondsToDuration', () => {
         expect(isBetween('2026-02-10', '2026-02-09', '2026-02-11')).toBe(true);
       });
     });
+  });
+});
+
+describe('isNumberOfMinutesInThePast', () => {
+  test('true when slightly more than the specified minutes ahead', () => {
+    const pastDate = new Date('2024-09-01T12:00:00Z');
+    const now = new Date('2024-09-01T12:01:01Z');
+    expect(isNumberOfMinutesInThePast(pastDate, 1, now.valueOf())).toBe(true);
+  });
+
+  test('true when exactly the specified minutes ahead', () => {
+    const pastDate = new Date('2024-09-01T12:00:00Z');
+    const now = new Date('2024-09-01T12:01:00Z');
+    expect(isNumberOfMinutesInThePast(pastDate, 1, now.valueOf())).toBe(true);
+  });
+
+  test('false when slightly less than the specified minutes ahead', () => {
+    const pastDate = new Date('2024-09-01T12:00:00Z');
+    const now = new Date('2024-09-01T12:00:59Z');
+    expect(isNumberOfMinutesInThePast(pastDate, 1, now.valueOf())).toBe(false);
+  });
+
+  test('handles non-round dates', () => {
+    const pastDate = new Date('2024-09-01T12:00:10Z');
+    const now = new Date('2024-09-01T12:01:11Z');
+    expect(isNumberOfMinutesInThePast(pastDate, 1, now.valueOf())).toBe(true);
+  });
+
+  test('handles non-round dates', () => {
+    const pastDate = new Date('2024-09-01T12:00:10Z');
+    const now = new Date('2024-09-01T12:01:09Z');
+    expect(isNumberOfMinutesInThePast(pastDate, 1, now.valueOf())).toBe(false);
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -318,9 +318,10 @@ export function isNumberOfMinutesInThePast(
   minutes: number,
   now?: number,
 ) {
-  return (
-    differenceInMinutesStrings(isoDate, new Date(now ?? Date.now())) < -minutes
-  );
+  const seconds = minutes * 60;
+  const nowDate = new Date(now ?? Date.now());
+  const difference = differenceInSeconds(parseIfNeeded(isoDate), nowDate);
+  return difference <= -seconds;
 }
 
 export function formatToLongDateTime(
@@ -571,13 +572,6 @@ export function dateWithReplacedTime(
     minutes: getMinutes(parsedTime),
     seconds: getSeconds(parsedTime),
   });
-}
-
-export function differenceInMinutesStrings(
-  dateLeft: string | Date,
-  dateRight: string | Date,
-) {
-  return differenceInMinutes(parseIfNeeded(dateLeft), parseIfNeeded(dateRight));
 }
 
 export const addMinutes = (date: string | Date, minutes: number): Date =>


### PR DESCRIPTION
## Issue Reference

https://github.com/AtB-AS/mittatb-app/pull/5956

https://mittatb.slack.com/archives/C0116FMPX4Y/p1775811535167259

## Description

After https://github.com/AtB-AS/mittatb-app/pull/5956, there were another couple of issues with filtering out old departures from the DeparturesWidget, which caused departures to hang around longer than they should have. This seems to be for two reasons:

1. The `isNumberOfMinutesInThePast` was inaccurate, because it used minutes for calculation without taking rounding into account. I've now converted this to use seconds.
2. A `useMemo` in quay-section.tsx prevented the sorted array of departures from updating. I've added `now` to the dependency array, which updates every 10s.

## Acceptance criteria

- [x] Departures favorites are removed 1 minute after departure (max 70s, since it only filters every 10s)