### PR TITLE
feat: reduce price of single ticket with bonus points

### DIFF
--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -24,7 +24,7 @@ import {isDefined} from '@atb/utils/presence';
 
 type Props = SectionProps & {
   bonusProduct: BonusProductType;
-  operatorName: string;
+  operatorName?: string;
   isChecked: boolean;
   onPress: () => void;
 };
@@ -68,9 +68,7 @@ export const PayWithBonusPointsCheckbox = ({
       <Section {...props}>
         <GenericClickableSectionItem
           active={isChecked}
-          onPress={() => {
-            onPress();
-          }}
+          onPress={onPress}
           disabled={isDisabled}
           accessibilityRole="checkbox"
           accessibilityState={{checked: isChecked}}
@@ -118,7 +116,7 @@ export const PayWithBonusPointsCheckbox = ({
             style={styles.infoMessage}
             type="warning"
             message={t(
-              BonusProgramTexts.log_in_operator_app_warning(operatorName),
+              BonusProgramTexts.log_in_operator_app_warning(operatorName ?? ''),
             )}
           />
         )}

--- a/src/modules/bonus/index.ts
+++ b/src/modules/bonus/index.ts
@@ -8,6 +8,7 @@ export {
   UserBonusBalanceContent,
 } from './components';
 export {useRelevantBonusProduct} from './use-relevant-bonus-product';
+export {useRelevantTicketBonusProduct} from './use-relevant-ticket-bonus-product';
 export type {ProductPointsItem} from './api/api';
 export {
   useBonusBalanceQuery,
@@ -19,7 +20,11 @@ export {
   useActiveBonusProductGroupsQuery,
 } from './queries';
 export {BonusProductTypeEnum} from './types';
-export type {BonusProductType, BonusProductGroupType} from './types';
+export type {
+  BonusProductType,
+  BonusProductGroupType,
+  TicketRuleType,
+} from './types';
 export {
   bonusOnboardingCarouselConfig,
   type BonusOnboardingScreenName,

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -2,6 +2,7 @@ import {FormFactorSchema} from '@atb/api/types/mobility';
 import {LanguageAndTextTypeArray} from '@atb/modules/configuration';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import {z} from 'zod';
+import {optionalNullish} from '@atb-as/config-specs/lib/utils/nullish';
 
 export enum BonusProductTypeEnum {
   VOUCHER = 'VOUCHER',
@@ -44,8 +45,8 @@ export const BonusProductSchema = z.object({
   productType: z.enum(BonusProductTypeEnum),
   description: LanguageAndTextTypeArray,
   paymentDescription: LanguageAndTextTypeArray,
-  priceAdjustments: z.array(BonusPriceAdjustmentSchema).optional(),
-  ticketRule: TicketRuleSchema.optional(),
+  priceAdjustments: optionalNullish(z.array(BonusPriceAdjustmentSchema)),
+  ticketRule: optionalNullish(TicketRuleSchema),
 });
 
 export type BonusProductType = z.infer<typeof BonusProductSchema>;

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -26,6 +26,14 @@ const BonusPriceAdjustmentSchema = z
     type: adjustmentType,
   }));
 
+const TicketRuleSchema = z.object({
+  preassignedFareProductIds: z.array(z.string()).nullish(),
+  userProfiles: z.array(z.string()).nullish(),
+  zoneIds: z.array(z.string()).nullish(),
+});
+
+export type TicketRuleType = z.infer<typeof TicketRuleSchema>;
+
 export const BonusProductSchema = z.object({
   id: z.string(),
   isActive: z.boolean(),
@@ -37,6 +45,7 @@ export const BonusProductSchema = z.object({
   description: LanguageAndTextTypeArray,
   paymentDescription: LanguageAndTextTypeArray,
   priceAdjustments: z.array(BonusPriceAdjustmentSchema).optional(),
+  ticketRule: TicketRuleSchema.optional(),
 });
 
 export type BonusProductType = z.infer<typeof BonusProductSchema>;

--- a/src/modules/bonus/use-relevant-ticket-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-ticket-bonus-product.ts
@@ -1,0 +1,60 @@
+import {useActiveBonusProductsQuery} from './queries';
+import {
+  BonusProductTypeEnum,
+  type TicketRuleType,
+  type BonusProductType,
+} from './types';
+import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
+
+export function useRelevantTicketBonusProduct(
+  selection: PurchaseSelectionType,
+): BonusProductType | undefined {
+  const {data: activeBonusProducts} = useActiveBonusProductsQuery(true);
+
+  if (selection.isOnBehalfOf) return undefined;
+  if (selection.userProfilesWithCount.length !== 1) return undefined;
+  if (selection.userProfilesWithCount[0].count !== 1) return undefined;
+
+  return activeBonusProducts?.find(
+    (p) =>
+      p.productType === BonusProductTypeEnum.TICKET &&
+      p.isActive &&
+      matchesTicketRule(p.ticketRule, selection),
+  );
+}
+
+function matchesTicketRule(
+  rule: TicketRuleType | undefined,
+  selection: PurchaseSelectionType,
+): boolean {
+  if (!rule) return false;
+
+  if (rule.preassignedFareProductIds?.length) {
+    if (
+      !rule.preassignedFareProductIds.includes(
+        selection.preassignedFareProduct.id,
+      )
+    ) {
+      return false;
+    }
+  }
+
+  if (rule.userProfiles?.length) {
+    const selectedProfiles = selection.userProfilesWithCount.map((p) => p.id);
+    if (!selectedProfiles.every((id) => rule.userProfiles!.includes(id))) {
+      return false;
+    }
+  }
+
+  if (rule.zoneIds?.length) {
+    const selectedZones = [
+      selection.zones?.from?.id,
+      selection.zones?.to?.id,
+    ].filter((id): id is string => id !== undefined);
+    if (!selectedZones.every((id) => rule.zoneIds!.includes(id))) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/modules/bonus/use-relevant-ticket-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-ticket-bonus-product.ts
@@ -29,29 +29,28 @@ function matchesTicketRule(
 ): boolean {
   if (!rule) return false;
 
-  if (rule.preassignedFareProductIds?.length) {
-    if (
-      !rule.preassignedFareProductIds.includes(
-        selection.preassignedFareProduct.id,
-      )
-    ) {
-      return false;
-    }
+  const {preassignedFareProductIds, userProfiles, zoneIds} = rule;
+
+  if (
+    preassignedFareProductIds?.length &&
+    !preassignedFareProductIds.includes(selection.preassignedFareProduct.id)
+  ) {
+    return false;
   }
 
-  if (rule.userProfiles?.length) {
+  if (userProfiles?.length) {
     const selectedProfiles = selection.userProfilesWithCount.map((p) => p.id);
-    if (!selectedProfiles.every((id) => rule.userProfiles!.includes(id))) {
+    if (!selectedProfiles.every((id) => userProfiles!.includes(id))) {
       return false;
     }
   }
 
-  if (rule.zoneIds?.length) {
+  if (zoneIds?.length) {
     const selectedZones = [
       selection.zones?.from?.id,
       selection.zones?.to?.id,
-    ].filter((id): id is string => id !== undefined);
-    if (!selectedZones.every((id) => rule.zoneIds!.includes(id))) {
+    ].filter((id) => id !== undefined);
+    if (!selectedZones.every((id) => zoneIds.includes(id))) {
       return false;
     }
   }

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-bonus-product-id.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-bonus-product-id.test.ts
@@ -1,0 +1,44 @@
+import {createEmptyBuilder} from '../purchase-selection-builder';
+import {TEST_INPUT} from './test-utils';
+
+describe('purchaseSelectionBuilder - bonusProductId', () => {
+  it('Should be undefined by default', () => {
+    const selection = createEmptyBuilder(TEST_INPUT).forType('single').build();
+    expect(selection.bonusProductId).toBeUndefined();
+  });
+
+  it('Should set bonusProductId', () => {
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .bonusProductId('some-bonus-id')
+      .build();
+    expect(selection.bonusProductId).toBe('some-bonus-id');
+  });
+
+  it('Should clear bonusProductId when called with undefined', () => {
+    const selection1 = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .bonusProductId('some-bonus-id')
+      .build();
+
+    const selection2 = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(selection1)
+      .bonusProductId(undefined)
+      .build();
+
+    expect(selection2.bonusProductId).toBeUndefined();
+  });
+
+  it('Should preserve bonusProductId across fromSelection', () => {
+    const selection1 = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .bonusProductId('some-bonus-id')
+      .build();
+
+    const selection2 = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(selection1)
+      .build();
+
+    expect(selection2.bonusProductId).toBe('some-bonus-id');
+  });
+});

--- a/src/modules/purchase-selection/purchase-selection-builder.ts
+++ b/src/modules/purchase-selection/purchase-selection-builder.ts
@@ -150,6 +150,13 @@ const createBuilder = (
       };
       return builder;
     },
+    bonusProductId(bonusProductId) {
+      currentSelection = {
+        ...currentSelection,
+        bonusProductId,
+      };
+      return builder;
+    },
 
     build: () => {
       const onlyProfilesWithActualCount =

--- a/src/modules/purchase-selection/types.ts
+++ b/src/modules/purchase-selection/types.ts
@@ -41,6 +41,7 @@ export type PurchaseSelectionType = {
   legs: Leg[];
   isOnBehalfOf: boolean;
   originFareContract?: FareContractStub;
+  bonusProductId?: string;
 };
 
 /**
@@ -146,6 +147,12 @@ export type PurchaseSelectionBuilder = {
    * @param p The information from the existing Fare Contract
    */
   originFareContract: (p?: FareContractStub) => PurchaseSelectionBuilder;
+
+  /**
+   * Apply the bonus product id to opt in to paying with bonus points.
+   * Pass undefined to opt out.
+   */
+  bonusProductId: (id?: string) => PurchaseSelectionBuilder;
 
   /**
    * Retrieve the built purchase selection. It is the purchase selection that

--- a/src/modules/ticketing/api.ts
+++ b/src/modules/ticketing/api.ts
@@ -46,6 +46,7 @@ export type OfferSearchParams = {
   from?: string;
   to?: string;
   legs?: OfferSearchLeg[];
+  bonusProductId?: string;
 };
 
 type Traveller = {

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -297,7 +297,6 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           fareProductTypeConfig={selection.fareProductTypeConfig}
           fromPlace={selection.zones?.from || selection.stopPlaces?.from}
           toPlace={selection.zones?.to || selection.stopPlaces?.to}
-          isSearchingOffer={isSearchingOffer}
           preassignedFareProduct={selection.preassignedFareProduct}
           recipient={recipient}
           travelDate={

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -359,10 +359,9 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             type="error"
           />
         )}
-        {relevantTicketBonusProduct && !isFree && !isBookingFlow && (
+        {!!relevantTicketBonusProduct && !isFree && !isBookingFlow && (
           <PayWithBonusPointsCheckbox
             bonusProduct={relevantTicketBonusProduct}
-            operatorName=""
             isChecked={
               selection.bonusProductId === relevantTicketBonusProduct.id
             }

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -110,7 +110,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
 
   const builder = usePurchaseSelectionBuilder();
   const relevantTicketBonusProduct = useRelevantTicketBonusProduct(selection);
-  const isBookingFlow = selection.legs.length > 0;
+
   const isFree = totalPrice === 0;
 
   const userProfileOffers: ReserveOffer[] = userProfilesWithCountAndOffer.map(
@@ -359,7 +359,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             type="error"
           />
         )}
-        {!!relevantTicketBonusProduct && !isFree && !isBookingFlow && (
+        {!!relevantTicketBonusProduct && !isFree && (
           <PayWithBonusPointsCheckbox
             bonusProduct={relevantTicketBonusProduct}
             isChecked={

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -58,6 +58,12 @@ import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {useProductAlternatives} from '@atb/modules/ticketing';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {isNonRecurringPaymentType} from '@atb/modules/payment';
+import {
+  PayWithBonusPointsCheckbox,
+  useRelevantTicketBonusProduct,
+} from '@atb/modules/bonus';
+import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
+import {useParamAsState} from '@atb/utils/use-param-as-state';
 import {startApplePayPayment} from './start-apple-pay';
 import {Loading} from '@atb/components/loading';
 import type {TripAnalytics} from '@atb/screen-components/travel-details-screens';
@@ -87,7 +93,8 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
   const focusRef = useFocusOnLoad(navigation);
 
-  const {selection, recipient} = params;
+  const [selection, setSelection] = useParamAsState(params.selection);
+  const {recipient} = params;
   const productAlternatives = useProductAlternatives(selection);
 
   const {
@@ -100,6 +107,11 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
     userProfilesWithCountAndOffer,
     supplementProductsWithCountAndOffer,
   } = useOfferState(productAlternatives, selection);
+
+  const builder = usePurchaseSelectionBuilder();
+  const relevantTicketBonusProduct = useRelevantTicketBonusProduct(selection);
+  const isBookingFlow = selection.legs.length > 0;
+  const isFree = totalPrice === 0;
 
   const userProfileOffers: ReserveOffer[] = userProfilesWithCountAndOffer.map(
     ({count, offer: {offerId}}) => ({
@@ -346,6 +358,26 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           <MessageInfoBox
             message={t(PurchaseConfirmationTexts.cancelPaymentError)}
             type="error"
+          />
+        )}
+        {relevantTicketBonusProduct && !isFree && !isBookingFlow && (
+          <PayWithBonusPointsCheckbox
+            bonusProduct={relevantTicketBonusProduct}
+            operatorName=""
+            isChecked={
+              selection.bonusProductId === relevantTicketBonusProduct.id
+            }
+            onPress={() => {
+              const isSelected =
+                selection.bonusProductId === relevantTicketBonusProduct.id;
+              const next = builder
+                .fromSelection(selection)
+                .bonusProductId(
+                  isSelected ? undefined : relevantTicketBonusProduct.id,
+                )
+                .build();
+              setSelection(next);
+            }}
           />
         )}
         <PaymentButton

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -32,7 +32,6 @@ type Props = {
   preassignedFareProduct: PreassignedFareProduct;
   fareProductTypeConfig: FareProductTypeConfig;
   recipient?: TicketRecipientType;
-  isSearchingOffer: boolean;
   fromPlace: FareZone | StopPlaceFragment | undefined;
   toPlace: FareZone | StopPlaceFragment | undefined;
   validDurationSeconds?: number;
@@ -44,7 +43,6 @@ export const PreassignedFareContractSummary = ({
   preassignedFareProduct,
   fareProductTypeConfig,
   recipient,
-  isSearchingOffer,
   fromPlace,
   toPlace,
   validDurationSeconds,
@@ -145,8 +143,7 @@ export const PreassignedFareContractSummary = ({
               ),
             )}
           <SummaryText />
-          {!isSearchingOffer &&
-            !!validDurationSeconds &&
+          {!!validDurationSeconds &&
             isShowValidTimeInfoEnabled &&
             summary(
               t(

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PriceSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PriceSummary.tsx
@@ -53,6 +53,7 @@ export const PriceSummary = ({
               name={getReferenceDataName(u, language)}
               offerPrice={u.offer.price}
               count={u.count}
+              isSearchingOffer={isSearchingOffer}
             />
           ))}
           {supplementProductsWithCountAndOffer.map((sp) => (
@@ -61,6 +62,7 @@ export const PriceSummary = ({
               name={getReferenceDataName(sp, language)}
               offerPrice={sp.offer.supplementProducts[0].price}
               count={sp.count}
+              isSearchingOffer={isSearchingOffer}
             />
           ))}
         </GenericSectionItem>
@@ -81,16 +83,21 @@ export const PriceSummary = ({
             </ThemeText>
           </View>
 
-          {!isSearchingOffer ? (
-            <ThemeText typography="heading__xl" testID="totalPrice">
+          <View style={styles.priceContainer}>
+            <ThemeText
+              typography="heading__xl"
+              testID="totalPrice"
+              style={{opacity: isSearchingOffer ? 0 : 1}}
+            >
               {totalPriceString} kr
             </ThemeText>
-          ) : (
-            <Loading
-              size={theme.spacing.medium}
-              style={{margin: theme.spacing.medium}}
-            />
-          )}
+            {isSearchingOffer && (
+              <Loading
+                size={theme.spacing.medium}
+                style={styles.priceLoadingOverlay}
+              />
+            )}
+          </View>
         </View>
       </GenericSectionItem>
     </Section>
@@ -101,12 +108,14 @@ type PricePerTravellerProps = {
   name: string;
   offerPrice: SearchOfferPrice;
   count: number;
+  isSearchingOffer: boolean;
 };
 
 const PricePerTraveller = ({
   name,
   offerPrice,
   count,
+  isSearchingOffer,
 }: PricePerTravellerProps) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
@@ -147,7 +156,9 @@ const PricePerTraveller = ({
       >
         {count} {name}
       </ThemeText>
-      <View style={styles.travellerPrice}>
+      <View
+        style={[styles.travellerPrice, {opacity: isSearchingOffer ? 0 : 1}]}
+      >
         {hasFlexDiscount && (
           <ThemeText
             typography="body__xs"
@@ -190,5 +201,12 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   totalContainerHeadings: {
     paddingVertical: theme.spacing.xSmall,
+  },
+  priceContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  priceLoadingOverlay: {
+    position: 'absolute',
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -42,10 +42,6 @@ import {useOnBehalfOf} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/u
 import {useBookingTrips} from '@atb/modules/booking';
 import {isValidSelection} from '@atb/modules/booking';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
-import {
-  PayWithBonusPointsCheckbox,
-  useRelevantTicketBonusProduct,
-} from '@atb/modules/bonus';
 
 type PurchaseOverviewError = OfferError | {type: 'booking-error'};
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
@@ -144,8 +140,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const {isBookingRequired, isError: isBookingError} = useBookingTrips({
     selection,
   });
-
-  const relevantTicketBonusProduct = useRelevantTicketBonusProduct(selection);
 
   const canProceed = (() => {
     const hasOffer =
@@ -366,28 +360,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 }}
               />
             </View>
-          )}
-
-          {relevantTicketBonusProduct && !isFree && !isBookingRequired && (
-            <PayWithBonusPointsCheckbox
-              bonusProduct={relevantTicketBonusProduct}
-              operatorName=""
-              isChecked={
-                selection.bonusProductId === relevantTicketBonusProduct.id
-              }
-              onPress={() => {
-                const isSelected =
-                  selection.bonusProductId === relevantTicketBonusProduct.id;
-                const next = builder
-                  .fromSelection(selection)
-                  .bonusProductId(
-                    isSelected ? undefined : relevantTicketBonusProduct.id,
-                  )
-                  .build();
-                setSelection(next);
-              }}
-              style={styles.selectionComponent}
-            />
           )}
 
           <Summary

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -42,6 +42,10 @@ import {useOnBehalfOf} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/u
 import {useBookingTrips} from '@atb/modules/booking';
 import {isValidSelection} from '@atb/modules/booking';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {
+  PayWithBonusPointsCheckbox,
+  useRelevantTicketBonusProduct,
+} from '@atb/modules/bonus';
 
 type PurchaseOverviewError = OfferError | {type: 'booking-error'};
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
@@ -140,6 +144,8 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const {isBookingRequired, isError: isBookingError} = useBookingTrips({
     selection,
   });
+
+  const relevantTicketBonusProduct = useRelevantTicketBonusProduct(selection);
 
   const canProceed = (() => {
     const hasOffer =
@@ -360,6 +366,28 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 }}
               />
             </View>
+          )}
+
+          {relevantTicketBonusProduct && !isFree && !isBookingRequired && (
+            <PayWithBonusPointsCheckbox
+              bonusProduct={relevantTicketBonusProduct}
+              operatorName=""
+              isChecked={
+                selection.bonusProductId === relevantTicketBonusProduct.id
+              }
+              onPress={() => {
+                const isSelected =
+                  selection.bonusProductId === relevantTicketBonusProduct.id;
+                const next = builder
+                  .fromSelection(selection)
+                  .bonusProductId(
+                    isSelected ? undefined : relevantTicketBonusProduct.id,
+                  )
+                  .build();
+                setSelection(next);
+              }}
+              style={styles.selectionComponent}
+            />
           )}
 
           <Summary

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -276,6 +276,7 @@ export function useOfferState(
                 selection?.supplementProductsWithCount.map((sp) => sp.id) ?? [],
               isOnBehalfOf: false,
               legs: mapToOfferSearchLegs(selection.legs),
+              bonusProductId: selection?.bonusProductId,
             };
             const response = await searchTripPatternOffers(params);
             offers = response.offers;
@@ -294,6 +295,7 @@ export function useOfferState(
               supplementProducts:
                 selection?.supplementProductsWithCount.map((sp) => sp.id) ?? [],
               travelDate: selection?.travelDate,
+              bonusProductId: selection?.bonusProductId,
             };
 
             const offerEndpoint = selection?.stopPlaces

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/use-offer-state.ts
@@ -276,7 +276,7 @@ export function useOfferState(
                 selection?.supplementProductsWithCount.map((sp) => sp.id) ?? [],
               isOnBehalfOf: false,
               legs: mapToOfferSearchLegs(selection.legs),
-              bonusProductId: selection?.bonusProductId,
+              bonusProductId: selection.bonusProductId,
             };
             const response = await searchTripPatternOffers(params);
             offers = response.offers;


### PR DESCRIPTION
## Summary

- Adds `bonusProductId?: string` to `OfferSearchParams` so the client can opt in to the 50% bonus-points discount on single-ticket search
- Extends `BonusProductSchema` with `ticketRule` (preassignedFareProductIds / userProfiles / zoneIds constraints)
- Adds `bonusProductId` to `PurchaseSelectionType` and the selection builder
- New `useRelevantTicketBonusProduct` hook: mirrors server eligibility checks (single traveller, single product, active TICKET-type bonus product matching selection's fare product / user profile / zone)
- Renders `PayWithBonusPointsCheckbox` in `Root_PurchaseConfirmationScreen` (payment screen) when a relevant bonus product is found; toggling re-triggers offer search with discounted price and updates the displayed total in real time

## Screenshots

<details><summary>Screenshots</summary>
<p>

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/92fc722a-0d29-40cd-b982-ac0424850d04" />
<img width="400" alt="8oLR9gAGuST" src="https://github.com/user-attachments/assets/1dcd5419-6a64-4134-9710-2c047a46c2ff" />

</p>
</details> 


## Dependencies

Depends on:
- Sales: https://github.com/AtB-AS/sales/pull/114
- Bonus: https://github.com/AtB-AS/bonus/pull/33

## Test plan

- [ ] Select single Adult, 1 single ticket for zone A → tap "To payment" → checkbox visible on payment screen
  - [ ] Add second traveller → no checkbox on payment screen
  - [ ] Selecting other ticket parameter (user_profile, period ticket, other zone) → no checkbox
- [ ] Toggle on → re-search → price halved, flex ladder shows 50% step
- [ ] Pay halved cash amount → fare contract issued, balance debited
- [ ] Toggle off → reverts to full price
- [ ] Drain balance below product price → checkbox visible but disabled
- [ ] `yarn typecheck` / `tsc --noEmit` passes (no new errors in changed files)


Closes https://github.com/AtB-AS/kundevendt/issues/23934