### PR TITLE
feat: Added rounded transport mode icons for TravelCard

### DIFF
--- a/src/components/icon-box/CounterIconBox.tsx
+++ b/src/components/icon-box/CounterIconBox.tsx
@@ -16,6 +16,7 @@ export const CounterIconBox = ({
   size = 'normal',
   spacing = 'compact',
   style,
+  rounded,
   notification,
 }: {
   count: number;
@@ -23,6 +24,7 @@ export const CounterIconBox = ({
   size?: keyof Theme['icon']['size'];
   spacing?: 'compact' | 'standard';
   style?: StyleProp<ViewStyle>;
+  rounded?: boolean;
   notification?: (props: SvgProps) => React.JSX.Element;
 }) => {
   const styles = useStyles();
@@ -44,7 +46,9 @@ export const CounterIconBox = ({
               {
                 padding: basePadding,
                 paddingRight: basePadding + extraPaddingRight,
-                borderRadius: getIconBoxBorderRadius(size, theme),
+                borderRadius: rounded
+                  ? theme.border.radius.circle
+                  : getIconBoxBorderRadius(size, theme),
               },
               style,
             ]}

--- a/src/screen-components/travel-card/TravelCardLegs.tsx
+++ b/src/screen-components/travel-card/TravelCardLegs.tsx
@@ -61,6 +61,7 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
                     spacing="standard"
                     textType="body__m__strong"
                     notification={overflowNotification}
+                    rounded
                   />
                 );
               }}

--- a/src/screen-components/travel-card/legs/FootLeg.tsx
+++ b/src/screen-components/travel-card/legs/FootLeg.tsx
@@ -25,7 +25,7 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     paddingHorizontal: theme.spacing.small,
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: theme.border.radius.regular,
+    borderRadius: theme.border.radius.circle,
   },
   walkDuration: {
     color: theme.color.foreground.dynamic.primary,

--- a/src/screen-components/travel-card/legs/TransportationLeg.tsx
+++ b/src/screen-components/travel-card/legs/TransportationLeg.tsx
@@ -19,5 +19,6 @@ export const TransportationLeg = ({
     spacious={true}
     testID={`${leg.mode}Leg`}
     notification={notification}
+    rounded={true}
   />
 );


### PR DESCRIPTION
## Issue Reference
Part of https://github.com/AtB-AS/kundevendt/issues/23634


## Description
Adds rounded icons to the TravelCard, according to Figma sketches. 

| Before | After |
|--------|-------|
| <img width="400" src="https://github.com/user-attachments/assets/2d3ef2c6-a064-4cb8-bfdf-e1c51cb1d4a0" /> | <img width="400" src="https://github.com/user-attachments/assets/66fd660e-4cf9-43fb-96b2-1eb7d772c2cf" /> |

