### PR TITLE
feat: enforce maxCountPerOrder limitation on orders

### DIFF
--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-user-profiles.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-user-profiles.test.ts
@@ -11,6 +11,7 @@ import {
   isSelectableSupplementProduct,
   isSelectableProfile,
   isWithinUserProfileMaxCount,
+  isWithinMaxCountPerOrder,
 } from '../utils';
 
 describe('purchaseSelectionBuilder - userProfiles', () => {
@@ -446,5 +447,116 @@ describe('isSelectableSupplementProduct - undefined limitations', () => {
     expect(isSelectableSupplementProduct(selection, supplementProduct)).toBe(
       true,
     );
+  });
+});
+
+describe('isWithinMaxCountPerOrder', () => {
+  it('returns true when maxCountPerOrder is undefined', () => {
+    const product = {
+      ...TEST_PRODUCT,
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        maxCountPerOrder: undefined,
+      },
+    };
+    expect(
+      isWithinMaxCountPerOrder(product, [{...TEST_USER_PROFILE, count: 100}]),
+    ).toBe(true);
+  });
+
+  it('returns true when total count is within maxCountPerOrder', () => {
+    const product = {
+      ...TEST_PRODUCT,
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        maxCountPerOrder: 5,
+      },
+    };
+    expect(
+      isWithinMaxCountPerOrder(product, [
+        {...TEST_USER_PROFILE, id: 'UP1', count: 2},
+        {...TEST_USER_PROFILE, id: 'UP2', count: 2},
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns true when total count equals maxCountPerOrder', () => {
+    const product = {
+      ...TEST_PRODUCT,
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        maxCountPerOrder: 3,
+      },
+    };
+    expect(
+      isWithinMaxCountPerOrder(product, [
+        {...TEST_USER_PROFILE, id: 'UP1', count: 2},
+        {...TEST_USER_PROFILE, id: 'UP2', count: 1},
+      ]),
+    ).toBe(true);
+  });
+
+  it('returns false when total count exceeds maxCountPerOrder', () => {
+    const product = {
+      ...TEST_PRODUCT,
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        maxCountPerOrder: 3,
+      },
+    };
+    expect(
+      isWithinMaxCountPerOrder(product, [
+        {...TEST_USER_PROFILE, id: 'UP1', count: 2},
+        {...TEST_USER_PROFILE, id: 'UP2', count: 2},
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe('purchaseSelectionBuilder - maxCountPerOrder', () => {
+  it('Should not apply user profiles when total count exceeds maxCountPerOrder', () => {
+    const originalSelection: PurchaseSelectionType = {
+      ...TEST_SELECTION,
+      preassignedFareProduct: {
+        ...TEST_PRODUCT,
+        limitations: {
+          ...TEST_PRODUCT.limitations,
+          maxCountPerOrder: 3,
+        },
+      },
+    };
+
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(originalSelection)
+      .userProfiles([
+        {...TEST_USER_PROFILE, id: 'UP1', count: 2},
+        {...TEST_USER_PROFILE, id: 'UP2', count: 2},
+      ])
+      .build();
+
+    expect(selection).toBe(originalSelection);
+  });
+
+  it('Should apply user profiles when total count is within maxCountPerOrder', () => {
+    const originalSelection: PurchaseSelectionType = {
+      ...TEST_SELECTION,
+      preassignedFareProduct: {
+        ...TEST_PRODUCT,
+        limitations: {
+          ...TEST_PRODUCT.limitations,
+          maxCountPerOrder: 5,
+        },
+      },
+    };
+
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(originalSelection)
+      .userProfiles([
+        {...TEST_USER_PROFILE, id: 'UP1', count: 2},
+        {...TEST_USER_PROFILE, id: 'UP2', count: 3},
+      ])
+      .build();
+
+    expect(selection.userProfilesWithCount).toHaveLength(2);
   });
 });

--- a/src/modules/purchase-selection/purchase-selection-builder.ts
+++ b/src/modules/purchase-selection/purchase-selection-builder.ts
@@ -15,6 +15,7 @@ import {
   isSelectableSupplementProduct,
   isSelectableZone,
   isValidSelection,
+  isWithinMaxCountPerOrder,
   isWithinUserProfileMaxCount,
 } from './utils';
 import {isValidDateTimeString} from '@atb/utils/date';
@@ -166,6 +167,10 @@ const createBuilder = (
       const areProfilesWithinMaxCount = onlyProfilesWithActualCount.every((p) =>
         isWithinUserProfileMaxCount(currentSelection.preassignedFareProduct, p),
       );
+      const isWithinOrderMax = isWithinMaxCountPerOrder(
+        currentSelection.preassignedFareProduct,
+        onlyProfilesWithActualCount,
+      );
       const areSupplementProductsValid =
         onlySupplementProductsWithActualCount.every((sp) =>
           isSelectableSupplementProduct(currentSelection, sp),
@@ -175,6 +180,7 @@ const createBuilder = (
         !anySelection ||
         !areProfilesValid ||
         !areProfilesWithinMaxCount ||
+        !isWithinOrderMax ||
         !areSupplementProductsValid
       ) {
         return currentSelection;

--- a/src/modules/purchase-selection/utils.ts
+++ b/src/modules/purchase-selection/utils.ts
@@ -266,3 +266,13 @@ export const isWithinUserProfileMaxCount = (
 
   return profile.count <= (maxCount ?? Number.POSITIVE_INFINITY);
 };
+
+export const isWithinMaxCountPerOrder = (
+  product: PreassignedFareProduct,
+  profiles: UserProfileWithCount[],
+) => {
+  const maxCountPerOrder = product.limitations.maxCountPerOrder;
+  if (maxCountPerOrder == null) return true;
+  const totalCount = profiles.reduce((sum, p) => sum + p.count, 0);
+  return totalCount <= maxCountPerOrder;
+};

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/MultipleTravellersSelection.tsx
@@ -49,11 +49,9 @@ export function MultipleTravellersSelection(props: Props) {
 
   const onDecrementTraveller = (userProfile: UserProfileWithCount) => {
     if (!props.userCountState.canDecrement(userProfile)) return;
-    if (userProfile.count === userProfile.limit) {
-      props.setInfoMessage(undefined);
-    }
     travellersModified.current = true;
     props.userCountState.decrement(userProfile);
+    props.setInfoMessage(undefined);
   };
 
   const onIncrementBaggage = (baggageProduct: BaggageProductWithCount) => {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-user-count-state.ts
@@ -24,5 +24,6 @@ export function useUserCountState(selection: PurchaseSelectionType) {
   return useUniqueCountState<UserProfile>(
     initialUserProfilesWithCount,
     findUserProfile,
+    selection.preassignedFareProduct.limitations.maxCountPerOrder,
   );
 }

--- a/src/utils/unique-with-count.ts
+++ b/src/utils/unique-with-count.ts
@@ -19,6 +19,7 @@ const subtractCount = (count: number) => count - 1;
 export function useUniqueCountState<T>(
   initialState: UniqueWithCount<T>[],
   equalityPredicate: (a: T, b: T) => boolean,
+  totalLimit?: number,
 ): UniqueCountState<T> {
   const [state, setState] = useState<UniqueWithCount<T>[]>(initialState);
 
@@ -40,6 +41,15 @@ export function useUniqueCountState<T>(
         newCount = Math.min(newCount, currentItem.limit);
       }
 
+      if (totalLimit != null) {
+        const otherTotal = prevState.reduce(
+          (sum, item, i) => sum + (i === index ? 0 : item.count),
+          0,
+        );
+        newCount = Math.min(newCount, totalLimit - otherTotal);
+        newCount = Math.max(0, newCount);
+      }
+
       newState[index] = {
         ...currentItem,
         count: newCount,
@@ -56,7 +66,12 @@ export function useUniqueCountState<T>(
   const canIncrement = (item: T) => {
     const currentItem = state.find((value) => equalityPredicate(value, item));
     if (!currentItem) return false;
-    if (currentItem.limit != null) return currentItem.count < currentItem.limit;
+    if (currentItem.limit != null && currentItem.count >= currentItem.limit)
+      return false;
+    if (totalLimit != null) {
+      const currentTotal = state.reduce((sum, s) => sum + s.count, 0);
+      if (currentTotal >= totalLimit) return false;
+    }
     return true;
   };
 


### PR DESCRIPTION
## Summary
- Enforce `maxCountPerOrder` from product limitations so that any order cannot have more total user profiles than the configured limit
- Add `totalLimit` support to `useUniqueCountState` to cap the UI counters at the order-level max
