### PR TITLE
feat: patch rnmapbox

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         // Setting androidXBrowser to avoid react-native-reborn picking newest alpha requiring SDK 33
         androidXBrowser = "1.7.0"
         RNMapboxMapsImpl = "mapbox"
-        RNMapboxMapsVersion = '11.18.0'
+        RNMapboxMapsVersion = '11.18.2'
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "27.1.12297006"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,7 +30,7 @@ $RNFirebaseAsStaticFramework = true
 production = ENV["PRODUCTION"] == "1"
 
 $RNMapboxMapsImpl = 'mapbox'
-$RNMapboxMapsVersion = '~> 11.16.2'
+$RNMapboxMapsVersion = '~> 11.18.2'
 
 target 'app' do
   config = use_native_modules!

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1522,7 +1522,7 @@ PODS:
     - SwiftNIOSSL (< 3.0.0, >= 2.14.0)
     - SwiftNIOTransportServices (< 2.0.0, >= 1.11.1)
     - SwiftProtobuf (< 2.0.0, >= 1.19.0)
-  - GTMSessionFetcher/Core (5.1.0)
+  - GTMSessionFetcher/Core (5.2.0)
   - hermes-engine (0.14.1):
     - hermes-engine/Pre-built (= 0.14.1)
   - hermes-engine/Pre-built (0.14.1)
@@ -1558,13 +1558,13 @@ PODS:
     - Yoga
   - leveldb-library (1.22.6)
   - Logging (1.4.0)
-  - MapboxCommon (24.16.6):
+  - MapboxCommon (24.18.3):
     - Turf (= 4.0.0)
-  - MapboxCoreMaps (11.16.6):
-    - MapboxCommon (= 24.16.6)
-  - MapboxMaps (11.16.6):
-    - MapboxCommon (= 24.16.6)
-    - MapboxCoreMaps (= 11.16.6)
+  - MapboxCoreMaps (11.18.3):
+    - MapboxCommon (= 24.18.3)
+  - MapboxMaps (11.18.3):
+    - MapboxCommon (= 24.18.3)
+    - MapboxCoreMaps (= 11.18.3)
     - Turf (= 4.0.0)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -4542,19 +4542,19 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - rnmapbox-maps (10.2.10):
-    - MapboxMaps (~> 11.16.2)
+  - rnmapbox-maps (10.3.0):
+    - MapboxMaps (~> 11.18.2)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.2.10)
+    - rnmapbox-maps/DynamicLibrary (= 10.3.0)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.2.10):
+  - rnmapbox-maps/DynamicLibrary (10.3.0):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - hermes-engine
-    - MapboxMaps (~> 11.16.2)
+    - MapboxMaps (~> 11.18.2)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -5602,15 +5602,15 @@ SPEC CHECKSUMS:
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   gRPC-Swift: 74adcaaa62ac5e0a018938840328cb1fdfb09e7b
-  GTMSessionFetcher: b8ab00db932816e14b0a0664a08cb73dda6d164b
-  hermes-engine: c3c1c691a6affcaac5e62c2f993626c251f52ad3
+  GTMSessionFetcher: 904bdd2a82c635bcd6f44edf94cc8775c5d1d6e6
+  hermes-engine: ab88302bc714f68a347ac3ea3787af0a6ea62f21
   Intercom: aca703f001cf9470b1f13b72cb8cc969a09bafca
   intercom-react-native: c8ee5e7d845955c5f6898c0f094ebcf1d6db9255
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MapboxCommon: 10cbf74edb23c9abcfe2424899d804f288a47334
-  MapboxCoreMaps: f19680d20681797067268284b2292349de861730
-  MapboxMaps: 04c7bf46d66265ad0f4b98484a251777a926c423
+  MapboxCommon: 371fd6db596531464b6fd751ae7daa382fe2da2b
+  MapboxCoreMaps: 811c4196843f5554b10a807d1231270d372ff148
+  MapboxMaps: 0e8fdc25eb3b1c2ff5cf9317266fe984eeb0e18f
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23
@@ -5710,7 +5710,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: c6327cf6e2bd384dc90351ccfff0da8142d62f54
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
   RNLocalize: d8ccb568b40c72c767714db3808ce66a1ecf444a
