### PR TITLE
test: also measure failures for e2e perf

### DIFF
--- a/.github/workflows/test-performance-android.yml
+++ b/.github/workflows/test-performance-android.yml
@@ -165,18 +165,11 @@ jobs:
           TESTED_VERSION: ${{ env.TESTED_VERSION }}
 
       # Slack
-      - name: Notify Slack - success
-        if: success()
-        working-directory: e2e/performance
+      - name: Notify Slack
+        if: always()
+        working-directory: e2e
         run: |
-          ./slack_notification.sh ${{ secrets.ATB_SLACK_TOKEN }} e2e_tests ${{ github.run_id }} ${{ needs.check-builds.outputs.TESTED_VERSION }} SUCCESS
-
-      # Slack
-      - name: Notify Slack - errors
-        if: failure()
-        working-directory: e2e/performance
-        run: |
-          ./slack_notification.sh ${{ secrets.ATB_SLACK_TOKEN }} e2e_tests ${{ github.run_id }} smoke ${{ needs.check-builds.outputs.TESTED_VERSION }} ERROR
+          ./performance/slack_notification.sh ${{ secrets.ATB_SLACK_TOKEN }} e2e_tests ${{ github.run_id }} ${{ needs.check-builds.outputs.TESTED_VERSION }}
 
       # Upload results
       - name: Upload performance reports

--- a/e2e/performance/createPerformanceSummary.ts
+++ b/e2e/performance/createPerformanceSummary.ts
@@ -111,22 +111,20 @@ const createSummary = (): void => {
     results: {},
   };
 
