### PR TITLE
refactor: remove anyFiltersApplied logic from trip search

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -471,9 +471,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 tripsIsError={tripsIsError}
                 tripsIsNetworkError={tripsIsNetworkError}
                 searchTime={searchTime}
-                anyFiltersApplied={
-                  filtersState.enabled && filtersState.anyFiltersApplied
-                }
               />
             </View>
           )}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -36,7 +36,6 @@ type Props = {
   tripsIsError: boolean;
   tripsIsNetworkError: boolean;
   searchTime: TripSearchTime;
-  anyFiltersApplied: boolean;
 };
 
 export const Results: React.FC<Props> = ({
@@ -48,7 +47,6 @@ export const Results: React.FC<Props> = ({
   tripsIsError,
   tripsIsNetworkError,
   searchTime,
-  anyFiltersApplied,
 }) => {
   const styles = useThemeStyles();
   const {t} = useTranslation();
@@ -82,11 +80,7 @@ export const Results: React.FC<Props> = ({
       <View style={styles.emptyStateContainer}>
         <EmptyState
           title={t(TripSearchTexts.results.info.emptySearchResultsTitle)}
-          details={getDetailsTextForEmptyResult(
-            resultReasons,
-            anyFiltersApplied,
-            t,
-          )}
+          details={getDetailsTextForEmptyResult(resultReasons, t)}
           illustrationComponent={<ThemedOnBehalfOf height={113} width={113} />}
           testID="searchResults"
         />
@@ -137,14 +131,11 @@ export const Results: React.FC<Props> = ({
 
 const getDetailsTextForEmptyResult = (
   resultReasons: string[],
-  anyFiltersApplied: boolean,
   t: TranslateFunction,
 ) => {
   let text = '';
   if (!resultReasons?.length) {
-    text += anyFiltersApplied
-      ? t(TripSearchTexts.results.info.emptySearchResultsDetailsWithFilters)
-      : t(TripSearchTexts.results.info.emptySearchResultsDetails);
+    text += t(TripSearchTexts.results.info.emptySearchResultsDetails);
   } else if (resultReasons.length === 1) {
     text += resultReasons[0];
   } else {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-travel-search-filters-state.tsx
@@ -11,7 +11,6 @@ type TravelSearchFiltersState =
       setFiltersSelection: React.Dispatch<
         React.SetStateAction<TravelSearchFiltersSelectionType>
       >;
-      anyFiltersApplied: boolean;
       resetTransportModes: () => void;
     }
   | {
@@ -66,9 +65,6 @@ export const useTravelSearchFiltersState = (): TravelSearchFiltersState => {
     enabled: true,
     filtersSelection,
     setFiltersSelection,
-    anyFiltersApplied: !!filtersSelection.transportModes?.some(
-      (m) => !m.selected,
-    ),
     resetTransportModes: () => {
       const filtersWithInitialTransportModes = {
         ...filtersSelection,

--- a/src/translations/screens/TripSearch.ts
+++ b/src/translations/screens/TripSearch.ts
@@ -166,11 +166,6 @@ const TripSearchTexts = {
         'Ingen kollektivreiser passar til søket ditt',
       ),
       emptySearchResultsDetails: _(
-        'Prøv å justere på sted eller tidspunkt.',
-        'Try adjusting your time or location input.',
-        'Prøv å justere på stad eller tidspunkt.',
-      ),
-      emptySearchResultsDetailsWithFilters: _(
         'Prøv å justere på sted, filter eller tidspunkt.',
         'Try adjusting your time, filters or location input.',
         'Prøv å justere på stad, filter eller tidspunkt.',


### PR DESCRIPTION
After removing the selected filters chip, anyFiltersApplied was
only used to vary the empty search results detail text. Remove
the flag and consolidate to a single message.
