### PR TITLE
feat: use useManualRefreshControlProps for all refresh controls

### DIFF
--- a/src/screen-components/place-screen/components/QuayView.tsx
+++ b/src/screen-components/place-screen/components/QuayView.tsx
@@ -23,6 +23,7 @@ import {useFavoritesContext} from '@atb/modules/favorites';
 import {hasFavorites} from '../utils';
 import {DeparturesProps, useDepartures} from '../hooks/use-departures';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 const NUMBER_OF_DEPARTURES_PER_QUAY_TO_SHOW = 1000;
 
@@ -98,6 +99,11 @@ export function QuayView({
     if (!placeHasFavorites) setShowOnlyFavorites(false);
   }, [placeHasFavorites, setShowOnlyFavorites]);
 
+  const refreshControlProps = useManualRefreshControlProps({
+    onRefresh: refetchDepartures,
+    refreshing: departuresIsLoading,
+  });
+
   return (
     <SectionList
       onScroll={onScroll}
@@ -132,11 +138,7 @@ export function QuayView({
         </>
       }
       refreshControl={
-        <RefreshControl
-          refreshing={departuresIsLoading}
-          onRefresh={refetchDepartures}
-          testID="isLoading"
-        />
+        <RefreshControl {...refreshControlProps} testID="isLoading" />
       }
       sections={quayListData}
       testID={testID}

--- a/src/screen-components/place-screen/components/StopPlacesView.tsx
+++ b/src/screen-components/place-screen/components/StopPlacesView.tsx
@@ -28,6 +28,7 @@ import {
 } from '../utils';
 import {DeparturesProps, useDepartures} from '../hooks/use-departures';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 type Props = {
   stopPlaces: StopPlace[];
@@ -131,6 +132,11 @@ export const StopPlacesView = (props: Props) => {
     if (!placeHasFavorites) setShowOnlyFavorites(false);
   }, [placeHasFavorites, setShowOnlyFavorites]);
 
+  const refreshControlProps = useManualRefreshControlProps({
+    onRefresh: refetchDepartures,
+    refreshing: departuresIsLoading,
+  });
+
   return (
     <SectionList
       onScroll={onScroll}
@@ -168,12 +174,7 @@ export const StopPlacesView = (props: Props) => {
           ) : null}
         </>
       }
-      refreshControl={
-        <RefreshControl
-          refreshing={departuresIsLoading}
-          onRefresh={refetchDepartures}
-        />
-      }
+      refreshControl={<RefreshControl {...refreshControlProps} />}
       sections={quayListData}
       testID={testID}
       keyExtractor={(item) => item.quay.id}

--- a/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
+++ b/src/stacks-hierarchy/Root_ChooseTicketRecipientScreen/Root_ChooseTicketRecipientScreen.tsx
@@ -17,6 +17,7 @@ import {Theme} from '@atb/theme/colors';
 import {SendToOtherButton} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/components/SendToOtherButton';
 import {FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY} from '@atb/modules/on-behalf-of';
 import {giveFocus, useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 type Props = RootStackScreenProps<'Root_ChooseTicketRecipientScreen'>;
 const getThemeColor = (theme: Theme) => theme.color.background.neutral[1];
@@ -37,6 +38,14 @@ export const Root_ChooseTicketRecipientScreen = ({
 
   const onDeleteRef = useRef(undefined);
 
+  const refreshControlProps = useManualRefreshControlProps({
+    onRefresh: () =>
+      queryClient.resetQueries({
+        queryKey: [FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY],
+      }),
+    refreshing: false,
+  });
+
   return (
     <View style={styles.container}>
       <FullScreenHeader
@@ -49,18 +58,7 @@ export const Root_ChooseTicketRecipientScreen = ({
         <ScrollView
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={styles.contentContainerStyle}
-          refreshControl={
-            <RefreshControl
-              onRefresh={() =>
-                queryClient.resetQueries({
-                  queryKey: [FETCH_ON_BEHALF_OF_ACCOUNTS_QUERY_KEY],
-                })
-              }
-              refreshing={false}
-              tintColor={themeColor.foreground.primary}
-              colors={[themeColor.foreground.primary]}
-            />
-          }
+          refreshControl={<RefreshControl {...refreshControlProps} />}
         >
           <TitleAndDescription themeColor={themeColor} ref={onDeleteRef} />
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -23,6 +23,7 @@ import {useNestedProfileScreenParams} from '@atb/utils/use-nested-profile-screen
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {ONE_SECOND_MS} from '@atb/utils/durations';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 type Props =
   TicketTabNavScreenProps<'TicketTabNav_AvailableFareContractsTabScreen'>;
@@ -67,28 +68,28 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
     [navigation],
   );
 
+  const refreshControlProps = useManualRefreshControlProps({
+    onRefresh: () => {
+      refetchAvailableFareContracts();
+      refetchPreassignedFareProducts();
+      queryClient.invalidateQueries({
+        queryKey: [SCHOOL_CARNET_QUERY_KEY],
+      });
+      analytics.logEvent('Ticketing', 'Pull to refresh tickets', {
+        reservationsCount: reservations.length,
+        availableFareContractsCount: availableFareContracts.length,
+      });
+    },
+    refreshing: isRefetchingAvailableFareContracts,
+  });
+
   return (
     <View style={styles.container}>
       <AnimatedGestureHandlerScrollView
         contentContainerStyle={styles.content}
         onScroll={scrollHandler}
         scrollEventThrottle={16}
-        refreshControl={
-          <RefreshControl
-            refreshing={isRefetchingAvailableFareContracts}
-            onRefresh={() => {
-              refetchAvailableFareContracts();
-              refetchPreassignedFareProducts();
-              queryClient.invalidateQueries({
-                queryKey: [SCHOOL_CARNET_QUERY_KEY],
-              });
-              analytics.logEvent('Ticketing', 'Pull to refresh tickets', {
-                reservationsCount: reservations.length,
-                availableFareContractsCount: availableFareContracts.length,
-              });
-            }}
-          />
-        }
+        refreshControl={<RefreshControl {...refreshControlProps} />}
         testID="availableFCScrollView"
       >
         <TravelTokenBox

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -20,6 +20,7 @@ import {
 import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
 import {AnimatedGestureHandlerScrollView} from '@atb/components/animated-gesture-handler-scroll-view';
 import {useTabScrollHandler} from '../Ticketing_TicketTabNavStack';
+import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 
 type Props = TicketTabNavScreenProps<'TicketTabNav_PurchaseTabScreen'>;
 
@@ -120,23 +121,23 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
     });
   };
 
+  const refreshControlProps = useManualRefreshControlProps({
+    onRefresh: () => {
+      recentFareContractsRefetch();
+      refetchPreassignedFareProducts();
+      analytics.logEvent('Ticketing', 'Pull to refresh products', {
+        fareProductsCount: preassignedFareProducts.length,
+        isPlaceholderData,
+      });
+    },
+    refreshing: isRefetchingPreassignedFareProducts,
+  });
+
   return authenticationType !== 'none' ? (
     <AnimatedGestureHandlerScrollView
       onScroll={scrollHandler}
       scrollEventThrottle={16}
-      refreshControl={
-        <RefreshControl
-          refreshing={isRefetchingPreassignedFareProducts}
-          onRefresh={() => {
-            recentFareContractsRefetch();
-            refetchPreassignedFareProducts();
-            analytics.logEvent('Ticketing', 'Pull to refresh products', {
-              fareProductsCount: preassignedFareProducts.length,
-              isPlaceholderData,
-            });
-          }}
-        />
-      }
+      refreshControl={<RefreshControl {...refreshControlProps} />}
     >
       <ErrorWithAccountMessage style={styles.accountWrongMessage} />
       <RecentFareContracts


### PR DESCRIPTION
## Issue Reference

Follow up to https://github.com/AtB-AS/mittatb-app/pull/6048

## Description
<!-- What does this PR do? -->

Uses `useManualRefreshControlProps` for the remaining uses of `refreshControl`

- Departures, when loading the list of departures for a stop or quay
- Choose ticket recipient screen
- "My tickets" / "Buy tickets" screens