### PR TITLE
feat: Experimentally enable new travel card in details

### DIFF
--- a/src/modules/experimental-store-trip-patterns/SwipeableResultRow.tsx
+++ b/src/modules/experimental-store-trip-patterns/SwipeableResultRow.tsx
@@ -8,6 +8,7 @@ import Animated, {SharedValue, useAnimatedStyle} from 'react-native-reanimated';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Delete, Save} from '@atb/assets/svg/mono-icons/actions';
 import {SvgProps} from 'react-native-svg';
+import {useRemoteConfigContext} from '@atb/modules/remote-config';
 
 export type RightActionKind = 'delete' | 'save';
 
@@ -21,6 +22,7 @@ export const SwipeableResultRow: React.FC<
   }>
 > = ({children, onRightAction, rightActionKind}) => {
   const swipeableRef = useRef<SwipeableMethods | null>(null);
+  const {save_trip_swipe_threshold} = useRemoteConfigContext();
 
   const closeSwipeable = useCallback(() => {
     swipeableRef.current?.close();
@@ -45,10 +47,10 @@ export const SwipeableResultRow: React.FC<
   return (
     <Swipeable
       ref={swipeableRef}
-      friction={1}
+      friction={2}
       overshootFriction={8}
       enableTrackpadTwoFingerGesture
-      rightThreshold={20}
+      rightThreshold={save_trip_swipe_threshold}
       renderRightActions={RightAction}
       onSwipeableOpen={handleSwipe}
     >

--- a/src/modules/experimental/use-is-experimental-enabled.ts
+++ b/src/modules/experimental/use-is-experimental-enabled.ts
@@ -1,6 +1,6 @@
 import {ExperimentalFeature} from '@atb/modules/native';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
-import {useTicketingContext} from '../ticketing/TicketingContext';
+import {useTicketingContext} from '@atb/modules/ticketing';
 import type {FeatureToggleNames} from '@atb/modules/feature-toggles';
 
 /**

--- a/src/modules/experimental/use-is-experimental-enabled.ts
+++ b/src/modules/experimental/use-is-experimental-enabled.ts
@@ -1,18 +1,26 @@
 import {ExperimentalFeature} from '@atb/modules/native';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {useTicketingContext} from '../ticketing/TicketingContext';
+import type {FeatureToggleNames} from '@atb/modules/feature-toggles';
 
 /**
  * Evaluates two conditions:
  * 1. Whether the experimental feature toggle is enabled. This means it can be overridden in the debug menu.
  * 2. Whether the current release channel is a non-production release channel.
+ *
+ * Optionally accepts a feature toggle name. If provided, the feature is also
+ * considered enabled when that specific toggle is true (via override or remote config).
  */
-export const useIsExperimentalEnabled = () => {
-  const {isExperimentalFeaturesEnabled} = useFeatureTogglesContext();
+export const useIsExperimentalEnabled = (
+  featureToggleName?: FeatureToggleNames,
+) => {
+  const featureToggles = useFeatureTogglesContext();
   const {customerProfile} = useTicketingContext();
+
   return (
-    isExperimentalFeaturesEnabled &&
-    (ExperimentalFeature.isNonProductionReleaseChannel() ||
-      customerProfile?.debug)
+    (featureToggles.isExperimentalFeaturesEnabled &&
+      (ExperimentalFeature.isNonProductionReleaseChannel() ||
+        customerProfile?.debug)) ||
+    (featureToggleName ? featureToggles[featureToggleName] : false)
   );
 };

--- a/src/modules/feature-toggles/index.ts
+++ b/src/modules/feature-toggles/index.ts
@@ -2,3 +2,4 @@ export {
   FeatureTogglesContextProvider,
   useFeatureTogglesContext,
 } from './FeatureTogglesContext';
+export type {FeatureToggleNames} from './types';

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -79,6 +79,7 @@ export type RemoteConfig = {
   mapbox_user_name: string;
   minimum_app_version: string;
   service_disruption_url: string;
+  save_trip_swipe_threshold: number;
   token_timeout_in_seconds: number;
   use_product_api_v2: boolean;
   use_trygg_overgang_qr_code: boolean;
@@ -157,6 +158,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   mapbox_user_name: MAPBOX_USER_NAME,
   minimum_app_version: '',
   service_disruption_url: '',
+  save_trip_swipe_threshold: 40,
   token_timeout_in_seconds: 10,
   use_product_api_v2: false,
   use_trygg_overgang_qr_code: false,
@@ -359,6 +361,9 @@ export function getConfig(): RemoteConfig {
   const service_disruption_url =
     values['service_disruption_url']?.asString() ??
     defaultRemoteConfig.service_disruption_url;
+  const save_trip_swipe_threshold =
+    values['save_trip_swipe_threshold']?.asNumber() ??
+    defaultRemoteConfig.save_trip_swipe_threshold;
   const token_timeout_in_seconds =
     values['token_timeout_in_seconds']?.asNumber() ??
     defaultRemoteConfig.token_timeout_in_seconds;
@@ -436,6 +441,7 @@ export function getConfig(): RemoteConfig {
     mapbox_user_name,
     minimum_app_version,
     service_disruption_url,
+    save_trip_swipe_threshold,
     token_timeout_in_seconds,
     use_product_api_v2,
     use_trygg_overgang_qr_code,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -22,6 +22,8 @@ import {ThemedOnBehalfOf} from '@atb/theme/ThemedAssets';
 import type {TripSearchTime} from '../../types';
 import {ResultRow} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultRow';
 import {SaveableTripSearchResultRow} from '@atb/modules/experimental-store-trip-patterns';
+import {useIsExperimentalEnabled} from '@atb/modules/experimental';
+import {TravelCard} from '@atb/screen-components/travel-card';
 
 type Props = {
   tripPatterns: TripPatternWithKey[];
@@ -50,6 +52,7 @@ export const Results: React.FC<Props> = ({
   const styles = useThemeStyles();
   const {t} = useTranslation();
   const now = useNow(30000);
+  const isExperimentalEnabled = useIsExperimentalEnabled();
 
   if (showEmptyScreen) {
     return null;
@@ -101,13 +104,24 @@ export const Results: React.FC<Props> = ({
               previousDepartureTime={tripPatterns[i - 1]?.expectedStartTime}
             />
             <SaveableTripSearchResultRow tripPattern={tripPattern}>
-              <ResultRow
-                tripPattern={tripPattern}
-                onDetailsPressed={onDetailsPressed}
-                resultIndex={i}
-                searchTime={searchTime}
-                testID={'tripSearchSearchResult' + i}
-              />
+              {isExperimentalEnabled ? (
+                <TravelCard
+                  tripPattern={tripPattern}
+                  onDetailsPressed={onDetailsPressed}
+                  cardIndex={i}
+                  numberOfCards={tripPatterns.length}
+                  testID={'tripSearchSearchResult' + i}
+                  type="trip-search"
+                />
+              ) : (
+                <ResultRow
+                  tripPattern={tripPattern}
+                  onDetailsPressed={onDetailsPressed}
+                  resultIndex={i}
+                  searchTime={searchTime}
+                  testID={'tripSearchSearchResult' + i}
+                />
+              )}
             </SaveableTripSearchResultRow>
           </Fragment>
         ))}


### PR DESCRIPTION
## Issue Reference
Duplicate of [this PR](https://github.com/AtB-AS/mittatb-app/pull/5941). Created a new one because of conflicts. 

## Description
This PR adds the new TravelCard to trip-search behind a feature toggle

<img width="300"  alt="simulator_screenshot_BC3C241E-0B11-4D3C-9886-26C3A0681B10" src="https://github.com/user-attachments/assets/361e5332-9649-47f2-9368-02f33fb443e9" />


### Other small changes
- Expands the experimentalFeature function to take a featureToggle name as a parameter. In practice that means that we OR the previous experimentalFeature logic and the featureToggle, so if either is true we display the logic. 
- Also tweaks some parameters to reduce accidental saving of trips. Also made this configurable through RemoteConfig, if we want to. 