### PR TITLE
feat(mobility): migrate violations-reporting to Tanstack Query

### DIFF
--- a/src/api/bff/mobility.ts
+++ b/src/api/bff/mobility.ts
@@ -2,49 +2,8 @@ import {client} from '@atb/api/index';
 import {stringifyUrl} from '@atb/api/utils';
 import qs from 'query-string';
 import {AxiosRequestConfig} from 'axios';
-import {
-  GetStationsQuery,
-  GetStationsQueryVariables,
-} from '@atb/api/types/generated/StationsQuery';
-
 import {GeofencingZones} from '@atb/api/types/generated/mobility-types_v2';
 import {GetGeofencingZonesQuery} from '@atb/api/types/generated/GeofencingZonesQuery';
-import {
-  ViolationsReportQuery,
-  ViolationsReportQueryResult,
-  ViolationsReportingInitQuery,
-  ViolationsReportingInitQueryResult,
-  ViolationsVehicleLookupQuery,
-  ViolationsVehicleLookupQueryResult,
-} from '../types/mobility';
-
-export const getStations = (
-  {
-    lat,
-    lon,
-    range,
-    includeBicycles,
-    includeCars,
-    bicycleOperators,
-    carOperators,
-  }: GetStationsQueryVariables,
-  opts?: AxiosRequestConfig,
-): Promise<GetStationsQuery> => {
-  if (!includeBicycles && !includeCars) return Promise.resolve({});
-  const url = '/bff/v2/mobility/stations_v2';
-  const query = qs.stringify({
-    lat,
-    lon,
-    range: Math.ceil(range),
-    includeBicycles,
-    includeCars,
-    bicycleOperators,
-    carOperators,
-  });
-  return client
-    .get<GetStationsQuery>(stringifyUrl(url, query), opts)
-    .then((res) => res.data ?? []);
-};
 
 export const getGeofencingZones = (
   systemIds: string[],
@@ -56,36 +15,4 @@ export const getGeofencingZones = (
   return client
     .get<GetGeofencingZonesQuery>(stringifyUrl(url, query), opts)
     .then((res) => res.data.geofencingZones ?? null);
-};
-
-export const initViolationsReporting = (
-  params: ViolationsReportingInitQuery,
-  opts?: AxiosRequestConfig,
-): Promise<ViolationsReportingInitQueryResult> => {
-  const url = '/bff/v2/mobility/violations-reporting/init';
-  const query = qs.stringify(params);
-  return client
-    .get<ViolationsReportingInitQueryResult>(stringifyUrl(url, query), opts)
-    .then((res) => res.data);
-};
-
-export const lookupVehicleByQr = (
-  params: ViolationsVehicleLookupQuery,
-  opts?: AxiosRequestConfig,
-): Promise<ViolationsVehicleLookupQueryResult> => {
-  const url = '/bff/v2/mobility/violations-reporting/vehicle';
-  const query = qs.stringify(params);
-  return client
-    .get<ViolationsVehicleLookupQueryResult>(stringifyUrl(url, query), opts)
-    .then((res) => res.data);
-};
-
-export const sendViolationsReport = (
-  data: ViolationsReportQuery,
-  opts?: AxiosRequestConfig,
-): Promise<ViolationsReportQueryResult> => {
-  const url = '/bff/v2/mobility/violations-reporting/report';
-  return client
-    .post<ViolationsReportQueryResult>(url, data, opts)
-    .then((res) => res.data);
 };

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -18,6 +18,12 @@ import {
   Vehicle,
   StationSchema,
   Station,
+  ViolationsReportingInitQuery,
+  ViolationsReportingInitQueryResult,
+  ViolationsVehicleLookupQuery,
+  ViolationsVehicleLookupQueryResult,
+  ViolationsReportQuery,
+  ViolationsReportQueryResult,
 } from './types/mobility';
 
 export const getActiveShmoBooking = (
@@ -167,4 +173,43 @@ export const getStation = (
       console.error('Error in StationSchema parsing: ', error);
       return null;
     });
+};
+
+export const initViolationsReporting = (
+  params: ViolationsReportingInitQuery,
+  opts?: AxiosRequestConfig,
+): Promise<ViolationsReportingInitQueryResult> => {
+  const query = qs.stringify(params);
+  return client
+    .get<ViolationsReportingInitQueryResult>(
+      stringifyUrl('/mobility/v1/violations-reporting/init', query),
+      opts,
+    )
+    .then((res) => res.data);
+};
+
+export const lookupVehicleByQr = (
+  params: ViolationsVehicleLookupQuery,
+  opts?: AxiosRequestConfig,
+): Promise<ViolationsVehicleLookupQueryResult> => {
+  const query = qs.stringify(params);
+  return client
+    .get<ViolationsVehicleLookupQueryResult>(
+      stringifyUrl('/mobility/v1/violations-reporting/vehicle', query),
+      opts,
+    )
+    .then((res) => res.data);
+};
+
+export const sendViolationsReport = (
+  data: ViolationsReportQuery,
+  opts?: AxiosRequestConfig,
+): Promise<ViolationsReportQueryResult> => {
+  return client
+    .post<ViolationsReportQueryResult>(
+      '/mobility/v1/violations-reporting/report',
+      data,
+      opts,
+    )
+    .then((res) => res.data);
 };

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -20,10 +20,13 @@ import {
   Station,
   ViolationsReportingInitQuery,
   ViolationsReportingInitQueryResult,
+  ViolationsReportingInitQueryResultSchema,
   ViolationsVehicleLookupQuery,
   ViolationsVehicleLookupQueryResult,
+  ViolationsVehicleLookupQueryResultSchema,
   ViolationsReportQuery,
   ViolationsReportQueryResult,
+  ViolationsReportQueryResultSchema,
 } from './types/mobility';
 
 export const getActiveShmoBooking = (
@@ -181,11 +184,17 @@ export const initViolationsReporting = (
 ): Promise<ViolationsReportingInitQueryResult> => {
   const query = qs.stringify(params);
   return client
-    .get<ViolationsReportingInitQueryResult>(
-      stringifyUrl('/mobility/v1/violations-reporting/init', query),
-      opts,
-    )
-    .then((res) => res.data);
+    .get(stringifyUrl('/mobility/v1/violations-reporting/init', query), opts)
+    .then((res) => {
+      const result = ViolationsReportingInitQueryResultSchema.safeParse(
+        res.data,
+      );
+      if (!result.success) {
+        console.error(result.error.format());
+        throw result.error;
+      }
+      return result.data;
+    });
 };
 
 export const lookupVehicleByQr = (
@@ -194,11 +203,17 @@ export const lookupVehicleByQr = (
 ): Promise<ViolationsVehicleLookupQueryResult> => {
   const query = qs.stringify(params);
   return client
-    .get<ViolationsVehicleLookupQueryResult>(
-      stringifyUrl('/mobility/v1/violations-reporting/vehicle', query),
-      opts,
-    )
-    .then((res) => res.data);
+    .get(stringifyUrl('/mobility/v1/violations-reporting/vehicle', query), opts)
+    .then((res) => {
+      const result = ViolationsVehicleLookupQueryResultSchema.safeParse(
+        res.data,
+      );
+      if (!result.success) {
+        console.error(result.error.format());
+        throw result.error;
+      }
+      return result.data;
+    });
 };
 
 export const sendViolationsReport = (
@@ -206,10 +221,13 @@ export const sendViolationsReport = (
   opts?: AxiosRequestConfig,
 ): Promise<ViolationsReportQueryResult> => {
   return client
-    .post<ViolationsReportQueryResult>(
-      '/mobility/v1/violations-reporting/report',
-      data,
-      opts,
-    )
-    .then((res) => res.data);
+    .post('/mobility/v1/violations-reporting/report', data, opts)
+    .then((res) => {
+      const result = ViolationsReportQueryResultSchema.safeParse(res.data);
+      if (!result.success) {
+        console.error(result.error.format());
+        throw result.error;
+      }
+      return result.data;
+    });
 };

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -7,55 +7,77 @@ import {isValidPhoneNumber} from 'libphonenumber-js';
 import {isValidEmail} from '@atb/utils/validation';
 import {Feature, Point} from 'geojson';
 
-export type ViolationsReportingInitQuery = {
-  lng: string;
-  lat: string;
-};
+export const ViolationsReportingInitQuerySchema = z.object({
+  lng: z.string(),
+  lat: z.string(),
+});
+export type ViolationsReportingInitQuery = z.infer<
+  typeof ViolationsReportingInitQuerySchema
+>;
 
-export type ViolationsReportingProvider = {
-  id?: number;
-  name: string;
-  image?: {
-    type: string;
-    base64: string;
-  };
-};
+export const ViolationsReportingProviderSchema = z.object({
+  id: z.number().optional(),
+  name: z.string(),
+  image: z
+    .object({
+      type: z.string(),
+      base64: z.string(),
+    })
+    .optional(),
+});
+export type ViolationsReportingProvider = z.infer<
+  typeof ViolationsReportingProviderSchema
+>;
 
-export type ParkingViolationType = {
-  code: string;
+export const ParkingViolationTypeSchema = z.object({
+  code: z.string(),
   /** @deprecated Icon is only used by the app in v. 1.61 and earlier */
-  icon: string;
-};
+  icon: z.string(),
+});
+export type ParkingViolationType = z.infer<typeof ParkingViolationTypeSchema>;
 
-export type ViolationsReportingInitQueryResult = {
-  providers: ViolationsReportingProvider[];
-  violations: ParkingViolationType[];
-};
+export const ViolationsReportingInitQueryResultSchema = z.object({
+  providers: z.array(ViolationsReportingProviderSchema),
+  violations: z.array(ParkingViolationTypeSchema),
+});
+export type ViolationsReportingInitQueryResult = z.infer<
+  typeof ViolationsReportingInitQueryResultSchema
+>;
 
-export type ViolationsVehicleLookupQuery = {
-  qr: string;
-};
+export const ViolationsVehicleLookupQuerySchema = z.object({
+  qr: z.string(),
+});
+export type ViolationsVehicleLookupQuery = z.infer<
+  typeof ViolationsVehicleLookupQuerySchema
+>;
 
-export type ViolationsVehicleLookupQueryResult = {
-  provider_id: number;
-  vehicle_id: string;
-};
+export const ViolationsVehicleLookupQueryResultSchema = z.object({
+  provider_id: z.number(),
+  vehicle_id: z.string(),
+});
+export type ViolationsVehicleLookupQueryResult = z.infer<
+  typeof ViolationsVehicleLookupQueryResultSchema
+>;
 
-export type ViolationsReportQuery = {
-  providerId: ViolationsReportingProvider['id'];
-  longitude: number;
-  latitude: number;
-  image?: string; //base64 encoded image blob
-  imageType?: string; // file name suffix;
-  qr?: string;
-  appId?: string; // Unique id identifying the customer
-  violations?: ParkingViolationType['code'][];
-  timestamp: string;
-};
+export const ViolationsReportQuerySchema = z.object({
+  providerId: z.number().optional(),
+  longitude: z.number(),
+  latitude: z.number(),
+  image: z.string().optional(), // base64-encoded image blob
+  imageType: z.string().optional(),
+  qr: z.string().optional(),
+  appId: z.string().optional(),
+  violations: z.array(z.string()).optional(),
+  timestamp: z.string(),
+});
+export type ViolationsReportQuery = z.infer<typeof ViolationsReportQuerySchema>;
 
-export type ViolationsReportQueryResult = {
-  status: 'OK';
-};
+export const ViolationsReportQueryResultSchema = z.object({
+  status: z.literal('OK'),
+});
+export type ViolationsReportQueryResult = z.infer<
+  typeof ViolationsReportQueryResultSchema
+>;
 
 /** Note: The shared mobility types below come from the `mobility` and `entur-client` crates in the mobility service. */
 

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -6,6 +6,7 @@ import {
 import {isValidPhoneNumber} from 'libphonenumber-js';
 import {isValidEmail} from '@atb/utils/validation';
 import {Feature, Point} from 'geojson';
+import {Base64ImageSchema} from '@atb/utils/image';
 
 export const ViolationsReportingInitQuerySchema = z.object({
   lng: z.string(),
@@ -63,7 +64,7 @@ export const ViolationsReportQuerySchema = z.object({
   providerId: z.number().optional(),
   longitude: z.number(),
   latitude: z.number(),
-  image: z.string().optional(), // base64-encoded image blob
+  image: Base64ImageSchema.optional(),
   imageType: z.string().optional(),
   qr: z.string().optional(),
   appId: z.string().optional(),

--- a/src/modules/announcements/types.ts
+++ b/src/modules/announcements/types.ts
@@ -3,31 +3,11 @@ import {LanguageAndTextTypeArray} from '@atb/modules/configuration';
 import {AppPlatform} from '@atb/modules/global-messages';
 import {Timestamp} from '@react-native-firebase/firestore';
 import {Rule} from '@atb/modules/rule-engine';
+import {Base64ImageSchema} from '@atb/utils/image';
 
 const TimestampSchema = z
   .custom<Timestamp>((value) => value instanceof Timestamp)
   .transform((ts) => new Date(ts.toMillis()));
-
-const Base64ImageSchema = z
-  .string()
-  .max(700000) // images should not be too large
-  .regex(/^data:image\/(png|jpeg|jpg);base64,.+$/, {
-    message: 'Invalid image data URI',
-  })
-  .refine(
-    (imgStr) => {
-      const base64Part = imgStr.split(',')[1];
-      if (!base64Part || base64Part.length % 4 !== 0) return false;
-      // Due to performance concerns, only validate the start and end as base64 data
-      const numberOfChars = 4 * 10; // must be divisible by 4
-      const start = base64Part.slice(0, numberOfChars);
-      const end = base64Part.slice(-numberOfChars);
-      return [start, end].every(
-        (part) => z.string().base64().safeParse(part).success,
-      );
-    },
-    {message: 'Invalid base64 payload'},
-  );
 
 export enum ActionType {
   external = 'external',

--- a/src/modules/parking-violations-reporting/index.ts
+++ b/src/modules/parking-violations-reporting/index.ts
@@ -1,2 +1,5 @@
 export {useParkingViolations} from './use-parking-violations';
+export {useInitViolationsReportingQuery} from './queries/use-init-violations-reporting-query';
+export {useLookupVehicleByQrMutation} from './queries/use-lookup-vehicle-by-qr-mutation';
+export {useSendViolationsReportMutation} from './queries/use-send-violations-report-mutation';
 export * from './utils';

--- a/src/modules/parking-violations-reporting/queries/use-init-violations-reporting-query.tsx
+++ b/src/modules/parking-violations-reporting/queries/use-init-violations-reporting-query.tsx
@@ -1,0 +1,24 @@
+import {useQuery} from '@tanstack/react-query';
+import {ONE_MINUTE_MS} from '@atb/utils/durations';
+import {initViolationsReporting} from '@atb/api/mobility';
+import {ViolationsReportingInitQuery} from '@atb/api/types/mobility';
+
+export const getInitViolationsReportingQueryKey = (
+  lat?: string,
+  lng?: string,
+) => ['GET_INIT_VIOLATIONS_REPORTING', lat, lng] as const;
+
+export const useInitViolationsReportingQuery = (
+  params?: ViolationsReportingInitQuery,
+) => {
+  const lat = params?.lat;
+  const lng = params?.lng;
+  return useQuery({
+    queryKey: getInitViolationsReportingQueryKey(lat, lng),
+    queryFn: ({signal}) =>
+      initViolationsReporting({lat: lat!, lng: lng!}, {signal}),
+    enabled: !!lat && !!lng,
+    gcTime: ONE_MINUTE_MS,
+    retry: 5,
+  });
+};

--- a/src/modules/parking-violations-reporting/queries/use-lookup-vehicle-by-qr-mutation.tsx
+++ b/src/modules/parking-violations-reporting/queries/use-lookup-vehicle-by-qr-mutation.tsx
@@ -1,0 +1,16 @@
+import {ErrorResponse} from '@atb-as/utils';
+import {lookupVehicleByQr} from '@atb/api/mobility';
+import {
+  ViolationsVehicleLookupQuery,
+  ViolationsVehicleLookupQueryResult,
+} from '@atb/api/types/mobility';
+import {useMutation} from '@tanstack/react-query';
+
+export const useLookupVehicleByQrMutation = () =>
+  useMutation<
+    ViolationsVehicleLookupQueryResult,
+    ErrorResponse,
+    ViolationsVehicleLookupQuery
+  >({
+    mutationFn: (params) => lookupVehicleByQr(params),
+  });

--- a/src/modules/parking-violations-reporting/queries/use-send-violations-report-mutation.tsx
+++ b/src/modules/parking-violations-reporting/queries/use-send-violations-report-mutation.tsx
@@ -1,0 +1,16 @@
+import {ErrorResponse} from '@atb-as/utils';
+import {sendViolationsReport} from '@atb/api/mobility';
+import {
+  ViolationsReportQuery,
+  ViolationsReportQueryResult,
+} from '@atb/api/types/mobility';
+import {useMutation} from '@tanstack/react-query';
+
+export const useSendViolationsReportMutation = () =>
+  useMutation<
+    ViolationsReportQueryResult,
+    ErrorResponse,
+    ViolationsReportQuery
+  >({
+    mutationFn: (data) => sendViolationsReport(data),
+  });

--- a/src/modules/parking-violations-reporting/use-parking-violations.tsx
+++ b/src/modules/parking-violations-reporting/use-parking-violations.tsx
@@ -1,11 +1,11 @@
-import {useEffect, useState} from 'react';
+import {useState, useEffect} from 'react';
 import {useGeolocationContext} from '@atb/modules/geolocation';
-import {initViolationsReporting} from '@atb/api/bff/mobility';
 import {
   ParkingViolationType,
   ViolationsReportingProvider,
 } from '@atb/api/types/mobility';
 import {Coordinates} from '@atb/utils/coordinates';
+import {useInitViolationsReportingQuery} from './queries/use-init-violations-reporting-query';
 
 type ParkingViolationsState =
   | 'loading'
@@ -14,39 +14,45 @@ type ParkingViolationsState =
   | 'violationsReportingDataError';
 
 export const useParkingViolations = () => {
+  const [coordinates, setCoordinates] = useState<Coordinates>();
   const [parkingViolationsState, setParkingViolationsState] =
     useState<ParkingViolationsState>('loading');
-
-  const [violations, setViolations] = useState<ParkingViolationType[]>([]);
-  const [providers, setProviders] = useState<ViolationsReportingProvider[]>([]);
-  const [coordinates, setCoordinates] = useState<Coordinates>();
 
   const {getCurrentCoordinates} = useGeolocationContext();
 
   useEffect(() => {
-    const getLocationAndInitReporting = async () => {
-      setParkingViolationsState('loading');
-      const coordinates = await getCurrentCoordinates(true);
-      setCoordinates(coordinates);
-      if (coordinates) {
-        try {
-          const violationsReportingData = await initViolationsReporting({
-            lat: coordinates.latitude.toString(),
-            lng: coordinates.longitude.toString(),
-          });
-          setViolations(violationsReportingData.violations);
-          setProviders(violationsReportingData.providers);
-          setParkingViolationsState('success');
-        } catch (err) {
-          console.warn(err);
-          setParkingViolationsState('violationsReportingDataError');
-        }
+    const resolveCoordinates = async () => {
+      const coords = await getCurrentCoordinates(true);
+      if (coords) {
+        setCoordinates(coords);
       } else {
         setParkingViolationsState('locationRequirementNotMet');
       }
     };
-    getLocationAndInitReporting();
+    resolveCoordinates();
   }, [getCurrentCoordinates]);
+
+  const queryParams = coordinates
+    ? {
+        lat: coordinates.latitude.toString(),
+        lng: coordinates.longitude.toString(),
+      }
+    : undefined;
+
+  const {data, isSuccess, isError} =
+    useInitViolationsReportingQuery(queryParams);
+
+  useEffect(() => {
+    if (!coordinates) return;
+    if (isSuccess) {
+      setParkingViolationsState('success');
+    } else if (isError) {
+      setParkingViolationsState('violationsReportingDataError');
+    }
+  }, [coordinates, isSuccess, isError]);
+
+  const violations: ParkingViolationType[] = data?.violations ?? [];
+  const providers: ViolationsReportingProvider[] = data?.providers ?? [];
 
   return {
     isLoading: parkingViolationsState === 'loading',

--- a/src/stacks-hierarchy/Root_ShmoHelp/Root_ParkingViolationsQrScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoHelp/Root_ParkingViolationsQrScreen.tsx
@@ -7,7 +7,10 @@ import {getThemeColor} from '../../components/PhotoCapture/ScreenContainer';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {SelectProviderBottomSheet} from './bottom-sheets/SelectProviderBottomSheet';
 import {VehicleLookupConfirmationBottomSheet} from './bottom-sheets/VehicleLookupBottomSheet';
-import {lookupVehicleByQr, sendViolationsReport} from '@atb/api/bff/mobility';
+import {
+  useLookupVehicleByQrMutation,
+  useSendViolationsReportMutation,
+} from '@atb/modules/parking-violations-reporting';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useParkingViolations} from '@atb/modules/parking-violations-reporting';
 import {useAuthContext} from '@atb/modules/auth';
@@ -36,6 +39,8 @@ export const Root_ParkingViolationsQrScreen = ({
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const {providers, coordinates} = useParkingViolations();
+  const {mutateAsync: lookupVehicleByQr} = useLookupVehicleByQrMutation();
+  const {mutateAsync: sendViolationsReport} = useSendViolationsReportMutation();
   const {userId} = useAuthContext();
   const onCloseFocusRef = useRef<View | null>(null);
   const providerAndVehicleBottomSheetModalRef =
@@ -92,38 +97,39 @@ export const Root_ParkingViolationsQrScreen = ({
     // Nivel uses the file name suffix as imageType.
     const imageType = params.photo.split('.').pop();
 
-    sendViolationsReport({
-      appId: userId,
-      image: base64data,
-      imageType,
-      latitude: coordinates?.latitude ?? 0,
-      longitude: coordinates?.longitude ?? 0,
-      providerId,
-      qr: capturedQr,
-      violations: params.selectedViolations.map((v) => v.code),
-      timestamp: new Date().toISOString(),
-    })
-      .then(() => {
-        navigation.navigate('Root_ParkingViolationsConfirmationScreen', {
-          providerName: providers.find((p) => p.id === providerId)?.name,
-        });
-        handleFinishSubmitReport();
-      })
-      .catch((e) => {
-        console.error(e);
-        setIsError(true);
-        handleFinishSubmitReport();
+    try {
+      await sendViolationsReport({
+        appId: userId,
+        image: base64data,
+        imageType,
+        latitude: coordinates?.latitude ?? 0,
+        longitude: coordinates?.longitude ?? 0,
+        providerId,
+        qr: capturedQr,
+        violations: params.selectedViolations.map((v) => v.code),
+        timestamp: new Date().toISOString(),
       });
+      navigation.navigate('Root_ParkingViolationsConfirmationScreen', {
+        providerName: providers.find((p) => p.id === providerId)?.name,
+      });
+      handleFinishSubmitReport();
+    } catch (e) {
+      console.error(e);
+      setIsError(true);
+      handleFinishSubmitReport();
+    }
   };
 
-  const getProviderByQr = async (qr: string) =>
-    lookupVehicleByQr({qr})
-      .then(({provider_id, vehicle_id}) => {
-        const provider = providers.find((p) => p.id === provider_id);
-        if (!provider) return undefined;
-        return {provider, vehicle_id};
-      })
-      .catch(() => undefined); // If lookup fails let user select operator manually.
+  const getProviderByQr = async (qr: string) => {
+    try {
+      const {provider_id, vehicle_id} = await lookupVehicleByQr({qr});
+      const provider = providers.find((p) => p.id === provider_id);
+      if (!provider) return undefined;
+      return {provider, vehicle_id};
+    } catch {
+      return undefined; // If lookup fails let user select operator manually.
+    }
+  };
 
   const handlePhotoCapture = async (qr: string) => {
     if (!capturedQr) {

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,6 +1,28 @@
 import ImageResizer from '@bam.tech/react-native-image-resizer';
 import {readFile} from '@dr.pogodin/react-native-fs';
+import {z} from 'zod';
 import {notifyBugsnag} from './bugsnag-utils';
+
+export const Base64ImageSchema = z
+  .string()
+  .max(700000) // images should not be too large
+  .regex(/^data:image\/(png|jpeg|jpg);base64,.+$/, {
+    message: 'Invalid image data URI',
+  })
+  .refine(
+    (imgStr) => {
+      const base64Part = imgStr.split(',')[1];
+      if (!base64Part || base64Part.length % 4 !== 0) return false;
+      // Due to performance concerns, only validate the start and end as base64 data
+      const numberOfChars = 4 * 10; // must be divisible by 4
+      const start = base64Part.slice(0, numberOfChars);
+      const end = base64Part.slice(-numberOfChars);
+      return [start, end].every(
+        (part) => z.string().base64().safeParse(part).success,
+      );
+    },
+    {message: 'Invalid base64 payload'},
+  );
 
 const EMPTY_IMAGE_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAABJRu5ErkJggg==';


### PR DESCRIPTION
## Summary

- Migrates `initViolationsReporting`, `lookupVehicleByQr`, and `sendViolationsReport` from BFF URLs to the new `/mobility/v1/violations-reporting/*` endpoints in mobility-svc
- Wraps all three in Tanstack Query hooks (`useInitViolationsReportingQuery`, `useLookupVehicleByQrMutation`, `useSendViolationsReportMutation`) — retries now come for free via Tanstack defaults
- Refactors `useParkingViolations` from manual `useState`/`useEffect` to `useInitViolationsReportingQuery`
- Refactors `Root_ParkingViolationsQrScreen` to use the two new mutation hooks instead of raw promise chains
- Removes dead `getStations` (zero consumers) and the three moved BFF functions from `src/api/bff/mobility.ts`

Depends on AtB-AS/mobility#102

Closes https://github.com/AtB-AS/kundevendt/issues/20118
Ref https://github.com/AtB-AS/kundevendt/issues/22414