### PR TITLE
Fix: only show Points on profile if program is active

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -81,7 +81,8 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const bonusProgram = useProgramQuery(KnownProgramId.BONUS, !isBonusEnabled);
   const showBonusSection =
-    isBonusActiveForUser || (bonusProgram?.isOpen && isBonusEnabled);
+    isBonusActiveForUser ||
+    (bonusProgram?.isOpen && bonusProgram?.isActive && isBonusEnabled);
 
   const focusRef = useFocusOnLoad(navigation);
 


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23671

## Description
Adds check for bonusProgram?.isActive as well as bonusProgram?.isOpen to determine if Poeng should be showed on Profile

<img width="200" alt="image" src="https://github.com/user-attachments/assets/64d47a70-f1d2-42f0-b645-bb710c68a4eb" />
