### PR TITLE
fix: add padding departures situation icon

### DIFF
--- a/src/screen-components/nearby-stop-places/components/StopPlaceItem.tsx
+++ b/src/screen-components/nearby-stop-places/components/StopPlaceItem.tsx
@@ -114,6 +114,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
     width: '100%',
     flexGrow: 1,
+    gap: theme.spacing.small,
   },
   stopPlaceInfo: {
     flexShrink: 1,


### PR DESCRIPTION
Small padding issue after https://github.com/AtB-AS/mittatb-app/pull/6028

## Before / after

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-11 at 15 51 17" src="https://github.com/user-attachments/assets/522158a8-8339-4281-8ccc-0298e9c649e0" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-11 at 15 51 04" src="https://github.com/user-attachments/assets/d5af7771-ab75-45bc-833a-348456fde178" />
