### PR TITLE
feat: only show refresh control when it is user initialized

### DIFF
--- a/src/modules/ticketing/use-recurring-payment.tsx
+++ b/src/modules/ticketing/use-recurring-payment.tsx
@@ -25,7 +25,8 @@ export const useRecurringPayment = () => {
     data: recurringPayment,
     refetch: refetchRecurringPayment,
     isError: recurringPaymentError,
-    isFetching: recurringPaymentLoading,
+    isFetching: recurringPaymentFetching,
+    isLoading: recurringPaymentIsLoading,
   } = useListRecurringPaymentsQuery();
 
   const {
@@ -89,7 +90,8 @@ export const useRecurringPayment = () => {
     recurringPayment,
     onAddRecurringPayment,
     isError,
-    recurringPaymentLoading,
+    recurringPaymentFetching,
+    recurringPaymentIsLoading,
     refetchRecurringPayment,
     deleteRecurringPayment,
     recurringPaymentError,

--- a/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -12,8 +12,8 @@ import {StopPlaces} from './components/StopPlaces';
 import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {DeparturesTexts, NearbyTexts, useTranslation} from '@atb/translations';
-import React, {Ref, useEffect, useMemo} from 'react';
-import {Platform, ScrollView, View} from 'react-native';
+import React, {Ref, useEffect} from 'react';
+import {ScrollView, View} from 'react-native';
 import {ScreenHeaderProps} from '@atb/components/screen-header';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
@@ -22,6 +22,7 @@ import SharedTexts from '@atb/translations/shared';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
 import {useNearestStopPlaceNodesQuery} from './use-nearest-stop-place-nodes-query';
+import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
 
 export type NearbyStopPlacesScreenParams = {
   location: Location | undefined;
@@ -112,20 +113,15 @@ export const NearbyStopPlacesScreenComponent = ({
           location.name
         : undefined;
 
-  const refreshControlProps = useMemo(() => {
-    // Quick fix for iOS to fix stuck spinner by removing the RefreshControl when not focused
-    return isFocused || Platform.OS === 'android'
-      ? {
-          refreshing: Platform.OS === 'ios' ? false : isLoading,
-          onRefresh: () =>
-            onUpdateLocation(
-              location?.resultType === 'geolocation'
-                ? (geolocation ?? undefined)
-                : location,
-            ),
-        }
-      : undefined;
-  }, [isFocused, isLoading, location, geolocation, onUpdateLocation]);
+  const refreshControlProps = useUserRefreshControlProps({
+    refreshing: isLoading,
+    onRefresh: () =>
+      onUpdateLocation(
+        location?.resultType === 'geolocation'
+          ? (geolocation ?? undefined)
+          : location,
+      ),
+  });
 
   return (
     <FullScreenView

--- a/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -22,7 +22,7 @@ import SharedTexts from '@atb/translations/shared';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
 import {useNearestStopPlaceNodesQuery} from './use-nearest-stop-place-nodes-query';
-import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 export type NearbyStopPlacesScreenParams = {
   location: Location | undefined;
@@ -113,7 +113,7 @@ export const NearbyStopPlacesScreenComponent = ({
           location.name
         : undefined;
 
-  const refreshControlProps = useUserRefreshControlProps({
+  const refreshControlProps = useManualRefreshControlProps({
     refreshing: isLoading,
     onRefresh: () =>
       onUpdateLocation(

--- a/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -42,7 +42,7 @@ import {useSingleTripQuery} from '@atb/modules/trip-patterns';
 import {getPosthogClientGlobal} from '@atb/modules/analytics';
 import {useScreenshotAware} from 'react-native-screenshot-aware';
 import {useTimeContext} from '@atb/modules/time';
-import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 export type TripDetailsScreenParams = {
   tripPattern: TripPattern;
@@ -106,7 +106,7 @@ export const TripDetailsScreenComponent = ({
   const fromToNames = getFromToName(updatedTripPattern.legs);
   const startEndTime = getStartEndTime(updatedTripPattern, language);
 
-  const refreshControlProps = useUserRefreshControlProps({
+  const refreshControlProps = useManualRefreshControlProps({
     refreshing: isFetching,
     onRefresh: refetch,
   });

--- a/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -29,7 +29,7 @@ import {
 import {formatToClock, secondsBetween} from '@atb/utils/date';
 import analytics from '@react-native-firebase/analytics';
 import {addMinutes, formatISO, hoursToSeconds, parseISO} from 'date-fns';
-import React, {Ref, useCallback, useEffect, useState} from 'react';
+import React, {Ref, useCallback} from 'react';
 import {View} from 'react-native';
 import {Trip} from './components/Trip';
 import {useHarbors} from '@atb/modules/harbors';
@@ -42,6 +42,7 @@ import {useSingleTripQuery} from '@atb/modules/trip-patterns';
 import {getPosthogClientGlobal} from '@atb/modules/analytics';
 import {useScreenshotAware} from 'react-native-screenshot-aware';
 import {useTimeContext} from '@atb/modules/time';
+import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
 
 export type TripDetailsScreenParams = {
   tripPattern: TripPattern;
@@ -105,17 +106,10 @@ export const TripDetailsScreenComponent = ({
   const fromToNames = getFromToName(updatedTripPattern.legs);
   const startEndTime = getStartEndTime(updatedTripPattern, language);
 
-  const [isManualRefresh, setIsManualRefresh] = useState(false);
-  const onManualRefresh = useCallback(() => {
-    setIsManualRefresh(true);
-    refetch();
-  }, [refetch]);
-
-  useEffect(() => {
-    if (!isFetching && isManualRefresh) {
-      setIsManualRefresh(false);
-    }
-  }, [isFetching, isManualRefresh]);
+  const refreshControlProps = useUserRefreshControlProps({
+    refreshing: isFetching,
+    onRefresh: refetch,
+  });
 
   return (
     <View style={styles.container}>
@@ -126,10 +120,7 @@ export const TripDetailsScreenComponent = ({
           title: t(TripDetailsTexts.header.title),
           color: themeColor,
         }}
-        refreshControlProps={{
-          refreshing: isFetching && isManualRefresh,
-          onRefresh: onManualRefresh,
-        }}
+        refreshControlProps={refreshControlProps}
         contentColor={theme.color.background.neutral[0]}
         headerContent={(focusRef) => (
           <View style={styles.headerContent}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -68,7 +68,7 @@ import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {WithOverlayButton} from '@atb/components/overlay-button';
 import {Loading} from '@atb/components/loading';
-import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 const RESULT_KEY_FROM = 'Dashboard_TripSearchScreen--fromLocation';
 const RESULT_KEY_TO = 'Dashboard_TripSearchScreen--toLocation';
@@ -270,7 +270,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
     refetchTrips();
   }, [from, to, currentLocation, searchTime, navigation, refetchTrips]);
 
-  const refreshControlProps = useUserRefreshControlProps({
+  const refreshControlProps = useManualRefreshControlProps({
     refreshing: tripsSearchState === 'searching' && !tripPatterns.length,
     onRefresh: forceRefresh,
   });

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -33,7 +33,7 @@ import Bugsnag from '@bugsnag/react-native';
 import {TFunc} from '@leile/lobo-t';
 import {useIsFocused, useNavigation, useRoute} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {Platform, View} from 'react-native';
+import {View} from 'react-native';
 import {DashboardScreenProps} from '../navigation-types';
 import {
   type SearchForLocations,
@@ -49,7 +49,6 @@ import {TripPattern} from '@atb/api/types/trips';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
 import {NativeBlockButton} from '@atb/components/native-button';
-import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {
   areDefaultFiltersSelected,
   getSearchTimeLabel,
@@ -69,6 +68,7 @@ import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {WithOverlayButton} from '@atb/components/overlay-button';
 import {Loading} from '@atb/components/loading';
+import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
 
 const RESULT_KEY_FROM = 'Dashboard_TripSearchScreen--fromLocation';
 const RESULT_KEY_TO = 'Dashboard_TripSearchScreen--toLocation';
@@ -98,7 +98,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const {language, t} = useTranslation();
   const [updatingLocation] = useState<boolean>(false);
   const analytics = useAnalyticsContext();
-  const isFocused = useIsFocusedAndActive();
   const filterButtonWrapperRef = useRef(null);
   const filterButtonRef = useRef(null);
   const travelSearchBottomSheetModalRef = useRef<BottomSheetModal | null>(null);
@@ -271,18 +270,10 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
     refetchTrips();
   }, [from, to, currentLocation, searchTime, navigation, refetchTrips]);
 
-  const refreshControlProps = useMemo(() => {
-    // Quick fix for iOS to fix stuck spinner by removing the RefreshControl when not focused
-    return isFocused || Platform.OS === 'android'
-      ? {
-          refreshing:
-            Platform.OS === 'ios'
-              ? false
-              : tripsSearchState === 'searching' && !tripPatterns.length,
-          onRefresh: forceRefresh,
-        }
-      : undefined;
-  }, [tripsSearchState, tripPatterns.length, forceRefresh, isFocused]);
+  const refreshControlProps = useUserRefreshControlProps({
+    refreshing: tripsSearchState === 'searching' && !tripPatterns.length,
+    onRefresh: forceRefresh,
+  });
 
   return (
     <View style={styles.container}>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -13,8 +13,8 @@ import {humanizePaymentType, RecurringPayment} from '@atb/modules/ticketing';
 import {useTranslation} from '@atb/translations';
 import PaymentMethodsTexts from '@atb/translations/screens/subscreens/PaymentMethods';
 import {useFontScale} from '@atb/utils/use-font-scale';
-import React, {useMemo} from 'react';
-import {RefreshControlProps, View} from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import {destructiveAlert} from './utils';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
@@ -22,6 +22,7 @@ import {ExpiryMessage, PaymentBrand} from '@atb/modules/payment';
 import {useRecurringPayment} from '@atb/modules/ticketing';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {ProfileScreenProps} from './navigation-types';
+import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
 
 type Props = ProfileScreenProps<'Profile_PaymentMethodsScreen'>;
 
@@ -40,12 +41,10 @@ export const Profile_PaymentMethodsScreen = ({navigation}: Props) => {
 
   const focusRef = useFocusOnLoad(navigation);
 
-  const refreshControlProps: RefreshControlProps = useMemo(() => {
-    return {
-      refreshing: recurringPaymentLoading,
-      onRefresh: refetchRecurringPayment,
-    };
-  }, [recurringPaymentLoading, refetchRecurringPayment]);
+  const refreshControlProps = useUserRefreshControlProps({
+    refreshing: recurringPaymentLoading,
+    onRefresh: refetchRecurringPayment,
+  });
 
   return (
     <FullScreenView

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -23,6 +23,7 @@ import {useRecurringPayment} from '@atb/modules/ticketing';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {ProfileScreenProps} from './navigation-types';
 import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
+import {Loading} from '@atb/components/loading';
 
 type Props = ProfileScreenProps<'Profile_PaymentMethodsScreen'>;
 
@@ -30,7 +31,8 @@ export const Profile_PaymentMethodsScreen = ({navigation}: Props) => {
   const styles = useStyles();
   const {t} = useTranslation();
   const {
-    recurringPaymentLoading,
+    recurringPaymentFetching,
+    recurringPaymentIsLoading,
     recurringPayment,
     refetchRecurringPayment,
     deleteRecurringPayment,
@@ -42,7 +44,7 @@ export const Profile_PaymentMethodsScreen = ({navigation}: Props) => {
   const focusRef = useFocusOnLoad(navigation);
 
   const refreshControlProps = useManualRefreshControlProps({
-    refreshing: recurringPaymentLoading,
+    refreshing: recurringPaymentFetching,
     onRefresh: refetchRecurringPayment,
   });
 
@@ -69,6 +71,7 @@ export const Profile_PaymentMethodsScreen = ({navigation}: Props) => {
             message={t(PaymentMethodsTexts.genericError)}
           />
         )}
+        {recurringPaymentIsLoading && <Loading />}
         {recurringPayment && recurringPayment.length > 0 && (
           <Section>
             {recurringPayment.map((card) => (
@@ -84,7 +87,7 @@ export const Profile_PaymentMethodsScreen = ({navigation}: Props) => {
           </Section>
         )}
         {!recurringPaymentError &&
-          !recurringPaymentLoading &&
+          !recurringPaymentFetching &&
           (!recurringPayment || recurringPayment?.length == 0) && (
             <NoCardsInfo />
           )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_PaymentMethodsScreen.tsx
@@ -22,7 +22,7 @@ import {ExpiryMessage, PaymentBrand} from '@atb/modules/payment';
 import {useRecurringPayment} from '@atb/modules/ticketing';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {ProfileScreenProps} from './navigation-types';
-import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 type Props = ProfileScreenProps<'Profile_PaymentMethodsScreen'>;
 
@@ -41,7 +41,7 @@ export const Profile_PaymentMethodsScreen = ({navigation}: Props) => {
 
   const focusRef = useFocusOnLoad(navigation);
 
-  const refreshControlProps = useUserRefreshControlProps({
+  const refreshControlProps = useManualRefreshControlProps({
     refreshing: recurringPaymentLoading,
     onRefresh: refetchRecurringPayment,
   });

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -27,7 +27,7 @@ import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useState} from 'react';
 import {ProfileScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
-import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 const MAX_VEHICLE_REGISTRATIONS = 2;
 
@@ -71,7 +71,7 @@ export const Profile_SmartParkAndRideScreen = ({route, navigation}: Props) => {
     }
   };
 
-  const refreshControlProps = useUserRefreshControlProps({
+  const refreshControlProps = useManualRefreshControlProps({
     refreshing: vehicleRegistrationsIsFetching,
     onRefresh: refetchVehicleRegistrations,
   });

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -24,9 +24,10 @@ import {ThemedCarRegister} from '@atb/theme/ThemedAssets';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useAuthContext} from '@atb/modules/auth';
 import {useAnalyticsContext} from '@atb/modules/analytics';
-import {useMemo, useState} from 'react';
+import {useState} from 'react';
 import {ProfileScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {useUserRefreshControlProps} from '@atb/utils/use-user-refresh-props';
 
 const MAX_VEHICLE_REGISTRATIONS = 2;
 
@@ -70,12 +71,10 @@ export const Profile_SmartParkAndRideScreen = ({route, navigation}: Props) => {
     }
   };
 
-  const refreshControlProps = useMemo(() => {
-    return {
-      refreshing: vehicleRegistrationsIsFetching,
-      onRefresh: refetchVehicleRegistrations,
-    };
-  }, [vehicleRegistrationsIsFetching, refetchVehicleRegistrations]);
+  const refreshControlProps = useUserRefreshControlProps({
+    refreshing: vehicleRegistrationsIsFetching,
+    onRefresh: refetchVehicleRegistrations,
+  });
 
   const focusRef = useFocusOnLoad(navigation);
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -28,6 +28,7 @@ import {useState} from 'react';
 import {ProfileScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
+import {Loading} from '@atb/components/loading';
 
 const MAX_VEHICLE_REGISTRATIONS = 2;
 
@@ -49,6 +50,7 @@ export const Profile_SmartParkAndRideScreen = ({route, navigation}: Props) => {
     data: vehicleRegistrations,
     refetch: refetchVehicleRegistrations,
     isFetching: vehicleRegistrationsIsFetching,
+    isLoading: vehicleRegistrationsIsLoading,
   } = useVehicleRegistrationsQuery();
   const {authenticationType} = useAuthContext();
   const analytics = useAnalyticsContext();
@@ -88,6 +90,7 @@ export const Profile_SmartParkAndRideScreen = ({route, navigation}: Props) => {
       refreshControlProps={refreshControlProps}
     >
       <View style={styles.container}>
+        {vehicleRegistrationsIsLoading && <Loading />}
         <ContentHeading
           text={t(
             SmartParkAndRideTexts.content.heading(

--- a/src/utils/use-manual-refresh-props.ts
+++ b/src/utils/use-manual-refresh-props.ts
@@ -6,7 +6,7 @@ import {RefreshControlProps} from 'react-native';
  * that the refreshing indicator is only shown when the user initiates a
  * pull-to-refresh and not when the refresh is triggered programmatically.
  */
-export function useUserRefreshControlProps({
+export function useManualRefreshControlProps({
   onRefresh,
   refreshing,
 }: {

--- a/src/utils/use-manual-refresh-props.ts
+++ b/src/utils/use-manual-refresh-props.ts
@@ -16,7 +16,7 @@ export function useManualRefreshControlProps({
   const [isUserRefreshing, setIsUserRefreshing] = useState(false);
 
   useEffect(() => {
-    if (refreshing && isUserRefreshing) setIsUserRefreshing(false);
+    if (!refreshing && isUserRefreshing) setIsUserRefreshing(false);
   }, [refreshing, isUserRefreshing]);
 
   return {

--- a/src/utils/use-user-refresh-props.ts
+++ b/src/utils/use-user-refresh-props.ts
@@ -1,0 +1,29 @@
+import {useEffect, useState} from 'react';
+import {RefreshControlProps} from 'react-native';
+
+/**
+ * Hook to manage the refreshing state of a pull-to-refresh control, ensuring
+ * that the refreshing indicator is only shown when the user initiates a
+ * pull-to-refresh and not when the refresh is triggered programmatically.
+ */
+export function useUserRefreshControlProps({
+  onRefresh,
+  refreshing,
+}: {
+  onRefresh: () => void;
+  refreshing: boolean;
+}): RefreshControlProps {
+  const [isUserRefreshing, setIsUserRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (refreshing && isUserRefreshing) setIsUserRefreshing(false);
+  }, [refreshing, isUserRefreshing]);
+
+  return {
+    refreshing: refreshing && isUserRefreshing,
+    onRefresh: () => {
+      setIsUserRefreshing(true);
+      onRefresh();
+    },
+  };
+}


### PR DESCRIPTION
## Issue Reference

fixes https://github.com/AtB-AS/kundevendt/issues/23323

## Description

Adds a new `useManualRefreshControlProps` hook that return refresh control props that only shows as refreshing when it is initiated by the user. This means that when navigating to a page that reloads on focus, the spinner won't trigger and get 'stuck' as described in https://github.com/AtB-AS/kundevendt/issues/23323.

Since the pull to refresh indicator isn't visible on open anymore, I added loading indicators on SPAR and payment method screens that shows on initial load.