### PR TITLE
fix: add actualDepartureTime when populating realtime data

### DIFF
--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -130,6 +130,7 @@ export function getDeparturesAugmentedWithRealtimeData(
       return {
         ...departure,
         expectedDepartureTime: departureRealtime.timeData.expectedDepartureTime,
+        actualDepartureTime: departureRealtime.timeData.actualDepartureTime,
         realtime: departureRealtime.timeData.realtime,
       };
     })


### PR DESCRIPTION
`actualDepartureTime` didn't have an effect on the departures tab since `getDeparturesAugmentedWithRealtimeData` didn't pass the field to the updated departures.

Fixes this comment: https://github.com/AtB-AS/mittatb-app/pull/5986#issuecomment-4266683724