### PR TITLE
feat: add enrollmentIds to ruleVariables for announcements

### DIFF
--- a/src/modules/enrollment/index.ts
+++ b/src/modules/enrollment/index.ts
@@ -1,5 +1,6 @@
 export {useEnrollIntoProgramWithCodeMutation} from './use-enroll-into-program-with-code-mutation';
 export {useEnrollIntoProgramWithIdMutation} from './use-enroll-into-program-with-id-mutation';
 export {useIsEnrolled} from './use-is-enrolled';
+export {useGetEnrollments} from './use-get-enrollments';
 export {useProgramQuery} from './use-program-query';
 export {KnownProgramId, isKnownProgramId} from './types';

--- a/src/modules/enrollment/use-get-enrollments.ts
+++ b/src/modules/enrollment/use-get-enrollments.ts
@@ -1,0 +1,9 @@
+import {useAuthContext} from '@atb/modules/auth';
+import {useGetEnrollmentsQuery} from './use-get-enrollments-query';
+import {EnrollmentType} from './types';
+
+export function useGetEnrollments(disabled: boolean = false): EnrollmentType[] {
+  const {isLoggedIn} = useAuthContext();
+  const {data} = useGetEnrollmentsQuery(!isLoggedIn || disabled);
+  return data ?? [];
+}

--- a/src/modules/enrollment/use-is-enrolled.ts
+++ b/src/modules/enrollment/use-is-enrolled.ts
@@ -1,15 +1,14 @@
 import {useMemo} from 'react';
-import {useGetEnrollmentsQuery} from './use-get-enrollments-query';
+import {useGetEnrollments} from './use-get-enrollments';
 import {KnownProgramId} from './types';
 
 export function useIsEnrolled(
   programId: KnownProgramId,
   disabled: boolean = false,
 ): boolean {
-  const {data: enrollments} = useGetEnrollmentsQuery(disabled);
+  const enrollments = useGetEnrollments(disabled);
 
   return useMemo(() => {
-    if (!enrollments) return false;
     return enrollments.some(
       (e) => e.programId === programId && e.programIsActive,
     );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -10,6 +10,7 @@ import {useTimeContext} from '@atb/modules/time';
 import {useFareContracts} from '@atb/modules/ticketing';
 import {ContentHeading} from '@atb/components/heading';
 import {useStableLocation} from '@atb/modules/geolocation';
+import {useGetEnrollments} from '@atb/modules/enrollment';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {findZoneInLocation} from '@atb/utils/use-find-zone-in-location';
 import {useMemo} from 'react';
@@ -34,6 +35,8 @@ export const Announcements = ({style, isFocused}: Props) => {
   );
   const hasValidFareContract = validFareContracts.length > 0;
 
+  const enrollmentIds = useGetEnrollments().map((e) => e.programId);
+
   const styles = useStyle();
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
@@ -44,6 +47,7 @@ export const Announcements = ({style, isFocused}: Props) => {
     fareZoneId: fareZone?.id ?? null,
     cityZoneId: cityZone?.id ?? null,
     carPoolingZoneId: carPoolingZone?.id ?? null,
+    enrollmentIds,
   };
 
   const filteredAnnouncements = findAnnouncements(ruleVariables).filter((a) =>


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23670

## Description
Adds enrollmentIds to ruleVariables for announcements, so announcement can be showed only to enrolled users (or only to unenrolled users)

<img width="200" alt="image" src="https://github.com/user-attachments/assets/66a4239a-c71e-4bbf-9d61-e9426efdbace" />

