### PR TITLE
Add BonusProductGroup support and update BonusProduct types

### DIFF
--- a/src/modules/bonus/api/api.ts
+++ b/src/modules/bonus/api/api.ts
@@ -1,5 +1,10 @@
 import {client} from '@atb/api';
-import {BonusProductSchema, BonusProductType} from '../types';
+import {
+  BonusProductGroupSchema,
+  BonusProductGroupType,
+  BonusProductSchema,
+  BonusProductType,
+} from '../types';
 import {z} from 'zod';
 
 export const getBonusBalance = async (): Promise<number> => {
@@ -73,4 +78,14 @@ export const getActiveBonusProducts = async (): Promise<BonusProductType[]> => {
   });
 
   return z.array(BonusProductSchema).parse(response.data);
+};
+
+export const getActiveBonusProductGroups = async (): Promise<
+  BonusProductGroupType[]
+> => {
+  const response = await client.get(`/bonus/v2/product-groups`, {
+    authWithIdToken: true,
+  });
+
+  return z.array(BonusProductGroupSchema).parse(response.data);
 };

--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -4,7 +4,7 @@ import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {BonusStarFill} from './BonusStarFill';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
-import {BonusProductType} from '@atb/modules/bonus';
+import {BonusProductGroupType, BonusProductType} from '@atb/modules/bonus';
 import {
   BonusProgramTexts,
   getTextForLanguage,
@@ -21,17 +21,17 @@ import {MapPin} from '@atb/assets/svg/mono-icons/tab-bar';
 import {MapFilterType, useMapContext} from '@atb/modules/map';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 
-const shouldShowMapButton = (bonusProduct: BonusProductType) =>
-  bonusProduct.formFactors.some(
-    (ff) => (ff as FormFactor) !== FormFactor.Other,
-  );
-
 type Props = {
+  bonusProductGroups: BonusProductGroupType[];
   bonusProducts: BonusProductType[];
   onNavigateToMap?: (initialFilters: MapFilterType) => void;
 };
 
-export const BonusProductList = ({bonusProducts, onNavigateToMap}: Props) => {
+export const BonusProductList = ({
+  bonusProductGroups,
+  bonusProducts,
+  onNavigateToMap,
+}: Props) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {mobilityOperators} = useFirestoreConfigurationContext();
@@ -39,10 +39,10 @@ export const BonusProductList = ({bonusProducts, onNavigateToMap}: Props) => {
   const analytics = useAnalyticsContext();
 
   const handleNavigateToMap = useCallback(
-    (bonusProduct: BonusProductType) => {
+    (formFactors: FormFactor[]) => {
       if (!onNavigateToMap || !mapFilter?.mobility) return;
       const updatedMobility = {...mapFilter.mobility};
-      bonusProduct.formFactors.forEach((ff) => {
+      formFactors.forEach((ff) => {
         updatedMobility[ff] = {
           operators: updatedMobility[ff]?.operators ?? [],
           showAll: true,
@@ -57,100 +57,109 @@ export const BonusProductList = ({bonusProducts, onNavigateToMap}: Props) => {
 
   return (
     <View style={styles.container}>
-      {bonusProducts.map((bonusProduct) => (
-        <Pressable
-          key={bonusProduct.id}
-          onPress={() =>
-            analytics.logEvent('Bonus', 'Bonus product pressed', {
-              productId: bonusProduct.id,
-            })
-          }
-          accessible={false}
-          importantForAccessibility="no"
-        >
-          <Section>
-            <GenericSectionItem>
-              <View style={styles.horizontalContainer}>
-                {(() => {
-                  const {mode, subMode} = getTransportModeAndSubMode(
-                    bonusProduct.formFactors[0] as FormFactor,
-                  );
-                  return (
-                    <TransportationIconBox
-                      mode={mode}
-                      subMode={subMode}
-                      rounded
-                    />
-                  );
-                })()}
-                <View style={{flex: 1}} accessible={true}>
-                  <ThemeText typography="body__s__strong">
-                    {[
-                      ...new Set(
-                        bonusProduct.formFactors.map((ff) =>
-                          t(MobilityTexts.vehicleName(ff as FormFactor)),
-                        ),
-                      ),
-                    ].join(', ')}
-                  </ThemeText>
-                  <ThemeText typography="body__s" color="secondary">
-                    {bonusProduct.operatorIds
-                      .map(
-                        (id) =>
-                          mobilityOperators?.find((op) => op.id === id)?.name ??
-                          id,
-                      )
-                      .join(', ')}
-                  </ThemeText>
+      {bonusProductGroups.map((group) => {
+        const memberProducts = bonusProducts.filter(
+          (bp) => bp.bonusProductGroupId === group.id,
+        );
+        const formFactors = [
+          ...new Set(memberProducts.flatMap((bp) => bp.formFactors)),
+        ] as FormFactor[];
+        const operatorNames = memberProducts
+          .map(
+            (bp) =>
+              mobilityOperators?.find((op) => op.id === bp.operatorId)?.name ??
+              bp.operatorId,
+          )
+          .join(', ');
+        const showMapButton =
+          !!onNavigateToMap &&
+          formFactors.some((ff) => ff !== FormFactor.Other);
+
+        return (
+          <Pressable
+            key={group.id}
+            onPress={() =>
+              analytics.logEvent('Bonus', 'Bonus product group pressed', {
+                bonusProductGroupId: group.id,
+              })
+            }
+            accessible={false}
+            importantForAccessibility="no"
+          >
+            <Section>
+              <GenericSectionItem>
+                <View style={styles.horizontalContainer}>
+                  {(() => {
+                    const {mode, subMode} = getTransportModeAndSubMode(
+                      formFactors[0],
+                    );
+                    return (
+                      <TransportationIconBox
+                        mode={mode}
+                        subMode={subMode}
+                        rounded
+                      />
+                    );
+                  })()}
+                  <View style={{flex: 1}} accessible={true}>
+                    <ThemeText typography="body__s__strong">
+                      {formFactors
+                        .map((ff) => t(MobilityTexts.vehicleName(ff)))
+                        .join(', ')}
+                    </ThemeText>
+                    <ThemeText typography="body__s" color="secondary">
+                      {operatorNames}
+                    </ThemeText>
+                  </View>
+                  {showMapButton && (
+                    <Pressable
+                      onPress={() => {
+                        analytics.logEvent(
+                          'Bonus',
+                          'Map button on bonus product group clicked',
+                          {
+                            bonusProductGroupId: group.id,
+                          },
+                        );
+                        handleNavigateToMap(formFactors);
+                      }}
+                      style={styles.mapButton}
+                      accessibilityRole="button"
+                      accessibilityLabel={t(
+                        BonusProgramTexts.bonusProfile.mapButton.a11yLabel,
+                      )}
+                      accessibilityHint={t(
+                        BonusProgramTexts.bonusProfile.mapButton.a11yHint,
+                      )}
+                    >
+                      <ThemeIcon svg={MapPin} />
+                      <ThemeIcon svg={ChevronRight} />
+                    </Pressable>
+                  )}
                 </View>
-                {onNavigateToMap && shouldShowMapButton(bonusProduct) && (
-                  <Pressable
-                    onPress={() => {
-                      analytics.logEvent(
-                        'Bonus',
-                        'Map button on bonus product clicked',
-                        {
-                          productId: bonusProduct.id,
-                        },
-                      );
-                      handleNavigateToMap(bonusProduct);
-                    }}
-                    style={styles.mapButton}
-                    accessibilityRole="button"
-                    accessibilityLabel={t(
-                      BonusProgramTexts.bonusProfile.mapButton.a11yLabel,
-                    )}
-                    accessibilityHint={t(
-                      BonusProgramTexts.bonusProfile.mapButton.a11yHint,
-                    )}
+              </GenericSectionItem>
+              <GenericSectionItem>
+                <View accessible={true}>
+                  <View style={styles.usePointsRow}>
+                    <ThemeText>{t(BonusProgramTexts.spend)}</ThemeText>
+                    <ThemeIcon svg={BonusStarFill} size="small" />
+                    <ThemeText>
+                      {t(BonusProgramTexts.amountPoints(group.price.amount))}
+                    </ThemeText>
+                  </View>
+                  <ThemeText
+                    isMarkdown={true}
+                    typography="body__s"
+                    color="secondary"
                   >
-                    <ThemeIcon svg={MapPin} />
-                    <ThemeIcon svg={ChevronRight} />
-                  </Pressable>
-                )}
-              </View>
-            </GenericSectionItem>
-            <GenericSectionItem>
-              <View accessible={true}>
-                <View style={styles.usePointsRow}>
-                  <ThemeText>{t(BonusProgramTexts.spend)}</ThemeText>
-                  <ThemeIcon svg={BonusStarFill} size="small" />
-                  <ThemeText>
-                    {t(BonusProgramTexts.amountPoints(bonusProduct.price))}
+                    {getTextForLanguage(group.description, language) ?? ''}
                   </ThemeText>
                 </View>
-                <ThemeText
-                  isMarkdown={true}
-                  typography="body__s"
-                  color="secondary"
-                >
-                  {getTextForLanguage(bonusProduct.description, language) ?? ''}
-                </ThemeText>
-              </View>
-            </GenericSectionItem>
-          </Section>
-        </Pressable>
-      ))}
+              </GenericSectionItem>
+            </Section>
+          </Pressable>
+        );
+      })}
     </View>
   );
 };

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -48,12 +48,12 @@ export const PayWithBonusPointsCheckbox = ({
     Number.isNaN(userBonusBalance) ||
     userBonusBalanceStatus === 'error';
 
-  const isDisabled = isError || userBonusBalance < bonusProduct.price;
+  const isDisabled = isError || userBonusBalance < bonusProduct.price.amount;
 
   const a11yLabel =
     (getTextForLanguage(bonusProduct.paymentDescription, language) ?? '') +
     screenReaderPause +
-    t(BonusProgramTexts.costA11yLabel(bonusProduct.price)) +
+    t(BonusProgramTexts.costA11yLabel(bonusProduct.price.amount)) +
     screenReaderPause +
     t(
       BonusProgramTexts.yourBonusBalanceA11yLabel(
@@ -99,7 +99,7 @@ export const PayWithBonusPointsCheckbox = ({
               </View>
             </View>
             <BonusPriceTag
-              amount={bonusProduct.price}
+              amount={bonusProduct.price.amount}
               style={{alignSelf: 'flex-start'}}
             />
           </View>

--- a/src/modules/bonus/index.ts
+++ b/src/modules/bonus/index.ts
@@ -16,9 +16,10 @@ export {
   getBonusAmountEarnedQueryKey,
   useProductPointsQuery,
   useActiveBonusProductsQuery,
+  useActiveBonusProductGroupsQuery,
 } from './queries';
 export {BonusProductTypeEnum} from './types';
-export type {BonusProductType} from './types';
+export type {BonusProductType, BonusProductGroupType} from './types';
 export {
   bonusOnboardingCarouselConfig,
   type BonusOnboardingScreenName,

--- a/src/modules/bonus/queries/index.tsx
+++ b/src/modules/bonus/queries/index.tsx
@@ -6,3 +6,4 @@ export {
 } from './use-bonus-amount-earned-query';
 export {useProductPointsQuery} from './use-product-points-query';
 export {useActiveBonusProductsQuery} from './use-active-bonus-products-query';
+export {useActiveBonusProductGroupsQuery} from './use-active-bonus-product-groups-query';

--- a/src/modules/bonus/queries/use-active-bonus-product-groups-query.tsx
+++ b/src/modules/bonus/queries/use-active-bonus-product-groups-query.tsx
@@ -1,0 +1,15 @@
+import {useQuery} from '@tanstack/react-query';
+import {getActiveBonusProductGroups} from '../api/api';
+import {useIsBonusActiveForUser} from '../use-is-bonus-active-for-user';
+import {useIsBonusEnrollable} from '../use-is-bonus-enrollable';
+
+export const useActiveBonusProductGroupsQuery = (enabled: boolean = true) => {
+  const isBonusActiveForUser = useIsBonusActiveForUser();
+  const isBonusEnrollable = useIsBonusEnrollable();
+
+  return useQuery({
+    enabled: enabled && (isBonusActiveForUser || isBonusEnrollable),
+    queryKey: ['activeBonusProductGroups'],
+    queryFn: getActiveBonusProductGroups,
+  });
+};

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -9,6 +9,11 @@ export enum BonusProductTypeEnum {
   SHARED_MOBILITY = 'SHARED_MOBILITY',
 }
 
+const PriceSchema = z.object({
+  amount: z.number(),
+  currency: z.string(),
+});
+
 const BonusPriceAdjustmentSchema = z
   .object({
     amount: z.number(),
@@ -24,9 +29,10 @@ const BonusPriceAdjustmentSchema = z
 export const BonusProductSchema = z.object({
   id: z.string(),
   isActive: z.boolean(),
-  operatorIds: z.array(z.string()),
+  bonusProductGroupId: z.string(),
+  operatorId: z.string(),
   formFactors: z.array(FormFactorSchema),
-  price: z.number(),
+  price: PriceSchema,
   productType: z.enum(BonusProductTypeEnum),
   description: LanguageAndTextTypeArray,
   paymentDescription: LanguageAndTextTypeArray,
@@ -34,3 +40,11 @@ export const BonusProductSchema = z.object({
 });
 
 export type BonusProductType = z.infer<typeof BonusProductSchema>;
+
+export const BonusProductGroupSchema = z.object({
+  id: z.string(),
+  description: LanguageAndTextTypeArray,
+  price: PriceSchema,
+});
+
+export type BonusProductGroupType = z.infer<typeof BonusProductGroupSchema>;

--- a/src/modules/bonus/use-relevant-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-bonus-product.ts
@@ -14,7 +14,7 @@ export const useRelevantBonusProduct = (
   return activeBonusProducts?.find(
     (bonusProduct) =>
       bonusProduct.formFactors.includes(formFactor) &&
-      bonusProduct.operatorIds.includes(operatorId) &&
+      bonusProduct.operatorId === operatorId &&
       (!productType || bonusProduct.productType === productType),
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusHowPointsWork.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusHowPointsWork.tsx
@@ -53,7 +53,7 @@ export const HowPointsWork = () => {
         .filter(
           (product) => product.productType === BonusProductTypeEnum.VOUCHER,
         )
-        .flatMap((product) => product.operatorIds),
+        .map((product) => product.operatorId),
     ),
   ]
     .map((operatorId) => {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -19,6 +19,7 @@ import {
   UserBonusBalanceContent,
   useBonusBalanceQuery,
   useActiveBonusProductsQuery,
+  useActiveBonusProductGroupsQuery,
   BonusProductList,
 } from '@atb/modules/bonus';
 import {
@@ -65,6 +66,11 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
     isLoading: isBonusProductsLoading,
     isError: isBonusProductsError,
   } = useActiveBonusProductsQuery();
+  const {
+    data: activeBonusProductGroups,
+    isLoading: isBonusGroupsLoading,
+    isError: isBonusGroupsError,
+  } = useActiveBonusProductGroupsQuery();
   const getHasReservationOrAvailableFareContract =
     useGetHasReservationOrAvailableFareContract();
 
@@ -215,9 +221,11 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
         <ContentHeading
           text={t(BonusProgramTexts.bonusProfile.spendPoints.heading)}
         />
-        {isBonusProductsLoading ? (
+        {isBonusProductsLoading || isBonusGroupsLoading ? (
           <Loading size="large" />
-        ) : isBonusProductsError || activeBonusProducts?.length === 0 ? (
+        ) : isBonusProductsError ||
+          isBonusGroupsError ||
+          activeBonusProductGroups?.length === 0 ? (
           <View style={styles.noAccount}>
             <MessageInfoBox
               type="error"
@@ -225,8 +233,10 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
             />
           </View>
         ) : (
+          activeBonusProductGroups &&
           activeBonusProducts && (
             <BonusProductList
+              bonusProductGroups={activeBonusProductGroups}
               bonusProducts={activeBonusProducts}
               onNavigateToMap={(initialFilters) =>
                 navigation.navigate('Root_TabNavigatorStack', {


### PR DESCRIPTION
## Summary

- Add `BonusProductGroupSchema`/`BonusProductGroupType` with `id`, `description`, `price: {amount, currency}`
- Add `getActiveBonusProductGroups` API call and `useActiveBonusProductGroupsQuery` hook
- Update `BonusProductSchema`: `operatorId` (singular string), `bonusProductGroupId`, `price` as `{amount, currency}` object
- Update `BonusProductList` to render one row per group, aggregating form factors and operator names from member products
- Fix all `operatorIds` → `operatorId` references across components and hooks

## Test plan

- [ ] Bonus screen shows one row per product group
- [ ] Map button navigates with correct form factors
- [ ] Pay with points checkbox shows correct point amount
- [ ] Voucher operator links render correctly in "How points work" screen



Resolves https://github.com/AtB-AS/kundevendt/issues/23862