### PR TITLE
fix: Move surfaceView after mapViewConfig

### DIFF
--- a/src/modules/map/components/MapTilePreloader.tsx
+++ b/src/modules/map/components/MapTilePreloader.tsx
@@ -86,7 +86,6 @@ export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
     return (
       <MapView
         id="preloaderOnlyMap"
-        surfaceView={false} // android won't render more than 1 map with surfaceView
         style={{
           pointerEvents: 'none',
           position: 'absolute',
@@ -108,6 +107,7 @@ export const MapTilePreloader = forwardRef<MapState, MapTilePreloaderProps>(
         }}
         pitchEnabled={false}
         {...mapViewConfig}
+        surfaceView={false} // android won't render more than 1 map with surfaceView
         attributionEnabled={false}
         compassEnabled={false}
         logoEnabled={false}


### PR DESCRIPTION
Fixes 'surfaceView' is specified more than once, so this usage will be overwritten.
https://github.com/AtB-AS/mittatb-app/actions/runs/24509841833