### PR TITLE
feat: add EditActionSectionItem section component

### DIFF
--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -6,6 +6,7 @@ export {SectionSeparator} from './SectionSeparator';
 export {InternalLabeledSectionItem} from './items/InternalLabeledSectionItem';
 
 // Links and actions
+export {EditActionSectionItem} from './items/EditActionSectionItem';
 export {LinkSectionItem} from './items/LinkSectionItem';
 export {HeaderSectionItem} from './items/HeaderSectionItem';
 export {RadioSectionItem} from './items/RadioSectionItem.tsx';

--- a/src/components/sections/items/EditActionSectionItem.tsx
+++ b/src/components/sections/items/EditActionSectionItem.tsx
@@ -1,0 +1,70 @@
+import {Edit} from '@atb/assets/svg/mono-icons/actions';
+import {NativeBlockButton} from '@atb/components/native-button';
+import {ThemeText} from '@atb/components/text';
+import {ThemeIcon, ThemeIconProps} from '@atb/components/theme-icon';
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import React, {forwardRef} from 'react';
+import {AccessibilityProps, View} from 'react-native';
+import {SectionItemProps} from '../types';
+import {useSectionItem} from '../use-section-item';
+import {useSectionStyle} from '../use-section-style';
+
+type Props = SectionItemProps<
+  {
+    leftIcon?: ThemeIconProps['svg'];
+    rightIcon?: ThemeIconProps['svg'];
+    text: string;
+    subText?: string;
+    onPress(): void;
+    testID?: string;
+  } & AccessibilityProps
+>;
+
+export const EditActionSectionItem = forwardRef<any, Props>(
+  ({leftIcon, rightIcon, text, subText, onPress, testID, ...props}, ref) => {
+    const {topContainer} = useSectionItem(props);
+    const sectionStyle = useSectionStyle();
+    const styles = useStyles();
+    const {theme} = useThemeContext();
+
+    return (
+      <NativeBlockButton
+        ref={ref}
+        accessible
+        accessibilityRole="button"
+        onPress={onPress}
+        style={[topContainer, styles.button]}
+        testID={testID}
+        {...props}
+      >
+        <View style={[sectionStyle.spaceBetween, styles.gap]}>
+          {leftIcon && <ThemeIcon svg={leftIcon} size="normal" />}
+          <View style={styles.textContainer}>
+            <ThemeText typography="body__m__strong">{text}</ThemeText>
+            {subText && (
+              <ThemeText typography="body__m" color="secondary">
+                {subText}
+              </ThemeText>
+            )}
+          </View>
+          <ThemeIcon
+            svg={rightIcon ?? Edit}
+            size="normal"
+            color={theme.color.interactive[0].default.background}
+          />
+        </View>
+      </NativeBlockButton>
+    );
+  },
+);
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  button: {flex: 1},
+  gap: {gap: theme.spacing.small, alignItems: 'flex-start'},
+  textContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.xSmall,
+  },
+}));

--- a/src/components/sections/items/EditActionSectionItem.tsx
+++ b/src/components/sections/items/EditActionSectionItem.tsx
@@ -7,7 +7,6 @@ import React, {forwardRef} from 'react';
 import {AccessibilityProps, View} from 'react-native';
 import {SectionItemProps} from '../types';
 import {useSectionItem} from '../use-section-item';
