### PR TITLE
fix: add missing padding with TransportationIconBoxList

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader.tsx
@@ -63,6 +63,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
+    gap: theme.spacing.small,
   },
   headerText: {
     flexShrink: 1,

--- a/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen/Root_TicketInformationScreen.tsx
@@ -141,6 +141,7 @@ const useStyle = StyleSheet.createThemeHook((theme, {bottom}) => {
     descriptionHeading: {
       flexDirection: 'row',
       alignItems: 'center',
+      gap: theme.spacing.xSmall,
       marginBottom: theme.spacing.small,
       flexShrink: 1,
     },


### PR DESCRIPTION
Discovered by @tormoseng, a bit of padding was missing after https://github.com/AtB-AS/mittatb-app/pull/5955
