### PR TITLE
fix: Standarized fetching of situations

### DIFF
--- a/src/api/types/generated/fragments/trips.ts
+++ b/src/api/types/generated/fragments/trips.ts
@@ -35,15 +35,17 @@ export type TripPatternFragment = {
       aimedDepartureTime: any;
       expectedDepartureTime: any;
       stopPositionInPattern: number;
+      cancellation: boolean;
       destinationDisplay?: {frontText?: string; via?: Array<string>};
       quay: {publicCode?: string; name: string};
       notices: Array<NoticeFragment>;
-      cancellation: boolean;
+      situations: Array<SituationFragment>;
     };
     toEstimatedCall?: {
       stopPositionInPattern: number;
-      notices: Array<NoticeFragment>;
       cancellation: boolean;
+      notices: Array<NoticeFragment>;
+      situations: Array<SituationFragment>;
     };
     situations: Array<SituationFragment>;
     fromPlace: {
@@ -111,8 +113,8 @@ export type TripPatternFragment = {
       aimedDepartureTime: any;
       expectedDepartureTime: any;
       predictionInaccurate: boolean;
-      quay: {name: string};
       cancellation: boolean;
+      quay: {name: string};
     }>;
     bookingArrangements?: BookingArrangementFragment;
     datedServiceJourney?: {

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -35,39 +35,36 @@ export function findAllNotices(tp: TripPatternFragment): NoticeFragment[] {
     .filter(onlyUniquesBasedOnField('id'));
 }
 
+/**
+ * Get all relevant situations for a leg. All sources (`leg.situations`,
+ * `fromEstimatedCall.situations`, `toEstimatedCall.situations`) are
+ * pre-filtered by Entur Journey Planner to only include situations valid
+ * for that specific leg's time and stops, so no additional validity
+ * filtering is needed.
+ *
+ * Note: `leg.fromPlace.quay?.situations` and `leg.toPlace.quay?.situations`
+ * are not used here as they are quay-level situations not scoped to
+ * this leg's time window.
+ */
 export function findAllSituationsFromLeg(leg: Leg): SituationFragment[] {
-  const situations: SituationFragment[] = [];
-  if (leg.situations) {
-    leg.situations.forEach((situation) => {
-      if (situation) {
-        situations.push(situation);
-      }
-    });
-  }
-  if (leg.fromPlace.quay?.situations) {
-    leg.fromPlace.quay.situations.forEach((situation) => {
-      if (situation) {
-        situations.push(situation);
-      }
-    });
-  }
-  if (leg.toPlace.quay?.situations) {
-    leg.toPlace.quay.situations.forEach((situation) => {
-      if (situation) {
-        situations.push(situation);
-      }
-    });
-  }
-  return situations;
+  return [
+    leg.situations,
+    leg.fromEstimatedCall?.situations ?? [],
+    leg.toEstimatedCall?.situations ?? [],
+  ].flat();
 }
 
+/**
+ * Get all unique situations across all legs of a trip pattern.
+ * Since `findAllSituationsFromLeg` returns only situations pre-filtered by
+ * Entur Journey Planner, no additional validity filtering is needed here.
+ */
 export function findAllSituations(
   tp: TripPatternFragment,
 ): SituationFragment[] {
   return tp.legs
     .map(findAllSituationsFromLeg)
     .flat()
-    .filter(isSituationValidAtDate(tp.expectedStartTime))
     .filter(onlyUniquesBasedOnField('id'));
 }
 
@@ -226,7 +223,7 @@ export const getLegsNotificationA11yLabel = (
       hasWarnings = true;
     }
 
-    for (const situation of leg.situations ?? []) {
+    for (const situation of findAllSituationsFromLeg(leg)) {
       if (getMessageTypeForSituation(situation) === 'warning') {
         hasWarnings = true;
       } else {


### PR DESCRIPTION
## Issue Reference
Closes https://github.com/AtB-AS/kundevendt/issues/23714

## Description
Previously, when in context of a trip-pattern leg we either looked at only `leg.situations`, or tried to compose situations from `leg.situations` and `leg.from/toPlace.quay.situations`. 

Neither of these approaches are correct, since `leg.situations` only displays situations regarding the actual transportation part of the leg, and not stop places in either end, and `leg.from/toPlace.quay.situations` can have situations not relevant for the leg. 

This PR tries to standardize the use of situations to only and always use `leg.situations` and `leg.estimatedFrom/toCall.situations` since these are "smart" and will filter out situations irrelevant for that leg, and _will_ capture both situations regarding the transportation part and for either stop place. 

Other uses of situations should not be affected. 

## Test input
@tormoseng Since we are changing to an Entur-curated source of situations, it is very hard to fabricate some response. But that means we can also shift the responsibility to them if something is wrong. So I think this is better, even if it is hard to verify that it solves the actual problem in the issue with synthetic data