### PR TITLE
feat: save zones instead of cancelling on back button

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByMapScreen.tsx
@@ -53,7 +53,7 @@ export const Root_PurchaseFareZonesSearchByMapScreen = ({
             ? t(FareZonesTexts.header.title.singleZone)
             : t(FareZonesTexts.header.title.multipleZone)
         }
-        leftButton={{type: 'back'}}
+        leftButton={{type: 'back', onPress: onSave}}
       />
 
       <FareZonesSelectorButtons


### PR DESCRIPTION
Request from @Sebstorvik / the OMS. There were reports from users that bought wrong tickets because zone selection wasn't saved when they clicked the back button from zone selection. We currently only save when the save button at the bottom is pressed.

Also saving when pressing the back button seems more consistent with bottoms sheets in ticket purchase (time and traveler selection), which saves on close.

## Acceptance criteria

- [x] In ticket purchase, zone selection is saved both when clicking the save button, and the back button.