-  rnmapbox-maps: af4fbec8592157b79d58db9d1464afc81f113f65
+  rnmapbox-maps: 1ade98ee061bc056539dad3571ca1003a29631f1
   RNPermissions: aa40c7e2acdc1e3f0ed85814657fb2841874006d
   RNReanimated: 9160d535792c6b3f9d1974d7bf5c5813afce1c91
   RNScreens: 199799bdab32fa1e17ebf938b06fec52033e81e5
@@ -5737,6 +5737,6 @@ SPEC CHECKSUMS:
   VisionCamera: 30b358b807324c692064f78385e9a732ce1bebfe
   Yoga: 40d1c9b0a92e75e3d9fdaffe6fbe695d72d83de4
 
-PODFILE CHECKSUM: ccc2a5b300396a61b5f4ee82d3c9a7b58cd103be
+PODFILE CHECKSUM: ea11d4aea655f7dfc5e0412e9c22c639eb01c076
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@react-navigation/material-top-tabs": "^7.4.12",
     "@react-navigation/native": "^7.1.27",
     "@react-navigation/stack": "^7.6.14",
-    "@rnmapbox/maps": "^10.2.10",
+    "@rnmapbox/maps": "10.3.0",
     "@sayem314/react-native-keep-awake": "^1.4.0",
     "@seznam/compose-react-refs": "^1.0.6",
     "@shopify/react-native-skia": "^2.4.21",

--- a/patches/@rnmapbox+maps+10.3.0.patch
+++ b/patches/@rnmapbox+maps+10.3.0.patch
@@ -1,3 +1,66 @@
+diff --git a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
+index bfbeff4..a270d5b 100644
+--- a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
++++ b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
+@@ -66,6 +66,11 @@ class RNMBXBackgroundLayerManager : ViewGroupManager<RNMBXBackgroundLayer>(),
+         layer.setFilter(filterList.asArray())
+     }
+ 
++    @ReactProp(name = "slot")
++    override fun setSlot(layer: RNMBXBackgroundLayer, slot: Dynamic) {
++        layer.setSlot(slot.asString())
++    }
++
+     companion object {
+         const val REACT_CLASS = "RNMBXBackgroundLayer"
+     }
+diff --git a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
+index 8f1a3ee..8ab230a 100644
+--- a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
++++ b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
+@@ -71,6 +71,11 @@ class RNMBXFillExtrusionLayerManager : ViewGroupManager<RNMBXFillExtrusionLayer>
+         layer.setFilter(filterList.asArray())
+     }
+ 
++    @ReactProp(name = "slot")
++    override fun setSlot(layer: RNMBXFillExtrusionLayer, slot: Dynamic) {
++        layer.setSlot(slot.asString())
++    }
++
+     companion object {
+         const val REACT_CLASS = "RNMBXFillExtrusionLayer"
+     }
+diff --git a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
+index 838851d..af2b24c 100644
+--- a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
++++ b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
+@@ -66,6 +66,11 @@ class RNMBXSkyLayerManager : ViewGroupManager<RNMBXSkyLayer>(),
+         layer.setFilter(filterList.asArray())
+     }
+ 
++    @ReactProp(name = "slot")
++    override fun setSlot(layer: RNMBXSkyLayer, slot: Dynamic) {
++        layer.setSlot(slot.asString())
++    }
++
+     companion object {
+         const val REACT_CLASS = "RNMBXSkyLayer"
+     }
+diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h
+index 974ee24..67bbc6a 100644
+--- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h
++++ b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h
+@@ -105,6 +105,10 @@ void RNMBXSetCommonLayerPropsWithoutSourceID(const T& newProps, RNMBXLayer *_vie
+     if (minZoomLevel != nil) {
+         _view.minZoomLevel = minZoomLevel;
+     }
++    id slot = RNMBXConvertFollyDynamicToId(newProps.slot);
++    if (slot != nil) {
++        _view.slot = slot;
++    }
+ }
+ 
+ template <typename T>
 diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm
 index 6ee6808..ca7efa2 100644
 --- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -14,3 +77,39 @@ index 6ee6808..ca7efa2 100644
      RNMBX_REMAP_OPTIONAL_PROP_NSDictionary(gestureSettings, reactGestureSettings)
  
      id preferredFramesPerSecond = RNMBXConvertFollyDynamicToId(newViewProps.preferredFramesPerSecond);
