### PR TITLE
feat: use House icon for favorites with house number

### DIFF
--- a/src/modules/favorites/FavoriteIcon.tsx
+++ b/src/modules/favorites/FavoriteIcon.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
 import {Pin} from '@atb/assets/svg/mono-icons/map';
+import {House} from '@atb/assets/svg/mono-icons/places';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
+import {LocationFavorite} from './types';
 
 type FavoriteIconProps = {
-  favorite?: {emoji?: string};
+  favorite?: LocationFavorite;
   fill?: string;
 };
 
 export function FavoriteIcon({favorite, fill}: FavoriteIconProps) {
   if (!favorite || !favorite.emoji) {
     const fillProp = fill ? {fill} : undefined;
-    return <ThemeIcon svg={Pin} {...fillProp} />;
+    return (
+      <ThemeIcon
+        svg={favorite?.location.housenumber ? House : Pin}
+        {...fillProp}
+      />
+    );
   }
   return (
     <ThemeText style={fill ? {color: fill} : undefined}>


### PR DESCRIPTION
## Issue Reference

Follow up to https://github.com/AtB-AS/kundevendt/issues/23696

## Description

This adds a House icon for favorites that have a house number, the same way as for search results in https://github.com/AtB-AS/kundevendt/issues/23696

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-13 at 11 17 38" src="https://github.com/user-attachments/assets/5ad2d2c0-4a7c-48dd-91da-8d009493595e" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-13 at 11 17 41" src="https://github.com/user-attachments/assets/df38f5e9-ca28-42db-a343-d29055fc5820" />
