### PR TITLE
feat: Icon transitions for vehicles and stations

### DIFF
--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -57,11 +57,7 @@ import {useMapContext} from '@atb/modules/map';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {NationalStopRegistryFeatures} from './components/national-stop-registry-features';
 import {OnPressEvent} from 'node_modules/@rnmapbox/maps/src/types/OnPressEvent';
-import {
-  StationsWithClusters,
-  VehiclesAndStations,
-  VehiclesWithClusters,
-} from './components/mobility/VehiclesAndStations';
+import {VehiclesAndStations} from './components/mobility/VehiclesAndStations';
 import {SelectedFeatureIcon} from './components/SelectedFeatureIcon';
 import {ShmoBookingState} from '@atb/api/types/mobility';
 import {useStablePreviousValue} from '@atb/utils/use-stable-previous-value';
@@ -526,19 +522,12 @@ export const Map = (props: MapProps) => {
           tabBarHeight={tabBarHeight}
           ref={mapStateRef}
         >
-          {!!showVehicles && (
-            <VehiclesWithClusters
-              selectedFeatureId={undefined}
-              hideSymbols={true}
-            />
-          )}
-          {!!showStations && (
-            <StationsWithClusters
-              selectedFeatureId={undefined}
-              showNonVirtualStations={true}
-              hideSymbols={true}
-            />
-          )}
+          <VehiclesAndStations
+            selectedFeatureId={undefined}
+            showVehicles={showVehicles}
+            showStations={showStations}
+            hideSymbols={true}
+          />
         </MapTilePreloader>
       )}
     </View>

--- a/src/modules/map/components/mobility/VehiclesAndStations.tsx
+++ b/src/modules/map/components/mobility/VehiclesAndStations.tsx
@@ -26,18 +26,33 @@ import {
   scaleTransitionZoomRange,
 } from '../../hooks/use-map-symbol-styles';
 
-const vehiclesAndStationsVectorSourceId =
-  'vehicles-clustered-and-stations-source';
+const vehiclesAndStationsMinZoom = 14;
+const vehiclesAndStationsMaxZoom = 17;
+const vehiclesAndStationsZoomLevels = Array.from(
+  {length: vehiclesAndStationsMaxZoom - vehiclesAndStationsMinZoom + 1},
+  (_, i) => i + vehiclesAndStationsMinZoom,
+);
 