+diff --git a/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts b/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts
+index fb1bcc8..59cd3ea 100644
+--- a/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts
++++ b/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts
+@@ -21,6 +21,7 @@ export interface NativeProps extends ViewProps {
+ 
+   maxZoomLevel?: OptionalProp<Double>;
+   minZoomLevel?: OptionalProp<Double>;
++  slot?: OptionalProp<string>;
+ }
+ 
+ // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
+diff --git a/node_modules/@rnmapbox/maps/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts b/node_modules/@rnmapbox/maps/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts
+index 9cced9e..5909e2b 100644
+--- a/node_modules/@rnmapbox/maps/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts
++++ b/node_modules/@rnmapbox/maps/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts
+@@ -22,6 +22,7 @@ export interface NativeProps extends ViewProps {
+   maxZoomLevel?: OptionalProp<Double>;
+   minZoomLevel?: OptionalProp<Double>;
+   sourceLayerID?: OptionalProp<string>;
++  slot?: OptionalProp<string>;
+ }
+ 
+ // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
+diff --git a/node_modules/@rnmapbox/maps/src/specs/RNMBXSkyLayerNativeComponent.ts b/node_modules/@rnmapbox/maps/src/specs/RNMBXSkyLayerNativeComponent.ts
+index 27f7e2f..6e28347 100644
+--- a/node_modules/@rnmapbox/maps/src/specs/RNMBXSkyLayerNativeComponent.ts
++++ b/node_modules/@rnmapbox/maps/src/specs/RNMBXSkyLayerNativeComponent.ts
+@@ -21,6 +21,7 @@ export interface NativeProps extends ViewProps {
+ 
+   maxZoomLevel?: OptionalProp<Double>;
+   minZoomLevel?: OptionalProp<Double>;
++  slot?: OptionalProp<string>;
+ }
+ 
+ // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast

--- a/patches/@rnmapbox+maps+10.3.0.patch
+++ b/patches/@rnmapbox+maps+10.3.0.patch
@@ -46,6 +46,59 @@ index 838851d..af2b24c 100644
      companion object {
          const val REACT_CLASS = "RNMBXSkyLayer"
      }
