### PR TITLE
feat: use the travel card component for booking screen

### DIFF
--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
@@ -10,7 +10,11 @@ import Animated, {
   ZoomOut,
 } from 'react-native-reanimated';
 import {ContentHeading} from '@atb/components/heading';
-import {translation as _, useTranslation} from '@atb/translations';
+import {
+  translation as _,
+  TravelCardTexts,
+  useTranslation,
+} from '@atb/translations';
 import {TravelCard} from '@atb/screen-components/travel-card';
 import {useStoredTripPatterns} from './StoredTripPatternsContext';
 import {RightActionKind, SwipeableResultRow} from './SwipeableResultRow';
@@ -117,6 +121,7 @@ const StoredTripPatternRow: React.FC<{
   isFocused,
 }) => {
   const {data} = useSingleTripQuery(tripPattern, isFocused);
+  const {t} = useTranslation();
 
   const updatedTripPattern = data ?? tripPattern;
 
@@ -140,9 +145,13 @@ const StoredTripPatternRow: React.FC<{
         tripPattern={updatedTripPattern}
         onDetailsPressed={onDetailsPressed}
         cardIndex={resultIndex}
-        numberOfCards={length}
         testID={'tripSearchSearchResult' + resultIndex}
-        type="saved-trip"
+        a11yPrefix={t(
+          TravelCardTexts.card.a11yPrefix.savedTrip(resultIndex, length),
+        )}
+        includeDayInfo
+        includeFromToInfo
+        includeLegNotifications
       />
     </SwipeableResultRow>
   );

--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
@@ -150,7 +150,7 @@ const StoredTripPatternRow: React.FC<{
         )}
         includeDayInfo
         includeFromToInfo
-        includeLegNotifications
+        includeSituationNotices
       />
     </SwipeableResultRow>
   );

