### PR TITLE
refactor: standardize Linking.openURL usage with openUrl utility

### DIFF
--- a/src/modules/fare-contracts/PurchaseReservation.tsx
+++ b/src/modules/fare-contracts/PurchaseReservation.tsx
@@ -29,7 +29,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation, now}) => {
   const {theme} = useThemeContext();
 
   async function openVippsUrl(vippsUrl: string) {
-    await openUrl(vippsUrl, 'Could not open Vipps URL');
+    await openUrl(vippsUrl);
   }
 
   const isSubAccountReservation = customerProfile?.subAccounts?.some(

--- a/src/modules/fare-contracts/PurchaseReservation.tsx
+++ b/src/modules/fare-contracts/PurchaseReservation.tsx
@@ -7,9 +7,9 @@ import {
   useTicketingContext,
 } from '@atb/modules/ticketing';
 import {TicketingTexts, useTranslation} from '@atb/translations';
-import Bugsnag from '@bugsnag/react-native';
+import {openUrl} from '@atb/utils/open-url';
 import React from 'react';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
 import {formatToLongDateTime} from '@atb/utils/date';
 import {fromUnixTime} from 'date-fns';
 import {NativeBlockButton} from '@atb/components/native-button';
@@ -29,11 +29,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation, now}) => {
   const {theme} = useThemeContext();
 
   async function openVippsUrl(vippsUrl: string) {
-    try {
-      await Linking.openURL(vippsUrl);
-    } catch (err: any) {
-      Bugsnag.notify(err);
-    }
+    await openUrl(vippsUrl, 'Could not open Vipps URL');
   }
 
   const isSubAccountReservation = customerProfile?.subAccounts?.some(

--- a/src/modules/fare-contracts/PurchaseReservation.tsx
+++ b/src/modules/fare-contracts/PurchaseReservation.tsx
@@ -28,10 +28,6 @@ export const PurchaseReservation: React.FC<Props> = ({reservation, now}) => {
   const {t, language} = useTranslation();
   const {theme} = useThemeContext();
 
-  async function openVippsUrl(vippsUrl: string) {
-    await openUrl(vippsUrl);
-  }
-
   const isSubAccountReservation = customerProfile?.subAccounts?.some(
     (id) => id === reservation.customerAccountId,
   );
@@ -86,7 +82,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation, now}) => {
               <View style={styles.vippsLinkContainer}>
                 <Button
                   expanded={true}
-                  onPress={() => openVippsUrl(reservation.url)}
+                  onPress={async () => await openUrl(reservation.url)}
                   accessibilityRole="link"
                   text={t(TicketingTexts.reservation.goToVipps)}
                   mode="tertiary"

--- a/src/modules/map/components/external-realtime-map/ExternalRealtimeMapSheet.tsx
+++ b/src/modules/map/components/external-realtime-map/ExternalRealtimeMapSheet.tsx
@@ -51,7 +51,7 @@ export const ExternalRealtimeMapSheet = ({
           expanded={true}
           text={t(MapTexts.externalRealtimeMap.bottomSheet.button)}
           onPress={() => {
-            openUrl(url, 'Could not open realtime map URL');
+            openUrl(url);
             onClose();
           }}
           rightIcon={{svg: ExternalLink}}

--- a/src/modules/map/components/external-realtime-map/ExternalRealtimeMapSheet.tsx
+++ b/src/modules/map/components/external-realtime-map/ExternalRealtimeMapSheet.tsx
@@ -10,7 +10,7 @@ import {
   BottomSheetHeaderType,
   MapBottomSheet,
 } from '@atb/components/bottom-sheet';
-import {Linking} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 
 type ExternalRealtimeMapLinkSheetProps = {
   onClose: () => void;
@@ -51,7 +51,7 @@ export const ExternalRealtimeMapSheet = ({
           expanded={true}
           text={t(MapTexts.externalRealtimeMap.bottomSheet.button)}
           onPress={() => {
-            Linking.openURL(url);
+            openUrl(url, 'Could not open realtime map URL');
             onClose();
           }}
           rightIcon={{svg: ExternalLink}}

--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
@@ -107,12 +107,7 @@ const ContactInfoContent = () => {
 
         <GenericSectionItem>
           <NativeBlockButton
-            onPress={async () =>
-              openUrl(
-                `tel:${telephoneNumbers['parking']}`,
-                'Could not call parking number',
-              )
-            }
+            onPress={async () => openUrl(`tel:${telephoneNumbers['parking']}`)}
             accessibilityRole="link"
           >
             <ThemeText
@@ -149,12 +144,7 @@ const ContactInfoContent = () => {
         </GenericSectionItem>
         <GenericSectionItem>
           <NativeBlockButton
-            onPress={async () =>
-              openUrl(
-                `tel:${telephoneNumbers['project']}`,
-                'Could not call project number',
-              )
-            }
+            onPress={async () => openUrl(`tel:${telephoneNumbers['project']}`)}
             accessibilityRole="link"
           >
             <ThemeText

--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
@@ -9,7 +9,8 @@ import {
 import {ThemedContact} from '@atb/theme/ThemedAssets';
 import {Confirm} from '@atb/assets/svg/mono-icons/actions';
 
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {sparOnboardingId} from './config';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {ThemeText} from '@atb/components/text';
@@ -107,7 +108,10 @@ const ContactInfoContent = () => {
         <GenericSectionItem>
           <NativeBlockButton
             onPress={async () =>
-              Linking.openURL(`tel:${telephoneNumbers['parking']}`)
+              openUrl(
+                `tel:${telephoneNumbers['parking']}`,
+                'Could not call parking number',
+              )
             }
             accessibilityRole="link"
           >
@@ -146,7 +150,10 @@ const ContactInfoContent = () => {
         <GenericSectionItem>
           <NativeBlockButton
             onPress={async () =>
-              Linking.openURL(`tel:${telephoneNumbers['project']}`)
+              openUrl(
+                `tel:${telephoneNumbers['project']}`,
+                'Could not call project number',
+              )
             }
             accessibilityRole="link"
           >

--- a/src/screen-components/error-boundary/FullScreenErrorView.tsx
+++ b/src/screen-components/error-boundary/FullScreenErrorView.tsx
@@ -3,7 +3,8 @@ import {ThemeText} from '@atb/components/text';
 import {StyleSheet, themes} from '@atb/theme';
 import {ThemedCrashSmall} from '@atb/theme/ThemedAssets';
 import React from 'react';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {CUSTOMER_SERVICE_URL} from '@env';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
@@ -41,7 +42,9 @@ export function FullScreenErrorView({onRestartApp}: ErrorProps) {
           expanded={true}
           text={getContactButtonText(CUSTOMER_SERVICE_URL)}
           rightIcon={{svg: ExternalLink}}
-          onPress={() => Linking.openURL(CUSTOMER_SERVICE_URL)}
+          onPress={() =>
+            openUrl(CUSTOMER_SERVICE_URL, 'Could not open customer service URL')
+          }
           style={styles.button}
         />
       </View>

--- a/src/screen-components/error-boundary/FullScreenErrorView.tsx
+++ b/src/screen-components/error-boundary/FullScreenErrorView.tsx
@@ -42,9 +42,7 @@ export function FullScreenErrorView({onRestartApp}: ErrorProps) {
           expanded={true}
           text={getContactButtonText(CUSTOMER_SERVICE_URL)}
           rightIcon={{svg: ExternalLink}}
-          onPress={() =>
-            openUrl(CUSTOMER_SERVICE_URL, 'Could not open customer service URL')
-          }
+          onPress={() => openUrl(CUSTOMER_SERVICE_URL)}
           style={styles.button}
         />
       </View>

--- a/src/screen-components/force-update-screen/ForceUpdateScreen.tsx
+++ b/src/screen-components/force-update-screen/ForceUpdateScreen.tsx
@@ -1,7 +1,8 @@
 import {ThemeText} from '@atb/components/text';
 import {Button} from '@atb/components/button';
 import {Logo} from '@atb/assets/svg/mono-icons/logo';
-import {Linking, Platform, ScrollView, View} from 'react-native';
+import {Platform, ScrollView, View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import React, {useState} from 'react';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
@@ -11,7 +12,6 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
-import Bugsnag from '@bugsnag/react-native';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 
 const getThemeColor = (theme: Theme) => theme.color.background.neutral[1];
@@ -63,14 +63,8 @@ export const ForceUpdateScreen = () => {
                 default: '',
               });
               setError(false);
-              Linking.canOpenURL(link).then(
-                (supported) => {
-                  supported && Linking.openURL(link);
-                },
-                (err) => {
-                  Bugsnag.notify(err);
-                  setError(true);
-                },
+              openUrl(link, 'Could not open app store for update', () =>
+                setError(true),
               );
             }}
             text={t(ForceUpdateTexts.externalButton)}

--- a/src/screen-components/force-update-screen/ForceUpdateScreen.tsx
+++ b/src/screen-components/force-update-screen/ForceUpdateScreen.tsx
@@ -63,9 +63,7 @@ export const ForceUpdateScreen = () => {
                 default: '',
               });
               setError(false);
-              openUrl(link, 'Could not open app store for update', () =>
-                setError(true),
-              );
+              openUrl(link, () => setError(true));
             }}
             text={t(ForceUpdateTexts.externalButton)}
           />

--- a/src/screen-components/travel-details-screens/components/BookingOptions.tsx
+++ b/src/screen-components/travel-details-screens/components/BookingOptions.tsx
@@ -1,7 +1,8 @@
 import {Phone} from '@atb/assets/svg/mono-icons/devices';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {TripDetailsTexts, useTranslation} from '@atb/translations';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {Button} from '@atb/components/button';
 import {BookingMethod} from '@atb/api/types/generated/journey_planner_v3_types';
@@ -60,7 +61,9 @@ export const BookingOptions = ({bookingArrangements}: Props) => {
             text={t(
               TripDetailsTexts.flexibleTransport.bookByPhone(bookingPhone),
             )}
-            onPress={() => Linking.openURL(`tel:${bookingPhone}`)}
+            onPress={() =>
+              openUrl(`tel:${bookingPhone}`, 'Could not open phone for booking')
+            }
             type="small"
             expanded={false}
             interactiveColor={theme.color.interactive[3]}

--- a/src/screen-components/travel-details-screens/components/BookingOptions.tsx
+++ b/src/screen-components/travel-details-screens/components/BookingOptions.tsx
@@ -61,9 +61,7 @@ export const BookingOptions = ({bookingArrangements}: Props) => {
             text={t(
               TripDetailsTexts.flexibleTransport.bookByPhone(bookingPhone),
             )}
-            onPress={() =>
-              openUrl(`tel:${bookingPhone}`, 'Could not open phone for booking')
-            }
+            onPress={() => openUrl(`tel:${bookingPhone}`)}
             type="small"
             expanded={false}
             interactiveColor={theme.color.interactive[3]}

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -546,9 +546,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
             TripDetailsTexts.trip.leg.buyTicketFromA11yLabel(name),
           )}
           leftIcon={{svg: ExternalLink}}
-          onPress={() =>
-            url && openUrl(url, 'Could not open ticket purchase URL')
-          }
+          onPress={() => url && openUrl(url)}
           mode="primary"
           type="small"
           expanded={false}

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -23,7 +23,8 @@ import {
 } from '@atb/utils/transportation-names';
 import {useTransportColor} from '@atb/utils/use-transport-color';
 import React from 'react';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {
   getLineName,
   getNoticesForLeg,
@@ -545,7 +546,9 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
             TripDetailsTexts.trip.leg.buyTicketFromA11yLabel(name),
           )}
           leftIcon={{svg: ExternalLink}}
-          onPress={() => url && Linking.openURL(url)}
+          onPress={() =>
+            url && openUrl(url, 'Could not open ticket purchase URL')
+          }
           mode="primary"
           type="small"
           expanded={false}

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-open-vipps-after-reservation.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-open-vipps-after-reservation.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
-import {Linking} from 'react-native';
 import {PaymentType} from '@atb/modules/ticketing';
+import {openUrl} from '@atb/utils/open-url';
 
 /**
  * Open Vipps after successful reservation if the payment type is Vipps.
@@ -12,7 +12,7 @@ export const useOpenVippsAfterReservation = (
 ) => {
   useEffect(() => {
     if (paymentType === PaymentType.Vipps && url) {
-      Linking.openURL(url).catch(onErrorCallback);
+      openUrl(url, 'Could not open Vipps for payment', onErrorCallback);
     }
   }, [paymentType, url, onErrorCallback]);
 };

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-open-vipps-after-reservation.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/use-open-vipps-after-reservation.tsx
@@ -12,7 +12,7 @@ export const useOpenVippsAfterReservation = (
 ) => {
   useEffect(() => {
     if (paymentType === PaymentType.Vipps && url) {
-      openUrl(url, 'Could not open Vipps for payment', onErrorCallback);
+      openUrl(url, onErrorCallback);
     }
   }, [paymentType, url, onErrorCallback]);
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
@@ -4,8 +4,9 @@ import {getTextForLanguage} from '@atb/translations';
 import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
 import {DashboardTexts} from '@atb/translations';
-import {AccessibilityRole, Linking} from 'react-native';
+import {AccessibilityRole} from 'react-native';
 import Bugsnag from '@bugsnag/react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {SvgProps} from 'react-native-svg';
 import {RefObject, useCallback} from 'react';
 import {
@@ -58,7 +59,7 @@ export const useActionButtonProps = (
       await openInAppBrowser(url, 'close');
     },
     [ActionType.deeplink]: async (url: string) => {
-      await Linking.openURL(url);
+      await openUrl(url, 'Could not open deeplink URL');
     },
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
@@ -59,7 +59,7 @@ export const useActionButtonProps = (
       await openInAppBrowser(url, 'close');
     },
     [ActionType.deeplink]: async (url: string) => {
-      await openUrl(url, 'Could not open deeplink URL');
+      await openUrl(url);
     },
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
@@ -4,7 +4,8 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {Location} from '@atb/modules/favorites';
 import {SvgProps} from 'react-native-svg';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -177,7 +178,7 @@ const useActionButtons = (cityZone?: CityZone) => {
           name: 'book_by_phone_action',
           phoneNumber: phoneNumber,
         });
-        Linking.openURL(`tel:${phoneNumber}`);
+        openUrl(`tel:${phoneNumber}`, 'Could not open phone for booking');
       },
     });
   }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
@@ -178,7 +178,7 @@ const useActionButtons = (cityZone?: CityZone) => {
           name: 'book_by_phone_action',
           phoneNumber: phoneNumber,
         });
-        openUrl(`tel:${phoneNumber}`, 'Could not open phone for booking');
+        openUrl(`tel:${phoneNumber}`);
       },
     });
   }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -413,9 +413,7 @@ const HowPointsWork = () => {
               <LinkSectionItem
                 key={product.operatorId}
                 rightIcon={{svg: ExternalLink}}
-                onPress={() =>
-                  openUrl(appUrl, 'Could not open operator app URL')
-                }
+                onPress={() => openUrl(appUrl)}
                 text={t(
                   BonusProgramTexts.bonusProfile.readMore.downloadOperator(
                     getOperatorName(product.operatorId),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -13,7 +13,8 @@ import {
   useTranslation,
 } from '@atb/translations';
 import React, {useEffect, useRef, useState} from 'react';
-import {Linking, Platform, View} from 'react-native';
+import {Platform, View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {FullScreenView} from '@atb/components/screen-view';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {
@@ -412,7 +413,9 @@ const HowPointsWork = () => {
               <LinkSectionItem
                 key={product.operatorId}
                 rightIcon={{svg: ExternalLink}}
-                onPress={() => Linking.openURL(appUrl)}
+                onPress={() =>
+                  openUrl(appUrl, 'Could not open operator app URL')
+                }
                 text={t(
                   BonusProgramTexts.bonusProfile.readMore.downloadOperator(
                     getOperatorName(product.operatorId),

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -101,7 +101,7 @@ export const Profile_EditProfileScreen = ({
 
   const handleOpenVippsApp = async () => {
     const deepLink = __DEV__ ? 'vippsMT://' : 'vipps://';
-    await openUrl(deepLink, 'Could not open Vipps for birthdate', () =>
+    await openUrl(deepLink, () =>
       Alert.alert(t(EditProfileTexts.personalDetails.birthdate.openVippsError)),
     );
   };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -1,5 +1,6 @@
 import {ProfileScreenProps} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types';
-import {Alert, Linking, View} from 'react-native';
+import {Alert, View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {Section, TextInputSectionItem} from '@atb/components/sections';
 import React, {useEffect, useState} from 'react';
 import {dictionary, useTranslation} from '@atb/translations';
@@ -100,14 +101,9 @@ export const Profile_EditProfileScreen = ({
 
   const handleOpenVippsApp = async () => {
     const deepLink = __DEV__ ? 'vippsMT://' : 'vipps://';
-
-    const canOpen = await Linking.canOpenURL(deepLink);
-
-    if (canOpen) {
-      await Linking.openURL(deepLink);
-    } else {
-      Alert.alert(t(EditProfileTexts.personalDetails.birthdate.openVippsError));
-    }
+    await openUrl(deepLink, 'Could not open Vipps for birthdate', () =>
+      Alert.alert(t(EditProfileTexts.personalDetails.birthdate.openVippsError)),
+    );
   };
 
   useEffect(() => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
@@ -141,12 +141,7 @@ export const Profile_HelpAndContactScreen = ({navigation}: Props) => {
                 rightIcon={{svg: Support}}
                 accessibilityRole="button"
                 testID="contactCustomerServiceButton"
-                onPress={async () =>
-                  openUrl(
-                    `tel:${contactPhoneNumber}`,
-                    'Could not call customer service',
-                  )
-                }
+                onPress={async () => openUrl(`tel:${contactPhoneNumber}`)}
               />
             </View>
           )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_HelpAndContactScreen.tsx
@@ -7,11 +7,11 @@ import {
 import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
 import {LinkSectionItem, Section} from '@atb/components/sections';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {Button} from '@atb/components/button';
-import Bugsnag from '@bugsnag/react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {Support} from '@atb/assets/svg/mono-icons/actions';
 import {CustomerServiceText} from '@atb/translations/screens/subscreens/CustomerService';
 import {ThemedContactIllustration} from '@atb/theme/ThemedAssets';
@@ -142,7 +142,10 @@ export const Profile_HelpAndContactScreen = ({navigation}: Props) => {
                 accessibilityRole="button"
                 testID="contactCustomerServiceButton"
                 onPress={async () =>
-                  Linking.openURL(`tel:${contactPhoneNumber}`)
+                  openUrl(
+                    `tel:${contactPhoneNumber}`,
+                    'Could not call customer service',
+                  )
                 }
               />
             </View>
@@ -154,11 +157,7 @@ export const Profile_HelpAndContactScreen = ({navigation}: Props) => {
 };
 
 const openLink = async (url: string) => {
-  if (await Linking.canOpenURL(url)) {
-    openInAppBrowser(url, 'close');
-  } else {
-    Bugsnag.notify(new Error(`Could not open URL: ${url}`));
-  }
+  openInAppBrowser(url, 'close');
 };
 
 const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelAidScreen.tsx
@@ -94,10 +94,7 @@ export const Profile_TravelAidScreen = ({navigation}: Props) => {
                   testID="travelAidContactCustomerServiceButton"
                   onPress={async () => {
                     const phoneNumber = `tel:${contactPhoneNumber}`;
-                    await openUrl(
-                      phoneNumber,
-                      'Could not open phone for travel aid',
-                    );
+                    await openUrl(phoneNumber);
                   }}
                 />
               </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelAidScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_TravelAidScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Linking, View} from 'react-native';
+import {View} from 'react-native';
+import {openUrl} from '@atb/utils/open-url';
 import {StyleSheet, Theme, useThemeContext} from '@atb/theme';
 import {useTranslation} from '@atb/translations';
 import {FullScreenView} from '@atb/components/screen-view';
@@ -12,7 +13,6 @@ import {
 } from '@atb/components/sections';
 import {Button} from '@atb/components/button';
 import {usePreferencesContext} from '@atb/modules/preferences';
-import Bugsnag from '@bugsnag/react-native';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
@@ -94,16 +94,10 @@ export const Profile_TravelAidScreen = ({navigation}: Props) => {
                   testID="travelAidContactCustomerServiceButton"
                   onPress={async () => {
                     const phoneNumber = `tel:${contactPhoneNumber}`;
-                    if (await Linking.canOpenURL(phoneNumber)) {
-                      Linking.openURL(phoneNumber);
-                    } else {
-                      Bugsnag.notify(
-                        new Error(
-                          'Could not open phone number in accessiblity settings' +
-                            contactPhoneNumber,
-                        ),
-                      );
-                    }
+                    await openUrl(
+                      phoneNumber,
+                      'Could not open phone for travel aid',
+                    );
                   }}
                 />
               </View>

--- a/src/utils/__tests__/open-url.test.ts
+++ b/src/utils/__tests__/open-url.test.ts
@@ -20,7 +20,7 @@ describe('openUrl', () => {
   it('should call Linking.openURL with the provided url', async () => {
     (Linking.openURL as jest.Mock).mockResolvedValue(undefined);
 
-    await openUrl('https://example.com', 'Test message');
+    await openUrl('https://example.com');
 
     expect(Linking.openURL).toHaveBeenCalledWith('https://example.com');
   });
@@ -28,7 +28,7 @@ describe('openUrl', () => {
   it('should not call notifyBugsnag on success', async () => {
     (Linking.openURL as jest.Mock).mockResolvedValue(undefined);
 
-    await openUrl('https://example.com', 'Test message');
+    await openUrl('https://example.com');
 
     expect(notifyBugsnag).not.toHaveBeenCalled();
   });
@@ -37,12 +37,11 @@ describe('openUrl', () => {
     const error = new Error('Cannot open URL');
     (Linking.openURL as jest.Mock).mockRejectedValue(error);
 
-    await openUrl('https://example.com', 'Could not open URL');
+    await openUrl('https://example.com');
 
     expect(notifyBugsnag).toHaveBeenCalledWith(error, {
       metadata: {
         url: 'https://example.com',
-        bugsnagMessage: 'Could not open URL',
       },
       errorGroupHash: 'linkingOpenUrl',
     });
@@ -52,7 +51,7 @@ describe('openUrl', () => {
     (Linking.openURL as jest.Mock).mockRejectedValue(new Error('fail'));
     const onError = jest.fn();
 
-    await openUrl('https://example.com', 'Test message', onError);
+    await openUrl('https://example.com', onError);
 
     expect(onError).toHaveBeenCalled();
   });
@@ -60,8 +59,6 @@ describe('openUrl', () => {
   it('should not throw if onError is not provided', async () => {
     (Linking.openURL as jest.Mock).mockRejectedValue(new Error('fail'));
 
-    await expect(
-      openUrl('https://example.com', 'Test message'),
-    ).resolves.toBeUndefined();
+    await expect(openUrl('https://example.com')).resolves.toBeUndefined();
   });
 });

--- a/src/utils/__tests__/open-url.test.ts
+++ b/src/utils/__tests__/open-url.test.ts
@@ -1,0 +1,67 @@
+import {Linking} from 'react-native';
+import {openUrl} from '../open-url';
+import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
+
+jest.mock('react-native', () => ({
+  Linking: {
+    openURL: jest.fn(),
+  },
+}));
+
+jest.mock('@atb/utils/bugsnag-utils', () => ({
+  notifyBugsnag: jest.fn(),
+}));
+
+describe('openUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call Linking.openURL with the provided url', async () => {
+    (Linking.openURL as jest.Mock).mockResolvedValue(undefined);
+
+    await openUrl('https://example.com', 'Test message');
+
+    expect(Linking.openURL).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('should not call notifyBugsnag on success', async () => {
+    (Linking.openURL as jest.Mock).mockResolvedValue(undefined);
+
+    await openUrl('https://example.com', 'Test message');
+
+    expect(notifyBugsnag).not.toHaveBeenCalled();
+  });
+
+  it('should call notifyBugsnag with metadata on error', async () => {
+    const error = new Error('Cannot open URL');
+    (Linking.openURL as jest.Mock).mockRejectedValue(error);
+
+    await openUrl('https://example.com', 'Could not open URL');
+
+    expect(notifyBugsnag).toHaveBeenCalledWith(error, {
+      metadata: {
+        url: 'https://example.com',
+        bugsnagMessage: 'Could not open URL',
+      },
+      errorGroupHash: 'linkingOpenUrl',
+    });
+  });
+
+  it('should call onError callback on error', async () => {
+    (Linking.openURL as jest.Mock).mockRejectedValue(new Error('fail'));
+    const onError = jest.fn();
+
+    await openUrl('https://example.com', 'Test message', onError);
+
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('should not throw if onError is not provided', async () => {
+    (Linking.openURL as jest.Mock).mockRejectedValue(new Error('fail'));
+
+    await expect(
+      openUrl('https://example.com', 'Test message'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/open-url.ts
+++ b/src/utils/open-url.ts
@@ -3,10 +3,9 @@ import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
 
 /**
  * Open a URL with consistent error handling.
- * Always reports failures to Bugsnag with the provided message.
+ * Always reports failures to Bugsnag.
  *
  * @param url - The URL to open (http, https, tel, etc.)
- * @param bugsnagMessage - Descriptive message for Bugsnag metadata
  * @param onError - Optional callback invoked on failure (after Bugsnag report)
  */
 export async function openUrl(

--- a/src/utils/open-url.ts
+++ b/src/utils/open-url.ts
@@ -11,14 +11,13 @@ import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
  */
 export async function openUrl(
   url: string,
-  bugsnagMessage: string,
   onError?: () => void,
 ): Promise<void> {
   try {
     await Linking.openURL(url);
   } catch (error: any) {
     notifyBugsnag(error, {
-      metadata: {url, bugsnagMessage},
+      metadata: {url},
       errorGroupHash: 'linkingOpenUrl',
     });
     onError?.();

--- a/src/utils/open-url.ts
+++ b/src/utils/open-url.ts
@@ -1,0 +1,26 @@
+import {Linking} from 'react-native';
+import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
+
+/**
+ * Open a URL with consistent error handling.
+ * Always reports failures to Bugsnag with the provided message.
+ *
+ * @param url - The URL to open (http, https, tel, etc.)
+ * @param bugsnagMessage - Descriptive message for Bugsnag metadata
+ * @param onError - Optional callback invoked on failure (after Bugsnag report)
+ */
+export async function openUrl(
+  url: string,
+  bugsnagMessage: string,
+  onError?: () => void,
+): Promise<void> {
+  try {
+    await Linking.openURL(url);
+  } catch (error: any) {
+    notifyBugsnag(error, {
+      metadata: {url, bugsnagMessage},
+      errorGroupHash: 'linkingOpenUrl',
+    });
+    onError?.();
+  }
+}


### PR DESCRIPTION
## Issue Reference
fixes https://github.com/AtB-AS/kundevendt/issues/22097

## Description
- Introduces a new `openUrl(url, bugsnagMessage, onError?)` utility in `src/utils/open-url.ts` that wraps `Linking.openURL` with consistent error handling — reports to Bugsnag and optionally calls an `onError` callback.
- All errors are grouped under the `linkingOpenUrl` Bugsnag grouping hash, with per-call-site context in metadata.