### PR TITLE
feat: add newTravelCardInTripSearch feature toggle

### DIFF
--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -82,6 +82,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_new_travel_card_booking',
   },
   {
+    name: 'isNewTravelCardInTripSearchEnabled',
+    remoteConfigKey: 'enable_new_travel_card_in_trip_search',
+  },
+  {
     name: 'isNynorskEnabled',
     remoteConfigKey: 'enable_nynorsk',
   },

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -42,6 +42,7 @@ export type RemoteConfig = {
   enable_new_token_barcode: boolean;
   enable_new_token_barcode_base64: boolean;
   enable_new_travel_card_booking: boolean;
+  enable_new_travel_card_in_trip_search: boolean;
   enable_on_behalf_of: boolean;
   enable_onboarding_login: boolean;
   enable_only_stop_places_checkbox: boolean;
@@ -120,6 +121,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_new_token_barcode: false,
   enable_new_token_barcode_base64: false,
   enable_new_travel_card_booking: false,
+  enable_new_travel_card_in_trip_search: false,
   enable_nynorsk: true,
   enable_on_behalf_of: false,
   enable_onboarding_login: true,
@@ -252,6 +254,9 @@ export function getConfig(): RemoteConfig {
   const enable_new_travel_card_booking =
     values['enable_new_travel_card_booking']?.asBoolean() ??
     defaultRemoteConfig.enable_new_travel_card_booking;
+  const enable_new_travel_card_in_trip_search =
+    values['enable_new_travel_card_in_trip_search']?.asBoolean() ??
+    defaultRemoteConfig.enable_new_travel_card_in_trip_search;
   const enable_nynorsk =
     values['enable_nynorsk']?.asBoolean() ?? defaultRemoteConfig.enable_nynorsk;
   const enable_on_behalf_of =
@@ -413,6 +418,7 @@ export function getConfig(): RemoteConfig {
     enable_new_token_barcode,
     enable_new_token_barcode_base64,
     enable_new_travel_card_booking,
+    enable_new_travel_card_in_trip_search,
     enable_nynorsk,
     enable_on_behalf_of,
     enable_onboarding_login,


### PR DESCRIPTION
Adds `enable_new_travel_card_in_trip_search` Remote Config key and the corresponding `isNewTravelCardInTripSearchEnabled` feature toggle. Defaults to `false`.