### PR TITLE
feat: add info about ending trip for regular citybikes

### DIFF
--- a/src/modules/announcements/index.ts
+++ b/src/modules/announcements/index.ts
@@ -10,5 +10,4 @@ export type {
   UrlActionButton,
   BottomSheetActionButton,
 } from './types';
-
 export {isBottomSheetAnnouncement, isLinkAnnouncement} from './types';

--- a/src/modules/mobility/components/EndManualTripCard.tsx
+++ b/src/modules/mobility/components/EndManualTripCard.tsx
@@ -1,0 +1,89 @@
+import {ThemeText} from '@atb/components/text';
+import {DashboardTexts, useTranslation} from '@atb/translations';
+import {View} from 'react-native';
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Close} from '@atb/assets/svg/mono-icons/actions';
+import {NativeBorderlessButton} from '@atb/components/native-button';
+import {insets} from '@atb/utils/insets';
+import {JSX} from 'react';
+
+type Props = {
+  title: string | undefined;
+  summary: string | undefined;
+  image?: JSX.Element;
+  handleDismiss: () => void;
+};
+
+export const EndManualTripCard = ({
+  title,
+  summary,
+  image,
+  handleDismiss,
+}: Props) => {
+  const styles = useStyle();
+  const {t} = useTranslation();
+  const {theme} = useThemeContext();
+
+  return (
+    <View style={styles.content}>
+      {image && <View style={styles.imageContainer}>{image}</View>}
+      <View style={styles.textContainer}>
+        <View style={styles.summaryTitle}>
+          <ThemeText
+            style={styles.summaryTitleText}
+            typography="body__m__strong"
+          >
+            {title}
+          </ThemeText>
+          <NativeBorderlessButton
+            style={styles.close}
+            role="button"
+            hitSlop={insets.all(theme.spacing.medium)}
+            accessibilityHint={t(
+              DashboardTexts.announcements.announcement.closeA11yHint,
+            )}
+            onPress={() => handleDismiss()}
+            testID="closeAnnouncement"
+          >
+            <ThemeIcon svg={Close} />
+          </NativeBorderlessButton>
+        </View>
+        <ThemeText style={styles.summary}>{summary}</ThemeText>
+      </View>
+    </View>
+  );
+};
+
+const useStyle = StyleSheet.createThemeHook((theme) => ({
+  content: {
+    flex: 1,
+    padding: theme.spacing.medium,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.color.background.neutral[0].background,
+    borderRadius: theme.border.radius.regular,
+  },
+  imageContainer: {
+    marginRight: theme.spacing.medium,
+    borderRadius: theme.border.radius.regular,
+    padding: theme.border.radius.regular,
+    overflow: 'hidden',
+  },
+  textContainer: {
+    flex: 1,
+  },
+  summaryTitle: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  summaryTitleText: {
+    flexShrink: 1,
+  },
+  summary: {
+    marginTop: theme.spacing.xSmall,
+  },
+  close: {
+    flexGrow: 0,
+  },
+}));

--- a/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
@@ -45,6 +45,10 @@ import {useOperators} from '../../use-operators';
 import {SupportButton} from '../SupportButton';
 import {BrandingImage} from '../BrandingImage';
 import {isValidKey} from '@atb/stacks-hierarchy';