-import {useSectionStyle} from '../use-section-style';
 
 type Props = SectionItemProps<
   {
@@ -23,7 +22,6 @@ type Props = SectionItemProps<
 export const EditActionSectionItem = forwardRef<any, Props>(
   ({leftIcon, rightIcon, text, subText, onPress, testID, ...props}, ref) => {
     const {topContainer} = useSectionItem(props);
-    const sectionStyle = useSectionStyle();
     const styles = useStyles();
     const {theme} = useThemeContext();
 
@@ -37,29 +35,27 @@ export const EditActionSectionItem = forwardRef<any, Props>(
         testID={testID}
         {...props}
       >
-        <View style={[sectionStyle.spaceBetween, styles.gap]}>
-          {leftIcon && <ThemeIcon svg={leftIcon} size="normal" />}
-          <View style={styles.textContainer}>
-            <ThemeText typography="body__m__strong">{text}</ThemeText>
-            {subText && (
-              <ThemeText typography="body__m" color="secondary">
-                {subText}
-              </ThemeText>
-            )}
-          </View>
-          <ThemeIcon
-            svg={rightIcon ?? Edit}
-            size="normal"
-            color={theme.color.interactive[0].default.background}
-          />
+        {leftIcon && <ThemeIcon svg={leftIcon} size="normal" />}
+        <View style={styles.textContainer}>
+          <ThemeText typography="body__m__strong">{text}</ThemeText>
+          {subText && (
+            <ThemeText typography="body__m" color="secondary">
+              {subText}
+            </ThemeText>
+          )}
         </View>
+        <ThemeIcon
+          svg={rightIcon ?? Edit}
+          size="normal"
+          color={theme.color.interactive[0].default.background}
+        />
       </NativeBlockButton>
     );
   },
 );
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  button: {flex: 1},
+  button: {flex: 1, flexDirection: 'row', gap: theme.spacing.small},
   gap: {gap: theme.spacing.small, alignItems: 'flex-start'},
   textContainer: {
     flex: 1,

--- a/src/modules/storybook/stories/Section.stories.tsx
+++ b/src/modules/storybook/stories/Section.stories.tsx
@@ -33,7 +33,10 @@ import {
 import {ThemeText} from '@atb/components/text';
 import {Warning} from '@atb/assets/svg/mono-icons/status';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {Edit} from '@atb/assets/svg/mono-icons/actions';
+import {Edit, Filter} from '@atb/assets/svg/mono-icons/actions';
+import {Time} from '@atb/assets/svg/mono-icons/time';
+import {EditActionSectionItem} from '@atb/components/sections';
+import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
 
 type SectionMetaProps = ThemedStoryProps<SectionProps>;
 const containerSizingType: ContainerSizingType[] = ['block', 'spacious'];
@@ -55,9 +58,10 @@ const SectionMeta: Meta<SectionMetaProps> = {
 };
 export default SectionMeta;
 
-export const ListedSectionItems: Meta<SectionMetaProps> = {
+export const AllSectionItemsList: Meta<SectionMetaProps> = {
   args: {
     style: {margin: 12},
+    storyColor: 'background neutral 1',
   },
   decorators: [
     (Story, {args}) => (
@@ -188,6 +192,12 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
                   onPress={() => {}}
                   onPressIcon={Edit}
                 />
+                <EditActionSectionItem
+                  leftIcon={Time}
+                  text="EditActionSectionItem"
+                  subText="Subtext"
+                  onPress={() => {}}
+                />
               </Section>
             ),
           }}
@@ -199,10 +209,10 @@ export const ListedSectionItems: Meta<SectionMetaProps> = {
 };
 
 export const OneSectionItem: Meta<SectionMetaProps> = {
-  args: {style: {margin: 12}},
+  args: {style: {margin: 12}, storyColor: 'background neutral 1'},
   decorators: [
     (Story, {args}) => (
-      <View style={{backgroundColor: 'pink'}}>
+      <View>
         <Story
           args={{
             ...args,
@@ -218,6 +228,56 @@ export const OneSectionItem: Meta<SectionMetaProps> = {
           }}
         />
       </View>
+    ),
+    ThemedStoryDecorator,
+  ],
+};
+
+export const EditActionSectionItemStory: Meta<SectionMetaProps> = {
+  args: {style: {margin: 12}, storyColor: 'background neutral 1'},
+  decorators: [
+    (Story, {args}) => (
+      <ScrollView>
+        <Story
+          args={{
+            ...args,
+            children: (
+              <Section>
+                <EditActionSectionItem
+                  leftIcon={Time}
+                  text="With everything"
+                  subText="Subtext"
+                  onPress={() => {}}
+                />
+                <EditActionSectionItem
+                  text="Without left icon"
+                  subText="Subtext"
+                  onPress={() => {}}
+                />
+                <EditActionSectionItem
+                  leftIcon={Travellers}
+                  text="Without subtext"
+                  onPress={() => {}}
+                />
+                <EditActionSectionItem
+                  leftIcon={Travellers}
+                  text="Custom right icon"
+                  subText="Subtext"
+                  rightIcon={Filter}
+                  onPress={() => {}}
+                />
+                <EditActionSectionItem
+                  leftIcon={Travellers}
+                  text="Quite long text on this one"
+                  subText="And a pretty long subtext"
+                  rightIcon={Filter}
+                  onPress={() => {}}
+                />
+              </Section>
+            ),
+          }}
+        />
+      </ScrollView>
     ),
     ThemedStoryDecorator,
   ],

--- a/src/modules/storybook/stories/Section.stories.tsx
+++ b/src/modules/storybook/stories/Section.stories.tsx
@@ -3,6 +3,7 @@ import {
   RadioSectionItem,
   ButtonSectionItem,
   CounterSectionItem,
+  EditActionSectionItem,
   ExpandableSectionItem,
   FavoriteDepartureSectionItem,
   FavoriteSectionItem,
@@ -35,7 +36,6 @@ import {Warning} from '@atb/assets/svg/mono-icons/status';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Edit, Filter} from '@atb/assets/svg/mono-icons/actions';
 import {Time} from '@atb/assets/svg/mono-icons/time';
-import {EditActionSectionItem} from '@atb/components/sections';
 import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
 
 type SectionMetaProps = ThemedStoryProps<SectionProps>;


### PR DESCRIPTION
Resolves [#23866](https://github.com/AtB-AS/kundevendt/issues/23886)

A section item with optional left icon, primary text, optional
inline subtext, and a right icon defaulting to the Edit icon.
Text and subtext wrap inline when they exceed available width.

Adds a dedicated Storybook story and includes the component in
the AllSectionItemsList story.

<div>
<img width="350" src="https://github.com/user-attachments/assets/75594dd3-acb7-459b-8510-d18bff7306dd" />
<img width="350" src="https://github.com/user-attachments/assets/f81cf00a-95fc-47ab-a2e6-01ef657f0f4e" />
</div>

