### PR TITLE
build: remove restore-keys on ios

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -69,9 +69,6 @@ jobs:
             ios/Pods
             ~/Library/Caches/CocoaPods
           key: pods-${{ hashFiles('yarn.lock') }}-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            pods-${{ hashFiles('yarn.lock') }}-
-            pods-
       - name: Cache node_modules
         uses: actions/cache@v4
         id: modules-cache


### PR DESCRIPTION
Fixes build issue: https://github.com/AtB-AS/mittatb-app/actions/runs/24499711585

## Description
`restore-keys` will restore cache even if it is not a hit, in order to try and save time by ignoring installed pods. Problem arises when something needs to be done to the installed pods. In this current case, the `bundle exec pod install` command fails because the `hermes-engine` requires update and needs to call `pod update hermes-engine --no-repo-update`. Instead of doing this, just start from scratch and let the podfile be created for the current build. 

A cache hit (same yarn.lock and podfile.lock), would not have this issue and build should go smoothly.