-export const VehiclesWithClusters = ({
+const getVehiclesAndStationsVectorSourceId = (zoomLevel: number) =>
+  `vehicles-clustered-and-stations-source-${zoomLevel}`;
+
+type VehiclesWithClustersProps = SelectedFeatureIdProp & {
+  minZoomLevel: number;
+  hideSymbols?: boolean;
+};
+
+const VehiclesWithClusters = ({
   selectedFeatureId,
+  minZoomLevel,
   hideSymbols = false,
-}: SelectedFeatureIdProp & {hideSymbols?: boolean}) => {
-  const minZoomLevel = 14;
+}: VehiclesWithClustersProps) => {
   const {isSelected, iconStyle, textStyle} = useMapSymbolStyles({
     selectedFeaturePropertyId: selectedFeatureId,
     pinType: 'vehicle',
-    reachFullScaleAtZoomLevel: minZoomLevel + scaleTransitionZoomRange + 0.3,
+    reachFullScaleAtZoomLevel:
+      minZoomLevel +
+      scaleTransitionZoomRange +
+      (minZoomLevel === vehiclesAndStationsMinZoom ? 0.15 : 0),
   });
 
   const filter: {filter: FilterExpression} | undefined = useMemo(
@@ -58,12 +73,17 @@ export const VehiclesWithClusters = ({
 
   return (
     <MapboxGL.SymbolLayer
-      id={`vehicles-clustered-symbol-layer-${
+      id={`vehicles-clustered-symbol-layer-${minZoomLevel}-${
         hideSymbols ? 'hidden' : 'visible'
       }`}
-      sourceID={vehiclesAndStationsVectorSourceId}
+      sourceID={getVehiclesAndStationsVectorSourceId(minZoomLevel)}
       sourceLayerID="combined_layer"
       minZoomLevel={minZoomLevel}
+      maxZoomLevel={
+        minZoomLevel === vehiclesAndStationsMaxZoom
+          ? undefined
+          : minZoomLevel + 1 + scaleTransitionZoomRange
+      }
       aboveLayerID={MapSlotLayerId.Vehicles}
       style={hideSymbols ? {} : style}
       {...filter}
@@ -71,20 +91,24 @@ export const VehiclesWithClusters = ({
   );
 };
 
-export const StationsWithClusters = ({
+const StationsWithClusters = ({
   selectedFeatureId,
   showNonVirtualStations,
   hideSymbols = false,
+  minZoomLevel,
 }: SelectedFeatureIdProp & {
   showNonVirtualStations: boolean;
   hideSymbols?: boolean;
+  minZoomLevel: number;
 }) => {
   const showVirtualStations = false; // not supported yet. Also – consider using a virtualStationsFilter prop instead
-  const minZoomLevel = 14;
   const {isSelected, iconStyle, textStyle} = useMapSymbolStyles({
     selectedFeaturePropertyId: selectedFeatureId,
     pinType: 'station',
-    reachFullScaleAtZoomLevel: minZoomLevel + scaleTransitionZoomRange + 0.2,
+    reachFullScaleAtZoomLevel:
+      minZoomLevel +
+      scaleTransitionZoomRange +
+      (minZoomLevel === vehiclesAndStationsMinZoom ? 0.05 : 0),
   });
 
   const {mapFilter} = useMapContext();
@@ -144,17 +168,29 @@ export const StationsWithClusters = ({
 
   return (
     <MapboxGL.SymbolLayer
-      id={`stations-clustered-symbol-layer-${
+      id={`stations-clustered-symbol-layer-${minZoomLevel}-${
         hideSymbols ? 'hidden' : 'visible'
       }`}
-      sourceID={vehiclesAndStationsVectorSourceId}
+      sourceID={getVehiclesAndStationsVectorSourceId(minZoomLevel)}
       sourceLayerID="combined_stations_layer"
       minZoomLevel={minZoomLevel}
+      maxZoomLevel={
+        minZoomLevel === vehiclesAndStationsMaxZoom
+          ? undefined
+          : minZoomLevel + 1 + scaleTransitionZoomRange
+      }
       aboveLayerID={MapSlotLayerId.Stations}
       style={hideSymbols ? {} : style}
       {...filter}
     />
   );
+};
+
+type VehiclesAndStationsProps = SelectedFeatureIdProp & {
+  onPress?: (e: OnPressEvent) => void;
+  showVehicles: boolean;
+  showStations: boolean;
+  hideSymbols?: boolean;
 };
 
 // Vehicles and stations are grouped to optimize tile loading (limiting the number of requests)
@@ -163,33 +199,36 @@ export const VehiclesAndStations = ({
   onPress,
   showVehicles,
   showStations,
-}: SelectedFeatureIdProp & {
-  onPress?: (e: OnPressEvent) => void;
-  showVehicles: boolean;
-  showStations: boolean;
-}) => {
+  hideSymbols = false,
+}: VehiclesAndStationsProps) => {
   if (!showVehicles && !showStations) return null;
-
-  return (
+  return vehiclesAndStationsZoomLevels.map((zoomLevel) => (
     <MapboxGL.VectorSource
-      id={vehiclesAndStationsVectorSourceId}
+      key={`${zoomLevel}`}
+      id={getVehiclesAndStationsVectorSourceId(zoomLevel)}
       existing={true}
       hitbox={hitboxCoveringIconOnly}
       onPress={onPress}
     >
       <>
         {!!showVehicles && (
-          <VehiclesWithClusters selectedFeatureId={selectedFeatureId} />
+          <VehiclesWithClusters
+            selectedFeatureId={selectedFeatureId}
+            minZoomLevel={zoomLevel}
+            hideSymbols={hideSymbols}
+          />
         )}
         {!!showStations && (
           <StationsWithClusters
             selectedFeatureId={selectedFeatureId}
             showNonVirtualStations={true}
+            minZoomLevel={zoomLevel}
+            hideSymbols={hideSymbols}
           />
         )}
       </>
     </MapboxGL.VectorSource>
-  );
+  ));
 };
 
 /**
@@ -201,8 +240,7 @@ export const VehiclesAndStations = ({
  * @returns {id: string, source: StyleJsonVectorSource}
  */
 export const useVehiclesAndStationsVectorSource: () => {
-  id: string;
-  source: StyleJsonVectorSource;
+  [key: string]: StyleJsonVectorSource;
 } = () => {
   // Could consider adding the sources only if shown.
   // The reason not to, is to simplify potential cache tile hotloading on the server.
@@ -212,17 +250,21 @@ export const useVehiclesAndStationsVectorSource: () => {
   ];
   const tileUrlTemplate = useTileUrlTemplate(tileLayerNames);
 
-  return useMemo(
-    () => ({
-      id: vehiclesAndStationsVectorSourceId,
-      source: {
+  return useMemo(() => {
+    const vehiclesAndStationsVectorSources: {
+      [key: string]: StyleJsonVectorSource;
+    } = {};
+    vehiclesAndStationsZoomLevels.forEach((zoomLevel) => {
+      vehiclesAndStationsVectorSources[
+        getVehiclesAndStationsVectorSourceId(zoomLevel)
+      ] = {
         type: 'vector',
         tiles: [tileUrlTemplate || ''],
-        minzoom: 14,
-        maxzoom: 17,
+        minzoom: zoomLevel,
+        maxzoom: zoomLevel,
         volatile: true,
-      },
-    }),
-    [tileUrlTemplate],
-  );
+      };
+    });
+    return vehiclesAndStationsVectorSources;
+  }, [tileUrlTemplate]);
 };

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -12,9 +12,9 @@ import {SelectedMapItemProperties} from '../types';
 import {getIconZoomTransitionStyle} from '../utils';
 import {PropulsionType} from '@atb/api/types/generated/mobility-types_v2';
 
-export const scaleTransitionZoomRange = 0.4;
-const opacityTransitionExtraZoomRange = scaleTransitionZoomRange / 8;
-const smallestAllowedSizeFactor = 0.3;
+export const scaleTransitionZoomRange = 0.3;
+const opacityTransitionExtraZoomRange = scaleTransitionZoomRange / 4;
+export const smallestAllowedSizeFactor = 0.3;
 
 type MapSymbolStylesProps = {
   selectedFeaturePropertyId: SelectedMapItemProperties['id'];
@@ -71,7 +71,31 @@ export const useMapSymbolStyles = ({
     ['!', isMinimized],
   ];
 
-  const iconFullSize: Expression = ['case', reduceIconSize, 0.855, 1];
+  const textOffsetXFactor = pinType == 'vehicle' ? 1 : 1.045;
+  const numberOfUnits = pinType == 'vehicle' ? count : numVehiclesAvailable;
+  const numberOfUnitsLimitedAt99Plus: Expression = [
+    'case',
+    isMinimized,
+    '+',
+    ['>', numberOfUnits, 99],
+    '99+',
+    numberOfUnits,
+  ];
+
+  const countAdjustmentMaxFactorIncrease = 0.2;
+  const countAdjustedSizeFactor = [
+    'step',
+    numberOfUnits,
+    ['+', 1, ['*', numberOfUnits, countAdjustmentMaxFactorIncrease / 100]],
+    100,
+    1 + countAdjustmentMaxFactorIncrease,
+  ];
+
+  const iconFullSize: Expression = [
+    '*',
+    ['case', reduceIconSize, 0.855, 1],
+    countAdjustedSizeFactor,
+  ];
 
   const {iconOpacity, iconSize} = getIconZoomTransitionStyle(
     reachFullScaleAtZoomLevel,
@@ -175,17 +199,6 @@ export const useMapSymbolStyles = ({
     suffix,
     '_',
     themeName,
-  ];
-
-  const textOffsetXFactor = pinType == 'vehicle' ? 1 : 1.045;
-  const numberOfUnits = pinType == 'vehicle' ? count : numVehiclesAvailable;
-  const numberOfUnitsLimitedAt99Plus: Expression = [
-    'case',
-    isMinimized,
-    '+',
-    ['>', numberOfUnits, 99],
-    '99+',
-    numberOfUnits,
   ];
 
   const symbolSortKey: Expression = [

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -247,7 +247,7 @@ export const useMapSymbolStyles = ({
       numberOfUnits,
       [0.82 * textOffsetXFactor, 0],
       100,
-      [1.0 * textOffsetXFactor, 0],
+      [1.2 * textOffsetXFactor, 0],
     ],
   ];
 

--- a/src/modules/map/hooks/use-mapbox-json-style.tsx
+++ b/src/modules/map/hooks/use-mapbox-json-style.tsx
@@ -50,10 +50,7 @@ export const useMapboxJsonStyle: (
     shouldShowGeofencingZonesLayers,
   );
 
-  const {
-    id: vehiclesAndStationsVectorSourceId,
-    source: vehiclesAndStationsVectorSource,
-  } = useVehiclesAndStationsVectorSource();
+  const vehiclesAndStationsVectorSources = useVehiclesAndStationsVectorSource();
 
   const themedStyleWithExtendedSourcesAndSlotLayers = useMemo(() => {
     const themedStyle =
@@ -87,10 +84,7 @@ export const useMapboxJsonStyle: (
     const extendedSources: StyleJsonVectorSourcesObj = {
       ...themedStyle.sources,
       ...(includeVehiclesAndStationsVectorSource
-        ? {
-            [vehiclesAndStationsVectorSourceId]:
-              vehiclesAndStationsVectorSource,
-          }
+        ? vehiclesAndStationsVectorSources
         : undefined),
     };
 
@@ -105,8 +99,7 @@ export const useMapboxJsonStyle: (
     mapbox_nsr_tileset_id,
     mapbox_user_name,
     themeName,
-    vehiclesAndStationsVectorSource,
-    vehiclesAndStationsVectorSourceId,
+    vehiclesAndStationsVectorSources,
   ]);
 
   const mapboxJsonStyle = useMemo(

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -38,6 +38,7 @@ import {MapBottomSheetType} from './MapContext';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import z from 'zod';
 import {GeofencingZoneCode} from '@atb-as/theme';
+import {smallestAllowedSizeFactor} from './hooks/use-map-symbol-styles';
 
 export const hitboxCoveringIconOnly = {width: 1, height: 1};
 
@@ -343,7 +344,7 @@ export function getIconZoomTransitionStyle(
     ['linear'],
     ['zoom'],
     reachFullScaleAtZoomLevel - scaleTransitionZoomRange,
-    0.3,
+    smallestAllowedSizeFactor,
     reachFullScaleAtZoomLevel,
     iconFullSize,
   ];


### PR DESCRIPTION
NOTE: Will create and merge another PR first to simplify volatile VectorSource definitions. That should simplify this a little.

## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->
This is part 2 of the revamped version of https://github.com/AtB-AS/mittatb-app/pull/5321. (Part 1  which is merged: https://github.com/AtB-AS/mittatb-app/pull/5961)

## Description
<!-- What does this PR do? -->
Adds smoother vehicle and station transitions in the map.
In order to start the in transition of items on the next zoom level while the previous is still visible, the VectorSource has been split up into one for each zoom level in the range.
Then all symbols are transitioned in.


**Before**

https://github.com/user-attachments/assets/28e7fb5f-a770-41b9-97c4-ee7f8e364726

**After**

https://github.com/user-attachments/assets/e2aebbbe-30e9-43a9-a662-10915efaf7d2

Acceptance Criteria:
- [ ] All vehicles and stations icons transition in (unless zooming _very_ fast)
- [ ] Tile requests same as before
- [ ] Note! This requires the preload feature flag to be enabled in order to work smoothly. We may have to allow higher burst rates for map svc
- [ ] Overall UX should be better than before