--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
@@ -144,9 +144,8 @@ const StoredTripPatternRow: React.FC<{
       <TravelCard
         tripPattern={updatedTripPattern}
         onDetailsPressed={onDetailsPressed}
-        cardIndex={resultIndex}
         testID={'tripSearchSearchResult' + resultIndex}
-        a11yPrefix={t(
+        a11yLabelPrefix={t(
           TravelCardTexts.card.a11yPrefix.savedTrip(resultIndex, length),
         )}
         includeDayInfo

--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
@@ -150,6 +150,7 @@ const StoredTripPatternRow: React.FC<{
         )}
         includeDayInfo
         includeFromToInfo
+        includeLegNotifications
         includeSituationNotices
       />
     </SwipeableResultRow>

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -78,6 +78,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_non_transit_trip_search',
   },
   {
+    name: 'isNewTravelCardBookingEnabled',
+    remoteConfigKey: 'enable_new_travel_card_booking',
+  },
+  {
     name: 'isNynorskEnabled',
     remoteConfigKey: 'enable_nynorsk',
   },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -41,6 +41,7 @@ export type RemoteConfig = {
   enable_nynorsk: boolean;
   enable_new_token_barcode: boolean;
   enable_new_token_barcode_base64: boolean;
+  enable_new_travel_card_booking: boolean;
   enable_on_behalf_of: boolean;
   enable_onboarding_login: boolean;
   enable_only_stop_places_checkbox: boolean;
@@ -117,6 +118,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_non_transit_trip_search: true,
   enable_new_token_barcode: false,
   enable_new_token_barcode_base64: false,
+  enable_new_travel_card_booking: false,
   enable_nynorsk: true,
   enable_on_behalf_of: false,
   enable_onboarding_login: true,
@@ -245,6 +247,9 @@ export function getConfig(): RemoteConfig {
   const enable_new_token_barcode_base64 =
     values['enable_new_token_barcode_base64']?.asBoolean() ??
     defaultRemoteConfig.enable_new_token_barcode_base64;
+  const enable_new_travel_card_booking =
+    values['enable_new_travel_card_booking']?.asBoolean() ??
+    defaultRemoteConfig.enable_new_travel_card_booking;
   const enable_nynorsk =
     values['enable_nynorsk']?.asBoolean() ?? defaultRemoteConfig.enable_nynorsk;
   const enable_on_behalf_of =
@@ -402,6 +407,7 @@ export function getConfig(): RemoteConfig {
     enable_non_transit_trip_search,
     enable_new_token_barcode,
     enable_new_token_barcode_base64,
+    enable_new_travel_card_booking,
     enable_nynorsk,
     enable_on_behalf_of,
     enable_onboarding_login,

--- a/src/modules/situations/__tests__/utils.test.ts
+++ b/src/modules/situations/__tests__/utils.test.ts
@@ -184,11 +184,9 @@ describe('findAllSituationsFromLeg', () => {
     } as Partial<Leg>);
     expect(findAllSituationsFromLeg(leg)).toHaveLength(3);
   });
-
 });
 
 describe('findAllSituations', () => {
-
   it('should deduplicate situations by id', () => {
     const sit = makeSituation({
       id: 's1',
@@ -445,4 +443,3 @@ describe('getSituationOrNoticeA11yLabel', () => {
     expect(result).toBeDefined();
   });
 });
-

--- a/src/modules/situations/__tests__/utils.test.ts
+++ b/src/modules/situations/__tests__/utils.test.ts
@@ -8,7 +8,6 @@ import {
   getMsgTypeForMostCriticalSituationOrNotice,
   toMostCriticalStatus,
   getMsgTypeForLeg,
-  getLegsNotificationA11yLabel,
   isSituationValidAtDate,
   getSituationOrNoticeA11yLabel,
 } from '../utils';
@@ -158,18 +157,18 @@ describe('findAllSituationsFromLeg', () => {
     expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
   });
 
-  it('should collect situations from fromPlace.quay', () => {
+  it('should collect situations from fromEstimatedCall', () => {
     const sit = makeSituation({id: 's2'});
     const leg = makeMinimalLeg({
-      fromPlace: {quay: {situations: [sit]}},
+      fromEstimatedCall: {situations: [sit]},
     } as Partial<Leg>);
     expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
   });
 
-  it('should collect situations from toPlace.quay', () => {
+  it('should collect situations from toEstimatedCall', () => {
     const sit = makeSituation({id: 's3'});
     const leg = makeMinimalLeg({
-      toPlace: {quay: {situations: [sit]}},
+      toEstimatedCall: {situations: [sit]},
     } as Partial<Leg>);
     expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
   });
@@ -180,47 +179,15 @@ describe('findAllSituationsFromLeg', () => {
     const s3 = makeSituation({id: 's3'});
     const leg = makeMinimalLeg({
       situations: [s1],
-      fromPlace: {quay: {situations: [s2]}},
-      toPlace: {quay: {situations: [s3]}},
+      fromEstimatedCall: {situations: [s2]},
+      toEstimatedCall: {situations: [s3]},
     } as Partial<Leg>);
     expect(findAllSituationsFromLeg(leg)).toHaveLength(3);
   });
 
-  it('should skip null situations in arrays', () => {
-    const sit = makeSituation({id: 's1'});
-    const leg = makeMinimalLeg({
-      situations: [null, sit, null],
-    } as unknown as Partial<Leg>);
-    expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
-  });
 });
 
 describe('findAllSituations', () => {
-  it('should filter out situations outside validity period', () => {
-    const validSituation = makeSituation({
-      id: 's1',
-      validityPeriod: {
-        startTime: '2024-06-15T08:00:00Z',
-        endTime: '2024-06-15T12:00:00Z',
-      },
-    });
-    const expiredSituation = makeSituation({
-      id: 's2',
-      validityPeriod: {
-        startTime: '2024-06-14T08:00:00Z',
-        endTime: '2024-06-14T12:00:00Z',
-      },
-    });
-    const tp = makeTripPattern(
-      [
-        makeMinimalLeg({
-          situations: [validSituation, expiredSituation],
-        } as Partial<Leg>),
-      ],
-      '2024-06-15T10:00:00Z',
-    );
-    expect(findAllSituations(tp)).toEqual([validSituation]);
-  });
 
   it('should deduplicate situations by id', () => {
     const sit = makeSituation({
@@ -479,37 +446,3 @@ describe('getSituationOrNoticeA11yLabel', () => {
   });
 });
 
-describe('getLegsNotificationA11yLabel', () => {
-  const t = (input: any) => {
-    if (typeof input === 'string') return input;
-    if (typeof input === 'object' && input !== null) {
-      return input[0] ?? String(input);
-    }
-    return String(input);
-  };
-
-  it('should return undefined when no notifications', () => {
-    expect(getLegsNotificationA11yLabel([makeMinimalLeg()], t)).toBeUndefined();
-  });
-
-  it('should return label for RailReplacementBus', () => {
-    const leg = makeMinimalLeg({
-      transportSubmode: TransportSubmode.RailReplacementBus,
-    } as Partial<Leg>);
-    expect(getLegsNotificationA11yLabel([leg], t)).toBeDefined();
-  });
-
-  it('should return label for legs with booking arrangements', () => {
-    const leg = makeMinimalLeg({
-      bookingArrangements: {latestBookingTime: '2024-06-15T09:00:00Z'},
-    } as Partial<Leg>);
-    expect(getLegsNotificationA11yLabel([leg], t)).toBeDefined();
-  });
-
-  it('should return label for legs with notices', () => {
-    const leg = makeMinimalLeg({
-      fromEstimatedCall: {notices: [makeNotice('n1', 'Notice text')]},
-    } as Partial<Leg>);
-    expect(getLegsNotificationA11yLabel([leg], t)).toBeDefined();
-  });
-});

--- a/src/modules/situations/__tests__/utils.test.ts
+++ b/src/modules/situations/__tests__/utils.test.ts
@@ -1,0 +1,524 @@
+import {
+  findAllNoticesFromLeg,
+  findAllNotices,
+  findAllSituationsFromLeg,
+  findAllSituations,
+  getSituationSummary,
+  getMessageTypeForSituation,
+  getMsgTypeForMostCriticalSituationOrNotice,
+  toMostCriticalStatus,
+  getMsgTypeForLeg,
+  getLegsNotificationA11yLabel,
+  isSituationValidAtDate,
+  getSituationOrNoticeA11yLabel,
+} from '../utils';
+import type {SituationFragment} from '@atb/api/types/generated/fragments/situations';
+import type {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
+import type {Leg} from '@atb/api/types/trips';
+import type {TripPatternFragment} from '@atb/api/types/generated/fragments/trips';
+import {
+  ReportType,
+  TransportSubmode,
+} from '@atb/api/types/generated/journey_planner_v3_types';
+import {Language} from '@atb/translations';
+
+// --- Helpers to build test fixtures ---
+
+const makeNotice = (
+  id: string,
+  text?: string,
+): NoticeFragment => ({id, text});
+
+const makeSituation = (
+  overrides: Partial<SituationFragment> = {},
+): SituationFragment => ({
+  id: overrides.id ?? 'sit-1',
+  summary: overrides.summary ?? [],
+  description: overrides.description ?? [],
+  advice: overrides.advice ?? [],
+  reportType: overrides.reportType ?? ReportType.General,
+  validityPeriod: overrides.validityPeriod,
+  situationNumber: overrides.situationNumber,
+  infoLinks: overrides.infoLinks,
+});
+
+const makeMinimalLeg = (overrides: Partial<Leg> = {}): Leg =>
+  ({
+    mode: 'bus',
+    fromPlace: {quay: null},
+    toPlace: {quay: null},
+    fromEstimatedCall: null,
+    toEstimatedCall: null,
+    situations: [],
+    bookingArrangements: null,
+    transportSubmode: null,
+    line: null,
+    ...overrides,
+  }) as unknown as Leg;
+
+const makeTripPattern = (
+  legs: Leg[],
+  expectedStartTime: string = '2024-06-15T10:00:00Z',
+): TripPatternFragment =>
+  ({
+    legs,
+    expectedStartTime,
+  }) as unknown as TripPatternFragment;
+
+// --- Tests ---
+
+describe('findAllNoticesFromLeg', () => {
+  it('should return empty array for leg with no estimated calls', () => {
+    const leg = makeMinimalLeg();
+    expect(findAllNoticesFromLeg(leg)).toEqual([]);
+  });
+
+  it('should collect notices from fromEstimatedCall', () => {
+    const leg = makeMinimalLeg({
+      fromEstimatedCall: {
+        notices: [makeNotice('n1', 'Notice 1')],
+      },
+    } as Partial<Leg>);
+    expect(findAllNoticesFromLeg(leg)).toEqual([
+      {id: 'n1', text: 'Notice 1'},
+    ]);
+  });
+
+  it('should collect notices from toEstimatedCall', () => {
+    const leg = makeMinimalLeg({
+      toEstimatedCall: {
+        notices: [makeNotice('n2', 'Notice 2')],
+      },
+    } as Partial<Leg>);
+    expect(findAllNoticesFromLeg(leg)).toEqual([
+      {id: 'n2', text: 'Notice 2'},
+    ]);
+  });
+
+  it('should collect notices from both estimated calls', () => {
+    const leg = makeMinimalLeg({
+      fromEstimatedCall: {notices: [makeNotice('n1', 'From notice')]},
+      toEstimatedCall: {notices: [makeNotice('n2', 'To notice')]},
+    } as Partial<Leg>);
+    expect(findAllNoticesFromLeg(leg)).toHaveLength(2);
+  });
+
+  it('should filter out notices without id', () => {
+    const leg = makeMinimalLeg({
+      fromEstimatedCall: {
+        notices: [makeNotice('', 'No ID notice')],
+      },
+    } as Partial<Leg>);
+    expect(findAllNoticesFromLeg(leg)).toEqual([]);
+  });
+
+  it('should filter out notices without text', () => {
+    const leg = makeMinimalLeg({
+      fromEstimatedCall: {
+        notices: [makeNotice('n1', undefined), makeNotice('n2', '')],
+      },
+    } as Partial<Leg>);
+    expect(findAllNoticesFromLeg(leg)).toEqual([]);
+  });
+});
+
+describe('findAllNotices', () => {
+  it('should return empty array for trip pattern with no notices', () => {
+    const tp = makeTripPattern([makeMinimalLeg()]);
+    expect(findAllNotices(tp)).toEqual([]);
+  });
+
+  it('should deduplicate notices by id', () => {
+    const tp = makeTripPattern([
+      makeMinimalLeg({
+        fromEstimatedCall: {notices: [makeNotice('n1', 'Same notice')]},
+      } as Partial<Leg>),
+      makeMinimalLeg({
+        fromEstimatedCall: {notices: [makeNotice('n1', 'Same notice')]},
+      } as Partial<Leg>),
+    ]);
+    expect(findAllNotices(tp)).toHaveLength(1);
+  });
+
+  it('should keep notices with different ids', () => {
+    const tp = makeTripPattern([
+      makeMinimalLeg({
+        fromEstimatedCall: {notices: [makeNotice('n1', 'Notice 1')]},
+      } as Partial<Leg>),
+      makeMinimalLeg({
+        fromEstimatedCall: {notices: [makeNotice('n2', 'Notice 2')]},
+      } as Partial<Leg>),
+    ]);
+    expect(findAllNotices(tp)).toHaveLength(2);
+  });
+});
+
+describe('findAllSituationsFromLeg', () => {
+  it('should return empty array for leg with no situations', () => {
+    const leg = makeMinimalLeg();
+    expect(findAllSituationsFromLeg(leg)).toEqual([]);
+  });
+
+  it('should collect situations from leg.situations', () => {
+    const sit = makeSituation({id: 's1'});
+    const leg = makeMinimalLeg({situations: [sit]} as Partial<Leg>);
+    expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
+  });
+
+  it('should collect situations from fromPlace.quay', () => {
+    const sit = makeSituation({id: 's2'});
+    const leg = makeMinimalLeg({
+      fromPlace: {quay: {situations: [sit]}},
+    } as Partial<Leg>);
+    expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
+  });
+
+  it('should collect situations from toPlace.quay', () => {
+    const sit = makeSituation({id: 's3'});
+    const leg = makeMinimalLeg({
+      toPlace: {quay: {situations: [sit]}},
+    } as Partial<Leg>);
+    expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
+  });
+
+  it('should collect situations from all sources', () => {
+    const s1 = makeSituation({id: 's1'});
+    const s2 = makeSituation({id: 's2'});
+    const s3 = makeSituation({id: 's3'});
+    const leg = makeMinimalLeg({
+      situations: [s1],
+      fromPlace: {quay: {situations: [s2]}},
+      toPlace: {quay: {situations: [s3]}},
+    } as Partial<Leg>);
+    expect(findAllSituationsFromLeg(leg)).toHaveLength(3);
+  });
+
+  it('should skip null situations in arrays', () => {
+    const sit = makeSituation({id: 's1'});
+    const leg = makeMinimalLeg({
+      situations: [null, sit, null],
+    } as unknown as Partial<Leg>);
+    expect(findAllSituationsFromLeg(leg)).toEqual([sit]);
+  });
+});
+
+describe('findAllSituations', () => {
+  it('should filter out situations outside validity period', () => {
+    const validSituation = makeSituation({
+      id: 's1',
+      validityPeriod: {
+        startTime: '2024-06-15T08:00:00Z',
+        endTime: '2024-06-15T12:00:00Z',
+      },
+    });
+    const expiredSituation = makeSituation({
+      id: 's2',
+      validityPeriod: {
+        startTime: '2024-06-14T08:00:00Z',
+        endTime: '2024-06-14T12:00:00Z',
+      },
+    });
+    const tp = makeTripPattern(
+      [
+        makeMinimalLeg({
+          situations: [validSituation, expiredSituation],
+        } as Partial<Leg>),
+      ],
+      '2024-06-15T10:00:00Z',
+    );
+    expect(findAllSituations(tp)).toEqual([validSituation]);
+  });
+
+  it('should deduplicate situations by id', () => {
+    const sit = makeSituation({
+      id: 's1',
+      validityPeriod: {
+        startTime: '2024-06-15T08:00:00Z',
+        endTime: '2024-06-15T12:00:00Z',
+      },
+    });
+    const tp = makeTripPattern(
+      [
+        makeMinimalLeg({situations: [sit]} as Partial<Leg>),
+        makeMinimalLeg({
+          fromPlace: {quay: {situations: [sit]}},
+        } as Partial<Leg>),
+      ],
+      '2024-06-15T10:00:00Z',
+    );
+    expect(findAllSituations(tp)).toHaveLength(1);
+  });
+});
+
+describe('getSituationSummary', () => {
+  it('should return summary text for matching language', () => {
+    const sit = makeSituation({
+      summary: [{language: 'nob', value: 'Norsk oppsummering'}],
+    });
+    expect(getSituationSummary(sit, Language.Norwegian)).toBe(
+      'Norsk oppsummering',
+    );
+  });
+
+  it('should fall back to description when no summary', () => {
+    const sit = makeSituation({
+      summary: [],
+      description: [{language: 'eng', value: 'English description'}],
+    });
+    expect(getSituationSummary(sit, Language.English)).toBe(
+      'English description',
+    );
+  });
+
+  it('should return undefined when neither summary nor description', () => {
+    const sit = makeSituation({summary: [], description: []});
+    expect(getSituationSummary(sit, Language.Norwegian)).toBeUndefined();
+  });
+});
+
+describe('getMessageTypeForSituation', () => {
+  it('should return warning for incident report type', () => {
+    const sit = makeSituation({reportType: ReportType.Incident});
+    expect(getMessageTypeForSituation(sit)).toBe('warning');
+  });
+
+  it('should return info for general report type', () => {
+    const sit = makeSituation({reportType: ReportType.General});
+    expect(getMessageTypeForSituation(sit)).toBe('info');
+  });
+
+  it('should return info for undefined report type', () => {
+    const sit = makeSituation({reportType: undefined});
+    expect(getMessageTypeForSituation(sit)).toBe('info');
+  });
+});
+
+describe('toMostCriticalStatus', () => {
+  it('should return msgType when currentlyMostCritical is undefined', () => {
+    expect(toMostCriticalStatus(undefined, 'warning')).toBe('warning');
+  });
+
+  it('should return currentlyMostCritical when msgType is undefined', () => {
+    expect(toMostCriticalStatus('warning', undefined)).toBe('warning');
+  });
+
+  it('should return the more critical of two statuses', () => {
+    expect(toMostCriticalStatus('info', 'warning')).toBe('warning');
+    expect(toMostCriticalStatus('warning', 'info')).toBe('warning');
+    expect(toMostCriticalStatus('warning', 'error')).toBe('error');
+    expect(toMostCriticalStatus('error', 'warning')).toBe('error');
+  });
+
+  it('should return either when both are the same', () => {
+    expect(toMostCriticalStatus('info', 'info')).toBe('info');
+    expect(toMostCriticalStatus('warning', 'warning')).toBe('warning');
+  });
+});
+
+describe('getMsgTypeForMostCriticalSituationOrNotice', () => {
+  it('should return error when cancellation is true', () => {
+    expect(getMsgTypeForMostCriticalSituationOrNotice([], [], true)).toBe(
+      'error',
+    );
+  });
+
+  it('should return undefined for no situations and no notices', () => {
+    expect(
+      getMsgTypeForMostCriticalSituationOrNotice([], []),
+    ).toBeUndefined();
+  });
+
+  it('should return info when only notices are present', () => {
+    expect(
+      getMsgTypeForMostCriticalSituationOrNotice([], [makeNotice('n1', 'Hi')]),
+    ).toBe('info');
+  });
+
+  it('should return info for general situations', () => {
+    expect(
+      getMsgTypeForMostCriticalSituationOrNotice([
+        makeSituation({reportType: ReportType.General}),
+      ]),
+    ).toBe('info');
+  });
+
+  it('should return warning for incident situations', () => {
+    expect(
+      getMsgTypeForMostCriticalSituationOrNotice([
+        makeSituation({reportType: ReportType.Incident}),
+      ]),
+    ).toBe('warning');
+  });
+
+  it('should return warning when mixed general and incident', () => {
+    expect(
+      getMsgTypeForMostCriticalSituationOrNotice([
+        makeSituation({id: 's1', reportType: ReportType.General}),
+        makeSituation({id: 's2', reportType: ReportType.Incident}),
+      ]),
+    ).toBe('warning');
+  });
+});
+
+describe('getMsgTypeForLeg', () => {
+  it('should return undefined for a leg with nothing notable', () => {
+    expect(getMsgTypeForLeg(makeMinimalLeg())).toBeUndefined();
+  });
+
+  it('should return warning for RailReplacementBus', () => {
+    const leg = makeMinimalLeg({
+      transportSubmode: TransportSubmode.RailReplacementBus,
+    } as Partial<Leg>);
+    expect(getMsgTypeForLeg(leg)).toBe('warning');
+  });
+
+  it('should return warning for legs with booking arrangements', () => {
+    const leg = makeMinimalLeg({
+      bookingArrangements: {latestBookingTime: '2024-06-15T09:00:00Z'},
+    } as Partial<Leg>);
+    expect(getMsgTypeForLeg(leg)).toBe('warning');
+  });
+
+  it('should return info for legs with only notices', () => {
+    const leg = makeMinimalLeg({
+      fromEstimatedCall: {notices: [makeNotice('n1', 'Some notice')]},
+    } as Partial<Leg>);
+    expect(getMsgTypeForLeg(leg)).toBe('info');
+  });
+
+  it('should return warning when combining info notices with RailReplacementBus', () => {
+    const leg = makeMinimalLeg({
+      transportSubmode: TransportSubmode.RailReplacementBus,
+      fromEstimatedCall: {notices: [makeNotice('n1', 'Notice')]},
+    } as Partial<Leg>);
+    expect(getMsgTypeForLeg(leg)).toBe('warning');
+  });
+});
+
+describe('isSituationValidAtDate', () => {
+  it('should return true when date is within validity period', () => {
+    const sit = makeSituation({
+      validityPeriod: {
+        startTime: '2024-06-15T08:00:00Z',
+        endTime: '2024-06-15T12:00:00Z',
+      },
+    });
+    expect(isSituationValidAtDate('2024-06-15T10:00:00Z')(sit)).toBe(true);
+  });
+
+  it('should return false when date is after validity period', () => {
+    const sit = makeSituation({
+      validityPeriod: {
+        startTime: '2024-06-15T08:00:00Z',
+        endTime: '2024-06-15T09:00:00Z',
+      },
+    });
+    expect(isSituationValidAtDate('2024-06-15T10:00:00Z')(sit)).toBe(false);
+  });
+
+  it('should return false when date is before validity period', () => {
+    const sit = makeSituation({
+      validityPeriod: {
+        startTime: '2024-06-15T11:00:00Z',
+        endTime: '2024-06-15T12:00:00Z',
+      },
+    });
+    expect(isSituationValidAtDate('2024-06-15T10:00:00Z')(sit)).toBe(false);
+  });
+
+  it('should check only after startTime when no endTime', () => {
+    const sit = makeSituation({
+      validityPeriod: {startTime: '2024-06-15T08:00:00Z'},
+    });
+    expect(isSituationValidAtDate('2024-06-15T10:00:00Z')(sit)).toBe(true);
+    expect(isSituationValidAtDate('2024-06-15T07:00:00Z')(sit)).toBe(false);
+  });
+
+  it('should check only before endTime when no startTime', () => {
+    const sit = makeSituation({
+      validityPeriod: {endTime: '2024-06-15T12:00:00Z'},
+    });
+    expect(isSituationValidAtDate('2024-06-15T10:00:00Z')(sit)).toBe(true);
+    expect(isSituationValidAtDate('2024-06-15T13:00:00Z')(sit)).toBe(false);
+  });
+
+  it('should return true when no validity period at all', () => {
+    const sit = makeSituation({validityPeriod: undefined});
+    expect(isSituationValidAtDate('2024-06-15T10:00:00Z')(sit)).toBe(true);
+  });
+});
+
+describe('getSituationOrNoticeA11yLabel', () => {
+  const t = (input: any) => {
+    if (typeof input === 'string') return input;
+    if (typeof input === 'object' && input !== null) {
+      // Return the Norwegian value or first available
+      return input[0] ?? input.nob ?? input.eng ?? String(input);
+    }
+    return String(input);
+  };
+
+  it('should return error label for cancellation', () => {
+    const result = getSituationOrNoticeA11yLabel([], [], true, t);
+    expect(result).toBeDefined();
+  });
+
+  it('should return undefined for no situations and no notices', () => {
+    expect(getSituationOrNoticeA11yLabel([], [], false, t)).toBeUndefined();
+  });
+
+  it('should return info label when only notices', () => {
+    const result = getSituationOrNoticeA11yLabel(
+      [],
+      [makeNotice('n1', 'Notice')],
+      false,
+      t,
+    );
+    expect(result).toBeDefined();
+  });
+
+  it('should return warning label when incident situation present', () => {
+    const result = getSituationOrNoticeA11yLabel(
+      [makeSituation({reportType: ReportType.Incident})],
+      [],
+      false,
+      t,
+    );
+    expect(result).toBeDefined();
+  });
+});
+
+describe('getLegsNotificationA11yLabel', () => {
+  const t = (input: any) => {
+    if (typeof input === 'string') return input;
+    if (typeof input === 'object' && input !== null) {
+      return input[0] ?? String(input);
+    }
+    return String(input);
+  };
+
+  it('should return undefined when no notifications', () => {
+    expect(getLegsNotificationA11yLabel([makeMinimalLeg()], t)).toBeUndefined();
+  });
+
+  it('should return label for RailReplacementBus', () => {
+    const leg = makeMinimalLeg({
+      transportSubmode: TransportSubmode.RailReplacementBus,
+    } as Partial<Leg>);
+    expect(getLegsNotificationA11yLabel([leg], t)).toBeDefined();
+  });
+
+  it('should return label for legs with booking arrangements', () => {
+    const leg = makeMinimalLeg({
+      bookingArrangements: {latestBookingTime: '2024-06-15T09:00:00Z'},
+    } as Partial<Leg>);
+    expect(getLegsNotificationA11yLabel([leg], t)).toBeDefined();
+  });
+
+  it('should return label for legs with notices', () => {
+    const leg = makeMinimalLeg({
+      fromEstimatedCall: {notices: [makeNotice('n1', 'Notice text')]},
+    } as Partial<Leg>);
+    expect(getLegsNotificationA11yLabel([leg], t)).toBeDefined();
+  });
+});

--- a/src/modules/situations/__tests__/utils.test.ts
+++ b/src/modules/situations/__tests__/utils.test.ts
@@ -24,10 +24,7 @@ import {Language} from '@atb/translations';
 
 // --- Helpers to build test fixtures ---
 
-const makeNotice = (
-  id: string,
-  text?: string,
-): NoticeFragment => ({id, text});
+const makeNotice = (id: string, text?: string): NoticeFragment => ({id, text});
 
 const makeSituation = (
   overrides: Partial<SituationFragment> = {},
@@ -79,9 +76,7 @@ describe('findAllNoticesFromLeg', () => {
         notices: [makeNotice('n1', 'Notice 1')],
       },
     } as Partial<Leg>);
-    expect(findAllNoticesFromLeg(leg)).toEqual([
-      {id: 'n1', text: 'Notice 1'},
-    ]);
+    expect(findAllNoticesFromLeg(leg)).toEqual([{id: 'n1', text: 'Notice 1'}]);
   });
 
   it('should collect notices from toEstimatedCall', () => {
@@ -90,9 +85,7 @@ describe('findAllNoticesFromLeg', () => {
         notices: [makeNotice('n2', 'Notice 2')],
       },
     } as Partial<Leg>);
-    expect(findAllNoticesFromLeg(leg)).toEqual([
-      {id: 'n2', text: 'Notice 2'},
-    ]);
+    expect(findAllNoticesFromLeg(leg)).toEqual([{id: 'n2', text: 'Notice 2'}]);
   });
 
   it('should collect notices from both estimated calls', () => {
@@ -323,9 +316,7 @@ describe('getMsgTypeForMostCriticalSituationOrNotice', () => {
   });
 
   it('should return undefined for no situations and no notices', () => {
-    expect(
-      getMsgTypeForMostCriticalSituationOrNotice([], []),
-    ).toBeUndefined();
+    expect(getMsgTypeForMostCriticalSituationOrNotice([], [])).toBeUndefined();
   });
 
   it('should return info when only notices are present', () => {

--- a/src/modules/situations/index.tsx
+++ b/src/modules/situations/index.tsx
@@ -16,4 +16,5 @@ export {
   getMsgTypeForLeg,
   getA11yLabelForLeg,
   getLegsNotificationA11yLabel,
+  getDetailedSituationOrNoticeA11yLabel,
 } from './utils';

--- a/src/modules/situations/index.tsx
+++ b/src/modules/situations/index.tsx
@@ -15,6 +15,5 @@ export {
   getNotificationSvgForLegs,
   getMsgTypeForLeg,
   getA11yLabelForLeg,
-  getLegsNotificationA11yLabel,
   getDetailedSituationOrNoticeA11yLabel,
 } from './utils';

--- a/src/modules/situations/index.tsx
+++ b/src/modules/situations/index.tsx
@@ -16,4 +16,5 @@ export {
   getMsgTypeForLeg,
   getA11yLabelForLeg,
   getDetailedSituationOrNoticeA11yLabel,
+  getLegNotificationsA11yLabel,
 } from './utils';

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -16,6 +16,7 @@ import type {SituationFragment} from '@atb/api/types/generated/fragments/situati
 import type {TripPatternFragment} from '@atb/api/types/generated/fragments/trips';
 import type {Leg} from '@atb/api/types/trips';
 import {TransportSubmode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {getTranslatedModeName} from '@atb/utils/transportation-names';
 
 export function findAllNoticesFromLeg(leg: Leg): NoticeFragment[] {
   const notices: NoticeFragment[] = [];
@@ -272,3 +273,53 @@ export const isSituationValidAtDate =
     }
     return true;
   };
+
+/**
+ * Build a detailed accessibility label that reads out each transit leg's
+ * situations and notices with the originating line.
+ *
+ * Example output: "Bus 1: Bus stop has moved. Bus 11: Does not stop at Prinsens Gate."
+ *
+ * Returns undefined when there is nothing to announce.
+ */
+export const getDetailedSituationOrNoticeA11yLabel = (
+  tripPattern: TripPatternFragment,
+  language: Language,
+  t: TranslateFunction,
+): string | undefined => {
+  const fragments: string[] = [];
+
+  for (const leg of tripPattern.legs) {
+    if (leg.mode === 'foot') continue;
+
+    const situations = findAllSituationsFromLeg(leg);
+    const notices = findAllNoticesFromLeg(leg);
+
+    if (situations.length === 0 && notices.length === 0) continue;
+
+    const modeName = t(
+      getTranslatedModeName(leg.mode, leg.line?.transportSubmode),
+    );
+    const publicCode = leg.line?.publicCode ?? '';
+    const legPrefix = `${modeName} ${publicCode}`.trim();
+
+    const texts: string[] = [];
+
+    for (const situation of situations) {
+      const text = getTextForLanguage(situation.description, language);
+      if (text) texts.push(text);
+    }
+
+    for (const notice of notices) {
+      if (notice.text) texts.push(notice.text);
+    }
+
+    if (texts.length > 0) {
+      fragments.push(`${legPrefix}: ${texts.join(', ')}`);
+    }
+  }
+
+  return fragments.length > 0
+    ? `. ${t(SituationsTexts.tripSummary.detailedPrefix)}. ${fragments.join('. ')}`
+    : undefined;
+};

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -26,7 +26,9 @@ export function findAllNoticesFromLeg(leg: Leg): NoticeFragment[] {
   if (leg.toEstimatedCall?.notices) {
     notices.push(...leg.toEstimatedCall.notices);
   }
-  return notices.filter((n) => !!n.id && (n.text?.length ?? 0) > 0);
+  return notices
+    .filter((n) => !!n.id && (n.text?.length ?? 0) > 0)
+    .filter(onlyUniquesBasedOnField('id'));
 }
 
 export function findAllNotices(tp: TripPatternFragment): NoticeFragment[] {
@@ -52,7 +54,9 @@ export function findAllSituationsFromLeg(leg: Leg): SituationFragment[] {
     leg.situations,
     leg.fromEstimatedCall?.situations ?? [],
     leg.toEstimatedCall?.situations ?? [],
-  ].flat();
+  ]
+    .flat()
+    .filter(onlyUniquesBasedOnField('id'));
 }
 
 /**
@@ -203,56 +207,6 @@ export const getSituationOrNoticeA11yLabel = (
 };
 
 /**
- * Get a generic legs accessibility label summarizing situations, notices,
- * rail replacement bus and booking across all legs. Classifies into warnings vs notices
- * and returns a short summary like "Reisen har advarsler" with an action prompt.
- * Returns undefined if there is nothing to announce.
- */
-export const getLegsNotificationA11yLabel = (
-  legs: Leg[],
-  t: TranslateFunction,
-): string | undefined => {
-  let hasWarnings = false;
-  let hasNotices = false;
-
-  for (const leg of legs) {
-    if (leg.transportSubmode === TransportSubmode.RailReplacementBus) {
-      hasWarnings = true;
-    }
-
-    if (leg.bookingArrangements) {
-      hasWarnings = true;
-    }
-
-    for (const situation of findAllSituationsFromLeg(leg)) {
-      if (getMessageTypeForSituation(situation) === 'warning') {
-        hasWarnings = true;
-      } else {
-        hasNotices = true;
-      }
-    }
-
-    const notices = findAllNoticesFromLeg(leg);
-    if (notices.length > 0) {
-      hasNotices = true;
-    }
-
-    if (hasWarnings && hasNotices) break;
-  }
-
-  if (!hasWarnings && !hasNotices) return undefined;
-
-  const summaryText =
-    hasWarnings && hasNotices
-      ? t(SituationsTexts.tripSummary.warningsAndNotices)
-      : hasWarnings
-        ? t(SituationsTexts.tripSummary.warnings)
-        : t(SituationsTexts.tripSummary.notices);
-
-  return `${summaryText}. ${t(SituationsTexts.tripSummary.openDetailsForMoreInfo)}`;
-};
-
-/**
  * Check if a situation is valid at a specific date by comparing it to the
  * validity period of the situation. If the situation has neither start time nor
  * end time it will be considered valid at all times.
@@ -292,8 +246,12 @@ export const getDetailedSituationOrNoticeA11yLabel = (
   for (const leg of tripPattern.legs) {
     if (leg.mode === 'foot') continue;
 
-    const situations = findAllSituationsFromLeg(leg);
-    const notices = findAllNoticesFromLeg(leg);
+    const situations = findAllSituationsFromLeg(leg).filter(
+      onlyUniquesBasedOnField('id'),
+    );
+    const notices = findAllNoticesFromLeg(leg).filter(
+      onlyUniquesBasedOnField('id'),
+    );
 
     if (situations.length === 0 && notices.length === 0) continue;
 

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -246,12 +246,8 @@ export const getDetailedSituationOrNoticeA11yLabel = (
   for (const leg of tripPattern.legs) {
     if (leg.mode === 'foot') continue;
 
-    const situations = findAllSituationsFromLeg(leg).filter(
-      onlyUniquesBasedOnField('id'),
-    );
-    const notices = findAllNoticesFromLeg(leg).filter(
-      onlyUniquesBasedOnField('id'),
-    );
+    const situations = findAllSituationsFromLeg(leg);
+    const notices = findAllNoticesFromLeg(leg);
 
     if (situations.length === 0 && notices.length === 0) continue;
 

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -276,7 +276,7 @@ export const getDetailedSituationOrNoticeA11yLabel = (
   }
 
   return fragments.length > 0
-    ? `. ${t(SituationsTexts.tripSummary.detailedPrefix)}. ${fragments.join('. ')}`
+    ? `${t(SituationsTexts.tripSummary.detailedPrefix)}. ${fragments.join('. ')}`
     : undefined;
 };
 

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -3,6 +3,8 @@ import {
   getTextForLanguage,
   Language,
   SituationsTexts,
+  TripDetailsTexts,
+  TripSearchTexts,
   TranslateFunction,
 } from '@atb/translations';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
@@ -276,4 +278,51 @@ export const getDetailedSituationOrNoticeA11yLabel = (
   return fragments.length > 0
     ? `. ${t(SituationsTexts.tripSummary.detailedPrefix)}. ${fragments.join('. ')}`
     : undefined;
+};
+
+/**
+ * Build an accessibility label for leg-level notifications (rail replacement
+ * bus, booking requirements) that aren't situations or notices.
+ *
+ * Example: "Bus 1: Rail replacement bus. Bus 11: Requires booking."
+ *
+ * Returns undefined when there is nothing to announce.
+ */
+export const getLegNotificationsA11yLabel = (
+  tripPattern: TripPatternFragment,
+  t: TranslateFunction,
+): string | undefined => {
+  const fragments: string[] = [];
+
+  for (const leg of tripPattern.legs) {
+    if (leg.mode === 'foot') continue;
+
+    const isRailReplacementBus =
+      leg.transportSubmode === TransportSubmode.RailReplacementBus;
+    const hasBooking = !!leg.bookingArrangements;
+
+    if (!isRailReplacementBus && !hasBooking) continue;
+
+    const modeName = t(
+      getTranslatedModeName(leg.mode, leg.line?.transportSubmode),
+    );
+    const publicCode = leg.line?.publicCode ?? '';
+    const legPrefix = `${modeName} ${publicCode}`.trim();
+
+    const texts: string[] = [];
+
+    if (isRailReplacementBus) {
+      texts.push(t(TripDetailsTexts.messages.departureIsRailReplacementBus));
+    }
+
+    if (hasBooking) {
+      texts.push(t(TripSearchTexts.results.resultItem.footer.requiresBooking));
+    }
+
+    if (texts.length > 0) {
+      fragments.push(`${legPrefix}: ${texts.join(', ')}`);
+    }
+  }
+
+  return fragments.length > 0 ? fragments.join('. ') : undefined;
 };

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, Statuses} from '@atb/theme';
 import type {TripPattern} from '@atb/api/types/trips';
 import {TravelCardLegs} from './TravelCardLegs';
 import Animated, {FadeIn} from 'react-native-reanimated';
@@ -13,6 +13,7 @@ import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {CompositeAccessibilityProvider} from '@atb/modules/composite-accessibility';
 import {getDetailedSituationOrNoticeA11yLabel} from '@atb/modules/situations';
 import {TravelCardNotices} from './TravelCardNotices';
+import {Tag} from '@atb/components/tag';
 
 type TravelCardProps = {
   tripPattern: TripPattern;
@@ -25,8 +26,8 @@ type TravelCardProps = {
   includeLegNotifications?: boolean;
   includeSituationNotices?: boolean;
   isDisabled?: boolean;
-  extraA11yLabels?: Record<string, string | undefined>;
-  extraA11yOrder?: {before?: string[]; after?: string[]};
+  tagLabel?: string;
+  tagType?: Statuses;
 };
 
 export const TravelCard: React.FC<TravelCardProps> = ({
@@ -40,8 +41,8 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   includeLegNotifications = false,
   includeSituationNotices = false,
   isDisabled = false,
-  extraA11yLabels,
-  extraA11yOrder,
+  tagLabel,
+  tagType = 'info',
 }) => {
   const styles = useThemeStyles();
   const [maxWidth, setMaxWidth] = useState(0);
@@ -59,22 +60,15 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       ? getDetailedSituationOrNoticeA11yLabel(tripPattern, language, t)
       : undefined;
 
-  const baseOrder = ['cardPrefix', 'header', 'legs', 'situationOrNotice'];
-  const order = [
-    ...(extraA11yOrder?.before ?? []),
-    ...baseOrder,
-    ...(extraA11yOrder?.after ?? []),
-  ];
-
   return (
     <Animated.View entering={FadeIn}>
       <CompositeAccessibilityProvider
         parentLabels={{
           cardPrefix: prefixA11yLabel,
           situationOrNotice: situationOrNoticeA11yLabel,
-          ...extraA11yLabels,
+          tag: tagLabel,
         }}
-        order={order}
+        order={['cardPrefix', 'header', 'legs', 'situationOrNotice', 'tag']}
       >
         {(accessibilityProps) => (
           <NativeBlockButton
@@ -87,6 +81,11 @@ export const TravelCard: React.FC<TravelCardProps> = ({
             }
             {...accessibilityProps}
           >
+            {tagLabel && (
+              <View aria-hidden={true}>
+                <Tag labels={[tagLabel]} tagType={tagType} />
+              </View>
+            )}
             <TravelCardHeader
               tripPattern={tripPattern}
               includeDayInfo={includeDayInfo}

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -14,15 +14,16 @@ import {CompositeAccessibilityProvider} from '@atb/modules/composite-accessibili
 import {getDetailedSituationOrNoticeA11yLabel} from '@atb/modules/situations';
 import {TravelCardNotices} from './TravelCardNotices';
 
-export type TravelCardType = 'trip-search' | 'saved-trip' | 'booking';
-
 type TravelCardProps = {
   tripPattern: TripPattern;
   onDetailsPressed(tripPattern: TripPattern, resultIndex?: number): void;
   cardIndex: number;
-  numberOfCards: number;
   testID?: string;
-  type: TravelCardType;
+  a11yPrefix: string;
+  includeDayInfo?: boolean;
+  includeFromToInfo?: boolean;
+  includeLegNotifications?: boolean;
+  includeSituationNotices?: boolean;
   isDisabled?: boolean;
   extraA11yLabels?: Record<string, string | undefined>;
   extraA11yOrder?: {before?: string[]; after?: string[]};
@@ -32,9 +33,12 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   tripPattern,
   onDetailsPressed,
   cardIndex,
-  numberOfCards,
   testID,
-  type,
+  a11yPrefix,
+  includeDayInfo = false,
+  includeFromToInfo = false,
+  includeLegNotifications = false,
+  includeSituationNotices = false,
   isDisabled = false,
   extraA11yLabels,
   extraA11yOrder,
@@ -43,20 +47,15 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   const [maxWidth, setMaxWidth] = useState(0);
   const {t, language} = useTranslation();
 
-  const includeDayInfo = type === 'saved-trip';
-  const includeFromToInfo = type === 'saved-trip';
-
   const uniqueModes = Array.from(
     new Set(tripPattern.legs.map((leg) => leg.mode)),
   );
   const modes = uniqueModes.map((mode) => t(getTranslatedModeName(mode)));
 
-  const prefixA11yLabel = `${t(
-    TravelCardTexts.card.typePrefix(type, cardIndex, numberOfCards),
-  )}. ${t(TravelCardTexts.card.modesPrefix(modes))}.`;
+  const prefixA11yLabel = `${a11yPrefix}. ${t(TravelCardTexts.card.modesPrefix(modes))}.`;
 
   const situationOrNoticeA11yLabel =
-    type === 'booking' && !isDisabled
+    includeSituationNotices && !isDisabled
       ? getDetailedSituationOrNoticeA11yLabel(tripPattern, language, t)
       : undefined;
 
@@ -103,7 +102,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
                 <TravelCardLegs
                   tripPattern={tripPattern}
                   maxWidth={maxWidth}
-                  type={type}
+                  includeLegNotifications={includeLegNotifications}
                 />
               </View>
               <View>

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -17,10 +17,9 @@ import {Tag} from '@atb/components/tag';
 
 type TravelCardProps = {
   tripPattern: TripPattern;
-  onDetailsPressed(tripPattern: TripPattern, resultIndex?: number): void;
-  cardIndex: number;
+  onDetailsPressed(tripPattern: TripPattern): void;
   testID?: string;
-  a11yPrefix: string;
+  a11yLabelPrefix: string;
   includeDayInfo?: boolean;
   includeFromToInfo?: boolean;
   includeLegNotifications?: boolean;
@@ -33,9 +32,8 @@ type TravelCardProps = {
 export const TravelCard: React.FC<TravelCardProps> = ({
   tripPattern,
   onDetailsPressed,
-  cardIndex,
   testID,
-  a11yPrefix,
+  a11yLabelPrefix,
   includeDayInfo = false,
   includeFromToInfo = false,
   includeLegNotifications = false,
@@ -53,7 +51,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   );
   const modes = uniqueModes.map((mode) => t(getTranslatedModeName(mode)));
 
-  const prefixA11yLabel = `${a11yPrefix}. ${t(TravelCardTexts.card.modesPrefix(modes))}.`;
+  const prefixA11yLabel = `${a11yLabelPrefix}. ${t(TravelCardTexts.card.modesPrefix(modes))}.`;
 
   const situationOrNoticeA11yLabel =
     includeSituationNotices && !isDisabled
@@ -76,9 +74,10 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       >
         {(accessibilityProps) => (
           <NativeBlockButton
-            onPress={() => onDetailsPressed(tripPattern, cardIndex)}
+            onPress={() => onDetailsPressed(tripPattern)}
             testID={testID}
             style={[styles.container, isDisabled && styles.containerDisabled]}
+            disabled={isDisabled}
             accessibilityRole={isDisabled ? 'none' : 'button'}
             accessibilityHint={
               isDisabled ? undefined : t(TravelCardTexts.card.a11yHint)

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -75,7 +75,6 @@ export const TravelCard: React.FC<TravelCardProps> = ({
             onPress={() => onDetailsPressed(tripPattern)}
             testID={testID}
             style={[styles.container, isDisabled && styles.containerDisabled]}
-            disabled={isDisabled}
             accessibilityRole={isDisabled ? 'none' : 'button'}
             accessibilityHint={
               isDisabled ? undefined : t(TravelCardTexts.card.a11yHint)

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -25,8 +25,7 @@ type TravelCardProps = {
   includeLegNotifications?: boolean;
   includeSituationNotices?: boolean;
   isDisabled?: boolean;
-  tagLabel?: string;
-  tagType?: Statuses;
+  tag?: {label: string; type: Statuses};
 };
 
 export const TravelCard: React.FC<TravelCardProps> = ({
@@ -39,8 +38,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   includeLegNotifications = false,
   includeSituationNotices = false,
   isDisabled = false,
-  tagLabel,
-  tagType = 'info',
+  tag,
 }) => {
   const styles = useThemeStyles();
   const [maxWidth, setMaxWidth] = useState(0);
@@ -58,8 +56,8 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       ? getDetailedSituationOrNoticeA11yLabel(tripPattern, language, t)
       : undefined;
 
-  const tagA11yLabel = tagLabel
-    ? `.. ${t(dictionary.messageTypes[tagType])}.. ${tagLabel}`
+  const tagA11yLabel = tag
+    ? `.. ${t(dictionary.messageTypes[tag.type])}.. ${tag.label}`
     : undefined;
 
   return (
@@ -84,9 +82,9 @@ export const TravelCard: React.FC<TravelCardProps> = ({
             }
             {...accessibilityProps}
           >
-            {tagLabel && (
+            {tag && (
               <View aria-hidden={true}>
-                <Tag labels={[tagLabel]} tagType={tagType} />
+                <Tag labels={[tag.label]} tagType={tag.type} />
               </View>
             )}
             <TravelCardHeader

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -8,20 +8,11 @@ import {TravelCardHeader} from './TravelCardHeader';
 import {LayoutChangeEvent, View} from 'react-native';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {
-  getTextForLanguage,
-  TravelCardTexts,
-  useTranslation,
-} from '@atb/translations';
+import {TravelCardTexts, useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {CompositeAccessibilityProvider} from '@atb/modules/composite-accessibility';
-import {
-  findAllNotices,
-  findAllSituations,
-  getDetailedSituationOrNoticeA11yLabel,
-  getMessageTypeForSituation,
-} from '@atb/modules/situations';
-import {MessageInfoText} from '@atb/components/message-info-text';
+import {getDetailedSituationOrNoticeA11yLabel} from '@atb/modules/situations';
+import {TravelCardNotices} from './TravelCardNotices';
 
 export type TravelCardType = 'trip-search' | 'saved-trip' | 'booking';
 
@@ -59,9 +50,6 @@ export const TravelCard: React.FC<TravelCardProps> = ({
     new Set(tripPattern.legs.map((leg) => leg.mode)),
   );
   const modes = uniqueModes.map((mode) => t(getTranslatedModeName(mode)));
-
-  const notices = findAllNotices(tripPattern);
-  const situations = findAllSituations(tripPattern);
 
   const prefixA11yLabel = `${t(
     TravelCardTexts.card.typePrefix(type, cardIndex, numberOfCards),
@@ -122,23 +110,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
                 <ThemeIcon svg={ChevronRight} />
               </View>
             </View>
-            <View aria-hidden={true}>
-              {situations.map((situation) => (
-                <MessageInfoText
-                  type={getMessageTypeForSituation(situation)}
-                  message={
-                    getTextForLanguage(situation.description, language) ?? ''
-                  }
-                />
-              ))}
-              {notices.map((notice) => (
-                <MessageInfoText
-                  type="info"
-                  message={notice.text ?? ''}
-                  key={notice.id}
-                />
-              ))}
-            </View>
+            <TravelCardNotices tripPattern={tripPattern} language={language} />
           </NativeBlockButton>
         )}
       </CompositeAccessibilityProvider>

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -8,7 +8,7 @@ import {TravelCardHeader} from './TravelCardHeader';
 import {LayoutChangeEvent, View} from 'react-native';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {TravelCardTexts, useTranslation} from '@atb/translations';
+import {dictionary, TravelCardTexts, useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {CompositeAccessibilityProvider} from '@atb/modules/composite-accessibility';
 import {getDetailedSituationOrNoticeA11yLabel} from '@atb/modules/situations';
@@ -60,13 +60,17 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       ? getDetailedSituationOrNoticeA11yLabel(tripPattern, language, t)
       : undefined;
 
+  const tagA11yLabel = tagLabel
+    ? `.. ${t(dictionary.messageTypes[tagType])}.. ${tagLabel}`
+    : undefined;
+
   return (
     <Animated.View entering={FadeIn}>
       <CompositeAccessibilityProvider
         parentLabels={{
           cardPrefix: prefixA11yLabel,
           situationOrNotice: situationOrNoticeA11yLabel,
-          tag: tagLabel,
+          tag: tagA11yLabel,
         }}
         order={['cardPrefix', 'header', 'legs', 'situationOrNotice', 'tag']}
       >

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -8,11 +8,22 @@ import {TravelCardHeader} from './TravelCardHeader';
 import {LayoutChangeEvent, View} from 'react-native';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {TravelCardTexts, useTranslation} from '@atb/translations';
+import {
+  getTextForLanguage,
+  TravelCardTexts,
+  useTranslation,
+} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {CompositeAccessibilityProvider} from '@atb/modules/composite-accessibility';
+import {
+  findAllNotices,
+  findAllSituations,
+  getDetailedSituationOrNoticeA11yLabel,
+  getMessageTypeForSituation,
+} from '@atb/modules/situations';
+import {MessageInfoText} from '@atb/components/message-info-text';
 
-export type TravelCardType = 'trip-search' | 'saved-trip';
+export type TravelCardType = 'trip-search' | 'saved-trip' | 'booking';
 
 type TravelCardProps = {
   tripPattern: TripPattern;
@@ -21,6 +32,9 @@ type TravelCardProps = {
   numberOfCards: number;
   testID?: string;
   type: TravelCardType;
+  isDisabled?: boolean;
+  extraA11yLabels?: Record<string, string | undefined>;
+  extraA11yOrder?: {before?: string[]; after?: string[]};
 };
 
 export const TravelCard: React.FC<TravelCardProps> = ({
@@ -30,10 +44,13 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   numberOfCards,
   testID,
   type,
+  isDisabled = false,
+  extraA11yLabels,
+  extraA11yOrder,
 }) => {
   const styles = useThemeStyles();
   const [maxWidth, setMaxWidth] = useState(0);
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
 
   const includeDayInfo = type === 'saved-trip';
   const includeFromToInfo = type === 'saved-trip';
@@ -43,23 +60,44 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   );
   const modes = uniqueModes.map((mode) => t(getTranslatedModeName(mode)));
 
-  const a11yLabel = `${t(
+  const notices = findAllNotices(tripPattern);
+  const situations = findAllSituations(tripPattern);
+
+  const prefixA11yLabel = `${t(
     TravelCardTexts.card.typePrefix(type, cardIndex, numberOfCards),
   )}. ${t(TravelCardTexts.card.modesPrefix(modes))}.`;
+
+  const situationOrNoticeA11yLabel =
+    type === 'booking' && !isDisabled
+      ? getDetailedSituationOrNoticeA11yLabel(tripPattern, language, t)
+      : undefined;
+
+  const baseOrder = ['cardPrefix', 'header', 'legs', 'situationOrNotice'];
+  const order = [
+    ...(extraA11yOrder?.before ?? []),
+    ...baseOrder,
+    ...(extraA11yOrder?.after ?? []),
+  ];
 
   return (
     <Animated.View entering={FadeIn}>
       <CompositeAccessibilityProvider
-        parentLabels={{cardPrefix: a11yLabel}}
-        order={['cardPrefix', 'header', 'legs']}
+        parentLabels={{
+          cardPrefix: prefixA11yLabel,
+          situationOrNotice: situationOrNoticeA11yLabel,
+          ...extraA11yLabels,
+        }}
+        order={order}
       >
         {(accessibilityProps) => (
           <NativeBlockButton
             onPress={() => onDetailsPressed(tripPattern, cardIndex)}
             testID={testID}
-            style={styles.container}
-            accessibilityRole="button"
-            accessibilityHint={t(TravelCardTexts.card.a11yHint)}
+            style={[styles.container, isDisabled && styles.containerDisabled]}
+            accessibilityRole={isDisabled ? 'none' : 'button'}
+            accessibilityHint={
+              isDisabled ? undefined : t(TravelCardTexts.card.a11yHint)
+            }
             {...accessibilityProps}
           >
             <TravelCardHeader
@@ -74,11 +112,32 @@ export const TravelCard: React.FC<TravelCardProps> = ({
                   setMaxWidth(e.nativeEvent.layout.width)
                 }
               >
-                <TravelCardLegs tripPattern={tripPattern} maxWidth={maxWidth} />
+                <TravelCardLegs
+                  tripPattern={tripPattern}
+                  maxWidth={maxWidth}
+                  type={type}
+                />
               </View>
               <View>
                 <ThemeIcon svg={ChevronRight} />
               </View>
+            </View>
+            <View aria-hidden={true}>
+              {situations.map((situation) => (
+                <MessageInfoText
+                  type={getMessageTypeForSituation(situation)}
+                  message={
+                    getTextForLanguage(situation.description, language) ?? ''
+                  }
+                />
+              ))}
+              {notices.map((notice) => (
+                <MessageInfoText
+                  type="info"
+                  message={notice.text ?? ''}
+                  key={notice.id}
+                />
+              ))}
             </View>
           </NativeBlockButton>
         )}
@@ -95,7 +154,10 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     padding: theme.spacing.medium,
     borderRadius: theme.border.radius.regular,
     marginHorizontal: theme.spacing.medium,
-    marginTop: theme.spacing.small,
+    marginVertical: theme.spacing.small,
+  },
+  containerDisabled: {
+    backgroundColor: theme.color.background.neutral[2].background,
   },
   legsContainer: {
     gap: theme.spacing.medium,

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -108,7 +108,9 @@ export const TravelCard: React.FC<TravelCardProps> = ({
                 <ThemeIcon svg={ChevronRight} />
               </View>
             </View>
-            <TravelCardNotices tripPattern={tripPattern} language={language} />
+            {includeSituationNotices && (
+              <TravelCardNotices tripPattern={tripPattern} language={language} />
+            )}
           </NativeBlockButton>
         )}
       </CompositeAccessibilityProvider>

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -11,7 +11,10 @@ import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
 import {dictionary, TravelCardTexts, useTranslation} from '@atb/translations';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {CompositeAccessibilityProvider} from '@atb/modules/composite-accessibility';
-import {getDetailedSituationOrNoticeA11yLabel} from '@atb/modules/situations';
+import {
+  getDetailedSituationOrNoticeA11yLabel,
+  getLegNotificationsA11yLabel,
+} from '@atb/modules/situations';
 import {TravelCardNotices} from './TravelCardNotices';
 import {Tag} from '@atb/components/tag';
 
@@ -56,6 +59,11 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       ? getDetailedSituationOrNoticeA11yLabel(tripPattern, language, t)
       : undefined;
 
+  const legNotificationsA11yLabel =
+    includeLegNotifications && !isDisabled
+      ? getLegNotificationsA11yLabel(tripPattern, t)
+      : undefined;
+
   const tagA11yLabel = tag
     ? `.. ${t(dictionary.messageTypes[tag.type])}.. ${tag.label}`
     : undefined;
@@ -66,9 +74,17 @@ export const TravelCard: React.FC<TravelCardProps> = ({
         parentLabels={{
           cardPrefix: prefixA11yLabel,
           situationOrNotice: situationOrNoticeA11yLabel,
+          legNotifications: legNotificationsA11yLabel,
           tag: tagA11yLabel,
         }}
-        order={['cardPrefix', 'header', 'legs', 'situationOrNotice', 'tag']}
+        order={[
+          'cardPrefix',
+          'header',
+          'legs',
+          'situationOrNotice',
+          'legNotifications',
+          'tag',
+        ]}
       >
         {(accessibilityProps) => (
           <NativeBlockButton
@@ -98,18 +114,19 @@ export const TravelCard: React.FC<TravelCardProps> = ({
                   setMaxWidth(e.nativeEvent.layout.width)
                 }
               >
-                <TravelCardLegs
-                  tripPattern={tripPattern}
-                  maxWidth={maxWidth}
-                  includeLegNotifications={includeLegNotifications}
-                />
+                <TravelCardLegs tripPattern={tripPattern} maxWidth={maxWidth} />
               </View>
               <View>
                 <ThemeIcon svg={ChevronRight} />
               </View>
             </View>
-            {includeSituationNotices && (
-              <TravelCardNotices tripPattern={tripPattern} language={language} />
+            {(includeSituationNotices || includeLegNotifications) && (
+              <TravelCardNotices
+                tripPattern={tripPattern}
+                language={language}
+                includeSituationNotices={includeSituationNotices}
+                includeLegNotifications={includeLegNotifications}
+              />
             )}
           </NativeBlockButton>
         )}

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -65,7 +65,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       : undefined;
 
   const tagA11yLabel = tag
-    ? `.. ${t(dictionary.messageTypes[tag.type])}.. ${tag.label}`
+    ? `. ${t(dictionary.messageTypes[tag.type])}. ${tag.label}`
     : undefined;
 
   return (

--- a/src/screen-components/travel-card/TravelCardLegs.tsx
+++ b/src/screen-components/travel-card/TravelCardLegs.tsx
@@ -21,18 +21,17 @@ import {secondsToDuration} from '@atb/utils/date';
 import {useAccessibilityLabelContribution} from '@atb/modules/composite-accessibility';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {isDefined} from '@atb/utils/presence';
-import type {TravelCardType} from './TravelCard';
 
 type TravelCardContentProps = {
   tripPattern: TripPattern;
   maxWidth: number;
-  type: TravelCardType;
+  includeLegNotifications?: boolean;
 };
 
 export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   tripPattern,
   maxWidth,
-  type,
+  includeLegNotifications = false,
 }) => {
   const {theme, themeName} = useThemeContext();
   const styles = useThemeStyles();
@@ -42,7 +41,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
     return previousLeg && previousLeg.interchangeTo?.staySeated === true;
   };
 
-  const a11yLabel = useA11yLabel(filteredLegs, type);
+  const a11yLabel = useA11yLabel(filteredLegs, includeLegNotifications);
   useAccessibilityLabelContribution('legs', a11yLabel);
 
   return (
@@ -94,7 +93,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   );
 };
 
-const useA11yLabel = (legs: Leg[], type: TravelCardType) => {
+const useA11yLabel = (legs: Leg[], includeLegNotifications: boolean) => {
   const {t, language} = useTranslation();
 
   if (legs.length === 0) return '';
@@ -125,8 +124,9 @@ const useA11yLabel = (legs: Leg[], type: TravelCardType) => {
     );
   };
 
-  const notificationLabel =
-    type !== 'booking' ? getLegsNotificationA11yLabel(legs, t) : undefined;
+  const notificationLabel = includeLegNotifications
+    ? getLegsNotificationA11yLabel(legs, t)
+    : undefined;
   const prefix = t(TravelCardTexts.legs.prefix);
   const legsLabel = legs
     .map((leg, idx) =>

--- a/src/screen-components/travel-card/TravelCardLegs.tsx
+++ b/src/screen-components/travel-card/TravelCardLegs.tsx
@@ -21,15 +21,18 @@ import {secondsToDuration} from '@atb/utils/date';
 import {useAccessibilityLabelContribution} from '@atb/modules/composite-accessibility';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {isDefined} from '@atb/utils/presence';
+import type {TravelCardType} from './TravelCard';
 
 type TravelCardContentProps = {
   tripPattern: TripPattern;
   maxWidth: number;
+  type: TravelCardType;
 };
 
 export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   tripPattern,
   maxWidth,
+  type,
 }) => {
   const {theme, themeName} = useThemeContext();
   const styles = useThemeStyles();
@@ -39,7 +42,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
     return previousLeg && previousLeg.interchangeTo?.staySeated === true;
   };
 
-  const a11yLabel = useA11yLabel(filteredLegs);
+  const a11yLabel = useA11yLabel(filteredLegs, type);
   useAccessibilityLabelContribution('legs', a11yLabel);
 
   return (
@@ -91,7 +94,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   );
 };
 
-const useA11yLabel = (legs: Leg[]) => {
+const useA11yLabel = (legs: Leg[], type: TravelCardType) => {
   const {t, language} = useTranslation();
 
   if (legs.length === 0) return '';
@@ -122,7 +125,8 @@ const useA11yLabel = (legs: Leg[]) => {
     );
   };
 
-  const notificationLabel = getLegsNotificationA11yLabel(legs, t);
+  const notificationLabel =
+    type !== 'booking' ? getLegsNotificationA11yLabel(legs, t) : undefined;
   const prefix = t(TravelCardTexts.legs.prefix);
   const legsLabel = legs
     .map((leg, idx) =>

--- a/src/screen-components/travel-card/TravelCardLegs.tsx
+++ b/src/screen-components/travel-card/TravelCardLegs.tsx
@@ -8,7 +8,6 @@ import {getFilteredLegsByWalkOrWaitTime} from '@atb/screen-components/travel-det
 import {OverflowContainer} from '@atb/components/overflow-container';
 import {
   getNotificationSvgForLegs,
-  getLegsNotificationA11yLabel,
   getMsgTypeForLeg,
   toMostCriticalStatus,
 } from '@atb/modules/situations';
@@ -31,7 +30,6 @@ type TravelCardContentProps = {
 export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   tripPattern,
   maxWidth,
-  includeLegNotifications = false,
 }) => {
   const {theme, themeName} = useThemeContext();
   const styles = useThemeStyles();
@@ -41,7 +39,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
     return previousLeg && previousLeg.interchangeTo?.staySeated === true;
   };
 
-  const a11yLabel = useA11yLabel(filteredLegs, includeLegNotifications);
+  const a11yLabel = useA11yLabel(filteredLegs);
   useAccessibilityLabelContribution('legs', a11yLabel);
 
   return (
@@ -93,7 +91,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   );
 };
 
-const useA11yLabel = (legs: Leg[], includeLegNotifications: boolean) => {
+const useA11yLabel = (legs: Leg[]) => {
   const {t, language} = useTranslation();
 
   if (legs.length === 0) return '';
@@ -124,9 +122,6 @@ const useA11yLabel = (legs: Leg[], includeLegNotifications: boolean) => {
     );
   };
 
-  const notificationLabel = includeLegNotifications
-    ? getLegsNotificationA11yLabel(legs, t)
-    : undefined;
   const prefix = t(TravelCardTexts.legs.prefix);
   const legsLabel = legs
     .map((leg, idx) =>
@@ -136,9 +131,7 @@ const useA11yLabel = (legs: Leg[], includeLegNotifications: boolean) => {
     )
     .join(', ');
 
-  return [notificationLabel, `${prefix}: ${legsLabel}`]
-    .filter(isDefined)
-    .join(', ');
+  return [`${prefix}: ${legsLabel}`].filter(isDefined).join(', ');
 };
 
 const getWaitTime = (leg: Leg, nextLeg?: Leg) => {

--- a/src/screen-components/travel-card/TravelCardLegs.tsx
+++ b/src/screen-components/travel-card/TravelCardLegs.tsx
@@ -24,7 +24,6 @@ import {isDefined} from '@atb/utils/presence';
 type TravelCardContentProps = {
   tripPattern: TripPattern;
   maxWidth: number;
-  includeLegNotifications?: boolean;
 };
 
 export const TravelCardLegs: React.FC<TravelCardContentProps> = ({

--- a/src/screen-components/travel-card/TravelCardNotices.tsx
+++ b/src/screen-components/travel-card/TravelCardNotices.tsx
@@ -30,6 +30,7 @@ export const TravelCardNotices: React.FC<TravelCardNoticesProps> = ({
         <MessageInfoText
           type={getMessageTypeForSituation(situation)}
           message={getTextForLanguage(situation.description, language) ?? ''}
+          key={situation.id}
         />
       ))}
       {notices.map((notice) => (

--- a/src/screen-components/travel-card/TravelCardNotices.tsx
+++ b/src/screen-components/travel-card/TravelCardNotices.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {View} from 'react-native';
+import type {TripPattern} from '@atb/api/types/trips';
+import {getTextForLanguage} from '@atb/translations';
+import {
+  findAllNotices,
+  findAllSituations,
+  getMessageTypeForSituation,
+} from '@atb/modules/situations';
+import {MessageInfoText} from '@atb/components/message-info-text';
+import type {Language} from '@atb/translations';
+
+type TravelCardNoticesProps = {
+  tripPattern: TripPattern;
+  language: Language;
+};
+
+export const TravelCardNotices: React.FC<TravelCardNoticesProps> = ({
+  tripPattern,
+  language,
+}) => {
+  const notices = findAllNotices(tripPattern);
+  const situations = findAllSituations(tripPattern);
+
+  if (situations.length === 0 && notices.length === 0) return null;
+
+  return (
+    <View aria-hidden={true}>
+      {situations.map((situation) => (
+        <MessageInfoText
+          type={getMessageTypeForSituation(situation)}
+          message={getTextForLanguage(situation.description, language) ?? ''}
+        />
+      ))}
+      {notices.map((notice) => (
+        <MessageInfoText
+          type="info"
+          message={notice.text ?? ''}
+          key={notice.id}
+        />
+      ))}
+    </View>
+  );
+};

--- a/src/screen-components/travel-card/TravelCardNotices.tsx
+++ b/src/screen-components/travel-card/TravelCardNotices.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import {View} from 'react-native';
 import type {TripPattern} from '@atb/api/types/trips';
-import {getTextForLanguage} from '@atb/translations';
+import {
+  getTextForLanguage,
+  TripDetailsTexts,
+  TripSearchTexts,
+  useTranslation,
+} from '@atb/translations';
 import {
   findAllNotices,
   findAllSituations,
@@ -9,20 +14,52 @@ import {
 } from '@atb/modules/situations';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import type {Language} from '@atb/translations';
+import {TransportSubmode} from '@atb/api/types/generated/journey_planner_v3_types';
 
 type TravelCardNoticesProps = {
   tripPattern: TripPattern;
   language: Language;
+  includeSituationNotices?: boolean;
+  includeLegNotifications?: boolean;
 };
 
 export const TravelCardNotices: React.FC<TravelCardNoticesProps> = ({
   tripPattern,
   language,
+  includeSituationNotices = false,
+  includeLegNotifications = false,
 }) => {
-  const notices = findAllNotices(tripPattern);
-  const situations = findAllSituations(tripPattern);
+  const {t} = useTranslation();
 
-  if (situations.length === 0 && notices.length === 0) return null;
+  const situations = includeSituationNotices
+    ? findAllSituations(tripPattern)
+    : [];
+  const notices = includeSituationNotices ? findAllNotices(tripPattern) : [];
+
+  const legNotifications: {key: string; message: string}[] = [];
+  if (includeLegNotifications) {
+    for (const leg of tripPattern.legs) {
+      if (leg.transportSubmode === TransportSubmode.RailReplacementBus) {
+        legNotifications.push({
+          key: `rail-replacement-${leg.id}`,
+          message: t(TripDetailsTexts.messages.departureIsRailReplacementBus),
+        });
+      }
+      if (leg.bookingArrangements) {
+        legNotifications.push({
+          key: `booking-${leg.id}`,
+          message: t(TripSearchTexts.results.resultItem.footer.requiresBooking),
+        });
+      }
+    }
+  }
+
+  if (
+    situations.length === 0 &&
+    notices.length === 0 &&
+    legNotifications.length === 0
+  )
+    return null;
 
   return (
     <View aria-hidden={true}>
@@ -38,6 +75,13 @@ export const TravelCardNotices: React.FC<TravelCardNoticesProps> = ({
           type="info"
           message={notice.text ?? ''}
           key={notice.id}
+        />
+      ))}
+      {legNotifications.map((notification) => (
+        <MessageInfoText
+          type="warning"
+          message={notification.message}
+          key={notification.key}
         />
       ))}
     </View>

--- a/src/screen-components/travel-card/index.ts
+++ b/src/screen-components/travel-card/index.ts
@@ -1,4 +1,4 @@
-export {TravelCard, type TravelCardType} from './TravelCard';
+export {TravelCard} from './TravelCard';
 import {withCompositeAccessibility} from '@atb/modules/composite-accessibility';
 import {TravelCardHeader as TravelCardHeaderComponent} from './TravelCardHeader';
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -5,6 +5,7 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {StyleSheet} from '@atb/theme';
 import {
   TranslateFunction,
+  TravelCardTexts,
   TripSearchTexts,
   useTranslation,
 } from '@atb/translations';
@@ -108,10 +109,16 @@ export const Results: React.FC<Props> = ({
                 <TravelCard
                   tripPattern={tripPattern}
                   onDetailsPressed={onDetailsPressed}
-                  cardIndex={i}
-                  numberOfCards={tripPatterns.length}
                   testID={'tripSearchSearchResult' + i}
-                  type="trip-search"
+                  a11yLabelPrefix={t(
+                    TravelCardTexts.card.a11yPrefix.tripSuggestion(
+                      i + 1,
+                      tripPatterns.length,
+                    ),
+                  )}
+                  includeDayInfo
+                  includeFromToInfo
+                  includeSituationNotices
                 />
               ) : (
                 <ResultRow

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -118,7 +118,6 @@ export const Results: React.FC<Props> = ({
                   )}
                   includeDayInfo
                   includeFromToInfo
-                  includeSituationNotices
                 />
               ) : (
                 <ResultRow

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -112,7 +112,7 @@ export const Results: React.FC<Props> = ({
                   testID={'tripSearchSearchResult' + i}
                   a11yLabelPrefix={t(
                     TravelCardTexts.card.a11yPrefix.tripSuggestion(
-                      i + 1,
+                      i,
                       tripPatterns.length,
                     ),
                   )}

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
@@ -1,5 +1,5 @@
-import {GenericSectionItem} from '@atb/components/sections';
 import React, {useState} from 'react';
+import {View} from 'react-native';
 import {useParamAsState} from '@atb/utils/use-param-as-state';
 import type {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {FullScreenView} from '@atb/components/screen-view';
@@ -12,7 +12,6 @@ import {
 import {ScreenHeading} from '@atb/components/heading';
 import TripSelectionTexts from '@atb/translations/screens/TripSelectionScreen';
 import {useTranslation} from '@atb/translations';
-import {View} from 'react-native';
 import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
@@ -76,7 +75,7 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
           backgroundColor={theme.color.background.neutral[1]}
         />
       </View>
-      <GenericSectionItem style={styles.content}>
+      <View style={styles.content}>
         <BookingTripSelection
           selection={selection}
           onSelect={(legs) => {
@@ -108,7 +107,7 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
             }
           }}
         />
-      </GenericSectionItem>
+      </View>
     </FullScreenView>
   );
 };
@@ -119,6 +118,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   content: {
     backgroundColor: theme.color.background.neutral[1].background,
-    borderWidth: 0,
   },
 }));

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -85,8 +85,7 @@ export function BookingTripSelection({
               )}
               includeSituationNotices
               isDisabled={!isAvailable}
-              tagLabel={tagInfo?.label}
-              tagType={tagInfo?.type}
+              tag={tagInfo}
             />
           );
         })

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -74,11 +74,10 @@ export function BookingTripSelection({
             <TravelCard
               key={`booking-trip-${i}`}
               tripPattern={tp}
-              cardIndex={i}
               onDetailsPressed={() => {
                 if (isAvailable) onSelect(tp.legs);
               }}
-              a11yPrefix={t(
+              a11yLabelPrefix={t(
                 TravelCardTexts.card.a11yPrefix.bookingOption(
                   i,
                   tripPatterns.length,

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -13,6 +13,7 @@ import {ThemeText} from '@atb/components/text';
 import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {
   TicketingTexts,
+  TravelCardTexts,
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
@@ -110,11 +111,11 @@ export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
       <TravelCard
         tripPattern={tripPattern}
         cardIndex={0}
-        numberOfCards={1}
         onDetailsPressed={() => {
           if (isAvailable) onSelect(tripPattern.legs);
         }}
-        type="booking"
+        a11yPrefix={t(TravelCardTexts.card.a11yPrefix.bookingOption(0, 1))}
+        includeSituationNotices
         isDisabled={!isAvailable}
         extraA11yLabels={{tag: tagLabel}}
         extraA11yOrder={{after: ['tag']}}

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -33,6 +33,7 @@ export function BookingTripSelection({
   onSelect,
 }: BookingTripSelectionProps) {
   const styles = useBookingTripSelectionStyles();
+  const {t} = useTranslation();
   const {
     tripPatterns,
     isEmpty,
@@ -60,58 +61,39 @@ export function BookingTripSelection({
         originFareContract={selection.originFareContract}
       />
       {!isEmpty ? (
-        tripPatterns.map((tp, i) => (
-          <BookingTrip
-            key={`booking-trip-${i}`}
-            onSelect={onSelect}
-            tripPattern={tp}
-          />
-        ))
+        tripPatterns.map((tp, i) => {
+          const isAvailable =
+            tp.booking.availability === 'available' &&
+            !tp.booking.disabledReason;
+          const tagInfo = getBookingTagInfo(
+            t,
+            tp.booking,
+            tp.booking.disabledReason,
+          );
+          return (
+            <TravelCard
+              key={`booking-trip-${i}`}
+              tripPattern={tp}
+              cardIndex={i}
+              onDetailsPressed={() => {
+                if (isAvailable) onSelect(tp.legs);
+              }}
+              a11yPrefix={t(
+                TravelCardTexts.card.a11yPrefix.bookingOption(
+                  i,
+                  tripPatterns.length,
+                ),
+              )}
+              includeSituationNotices
+              isDisabled={!isAvailable}
+              tagLabel={tagInfo?.label}
+              tagType={tagInfo?.type}
+            />
+          );
+        })
       ) : (
         <EmptyState />
       )}
-    </View>
-  );
-}
-
-type BookingTripProps = {
-  tripPattern: TripPatternWithBooking;
-  onSelect: (legs: TripPatternLegs) => void;
-};
-
-export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
-  const styles = useBookingTripStyles();
-  const {t} = useTranslation();
-
-  const isAvailable =
-    tripPattern.booking.availability === 'available' &&
-    !tripPattern.booking.disabledReason;
-
-  const tagInfo = getBookingTagInfo(
-    t,
-    tripPattern.booking,
-    tripPattern.booking.disabledReason,
-  );
-
-  return (
-    <View
-      style={[
-        styles.container,
-        isAvailable ? styles.containerAvailable : styles.containerDisabled,
-      ]}
-    >
-      <TravelCard
-        tripPattern={tripPattern}
-        cardIndex={0}
-        onDetailsPressed={() => {
-          if (isAvailable) onSelect(tripPattern.legs);
-        }}
-        a11yPrefix={t(TravelCardTexts.card.a11yPrefix.bookingOption(0, 1))}
-        includeSituationNotices
-        isDisabled={!isAvailable}
-        tagLabel={tagInfo?.label}
-        tagType={tagInfo?.type}
-      />
     </View>
   );
 }
@@ -165,26 +147,10 @@ function getBookingTagInfo(
   return undefined;
 }
 
-const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
-  return {
-    container: {
-      borderRadius: theme.border.radius.regular,
-      overflow: 'hidden',
-    },
-    containerAvailable: {
-      backgroundColor: theme.color.interactive[2].default.background,
-    },
-    containerDisabled: {
-      backgroundColor: theme.color.background.neutral[2].background,
-    },
-  };
-});
-
-const useBookingTripSelectionStyles = StyleSheet.createThemeHook((theme) => {
+const useBookingTripSelectionStyles = StyleSheet.createThemeHook(() => {
   return {
     container: {
       width: '100%',
-      rowGap: theme.spacing.medium,
     },
   };
 });

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -6,9 +6,8 @@ import {
   useBookingTrips,
 } from '@atb/modules/booking';
 import type {TripPatternLegs} from '../types';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet, useThemeContext, Statuses} from '@atb/theme';
 import {TripPatternWithBooking} from '@atb/api/types/trips';
-import {Tag} from '@atb/components/tag';
 import {ThemeText} from '@atb/components/text';
 import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {
@@ -88,12 +87,11 @@ export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
     tripPattern.booking.availability === 'available' &&
     !tripPattern.booking.disabledReason;
 
-  const rawTagLabel = getBookingTagLabel(
+  const tagInfo = getBookingTagInfo(
     t,
     tripPattern.booking,
     tripPattern.booking.disabledReason,
   );
-  const tagLabel = rawTagLabel ? `. ${rawTagLabel}` : undefined;
 
   return (
     <View
@@ -102,12 +100,6 @@ export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
         isAvailable ? styles.containerAvailable : styles.containerDisabled,
       ]}
     >
-      <View aria-hidden={true}>
-        <TripSelectionTag
-          bookingInfo={tripPattern.booking}
-          disabledReason={tripPattern.booking.disabledReason}
-        />
-      </View>
       <TravelCard
         tripPattern={tripPattern}
         cardIndex={0}
@@ -117,8 +109,8 @@ export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
         a11yPrefix={t(TravelCardTexts.card.a11yPrefix.bookingOption(0, 1))}
         includeSituationNotices
         isDisabled={!isAvailable}
-        extraA11yLabels={{tag: tagLabel}}
-        extraA11yOrder={{after: ['tag']}}
+        tagLabel={tagInfo?.label}
+        tagType={tagInfo?.type}
       />
     </View>
   );
@@ -146,83 +138,32 @@ function EmptyState() {
   );
 }
 
-function getBookingTagLabel(
+function getBookingTagInfo(
   t: TranslateFunction,
   bookingInfo: TripPatternWithBooking['booking'],
   disabledReason?: BookingDisabledReason,
-): string | undefined {
+): {label: string; type: Statuses} | undefined {
   if (disabledReason === 'expired_fare_contract') {
-    return t(TicketingTexts.booking.expiredFareContract);
+    return {label: t(TicketingTexts.booking.expiredFareContract), type: 'info'};
   } else if (disabledReason === 'inactive_fare_contract') {
-    return t(TicketingTexts.booking.beforeStartOfFareContract);
+    return {
+      label: t(TicketingTexts.booking.beforeStartOfFareContract),
+      type: 'info',
+    };
   } else if (bookingInfo.availability === 'closed') {
-    return t(TicketingTexts.booking.closed);
+    return {label: t(TicketingTexts.booking.closed), type: 'warning'};
   } else if (bookingInfo.availability === 'sold_out') {
-    return t(TicketingTexts.booking.soldOut);
+    return {label: t(TicketingTexts.booking.soldOut), type: 'warning'};
   }
   const availableSeats = bookingInfo?.offer?.available ?? 0;
   if (!!availableSeats && availableSeats <= SEAT_TAG_LIMIT) {
-    return t(TicketingTexts.booking.numAvailableTickets(availableSeats));
+    return {
+      label: t(TicketingTexts.booking.numAvailableTickets(availableSeats)),
+      type: 'info',
+    };
   }
   return undefined;
 }
-
-/**
- * We only want to show one tag at a time
- */
-function TripSelectionTag({
-  bookingInfo,
-  disabledReason,
-}: {
-  bookingInfo: TripPatternWithBooking['booking'];
-  disabledReason?: BookingDisabledReason;
-}) {
-  const {t} = useTranslation();
-  const styles = useTripSelectionTagStyles();
-  const availableSeats = bookingInfo?.offer?.available ?? 0;
-
-  let tag: React.ReactNode = null;
-
-  if (disabledReason === 'expired_fare_contract') {
-    tag = (
-      <Tag
-        labels={[t(TicketingTexts.booking.expiredFareContract)]}
-        tagType="info"
-      />
-    );
-  } else if (disabledReason === 'inactive_fare_contract') {
-    tag = (
-      <Tag
-        labels={[t(TicketingTexts.booking.beforeStartOfFareContract)]}
-        tagType="info"
-      />
-    );
-  } else if (bookingInfo.availability === 'closed') {
-    tag = <Tag labels={[t(TicketingTexts.booking.closed)]} tagType="warning" />;
-  } else if (bookingInfo.availability === 'sold_out') {
-    tag = (
-      <Tag labels={[t(TicketingTexts.booking.soldOut)]} tagType="warning" />
-    );
-  } else if (!!availableSeats && availableSeats <= SEAT_TAG_LIMIT) {
-    tag = (
-      <Tag
-        labels={[t(TicketingTexts.booking.numAvailableTickets(availableSeats))]}
-        tagType="info"
-      />
-    );
-  }
-
-  if (!tag) return null;
-
-  return <View style={styles.tagContainer}>{tag}</View>;
-}
-
-const useTripSelectionTagStyles = StyleSheet.createThemeHook((theme) => ({
-  tagContainer: {
-    padding: theme.spacing.medium,
-    paddingBottom: 0,
-  },
-}));
 
 const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
   return {

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -1,35 +1,25 @@
 import {type PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import {View} from 'react-native';
 import React from 'react';
-import {MemoizedResultItem} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem';
 import {
   type BookingDisabledReason,
   useBookingTrips,
 } from '@atb/modules/booking';
 import type {TripPatternLegs} from '../types';
-import {Button} from '@atb/components/button';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {SectionSeparator} from '@atb/components/sections';
 import {TripPatternWithBooking} from '@atb/api/types/trips';
 import {Tag} from '@atb/components/tag';
 import {ThemeText} from '@atb/components/text';
-import {NativeBlockButton} from '@atb/components/native-button';
 import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {
-  getTextForLanguage,
   TicketingTexts,
+  TranslateFunction,
   useTranslation,
 } from '@atb/translations';
 import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
-import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {
-  getMessageTypeForSituation,
-  getSituationOrNoticeA11yLabel,
-} from '@atb/modules/situations';
-import {MessageInfoText} from '@atb/components/message-info-text';
-import {findAllNotices, findAllSituations} from '@atb/modules/situations';
 import {Loading} from '@atb/components/loading';
 import {BookingValidityInfoBox} from '@atb/stacks-hierarchy/Root_TripSelectionScreen/components/BookingValidityInfoBox';
+import {TravelCard} from '@atb/screen-components/travel-card';
 
 type BookingTripSelectionProps = {
   selection: PurchaseSelectionType;
@@ -90,89 +80,46 @@ type BookingTripProps = {
 };
 
 export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
-  const {theme} = useThemeContext();
   const styles = useBookingTripStyles();
-  const {t, language} = useTranslation();
-
-  const onPress = () => {
-    if (isAvailable && !tripPattern.booking.disabledReason) {
-      onSelect(tripPattern.legs);
-    }
-  };
+  const {t} = useTranslation();
 
   const isAvailable =
     tripPattern.booking.availability === 'available' &&
     !tripPattern.booking.disabledReason;
 
-  const notices = findAllNotices(tripPattern);
-  const situations = findAllSituations(tripPattern);
+  const rawTagLabel = getBookingTagLabel(
+    t,
+    tripPattern.booking,
+    tripPattern.booking.disabledReason,
+  );
+  const tagLabel = rawTagLabel ? `. ${rawTagLabel}` : undefined;
 
   return (
-    <NativeBlockButton
-      onPress={onPress}
+    <View
       style={[
         styles.container,
         isAvailable ? styles.containerAvailable : styles.containerDisabled,
       ]}
     >
-      <View style={styles.mainContent}>
+      <View aria-hidden={true}>
         <TripSelectionTag
           bookingInfo={tripPattern.booking}
           disabledReason={tripPattern.booking.disabledReason}
         />
-        <MemoizedResultItem
-          tripPattern={tripPattern}
-          key={tripPattern.compressedQuery}
-          state={isAvailable ? 'enabled' : 'disabled'}
-        />
-        <View
-          accessibilityLabel={getSituationOrNoticeA11yLabel(
-            situations,
-            notices,
-            false,
-            t,
-          )}
-        >
-          {situations.map((situation) => (
-            <MessageInfoText
-              type={getMessageTypeForSituation(situation)}
-              message={
-                getTextForLanguage(situation.description, language) ?? ''
-              }
-            />
-          ))}
-          {notices.map((notice) => (
-            <MessageInfoText
-              type="info"
-              message={notice.text ?? ''}
-              key={notice.id}
-            />
-          ))}
-        </View>
       </View>
-      {isAvailable && (
-        <>
-          <SectionSeparator />
-          <View
-            style={[
-              styles.footer,
-              isAvailable ? styles.footerAvailable : styles.footerDisabled,
-            ]}
-          >
-            <Button
-              text={t(TicketingTexts.booking.select)}
-              expanded={false}
-              type="small"
-              mode="tertiary"
-              onPress={onPress}
-              backgroundColor={theme.color.interactive[2].default}
-              style={{marginLeft: 'auto'}}
-              rightIcon={{svg: ChevronRight}}
-            />
-          </View>
-        </>
-      )}
-    </NativeBlockButton>
+      <TravelCard
+        tripPattern={tripPattern}
+        cardIndex={0}
+        numberOfCards={1}
+        onDetailsPressed={() => {
+          if (isAvailable) onSelect(tripPattern.legs);
+        }}
+        type="booking"
+        isDisabled={!isAvailable}
+        extraA11yLabels={{tag: tagLabel}}
+        extraA11yOrder={{after: ['tag']}}
+      />
+    </View>
   );
 }
 
@@ -198,6 +145,27 @@ function EmptyState() {
   );
 }
 
+function getBookingTagLabel(
+  t: TranslateFunction,
+  bookingInfo: TripPatternWithBooking['booking'],
+  disabledReason?: BookingDisabledReason,
+): string | undefined {
+  if (disabledReason === 'expired_fare_contract') {
+    return t(TicketingTexts.booking.expiredFareContract);
+  } else if (disabledReason === 'inactive_fare_contract') {
+    return t(TicketingTexts.booking.beforeStartOfFareContract);
+  } else if (bookingInfo.availability === 'closed') {
+    return t(TicketingTexts.booking.closed);
+  } else if (bookingInfo.availability === 'sold_out') {
+    return t(TicketingTexts.booking.soldOut);
+  }
+  const availableSeats = bookingInfo?.offer?.available ?? 0;
+  if (!!availableSeats && availableSeats <= SEAT_TAG_LIMIT) {
+    return t(TicketingTexts.booking.numAvailableTickets(availableSeats));
+  }
+  return undefined;
+}
+
 /**
  * We only want to show one tag at a time
  */
@@ -209,37 +177,51 @@ function TripSelectionTag({
   disabledReason?: BookingDisabledReason;
 }) {
   const {t} = useTranslation();
+  const styles = useTripSelectionTagStyles();
   const availableSeats = bookingInfo?.offer?.available ?? 0;
-  if (disabledReason === 'expired_fare_contract')
-    return (
+
+  let tag: React.ReactNode = null;
+
+  if (disabledReason === 'expired_fare_contract') {
+    tag = (
       <Tag
         labels={[t(TicketingTexts.booking.expiredFareContract)]}
         tagType="info"
       />
     );
-  if (disabledReason === 'inactive_fare_contract')
-    return (
+  } else if (disabledReason === 'inactive_fare_contract') {
+    tag = (
       <Tag
         labels={[t(TicketingTexts.booking.beforeStartOfFareContract)]}
         tagType="info"
       />
     );
-  if (bookingInfo.availability === 'closed')
-    return (
-      <Tag labels={[t(TicketingTexts.booking.closed)]} tagType="warning" />
-    );
-  if (bookingInfo.availability === 'sold_out')
-    return (
+  } else if (bookingInfo.availability === 'closed') {
+    tag = <Tag labels={[t(TicketingTexts.booking.closed)]} tagType="warning" />;
+  } else if (bookingInfo.availability === 'sold_out') {
+    tag = (
       <Tag labels={[t(TicketingTexts.booking.soldOut)]} tagType="warning" />
     );
-  if (!!availableSeats && availableSeats <= SEAT_TAG_LIMIT)
-    return (
+  } else if (!!availableSeats && availableSeats <= SEAT_TAG_LIMIT) {
+    tag = (
       <Tag
         labels={[t(TicketingTexts.booking.numAvailableTickets(availableSeats))]}
         tagType="info"
       />
     );
+  }
+
+  if (!tag) return null;
+
+  return <View style={styles.tagContainer}>{tag}</View>;
 }
+
+const useTripSelectionTagStyles = StyleSheet.createThemeHook((theme) => ({
+  tagContainer: {
+    padding: theme.spacing.medium,
+    paddingBottom: 0,
+  },
+}));
 
 const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
   return {
@@ -251,22 +233,6 @@ const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
       backgroundColor: theme.color.interactive[2].default.background,
     },
     containerDisabled: {
-      backgroundColor: theme.color.background.neutral[2].background,
-    },
-    mainContent: {
-      padding: theme.spacing.medium,
-      rowGap: theme.spacing.medium,
-    },
-    footer: {
-      flexDirection: 'row',
-      paddingVertical: theme.spacing.small,
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    },
-    footerAvailable: {
-      backgroundColor: theme.color.interactive[2].default.background,
-    },
-    footerDisabled: {
       backgroundColor: theme.color.background.neutral[2].background,
     },
   };

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -1,25 +1,39 @@
 import {type PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import {View} from 'react-native';
 import React from 'react';
+import {MemoizedResultItem} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem';
 import {
   type BookingDisabledReason,
   useBookingTrips,
 } from '@atb/modules/booking';
 import type {TripPatternLegs} from '../types';
+import {Button} from '@atb/components/button';
 import {StyleSheet, useThemeContext, Statuses} from '@atb/theme';
+import {SectionSeparator} from '@atb/components/sections';
 import {TripPatternWithBooking} from '@atb/api/types/trips';
+import {Tag} from '@atb/components/tag';
 import {ThemeText} from '@atb/components/text';
+import {NativeBlockButton} from '@atb/components/native-button';
 import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {
+  getTextForLanguage,
   TicketingTexts,
   TravelCardTexts,
   TranslateFunction,
   useTranslation,
 } from '@atb/translations';
 import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
+import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
+import {
+  getMessageTypeForSituation,
+  getSituationOrNoticeA11yLabel,
+} from '@atb/modules/situations';
+import {MessageInfoText} from '@atb/components/message-info-text';
+import {findAllNotices, findAllSituations} from '@atb/modules/situations';
 import {Loading} from '@atb/components/loading';
 import {BookingValidityInfoBox} from '@atb/stacks-hierarchy/Root_TripSelectionScreen/components/BookingValidityInfoBox';
 import {TravelCard} from '@atb/screen-components/travel-card';
+import {useIsExperimentalEnabled} from '@atb/modules/experimental';
 
 type BookingTripSelectionProps = {
   selection: PurchaseSelectionType;
@@ -34,6 +48,9 @@ export function BookingTripSelection({
 }: BookingTripSelectionProps) {
   const styles = useBookingTripSelectionStyles();
   const {t} = useTranslation();
+  const isNewTravelCardBooking = useIsExperimentalEnabled(
+    'isNewTravelCardBookingEnabled',
+  );
   const {
     tripPatterns,
     isEmpty,
@@ -61,20 +78,15 @@ export function BookingTripSelection({
         originFareContract={selection.originFareContract}
       />
       {!isEmpty ? (
-        tripPatterns.map((tp, i) => {
-          const isAvailable =
-            tp.booking.availability === 'available' &&
-            !tp.booking.disabledReason;
-          const tagInfo = getBookingTagInfo(
-            t,
-            tp.booking,
-            tp.booking.disabledReason,
-          );
-          return (
+        tripPatterns.map((tp, i) =>
+          isNewTravelCardBooking ? (
             <TravelCard
               key={`booking-trip-${i}`}
               tripPattern={tp}
               onDetailsPressed={() => {
+                const isAvailable =
+                  tp.booking.availability === 'available' &&
+                  !tp.booking.disabledReason;
                 if (isAvailable) onSelect(tp.legs);
               }}
               a11yLabelPrefix={t(
@@ -85,15 +97,118 @@ export function BookingTripSelection({
               )}
               includeLegNotifications
               includeSituationNotices
-              isDisabled={!isAvailable}
-              tag={tagInfo}
+              isDisabled={
+                !(
+                  tp.booking.availability === 'available' &&
+                  !tp.booking.disabledReason
+                )
+              }
+              tag={getBookingTagInfo(t, tp.booking, tp.booking.disabledReason)}
             />
-          );
-        })
+          ) : (
+            <BookingTrip
+              key={`booking-trip-${i}`}
+              onSelect={onSelect}
+              tripPattern={tp}
+            />
+          ),
+        )
       ) : (
         <EmptyState />
       )}
     </View>
+  );
+}
+
+type BookingTripProps = {
+  tripPattern: TripPatternWithBooking;
+  onSelect: (legs: TripPatternLegs) => void;
+};
+
+function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
+  const {theme} = useThemeContext();
+  const styles = useBookingTripStyles();
+  const {t, language} = useTranslation();
+
+  const onPress = () => {
+    if (isAvailable && !tripPattern.booking.disabledReason) {
+      onSelect(tripPattern.legs);
+    }
+  };
+
+  const isAvailable =
+    tripPattern.booking.availability === 'available' &&
+    !tripPattern.booking.disabledReason;
+
+  const notices = findAllNotices(tripPattern);
+  const situations = findAllSituations(tripPattern);
+
+  return (
+    <NativeBlockButton
+      onPress={onPress}
+      style={[
+        styles.container,
+        isAvailable ? styles.containerAvailable : styles.containerDisabled,
+      ]}
+    >
+      <View style={styles.mainContent}>
+        <TripSelectionTag
+          bookingInfo={tripPattern.booking}
+          disabledReason={tripPattern.booking.disabledReason}
+        />
+        <MemoizedResultItem
+          tripPattern={tripPattern}
+          key={tripPattern.compressedQuery}
+          state={isAvailable ? 'enabled' : 'disabled'}
+        />
+        <View
+          accessibilityLabel={getSituationOrNoticeA11yLabel(
+            situations,
+            notices,
+            false,
+            t,
+          )}
+        >
+          {situations.map((situation) => (
+            <MessageInfoText
+              type={getMessageTypeForSituation(situation)}
+              message={
+                getTextForLanguage(situation.description, language) ?? ''
+              }
+            />
+          ))}
+          {notices.map((notice) => (
+            <MessageInfoText
+              type="info"
+              message={notice.text ?? ''}
+              key={notice.id}
+            />
+          ))}
+        </View>
+      </View>
+      {isAvailable && (
+        <>
+          <SectionSeparator />
+          <View
+            style={[
+              styles.footer,
+              isAvailable ? styles.footerAvailable : styles.footerDisabled,
+            ]}
+          >
+            <Button
+              text={t(TicketingTexts.booking.select)}
+              expanded={false}
+              type="small"
+              mode="tertiary"
+              onPress={onPress}
+              backgroundColor={theme.color.interactive[2].default}
+              style={{marginLeft: 'auto'}}
+              rightIcon={{svg: ChevronRight}}
+            />
+          </View>
+        </>
+      )}
+    </NativeBlockButton>
   );
 }
 
@@ -145,6 +260,80 @@ function getBookingTagInfo(
   }
   return undefined;
 }
+
+/**
+ * We only want to show one tag at a time
+ */
+function TripSelectionTag({
+  bookingInfo,
+  disabledReason,
+}: {
+  bookingInfo: TripPatternWithBooking['booking'];
+  disabledReason?: BookingDisabledReason;
+}) {
+  const {t} = useTranslation();
+  const availableSeats = bookingInfo?.offer?.available ?? 0;
+  if (disabledReason === 'expired_fare_contract')
+    return (
+      <Tag
+        labels={[t(TicketingTexts.booking.expiredFareContract)]}
+        tagType="info"
+      />
+    );
+  if (disabledReason === 'inactive_fare_contract')
+    return (
+      <Tag
+        labels={[t(TicketingTexts.booking.beforeStartOfFareContract)]}
+        tagType="info"
+      />
+    );
+  if (bookingInfo.availability === 'closed')
+    return (
+      <Tag labels={[t(TicketingTexts.booking.closed)]} tagType="warning" />
+    );
+  if (bookingInfo.availability === 'sold_out')
+    return (
+      <Tag labels={[t(TicketingTexts.booking.soldOut)]} tagType="warning" />
+    );
+  if (!!availableSeats && availableSeats <= SEAT_TAG_LIMIT)
+    return (
+      <Tag
+        labels={[t(TicketingTexts.booking.numAvailableTickets(availableSeats))]}
+        tagType="info"
+      />
+    );
+}
+
+const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
+  return {
+    container: {
+      borderRadius: theme.border.radius.regular,
+      overflow: 'hidden',
+    },
+    containerAvailable: {
+      backgroundColor: theme.color.interactive[2].default.background,
+    },
+    containerDisabled: {
+      backgroundColor: theme.color.background.neutral[2].background,
+    },
+    mainContent: {
+      padding: theme.spacing.medium,
+      rowGap: theme.spacing.medium,
+    },
+    footer: {
+      flexDirection: 'row',
+      paddingVertical: theme.spacing.small,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+    footerAvailable: {
+      backgroundColor: theme.color.interactive[2].default.background,
+    },
+    footerDisabled: {
+      backgroundColor: theme.color.background.neutral[2].background,
+    },
+  };
+});
 
 const useBookingTripSelectionStyles = StyleSheet.createThemeHook(() => {
   return {

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -83,6 +83,7 @@ export function BookingTripSelection({
                   tripPatterns.length,
                 ),
               )}
+              includeLegNotifications
               includeSituationNotices
               isDisabled={!isAvailable}
               tag={tagInfo}

--- a/src/translations/components/SituationsTexts.ts
+++ b/src/translations/components/SituationsTexts.ts
@@ -11,6 +11,11 @@ const SituationsTexts = {
     info: _('Med ekstra info', 'With extra information', 'Med ekstra info'),
   },
   tripSummary: {
+    detailedPrefix: _(
+      'Denne reisen har følgende meldinger',
+      'This trip has the following notices',
+      'Denne reisa har følgjande meldingar',
+    ),
     warnings: _(
       'Reisen har advarsler',
       'The trip has warnings',

--- a/src/translations/components/SituationsTexts.ts
+++ b/src/translations/components/SituationsTexts.ts
@@ -16,26 +16,6 @@ const SituationsTexts = {
       'This trip has the following notices',
       'Denne reisa har følgjande meldingar',
     ),
-    warnings: _(
-      'Reisen har advarsler',
-      'The trip has warnings',
-      'Reisa har åtvaringar',
-    ),
-    notices: _(
-      'Reisen har ekstra info',
-      'The trip has extra information',
-      'Reisa har ekstra info',
-    ),
-    warningsAndNotices: _(
-      'Reisen har advarsler og ekstra info',
-      'The trip has warnings and extra information',
-      'Reisa har åtvaringar og ekstra info',
-    ),
-    openDetailsForMoreInfo: _(
-      'Åpne detaljer for mer informasjon',
-      'Open details for more information',
-      'Opne detaljar for meir informasjon',
-    ),
   },
   bottomSheet: {
     title: {
@@ -43,7 +23,6 @@ const SituationsTexts = {
       warning: _('Advarsel', 'Warning', 'Advarsel'),
       error: _('Feil', 'Error', 'Feil'),
     },
-    button: _('Lukk', 'Close', 'Lukk'),
     validity: {
       from: (fromDate: string) =>
         _(

--- a/src/translations/components/TravelCard.ts
+++ b/src/translations/components/TravelCard.ts
@@ -28,6 +28,12 @@ const TravelCardTexts = {
             `Saved trip${index}.`,
             `Lagret reise${index}.`,
           );
+        case 'booking':
+          return _(
+            `Bestillingsalternativ${index}.`,
+            `Booking option${index}.`,
+            `Bestillingsalternativ${index}.`,
+          );
       }
     },
     modesPrefix: (modes: string[]) => {

--- a/src/translations/components/TravelCard.ts
+++ b/src/translations/components/TravelCard.ts
@@ -1,4 +1,3 @@
-import {type TravelCardType} from '@atb/screen-components/travel-card';
 import {translation as _} from '../commons';
 
 const TravelCardTexts = {
@@ -8,33 +7,31 @@ const TravelCardTexts = {
       'Activate to see trip details.',
       'Aktivér for å se detaljer om reisen.',
     ),
-    typePrefix: (
-      type: TravelCardType,
-      cardIndex: number,
-      numberOfCards: number,
-    ) => {
-      const singular = numberOfCards === 1;
-      const index = singular ? '' : ` ${cardIndex + 1}`;
-      switch (type) {
-        case 'trip-search':
-          return _(
-            `Reiseforslag${index}.`,
-            `Trip suggestion${index}.`,
-            `Reiseforslag${index}.`,
-          );
-        case 'saved-trip':
-          return _(
-            `Lagret reise${index}.`,
-            `Saved trip${index}.`,
-            `Lagret reise${index}.`,
-          );
-        case 'booking':
-          return _(
-            `Bestillingsalternativ${index}.`,
-            `Booking option${index}.`,
-            `Bestillingsalternativ${index}.`,
-          );
-      }
+    a11yPrefix: {
+      tripSuggestion: (cardIndex: number, numberOfCards: number) => {
+        const index = numberOfCards === 1 ? '' : ` ${cardIndex + 1}`;
+        return _(
+          `Reiseforslag${index}.`,
+          `Trip suggestion${index}.`,
+          `Reiseforslag${index}.`,
+        );
+      },
+      savedTrip: (cardIndex: number, numberOfCards: number) => {
+        const index = numberOfCards === 1 ? '' : ` ${cardIndex + 1}`;
+        return _(
+          `Lagret reise${index}.`,
+          `Saved trip${index}.`,
+          `Lagret reise${index}.`,
+        );
+      },
+      bookingOption: (cardIndex: number, numberOfCards: number) => {
+        const index = numberOfCards === 1 ? '' : ` ${cardIndex + 1}`;
+        return _(
+          `Bestillingsalternativ${index}.`,
+          `Booking option${index}.`,
+          `Bestillingsalternativ${index}.`,
+        );
+      },
     },
     modesPrefix: (modes: string[]) => {
       return _(


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/23646

## Summary
Refactors the `TravelCard` component to be more modular and reuses it for the booking trip selection screen, replacing the previous custom card implementation.

### Key changes

- **Modular TravelCard API** — Replaced the `TravelCardType` enum (`'trip-search' | 'saved-trip' | 'booking'`) with boolean feature flags (`includeDayInfo`, `includeFromToInfo`, `includeLegNotifications`, `includeSituationNotices`), so callers declare exactly which features they need.
- **Tag support** — Added `tagLabel` / `tagType` props to `TravelCard`, rendering a `Tag` inside the card with proper accessibility (reads tag type + label with a screenreader pause).
- **Accessibility prefix** — Replaced the internal type-based a11y prefix with a required `a11yPrefix` prop, giving callers full control over the screenreader prefix text.
- **Disabled state** — Added `isDisabled` prop that visually dims the card and disables interaction.
- **TravelCardNotices** — Extracted situation/notice display into a separate `TravelCardNotices` component shown below the journey legs.
- **Detailed a11y labels** — Added `getDetailedSituationOrNoticeA11yLabel` that reads out per-leg situation/notice text (e.g. "Bus 1: Bus stop has moved").
- **TripSelection cleanup** — Removed `BookingTrip` wrapper, `TripSelectionTag`, and related styles. Consolidated `getBookingTagLabel`/`getBookingTagType` into a single `getBookingTagInfo` helper.
- **Test coverage** — Added 52 tests for `situations/utils.ts` covering notice/situation collection, validity filtering, criticality ranking, and a11y label generation.

### Troms
<img width="320" alt="image" src="https://github.com/user-attachments/assets/f3113a75-490e-436e-9def-ca92f13e6e86" />

### NFK
<img width="320" alt="image" src="https://github.com/user-attachments/assets/15485b44-b710-4e6b-864c-a62d76cb8f40" />
