### PR TITLE
fix: strictly parse fare contract dates

### DIFF
--- a/src/modules/purchase-selection/purchase-selection-builder.ts
+++ b/src/modules/purchase-selection/purchase-selection-builder.ts
@@ -17,7 +17,7 @@ import {
   isValidSelection,
   isWithinUserProfileMaxCount,
 } from './utils';
-import {isValidDateString} from '@atb/utils/date';
+import {isValidDateTimeString} from '@atb/utils/date';
 import {isSameDay} from 'date-fns';
 import type {SupplementProductWithCount} from '@atb/modules/fare-contracts';
 
@@ -115,7 +115,7 @@ const createBuilder = (
       return builder;
     },
     date: (travelDate) => {
-      if (!travelDate || isValidDateString(travelDate)) {
+      if (!travelDate || isValidDateTimeString(travelDate)) {
         currentSelection = {...currentSelection, travelDate};
       }
       return builder;

--- a/src/modules/purchase-selection/utils.ts
+++ b/src/modules/purchase-selection/utils.ts
@@ -12,7 +12,7 @@ import {
   type SupplementProduct,
   UserProfile,
 } from '@atb-as/config-specs';
-import {isValidDateString} from '@atb/utils/date';
+import {isValidDateTimeString} from '@atb/utils/date';
 import {decodePolylineEncodedGeometry} from '@atb/utils/decode-polyline-geometry';
 import {isProductSellableInApp} from '@atb/utils/is-product-sellable-in-app';
 
@@ -186,7 +186,7 @@ export const isValidSelection = (
   if (!isToZoneValid) return false;
 
   const isDateValid = selection.travelDate
-    ? isValidDateString(selection.travelDate)
+    ? isValidDateTimeString(selection.travelDate)
     : true;
   if (!isDateValid) return false;
 

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -14,6 +14,7 @@ import {
   isBetween,
   isEqualOrAfter,
   isNumberOfMinutesInThePast,
+  isValidDateTimeString,
   minutesBetween,
   secondsToDuration,
 } from '../date'; // Adjust the path if needed
@@ -520,5 +521,55 @@ describe('minutesBetween', () => {
     const start = new Date('2024-09-01T12:00:20Z');
     const end = new Date('2024-09-01T12:30:19Z');
     expect(minutesBetween(start, end)).toBe(29);
+  });
+});
+
+describe('convertIsoStringFieldsToDate', () => {
+  test('converts ISO string fields to Date objects', () => {
+    const input = {
+      string: 'Hello world!',
+      date: '2024-01-01T00:00:00.000Z',
+      dateWithTimeZone: '2024-01-01T00:00:00.000+01:00',
+      year: '2026',
+      partialDate: '2024-01-01',
+      number: 42,
+      orderId: '41ABC5123',
+      nested: {
+        string: 'Nested string',
+        date: '2024-02-01T00:00:00.000Z',
+      },
+      array: [{date: '2024-04-01T00:00:00.000Z'}],
+    };
+    const expectedOutput = {
+      string: 'Hello world!',
+      date: new Date('2024-01-01T00:00:00.000Z'),
+      dateWithTimeZone: new Date('2024-01-01T00:00:00.000+01:00'),
+      year: '2026',
+      partialDate: '2024-01-01',
+      number: 42,
+      orderId: '41ABC5123',
+      nested: {
+        string: 'Nested string',
+        date: new Date('2024-02-01T00:00:00.000Z'),
+      },
+      array: [{date: new Date('2024-04-01T00:00:00.000Z')}],
+    };
+    const result = convertIsoStringFieldsToDate(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe('isValidDateString', () => {
+  test('ISO strings are valid', () => {
+    expect(isValidDateTimeString('2024-09-01T12:00:00.000Z')).toBe(true);
+    expect(isValidDateTimeString('2024-09-01T12:00:00.000+01:00')).toBe(true);
+    expect(isValidDateTimeString('2024-09-01T12:00:00.000-01:00')).toBe(true);
+  });
+  test('non-ISO strings are invalid', () => {
+    expect(isValidDateTimeString('2024')).toBe(false);
+    expect(isValidDateTimeString('2024-09-01')).toBe(false);
+    expect(isValidDateTimeString('12:00')).toBe(false);
+    expect(isValidDateTimeString('41ABCD5E')).toBe(false);
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -26,6 +26,7 @@ import {
   set,
   isValid,
   intervalToDuration,
+  parseJSON as parseJSONDate,
 } from 'date-fns';
 import {
   FormatOptionsWithTZ,
@@ -660,8 +661,19 @@ function getHumanizer(
   return humanizer(ms, opts);
 }
 
-export const isValidDateString = (dateString: string) => {
-  const parsedDate = parseISO(dateString);
+/**
+ * Validates that the input string is a valid ISO date and time string on the
+ * format `YYYY-MM-DDTHH:mm:ss.sssZ` or `YYYY-MM-DDTHH:mm:ss.sss±hh:mm`
+ *
+ * @example
+ * assert(isValidDateTimeString('2024-09-01T12:00:00.000Z') === true);
+ * assert(isValidDateTimeString('2024-09-01T12:00:00.000+01:00') === true);
+ * assert(isValidDateTimeString('2024-09-01T12:00:00.000-01:00') === true);
+ * assert(isValidDateTimeString('2024') === false);
+ * assert(isValidDateTimeString('2024-09-01') === false);
+ */
+export const isValidDateTimeString = (dateString: string) => {
+  const parsedDate = parseJSONDate(dateString);
   return isValid(parsedDate);
 };
 
@@ -677,8 +689,8 @@ export const convertIsoStringFieldsToDate = (value: any): any => {
       acc[key] = convertIsoStringFieldsToDate(fieldValue);
       return acc;
     }, {});
-  } else if (typeof value === 'string' && isValidDateString(value)) {
-    return parseISO(value);
+  } else if (typeof value === 'string' && isValidDateTimeString(value)) {
+    return parseJSONDate(value);
   }
   return value;
 };


### PR DESCRIPTION
Turns out date-fns `parseISO` handles more of ISO 8601 than we took into account when using it in `convertIsoStringFieldsToDate`. It's quite liberal when parsing dates, and can ends up converting some order IDs to dates if they contains numbers in the right places.

This caused the following Zod error when fetching `ticket/v4/list`

```json
[
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "orderId"
    ],
    "message": "Invalid input: expected string, received Date"
  }
]
```

https://mittatb.slack.com/archives/C02DL21RK7C/p1776415955164209