### PR TITLE
fix: hide live map button when screen reader is active

### DIFF
--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -196,7 +196,7 @@ export const Trip: React.FC<TripProps> = ({
                 leg={leg}
                 testID={'leg' + index}
                 onPressShowLive={
-                  legVehiclePosition
+                  !isScreenReaderEnabled && legVehiclePosition
                     ? (serviceJourneyPolylines: ServiceJourneyPolylines) => {
                         shouldShowRequestReview.current = true;
                         onPressDetailsMap({

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -218,7 +218,7 @@ export const Trip: React.FC<TripProps> = ({
           })}
       </View>
       <Divider />
-      {tripPatternLegs && (
+      {!isScreenReaderEnabled && tripPatternLegs && (
         <CompactTravelDetailsMap
           serviceJourneyPolylines={tripPatternLegs}
           fromPlace={tripPatternLegs[0]?.fromPlace}


### PR DESCRIPTION
Gate onPressShowLive behind !isScreenReaderEnabled so users
with screen readers are not directed to a map-based live view
they cannot interact with.