+import {EndManualTripCard} from '../EndManualTripCard';
+import {ThemedCityBike} from '@atb/theme/ThemedAssets';
+import {usePersistedBoolState} from '@atb/utils/use-persisted-bool-state';
+import {storage, StorageModelKeysEnum} from '@atb/modules/storage';
 
 type Props = {
   navigateSupportCallback: () => void;
@@ -71,6 +75,11 @@ export const ActiveShmoSheet = ({
     isError,
   } = useActiveShmoBookingQuery(isFocusedAndActive, ONE_SECOND_MS * 10);
   const {logEvent} = useAnalyticsContext();
+  const [endTripInfoClosed, setEndTripInfoClosed] = usePersistedBoolState(
+    storage,
+    StorageModelKeysEnum.CityBikeEndTripInfoDismissed,
+    false,
+  );
 
   const {mode, subMode} = getTransportModeAndSubMode(
     activeBooking?.asset?.formFactor,
@@ -231,32 +240,42 @@ export const ActiveShmoSheet = ({
                 />
 
                 <View style={styles.footer}>
-                  <View style={styles.endTripWrapper}>
-                    {geofencingZoneWarning && (
-                      <View style={styles.geofencingZoneWarning}>
-                        {geofencingZoneWarning.iconNode}
-                        <View style={styles.geofencingZoneWarningText}>
-                          <ThemeText typography="body__s">
-                            {geofencingZoneWarning.description}
-                          </ThemeText>
-                        </View>
+                  {geofencingZoneWarning && (
+                    <View style={styles.geofencingZoneWarning}>
+                      {geofencingZoneWarning.iconNode}
+                      <View style={styles.geofencingZoneWarningText}>
+                        <ThemeText typography="body__s">
+                          {geofencingZoneWarning.description}
+                        </ThemeText>
                       </View>
-                    )}
-                    {warningMessage && (
-                      <MessageInfoText
-                        type="warning"
-                        message={warningMessage}
-                      />
-                    )}
-                    {sendShmoBookingEventIsError && (
-                      <MessageInfoBox
-                        type="error"
-                        message={formatFriendlyShmoErrorMessage(
-                          sendShmoBookingEventError,
-                          t,
+                    </View>
+                  )}
+                  {warningMessage && (
+                    <MessageInfoText type="warning" message={warningMessage} />
+                  )}
+                  {sendShmoBookingEventIsError && (
+                    <MessageInfoBox
+                      type="error"
+                      message={formatFriendlyShmoErrorMessage(
+                        sendShmoBookingEventError,
+                        t,
+                      )}
+                    />
+                  )}
+                  {activeBooking.asset.formFactor === FormFactor.Bicycle &&
+                  activeBooking.asset.propulsionType ===
+                    PropulsionType.Human ? (
+                    !endTripInfoClosed && (
+                      <EndManualTripCard
+                        title={t(MobilityTexts.cityBike.endManualTrip.title)}
+                        summary={t(
+                          MobilityTexts.cityBike.endManualTrip.summary,
                         )}
+                        image={<ThemedCityBike height={54} width={50} />}
+                        handleDismiss={() => setEndTripInfoClosed(true)}
                       />
-                    )}
+                    )
+                  ) : (
                     <Button
                       mode="primary"
                       active={false}
@@ -273,7 +292,8 @@ export const ActiveShmoSheet = ({
                           : t(MobilityTexts.trip.button.end)
                       }
                     />
-                  </View>
+                  )}
+
                   <SupportButton navigateToSupport={navigateSupportCallback} />
                 </View>
               </View>
@@ -307,9 +327,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       gap: theme.spacing.medium,
     },
     footer: {
-      gap: theme.spacing.medium,
-    },
-    endTripWrapper: {
       gap: theme.spacing.medium,
     },
     tripWrapper: {

--- a/src/modules/storage/StorageModel.tsx
+++ b/src/modules/storage/StorageModel.tsx
@@ -4,6 +4,7 @@ import Bugsnag from '@bugsnag/react-native';
 export enum StorageModelKeysEnum {
   PreviousPaymentMethods = '@ATB_previous_payment_methods',
   ScooterConsent = '@ATB_scooter_consent',
+  CityBikeEndTripInfoDismissed = '@ATB_city_bike_end_trip_info_dismissed',
 }
 
 type StorageModelKeysTypes = keyof typeof StorageModelKeysEnum;

--- a/src/stacks-hierarchy/Root_ParkingPhotoScreen.tsx
+++ b/src/stacks-hierarchy/Root_ParkingPhotoScreen.tsx
@@ -2,7 +2,10 @@ import {useTranslation} from '@atb/translations';
 import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {ShmoBookingEvent, ShmoBookingEventType} from '@atb/api/types/mobility';
-import {useSendShmoBookingEventMutation} from '@atb/modules/mobility';
+import {
+  useSendShmoBookingEventMutation,
+  useShmoBookingQuery,
+} from '@atb/modules/mobility';
 import {PhotoCapture} from '@atb/components/PhotoCapture';
 import {PhotoFile} from '@atb/components/camera';
 import {View} from 'react-native';
@@ -13,6 +16,8 @@ import {useCallback} from 'react';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {Loading} from '@atb/components/loading';
+import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 
 export type ParkingPhotoScreenProps =
   RootStackScreenProps<'Root_ParkingPhotoScreen'>;
@@ -26,6 +31,11 @@ export const Root_ParkingPhotoScreen = ({
   const styles = useStyles();
   const {dispatchMapState} = useMapContext();
   const {logEvent} = useAnalyticsContext();
+  const isFocusedAndActive = useIsFocusedAndActive();
+  const {data: shmoBooking} = useShmoBookingQuery(
+    isFocusedAndActive,
+    route.params.bookingId,
+  );
 
   const {mutateAsync: sendShmoBookingEvent, isPending} =
     useSendShmoBookingEventMutation();
@@ -86,7 +96,11 @@ export const Root_ParkingPhotoScreen = ({
     <PhotoCapture
       onConfirmImage={onConfirmImage}
       onGoBack={onGoBack}
-      title={t(MobilityTexts.photo.header)}
+      title={t(
+        MobilityTexts.photo.header(
+          shmoBooking?.asset?.formFactor ?? FormFactor.Other,
+        ),
+      )}
       secondaryText={t(MobilityTexts.photo.subHeader)}
       focusRef={focusRef}
     />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_CityBikeStartTripScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_CityBikeStartTripScreen.tsx
@@ -86,8 +86,7 @@ export const Map_CityBikeStartTripScreen = ({navigation}: Props) => {
           <View style={styles.title}>
             <ThemeIcon size="large" svg={Parking} />
             <ThemeText style={theme.typography.heading__xl}>
-              {t(MobilityTexts.cityBike.location(1))} // TODO: UPDATE WITH
-              LOCATION WHEN ITS ADDED TO ENTUR API
+              {t(MobilityTexts.cityBike.location(1))}
             </ThemeText>
           </View>
           <ThemedCityBike />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -6,7 +6,11 @@ import {Alert, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {getIdTokenGlobal, useAuthContext} from '@atb/modules/auth';
-import {KeyValuePair, storage} from '@atb/modules/storage';
+import {
+  KeyValuePair,
+  storage,
+  StorageModelKeysEnum,
+} from '@atb/modules/storage';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
 import {usePreferencesContext, UserPreferences} from '@atb/modules/preferences';
 import {get, keys} from 'lodash';
@@ -318,6 +322,15 @@ export const Profile_DebugInfoScreen = () => {
           <LinkSectionItem
             text="Reset scooter consent"
             onPress={() => setGivenShmoConsent(false)}
+          />
+          <LinkSectionItem
+            text="Reset city bike end trip info"
+            onPress={() =>
+              storage.set(
+                StorageModelKeysEnum.CityBikeEndTripInfoDismissed,
+                'false',
+              )
+            }
           />
         </Section>
         <Section style={styles.section}>

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -108,6 +108,18 @@ export const MobilityTexts = {
       safeTrip: _('God tur!', 'Have a nice trip!', 'God tur!'),
       header: _('Start tur', 'Start trip', 'Start tur'),
     },
+    endManualTrip: {
+      title: _(
+        'Skal du avslutte turen?',
+        'Are you ending your trip?',
+        'Skal du avslutte turen?',
+      ),
+      summary: _(
+        'Parker i nærmeste stativ. Husk å sjekke AtB-appen for bekreftelse.',
+        'Park at the nearest dock. Remember to check the AtB app for confirmation.',
+        'Parker i nærmeste stativ. Husk å sjekke AtB-appen for bekreftelse.',
+      ),
+    },
   },
   loadingBookingFailed: _(
     'Ops! Vi kunne ikke hente informasjon om turen',
@@ -133,11 +145,38 @@ export const MobilityTexts = {
     ),
   },
   photo: {
-    header: _(
-      'Ta bilde av elsparkesykkelen',
-      'Take a photo of the e-scooter',
-      'Ta bilete av elsparkesykkelen',
-    ),
+    header: (formFactor: FormFactor) => {
+      switch (formFactor) {
+        case FormFactor.Scooter:
+        case FormFactor.ScooterStanding:
+          return _(
+            'Ta bilde av elsparkesykkelen',
+            'Take a photo of the e-scooter',
+            'Ta bilete av elsparkesykkelen',
+          );
+
+        case FormFactor.Bicycle:
+          return _(
+            'Ta bilde av sykkelen',
+            'Take a photo of the bike',
+            'Ta bilete av sykkelen',
+          );
+
+        case FormFactor.Car:
+          return _(
+            'Ta bilde av bilen',
+            'Take a photo of the car',
+            'Ta bilete av bilen',
+          );
+
+        default:
+          return _(
+            'Ta bilde av kjøretøyet',
+            'Take a photo of the vehicle',
+            'Ta bilete av køyretøyet',
+          );
+      }
+    },
     subHeader: _(
       'Du blir ikke belastet for tiden du bruker på å ta bilde.',
       'You will not be charged for the time you spend taking the photo.',


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/23754

Adding a infobox on the activeShmoSheet when there is a regular citybike trip, since there should not be possible to end the trip manually without the user placing the bike in a parkingslot. Also added the possibility to reset the removed info state from debug menu for testing. But in production, if the user closes the info, it should not appear again

<img width="250" alt="image" src="https://github.com/user-attachments/assets/9988d337-7857-4001-9f64-b4420e8b6d48" />
