### PR TITLE
fix: update Poeng design and texts

### DIFF
--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -21,6 +21,7 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
 import {MapPin} from '@atb/assets/svg/mono-icons/tab-bar';
 import {MapFilterType, useMapContext} from '@atb/modules/map';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 
 const shouldShowMapButton = (bonusProduct: BonusProductType) =>
   bonusProduct.formFactors.some(
@@ -37,6 +38,7 @@ export const BonusProductList = ({bonusProducts, onNavigateToMap}: Props) => {
   const styles = useStyles();
   const {mobilityOperators} = useFirestoreConfigurationContext();
   const {mapFilter, setMapFilter} = useMapContext();
+  const analytics = useAnalyticsContext();
 
   const handleNavigateToMap = useCallback(
     (bonusProduct: BonusProductType) => {
@@ -58,67 +60,93 @@ export const BonusProductList = ({bonusProducts, onNavigateToMap}: Props) => {
   return (
     <View style={styles.container}>
       {bonusProducts.map((bonusProduct) => (
-        <Section key={bonusProduct.id}>
-          <GenericSectionItem>
-            <View style={styles.horizontalContainer}>
-              {(() => {
-                const {mode, subMode} = getModeAndSubModeFromFormFactor(
-                  bonusProduct.formFactors[0] as FormFactor,
-                );
-                return (
-                  <TransportationIconBox
-                    mode={mode}
-                    subMode={subMode}
-                    rounded
-                  />
-                );
-              })()}
-              <View style={{flex: 1}}>
-                <ThemeText typography="body__s__strong">
-                  {bonusProduct.formFactors
-                    .map((ff) => t(MobilityTexts.formFactor(ff as FormFactor)))
-                    .join(', ')}
-                </ThemeText>
-                <ThemeText typography="body__s" color="secondary">
-                  {mobilityOperators?.find(
-                    (op) => op.id === bonusProduct.operatorId,
-                  )?.name ?? bonusProduct.operatorId}
+        <Pressable
+          key={bonusProduct.id}
+          onPress={() =>
+            analytics.logEvent('Bonus', 'Bonus product pressed', {
+              productId: bonusProduct.id,
+            })
+          }
+          accessible={false}
+          importantForAccessibility="no"
+        >
+          <Section>
+            <GenericSectionItem>
+              <View style={styles.horizontalContainer}>
+                {(() => {
+                  const {mode, subMode} = getModeAndSubModeFromFormFactor(
+                    bonusProduct.formFactors[0] as FormFactor,
+                  );
+                  return (
+                    <TransportationIconBox
+                      mode={mode}
+                      subMode={subMode}
+                      rounded
+                    />
+                  );
+                })()}
+                <View style={{flex: 1}}>
+                  <ThemeText typography="body__s__strong">
+                    {bonusProduct.formFactors
+                      .map((ff) =>
+                        t(MobilityTexts.formFactor(ff as FormFactor)),
+                      )
+                      .join(', ')}
+                  </ThemeText>
+                  <ThemeText typography="body__s" color="secondary">
+                    {mobilityOperators?.find(
+                      (op) => op.id === bonusProduct.operatorId,
+                    )?.name ?? bonusProduct.operatorId}
+                  </ThemeText>
+                </View>
+                {onNavigateToMap && shouldShowMapButton(bonusProduct) && (
+                  <Pressable
+                    onPress={() => {
+                      analytics.logEvent(
+                        'Bonus',
+                        'Map button on bonus product clicked',
+                        {
+                          productId: bonusProduct.id,
+                        },
+                      );
+                      handleNavigateToMap(bonusProduct);
+                    }}
+                    style={styles.mapButton}
+                    accessibilityRole="button"
+                    accessibilityLabel={t(
+                      BonusProgramTexts.bonusProfile.mapButton.a11yLabel,
+                    )}
+                    accessibilityHint={t(
+                      BonusProgramTexts.bonusProfile.mapButton.a11yHint,
+                    )}
+                  >
+                    <ThemeIcon svg={MapPin} />
+                    <ThemeIcon svg={ChevronRight} />
+                  </Pressable>
+                )}
+              </View>
+            </GenericSectionItem>
+            <GenericSectionItem>
+              <View style={styles.usePointsRow}>
+                <ThemeText>{t(BonusProgramTexts.spend)}</ThemeText>
+                <ThemeIcon svg={BonusStarFill} size="small" />
+                <ThemeText>
+                  {t(BonusProgramTexts.amountPoints(bonusProduct.price.amount))}
                 </ThemeText>
               </View>
-              {onNavigateToMap && shouldShowMapButton(bonusProduct) && (
-                <Pressable
-                  onPress={() => handleNavigateToMap(bonusProduct)}
-                  style={styles.mapButton}
-                  accessibilityRole="button"
-                  accessibilityLabel={t(
-                    BonusProgramTexts.bonusProfile.mapButton.a11yLabel,
-                  )}
-                  accessibilityHint={t(
-                    BonusProgramTexts.bonusProfile.mapButton.a11yHint,
-                  )}
-                >
-                  <ThemeIcon svg={MapPin} />
-                  <ThemeIcon svg={ChevronRight} />
-                </Pressable>
-              )}
-            </View>
-          </GenericSectionItem>
-          <GenericSectionItem>
-            <View style={styles.usePointsRow}>
-              <ThemeText>{t(BonusProgramTexts.spend)}</ThemeText>
-              <ThemeIcon svg={BonusStarFill} size="small" />
-              <ThemeText>
-                {t(BonusProgramTexts.amountPoints(bonusProduct.price.amount))}
+              <ThemeText
+                isMarkdown={true}
+                typography="body__s"
+                color="secondary"
+              >
+                {getTextForLanguage(
+                  bonusProduct.productDescription.description,
+                  language,
+                ) ?? ''}
               </ThemeText>
-            </View>
-            <ThemeText isMarkdown={true} typography="body__s" color="secondary">
-              {getTextForLanguage(
-                bonusProduct.productDescription.description,
-                language,
-              ) ?? ''}
-            </ThemeText>
-          </GenericSectionItem>
-        </Section>
+            </GenericSectionItem>
+          </Section>
+        </Pressable>
       ))}
     </View>
   );
@@ -138,7 +166,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     gap: theme.spacing.xSmall,
-    marginBottom: theme.spacing.xSmall,
+    marginBottom: theme.spacing.small,
   },
   mapButton: {
     flexDirection: 'row',

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusFaqSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusFaqSection.tsx
@@ -1,15 +1,9 @@
-import {BonusProgramTexts, dictionary, useTranslation} from '@atb/translations';
+import {BonusProgramTexts, useTranslation} from '@atb/translations';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {ExpandableSectionItem, Section} from '@atb/components/sections';
 import {useProgramQuery, KnownProgramId} from '@atb/modules/enrollment';
-import {useProductPointsQuery} from '@atb/modules/bonus';
-import type {ProductPointsItem} from '@atb/modules/bonus';
-import {useGetFareProductsQuery} from '@atb/modules/ticketing';
-import {getReferenceDataName} from '@atb/modules/configuration';
 import {formatToVerboseFullDate} from '@atb/utils/date';
-import type {PreassignedFareProduct} from '@atb/modules/ticketing';
-import type {Language, TranslateFunction} from '@atb/translations';
 
 export const BonusFaqSection = () => {
   const {t, language} = useTranslation();
@@ -17,19 +11,8 @@ export const BonusFaqSection = () => {
   const endDateString = bonusProgram?.endAt
     ? formatToVerboseFullDate(bonusProgram.endAt, language)
     : '';
-  const {data: preassignedFareProducts} = useGetFareProductsQuery();
-  const {data: productPoints} = useProductPointsQuery();
-
-  const pointsPerProduct = buildPointsPerProductString(
-    productPoints,
-    preassignedFareProducts,
-    language,
-    t,
-  );
-
   const faqContext = {
     endDate: endDateString,
-    pointsPerProduct,
   };
 
   return (
@@ -52,39 +35,5 @@ export const BonusFaqSection = () => {
         )
       }
     </Section>
-  );
-};
-
-/**
- * Builds a human-readable string describing how many points each ticket type earns.
- * Handles multiple or a single ticket type.
- */
-const buildPointsPerProductString = (
-  productPoints: ProductPointsItem[] | undefined,
-  fareProducts: PreassignedFareProduct[],
-  language: Language,
-  t: TranslateFunction,
-): string => {
-  const parts = (productPoints ?? [])
-    .map((pp) => {
-      const fareProduct = fareProducts.find((fp) => fp.id === pp.fareProduct);
-      if (!fareProduct) return null;
-      const name = getReferenceDataName(fareProduct, language);
-      return t(
-        BonusProgramTexts.bonusProfile.faq.pointsPerProductLabel(
-          pp.value,
-          name.toLowerCase(),
-        ),
-      );
-    })
-    .filter(Boolean);
-
-  if (parts.length <= 1) return parts.join('');
-  return (
-    parts.slice(0, -1).join(', ') +
-    ' ' +
-    t(dictionary.listConcatWord) +
-    ' ' +
-    parts[parts.length - 1]
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -310,7 +310,7 @@ const HowPointsWork = () => {
   const {data: productPoints} = useProductPointsQuery();
 
   const pointsPerProduct = buildPointsPerProductString(
-    productPoints,
+    productPoints ?? [],
     preassignedFareProducts ?? [],
     language,
     t,
@@ -422,19 +422,21 @@ const BonusInfoSectionItem = ({
 };
 
 const buildPointsPerProductString = (
-  productPoints: ProductPointsItem[] | undefined,
+  productPoints: ProductPointsItem[],
   fareProducts: PreassignedFareProduct[],
   language: Language,
   t: TranslateFunction,
 ): string => {
-  const parts = (productPoints ?? [])
-    .map((pp) => {
-      const fareProduct = fareProducts.find((fp) => fp.id === pp.fareProduct);
+  const parts = productPoints
+    .map((productPoint) => {
+      const fareProduct = fareProducts.find(
+        (fareProduct) => fareProduct.id === productPoint.fareProduct,
+      );
       if (!fareProduct) return null;
       const name = getReferenceDataName(fareProduct, language);
       return t(
         BonusProgramTexts.bonusProfile.faq.pointsPerProductLabel(
-          pp.value,
+          productPoint.value,
           name.toLowerCase(),
         ),
       );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -10,6 +10,7 @@ import {
   ProfileTexts,
   useTranslation,
 } from '@atb/translations';
+import type {Language, TranslateFunction} from '@atb/translations';
 import React, {useEffect, useRef, useState} from 'react';
 import {Platform, View} from 'react-native';
 import {openUrl} from '@atb/utils/open-url';
@@ -25,8 +26,10 @@ import {
   UserBonusBalanceContent,
   isActive,
   useBonusBalanceQuery,
+  useProductPointsQuery,
   BonusProductList,
 } from '@atb/modules/bonus';
+import type {ProductPointsItem} from '@atb/modules/bonus';
 import {
   useIsEnrolled,
   useProgramQuery,
@@ -34,7 +37,10 @@ import {
 } from '@atb/modules/enrollment';
 import {useAuthContext} from '@atb/modules/auth';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {
+  useFirestoreConfigurationContext,
+  getReferenceDataName,
+} from '@atb/modules/configuration';
 import {isDefined} from '@atb/utils/presence';
 import {Chat} from '@atb/assets/svg/mono-icons/actions';
 import {LogIn} from '@atb/assets/svg/mono-icons/profile';
@@ -45,6 +51,8 @@ import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {Button} from '@atb/components/button';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {ProfileScreenProps} from './navigation-types';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
+import type {PreassignedFareProduct} from '@atb/modules/ticketing';
 import {formatToDate} from '@atb/utils/date';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {
@@ -233,6 +241,9 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
             />
           )
         )}
+        <ContentHeading text={t(BonusProgramTexts.bonusProfile.faq.heading)} />
+        <BonusFaqSection />
+
         <ContentHeading
           text={t(BonusProgramTexts.bonusProfile.feedback.heading)}
         />
@@ -246,8 +257,6 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
             }}
           />
         </Section>
-        <ContentHeading text={t(BonusProgramTexts.bonusProfile.faq.heading)} />
-        <BonusFaqSection />
       </View>
     </FullScreenView>
   );
@@ -263,7 +272,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    gap: theme.spacing.medium,
+    gap: theme.spacing.large,
   },
   currentBalanceDisplay: {
     flexDirection: 'row',
@@ -295,8 +304,17 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
 }));
 
 const HowPointsWork = () => {
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const {bonusProducts, mobilityOperators} = useFirestoreConfigurationContext();
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
+  const {data: productPoints} = useProductPointsQuery();
+
+  const pointsPerProduct = buildPointsPerProductString(
+    productPoints,
+    preassignedFareProducts ?? [],
+    language,
+    t,
+  );
 
   const getOperatorName = (operatorId: string) => {
     return (
@@ -320,7 +338,9 @@ const HowPointsWork = () => {
         <BonusInfoSectionItem
           title={t(BonusProgramTexts.bonusProfile.readMore.earnPoints.title)}
           description={t(
-            BonusProgramTexts.bonusProfile.readMore.earnPoints.description,
+            BonusProgramTexts.bonusProfile.readMore.earnPoints.description(
+              pointsPerProduct,
+            ),
           )}
           SymbolComponent={
             <ThemedBonusTransaction height={iconSize} width={iconSize} />
@@ -398,5 +418,35 @@ const BonusInfoSectionItem = ({
         {SymbolComponent}
       </View>
     </GenericSectionItem>
+  );
+};
+
+const buildPointsPerProductString = (
+  productPoints: ProductPointsItem[] | undefined,
+  fareProducts: PreassignedFareProduct[],
+  language: Language,
+  t: TranslateFunction,
+): string => {
+  const parts = (productPoints ?? [])
+    .map((pp) => {
+      const fareProduct = fareProducts.find((fp) => fp.id === pp.fareProduct);
+      if (!fareProduct) return null;
+      const name = getReferenceDataName(fareProduct, language);
+      return t(
+        BonusProgramTexts.bonusProfile.faq.pointsPerProductLabel(
+          pp.value,
+          name.toLowerCase(),
+        ),
+      );
+    })
+    .filter(Boolean);
+
+  if (parts.length <= 1) return parts.join('');
+  return (
+    parts.slice(0, -1).join(', ') +
+    ' ' +
+    t(dictionary.listConcatWord) +
+    ' ' +
+    parts[parts.length - 1]
   );
 };

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -2,7 +2,6 @@ import {translation as _} from '../../commons';
 
 export type BonusFaqContext = {
   endDate: string;
-  pointsPerProduct: string;
 };
 
 const BonusProgramTexts = {
@@ -57,14 +56,14 @@ const BonusProgramTexts = {
 
     joinProgram: {
       title: _(
-        'Vil du samle Poeng?',
-        'Do you want to earn Points?',
-        'Vil du samle Poeng?',
+        'Tjen poeng på enkeltbilletter!',
+        'Earn Points on single tickets!',
+        'Tjen poeng på enkeltbilletter!',
       ),
       description: _(
-        'Kjøp enkeltbilletter for voksen eller student i sone A og få Poeng. Bruk Poeng på turer med bysykkel og Hyre-biler.',
-        'Buy single tickets for adults or students in zone A and earn Points. Use the Points on trips with city bikes and Hyre cars.',
-        'Kjøp enkeltbilletter for vaksen eller student i sone A og få Poeng. Bruk Poeng på turer med bysykkel og Hyre-biler.',
+        'Du tjener Poeng hver gang du kjøper en enkeltbillett for voksen eller student i sone A. Bruk Poeng på turer med bysykler og Hyre-biler.',
+        'You earn Points every time you buy a single ticket for adults or students in zone A. Use the Points on trips with city bikes and Hyre cars.',
+        'Du tener Poeng kvar gong du kjøper ein enkeltbillett for vaksen eller student i sone A. Bruk Poeng på turer med bysykkler og Hyre-biler.',
       ),
       footer: (endDate: string) =>
         _(
@@ -137,25 +136,32 @@ const BonusProgramTexts = {
           'Last ned appane fyrst',
         ),
         description: _(
-          'Du må laste ned og logge inn i appene til Hyre og Trondheim Bysykkel før du bruker Poeng.',
-          'You need to download and log in to the apps for Hyre and Trondheim City Bike before using Points.',
-          'Du må lasta ned og logga inn i appane til Hyre og Trondheim Bysykkel før du brukar Poeng.',
+          'Du må laste ned og logge inn i appene til Trondheim Bysykkel og Hyre før du bruker Poeng.',
+          'You need to download and log in to the apps for Trondheim City Bike and Hyre before using Points.',
+          'Du må lasta ned og logga inn i appane til Trondheim Bysykkel og Hyre før du brukar Poeng.',
         ),
       },
       earnPoints: {
-        title: _('Samle Poeng', 'Earn Points', 'Samle Poeng'),
-        description: _(
-          'Kjøp enkeltbilletter for voksen eller student i sone A og få Poeng.',
-          'Buy single tickets for adults or students in zone A and earn Points.',
-          'Kjøp enkeltbilletter for vaksen eller student i sone A og få Poeng.',
-        ),
+        title: _('Tjen Poeng', 'Earn Points', 'Tjen Poeng'),
+        description: (pointsPerProduct: string) =>
+          pointsPerProduct
+            ? _(
+                `Du tjener ${pointsPerProduct} for voksen eller student i sone A.`,
+                `You earn ${pointsPerProduct} for adults or students in zone A.`,
+                `Du tjener ${pointsPerProduct} for vaksen eller student i sone A.`,
+              )
+            : _(
+                'Du tjener Poeng hver gang du kjøper en enkeltbillett for voksen eller student i sone A.',
+                'You earn Points every time you buy a single ticket for adults or students in zone A.',
+                'Du tener Poeng kvar gong du kjøper ein enkeltbillett for vaksen eller student i sone A.',
+              ),
       },
       spendPoints: {
         title: _('Bruk Poeng', 'Spend Points', 'Bruk Poeng'),
         description: _(
-          'Poengene kan du bruke til å betale for  turer med bysykkel og Hyre-biler.',
-          'You can spend the points to pay for trips with city bikes and Hyre cars.',
-          'Poenga kan du bruke til å betale for turer med bysykkel og Hyre-biler.',
+          'Du kan bruke Poeng på turer med bysykler og Hyre-biler.',
+          'You may use Points on trips with city bikes and Hyre cars.',
+          'Du kan bruke Poeng på turer med bysykler og Hyre-biler.',
         ),
       },
       downloadOperator: (operator: string) =>
@@ -182,28 +188,15 @@ const BonusProgramTexts = {
       faqs: [
         {
           question: _(
-            'Hvordan tjener jeg Poeng?',
-            'How do I earn Points?',
-            'Korleis tener eg Poeng?',
-          ),
-          answer: ({pointsPerProduct}: BonusFaqContext) =>
-            _(
-              `Du får ${pointsPerProduct} for voksen eller student i sone A.`,
-              `You earn ${pointsPerProduct} for adults or students in zone A.`,
-              `Du får ${pointsPerProduct} for vaksen eller student i sone A.`,
-            ),
-        },
-        {
-          question: _(
-            'Hvordan bruker jeg Poengene?',
-            'How do I use the Points?',
-            'Korleis brukar eg Poenga?',
+            'Hvordan bruker jeg Poeng?',
+            'How do I use Points?',
+            'Korleis brukar eg Poeng?',
           ),
           answer: () =>
             _(
-              'Når du har samlet nok Poeng, kan du bruke dem på turer med bysykkel og Hyre-bil som du finner i kartet. For å bruke Poeng i kartet, trykker du på ikonet for bysykkel eller Hyre-bil, og krysser av for at du vil bruke Poeng før du starter turen.',
+              'Når du har samlet nok Poeng, kan du bruke dem på turer med bysykler og Hyre-biler som du finner i kartet. For å bruke Poeng i kartet, trykker du på ikonet for bysykkel eller Hyre-bil, og krysser av for at du vil bruke Poeng før du starter turen.',
               'When you have collected enough Points, you can use them on trips with city bikes and Hyre cars that you find in the map. To use Points in the map, tap on the icon for city bike or Hyre car, and check the box that you want to use Points before you start the trip.',
-              'Når du har samla nok Poeng, kan du bruke dem på turer med bysykkel og Hyre-bil som du finn i kartet. For å bruke Poeng i kartet, trykker du på ikonet for bysykkel eller Hyre-bil, og krysser av for at du vil bruke Poeng før du startar turen.',
+              'Når du har samla nok Poeng, kan du bruke dem på turer med bysykler og Hyre-biler som du finn i kartet. For å bruke Poeng i kartet, trykker du på ikonet for bysykkel eller Hyre-bil, og krysser av for at du vil bruke Poeng før du startar turen.',
             ),
         },
         {


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23551
closes https://github.com/AtB-AS/kundevendt/issues/23564
closes https://github.com/AtB-AS/kundevendt/issues/23555

## Description
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f534e26d-3299-456f-af0c-f840220d0d57" /> <img width="200" halt="image" src="https://github.com/user-attachments/assets/e3b2a5be-52df-4184-9be8-c3916fe4d42c" />

Some updates worth noting:
- 'Tjene' is now used all over regarding Points (not 'samle' or 'få')
- Info about how many points earned per ticket is moved up (under 'Slik Funker det')
  - Text now makes more sense also before user joins
