### PR TITLE
feat: add location requirement handling for QR code scanning

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -383,8 +383,8 @@ export const AssetFromQrCodeQuerySchema = z.object({
   qrCodeUrl: z
     .string()
     .min(1, {message: 'qrCodeUrl must be at least 1 character long'}),
-  longitude,
-  latitude,
+  longitude: longitude.optional(),
+  latitude: latitude.optional(),
 });
 
 export type AssetFromQrCodeQuery = z.infer<typeof AssetFromQrCodeQuerySchema>;

--- a/src/modules/mobility/queries/use-get-ids-from-qr-code-mutation.tsx
+++ b/src/modules/mobility/queries/use-get-ids-from-qr-code-mutation.tsx
@@ -1,11 +1,19 @@
+import {ErrorResponse} from '@atb-as/utils';
 import {getAssetFromQrCode} from '@atb/api/mobility';
-import {AssetFromQrCodeQuery} from '@atb/api/types/mobility';
+import {
+  AssetFromQrCodeQuery,
+  AssetFromQrCodeResponse,
+} from '@atb/api/types/mobility';
 import {useAcceptLanguage} from '@atb/api/use-accept-language';
 import {useMutation} from '@tanstack/react-query';
 
 export const useGetAssetFromQrCodeMutation = () => {
   const acceptLanguage = useAcceptLanguage();
-  return useMutation({
+  return useMutation<
+    AssetFromQrCodeResponse,
+    ErrorResponse,
+    AssetFromQrCodeQuery
+  >({
     mutationFn: (assetFromQrCodeQuery: AssetFromQrCodeQuery) =>
       getAssetFromQrCode(assetFromQrCodeQuery, acceptLanguage),
   });

--- a/src/stacks-hierarchy/Root_ScanQrCodeScreen.tsx
+++ b/src/stacks-hierarchy/Root_ScanQrCodeScreen.tsx
@@ -34,6 +34,7 @@ export const Root_ScanQrCodeScreen: React.FC<Props> = ({navigation}) => {
     mutateAsync: getAssetFromQrCode,
     isPending: getAssetFromQrCodeIsLoading,
     isError: getAssetFromQrCodeIsError,
+    error: getAssetFromQrCodeError,
   } = useGetAssetFromQrCodeMutation();
 
   const onGoBack = useCallback(() => {
@@ -44,9 +45,21 @@ export const Root_ScanQrCodeScreen: React.FC<Props> = ({navigation}) => {
     dispatchMapState({
       type: MapStateActionType.None,
     });
+
+    const isLocationRequired =
+      getAssetFromQrCodeError?.kind === 'LOCATION_REQUIRED';
+
     Alert.alert(
-      tGlobal(MapTexts.qr.notFound.title),
-      tGlobal(MapTexts.qr.notFound.description),
+      tGlobal(
+        isLocationRequired
+          ? MapTexts.qr.locationRequired.title
+          : MapTexts.qr.notFound.title,
+      ),
+      tGlobal(
+        isLocationRequired
+          ? MapTexts.qr.locationRequired.description
+          : MapTexts.qr.notFound.description,
+      ),
       [
         {
           text: tGlobal(MapTexts.qr.notFound.ok),
@@ -55,7 +68,7 @@ export const Root_ScanQrCodeScreen: React.FC<Props> = ({navigation}) => {
         },
       ],
     );
-  }, [dispatchMapState, onGoBack]);
+  }, [dispatchMapState, onGoBack, getAssetFromQrCodeError]);
 
   const assetFromQrCodeReceivedHandler = useCallback(
     (assetFromQrCode: AssetFromQrCodeResponse) => {
@@ -118,11 +131,13 @@ export const Root_ScanQrCodeScreen: React.FC<Props> = ({navigation}) => {
       setHasCapturedQr(true);
 
       const coordinates = getCurrentCoordinatesGlobal();
+      const locationParams = coordinates
+        ? {latitude: coordinates.latitude, longitude: coordinates.longitude}
+        : {};
 
       const assetFromQrCode = await getAssetFromQrCode({
         qrCodeUrl: qr,
-        latitude: coordinates?.latitude ?? 0,
-        longitude: coordinates?.longitude ?? 0,
+        ...locationParams,
       });
       assetFromQrCodeReceivedHandler(assetFromQrCode);
     },

--- a/src/translations/components/Map.ts
+++ b/src/translations/components/Map.ts
@@ -17,6 +17,18 @@ const MapTexts = {
       ),
       ok: _('OK', 'OK', 'OK'),
     },
+    locationRequired: {
+      title: _(
+        'Posisjon utilgjengelig',
+        'Location unavailable',
+        'Posisjon utilgjengeleg',
+      ),
+      description: _(
+        'Posisjon er påkrevd for å skanne en QR-kode for delingsmobilitet.',
+        'Location is required to scan a QR code for shared mobility.',
+        'Posisjon er påkravd for å skanne ein QR-kode for delingsmobilitet.',
+      ),
+    },
   },
   exitButton: {
     a11yLabel: _('Gå tilbake', 'Go back', 'Gå tilbake'),

--- a/src/translations/components/Map.ts
+++ b/src/translations/components/Map.ts
@@ -24,9 +24,9 @@ const MapTexts = {
         'Posisjon utilgjengeleg',
       ),
       description: _(
-        'Posisjon er påkrevd for å skanne en QR-kode for delingsmobilitet.',
-        'Location is required to scan a QR code for shared mobility.',
-        'Posisjon er påkravd for å skanne ein QR-kode for delingsmobilitet.',
+        'Posisjon er påkrevd for å skanne en QR-kode.',
+        'Location is required to scan a QR code.',
+        'Posisjon er påkravd for å skanne ein QR-kode.',
       ),
     },
   },


### PR DESCRIPTION
Add handling for location requirements when scanning QR codes. The latitude and longitude fields are now optional, and appropriate alerts are displayed when location is required.

<details><summary>Screenshot

</summary>
<p>

<img width="300" height="1368" alt="Screenshot 2026-04-16 at 15 23 00" src="https://github.com/user-attachments/assets/4ffed55d-781f-4e8a-8f6c-d0c9f22b86ac" />

</p>
</details> 

resolve https://github.com/AtB-AS/kundevendt/issues/23669
