### PR TITLE
feat: filter out departures with actual departure time

### DIFF
--- a/src/api/bff/departures.ts
+++ b/src/api/bff/departures.ts
@@ -24,6 +24,7 @@ export type RealtimeData = {
     realtime: boolean;
     expectedDepartureTime: string;
     aimedDepartureTime: string;
+    actualDepartureTime?: string;
   };
 };
 export type DepartureRealtimeData = {

--- a/src/api/bff/types.ts
+++ b/src/api/bff/types.ts
@@ -51,6 +51,7 @@ export type DeparturesWithLineName = DeparturesQuery & {
 export type DepartureTime = {
   time: string;
   aimedTime: string;
+  actualTime?: string;
   realtime?: boolean;
   predictionInaccurate?: boolean;
   situations: SituationFragment[];

--- a/src/api/types/generated/DeparturesQuery.ts
+++ b/src/api/types/generated/DeparturesQuery.ts
@@ -2,6 +2,7 @@ import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
 import type {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import type {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import type {BookingArrangementFragment} from '@atb/api/types/generated/fragments/booking-arrangements';
+import {LineFragment} from './fragments/lines';
 
 export type DeparturesQuery = {
   quays: Array<{
@@ -13,6 +14,7 @@ export type DeparturesQuery = {
       date: any;
       expectedDepartureTime: any;
       aimedDepartureTime: any;
+      actualDepartureTime?: any;
       realtime: boolean;
       predictionInaccurate: boolean;
       cancellation: boolean;
@@ -23,14 +25,7 @@ export type DeparturesQuery = {
         id: string;
         transportMode?: Types.TransportMode;
         transportSubmode?: Types.TransportSubmode;
-        line: {
-          id: string;
-          description?: string;
-          publicCode?: string;
-          transportMode?: Types.TransportMode;
-          transportSubmode?: Types.TransportSubmode;
-          notices: Array<NoticeFragment>;
-        };
+        line: {description?: string} & LineFragment;
         journeyPattern?: {notices: Array<NoticeFragment>};
         notices: Array<NoticeFragment>;
       };

--- a/src/departure-list/section-items/line.tsx
+++ b/src/departure-list/section-items/line.tsx
@@ -27,7 +27,7 @@ import {insets} from '@atb/utils/insets';
 import {TFunc} from '@leile/lobo-t';
 import React from 'react';
 import {ScrollView, View} from 'react-native';
-import {hasNoDeparturesOnGroup, isValidDeparture} from '../utils';
+import {hasNoDeparturesOnGroup, isUpcomingDepartureTime} from '../utils';
 import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
 import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 import {
@@ -83,7 +83,9 @@ export function LineItem({
   }));
 
   // we know we have a departure as we've checked hasNoDeparturesOnGroup
-  const nextValids = group.departures.filter((d) => isValidDeparture(d, now));
+  const nextValids = group.departures.filter((d) =>
+    isUpcomingDepartureTime(d, now),
+  );
 
   return (
     <View style={[topContainer, {paddingVertical: 0, paddingHorizontal: 0}]}>
@@ -249,7 +251,7 @@ function DepartureTimeItem({
         : RealtimeLight
       : undefined;
 
-  if (!isValidDeparture(departure, now)) {
+  if (!isUpcomingDepartureTime(departure, now)) {
     return null;
   }
   return (

--- a/src/departure-list/section-items/quay-section.tsx
+++ b/src/departure-list/section-items/quay-section.tsx
@@ -6,7 +6,7 @@ import haversineDistance from 'haversine-distance';
 import {sortBy} from 'lodash';
 import React, {Fragment, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
-import {hasNoGroupsWithDepartures, isValidDeparture} from '../utils';
+import {hasNoGroupsWithDepartures, isUpcomingDepartureTime} from '../utils';
 import {LineItem} from './line';
 import {QuayHeaderItem} from './quay-header';
 import {Location} from '@atb/modules/favorites';
@@ -91,7 +91,7 @@ function sortAndLimit(quayGroup: QuayGroup, limit: number, now: number) {
   }
   const sorted = sortBy(
     quayGroup.group,
-    (v) => v.departures.find((d) => isValidDeparture(d, now))?.time,
+    (v) => v.departures.find((d) => isUpcomingDepartureTime(d, now))?.time,
   ).slice(0, limit);
   return sorted;
 }

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -50,7 +50,7 @@ export function updateStopsWithRealtime(
 function filterOutOutdatedDepartures(quayGroup: QuayGroup) {
   const newDepartureGroups = quayGroup.group.map(function (group) {
     const newDepartures = group.departures.filter((departure) =>
-      isValidDeparture(departure, Date.now()),
+      isUpcomingDepartureTime(departure, Date.now()),
     );
     // Optimization to avoid having to sort list to often.
     // If after filtering it has the same length it means we could
@@ -151,11 +151,11 @@ export function hasNoGroupsWithDepartures(
 export function hasNoDeparturesOnGroup(group: DepartureGroup, now: number) {
   return (
     group.departures.length === 0 ||
-    group.departures.every((d) => !isValidDeparture(d, now))
+    group.departures.every((d) => !isUpcomingDepartureTime(d, now))
   );
 }
 
-export function isValidDeparture(departure: DepartureTime, now: number) {
+export function isUpcomingDepartureTime(departure: DepartureTime, now: number) {
   if (departure.actualTime) return false;
   return !isNumberOfMinutesInThePast(
     departure.time,
@@ -164,7 +164,7 @@ export function isValidDeparture(departure: DepartureTime, now: number) {
   );
 }
 
-export function isValidDepartureTime(
+export function isUpcomingEstimatedCall(
   estimatedCall: EstimatedCall,
   now?: number,
 ) {

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -156,6 +156,7 @@ export function hasNoDeparturesOnGroup(group: DepartureGroup, now: number) {
 }
 
 export function isValidDeparture(departure: DepartureTime, now: number) {
+  if (departure.actualTime) return false;
   return !isNumberOfMinutesInThePast(
     departure.time,
     HIDE_AFTER_NUM_MINUTES,
@@ -163,6 +164,14 @@ export function isValidDeparture(departure: DepartureTime, now: number) {
   );
 }
 
-export function isValidDepartureTime(time: string, now?: number) {
-  return !isNumberOfMinutesInThePast(time, HIDE_AFTER_NUM_MINUTES, now);
+export function isValidDepartureTime(
+  estimatedCall: EstimatedCall,
+  now?: number,
+) {
+  if (estimatedCall.actualDepartureTime) return false;
+  return !isNumberOfMinutesInThePast(
+    estimatedCall.expectedDepartureTime,
+    HIDE_AFTER_NUM_MINUTES,
+    now,
+  );
 }

--- a/src/screen-components/place-screen/components/QuaySection.tsx
+++ b/src/screen-components/place-screen/components/QuaySection.tsx
@@ -19,7 +19,7 @@ import {
   SituationSectionItem,
 } from '@atb/modules/situations';
 import {EstimatedCallList} from './EstimatedCallList';
-import {isValidDepartureTime} from '@atb/departure-list/utils';
+import {isUpcomingEstimatedCall} from '@atb/departure-list/utils';
 import {ONE_SECOND_MS} from '@atb/utils/durations';
 import {useNow} from '@atb/utils/use-now';
 import {Loading} from '@atb/components/loading';
@@ -66,7 +66,7 @@ export function QuaySection({
   const now = useNow(5 * ONE_SECOND_MS);
 
   const departuresToDisplay = departures.filter((departure) =>
-    isValidDepartureTime(departure, now),
+    isUpcomingEstimatedCall(departure, now),
   );
 
   const navigateToQuayEnabled = !!navigateToQuay;

--- a/src/screen-components/place-screen/components/QuaySection.tsx
+++ b/src/screen-components/place-screen/components/QuaySection.tsx
@@ -66,7 +66,7 @@ export function QuaySection({
   const now = useNow(5 * ONE_SECOND_MS);
 
   const departuresToDisplay = departures.filter((departure) =>
-    isValidDepartureTime(departure.expectedDepartureTime, now),
+    isValidDepartureTime(departure, now),
   );
 
   const navigateToQuayEnabled = !!navigateToQuay;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departures-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departures-query.ts
@@ -17,7 +17,7 @@ import {isDefined} from '@atb/utils/presence';
 
 const DEFAULT_NUMBER_OF_DEPARTURES_PER_LINE_TO_SHOW = 7;
 const FAVORITE_DEPARTURES_REFETCH_INTERVAL_SECONDS = 30;
-const FAVORITE_DEPARTURES_FULL_REFRESH_INTERVAL_MINUTES = 10;
+const FAVORITE_DEPARTURES_FULL_REFRESH_INTERVAL_MINUTES = 5;
 
 type FavoriteDeparturesData = {
   data: DepartureGroupMetadata['data'];

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departures-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/use-favorite-departures-query.ts
@@ -66,7 +66,7 @@ export const useFavoriteDeparturesQuery = (enabled: boolean) => {
 
       const fullRefresh =
         !existingData ||
-        minutesBetween(existingData.startTime, new Date()) >
+        minutesBetween(existingData.startTime, new Date()) >=
           FAVORITE_DEPARTURES_FULL_REFRESH_INTERVAL_MINUTES;
 
       if (fullRefresh) {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -178,8 +178,8 @@ export function secondsBetween(
 }
 
 /**
- * Return minutes between start and end. If end is before start the returned
- * value will be negative.
+ * Return minutes between start and end, rounded down. If end is before start,
+ * the returned value will be negative.
  */
 export function minutesBetween(
   start: string | Date,


### PR DESCRIPTION
## Description

Filters out any departures that have `actualDepartureTime` (front page and departures). BFF PR: https://github.com/AtB-AS/atb-bff/pull/441

Also does a full refresh of dashboard departures every 5 minutes, instead of 10.

## Acceptance criteria

- [ ] If data from `bff/v2/departures/realtime`, `/bff/v2/departure-favorites` or `bff/v2/departures/departures` contains `actualDepartureTime`, it is removed from the list of departures.
- [x] Otherwise, we still fall back to the current functionality of removing depature 1 minute after estimated depature time.
- [x] Calls to `/bff/v2/departure-favorites` (full refresh) are made every 5 minutes on the front page, instead of 10