### PR TITLE
chore: remove workaround needed for imagemagick

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -114,5 +114,5 @@ runs:
           rm '/usr/local/bin/pydoc3.11'
           rm '/usr/local/bin/python3.11'
           rm '/usr/local/bin/python3.11-config'
-          brew install shared-mime-info imagemagick
+          brew install imagemagick
           yarn generate-native-assets


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/mittatb-app/pull/5963
https://github.com/actions/runner-images/issues/13902

## Description
Newer runner image has been deployed and fixed the imagemagick installation issue