-  if (testStatus === 'SUCCESS') {
-    summary.results = {
-      cpu: {
-        avg: getAvgCPU(),
-        threads: {
-          RN_JS: getAvgProcessCPU('mqt_v_js'),
-          RN_Native: getAvgProcessCPU('mqt_v_native'),
-          Render: getAvgProcessCPU('RenderThread'),
-          UI: getAvgProcessCPU('UI Thread'),
-        },
+  summary.results = {
+    cpu: {
+      avg: getAvgCPU(),
+      threads: {
+        RN_JS: getAvgProcessCPU('mqt_v_js'),
+        RN_Native: getAvgProcessCPU('mqt_v_native'),
+        Render: getAvgProcessCPU('RenderThread'),
+        UI: getAvgProcessCPU('UI Thread'),
       },
-      fps: getAvgFPS(),
-      ram: getAvgRAM(),
-      score: getTestScore(performanceMeasures),
-    };
-  }
+    },
+    fps: getAvgFPS(),
+    ram: getAvgRAM(),
+    score: getTestScore(performanceMeasures),
+  };
 
   fs.writeFile(
     'performance_measures_summary.json',

--- a/e2e/performance/slack_notification.sh
+++ b/e2e/performance/slack_notification.sh
@@ -1,46 +1,43 @@
 #!/bin/bash
 
-if [ "$#" -ne 5 ]
+if [ "$#" -ne 4 ]
 then
     echo "Argument error!"
     echo "First argument should be the Slack token"
     echo "Second argument should be the Slack channel"
     echo "Third argument should be the GitHub run id"
     echo "Fourth argument should be the tested app version"
-    echo "Fifth argument should be SUCCESS or ERROR"
     exit 1
 else
     SLACK_TOKEN=$1
     SLACK_CHANNEL=$2
     GH_RUN_ID=$3
     TESTED_VERSION=$4
-    TEST_RESULT=$5
     GH_REF="https://github.com/AtB-AS/mittatb-app/actions/runs/${GH_RUN_ID}"
 
-    if [ "$TEST_RESULT" = "SUCCESS" ]
+    # Get measures from test
+    STATUS=$(jq -r '.status' performance_measures_summary.json)
+    CPU_AVG=$(jq -r '.results.cpu.avg' performance_measures_summary.json)
+    CPU_JS=$(jq -r '.results.cpu.threads.RN_JS' performance_measures_summary.json)
+    CPU_NATIVE=$(jq -r '.results.cpu.threads.RN_Native' performance_measures_summary.json)
+    CPU_RENDER=$(jq -r '.results.cpu.threads.Render' performance_measures_summary.json)
+    CPU_UI=$(jq -r '.results.cpu.threads.UI' performance_measures_summary.json)
+    FPS=$(jq -r '.results.fps' performance_measures_summary.json)
+    RAM=$(jq -r '.results.ram' performance_measures_summary.json)
+    SCORE=$(jq -r '.results.score' performance_measures_summary.json)
+
+    PAYLOAD="{\"channel\": \"${SLACK_CHANNEL}\", \"blocks\": [{\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \"\n\"}}, {\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \":zap: *E2E App performance measures - version ${TESTED_VERSION} (<${GH_REF}|GH action>)*\"}}]}"
+
+    if [ "$STATUS" = "SUCCESS" ]
     then
-      # Get measures from test
-      CPU_AVG=$(jq -r '.results.cpu.avg' performance_measures_summary.json)
-      CPU_JS=$(jq -r '.results.cpu.threads.RN_JS' performance_measures_summary.json)
-      CPU_NATIVE=$(jq -r '.results.cpu.threads.RN_Native' performance_measures_summary.json)
-      CPU_RENDER=$(jq -r '.results.cpu.threads.Render' performance_measures_summary.json)
-      CPU_UI=$(jq -r '.results.cpu.threads.UI' performance_measures_summary.json)
-      FPS=$(jq -r '.results.fps' performance_measures_summary.json)
-      RAM=$(jq -r '.results.ram' performance_measures_summary.json)
-      SCORE=$(jq -r '.results.score' performance_measures_summary.json)
-
-      PAYLOAD="{\"channel\": \"${SLACK_CHANNEL}\", \"blocks\": [{\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \"\n\"}}, {\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \":zap: *E2E App performance measures - version ${TESTED_VERSION} (<${GH_REF}|GH action>)*\"}}]}"
-
       PAYLOAD_DETAILS="{
         \"channel\": \"$SLACK_CHANNEL\",
         \"text\": \"- Score ($SCORE), FPS ($FPS), CPU ($CPU_AVG), RAM ($RAM)\n- CPU Threads: RN JS ($CPU_JS), RN Native ($CPU_NATIVE), Render ($CPU_RENDER), UI ($CPU_UI)\"
         }"
     else
-      PAYLOAD="{\"channel\": \"${SLACK_CHANNEL}\", \"blocks\": [{\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \"\n\"}}, {\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": \":zap: *E2E App performance measures - version ${TESTED_VERSION} (<${GH_REF}|GH action>)*\"}}]}"
-
       PAYLOAD_DETAILS="{
         \"channel\": \"$SLACK_CHANNEL\",
-        \"text\": \":warning: The tests failed. See details in <${GH_REF}|GH action>\"
+        \"text\": \":warning: *The tests failed*\n- Score ($SCORE), FPS ($FPS), CPU ($CPU_AVG), RAM ($RAM)\n- CPU Threads: RN JS ($CPU_JS), RN Native ($CPU_NATIVE), Render ($CPU_RENDER), UI ($CPU_UI)\"
         }"
     fi
 

--- a/e2e/test/pageobjects/ticket.active.page.ts
+++ b/e2e/test/pageobjects/ticket.active.page.ts
@@ -63,6 +63,7 @@ class TicketActivePage {
     const reqId = `//*[@resource-id="historicTicketsButton"]`;
     await $(reqId).click();
     await AppHelper.pause();
+    await ElementHelper.waitForElement('id', 'ticket0');
   }
 }
 


### PR DESCRIPTION
If the E2E performance action fails, it's only noticeable on the Slack messages that the values are `null`. Here, I also take care of the values for failures - along with a warning on failures.

Also, added wait until tickets show on the purchased history check.