### PR TITLE
fix: Add emissive strengths to fill, line and circle layers

### DIFF
--- a/src/fare-zones-selector/FareZonesSelectorMap.tsx
+++ b/src/fare-zones-selector/FareZonesSelectorMap.tsx
@@ -161,6 +161,7 @@ const FareZonesSelectorMap = ({
                       : 'transparent',
                     'transparent',
                   ],
+                  fillEmissiveStrength: 1,
                 }}
               />
               <MapboxGL.LineLayer
@@ -168,6 +169,7 @@ const FareZonesSelectorMap = ({
                 style={{
                   lineWidth: 1,
                   lineColor: '#666666',
+                  lineEmissiveStrength: 1,
                 }}
               />
             </MapboxGL.ShapeSource>
@@ -184,6 +186,7 @@ const FareZonesSelectorMap = ({
                     textField: f.properties!.name,
                     textHaloColor: 'white',
                     textHaloWidth: 2,
+                    iconEmissiveStrength: 1,
                   }}
                 />
               </MapboxGL.ShapeSource>

--- a/src/modules/map/components/national-stop-registry-features/use-nsr-circle-layers.ts
+++ b/src/modules/map/components/national-stop-registry-features/use-nsr-circle-layers.ts
@@ -47,6 +47,7 @@ export const useNsrCircleLayers = (
           circleStrokeColor: themeName === 'light' ? '#ffffff' : '#000000',
           circleStrokeWidth: 1.1,
           circleTranslate: [0, 0] as const,
+          circleEmissiveStrength: 1,
         };
 
         const circleLayerProps: SymbolLayerProps = {

--- a/src/modules/map/hooks/use-geofencing-zones-layers.ts
+++ b/src/modules/map/hooks/use-geofencing-zones-layers.ts
@@ -52,6 +52,7 @@ export const useGeofencingZonesLayers = (
               'fill-opacity': geofencingZoneStyle.fillOpacity,
               'fill-antialias': true,
               visibility,
+              'fill-emissive-strength': 1,
             },
             filter: filterByGfzCode,
           },

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -212,6 +212,7 @@ export const useMapSymbolStyles = ({
     iconOpacity,
     iconSize,
     symbolSortKey,
+    iconEmissiveStrength: 1,
   };
 
   const textField: Expression =

--- a/src/screen-components/travel-details-map-screen/components/MapRoute.tsx
+++ b/src/screen-components/travel-details-map-screen/components/MapRoute.tsx
@@ -52,6 +52,7 @@ function MapLineItem({line, index}: MapLineItemProps) {
             lineWidth: 4,
             lineOffset: -1,
             lineColor,
+            lineEmissiveStrength: 1,
             ...customStyle,
           }}
         />
@@ -69,6 +70,7 @@ function MapLineItem({line, index}: MapLineItemProps) {
           style={{
             circleRadius: 7.5,
             circleColor: lineColor,
+            circleEmissiveStrength: 1,
           }}
         />
       </MapboxGL.ShapeSource>


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->
See https://mittatb.slack.com/archives/C0116FMPX4Y/p1775848114755929

## Description
<!-- What does this PR do? -->
With 3D enabled, we need to add emissive strengths to keep the same color as without for drawn layers in the map.
Matters mostly in dark mode with night light settings:

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/a66e7d1c-3b1c-44bd-aa03-1afcfeb41da1" /> | <img width="200" src="https://github.com/user-attachments/assets/a3ed1a16-47f0-4185-afe5-e0584f11c75f" /> |
| <img width="200" src="https://github.com/user-attachments/assets/5dbc40a9-6e83-451f-8207-69a14fc126f8" /> | <img width="200" src="https://github.com/user-attachments/assets/8d08f41d-e9d2-4453-84da-0efb30d5ef06" /> |
| <img width="200" src="https://github.com/user-attachments/assets/eae6aad9-380d-43bd-8571-4fe4d5dc4408" /> | <img width="200" src="https://github.com/user-attachments/assets/a877c938-b1a4-4889-8702-e55d828de07f" /> |
| <img width="200" src="https://github.com/user-attachments/assets/047bba80-ed5e-4e7d-8851-ec552cd94f60" /> | <img width="200" src="https://github.com/user-attachments/assets/c943d358-bbc8-4eff-af34-c8a1d2c0595b" /> |


