### PR TITLE
feat: add bonus checkbox to scooter sheet

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -343,6 +343,7 @@ export const InitShmoOneStopBookingRequestBodySchema = z.object({
   operatorId: z.string(),
   vehicleTypeId: z.string().nullish().optional(),
   stationId: z.string().nullish().optional(),
+  bonusProductId: z.string().nullish().optional(),
 });
 
 export type InitShmoOneStopBookingRequestBody = z.infer<

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -1,5 +1,6 @@
 import {FormFactorSchema} from '@atb/api/types/mobility';
 import {LanguageAndTextTypeArray} from '@atb/modules/configuration';
+import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import {z} from 'zod';
 
 export enum BonusProductTypeEnum {
@@ -7,6 +8,18 @@ export enum BonusProductTypeEnum {
   TICKET = 'TICKET',
   SHARED_MOBILITY = 'SHARED_MOBILITY',
 }
+
+const BonusPriceAdjustmentSchema = z
+  .object({
+    amount: z.number(),
+    description: z.string(),
+    adjustmentType: PriceAdjustmentEnum,
+    systemIds: z.array(z.string()),
+  })
+  .transform(({adjustmentType, ...rest}) => ({
+    ...rest,
+    type: adjustmentType,
+  }));
 
 export const BonusProductSchema = z.object({
   id: z.string(),
@@ -17,6 +30,7 @@ export const BonusProductSchema = z.object({
   productType: z.enum(BonusProductTypeEnum),
   description: LanguageAndTextTypeArray,
   paymentDescription: LanguageAndTextTypeArray,
+  priceAdjustments: z.array(BonusPriceAdjustmentSchema).optional(),
 });
 
 export type BonusProductType = z.infer<typeof BonusProductSchema>;

--- a/src/modules/mobility/components/ShmoActionButton.tsx
+++ b/src/modules/mobility/components/ShmoActionButton.tsx
@@ -25,6 +25,7 @@ type ShmoActionButtonProps = {
   vehicleId: string;
   operatorId: string;
   paymentMethod: PaymentMethod | undefined;
+  bonusProductId?: string;
 };
 
 export const ShmoActionButton = ({
@@ -33,6 +34,7 @@ export const ShmoActionButton = ({
   operatorId,
   paymentMethod,
   loginCallback,
+  bonusProductId,
 }: ShmoActionButtonProps) => {
   const {authenticationType, userId} = useAuthContext();
   const {hasBlockers, numberOfBlockers, ageVerification, operatorAgeLimit} =
@@ -66,6 +68,7 @@ export const ShmoActionButton = ({
         : undefined,
       operatorId: operatorId,
       vehicleTypeId: vehicle?.vehicleType.id,
+      bonusProductId: bonusProductId,
     };
     const res = await initShmoOneStopBooking(initReqBody);
     logEvent('Mobility', 'Shmo booking started', {
@@ -92,6 +95,7 @@ export const ShmoActionButton = ({
     initShmoOneStopBooking,
     logEvent,
     userId,
+    bonusProductId,
   ]);
 
   if (authenticationType != 'phone') {

--- a/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
@@ -40,11 +40,9 @@ import {
   FormFactor,
   PropulsionType,
 } from '@atb/api/types/generated/mobility-types_v2';
-import {PriceDetailsCard} from '../PriceDetailsCard';
 import {useOperators} from '../../use-operators';
 import {SupportButton} from '../SupportButton';
 import {BrandingImage} from '../BrandingImage';
-import {isValidKey} from '@atb/stacks-hierarchy';
 import {EndManualTripCard} from '../EndManualTripCard';
 import {ThemedCityBike} from '@atb/theme/ThemedAssets';
 import {usePersistedBoolState} from '@atb/utils/use-persisted-bool-state';
@@ -88,13 +86,6 @@ export const ActiveShmoSheet = ({
 
   const operator = useOperators().byId(activeBooking?.asset.operator.id);
   const operatorLogo = operator?.brandAssets?.brandImageUrl;
-
-  const priceAdjustments =
-    operator?.priceAdjustments &&
-    activeBooking?.asset?.formFactor &&
-    isValidKey(operator.priceAdjustments, activeBooking.asset.formFactor)
-      ? operator.priceAdjustments[activeBooking.asset.formFactor]
-      : [];
 
   const {t} = useTranslation();
   const {theme} = useThemeContext();
@@ -233,12 +224,6 @@ export const ActiveShmoSheet = ({
                       formFactor={activeBooking.asset.formFactor ?? undefined}
                     />
                   )}
-                <PriceDetailsCard
-                  pricingPlan={activeBooking.pricingPlan}
-                  priceAdjustments={priceAdjustments}
-                  systemId={activeBooking.asset.systemId ?? ''}
-                />
-
                 <View style={styles.footer}>
                   {geofencingZoneWarning && (
                     <View style={styles.geofencingZoneWarning}>

--- a/src/modules/mobility/components/sheets/ScooterSheet.tsx
+++ b/src/modules/mobility/components/sheets/ScooterSheet.tsx
@@ -1,5 +1,5 @@
 import {VehicleId} from '@atb/api/types/generated/fragments/vehicles';
-import React from 'react';
+import React, {useState} from 'react';
 import {useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
@@ -38,6 +38,13 @@ import {SupportButton} from '../SupportButton';
 import {TransportationIconBox} from '@atb/components/icon-box';
 import {BrandingImage} from '../BrandingImage';
 import {getTransportModeAndSubMode} from '../../utils';
+import {
+  BonusProductTypeEnum,
+  PayWithBonusPointsCheckbox,
+  useIsBonusActiveForUser,
+  useRelevantBonusProduct,
+} from '@atb/modules/bonus';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 
 type Props = {
   selectPaymentMethod: () => void;
@@ -97,6 +104,15 @@ export const ScooterSheet = ({
 
   const {isParkingViolationsReportingEnabled, isShmoDeepIntegrationEnabled} =
     useFeatureTogglesContext();
+
+  const isBonusActiveForUser = useIsBonusActiveForUser();
+  const bonusProduct = useRelevantBonusProduct(
+    operatorId,
+    FormFactor.Scooter,
+    BonusProductTypeEnum.SHARED_MOBILITY,
+  );
+  const {logEvent} = useAnalyticsContext();
+  const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
 
   return (
     <MapBottomSheet
@@ -161,7 +177,11 @@ export const ScooterSheet = ({
 
             <PriceDetailsCard
               pricingPlan={vehicle.pricingPlan}
-              priceAdjustments={priceAdjustments}
+              priceAdjustments={
+                payWithBonusPoints && bonusProduct?.priceAdjustments
+                  ? bonusProduct.priceAdjustments
+                  : priceAdjustments
+              }
               systemId={vehicle.system.id}
             />
           </View>
@@ -170,12 +190,32 @@ export const ScooterSheet = ({
           operatorId &&
           operatorIsIntegrationEnabled ? (
             <>
+              {isBonusActiveForUser && !!bonusProduct && (
+                <PayWithBonusPointsCheckbox
+                  bonusProduct={bonusProduct}
+                  operatorName={operatorName}
+                  isChecked={payWithBonusPoints}
+                  onPress={() =>
+                    setPayWithBonusPoints((prev) => {
+                      const newState = !prev;
+                      logEvent('Bonus', 'bonus points checkbox toggled', {
+                        bonusProductId: bonusProduct.id,
+                        newState,
+                      });
+                      return newState;
+                    })
+                  }
+                />
+              )}
               <ShmoActionButton
                 onStartOnboarding={startOnboardingCallback}
                 loginCallback={navigateToLogin}
                 vehicleId={id}
                 operatorId={operatorId}
                 paymentMethod={selectedPaymentMethod}
+                bonusProductId={
+                  payWithBonusPoints ? bonusProduct?.id : undefined
+                }
               />
               <View style={styles.helpButtons}>
                 {selectedPaymentMethod && !hasBlockers && (


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23800

## Description
Adds checkbox to use bonus on scooter sheet.
Functionality:
- If there exists a BonusProduct for current operator and FormFactor, checkbox shows
- If checkbox is checked, price updates are highlightet
- When button is pressed BonusProductId (if checkbox is active) is sent in initShmoOneStopBooking call to MobilityService, priceadjustments are applied there

Worth noting:
- Price info is removed from activeShmoSheet, as this will not be there in updated future design anyways

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8f745b49-d6ba-4aa1-8a07-0feaa4050ec2" />  <img width="200" alt="image" src="https://github.com/user-attachments/assets/93cc9ac4-9897-49b3-a5dc-d7ac0e26fed9" />

