### PR TITLE
fix: do not display sent or received ticket info if self purchase

### DIFF
--- a/src/modules/fare-contracts/components/SentOrReceivedMessageBox.tsx
+++ b/src/modules/fare-contracts/components/SentOrReceivedMessageBox.tsx
@@ -17,9 +17,11 @@ export const SentOrReceivedMessageBox = ({fc}: {fc: FareContractType}) => {
 
   const displayUserId = isSent ? fc.customerAccountId : fc.purchasedBy;
 
-  const {data: phoneNumber} = useGetPhoneByAccountIdQuery(displayUserId);
+  const {data: phoneNumber} = useGetPhoneByAccountIdQuery(
+    isSentOrReceived ? displayUserId : undefined,
+  );
   const {data: onBehalfOfAccounts} = useFetchOnBehalfOfAccountsQuery({
-    enabled: !!phoneNumber,
+    enabled: isSentOrReceived && !!phoneNumber,
   });
 
   if (!isSentOrReceived || !phoneNumber) return null;

--- a/src/modules/fare-contracts/components/TravelInfoSectionItem.tsx
+++ b/src/modules/fare-contracts/components/TravelInfoSectionItem.tsx
@@ -2,7 +2,6 @@ import {useTranslation} from '@atb/translations';
 import {useAuthContext} from '@atb/modules/auth';
 import {
   isCanBeActivatedNowFareContract,
-  isSentOrReceivedFareContract,
   useGetFareProductsQuery,
   useGetSupplementProductsQuery,
 } from '@atb/modules/ticketing';
@@ -191,7 +190,7 @@ export const TravelInfoSectionItem = ({
         )}
       </View>
 
-      {isSentOrReceivedFareContract(fc) && <SentOrReceivedMessageBox fc={fc} />}
+      <SentOrReceivedMessageBox fc={fc} />
 
       {(shouldShowSupplementPurchase || shouldShowActivateNow) && (
         <View style={styles.buttons}>

--- a/src/modules/fare-contracts/components/TravelInfoSectionItem.tsx
+++ b/src/modules/fare-contracts/components/TravelInfoSectionItem.tsx
@@ -2,6 +2,7 @@ import {useTranslation} from '@atb/translations';
 import {useAuthContext} from '@atb/modules/auth';
 import {
   isCanBeActivatedNowFareContract,
+  isSentOrReceivedFareContract,
   useGetFareProductsQuery,
   useGetSupplementProductsQuery,
 } from '@atb/modules/ticketing';
@@ -190,7 +191,8 @@ export const TravelInfoSectionItem = ({
         )}
       </View>
 
-      <SentOrReceivedMessageBox fc={fc} />
+      {isSentOrReceivedFareContract(fc) && <SentOrReceivedMessageBox fc={fc} />}
+
       {(shouldShowSupplementPurchase || shouldShowActivateNow) && (
         <View style={styles.buttons}>
           {shouldShowSupplementPurchase && (


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/23683

## Description
Do not show the component if not sent/received fare contract (self purchase)