### PR TITLE
refactor: improve how colors are passed to ThemeText

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,6 +194,9 @@ module.exports = {
 
     // Error on React hooks being called inside StyleSheet.createThemeHook
     'rulesdir/no-hooks-in-create-theme-hook': 'error',
+
+    // Error on passing TextColor string literals as the color prop of ThemeText
+    'rulesdir/no-text-color-in-theme-text': 'error',
   },
   overrides: [
     // Allow 'export default' from these paths

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -4,6 +4,7 @@ const avoidImports = require('./avoid-imports');
 const navigationOnlyInScreens = require('./navigation-only-in-screens');
 const noAnyNavigationParams = require('./no-any-navigation-params');
 const noHooksInCreateThemeHook = require('./no-hooks-in-create-theme-hook');
+const noTextColorInThemeText = require('./no-text-color-in-theme-text');
 
 module.exports = {
   rules: {
@@ -13,5 +14,6 @@ module.exports = {
     ['navigation-only-in-screens']: navigationOnlyInScreens,
     ['no-any-navigation-params']: noAnyNavigationParams,
     ['no-hooks-in-create-theme-hook']: noHooksInCreateThemeHook,
+    ['no-text-color-in-theme-text']: noTextColorInThemeText,
   },
 };

--- a/eslint-rules/no-text-color-in-theme-text.js
+++ b/eslint-rules/no-text-color-in-theme-text.js
@@ -1,0 +1,61 @@
+const TEXT_COLOR_VALUES = ['primary', 'secondary', 'disabled'];
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Prevent passing TextColor string literals as the color prop of ThemeText. Use the `type` prop instead.',
+    },
+    messages: {
+      noTextColor:
+        'Do not pass TextColor string \'{{ value }}\' as the color prop of ThemeText. Use the `type` prop instead (e.g. type="{{ value }}"), or pass a ContrastColor object.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (
+          node.name.type !== 'JSXIdentifier' ||
+          node.name.name !== 'ThemeText'
+        )
+          return;
+
+        for (const attr of node.attributes) {
+          if (
+            attr.type !== 'JSXAttribute' ||
+            attr.name.name !== 'color' ||
+            !attr.value
+          )
+            continue;
+
+          // color="secondary"
+          if (
+            attr.value.type === 'Literal' &&
+            TEXT_COLOR_VALUES.includes(attr.value.value)
+          ) {
+            context.report({
+              node: attr,
+              messageId: 'noTextColor',
+              data: {value: attr.value.value},
+            });
+          }
+
+          // color={"secondary"}
+          if (
+            attr.value.type === 'JSXExpressionContainer' &&
+            attr.value.expression.type === 'Literal' &&
+            TEXT_COLOR_VALUES.includes(attr.value.expression.value)
+          ) {
+            context.report({
+              node: attr,
+              messageId: 'noTextColor',
+              data: {value: attr.value.expression.value},
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/components/bottom-sheet/BottomSheetHeader.tsx
+++ b/src/components/bottom-sheet/BottomSheetHeader.tsx
@@ -2,7 +2,7 @@ import {View} from 'react-native';
 import {NativeBorderlessButton} from '../native-button';
 import {ThemeText} from '../text';
 import {ThemeIcon} from '../theme-icon';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import BottomSheet, {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {BrandingImage} from '@atb/modules/mobility';
 import {Ref} from 'react';
@@ -35,7 +35,6 @@ export const BottomSheetHeader = ({
   bottomSheetHeaderType,
 }: BottomSheetHeaderProps) => {
   const styles = useStyles();
-  const {theme} = useThemeContext();
   const headerData = useBottomSheetHeaderType(bottomSheetHeaderType);
 
   return (
@@ -54,10 +53,7 @@ export const BottomSheetHeader = ({
                 <ThemeText typography="heading__l">{heading}</ThemeText>
               )}
               {subText && (
-                <ThemeText
-                  typography="body__s"
-                  color={theme.color.foreground.dynamic.secondary}
-                >
+                <ThemeText typography="body__s" type="secondary">
                   {subText}
                 </ThemeText>
               )}

--- a/src/components/camera/CameraScreenContainer.tsx
+++ b/src/components/camera/CameraScreenContainer.tsx
@@ -46,7 +46,7 @@ export const CameraScreenContainer = ({
           />
           <View style={styles.header} ref={focusRef}>
             <NativeBorderlessButton onPress={onGoBack} style={styles.back}>
-              <ThemeIcon svg={SvgChevronLeft} color="white" />
+              <ThemeIcon svg={SvgChevronLeft} color="#ffffff" />
               <ThemeText typography="body__s__strong" color="#ffffff">
                 {t(ScreenHeaderTexts.headerButton.back.text)}
               </ThemeText>

--- a/src/components/camera/CameraScreenContainer.tsx
+++ b/src/components/camera/CameraScreenContainer.tsx
@@ -47,17 +47,17 @@ export const CameraScreenContainer = ({
           <View style={styles.header} ref={focusRef}>
             <NativeBorderlessButton onPress={onGoBack} style={styles.back}>
               <ThemeIcon svg={SvgChevronLeft} color="white" />
-              <ThemeText typography="body__s__strong" color="white">
+              <ThemeText typography="body__s__strong" color="#ffffff">
                 {t(ScreenHeaderTexts.headerButton.back.text)}
               </ThemeText>
             </NativeBorderlessButton>
           </View>
           <View style={styles.content}>
-            <ThemeText typography="heading__l" color="white">
+            <ThemeText typography="heading__l" color="#ffffff">
               {title}
             </ThemeText>
             {!!secondaryText && (
-              <ThemeText typography="body__s" color="white">
+              <ThemeText typography="body__s" color="#ffffff">
                 {secondaryText}
               </ThemeText>
             )}

--- a/src/components/empty-state/EmptyState.tsx
+++ b/src/components/empty-state/EmptyState.tsx
@@ -35,14 +35,14 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
       <View style={styles.emptyStateIllustration}>{illustrationComponent}</View>
       <ThemeText
         typography="body__m__strong"
-        color="secondary"
+        type="secondary"
         style={styles.emptyStateTitle}
       >
         {title}
       </ThemeText>
       <ThemeText
         typography="body__s"
-        color="secondary"
+        type="secondary"
         style={styles.emptyStateDetails}
       >
         {details}

--- a/src/components/estimated-call/EstimatedCallInfo.tsx
+++ b/src/components/estimated-call/EstimatedCallInfo.tsx
@@ -42,7 +42,7 @@ export function EstimatedCallInfo({
       )}
       <ThemeText
         typography={departure.cancellation ? 'body__m__strike' : 'body__m'}
-        color={departure.cancellation ? 'secondary' : 'primary'}
+        type={departure.cancellation ? 'secondary' : 'primary'}
         style={styles.lineName}
         testID="lineName"
       >

--- a/src/components/heading/ContentHeading.tsx
+++ b/src/components/heading/ContentHeading.tsx
@@ -2,18 +2,15 @@ import {StyleSheet} from '@atb/theme';
 import React from 'react';
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {ThemeText} from '../text';
-import {ContrastColor, TextColor} from '@atb/theme/colors';
 
 type ContentHeadingProps = {
   text: string;
-  color?: TextColor | ContrastColor;
   accessibilityLabel?: string;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ContentHeading({
   text,
-  color = 'secondary',
   accessibilityLabel,
   style,
 }: ContentHeadingProps): React.JSX.Element {
@@ -27,7 +24,7 @@ export function ContentHeading({
     >
       <ThemeText
         typography="body__s"
-        color={color}
+        type="secondary"
         accessibilityLabel={accessibilityLabel}
       >
         {text}

--- a/src/components/heading/ScreenHeading.tsx
+++ b/src/components/heading/ScreenHeading.tsx
@@ -2,19 +2,17 @@ import {useThemeContext} from '@atb/theme';
 import React, {forwardRef} from 'react';
 import {View} from 'react-native';
 import {ThemeText} from '../text';
-import {ContrastColor, TextColor} from '@atb/theme/colors';
 
 type ScreenHeadingProps = {
   text: string;
-  color?: TextColor | ContrastColor;
   accessibilityLabel?: string;
   isLarge?: boolean;
 };
 
 export const ScreenHeading = forwardRef<any, ScreenHeadingProps>(
-  ({text, color, accessibilityLabel, isLarge}: ScreenHeadingProps, ref) => {
+  ({text, accessibilityLabel, isLarge}: ScreenHeadingProps, ref) => {
     const {theme} = useThemeContext();
-    color = color ?? theme.color.background.accent[0];
+    const color = theme.color.background.accent[0];
 
     return (
       <View

--- a/src/components/journey-legs-summary/LegsSummary.tsx
+++ b/src/components/journey-legs-summary/LegsSummary.tsx
@@ -42,7 +42,7 @@ export function LegsSummary({
   return (
     <View style={styles.legSection}>
       {!compact && (
-        <ThemeText typography="body__m" color="secondary">
+        <ThemeText typography="body__m" type="secondary">
           {t(PurchaseConfirmationTexts.confirmations.onlyValidDeparture)}
         </ThemeText>
       )}
@@ -81,21 +81,21 @@ export function LegsSummary({
               <View style={styles.legSectionItem}>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.legLabel}
                 >
                   {t(SharedTexts.from)}:
                 </ThemeText>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.legName}
                 >
                   {leg.fromPlace.quay?.stopPlace?.name}
                 </ThemeText>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.legSectionItemTime}
                 >
                   {!!leg.expectedStartTime &&
@@ -105,21 +105,21 @@ export function LegsSummary({
               <View style={styles.legSectionItem}>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.legLabel}
                 >
                   {t(SharedTexts.to)}:
                 </ThemeText>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.legName}
                 >
                   {leg.toPlace.quay?.stopPlace?.name}
                 </ThemeText>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.legSectionItemTime}
                 >
                   {!!leg.expectedEndTime &&

--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -172,7 +172,7 @@ export const MessageInfoBox = ({
           <ThemeText
             style={styles.installId}
             typography="body__xs"
-            color="secondary"
+            type="secondary"
             allowFontScaling={false}
           >
             id: {config.installId}

--- a/src/components/message-info-text/MessageInfoText.tsx
+++ b/src/components/message-info-text/MessageInfoText.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {StyleProp, View, ViewStyle} from 'react-native';
+import {ColorValue, StyleProp, View, ViewStyle} from 'react-native';
 import {Statuses, StyleSheet, useThemeContext} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
-import {ContrastColor, TextColor} from '@atb/theme/colors';
+import {ContrastColor} from '@atb/theme/colors';
 
 export type MessageInfoTextProps = {
   type: Statuses;
@@ -13,7 +13,7 @@ export type MessageInfoTextProps = {
   style?: StyleProp<ViewStyle>;
   testID?: string;
   iconPosition?: 'right' | 'left';
-  textColor?: ContrastColor | TextColor;
+  textColor?: ContrastColor | ColorValue;
   isMarkdown?: boolean;
 };
 

--- a/src/components/sections/items/CounterSectionItem.tsx
+++ b/src/components/sections/items/CounterSectionItem.tsx
@@ -65,7 +65,7 @@ export function CounterSectionItem({
         {subtext && (
           <ThemeText
             typography="body__s"
-            color="secondary"
+            type="secondary"
             style={counterStyles.infoSubtext}
           >
             {subtext}

--- a/src/components/sections/items/FavoriteDepartureSectionItem.tsx
+++ b/src/components/sections/items/FavoriteDepartureSectionItem.tsx
@@ -77,7 +77,7 @@ function FavoriteItemContent({favorite, icon, ...props}: BaseProps) {
           {formatDestinationDisplay(t, favorite.destinationDisplay) ??
             t(SectionTexts.favoriteDeparture.allVariations)}
         </ThemeText>
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(SectionTexts.favoriteDeparture.from)} {favorite.quayName}{' '}
           {favorite.quayPublicCode ?? ''}
         </ThemeText>

--- a/src/components/sections/items/HeaderSectionItem.tsx
+++ b/src/components/sections/items/HeaderSectionItem.tsx
@@ -31,7 +31,7 @@ export function HeaderSectionItem({
       {subtitle && (
         <ThemeText
           style={[styles.subtitle, contentContainer]}
-          color="secondary"
+          type="secondary"
           typography={mode === 'heading' ? 'body__s' : 'body__xs'}
         >
           {subtitle}

--- a/src/components/sections/items/InternalLabeledSectionItem.tsx
+++ b/src/components/sections/items/InternalLabeledSectionItem.tsx
@@ -40,7 +40,7 @@ export function InternalLabeledSectionItem({
         {subtext && (
           <ThemeText
             typography="body__s"
-            color="secondary"
+            type="secondary"
             style={itemStyle.label}
             accessible={accessibleLabel}
           >

--- a/src/components/sections/items/LinkSectionItem.tsx
+++ b/src/components/sections/items/LinkSectionItem.tsx
@@ -101,7 +101,7 @@ export const LinkSectionItem = forwardRef<any, Props>(
             </ThemeText>
             {subtitle && (
               <View>
-                <ThemeText color="secondary" typography="body__s">
+                <ThemeText type="secondary" typography="body__s">
                   {subtitle}
                 </ThemeText>
               </View>

--- a/src/components/sections/items/MessageSectionItem.tsx
+++ b/src/components/sections/items/MessageSectionItem.tsx
@@ -68,16 +68,16 @@ export function MessageSectionItem({
           <ThemeText
             typography="body__m__strong"
             style={styles.title}
-            color={messageType}
+            color={themeColor}
             testID="title"
           >
             {title}
           </ThemeText>
         )}
-        <ThemeText color={messageType}>{message}</ThemeText>
+        <ThemeText color={themeColor}>{message}</ThemeText>
         {onPressConfig?.text && (
           <ThemeText
-            color={messageType}
+            color={themeColor}
             style={styles.linkText}
             typography="body__m__underline"
           >

--- a/src/components/sections/items/RadioSectionItem.tsx
+++ b/src/components/sections/items/RadioSectionItem.tsx
@@ -100,7 +100,7 @@ export function RadioSectionItem({
           {subtext && (
             <ThemeText
               typography="body__s"
-              color="secondary"
+              type="secondary"
               style={{marginTop: theme.spacing.small}}
               testID={`${testID}SubText`}
             >

--- a/src/components/sections/items/SelectionInlineSectionItem.tsx
+++ b/src/components/sections/items/SelectionInlineSectionItem.tsx
@@ -59,7 +59,7 @@ export function SelectionInlineSectionItem({
 
       <View style={[contentContainer, styles.labelValueContainer]}>
         <ThemeText typography="body__m__strong">{label}</ThemeText>
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {value}
         </ThemeText>
       </View>

--- a/src/components/sections/items/ToggleSectionItem.tsx
+++ b/src/components/sections/items/ToggleSectionItem.tsx
@@ -118,7 +118,7 @@ export function ToggleSectionItem({
             />
           </View>
           {subtext && (
-            <ThemeText typography="body__s" color="secondary">
+            <ThemeText typography="body__s" type="secondary">
               {subtext}
             </ThemeText>
           )}

--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -122,7 +122,7 @@ const SnackbarInstance = ({
             {activeContent?.title && (
               <ThemeText
                 typography="body__m__strong"
-                color="primary"
+                type="primary"
                 numberOfLines={4} // max limit, should normally not come into play
               >
                 {activeContent?.title}
@@ -131,7 +131,7 @@ const SnackbarInstance = ({
             {activeContent?.description && (
               <ThemeText
                 typography="body__m"
-                color={activeContent?.title ? 'secondary' : 'primary'}
+                type={activeContent?.title ? 'secondary' : 'primary'}
                 numberOfLines={7} // max limit, should normally not come into play
               >
                 {activeContent?.description}

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -120,7 +120,6 @@ const SecondaryTag: React.FC<
 > = ({labels, a11yLabel, size = 'regular', icon, customStyle}) => {
   const commonStyles = useCommonTagStyles();
   const styles = useSecondaryTagStyles();
-  const {theme} = useThemeContext();
 
   const sizeDependentStyle =
     size === 'small'
@@ -142,7 +141,7 @@ const SecondaryTag: React.FC<
       )}
       {labels.map((content) => (
         <ThemeText
-          color={theme.color.foreground.dynamic.primary}
+          type="primary"
           typography="body__xs"
           key={content}
           style={commonStyles.text}
@@ -165,7 +164,7 @@ const useSecondaryTagStyles = StyleSheet.createThemeHook((theme) => ({
 const SemanticTag: React.FC<
   BaseTagProps & {tagType: Exclude<TagStatuses, 'primary' | 'secondary'>}
 > = ({labels, a11yLabel, tagType, size = 'regular', customStyle}) => {
-  const {theme, themeName} = useThemeContext();
+  const {themeName} = useThemeContext();
   const commonStyles = useCommonTagStyles();
   const styles = useSemanticTagStyles();
 
@@ -190,7 +189,7 @@ const SemanticTag: React.FC<
       )}
       {labels.map((content) => (
         <ThemeText
-          color={theme.color.foreground.dynamic.primary}
+          type="primary"
           typography="body__xs"
           key={content}
           style={commonStyles.text}

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useThemeContext} from '@atb/theme';
+import {resolveColorValue, useThemeContext} from '@atb/theme';
 import {
   ColorValue,
   Platform,
@@ -10,19 +10,13 @@ import {
 } from 'react-native';
 import {renderMarkdown} from './markdown-renderer';
 import {getTextWeightStyle, MAX_FONT_SCALE} from './utils';
-import {
-  ContrastColor,
-  Statuses,
-  TextColor,
-  TextNames,
-  resolveColorValue,
-} from '@atb/theme/colors';
+import {ContrastColor, TextNames} from '@atb/theme/colors';
 import {useFontScale} from '@atb/utils/use-font-scale';
 
 export type ThemeTextProps = TextProps & {
   typography?: TextNames;
   type?: keyof ContrastColor['foreground'];
-  color?: ContrastColor | Statuses | TextColor | ColorValue;
+  color?: ContrastColor | ColorValue;
   isMarkdown?: boolean;
 };
 

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -10,12 +10,12 @@ import {
 } from 'react-native';
 import {renderMarkdown} from './markdown-renderer';
 import {getTextWeightStyle, MAX_FONT_SCALE} from './utils';
-import {ContrastColor, TextNames} from '@atb/theme/colors';
+import {ContrastColor, ForegroundType, TextNames} from '@atb/theme/colors';
 import {useFontScale} from '@atb/utils/use-font-scale';
 
 export type ThemeTextProps = TextProps & {
   typography?: TextNames;
-  type?: keyof ContrastColor['foreground'];
+  type?: ForegroundType;
   color?: ContrastColor | ColorValue;
   isMarkdown?: boolean;
 };

--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -16,6 +16,13 @@ import {useFontScale} from '@atb/utils/use-font-scale';
 export type ThemeTextProps = TextProps & {
   typography?: TextNames;
   type?: ForegroundType;
+  /**
+   * Pass a ContrastColor from the theme for semantic color resolution.
+   * The foreground tier is selected via the `type` prop.
+   * Use a resolved hex string only for explicit color overrides.
+   * Do NOT pass TextColor strings like 'primary' or 'secondary' —
+   * use the `type` prop instead.
+   */
   color?: ContrastColor | ColorValue;
   isMarkdown?: boolean;
 };

--- a/src/components/theme-icon/ThemeIcon.tsx
+++ b/src/components/theme-icon/ThemeIcon.tsx
@@ -1,10 +1,10 @@
 import {useThemeContext} from '@atb/theme';
 import {
   ContrastColor,
+  resolveColorValue,
   Statuses,
   TextColor,
   Theme,
-  resolveColorValue,
 } from '@atb/theme/colors';
 import {SvgProps} from 'react-native-svg';
 import {useFontScale} from '@atb/utils/use-font-scale';

--- a/src/components/walking-distance/WalkingDistance.tsx
+++ b/src/components/walking-distance/WalkingDistance.tsx
@@ -20,7 +20,7 @@ export const WalkingDistance = ({style, distance}: Props) => {
   return (
     <View style={[style, sheetStyles.distanceLabel]}>
       <ThemeIcon svg={WalkFill} color="secondary" style={sheetStyles.icon} />
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {humanizedDistance}
       </ThemeText>
     </View>

--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -107,7 +107,7 @@ export const BonusProductList = ({
                         .map((ff) => t(MobilityTexts.vehicleName(ff)))
                         .join(', ')}
                     </ThemeText>
-                    <ThemeText typography="body__s" color="secondary">
+                    <ThemeText typography="body__s" type="secondary">
                       {operatorNames}
                     </ThemeText>
                   </View>
@@ -150,7 +150,7 @@ export const BonusProductList = ({
                   <ThemeText
                     isMarkdown={true}
                     typography="body__s"
-                    color="secondary"
+                    type="secondary"
                   >
                     {getTextForLanguage(group.description, language) ?? ''}
                   </ThemeText>

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -86,14 +86,14 @@ export const PayWithBonusPointsCheckbox = ({
                 ) ?? ''}
               </ThemeText>
               <View style={styles.currentPointsRow}>
-                <ThemeText typography="body__s" color="secondary">
+                <ThemeText typography="body__s" type="secondary">
                   {t(BonusProgramTexts.youHave)}
                 </ThemeText>
                 <UserBonusBalance
                   typography="body__s"
                   color={theme.color.foreground.dynamic.secondary}
                 />
-                <ThemeText typography="body__s" color="secondary">
+                <ThemeText typography="body__s" type="secondary">
                   {t(BonusProgramTexts.points)}
                 </ThemeText>
               </View>

--- a/src/modules/bonus/components/UserBonusBalance.tsx
+++ b/src/modules/bonus/components/UserBonusBalance.tsx
@@ -1,3 +1,4 @@
+import {ColorValue} from 'react-native';
 import {TextNames} from '@atb/theme';
 import {useBonusBalanceQuery} from '..';
 import {ThemeText} from '@atb/components/text';
@@ -6,7 +7,7 @@ import {Loading} from '@atb/components/loading';
 
 type Props = {
   typography: TextNames;
-  color: string;
+  color: ColorValue;
 };
 
 export const UserBonusBalance = ({color, typography}: Props) => {

--- a/src/modules/bonus/components/UserBonusBalanceContent.tsx
+++ b/src/modules/bonus/components/UserBonusBalanceContent.tsx
@@ -41,7 +41,7 @@ export function UserBonusBalanceContent(): React.JSX.Element {
           />
         </View>
 
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(BonusProgramTexts.bonusProfile.yourPoints)}
         </ThemeText>
       </View>

--- a/src/modules/bonus/onboarding/BonusOnboarding_JoinScreen.tsx
+++ b/src/modules/bonus/onboarding/BonusOnboarding_JoinScreen.tsx
@@ -69,7 +69,7 @@ export const Terms = ({error}: {error: Error | null}) => {
             />
             <ThemeText
               typography="body__m"
-              color="primary"
+              type="primary"
               style={styles.termDescription}
             >
               {t(BonusProgramTexts.terms.term1)}
@@ -86,7 +86,7 @@ export const Terms = ({error}: {error: Error | null}) => {
             />
             <ThemeText
               typography="body__m"
-              color="primary"
+              type="primary"
               style={styles.termDescription}
             >
               {t(BonusProgramTexts.terms.term2)}
@@ -103,7 +103,7 @@ export const Terms = ({error}: {error: Error | null}) => {
             />
             <ThemeText
               typography="body__m"
-              color="primary"
+              type="primary"
               style={styles.termDescription}
             >
               {t(BonusProgramTexts.terms.term3)}

--- a/src/modules/fare-contracts/CompactFareContractInfo.tsx
+++ b/src/modules/fare-contracts/CompactFareContractInfo.tsx
@@ -91,31 +91,31 @@ const CompactFareContractInfoTexts = (
         {timeUntilExpire}
       </ThemeText>
       {firstTravelRight.travelerName ? (
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {firstTravelRight.travelerName}
         </ThemeText>
       ) : (
         userProfilesWithCount
           .map((u) => (
-            <ThemeText key={u.id} typography="body__s" color="secondary">
+            <ThemeText key={u.id} typography="body__s" type="secondary">
               {toCountAndReferenceDataName(u, language)}
             </ThemeText>
           ))
           .concat(
             baggageProductsWithCount.map((p) => (
-              <ThemeText key={p.id} typography="body__s" color="secondary">
+              <ThemeText key={p.id} typography="body__s" type="secondary">
                 {toCountAndReferenceDataName(p, language)}
               </ThemeText>
             )),
           )
       )}
       {productName && (
-        <ThemeText typography="body__s" color="secondary" testID="productName">
+        <ThemeText typography="body__s" type="secondary" testID="productName">
           {productName}
         </ThemeText>
       )}
       {fareZoneSummary && (
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {fareZoneSummary}
         </ThemeText>
       )}

--- a/src/modules/fare-contracts/PurchaseReservation.tsx
+++ b/src/modules/fare-contracts/PurchaseReservation.tsx
@@ -56,7 +56,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation, now}) => {
         </GenericSectionItem>
         <GenericSectionItem accessibility={{accessible: true}}>
           {status == 'rejected' && (
-            <ThemeText typography="body__s" color="secondary">
+            <ThemeText typography="body__s" type="secondary">
               {t(
                 TicketingTexts.reservation.orderDate(
                   formatToLongDateTime(
@@ -69,7 +69,7 @@ export const PurchaseReservation: React.FC<Props> = ({reservation, now}) => {
           )}
           <ThemeText
             typography="body__s"
-            color="secondary"
+            type="secondary"
             style={styles.detail}
           >
             {t(TicketingTexts.reservation.paymentMethod(paymentType))}

--- a/src/modules/fare-contracts/components/FareContractDescription.tsx
+++ b/src/modules/fare-contracts/components/FareContractDescription.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {type FareContractType} from '@atb-as/utils';
 import {findReferenceDataById} from '@atb/modules/configuration';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 type Props = {
@@ -13,7 +13,6 @@ type Props = {
 export const Description = ({fc}: Props) => {
   const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {language} = useTranslation();
-  const {theme} = useThemeContext();
   const styles = useStyles();
 
   const travelRight = fc.travelRights[0];
@@ -29,7 +28,7 @@ export const Description = ({fc}: Props) => {
     <ThemeText
       typography="body__s"
       accessibilityLabel={description + screenReaderPause}
-      color={theme.color.foreground.dynamic.secondary}
+      type="secondary"
       style={styles.text}
     >
       {description}

--- a/src/modules/fare-contracts/components/FareContractDetailItem.tsx
+++ b/src/modules/fare-contracts/components/FareContractDetailItem.tsx
@@ -2,7 +2,6 @@ import {StyleProp, View, ViewStyle} from 'react-native';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {StyleSheet} from '@atb/theme';
-import {useThemeContext} from '@atb/theme';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {SvgProps} from 'react-native-svg';
 import {Size, getContentTypography} from '../utils';
@@ -21,14 +20,11 @@ export function FareContractDetailItem({
   style?: StyleProp<ViewStyle>;
 }) {
   const styles = useStyles();
-  const {theme} = useThemeContext();
-
-  const headerTextColor = theme.color.foreground.dynamic.secondary;
 
   return (
     <View style={[styles.container, style]}>
       {header && (
-        <ThemeText typography="body__s" color={headerTextColor}>
+        <ThemeText typography="body__s" type="secondary">
           {header}
         </ThemeText>
       )}

--- a/src/modules/fare-contracts/components/ProductName.tsx
+++ b/src/modules/fare-contracts/components/ProductName.tsx
@@ -6,7 +6,7 @@ import {
   getReferenceDataName,
 } from '@atb/modules/configuration';
 import {useTranslation} from '@atb/translations';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {useGetFareProductsQuery} from '@atb/modules/ticketing';
 
 type Props = {
@@ -16,7 +16,6 @@ type Props = {
 export const ProductName = ({fc}: Props) => {
   const {data: preassignedFareProducts} = useGetFareProductsQuery();
   const {language} = useTranslation();
-  const {theme} = useThemeContext();
   const styles = useStyles();
 
   const travelRight = fc.travelRights[0];
@@ -32,7 +31,7 @@ export const ProductName = ({fc}: Props) => {
       typography="body__s__strong"
       accessibilityLabel={productName + screenReaderPause}
       testID="productName"
-      color={theme.color.foreground.dynamic.secondary}
+      type="secondary"
       style={styles.text}
     >
       {productName}

--- a/src/modules/fare-contracts/components/ValidTo.tsx
+++ b/src/modules/fare-contracts/components/ValidTo.tsx
@@ -5,7 +5,6 @@ import {ThemeText} from '@atb/components/text';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {fullDateTime} from '@atb/utils/date';
 import {getValidityStatus} from '@atb/modules/fare-contracts';
-import {useThemeContext} from '@atb/theme';
 import {getAccesses} from '@atb-as/utils';
 
 type Props = {
@@ -15,7 +14,6 @@ type Props = {
 
 export const ValidTo = ({fc, now}: Props) => {
   const {t, language} = useTranslation();
-  const {theme} = useThemeContext();
   const firstTravelRight = fc.travelRights[0];
   if (getValidityStatus(now, fc) !== 'valid') return null;
 
@@ -32,11 +30,7 @@ export const ValidTo = ({fc, now}: Props) => {
   }
 
   return (
-    <ThemeText
-      typography="body__s"
-      color={theme.color.foreground.dynamic.secondary}
-      style={{}}
-    >
+    <ThemeText typography="body__s" type="secondary" style={{}}>
       {t(
         FareContractTexts.details.validTo(fullDateTime(endDateTime, language)),
       )}

--- a/src/modules/fare-contracts/details/UsedAccessesSectionItem.tsx
+++ b/src/modules/fare-contracts/details/UsedAccessesSectionItem.tsx
@@ -26,7 +26,7 @@ export const UsedAccessesSectionItem = ({usedAccesses}: Props) => {
         {t(FareContractTexts.details.usedAccesses)}
       </ThemeText>
       {dateStrings.map((dateString) => (
-        <ThemeText key={dateString} typography="body__s" color="secondary">
+        <ThemeText key={dateString} typography="body__s" type="secondary">
           {dateString}
         </ThemeText>
       ))}

--- a/src/modules/fare-contracts/sections/FareContractShmoHeaderSectionItem.tsx
+++ b/src/modules/fare-contracts/sections/FareContractShmoHeaderSectionItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {FareContractType} from '@atb-as/utils';
 import {SectionItemProps, useSectionItem} from '@atb/components/sections';
 import {View} from 'react-native';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleSheet} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {useAuthContext} from '@atb/modules/auth';
@@ -31,8 +31,6 @@ export const FareContractShmoHeaderSectionItem = ({
   const {t, language} = useTranslation();
   const {abtCustomerId: currentUserId} = useAuthContext();
   const {isInspectable} = useMobileTokenContext();
-  const {theme} = useThemeContext();
-
   const {validTo} = getFareContractInfo(now, fc, currentUserId);
   const dateTime = formatToLongDateTime(toDate(validTo), language);
   const label = t(FareContractTexts.shmoDetails.tripEnded(dateTime));
@@ -52,7 +50,7 @@ export const FareContractShmoHeaderSectionItem = ({
             accessibilityLabel={t(
               MobilityTexts.fareContractHeader(fc.formFactor, operatorName),
             )}
-            color={theme.color.foreground.dynamic.secondary}
+            type="secondary"
             style={styles.headerText}
           >
             {t(MobilityTexts.fareContractHeader(fc.formFactor, operatorName))}

--- a/src/modules/fare-contracts/sections/OrderDetailsSectionItem.tsx
+++ b/src/modules/fare-contracts/sections/OrderDetailsSectionItem.tsx
@@ -33,7 +33,7 @@ export const OrderDetailsSectionItem = ({
   return (
     <View style={[topContainer, styles.container]} accessible={true}>
       {!hasShmoBookingId(fareContract) && (
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(
             FareContractTexts.details.purchaseTime(
               fullDateTime(
@@ -45,7 +45,7 @@ export const OrderDetailsSectionItem = ({
         </ThemeText>
       )}
 
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {hasShmoBookingId(fareContract)
           ? t(
               FareContractTexts.shmoDetails.tripStarted(
@@ -59,7 +59,7 @@ export const OrderDetailsSectionItem = ({
             )}
       </ThemeText>
 
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {hasShmoBookingId(fareContract)
           ? t(
               FareContractTexts.shmoDetails.tripEnded(
@@ -74,20 +74,20 @@ export const OrderDetailsSectionItem = ({
       </ThemeText>
 
       {fareContract.state !== FareContractState.Refunded && priceString && (
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(FareContractTexts.details.totalPrice(priceString))}
         </ThemeText>
       )}
 
       {!!fareContract.paymentType.length &&
         fareContract.state !== FareContractState.Refunded && (
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {t(FareContractTexts.details.paymentMethod)}
             {fareContract.paymentType.map(humanizePaymentTypeString).join(', ')}
           </ThemeText>
         )}
       {hasShmoBookingId(fareContract) && (
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(FareContractTexts.details.bookingId(fareContract.bookingId ?? ''))}
         </ThemeText>
       )}

--- a/src/modules/fare-zones-selector/FareZoneResults.tsx
+++ b/src/modules/fare-zones-selector/FareZoneResults.tsx
@@ -28,7 +28,7 @@ export const FareZoneResults: React.FC<Props> = ({fareZones, onSelect}) => {
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(FareZoneSearchTexts.zones.heading)}
         </ThemeText>
       </View>

--- a/src/modules/global-messages/GlobalMessage.tsx
+++ b/src/modules/global-messages/GlobalMessage.tsx
@@ -8,7 +8,8 @@ import {getTextForLanguage} from '@atb/translations';
 import {useNow} from '@atb/utils/use-now';
 import {isWithinTimeRange} from '@atb/utils/is-within-time-range';
 import {RuleVariables} from '@atb/modules/rule-engine';
-import {ContrastColor, TextColor} from '@atb/theme/colors';
+import {ContrastColor} from '@atb/theme/colors';
+import {ColorValue} from 'react-native';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {useAuthContext} from '@atb/modules/auth';
 
@@ -17,7 +18,7 @@ type Props = {
   style?: StyleProp<ViewStyle>;
   includeDismissed?: boolean;
   ruleVariables?: RuleVariables;
-  textColor: ContrastColor | TextColor;
+  textColor?: ContrastColor | ColorValue;
 };
 
 const GlobalMessage = ({

--- a/src/modules/mobility/components/BenefitTiles.tsx
+++ b/src/modules/mobility/components/BenefitTiles.tsx
@@ -87,7 +87,7 @@ export const BenefitTile = ({
         </ThemeText>
         <ThemeText
           typography="body__xs"
-          color="secondary"
+          type="secondary"
           style={styles.description}
         >
           {description}

--- a/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
+++ b/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
@@ -79,7 +79,7 @@ export const BikeStationNotIntegratedView = ({
               style={styles.operatorNameAndLogo}
             />
             <View style={styles.stationText}>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {stationName}
               </ThemeText>
             </View>

--- a/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
@@ -118,7 +118,7 @@ export const CarSharingStationBottomSheet = ({
                     style={styles.operatorNameAndLogo}
                   />
                   <View style={styles.stationText}>
-                    <ThemeText typography="body__s" color="secondary">
+                    <ThemeText typography="body__s" type="secondary">
                       {stationName}
                     </ThemeText>
                     <WalkingDistance distance={distance} />

--- a/src/modules/mobility/components/MobilityBenefitsActionSectionItem.tsx
+++ b/src/modules/mobility/components/MobilityBenefitsActionSectionItem.tsx
@@ -26,7 +26,7 @@ export const MobilityBenefitsActionSectionItem = ({
 
   return (
     <View style={[topContainer, styles.benefitSection]}>
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {t(FareContractTexts.label.includedBenefits)}
       </ThemeText>
       <BenefitTiles

--- a/src/modules/mobility/components/MobilityBenefitsInfoSectionItem.tsx
+++ b/src/modules/mobility/components/MobilityBenefitsInfoSectionItem.tsx
@@ -44,7 +44,7 @@ export const MobilityBenefitsInfoSectionItem = ({
       accessible={true}
       accessibilityLabel={accessibilityLabel}
     >
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {t(MobilityTexts.includedWithTheTicket)}
       </ThemeText>
       <BorderedInfoBox

--- a/src/modules/mobility/components/MobilityStat.tsx
+++ b/src/modules/mobility/components/MobilityStat.tsx
@@ -34,7 +34,7 @@ export const StatWithIcon = ({svg, text}: StatWithIconProps) => {
   return (
     <View style={styles.statWithIcon}>
       {svg && <ThemeIcon svg={svg} color="secondary" style={styles.statIcon} />}
-      <ThemeText typography="body__s" color="secondary" isMarkdown={true}>
+      <ThemeText typography="body__s" type="secondary" isMarkdown={true}>
         {text}
       </ThemeText>
     </View>

--- a/src/modules/mobility/components/OperatorBenefit.tsx
+++ b/src/modules/mobility/components/OperatorBenefit.tsx
@@ -51,7 +51,7 @@ export const OperatorBenefit = ({benefit, formFactor, style}: Props) => {
               {heading && (
                 <ThemeText typography="body__m__strong">{heading}</ThemeText>
               )}
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {text}
               </ThemeText>
             </View>

--- a/src/modules/mobility/components/ParkAndRideBottomSheet.tsx
+++ b/src/modules/mobility/components/ParkAndRideBottomSheet.tsx
@@ -101,7 +101,7 @@ export const ParkAndRideBottomSheet = ({
         <Section>
           <GenericSectionItem>
             <View style={styles.parkingName}>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {heading}
               </ThemeText>
               <WalkingDistance distance={distance} />

--- a/src/modules/mobility/components/ShmoTripDetailsSectionItem.tsx
+++ b/src/modules/mobility/components/ShmoTripDetailsSectionItem.tsx
@@ -55,7 +55,7 @@ export const ShmoTripDetailsSectionItem = ({
         {withHeader && (
           <ThemeText
             typography="body__s"
-            color="secondary"
+            type="secondary"
             accessibilityRole="header"
           >
             {t(MobilityTexts.time)}
@@ -75,7 +75,7 @@ export const ShmoTripDetailsSectionItem = ({
         {withHeader && (
           <ThemeText
             typography="body__s"
-            color="secondary"
+            type="secondary"
             accessibilityRole="header"
           >
             {t(MobilityTexts.cost)}

--- a/src/modules/mobility/components/VehicleCardStat.tsx
+++ b/src/modules/mobility/components/VehicleCardStat.tsx
@@ -32,10 +32,10 @@ export const VehicleCardStat = ({
     >
       <ThemeIcon svg={icon} color="primary" size="large" />
       <View>
-        <ThemeText typography="body__m__strong" color="primary">
+        <ThemeText typography="body__m__strong" type="primary">
           {stat}
         </ThemeText>
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {description}
         </ThemeText>
       </View>

--- a/src/modules/payment/MultiplePaymentMethodsRadioSection.tsx
+++ b/src/modules/payment/MultiplePaymentMethodsRadioSection.tsx
@@ -108,7 +108,7 @@ export const MultiplePaymentMethodsRadioSection = ({
           <ThemeText>
             {t(SelectPaymentMethodTexts.multiple_payment.text)}
           </ThemeText>
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {t(SelectPaymentMethodTexts.multiple_payment.information)}
           </ThemeText>
           <View style={styles.saveButton}>

--- a/src/modules/payment/SelectPaymentMethodSheet.tsx
+++ b/src/modules/payment/SelectPaymentMethodSheet.tsx
@@ -115,7 +115,7 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
         <View>
           {recurringPaymentMethods && recurringPaymentMethods?.length > 0 && (
             <View style={styles.listHeading}>
-              <ThemeText color="secondary">
+              <ThemeText type="secondary">
                 {t(SelectPaymentMethodTexts.saved_cards.text)}
               </ThemeText>
             </View>
@@ -139,7 +139,7 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
         <View>
           {recurringPaymentMethods && recurringPaymentMethods?.length > 0 && (
             <View style={styles.listHeading}>
-              <ThemeText color="secondary">
+              <ThemeText type="secondary">
                 {t(SelectPaymentMethodTexts.other_cards.text)}
               </ThemeText>
             </View>

--- a/src/modules/situations/SituationBottomSheet.tsx
+++ b/src/modules/situations/SituationBottomSheet.tsx
@@ -93,7 +93,7 @@ export const SituationBottomSheet = ({
               />
               <ThemeText
                 typography="body__s"
-                color="secondary"
+                type="secondary"
                 style={styles.validityText}
               >
                 {validityPeriodText}
@@ -160,7 +160,7 @@ const InfoLink = ({infoLink}: {infoLink: InfoLinkFragment}) => {
       accessibilityRole="link"
       style={styles.infoLink}
     >
-      <ThemeText typography="body__m__underline" color="secondary">
+      <ThemeText typography="body__m__underline" type="secondary">
         {infoLink.label || t(dictionary.readMore)}
       </ThemeText>
     </NativeBlockButton>

--- a/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
+++ b/src/modules/smart-park-and-ride/onboarding/SmartParkAndRideOnboarding_ContactInfoScreen.tsx
@@ -95,7 +95,7 @@ const ContactInfoContent = () => {
                   SmartParkAndRideTexts.onboarding.contactInfo.parking.heading,
                 )}
               </ThemeText>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {t(
                   SmartParkAndRideTexts.onboarding.contactInfo.parking
                     .subheading,
@@ -133,7 +133,7 @@ const ContactInfoContent = () => {
                   SmartParkAndRideTexts.onboarding.contactInfo.project.heading,
                 )}
               </ThemeText>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {t(
                   SmartParkAndRideTexts.onboarding.contactInfo.project
                     .subheading,

--- a/src/modules/storybook/stories/Snackbar.stories.tsx
+++ b/src/modules/storybook/stories/Snackbar.stories.tsx
@@ -80,7 +80,7 @@ const SnackbarMeta: Meta<SnackbarMetaProps> = {
           }}
         />
         <ThemeText
-          color="secondary"
+          type="secondary"
           style={{
             width: '50%',
             textAlign: 'center',

--- a/src/screen-components/favorite-departures/components/FavoriteLineList.tsx
+++ b/src/screen-components/favorite-departures/components/FavoriteLineList.tsx
@@ -189,7 +189,7 @@ export function QuayLineSection({
             <View style={styles.stopPlaceHeaderText}>
               <ThemeText
                 typography="body__s__strong"
-                color="secondary"
+                type="secondary"
                 style={styles.rightMargin}
                 testID={testID + 'Name'}
               >
@@ -201,7 +201,7 @@ export function QuayLineSection({
                 <ThemeText
                   style={styles.rightMargin}
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   testID={testID + 'Description'}
                 >
                   {quay.description}
@@ -213,7 +213,7 @@ export function QuayLineSection({
         {sortedDepartures.length === 0 && !isLoading && !didLoadingDataFail && (
           <GenericSectionItem>
             <ThemeText
-              color="secondary"
+              type="secondary"
               typography="body__s"
               style={{textAlign: 'center', width: '100%'}}
             >
@@ -238,7 +238,7 @@ export function QuayLineSection({
         {didLoadingDataFail && !isLoading && (
           <GenericSectionItem>
             <View style={styles.messageBox}>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {t(DeparturesTexts.message.noData)}
               </ThemeText>
             </View>

--- a/src/screen-components/nearby-stop-places/components/StopPlaceItem.tsx
+++ b/src/screen-components/nearby-stop-places/components/StopPlaceItem.tsx
@@ -82,7 +82,7 @@ export const StopPlaceItem = ({
               {description}
             </ThemeText>
             {humanizedDistance && (
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {humanizedDistance}
               </ThemeText>
             )}

--- a/src/screen-components/place-screen/components/EstimatedCallList.tsx
+++ b/src/screen-components/place-screen/components/EstimatedCallList.tsx
@@ -150,7 +150,7 @@ export const EstimatedCallList = ({
                 radius={!shouldShowMoreItemsLink ? 'bottom' : undefined}
               >
                 <ThemeText
-                  color="secondary"
+                  type="secondary"
                   typography="body__s"
                   style={{textAlign: 'center', width: '100%'}}
                 >

--- a/src/screen-components/place-screen/components/MapStopPlacesListHeader.tsx
+++ b/src/screen-components/place-screen/components/MapStopPlacesListHeader.tsx
@@ -58,7 +58,7 @@ export function MapStopPlacesListHeader({
           />
         </View>
       </View>
-      <ThemeText typography="body__s" color="secondary" style={styles.title}>
+      <ThemeText typography="body__s" type="secondary" style={styles.title}>
         {t(DeparturesTexts.header.title)}
       </ThemeText>
     </>

--- a/src/screen-components/place-screen/components/QuaySection.tsx
+++ b/src/screen-components/place-screen/components/QuaySection.tsx
@@ -107,7 +107,7 @@ export function QuaySection({
             <View style={styles.stopPlaceHeaderText}>
               <ThemeText
                 typography="body__s__strong"
-                color="secondary"
+                type="secondary"
                 style={styles.rightMargin}
                 testID={testID + 'Name'}
               >
@@ -119,7 +119,7 @@ export function QuaySection({
                 <ThemeText
                   style={styles.rightMargin}
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   testID={testID + 'Description'}
                 >
                   {quay.description}
@@ -153,7 +153,7 @@ export function QuaySection({
         {!isMinimized && didLoadingDataFail && !isLoading && (
           <GenericSectionItem>
             <View style={styles.messageBox}>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {t(DeparturesTexts.message.noData)}
               </ThemeText>
             </View>

--- a/src/screen-components/travel-card/TravelCardHeader.tsx
+++ b/src/screen-components/travel-card/TravelCardHeader.tsx
@@ -93,7 +93,7 @@ export const TravelCardHeader: React.FC<
               : `${expectedStartTimeLabel} - ${expectedEndTimeLabel}`}
           </ThemeText>
           {(!areTimesEquivalentInMinutes || isInPast) && (
-            <ThemeText typography="body__s" color="secondary">
+            <ThemeText typography="body__s" type="secondary">
               {t(TravelCardTexts.header.originalTime)} {aimedStartTimeLabel} -{' '}
               {aimedEndTimeLabel}
             </ThemeText>
@@ -103,7 +103,7 @@ export const TravelCardHeader: React.FC<
         <View style={styles.durationContainer}>
           <ThemeText
             typography="body__m"
-            color="secondary"
+            type="secondary"
             testID="resultDuration"
           >
             {secondsToDurationShort(tripPattern.duration, language)}

--- a/src/screen-components/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
+++ b/src/screen-components/travel-details-map-screen/components/CompactTravelDetailsMap.tsx
@@ -98,7 +98,7 @@ export const CompactTravelDetailsMap: React.FC<MapProps> = ({
         onPress={onExpand}
         accessibilityRole="button"
       >
-        <ThemeText typography="body__s__strong" color="primary">
+        <ThemeText typography="body__s__strong" type="primary">
           {buttonText}
         </ThemeText>
         <ThemeIcon svg={ChevronRight} />

--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -393,7 +393,7 @@ export const DepartureDetailsScreenComponent = ({
           ) : !isWithinSameDate(new Date(), activeItem.date) ? (
             <>
               <View style={styles.date}>
-                <ThemeText typography="body__m" color="secondary">
+                <ThemeText typography="body__m" type="secondary">
                   {formatToVerboseFullDate(activeItem.date, language)}
                 </ThemeText>
               </View>
@@ -653,7 +653,7 @@ function EstimatedCallRow({
           <ThemeText
             testID="quayDescription"
             typography="body__s"
-            color="secondary"
+            type="secondary"
           >
             {call.quay.description}
           </ThemeText>
@@ -663,7 +663,7 @@ function EstimatedCallRow({
         {call.cancellation && !call.metadata.isStartOfServiceJourney && (
           <AccessibleText
             typography="body__s"
-            color="secondary"
+            type="secondary"
             style={styles.boardingInfo}
             pause="before"
           >
@@ -679,7 +679,7 @@ function EstimatedCallRow({
           !call.metadata.isStartOfServiceJourney && (
             <AccessibleText
               typography="body__s"
-              color="secondary"
+              type="secondary"
               style={styles.boardingInfo}
               pause="before"
             >
@@ -691,7 +691,7 @@ function EstimatedCallRow({
           !call.metadata.isEndOfServiceJourney && (
             <AccessibleText
               typography="body__s"
-              color="secondary"
+              type="secondary"
               style={styles.boardingInfo}
               pause="before"
             >
@@ -753,7 +753,7 @@ function CollapseButtonRow({
 }: CollapseButtonRowProps) {
   const styles = useCollapseButtonStyle();
   const text = (
-    <ThemeText color="secondary" style={styles.text}>
+    <ThemeText type="secondary" style={styles.text}>
       {label}
     </ThemeText>
   );

--- a/src/screen-components/travel-details-screens/components/EmpiricalDelay.tsx
+++ b/src/screen-components/travel-details-screens/components/EmpiricalDelay.tsx
@@ -17,12 +17,12 @@ export function EmpiricalDelay({call}: {call: EstimatedCallWithMetadata}) {
   return (
     <View>
       {!!p50 && (
-        <ThemeText typography="body__xs" color="secondary">
+        <ThemeText typography="body__xs" type="secondary">
           p50 = {formatDuration(p50)}
         </ThemeText>
       )}
       {!!p90 && (
-        <ThemeText typography="body__xs" color="secondary">
+        <ThemeText typography="body__xs" type="secondary">
           p90 = {formatDuration(p90)}
         </ThemeText>
       )}

--- a/src/screen-components/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
+++ b/src/screen-components/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
@@ -125,7 +125,7 @@ export const FlexibleTransportBookingDetailsSheet: React.FC<
             )}
           >
             <ThemeText
-              color="secondary"
+              type="secondary"
               style={style.linkText}
               typography="body__m__underline"
             >

--- a/src/screen-components/travel-details-screens/components/SummaryDetail.tsx
+++ b/src/screen-components/travel-details-screens/components/SummaryDetail.tsx
@@ -23,7 +23,7 @@ export const SummaryDetail = ({
     <View style={styles.summaryDetail}>
       <ThemeIcon color="secondary" style={styles.leftIcon} svg={icon} />
       <ThemeText
-        color="secondary"
+        type="secondary"
         accessible={true}
         style={styles.detailText}
         accessibilityLabel={accessibilityLabel}

--- a/src/screen-components/travel-details-screens/components/Time.tsx
+++ b/src/screen-components/travel-details-screens/components/Time.tsx
@@ -47,7 +47,7 @@ export const Time: React.FC<{
           </View>
           <AccessibleText
             typography="body__xs"
-            color="secondary"
+            type="secondary"
             prefix={t(dictionary.travel.time.aimedPrefix)}
             style={{textDecorationLine: 'line-through'}}
             testID="aimTime"

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -135,7 +135,7 @@ export const Trip: React.FC<TripProps> = ({
     <View style={styles.container}>
       {shouldShowDate && (
         <>
-          <ThemeText typography="body__s" color="secondary" style={styles.date}>
+          <ThemeText typography="body__s" type="secondary" style={styles.date}>
             {formatToVerboseFullDate(tripPattern.expectedStartTime, language)}
           </ThemeText>
           <Divider />

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -201,7 +201,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
               <ThemeText
                 testID={`${testID}FromPlaceQuayDescription`}
                 typography="body__s"
-                color="secondary"
+                type="secondary"
               >
                 {leg.fromPlace.quay?.description}
               </ThemeText>
@@ -239,7 +239,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
           >
             {leg.transportSubmode === TransportSubmode.NightBus && (
               <ThemeText
-                color="secondary"
+                type="secondary"
                 typography="body__s"
                 style={style.secondaryTransportLabel}
               >
@@ -251,7 +251,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
             </ThemeText>
             {isFlexible && (
               <ThemeText
-                color="secondary"
+                type="secondary"
                 typography="body__s"
                 style={style.onDemandTransportLabel}
               >
@@ -339,7 +339,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
               <ThemeText
                 style={style.realtimeText}
                 typography="body__s"
-                color="secondary"
+                type="secondary"
               >
                 {realtimeText}
               </ThemeText>
@@ -455,7 +455,7 @@ const IntermediateInfo = ({
         TripDetailsTexts.trip.leg.intermediateStops.a11yHint,
       )}
     >
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {t(
           TripDetailsTexts.trip.leg.intermediateStops.label(
             numberOfIntermediateCalls,
@@ -480,7 +480,7 @@ const WalkSection = (leg: Leg) => {
       }
       testID="footLeg"
     >
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {isWalkTimeOfSignificance
           ? t(
               TripDetailsTexts.trip.leg.walk.label(
@@ -505,7 +505,7 @@ const BikeSection = (leg: Leg) => {
       }
       testID="bikeLeg"
     >
-      <ThemeText typography="body__s" color="secondary">
+      <ThemeText typography="body__s" type="secondary">
         {t(
           TripDetailsTexts.trip.leg.bicycle.label(
             secondsToDuration(leg.duration ?? 0, language),
@@ -527,7 +527,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
     return (
       <TripRow>
         <View style={style.authoritySection}>
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {t(TripDetailsTexts.trip.leg.buyTicketFrom) + ' ' + name}
           </ThemeText>
         </View>
@@ -537,7 +537,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   return (
     <TripRow accessible={false}>
       <View style={style.authoritySection}>
-        <ThemeText typography="body__s" color="secondary" accessible={false}>
+        <ThemeText typography="body__s" type="secondary" accessible={false}>
           {t(TripDetailsTexts.trip.leg.buyTicketFrom)}
         </ThemeText>
         <Button

--- a/src/screen-components/travel-details-screens/components/WaitSection.tsx
+++ b/src/screen-components/travel-details-screens/components/WaitSection.tsx
@@ -44,7 +44,7 @@ export const WaitSection: React.FC<WaitDetails> = (wait) => {
           <ThemeIcon svg={Time} color={legColor.secondary.background} />
         }
       >
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
         </ThemeText>
       </TripRow>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -74,7 +74,7 @@ export const PreassignedFareContractSummary = ({
       <ThemeText
         style={styles.smallTopMargin}
         typography="body__s"
-        color="secondary"
+        type="secondary"
         testID="summaryText"
       >
         {text}
@@ -125,7 +125,7 @@ export const PreassignedFareContractSummary = ({
           {recipient && (
             <ThemeText
               typography="body__s"
-              color="secondary"
+              type="secondary"
               style={styles.sendingToText}
               testID="onBehalfOfText"
             >

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PriceSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PriceSummary.tsx
@@ -71,7 +71,7 @@ export const PriceSummary = ({
             <ThemeText typography="body__m">
               {t(PurchaseConfirmationTexts.totalCost.title)}
             </ThemeText>
-            <ThemeText typography="body__xs" color="secondary">
+            <ThemeText typography="body__xs" type="secondary">
               {t(
                 PurchaseConfirmationTexts.totalCost.label(
                   vatPercentString,
@@ -141,7 +141,7 @@ const PricePerTraveller = ({
     >
       <ThemeText
         style={styles.travellerCountAndName}
-        color="secondary"
+        type="secondary"
         typography="body__s"
         testID="travellerCountAndName"
       >
@@ -151,13 +151,13 @@ const PricePerTraveller = ({
         {hasFlexDiscount && (
           <ThemeText
             typography="body__xs"
-            color="secondary"
+            type="secondary"
             style={styles.travellerOriginalPriceAmount}
           >
             {originalPriceString} kr
           </ThemeText>
         )}
-        <ThemeText color="secondary" typography="body__s">
+        <ThemeText type="secondary" typography="body__s">
           {priceString} kr
         </ThemeText>
       </View>

--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/VenueResults.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/VenueResults.tsx
@@ -29,7 +29,7 @@ export const VenueResults: React.FC<Props> = ({
   return (
     <>
       <View accessibilityRole="header" style={styles.subHeader}>
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {t(FareZoneSearchTexts.results.heading)}
         </ThemeText>
       </View>

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/HarborResults.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/HarborResults.tsx
@@ -56,7 +56,7 @@ export const HarborResults: React.FC<Props> = ({
             message={t(HarborSearchTexts.messages.emptyResult)}
           />
         ) : (
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {getHeading(t, searchText, fromHarborName, currentLocation)}
           </ThemeText>
         )}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FlexTicketDiscountInfo.tsx
@@ -64,7 +64,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
         />
         {expanded && (
           <GenericSectionItem accessibility={{accessible: true}}>
-            <ThemeText typography="body__s" color="secondary">
+            <ThemeText typography="body__s" type="secondary">
               {description}
             </ThemeText>
           </GenericSectionItem>
@@ -99,7 +99,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                 key={u.id}
               >
                 <View style={styles.userProfileDiscountInfo}>
-                  <ThemeText typography="body__s" color="secondary">
+                  <ThemeText typography="body__s" type="secondary">
                     {t(
                       PurchaseOverviewTexts.flexDiscount.per(
                         userProfileName.toLowerCase(),
@@ -118,7 +118,7 @@ export const FlexTicketDiscountInfo = ({userProfiles, style}: Props) => {
                     <ThemeText
                       style={styles.priceInfo}
                       typography="body__xs"
-                      color="primary"
+                      type="primary"
                     >
                       {priceText}
                     </ThemeText>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -135,7 +135,7 @@ const HarborSelectionItem = forwardRef<
     >
       <View style={styles.sectionContent}>
         <ThemeText
-          color={disabled ? 'disabled' : 'secondary'}
+          type={disabled ? 'disabled' : 'secondary'}
           typography="body__s"
           style={styles.toFromLabel}
         >
@@ -159,10 +159,7 @@ const HarborLabel = ({
   return harborName ? (
     <ThemeText typography="body__m__strong">{harborName}</ThemeText>
   ) : (
-    <ThemeText
-      style={{flexShrink: 1}}
-      color={disabled ? 'disabled' : 'primary'}
-    >
+    <ThemeText style={{flexShrink: 1}} type={disabled ? 'disabled' : 'primary'}>
       {t(PurchaseOverviewTexts.stopPlaces.harborSelection.noneSelected.text)}
     </ThemeText>
   );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductDescriptionToggle.tsx
@@ -17,7 +17,7 @@ export function ProductDescriptionToggle({title}: {title: string}) {
   return (
     <View style={styles.container}>
       <View style={{flexShrink: 1}}>
-        <ThemeText typography="body__s" color="secondary">
+        <ThemeText typography="body__s" type="secondary">
           {title}
         </ThemeText>
       </View>

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -107,7 +107,7 @@ export function TravellerSelection({
           {travellersDetailsText}
         </ThemeText>
         {!canSelectUserProfile && (
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {travellerInfo}
           </ThemeText>
         )}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -77,7 +77,7 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
             <>
               <View style={styles.fromZone}>
                 <ThemeText
-                  color="secondary"
+                  type="secondary"
                   typography="body__s"
                   style={styles.toFromLabel}
                 >
@@ -87,7 +87,7 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
               </View>
               <View style={styles.toZone}>
                 <ThemeText
-                  color="secondary"
+                  type="secondary"
                   typography="body__s"
                   style={styles.toFromLabel}
                 >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -87,7 +87,7 @@ export const DeparturesWidget = ({
               <View style={styles.noFavouritesTextContainer}>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   style={styles.noFavouritesText}
                   testID="noFavoriteWidget"
                 >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -393,7 +393,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
           <ScreenReaderAnnouncement message={searchStateMessage} />
           {(!from || !to) && (
             <ThemeText
-              color="secondary"
+              type="secondary"
               style={styles.missingLocationText}
               testID="missingLocation"
             >
@@ -494,12 +494,12 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                           marginRight: theme.spacing.medium,
                         }}
                       />
-                      <ThemeText color="secondary" testID="searchingForResults">
+                      <ThemeText type="secondary" testID="searchingForResults">
                         {t(TripSearchTexts.results.fetchingMore)}
                       </ThemeText>
                     </>
                   ) : (
-                    <ThemeText color="secondary" testID="searchingForResults">
+                    <ThemeText type="secondary" testID="searchingForResults">
                       {t(TripSearchTexts.searchState.searching)}
                     </ThemeText>
                   )}
@@ -513,7 +513,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                         svg={ExpandMore}
                         size="normal"
                       />
-                      <ThemeText color="secondary" testID="resultsLoaded">
+                      <ThemeText type="secondary" testID="resultsLoaded">
                         {' '}
                         {t(TripSearchTexts.results.fetchMore)}
                       </ThemeText>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/ResultItem.tsx
@@ -108,7 +108,7 @@ const ResultItemHeader: React.FC<{
       <View style={styles.durationContainer}>
         <AccessibleText
           typography="body__s"
-          color="secondary"
+          type="secondary"
           testID="resultDuration"
           prefix={t(TripSearchTexts.results.resultItem.header.totalDuration)}
         >
@@ -252,7 +252,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                           typography={
                             isCancelled ? 'body__xs__strike' : 'body__xs'
                           }
-                          color="primary"
+                          type="primary"
                           testID={'schTime' + i}
                         >
                           {(isLineFlexibleTransport(leg.line)
@@ -269,7 +269,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
                         <ThemeText
                           style={styles.scheduledTime}
                           typography="body__xs__strike"
-                          color="secondary"
+                          type="secondary"
                           testID={'aimTime' + i}
                         >
                           {formatToClock(leg.aimedStartTime, language, 'floor')}
@@ -298,7 +298,7 @@ const ResultItem: React.FC<ResultItemProps & AccessibilityProps> = ({
           <View style={styles.departureTimes}>
             <ThemeText
               typography={isCancelled ? 'body__xs__strike' : 'body__xs'}
-              color="primary"
+              type="primary"
               testID="endTime"
             >
               {(lastLegIsFlexible ? t(dictionary.missingRealTimePrefix) : '') +

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusFaqSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusFaqSection.tsx
@@ -26,7 +26,7 @@ export const BonusFaqSection = () => {
               text={t(question)}
               showIconText={false}
               expandContent={
-                <ThemeText isMarkdown={false} color="secondary">
+                <ThemeText isMarkdown={false} type="secondary">
                   {t(answer(faqContext))}
                 </ThemeText>
               }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusHowPointsWork.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusHowPointsWork.tsx
@@ -143,7 +143,7 @@ const BonusInfoSectionItem = ({
       <View style={styles.horizontalContainer}>
         <View style={styles.bonusProgramDescription}>
           <ThemeText typography="body__m__strong">{title}</ThemeText>
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {description}
           </ThemeText>
         </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -127,13 +127,13 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
             </View>
             <Section>
               <GenericSectionItem style={{gap: theme.spacing.large}}>
-                <ThemeText typography="heading__xl" color="primary">
+                <ThemeText typography="heading__xl" type="primary">
                   {t(BonusProgramTexts.bonusProfile.joinProgram.title)}
                 </ThemeText>
-                <ThemeText typography="body__m" color="primary">
+                <ThemeText typography="body__m" type="primary">
                   {t(BonusProgramTexts.bonusProfile.joinProgram.description)}
                 </ThemeText>
-                <ThemeText typography="body__m" color="primary">
+                <ThemeText typography="body__m" type="primary">
                   {t(
                     BonusProgramTexts.bonusProfile.joinProgram.footer(
                       endDateString,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -685,7 +685,7 @@ function MapValue({value}: {value: any}) {
               <MapEntry key={key} title={key} value={value} />
             ))
           ) : (
-            <ThemeText color="secondary">Empty object</ThemeText>
+            <ThemeText type="secondary">Empty object</ThemeText>
           )}
         </View>
       );
@@ -713,7 +713,7 @@ function MapEntry({title, value}: {title: string; value: any}) {
           style={{flexDirection: 'row'}}
           onPress={() => setIsExpanded(!isExpanded)}
         >
-          <ThemeText typography="heading__m" color="secondary">
+          <ThemeText typography="heading__m" type="secondary">
             {title}
           </ThemeText>
           <ThemeIcon svg={isExpanded ? ExpandLess : ExpandMore} />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EditProfileScreen.tsx
@@ -149,7 +149,7 @@ export const Profile_EditProfileScreen = ({
       ) : (
         <>
           <View style={styles.personalDetails}>
-            <ThemeText accessibilityRole="header" color="secondary">
+            <ThemeText accessibilityRole="header" type="secondary">
               {t(EditProfileTexts.personalDetails.header)}
             </ThemeText>
             {(isLoadingGetProfile || isRefetchingProfile) && (
@@ -202,7 +202,7 @@ export const Profile_EditProfileScreen = ({
                   <ThemeText>
                     {t(EditProfileTexts.personalDetails.email.label)}
                   </ThemeText>
-                  <ThemeText typography="body__s" color="secondary">
+                  <ThemeText typography="body__s" type="secondary">
                     {t(
                       EditProfileTexts.personalDetails.email
                         .disabledWithRemoteConfig,
@@ -236,7 +236,7 @@ export const Profile_EditProfileScreen = ({
                   <ThemeText typography="body__s">
                     {t(EditProfileTexts.personalDetails.phone.header)}
                   </ThemeText>
-                  <ThemeText typography="body__s" color="secondary">
+                  <ThemeText typography="body__s" type="secondary">
                     {t(
                       EditProfileTexts.personalDetails.phone.loggedIn(
                         phoneNumber,
@@ -258,7 +258,7 @@ export const Profile_EditProfileScreen = ({
                       year: 'numeric',
                     }).format(new Date(birthdateRes.birthdate))}
                   </ThemeText>
-                  <ThemeText typography="body__s" color="secondary">
+                  <ThemeText typography="body__s" type="secondary">
                     {t(EditProfileTexts.personalDetails.birthdate.info)}
                   </ThemeText>
 
@@ -306,7 +306,7 @@ export const Profile_EditProfileScreen = ({
             </>
           )}
           <View style={styles.profileContainer}>
-            <ThemeText color="secondary" style={styles.profileItem}>
+            <ThemeText type="secondary" style={styles.profileItem}>
               {t(EditProfileTexts.profileInfo.profile)}
             </ThemeText>
             <ThemeText>
@@ -315,7 +315,7 @@ export const Profile_EditProfileScreen = ({
             {phoneNumber && (
               <ThemeText
                 typography="body__s"
-                color="secondary"
+                type="secondary"
                 style={styles.profileItem}
               >
                 {t(EditProfileTexts.profileInfo.otp(phoneNumber))}
@@ -328,7 +328,7 @@ export const Profile_EditProfileScreen = ({
                 </ThemeText>
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   accessibilityLabel={numberToAccessibilityString(
                     customerNumber,
                   )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EnrollmentScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EnrollmentScreen.tsx
@@ -81,7 +81,7 @@ export const Profile_EnrollmentScreen = ({navigation}: Props) => {
                   }}
                 />
                 <View style={styles.headerTextContainer}>
-                  <ThemeText typography="body__s" color="secondary">
+                  <ThemeText typography="body__s" type="secondary">
                     {t(EnrollmentTexts.info)}
                   </ThemeText>
                 </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_RootScreen.tsx
@@ -353,7 +353,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
             />
           )}
           <View style={style.debugInfoContainer}>
-            <ThemeText typography="body__s" color="secondary">
+            <ThemeText typography="body__s" type="secondary">
               v{version} ({buildNumber}){' '}
               {isEventStreamEnabled && isEventStreamFareContractsEnabled && 'S'}
             </ThemeText>
@@ -364,7 +364,7 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                     <ScreenReaderAnnouncement
                       message={t(ProfileTexts.installId.wasCopiedAlert)}
                     />
-                    <ThemeText typography="body__s" color="secondary">
+                    <ThemeText typography="body__s" type="secondary">
                       ✅ {t(ProfileTexts.installId.wasCopiedAlert)}
                     </ThemeText>
                   </>
@@ -375,14 +375,14 @@ export const Profile_RootScreen = ({navigation}: ProfileProps) => {
                 )}
                 accessibilityHint={t(ProfileTexts.installId.a11yHint)}
               >
-                <ThemeText typography="body__s" color="secondary">
+                <ThemeText typography="body__s" type="secondary">
                   {t(ProfileTexts.installId.label(config.installId))}
                 </ThemeText>
               </ClickableCopy>
             )}
             <ThemeText
               typography="body__s"
-              color="secondary"
+              type="secondary"
               accessibilityLabel={t(
                 ProfileTexts.orgNumberA11yLabel(APP_ORG_NUMBER),
               )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SmartParkAndRideScreen.tsx
@@ -221,7 +221,7 @@ const HowItWorksSection = ({onPress}: HowItWorksSectionProps) => {
               <ThemeText typography="body__m__strong">
                 {t(SmartParkAndRideTexts.howItWorks.title)}
               </ThemeText>
-              <ThemeText typography="body__s" color="secondary">
+              <ThemeText typography="body__s" type="secondary">
                 {t(SmartParkAndRideTexts.howItWorks.description)}
               </ThemeText>
             </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/components/UserInfo.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/components/UserInfo.tsx
@@ -106,7 +106,7 @@ const LoggedInInfoSectionItem = forwardRef<any, LoggedInInfoSectionItemProps>(
               {formattedPhoneNumber && (
                 <ThemeText
                   typography="body__s"
-                  color="secondary"
+                  type="secondary"
                   testID="loggedInWith"
                 >
                   {t(
@@ -117,7 +117,7 @@ const LoggedInInfoSectionItem = forwardRef<any, LoggedInInfoSectionItemProps>(
                 </ThemeText>
               )}
               {customerNumber !== undefined && (
-                <ThemeText typography="body__s" color="secondary">
+                <ThemeText typography="body__s" type="secondary">
                   {t(
                     ProfileTexts.sections.account.infoItems.customerNumber(
                       customerNumber,
@@ -147,7 +147,7 @@ const LoggedOutInfoSectionItem = ({...props}) => {
           {t(ProfileTexts.sections.account.infoItems.notLoggedInHeading)}
         </ThemeText>
         {customerNumber !== undefined && (
-          <ThemeText typography="body__s" color="secondary">
+          <ThemeText typography="body__s" type="secondary">
             {t(
               ProfileTexts.sections.account.infoItems.customerNumber(
                 customerNumber,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/TicketingTile.tsx
@@ -66,7 +66,7 @@ export const TicketingTile = ({
           <ThemeText
             typography="body__xs"
             style={styles.description}
-            color="secondary"
+            type="secondary"
           >
             {description}
           </ThemeText>

--- a/src/stacks-hierarchy/Root_TicketInformationScreen/tips-and-information/TipsAndInformation.tsx
+++ b/src/stacks-hierarchy/Root_TicketInformationScreen/tips-and-information/TipsAndInformation.tsx
@@ -48,7 +48,7 @@ export const TipsAndInformation = () => {
             expandContent={
               <ThemeText
                 typography="body__s"
-                color="secondary"
+                type="secondary"
                 isMarkdown={true}
               >
                 {description}

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -177,21 +177,14 @@ export function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
 }
 
 function EmptyState() {
-  const {theme} = useThemeContext();
   const {t} = useTranslation();
   return (
     <View style={{justifyContent: 'center', alignItems: 'center'}}>
       <ThemedOnBehalfOf />
-      <ThemeText
-        typography="body__m__strong"
-        color={theme.color.foreground.dynamic.secondary}
-      >
+      <ThemeText typography="body__m__strong" type="secondary">
         {t(TicketingTexts.booking.cannotFindDepartures)}
       </ThemeText>
-      <ThemeText
-        typography="body__s"
-        color={theme.color.foreground.dynamic.secondary}
-      >
+      <ThemeText typography="body__s" type="secondary">
         {t(TicketingTexts.booking.adjustTime)}
       </ThemeText>
     </View>

--- a/src/theme/__tests__/resolve-color-value.test.ts
+++ b/src/theme/__tests__/resolve-color-value.test.ts
@@ -102,8 +102,13 @@ describe('resolveColorValue', () => {
   });
 
   describe('undefined', () => {
-    it('should fall back to foreground.dynamic.primary', () => {
+    it('should fall back to foreground.dynamic.primary when type is primary', () => {
       expect(resolveColorValue(undefined, 'primary', theme)).toBe('#000000');
+    });
+
+    it('should use type as fallback when color is undefined', () => {
+      expect(resolveColorValue(undefined, 'secondary', theme)).toBe('#415058');
+      expect(resolveColorValue(undefined, 'disabled', theme)).toBe('#73848c');
     });
   });
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,5 +1,4 @@
-import {Platform, StatusBarProps} from 'react-native';
-import type {ColorValue} from 'react-native';
+import {type ColorValue, Platform, StatusBarProps} from 'react-native';
 import {APP_ORG} from '@env';
 
 import {
@@ -97,8 +96,13 @@ export function resolveColorValue(
   } else if (isStatusColor(color, theme)) {
     return theme.color.status[color].primary.background;
   } else if (isTextColor(color, theme) || color === undefined) {
-    return theme.color.foreground.dynamic[color ?? 'primary'];
+    return theme.color.foreground.dynamic[color ?? type];
   } else {
+    if (typeof color === 'string' && !color.startsWith('#')) {
+      console.warn(
+        `[resolveColorValue] Expected hex color, got: "${String(color)}"`,
+      );
+    }
     return color as string;
   }
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -85,10 +85,11 @@ export const isTextColor = (color: unknown, theme: Theme): color is TextColor =>
 
 export type Themes = typeof themes;
 export type Theme = Themes['light'];
+export type ForegroundType = keyof ContrastColor['foreground'];
 
 export function resolveColorValue(
   color: ContrastColor | StatusColorName | TextColor | ColorValue | undefined,
-  type: keyof ContrastColor['foreground'],
+  type: ForegroundType,
   theme: Theme,
 ): string {
   if (typeof color === 'object') {


### PR DESCRIPTION
## Summary

`ThemeText` has two separate color-related props: `color` (which `ContrastColor` to derive a foreground from) and `type` (which what "mode" the text should be in (`primary`, `secondary`, `disabled`)). Many call sites were confusing these by passing `"primary"` or `"secondary"` to `color`, which is wrong and unnecessary when we already have the type prop to do the exact same thing. This PR cleans that up.

**Core changes:**
- Added `resolveColorValue()` to `src/theme/colors.ts` — a tested, pure helper that resolves any color input (`ContrastColor`, status name, text-color name, or raw hex) to a final `string`. Centralises logic that was previously duplicated in both ThemeText and ThemeIcon.
- Added unit tests in `src/theme/__tests__/resolve-color-value.test.ts` covering all branches.
- Narrowed the public `ThemeText` `color` prop type to `ContrastColor | ColorValue` — string semantic aliases (`"primary"`, `"info"`, etc.) are no longer part of the documented API. 
- Removed the unused `color` prop from `ScreenHeading` (no caller ever supplied a non-default value).

**Call-site migrations (~70 files, no visual change):**
- `color="primary"` / `color="secondary"` / `color="disabled"` → `type="primary"` etc.
- `color={theme.color.foreground.dynamic.primary}` → `type="primary"` (removes manual theme lookup for a value `ThemeText` already derives internally)

## Test input
- This has changed colors in a lot of files, but the main thing to check is that no colors are wrong or different in text or icons. In my testing I could not find anything wrong
