### PR TITLE
fix: use useSafeAreaInsets to handle android compass bonusButton overlap

### DIFF
--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -17,6 +17,7 @@ import {
 import {Feature} from 'geojson';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Platform, View} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MapCameraConfig, getSlightlyRaisedMapPadding} from './MapConfig';
 import {MapPropertiesType, MapProps} from './types';
 
@@ -159,11 +160,15 @@ export const Map = (props: MapProps) => {
     vehicle?.vehicleType.id ?? activeShmoBooking?.asset.vehicleTypeId ?? null;
 
   const {theme} = useThemeContext();
+  const {top: safeAreaTop} = useSafeAreaInsets();
   const {isVisible: isBonusBalanceButtonVisible} =
     useIsBonusBalanceButtonVisible();
   const [bonusButtonHeight, setBonusButtonHeight] = useState(44);
   const compassOffsetTop = isBonusBalanceButtonVisible
-    ? theme.spacing.xSmall + bonusButtonHeight + theme.spacing.small
+    ? Platform.select({android: safeAreaTop, default: 0}) +
+      theme.spacing.xSmall +
+      bonusButtonHeight +
+      theme.spacing.small
     : 0;
   // Always including the vector sources avoids laggy transitions for iOS (but buggy on Android, so skipped there),
   // and tile requests are only sent when they are used anyway.

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -17,7 +17,6 @@ import {
 import {Feature} from 'geojson';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Platform, View} from 'react-native';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MapCameraConfig, getSlightlyRaisedMapPadding} from './MapConfig';
 import {MapPropertiesType, MapProps} from './types';
 
@@ -160,15 +159,11 @@ export const Map = (props: MapProps) => {
     vehicle?.vehicleType.id ?? activeShmoBooking?.asset.vehicleTypeId ?? null;
 
   const {theme} = useThemeContext();
-  const {top: safeAreaTop} = useSafeAreaInsets();
   const {isVisible: isBonusBalanceButtonVisible} =
     useIsBonusBalanceButtonVisible();
   const [bonusButtonHeight, setBonusButtonHeight] = useState(44);
   const compassOffsetTop = isBonusBalanceButtonVisible
-    ? Platform.select({android: safeAreaTop, default: 0}) +
-      theme.spacing.xSmall +
-      bonusButtonHeight +
-      theme.spacing.small
+    ? theme.spacing.xSmall + bonusButtonHeight + theme.spacing.small
     : 0;
   // Always including the vector sources avoids laggy transitions for iOS (but buggy on Android, so skipped there),
   // and tile requests are only sent when they are used anyway.

--- a/src/modules/map/hooks/use-map-view-config.ts
+++ b/src/modules/map/hooks/use-map-view-config.ts
@@ -1,4 +1,5 @@
 import {Platform} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useMapboxJsonStyle} from './use-mapbox-json-style';
 import {useMemo} from 'react';
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
@@ -38,14 +39,20 @@ export const useMapViewConfig = (
   );
   const {enable_surface_view_map, map_max_pitch} = useRemoteConfigContext();
 
+  const {top: safeAreaTop} = useSafeAreaInsets();
+  const androidSafeAreaTop = Platform.select({
+    android: safeAreaTop,
+    default: 0,
+  });
+
   // `mapbox` (v10) Adds compass offset `compassViewMargins` is still supported but generates issues:
   // Mapbox error fireEvent failed: <rnmapbox_maps.RCTMGLEvent: 0x6000028a0fe0>
   const compassPosition = useMemo(
     () => ({
-      top: compassOffsetTop || COMPASS_BASE_TOP,
+      top: (compassOffsetTop || COMPASS_BASE_TOP) + androidSafeAreaTop,
       right: Platform.select({default: 10, android: 6}),
     }),
-    [compassOffsetTop],
+    [compassOffsetTop, androidSafeAreaTop],
   );
 
   return useMemo(


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/22159

## Description
Now the button does not overlap on android either:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9f047284-1c8c-4978-8692-e00d3f8e996e" />
