### PR TITLE
fix: Prevent undefined values to propagate

### DIFF
--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -53,7 +53,7 @@ export function findAllNotices(tp: TripPatternFragment): NoticeFragment[] {
  */
 export function findAllSituationsFromLeg(leg: Leg): SituationFragment[] {
   return [
-    leg.situations,
+    leg.situations ?? [],
     leg.fromEstimatedCall?.situations ?? [],
     leg.toEstimatedCall?.situations ?? [],
   ]


### PR DESCRIPTION
## Description
Small fix of a bug. This is just a fallback, but is properly fixed in the BFF here: https://github.com/AtB-AS/atb-bff/pull/452