+diff --git a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt
+index 66280ed..4e23817 100644
+--- a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt
++++ b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt
+@@ -18,6 +18,9 @@ import com.rnmapbox.rnmbx.v11compat.feature.*
+ 
+ class RNMBXVectorSource(context: Context?, private val mManager: RNMBXVectorSourceManager) :
+     RNMBXTileSource<VectorSource?>(context) {
++    
++    var volatile: Boolean? = null
++
+     override fun onPress(event: OnPressEvent?) {
+         mManager.handleEvent(FeatureClickEvent.makeVectorSourceEvent(this, event))
+     }
+@@ -35,15 +38,13 @@ class RNMBXVectorSource(context: Context?, private val mManager: RNMBXVectorSour
+             return mMap!!.getStyle()!!.getSource(DEFAULT_ID) as VectorSource
+         }
+         val configurationUrl = uRL
+-        return if (configurationUrl != null) {
+-            VectorSource(
+-                VectorSource.Builder(id)
+-                    .url(configurationUrl)
+-            )
+-        } else VectorSource(
+-            VectorSource.Builder(id)
+-                .tileSet(buildTileset())
+-        )
++        val builder = if (configurationUrl != null) {
++            VectorSource.Builder(id).url(configurationUrl)
++        } else {
++            VectorSource.Builder(id).tileSet(buildTileset())
++        }
++        volatile?.let { builder.volatile(it) }
++        return VectorSource(builder)
+     }
+ 
+     fun querySourceFeatures(
+diff --git a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
+index 68d619f..edc49a8 100644
+--- a/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
++++ b/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
+@@ -44,6 +44,11 @@ class RNMBXVectorSourceManager(reactApplicationContext: ReactApplicationContext)
+         view.mExisting = value.asBoolean()
+     }
+ 
++    @ReactProp(name = "isVolatile")
++    override fun setIsVolatile(view: RNMBXVectorSource, value: Dynamic) {
++        view.volatile = value.asBoolean()
++    }
++
+     override fun customEvents(): Map<String, String>? {
+         return eventMapOf(
+             EventKeys.VECTOR_SOURCE_LAYER_CLICK to "onMapboxVectorSourcePress",
 diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h
 index 974ee24..67bbc6a 100644
 --- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXFabricHelpers.h
@@ -77,6 +130,133 @@ index 6ee6808..ca7efa2 100644
      RNMBX_REMAP_OPTIONAL_PROP_NSDictionary(gestureSettings, reactGestureSettings)
  
      id preferredFramesPerSecond = RNMBXConvertFollyDynamicToId(newViewProps.preferredFramesPerSecond);
+diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXSource.swift b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXSource.swift
+index d13af2a..317238d 100644
+--- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXSource.swift
++++ b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXSource.swift
+@@ -29,6 +29,10 @@ public class RNMBXSource : RNMBXInteractiveElement {
+     fatalError("Subclasses should override makeSource")
+   }
+ 
++  func doAddSource(style: Style, source: Source) throws {
++    try style.addSource(source)
++  }
++  
+   // MARK: - UIView+React
+ 
+   @objc public override func insertReactSubview(_ subview: UIView!, at atIndex: Int) {
+@@ -108,7 +112,7 @@ public class RNMBXSource : RNMBXInteractiveElement {
+       self.ownsSource = true
+       self.source = source
+       logged("SyleSource.addToMap", info: {"id: \(optional: self.id)"}) {
+-        try style.addSource(source)
++        try self.doAddSource(style: style, source: source)
+       }
+     }
+ 
+diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSource.swift b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSource.swift
+index ad07b5b..8a5a134 100644
+--- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSource.swift
++++ b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSource.swift
+@@ -8,6 +8,7 @@ public class RNMBXVectorSource : RNMBXTileSource {
+   @objc public var minZoomLevel: NSNumber?
+   @objc public var tileUrlTemplates: [String] = []
+   @objc public var tms: Bool = false
++  @objc public var isVolatile: NSNumber?
+   
+   override func sourceType() -> Source.Type {
+     return VectorSource.self
+@@ -33,10 +34,25 @@ public class RNMBXVectorSource : RNMBXTileSource {
+     if tms {
+       result.scheme = .tms
+     }
++    if let isVolatile = isVolatile {
++      result.volatile = isVolatile.boolValue
++    }
+     return result
+   }
+   
+-  
++  override func doAddSource(style: Style, source: Source) throws {
++    guard let isVolatile = isVolatile else {
++      try style.addSource(source)
++      return
++    }
++    let data = try JSONEncoder().encode(source as? VectorSource ?? VectorSource(id: self.id))
++    guard var properties = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
++      try style.addSource(source)
++      return
++    }
++    properties["volatile"] = isVolatile.boolValue
++    try style.addSource(withId: self.id, properties: properties)
++  }
+   
+   /*
+   - (nullable MGLSource*)makeSource
+diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSourceComponentView.mm b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSourceComponentView.mm
+index a8bf74c..1a406df 100644
+--- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSourceComponentView.mm
++++ b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXVectorSourceComponentView.mm
+@@ -117,6 +117,10 @@ - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &
+     if (tms != nil) {
+         _view.tms = tms;
+     }
++    id isVolatile = RNMBXConvertFollyDynamicToId(newProps.isVolatile);
++    if (isVolatile != nil) {
++        _view.isVolatile = isVolatile;
++    }
+     id attribution = RNMBXConvertFollyDynamicToId(newProps.attribution);
+     if (attribution != nil) {
+         _view.attribution = attribution;
+diff --git a/node_modules/@rnmapbox/maps/lib/module/components/VectorSource.js b/node_modules/@rnmapbox/maps/lib/module/components/VectorSource.js
+index 72a72a9..e9523a9 100644
+--- a/node_modules/@rnmapbox/maps/lib/module/components/VectorSource.js
++++ b/node_modules/@rnmapbox/maps/lib/module/components/VectorSource.js
+@@ -69,6 +69,7 @@ class VectorSource extends AbstractSource {
+       minZoomLevel: this.props.minZoomLevel,
+       maxZoomLevel: this.props.maxZoomLevel,
+       tms: this.props.tms,
++      isVolatile: this.props.volatile,
+       attribution: this.props.attribution,
+       hitbox: this.props.hitbox,
+       hasPressListener: isFunction(this.props.onPress),
+diff --git a/node_modules/@rnmapbox/maps/lib/module/specs/RNMBXVectorSourceNativeComponent.ts b/node_modules/@rnmapbox/maps/lib/module/specs/RNMBXVectorSourceNativeComponent.ts
+index f7aa0ee..cce51af 100644
+--- a/node_modules/@rnmapbox/maps/lib/module/specs/RNMBXVectorSourceNativeComponent.ts
++++ b/node_modules/@rnmapbox/maps/lib/module/specs/RNMBXVectorSourceNativeComponent.ts
+@@ -19,6 +19,7 @@ export interface NativeProps extends ViewProps {
+   maxZoomLevel: UnsafeMixed<Double>;
+   minZoomLevel: UnsafeMixed<Double>;
+   tms: UnsafeMixed<boolean>;
++  isVolatile: UnsafeMixed<boolean>;
+   hasPressListener: UnsafeMixed<boolean>;
+   hitbox: UnsafeMixed<any>;
+   onMapboxVectorSourcePress: DirectEventHandler<OnMapboxVectorSourcePressEventType>;
+diff --git a/node_modules/@rnmapbox/maps/src/components/VectorSource.tsx b/node_modules/@rnmapbox/maps/src/components/VectorSource.tsx
+index 51afb11..9dcb4b7 100644
+--- a/node_modules/@rnmapbox/maps/src/components/VectorSource.tsx
++++ b/node_modules/@rnmapbox/maps/src/components/VectorSource.tsx
+@@ -53,6 +53,12 @@ interface Props {
+    */
+   tms?: boolean;
+ 
++  /**
++   * A setting to determine whether a source's tiles are cached locally.
++   * If true, tiles are not cached and re-requested every time they are needed.
++   */
++  volatile?: boolean;
++
+   /**
+    * An HTML or literal text string defining the buttons to be displayed in an action sheet when the
+    * source is part of a map view’s style and the map view’s attribution button is pressed.
+@@ -154,6 +160,7 @@ class VectorSource extends AbstractSource<Props, NativeProps> {
+       minZoomLevel: this.props.minZoomLevel,
+       maxZoomLevel: this.props.maxZoomLevel,
+       tms: this.props.tms,
++      isVolatile: this.props.volatile,
+       attribution: this.props.attribution,
+       hitbox: this.props.hitbox,
+       hasPressListener: isFunction(this.props.onPress),
 diff --git a/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts b/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts
 index fb1bcc8..59cd3ea 100644
 --- a/node_modules/@rnmapbox/maps/src/specs/RNMBXBackgroundLayerNativeComponent.ts
@@ -113,3 +293,15 @@ index 27f7e2f..6e28347 100644
  }
  
  // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
+diff --git a/node_modules/@rnmapbox/maps/src/specs/RNMBXVectorSourceNativeComponent.ts b/node_modules/@rnmapbox/maps/src/specs/RNMBXVectorSourceNativeComponent.ts
+index f7aa0ee..cce51af 100644
+--- a/node_modules/@rnmapbox/maps/src/specs/RNMBXVectorSourceNativeComponent.ts
++++ b/node_modules/@rnmapbox/maps/src/specs/RNMBXVectorSourceNativeComponent.ts
+@@ -19,6 +19,7 @@ export interface NativeProps extends ViewProps {
+   maxZoomLevel: UnsafeMixed<Double>;
+   minZoomLevel: UnsafeMixed<Double>;
+   tms: UnsafeMixed<boolean>;
++  isVolatile: UnsafeMixed<boolean>;
+   hasPressListener: UnsafeMixed<boolean>;
+   hitbox: UnsafeMixed<any>;
+   onMapboxVectorSourcePress: DirectEventHandler<OnMapboxVectorSourcePressEventType>;

--- a/patches/@rnmapbox+maps+10.3.0.patch
+++ b/patches/@rnmapbox+maps+10.3.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm
+index 6ee6808..ca7efa2 100644
+--- a/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm
++++ b/node_modules/@rnmapbox/maps/ios/RNMBX/RNMBXMapViewComponentView.mm
+@@ -193,6 +193,11 @@ - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &
+ 
+     RNMBX_REMAP_OPTIONAL_PROP_BOOL(pitchEnabled, reactPitchEnabled)
+   
++    id maxPitch = RNMBXConvertFollyDynamicToId(newViewProps.maxPitch);
++    if (maxPitch != nil) {
++        _view.reactMaxPitch = maxPitch;
++    }
++
+     RNMBX_REMAP_OPTIONAL_PROP_NSDictionary(gestureSettings, reactGestureSettings)
+ 
+     id preferredFramesPerSecond = RNMBXConvertFollyDynamicToId(newViewProps.preferredFramesPerSecond);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,10 +3488,10 @@
     color "^4.2.3"
     use-latest-callback "^0.2.4"
 
-"@rnmapbox/maps@^10.2.10":
-  version "10.2.10"
-  resolved "https://registry.yarnpkg.com/@rnmapbox/maps/-/maps-10.2.10.tgz#5ba121ffd1017e5a5550e9d4829f53701e87ce87"
-  integrity sha512-OfjW0rHp5bUWfzBo5fZ7qdKwAzGoocXYTsSssSPVMxZ2Y7axuhcbmsO5bV6gg+BJs5RwEsghzwTIoGydBNUClA==
+"@rnmapbox/maps@10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@rnmapbox/maps/-/maps-10.3.0.tgz#73954ab3f87895ce543b5f07e59d3d0dbf97fba0"
+  integrity sha512-g5A6hkz6imuA5qy3EGQIbtaofBUbP2YiiyKzj7GJ9ryRXC9gRsnVaJ/8pmAts+0/aIZ5o5w63eboTKjCdO2HrQ==
   dependencies:
     "@turf/along" "6.5.0"
     "@turf/distance" "6.5.0"


### PR DESCRIPTION
_Can be reviewed commit by commit._

Upgrade and patch rnmapbox.
Two existing props weren't propagated correctly, but are now: `maxPitch` and `slot`.
`volatile` support was missing completely in the rnmapbox wrapper, but is added now.

This allows us to do the following in upcoming PRs:
- control how far users can tilt the map (relevant for mitigating number of tile requests)
- fix a bug for geofencing zones where layers were removed and re-added when toggled
- remove hacky workarounds where we add layers in styleJSON and refer to them as existing

Note:
- there is an existing PR in the rnmapbox repo to fix maxPitch: https://github.com/rnmapbox/maps/pull/4191/changes
- I might create PRs for the other two fixes

Acceptance Criteria:
- [x] There should be no changes to the map until we actually use the new props. Just ensure that the new rnmapbox version + patch works well.