### PR TITLE
feat: add booking grace period

### DIFF
--- a/src/modules/booking/__tests__/utils.test.ts
+++ b/src/modules/booking/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import {
   tripPatternDisplayTimeFilter,
 } from '../utils';
 import type {TripPatternWithBooking} from '@atb/api/types/trips';
-import {endOfDay} from 'date-fns';
+import {endOfDay, subSeconds} from 'date-fns';
 
 describe('tripPatternAvailabilityFilter', () => {
   it('returns true for supported booking availability', () => {
@@ -50,5 +50,50 @@ describe('tripPatternDisplayTimeFilter', () => {
       expectedStartTime: endOfDay(travelDate).toISOString(),
     } as TripPatternWithBooking;
     expect(tripPatternDisplayTimeFilter(tripPattern, travelDate)).toBe(false);
+  });
+
+  describe('with gracePeriodSeconds', () => {
+    it('returns true for trip 5 minutes before travelDate with 600s grace period', () => {
+      const tripPattern = {
+        expectedStartTime: subSeconds(
+          new Date(travelDate),
+          300,
+        ).toISOString(),
+      } as TripPatternWithBooking;
+      expect(tripPatternDisplayTimeFilter(tripPattern, travelDate, 600)).toBe(
+        true,
+      );
+    });
+
+    it('returns false for trip 11 minutes before travelDate with 600s grace period', () => {
+      const tripPattern = {
+        expectedStartTime: subSeconds(
+          new Date(travelDate),
+          660,
+        ).toISOString(),
+      } as TripPatternWithBooking;
+      expect(tripPatternDisplayTimeFilter(tripPattern, travelDate, 600)).toBe(
+        false,
+      );
+    });
+
+    it('returns true for trip exactly 10 minutes before travelDate with 600s grace period', () => {
+      const tripPattern = {
+        expectedStartTime: subSeconds(
+          new Date(travelDate),
+          600,
+        ).toISOString(),
+      } as TripPatternWithBooking;
+      expect(tripPatternDisplayTimeFilter(tripPattern, travelDate, 600)).toBe(
+        true,
+      );
+    });
+
+    it('returns false for trip before travelDate with default (0s) grace period', () => {
+      const tripPattern = {
+        expectedStartTime: subSeconds(new Date(travelDate), 1).toISOString(),
+      } as TripPatternWithBooking;
+      expect(tripPatternDisplayTimeFilter(tripPattern, travelDate)).toBe(false);
+    });
   });
 });

--- a/src/modules/booking/__tests__/utils.test.ts
+++ b/src/modules/booking/__tests__/utils.test.ts
@@ -55,10 +55,7 @@ describe('tripPatternDisplayTimeFilter', () => {
   describe('with gracePeriodSeconds', () => {
     it('returns true for trip 5 minutes before travelDate with 600s grace period', () => {
       const tripPattern = {
-        expectedStartTime: subSeconds(
-          new Date(travelDate),
-          300,
-        ).toISOString(),
+        expectedStartTime: subSeconds(new Date(travelDate), 300).toISOString(),
       } as TripPatternWithBooking;
       expect(tripPatternDisplayTimeFilter(tripPattern, travelDate, 600)).toBe(
         true,
@@ -67,10 +64,7 @@ describe('tripPatternDisplayTimeFilter', () => {
 
     it('returns false for trip 11 minutes before travelDate with 600s grace period', () => {
       const tripPattern = {
-        expectedStartTime: subSeconds(
-          new Date(travelDate),
-          660,
-        ).toISOString(),
+        expectedStartTime: subSeconds(new Date(travelDate), 660).toISOString(),
       } as TripPatternWithBooking;
       expect(tripPatternDisplayTimeFilter(tripPattern, travelDate, 600)).toBe(
         false,
@@ -79,10 +73,7 @@ describe('tripPatternDisplayTimeFilter', () => {
 
     it('returns true for trip exactly 10 minutes before travelDate with 600s grace period', () => {
       const tripPattern = {
-        expectedStartTime: subSeconds(
-          new Date(travelDate),
-          600,
-        ).toISOString(),
+        expectedStartTime: subSeconds(new Date(travelDate), 600).toISOString(),
       } as TripPatternWithBooking;
       expect(tripPatternDisplayTimeFilter(tripPattern, travelDate, 600)).toBe(
         true,

--- a/src/modules/booking/use-booking-trips.ts
+++ b/src/modules/booking/use-booking-trips.ts
@@ -82,6 +82,7 @@ export function useBookingTrips({
           tripPatternDisplayTimeFilter(
             tp,
             travelDate ?? new Date().toISOString(),
+            600,
           ),
         )
         .map((tp) => ({

--- a/src/modules/booking/use-booking-trips.ts
+++ b/src/modules/booking/use-booking-trips.ts
@@ -84,7 +84,7 @@ export function useBookingTrips({
           tripPatternDisplayTimeFilter(
             tp,
             travelDate ?? new Date().toISOString(),
-            booking_grace_period_seconds,
+            travelDate ? 0 : booking_grace_period_seconds,
           ),
         )
         .map((tp) => ({

--- a/src/modules/booking/use-booking-trips.ts
+++ b/src/modules/booking/use-booking-trips.ts
@@ -10,6 +10,7 @@ import {
   tripPatternDisplayTimeFilter,
 } from './utils';
 import {useProductAlternatives} from '@atb/modules/ticketing';
+import {useRemoteConfigContext} from '@atb/modules/remote-config';
 import type {BookingDisabledReason} from './types';
 import {startOfDay} from 'date-fns';
 
@@ -29,6 +30,7 @@ export function useBookingTrips({
 }): BookingTripsType {
   const {stopPlaces, travelDate, userProfilesWithCount} = selection;
   const productAlternatives = useProductAlternatives(selection);
+  const {booking_grace_period_seconds} = useRemoteConfigContext();
 
   // We always search from the start of the day to ensure we get all trips for that day
   // The trip search in BFF searches 24 hours from searchTime
@@ -82,7 +84,7 @@ export function useBookingTrips({
           tripPatternDisplayTimeFilter(
             tp,
             travelDate ?? new Date().toISOString(),
-            600,
+            booking_grace_period_seconds,
           ),
         )
         .map((tp) => ({

--- a/src/modules/booking/utils.ts
+++ b/src/modules/booking/utils.ts
@@ -1,7 +1,7 @@
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import type {TripPatternWithBooking} from '@atb/api/types/trips';
 import {isBefore, isEqualOrAfter} from '@atb/utils/date';
-import {endOfDay} from 'date-fns';
+import {endOfDay, subSeconds} from 'date-fns';
 
 export function isValidSelection(selection: PurchaseSelectionType) {
   return !!selection.stopPlaces?.from && !!selection.stopPlaces?.to;
@@ -18,13 +18,20 @@ export function tripPatternAvailabilityFilter(
 
 /**
  * Returns true for trip patterns with expected departure on or after the
- * given travelDate and before the end of that same day.
+ * given travelDate (minus an optional grace period) and before the end of
+ * that same day.
+ *
+ * @param gracePeriodSeconds - Number of seconds before travelDate to still
+ *   include. For example, 600 allows trips that departed up to 10 minutes
+ *   before travelDate.
  */
 export function tripPatternDisplayTimeFilter(
   tp: TripPatternWithBooking,
   travelDate: string,
+  gracePeriodSeconds: number = 0,
 ): boolean {
-  const isAfterSearchTime = isEqualOrAfter(tp.expectedStartTime, travelDate);
+  const earliestTime = subSeconds(new Date(travelDate), gracePeriodSeconds);
+  const isAfterSearchTime = isEqualOrAfter(tp.expectedStartTime, earliestTime);
   const isBeforeEndOfDay = isBefore(tp.expectedStartTime, endOfDay(travelDate));
   return isAfterSearchTime && isBeforeEndOfDay;
 }

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -148,7 +148,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_in_app_review_for_announcements: false,
   enable_smart_park_and_ride: false,
   enable_harbor_distances_api: false,
-  booking_grace_period_seconds: 600,
+  booking_grace_period_seconds: 0,
   flex_booking_number_of_days_available: 7,
   flex_ticket_url: '',
   live_vehicle_stale_threshold: 15,

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -68,6 +68,7 @@ export type RemoteConfig = {
   enable_in_app_review_for_announcements: boolean;
   enable_smart_park_and_ride: boolean;
   enable_harbor_distances_api: boolean;
+  booking_grace_period_seconds: number;
   flex_booking_number_of_days_available: number;
   flex_ticket_url: string;
   live_vehicle_stale_threshold: number;
@@ -147,6 +148,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_in_app_review_for_announcements: false,
   enable_smart_park_and_ride: false,
   enable_harbor_distances_api: false,
+  booking_grace_period_seconds: 600,
   flex_booking_number_of_days_available: 7,
   flex_ticket_url: '',
   live_vehicle_stale_threshold: 15,
@@ -324,6 +326,9 @@ export function getConfig(): RemoteConfig {
   const enable_harbor_distances_api =
     values['enable_harbor_distances_api']?.asBoolean() ??
     defaultRemoteConfig.enable_harbor_distances_api;
+  const booking_grace_period_seconds =
+    values['booking_grace_period_seconds']?.asNumber() ??
+    defaultRemoteConfig.booking_grace_period_seconds;
   const flex_booking_number_of_days_available =
     values['flex_booking_number_of_days_available']?.asNumber() ??
     defaultRemoteConfig.flex_booking_number_of_days_available;
@@ -430,6 +435,7 @@ export function getConfig(): RemoteConfig {
     enable_in_app_review_for_announcements,
     enable_smart_park_and_ride,
     enable_harbor_distances_api,
+    booking_grace_period_seconds,
     flex_booking_number_of_days_available,
     flex_ticket_url,
     live_vehicle_stale_threshold,


### PR DESCRIPTION
## Description
Troms wants to be able to purchase a ticket up to 10 minutes in the past. This adds a grace period controlled by a remote config variable for each fylke, which defaults to 0 (as today). 