### PR TITLE
fix: nynorsk 'bilett' typo

### DIFF
--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -259,7 +259,7 @@ const PurchaseOverviewTexts = {
     sendToOthersText: _(
       'Send billetten til noen andre',
       'Send the ticket to someone else',
-      'Send biletten til nokon andre',
+      'Send billetten til nokon andre',
     ),
   },
   ticketInformation: {


### PR DESCRIPTION
A nynorsk typo observed during the AtB demo today