### PR TITLE
feat: update departures date selection component

### DIFF
--- a/src/components/date-selection/DateSelection.tsx
+++ b/src/components/date-selection/DateSelection.tsx
@@ -87,7 +87,7 @@ export const DateSelection = ({
             }
             subText={
               searchTime.option === 'now'
-                ? ''
+                ? undefined
                 : formatToLongDateTime(searchTime.date, language)
             }
             testID="setDateButton"

--- a/src/components/date-selection/DateSelection.tsx
+++ b/src/components/date-selection/DateSelection.tsx
@@ -1,10 +1,9 @@
 import {ChevronLeft, ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {Time} from '@atb/assets/svg/mono-icons/time';
+import {Date as DateIcon} from '@atb/assets/svg/mono-icons/time';
 import {Button} from '@atb/components/button';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import {
-  formatToDate,
   formatToLongDateTime,
   isInThePast,
   parseISOFromCET,
@@ -13,24 +12,18 @@ import {addDays, isToday, parseISO} from 'date-fns';
 import React, {useRef} from 'react';
 import {View} from 'react-native';
 import {DatePickerSheet} from './DatePickerSheet';
-import type {ContrastColor} from '@atb-as/theme';
 import {DepartureDateOptions, type DepartureSearchTime} from './types';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
-import {ThemeText} from '@atb/components/text';
-import {ThemeIcon} from '../theme-icon';
-import {NativeBlockButton} from '../native-button';
-import {Edit} from '@atb/assets/svg/mono-icons/actions';
+import {EditActionSectionItem, Section} from '../sections';
 
 type DateSelectionProps = {
   searchTime: DepartureSearchTime;
   setSearchTime: (searchTime: DepartureSearchTime) => void;
-  backgroundColor: ContrastColor;
 };
 
 export const DateSelection = ({
   searchTime,
   setSearchTime,
-  backgroundColor,
 }: DateSelectionProps): React.JSX.Element => {
   const styles = useStyles();
   const {t, language} = useTranslation();
@@ -79,39 +72,27 @@ export const DateSelection = ({
             testID="previousDayButton"
           />
         )}
-        <NativeBlockButton
-          onPress={onLaterTimePress}
-          testID="setDateButton"
-          accessibilityHint={t(
-            DeparturesTexts.dateNavigation.a11yChangeDateHint,
-          )}
-          ref={onCloseFocusRef}
-          style={styles.setDateButton}
-        >
-          <ThemeIcon svg={Time} color={backgroundColor} />
-          <View style={styles.textContainer}>
-            <ThemeText
-              style={styles.setDateText}
-              color={backgroundColor}
-              typography="body__m__strong"
-            >
-              {searchTime.option === 'now'
+        <Section style={styles.setDateButton}>
+          <EditActionSectionItem
+            ref={onCloseFocusRef}
+            onPress={onLaterTimePress}
+            leftIcon={DateIcon}
+            accessibilityHint={t(
+              DeparturesTexts.dateNavigation.a11yChangeDateHint,
+            )}
+            text={
+              searchTime.option === 'now'
                 ? t(DeparturesTexts.dateNavigation.leaveNow)
-                : t(DeparturesTexts.dateNavigation.leaveAt)}
-            </ThemeText>
-            <ThemeText
-              color={theme.color.background.neutral[0].foreground.secondary}
-            >
-              {searchTime.option === 'now'
-                ? formatToDate(searchTime.date, language)
-                : formatToLongDateTime(searchTime.date, language)}
-            </ThemeText>
-          </View>
-          <ThemeIcon
-            svg={Edit}
-            color={theme.color.interactive[0].default.background}
+                : t(DeparturesTexts.dateNavigation.leaveAt)
+            }
+            subText={
+              searchTime.option === 'now'
+                ? ''
+                : formatToLongDateTime(searchTime.date, language)
+            }
+            testID="setDateButton"
           />
-        </NativeBlockButton>
+        </Section>
         <Button
           expanded={false}
           onPress={() => {
@@ -172,14 +153,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   setDateButton: {
     flex: 1,
-    flexDirection: 'row',
-    gap: theme.spacing.small,
-    backgroundColor: theme.color.background.neutral[0].background,
-    borderRadius: theme.border.radius.regular,
-    padding: theme.spacing.medium,
-    alignItems: 'center',
-  },
-  setDateText: {
-    flexWrap: 'wrap',
   },
 }));

--- a/src/components/date-selection/DateSelection.tsx
+++ b/src/components/date-selection/DateSelection.tsx
@@ -4,6 +4,7 @@ import {Button} from '@atb/components/button';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import {
+  formatToDate,
   formatToLongDateTime,
   isInThePast,
   parseISOFromCET,
@@ -58,24 +59,26 @@ export const DateSelection = ({
   return (
     <>
       <View style={styles.dateNavigator}>
-        <Button
-          expanded={false}
-          onPress={() => {
-            setSearchTime(changeDay(searchTime, -1));
-          }}
-          accessibilityLabel={t(DeparturesTexts.dateNavigation.prevDay)}
-          mode="primary"
-          interactiveColor={theme.color.interactive[2]}
-          style={styles.nextPrevButtons}
-          leftIcon={{svg: ChevronLeft}}
-          disabled={disablePreviousDayNavigation}
-          accessibilityHint={
-            disablePreviousDayNavigation
-              ? t(DeparturesTexts.dateNavigation.a11yDisabled)
-              : t(DeparturesTexts.dateNavigation.a11yPreviousDayHint)
-          }
-          testID="previousDayButton"
-        />
+        {!disablePreviousDayNavigation && (
+          <Button
+            expanded={false}
+            onPress={() => {
+              setSearchTime(changeDay(searchTime, -1));
+            }}
+            accessibilityLabel={t(DeparturesTexts.dateNavigation.prevDay)}
+            mode="primary"
+            interactiveColor={theme.color.interactive[2]}
+            style={styles.nextPrevButtons}
+            leftIcon={{svg: ChevronLeft}}
+            disabled={disablePreviousDayNavigation}
+            accessibilityHint={
+              disablePreviousDayNavigation
+                ? t(DeparturesTexts.dateNavigation.a11yDisabled)
+                : t(DeparturesTexts.dateNavigation.a11yPreviousDayHint)
+            }
+            testID="previousDayButton"
+          />
+        )}
         <NativeBlockButton
           onPress={onLaterTimePress}
           testID="setDateButton"
@@ -86,19 +89,24 @@ export const DateSelection = ({
           style={styles.setDateButton}
         >
           <ThemeIcon svg={Time} color={backgroundColor} />
-          <ThemeText
-            style={styles.setDateText}
-            color={backgroundColor}
-            typography="body__m__strong"
-          >
-            {searchTime.option === 'now'
-              ? t(DeparturesTexts.dateNavigation.leaveNow)
-              : t(
-                  DeparturesTexts.dateNavigation.leaveAt(
-                    formatToLongDateTime(searchTime.date, language),
-                  ),
-                )}
-          </ThemeText>
+          <View style={styles.textContainer}>
+            <ThemeText
+              style={styles.setDateText}
+              color={backgroundColor}
+              typography="body__m__strong"
+            >
+              {searchTime.option === 'now'
+                ? t(DeparturesTexts.dateNavigation.leaveNow)
+                : t(DeparturesTexts.dateNavigation.leaveAt)}
+            </ThemeText>
+            <ThemeText
+              color={theme.color.background.neutral[0].foreground.secondary}
+            >
+              {searchTime.option === 'now'
+                ? formatToDate(searchTime.date, language)
+                : formatToLongDateTime(searchTime.date, language)}
+            </ThemeText>
+          </View>
           <ThemeIcon
             svg={Edit}
             color={theme.color.interactive[0].default.background}
@@ -156,6 +164,12 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   nextPrevButtons: {
     alignSelf: 'center',
   },
+  textContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    flex: 1,
+    gap: theme.spacing.xSmall,
+  },
   setDateButton: {
     flex: 1,
     flexDirection: 'row',
@@ -166,7 +180,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
   },
   setDateText: {
-    flex: 1,
     flexWrap: 'wrap',
   },
 }));

--- a/src/components/date-selection/DateSelection.tsx
+++ b/src/components/date-selection/DateSelection.tsx
@@ -1,7 +1,7 @@
 import {ChevronLeft, ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {Date as DateIcon} from '@atb/assets/svg/mono-icons/time';
+import {Time} from '@atb/assets/svg/mono-icons/time';
 import {Button} from '@atb/components/button';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import {
   formatToLongDateTime,
@@ -15,10 +15,10 @@ import {DatePickerSheet} from './DatePickerSheet';
 import type {ContrastColor} from '@atb-as/theme';
 import {DepartureDateOptions, type DepartureSearchTime} from './types';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
-import {NativeBlockButton} from '@atb/components/native-button';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '../theme-icon';
-import {useFontScale} from '@atb/utils/use-font-scale';
+import {NativeBlockButton} from '../native-button';
+import {Edit} from '@atb/assets/svg/mono-icons/actions';
 
 type DateSelectionProps = {
   searchTime: DepartureSearchTime;
@@ -33,19 +33,12 @@ export const DateSelection = ({
 }: DateSelectionProps): React.JSX.Element => {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const {theme} = useThemeContext();
   const disablePreviousDayNavigation = isToday(
     parseISOFromCET(searchTime.date),
   );
   const onCloseFocusRef = useRef<View | null>(null);
   const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
-
-  const fontScale = useFontScale();
-  const shouldShowNextPrevTexts = fontScale <= 1.3;
-
-  const searchTimeText =
-    searchTime.option === 'now'
-      ? t(DeparturesTexts.dateNavigation.today)
-      : formatToLongDateTime(searchTime.date, language);
 
   const onSetSearchTime = (time: DepartureSearchTime) => {
     if (isInThePast(time.date)) {
@@ -70,13 +63,9 @@ export const DateSelection = ({
           onPress={() => {
             setSearchTime(changeDay(searchTime, -1));
           }}
-          text={
-            shouldShowNextPrevTexts
-              ? t(DeparturesTexts.dateNavigation.prevDay)
-              : undefined
-          }
-          mode="tertiary"
-          type="small"
+          accessibilityLabel={t(DeparturesTexts.dateNavigation.prevDay)}
+          mode="primary"
+          interactiveColor={theme.color.interactive[2]}
           style={styles.nextPrevButtons}
           leftIcon={{svg: ChevronLeft}}
           disabled={disablePreviousDayNavigation}
@@ -86,43 +75,47 @@ export const DateSelection = ({
               : t(DeparturesTexts.dateNavigation.a11yPreviousDayHint)
           }
           testID="previousDayButton"
-          backgroundColor={backgroundColor}
         />
-
         <NativeBlockButton
           onPress={onLaterTimePress}
-          style={[
-            styles.setDateButton,
-            {flexDirection: searchTime.option === 'now' ? 'row' : 'column'},
-          ]}
+          testID="setDateButton"
           accessibilityHint={t(
             DeparturesTexts.dateNavigation.a11yChangeDateHint,
           )}
-          testID="setDateButton"
           ref={onCloseFocusRef}
+          style={styles.setDateButton}
         >
-          <ThemeIcon svg={DateIcon} color={backgroundColor} />
-          <ThemeText color={backgroundColor} typography="body__s">
-            {searchTimeText}
+          <ThemeIcon svg={Time} color={backgroundColor} />
+          <ThemeText
+            style={styles.setDateText}
+            color={backgroundColor}
+            typography="body__m__strong"
+          >
+            {searchTime.option === 'now'
+              ? t(DeparturesTexts.dateNavigation.leaveNow)
+              : t(
+                  DeparturesTexts.dateNavigation.leaveAt(
+                    formatToLongDateTime(searchTime.date, language),
+                  ),
+                )}
           </ThemeText>
+          <ThemeIcon
+            svg={Edit}
+            color={theme.color.interactive[0].default.background}
+          />
         </NativeBlockButton>
         <Button
           expanded={false}
           onPress={() => {
             setSearchTime(changeDay(searchTime, 1));
           }}
-          text={
-            shouldShowNextPrevTexts
-              ? t(DeparturesTexts.dateNavigation.nextDay)
-              : undefined
-          }
-          type="small"
-          mode="tertiary"
+          mode="primary"
+          interactiveColor={theme.color.interactive[2]}
           style={styles.nextPrevButtons}
           rightIcon={{svg: ChevronRight}}
+          accessibilityLabel={t(DeparturesTexts.dateNavigation.nextDay)}
           accessibilityHint={t(DeparturesTexts.dateNavigation.a11yNextDayHint)}
           testID="nextDayButton"
-          backgroundColor={backgroundColor}
         />
       </View>
       <DatePickerSheet
@@ -158,15 +151,22 @@ function changeDay(
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   dateNavigator: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    gap: theme.spacing.small,
   },
   nextPrevButtons: {
     alignSelf: 'center',
   },
   setDateButton: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: theme.spacing.small,
+    backgroundColor: theme.color.background.neutral[0].background,
+    borderRadius: theme.border.radius.regular,
+    padding: theme.spacing.medium,
     alignItems: 'center',
-    alignSelf: 'center',
-    gap: theme.spacing.xSmall,
+  },
+  setDateText: {
+    flex: 1,
+    flexWrap: 'wrap',
   },
 }));

--- a/src/components/sections/items/EditActionSectionItem.tsx
+++ b/src/components/sections/items/EditActionSectionItem.tsx
@@ -55,12 +55,18 @@ export const EditActionSectionItem = forwardRef<any, Props>(
 );
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  button: {flex: 1, flexDirection: 'row', gap: theme.spacing.small},
+  button: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: theme.spacing.small,
+    alignItems: 'center',
+  },
   gap: {gap: theme.spacing.small, alignItems: 'flex-start'},
   textContainer: {
     flex: 1,
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: theme.spacing.xSmall,
+    alignSelf: 'center',
   },
 }));

--- a/src/components/sections/items/EditActionSectionItem.tsx
+++ b/src/components/sections/items/EditActionSectionItem.tsx
@@ -40,7 +40,7 @@ export const EditActionSectionItem = forwardRef<any, Props>(
           <ThemeText typography="body__m__strong">{text}</ThemeText>
           {subText && (
             <ThemeText typography="body__m" type="secondary">
-              {subText}
+              ({subText})
             </ThemeText>
           )}
         </View>

--- a/src/components/sections/items/FavoriteSectionItem.tsx
+++ b/src/components/sections/items/FavoriteSectionItem.tsx
@@ -3,7 +3,7 @@ import {AccessibilityProps, View} from 'react-native';
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {FavoriteIcon} from '@atb/modules/favorites';
 import {StoredLocationFavorite} from '@atb/modules/favorites';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {screenReaderPause} from '@atb/components/text';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -52,6 +52,7 @@ function withOnPress(a: any): a is WithOnPress {
 
 function FavoriteItemContent({favorite, icon, testID, ...props}: BaseProps) {
   const {contentContainer, topContainer} = useSectionItem(props);
+  const {theme} = useThemeContext();
   const style = useSectionStyle();
 
   return (
@@ -64,7 +65,12 @@ function FavoriteItemContent({favorite, icon, testID, ...props}: BaseProps) {
           {favorite.name ?? favorite.location.name}
         </ThemeText>
       </View>
-      {icon ?? <ThemeIcon svg={Edit} />}
+      {icon ?? (
+        <ThemeIcon
+          svg={Edit}
+          color={theme.color.interactive[0].default.background}
+        />
+      )}
     </View>
   );
 }

--- a/src/components/sections/items/SelectionInlineSectionItem.tsx
+++ b/src/components/sections/items/SelectionInlineSectionItem.tsx
@@ -5,7 +5,7 @@ import {
   NavigationIconTypes,
   ThemeIcon,
 } from '@atb/components/theme-icon';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import React from 'react';
 import {AccessibilityProps, View} from 'react-native';
 import {SectionItemProps} from '../types';
@@ -38,6 +38,7 @@ export function SelectionInlineSectionItem({
   ...props
 }: SelectionInlineSectionItemProps) {
   const styles = useStyles();
+  const {theme} = useThemeContext();
   const {topContainer, contentContainer} = useSectionItem(props);
 
   const onPressIconSize = !!onPressLabel ? 'small' : 'normal';
@@ -46,7 +47,11 @@ export function SelectionInlineSectionItem({
     (isNavigationIcon(onPressIcon) ? (
       <NavigationIcon mode={onPressIcon} size={onPressIconSize} />
     ) : (
-      <ThemeIcon svg={onPressIcon} size={onPressIconSize} />
+      <ThemeIcon
+        svg={onPressIcon}
+        size={onPressIconSize}
+        color={theme.color.interactive[0].default.background}
+      />
     ));
 
   return (

--- a/src/screen-components/place-screen/PlaceScreenComponent.tsx
+++ b/src/screen-components/place-screen/PlaceScreenComponent.tsx
@@ -1,6 +1,6 @@
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {FullScreenHeader} from '@atb/components/screen-header';
-import {StyleSheet, type Theme, useThemeContext} from '@atb/theme';
+import {StyleSheet, type Theme} from '@atb/theme';
 import {DeparturesTexts, useTranslation} from '@atb/translations';
 import React, {useState} from 'react';
 import {View} from 'react-native';
@@ -38,8 +38,6 @@ export const PlaceScreenComponent = ({
 }: Props) => {
   const styles = useStyles();
   const {t} = useTranslation();
-  const {theme} = useThemeContext();
-  const themeColor = getThemeColor(theme);
   const {onScroll, borderStyle} = useScrollBorder();
 
   const [searchTime, setSearchTime] = useState<DepartureSearchTime>({
@@ -134,7 +132,6 @@ export const PlaceScreenComponent = ({
             setShowOnlyFavorites={setShowOnlyFavorites}
             testID="departuresContentView"
             stopPlace={place}
-            backgroundColor={themeColor}
             onScroll={onScroll}
           />
         ) : (
@@ -148,7 +145,6 @@ export const PlaceScreenComponent = ({
             showOnlyFavorites={showOnlyFavorites}
             setShowOnlyFavorites={setShowOnlyFavorites}
             testID="departuresContentView"
-            backgroundColor={themeColor}
             onScroll={onScroll}
           />
         )}

--- a/src/screen-components/place-screen/components/QuayView.tsx
+++ b/src/screen-components/place-screen/components/QuayView.tsx
@@ -18,7 +18,6 @@ import {QuaySection} from './QuaySection';
 import {StopPlacesMode} from '@atb/screen-components/nearby-stop-places';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {DeparturesTexts, dictionary, useTranslation} from '@atb/translations';
-import type {ContrastColor} from '@atb-as/theme';
 import {useFavoritesContext} from '@atb/modules/favorites';
 import {hasFavorites} from '../utils';
 import {DeparturesProps, useDepartures} from '../hooks/use-departures';
@@ -42,7 +41,6 @@ export type QuayViewProps = {
   testID?: string;
   stopPlace: StopPlace;
   mode: StopPlacesMode;
-  backgroundColor: ContrastColor;
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 };
 
@@ -56,7 +54,6 @@ export function QuayView({
   testID,
   stopPlace,
   mode,
-  backgroundColor,
   onScroll,
 }: QuayViewProps) {
   const styles = useStyles();
@@ -132,7 +129,6 @@ export function QuayView({
             <DateSelection
               searchTime={searchTime}
               setSearchTime={setSearchTime}
-              backgroundColor={backgroundColor}
             />
           </View>
         </>

--- a/src/screen-components/place-screen/components/StopPlacesView.tsx
+++ b/src/screen-components/place-screen/components/StopPlacesView.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react-native';
 import {QuaySection} from './QuaySection';
 import {FavoriteToggle} from './FavoriteToggle';
-import type {ContrastColor} from '@atb-as/theme';
 import {
   DateSelection,
   type DepartureSearchTime,
@@ -46,7 +45,6 @@ type Props = {
   setShowOnlyFavorites: (enabled: boolean) => void;
   testID?: string;
   mode: StopPlacesMode;
-  backgroundColor: ContrastColor;
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 } & (
   | {
@@ -74,7 +72,6 @@ export const StopPlacesView = (props: Props) => {
     setShowOnlyFavorites,
     testID,
     mode,
-    backgroundColor,
     onScroll,
   } = props;
 
@@ -167,7 +164,6 @@ export const StopPlacesView = (props: Props) => {
                 <DateSelection
                   searchTime={searchTime}
                   setSearchTime={setSearchTime}
-                  backgroundColor={backgroundColor}
                 />
               )}
             </View>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -12,7 +12,7 @@ import {GenericClickableSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 type StartTimeSelectionProps = {
@@ -27,6 +27,7 @@ export function StartTimeSelection({
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
+  const {theme} = useThemeContext();
   const styles = useStyles();
   const selectionBuilder = usePurchaseSelectionBuilder();
   const onCloseFocusRef = useRef<View | null>(null);
@@ -69,7 +70,11 @@ export function StartTimeSelection({
                     )
                   : t(PurchaseOverviewTexts.startTime.now)}
               </ThemeText>
-              <ThemeIcon svg={Edit} size="normal" />
+              <ThemeIcon
+                svg={Edit}
+                size="normal"
+                color={theme.color.interactive[0].default.background}
+              />
             </View>
           </GenericClickableSectionItem>
         </Section>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -12,7 +12,7 @@ import {
   Section,
 } from '@atb/components/sections';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {TravellerSelectionSheet} from './TravellerSelectionSheet';
 
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
@@ -38,6 +38,7 @@ export function TravellerSelection({
   style,
 }: TravellerSelectionProps) {
   const {t, language} = useTranslation();
+  const {theme} = useThemeContext();
   const styles = useStyles();
   const onCloseFocusRef = useRef<View | null>(null);
   const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
@@ -113,7 +114,13 @@ export function TravellerSelection({
         )}
       </View>
 
-      {canSelectUserProfile && <ThemeIcon svg={Edit} size="normal" />}
+      {canSelectUserProfile && (
+        <ThemeIcon
+          svg={Edit}
+          size="normal"
+          color={theme.color.interactive[0].default.background}
+        />
+      )}
     </View>
   );
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -1,5 +1,5 @@
 import {screenReaderPause, ThemeText} from '@atb/components/text';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
   Language,
   PurchaseOverviewTexts,
@@ -33,6 +33,7 @@ type ZonesSelectionProps = {
 export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
   ({selection, selectionMode, onSelect, style}: ZonesSelectionProps, ref) => {
     const styles = useStyles();
+    const {theme} = useThemeContext();
     const {t, language} = useTranslation();
 
     const zonesRef = useRef<typeof NativeBlockButton>(null);
@@ -98,7 +99,13 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
             </>
           )}
         </View>
-        {canSelectZone && <ThemeIcon svg={Edit} size="normal" />}
+        {canSelectZone && (
+          <ThemeIcon
+            svg={Edit}
+            size="normal"
+            color={theme.color.interactive[0].default.background}
+          />
+        )}
       </View>
     );
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -336,11 +336,11 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 <EditActionSectionItem
                   ref={timePickerCloseRef}
                   text={t(TripSearchTexts.dateInput.options[searchTime.option])}
-                  subText={`(${getSearchTime(
+                  subText={getSearchTime(
                     searchTime,
                     timeOfLastSearch,
                     language,
-                  )})`}
+                  )}
                   accessibilityLabel={getSearchTimeLabel(
                     searchTime,
                     timeOfLastSearch,
@@ -674,7 +674,7 @@ const getFiltersSubText = (
   if (!transportModes) return undefined;
 
   const count = transportModes.filter((tm) => tm.selected).length;
-  return `(${count})`;
+  return `${count}`;
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
@@ -3,7 +3,7 @@ import {View} from 'react-native';
 import {useParamAsState} from '@atb/utils/use-param-as-state';
 import type {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {FullScreenView} from '@atb/components/screen-view';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {BookingTripSelection} from '@atb/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection';
 import {
   DateSelection,
@@ -34,7 +34,6 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
         },
   );
   const {t} = useTranslation();
-  const {theme} = useThemeContext();
   const styles = useStyles();
   const builder = usePurchaseSelectionBuilder();
 
@@ -72,7 +71,6 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
                 .build(),
             );
           }}
-          backgroundColor={theme.color.background.neutral[1]}
         />
       </View>
       <View style={styles.content}>
@@ -114,7 +112,7 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   header: {
-    marginTop: theme.spacing.medium,
+    margin: theme.spacing.medium,
   },
   content: {
     backgroundColor: theme.color.background.neutral[1].background,

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -43,12 +43,12 @@ const DeparturesTexts = {
       'Aktiver for å gå til førre dag',
     ),
     options: {
-      now: _('Dra nå', 'Leave now', 'Dra no'),
+      now: _('Nå', 'Now', 'No'),
       departure: _('Avreise', 'Leave at', 'Avreise'),
     },
     today: _('I dag', 'Today', 'I dag'),
     a11yDisabled: _('Deaktivert', 'Disabled', 'Deaktivert'),
-    leaveNow: _(`Dra nå`, `Leave now`, `Dra no`),
+    leaveNow: _(`Nå`, `Now`, `No`),
     leaveAt: _('Avreise', 'Leave at', 'Avreise'),
     a11yChangeDateHint: _(
       'Aktiver for å forandre dato',

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -49,8 +49,7 @@ const DeparturesTexts = {
     today: _('I dag', 'Today', 'I dag'),
     a11yDisabled: _('Deaktivert', 'Disabled', 'Deaktivert'),
     leaveNow: _(`Dra nå`, `Leave now`, `Dra no`),
-    leaveAt: (time: string) =>
-      _(`Avreise (${time})`, `Leave at (${time})`, `Avreise (${time})`),
+    leaveAt: _('Avreise', 'Leave at', 'Avreise'),
     a11yChangeDateHint: _(
       'Aktiver for å forandre dato',
       'Activate to change date',

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -43,22 +43,19 @@ const DeparturesTexts = {
       'Aktiver for å gå til førre dag',
     ),
     options: {
-      now: _('Nå', 'Leave now', 'Nå'),
-      departure: _('Velg tid', 'Leave at', 'Velg tid'),
+      now: _('Dra nå', 'Leave now', 'Dra no'),
+      departure: _('Avreise', 'Leave at', 'Avreise'),
     },
     today: _('I dag', 'Today', 'I dag'),
     a11yDisabled: _('Deaktivert', 'Disabled', 'Deaktivert'),
+    leaveNow: _(`Dra nå`, `Leave now`, `Dra no`),
+    leaveAt: (time: string) =>
+      _(`Avreise (${time})`, `Leave at (${time})`, `Avreise (${time})`),
     a11yChangeDateHint: _(
       'Aktiver for å forandre dato',
       'Activate to change date',
       'Aktiver for å endre dato',
     ),
-    a11ySelectedLabel: (dateTime: string) =>
-      _(
-        `Valgt dato: ${dateTime}`,
-        `Selected date, ${dateTime}`,
-        `Vald dato: ${dateTime}`,
-      ),
   },
   noDepartures: _(
     'Ingen avganger i dette tidsrommet.',

--- a/src/translations/screens/TripSearch.ts
+++ b/src/translations/screens/TripSearch.ts
@@ -106,7 +106,7 @@ const TripSearchTexts = {
   },
   dateInput: {
     options: {
-      now: _('Dra nå', 'Leave now', 'Dra no'),
+      now: _('Nå', 'Now', 'No'),
       departure: _('Avreise', 'Leave at', 'Avreise'),
       arrival: _('Ankomst', 'Arrive by', 'Ankomst'),
     },


### PR DESCRIPTION
## Issue Reference

closes https://github.com/AtB-AS/kundevendt/issues/23884

## Description

Updates the departure date selection component:

https://github.com/user-attachments/assets/4369eda7-39dc-430c-afbf-f03778eb02cb

Also in the booking flow:

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-26 at 13 48 21" src="https://github.com/user-attachments/assets/ae5811b7-a7e3-47b3-9898-f695aa24c6ff" />


Changes a bunch of 'Edit' SVGs to be interactive[0], in line with new guidelines:

<img width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-12 at 15 53 58" src="https://github.com/user-attachments/assets/4011b8a2-71fc-4d96-95a9-0d6f7bd21836" />
<img width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-12 at 15 55 53" src="https://github.com/user-attachments/assets/fb943e81-fe53-42bf-8688-c2b491f9523f" />
<img width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-12 at 15 58 08" src="https://github.com/user-attachments/assets/59e09474-55bf-4edc-8729-5ca85bbe7347" />
