### PR TITLE
fix: Add hitslop for the close header button in mapBottomSheet

### DIFF
--- a/src/components/bottom-sheet/BottomSheetHeader.tsx
+++ b/src/components/bottom-sheet/BottomSheetHeader.tsx
@@ -10,6 +10,7 @@ import {
   BottomSheetHeaderType,
   useBottomSheetHeaderType,
 } from './use-bottom-sheet-header-type';
+import {insets} from '@atb/utils/insets';
 
 type BottomSheetHeaderProps = {
   heading?: string;
@@ -71,6 +72,7 @@ export const BottomSheetHeader = ({
                 testID="closeBottomSheet"
                 accessibilityRole="button"
                 onPress={() => bottomSheetRef.current?.close()}
+                hitSlop={insets.all(theme.spacing.small)}
               >
                 {headerData?.text && (
                   <ThemeText typography="body__s__strong">


### PR DESCRIPTION
This makes it easier to close the map bottom sheets and bottom sheet modals.