### PR TITLE
feat: show tariff zones in the regular map view

### DIFF
--- a/src/modules/fare-zones-selector/FareZonesSelectorMap.tsx
+++ b/src/modules/fare-zones-selector/FareZonesSelectorMap.tsx
@@ -2,7 +2,7 @@ import {FareZoneResultType, type FareZoneWithMetadata} from './types';
 import {FareZoneResults} from './FareZoneResults';
 import {View} from 'react-native';
 import {Button} from '@atb/components/button';
-import {Language, FareZonesTexts, useTranslation} from '@atb/translations';
+import {FareZonesTexts, useTranslation} from '@atb/translations';
 import MapboxGL, {UserLocationRenderMode} from '@rnmapbox/maps';
 
 import {
@@ -12,15 +12,14 @@ import {
   NationalStopRegistryFeatures,
   LocationArrow,
   useMapViewConfig,
+  TariffZoneLinesAndLabels,
+  mapZonesToPolygonCollection,
 } from '@atb/modules/map';
 import hexToRgba from 'hex-to-rgba';
 import React, {useRef} from 'react';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {useGeolocationContext} from '@atb/modules/geolocation';
 import {useAccessibilityContext} from '@atb/modules/accessibility';
-import {getReferenceDataName, FareZone} from '@atb/modules/configuration';
-import {FeatureCollection, Polygon} from 'geojson';
-import turfCentroid from '@turf/centroid';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {OnPressEvent} from 'node_modules/@rnmapbox/maps/src/types/OnPressEvent';
 import {useInitialCoordinates} from '@atb/utils/use-initial-coordinates';
@@ -29,7 +28,6 @@ import {
   usePurchaseSelectionBuilder,
   useSelectableFareZones,
 } from '@atb/modules/purchase-selection';
-import {decodePolylineEncodedGeometry} from '@atb/utils/decode-polyline-geometry';
 import {Loading} from '@atb/components/loading';
 
 type Props = {
@@ -68,7 +66,7 @@ const FareZonesSelectorMap = ({
     updateSelectedZones(feature.id as string);
   };
 
-  const featureCollection = mapZonesToFeatureCollection(fareZones, language);
+  const featureCollection = mapZonesToPolygonCollection(fareZones, language);
 
   const {bottom: safeAreaBottom} = useSafeAreaInsets();
 
@@ -141,7 +139,7 @@ const FareZonesSelectorMap = ({
             />
 
             <MapboxGL.ShapeSource
-              id="tariffZonesShape"
+              id="tariffZonesFillShape"
               shape={featureCollection}
               hitbox={hitboxCoveringIconOnly} // to not be able to hit multiple zones with one click
               onPress={selectFeature}
@@ -164,33 +162,11 @@ const FareZonesSelectorMap = ({
                   fillEmissiveStrength: 1,
                 }}
               />
-              <MapboxGL.LineLayer
-                id="tariffZonesLine"
-                style={{
-                  lineWidth: 1,
-                  lineColor: '#666666',
-                  lineEmissiveStrength: 1,
-                }}
-              />
             </MapboxGL.ShapeSource>
-            {featureCollection.features.map((f) => (
-              <MapboxGL.ShapeSource
-                key={String(f.id)}
-                id={`label-shape-${f.id}`}
-                shape={f.properties!.midPoint}
-              >
-                <MapboxGL.SymbolLayer
-                  id={`label-symbol-${f.id}`}
-                  style={{
-                    textSize: 20,
-                    textField: f.properties!.name,
-                    textHaloColor: 'white',
-                    textHaloWidth: 2,
-                    iconEmissiveStrength: 1,
-                  }}
-                />
-              </MapboxGL.ShapeSource>
-            ))}
+            <TariffZoneLinesAndLabels
+              polygonCollection={featureCollection}
+              showLabelsAtAllZoom
+            />
             <MapboxGL.Camera
               ref={mapCameraRef}
               zoomLevel={6}
@@ -238,26 +214,6 @@ const FareZonesSelectorMap = ({
     </>
   );
 };
-const mapZonesToFeatureCollection = (
-  zones: FareZone[],
-  language: Language,
-): FeatureCollection<Polygon> => ({
-  type: 'FeatureCollection',
-  features: zones.map((t) => {
-    const geometry = decodePolylineEncodedGeometry(t.geometry);
-    return {
-      type: 'Feature',
-      id: t.id,
-      properties: {
-        name: getReferenceDataName(t, language),
-        midPoint: turfCentroid(geometry, {
-          properties: {name: getReferenceDataName(t, language)},
-        }),
-      },
-      geometry: geometry,
-    };
-  }),
-});
 
 export {FareZonesSelectorMap};
 

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -125,7 +125,7 @@ export const Map = (props: MapProps) => {
     (mapFilter?.mobility.BICYCLE?.showAll ||
       mapFilter?.mobility.CAR?.showAll) ??
     false;
-  const showZones = mapFilter?.showZones ?? true;
+  const showTariffZones = mapFilter?.showTariffZones ?? true;
   const shouldShowVehiclesAndStations =
     isFocused && (showVehicles || showStations); // don't send tile requests while in the background, and always get fresh data upon enter
 
@@ -485,7 +485,7 @@ export const Map = (props: MapProps) => {
               />
             ))}
 
-          {showZones && (
+          {showTariffZones && (
             <TariffZoneLinesAndLabels polygonCollection={fareZonePolygons} />
           )}
 

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -71,6 +71,10 @@ import {MapBottomSheets} from './MapBottomSheets';
 import {MapButtons} from './components/MapButtons';
 import {GeofencingZoneCode} from '@atb-as/theme';
 import {ShmoTesting} from './components/mobility/ShmoTesting';
+import {TariffZoneLinesAndLabels} from './components/TariffZoneLinesAndLabels';
+import {mapZonesToPolygonCollection} from './zone-utils';
+import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {useTranslation} from '@atb/translations';
 import {usePreferencesContext} from '../preferences';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {GeofencingZonesAsTiles} from './components/mobility/GeofencingZonesAsTiles';
@@ -96,6 +100,10 @@ export const Map = (props: MapProps) => {
     preferences: {showShmoTesting},
   } = usePreferencesContext();
 
+  const {fareZones} = useFirestoreConfigurationContext();
+  const {language} = useTranslation();
+  const fareZonePolygons = mapZonesToPolygonCollection(fareZones, language);
+
   const {getCurrentCoordinates} = useGeolocationContext();
   const mapCameraRef = useRef<Camera>(null);
   const mapViewRef = useRef<MapView>(null);
@@ -117,6 +125,7 @@ export const Map = (props: MapProps) => {
     (mapFilter?.mobility.BICYCLE?.showAll ||
       mapFilter?.mobility.CAR?.showAll) ??
     false;
+  const showZones = mapFilter?.showZones ?? true;
   const shouldShowVehiclesAndStations =
     isFocused && (showVehicles || showStations); // don't send tile requests while in the background, and always get fresh data upon enter
 
@@ -475,6 +484,10 @@ export const Map = (props: MapProps) => {
                 vehicleTypeId={vehicleTypeId}
               />
             ))}
+
+          {showZones && (
+            <TariffZoneLinesAndLabels polygonCollection={fareZonePolygons} />
+          )}
 
           <NationalStopRegistryFeatures
             selectedFeaturePropertyId={activeFeatureId}

--- a/src/modules/map/components/TariffZoneLinesAndLabels.tsx
+++ b/src/modules/map/components/TariffZoneLinesAndLabels.tsx
@@ -1,0 +1,75 @@
+import MapboxGL from '@rnmapbox/maps';
+import {Expression} from 'node_modules/@rnmapbox/maps/src/utils/MapboxStyles';
+import turfCentroid from '@turf/centroid';
+import {FeatureCollection, Point, Polygon} from 'geojson';
+import React from 'react';
+import {useThemeContext} from '@atb/theme';
+
+const labelZoomOpacity: Expression = [
+  'interpolate',
+  ['linear'],
+  ['zoom'],
+  10,
+  1,
+  10.5,
+  0,
+];
+
+type TariffZonesProps = {
+  polygonCollection: FeatureCollection<Polygon>;
+  showLabelsAtAllZoom?: boolean;
+};
+
+export const TariffZoneLinesAndLabels = ({
+  polygonCollection,
+  showLabelsAtAllZoom,
+}: TariffZonesProps) => {
+  const {theme} = useThemeContext();
+
+  const labelPointsCollection =
+    mapPolygonsToLabelPointsCollection(polygonCollection);
+
+  return (
+    <>
+      <MapboxGL.ShapeSource id="tariffZonesShape" shape={polygonCollection}>
+        <MapboxGL.LineLayer
+          id="tariffZonesLine"
+          style={{
+            lineWidth: 2,
+            lineColor: theme.color.foreground.dynamic.secondary,
+            lineEmissiveStrength: 1,
+          }}
+        />
+      </MapboxGL.ShapeSource>
+
+      <MapboxGL.ShapeSource id="tariffZoneLabels" shape={labelPointsCollection}>
+        <MapboxGL.SymbolLayer
+          id="tariffZoneLabelText"
+          style={{
+            textField: ['get', 'name'],
+            textSize: 20,
+            textHaloColor: 'white',
+            textHaloWidth: 2,
+            iconEmissiveStrength: 1,
+            textOpacity: showLabelsAtAllZoom ? 1 : labelZoomOpacity,
+          }}
+        />
+      </MapboxGL.ShapeSource>
+    </>
+  );
+};
+
+const mapPolygonsToLabelPointsCollection = (
+  polygonCollection: FeatureCollection<Polygon>,
+): FeatureCollection<Point> => ({
+  type: 'FeatureCollection',
+  features: polygonCollection.features.map((f) => {
+    const centroid = turfCentroid(f.geometry);
+    return {
+      type: 'Feature',
+      id: f.id,
+      properties: {name: f.properties?.name},
+      geometry: centroid.geometry,
+    };
+  }),
+});

--- a/src/modules/map/hooks/use-map-filter.tsx
+++ b/src/modules/map/hooks/use-map-filter.tsx
@@ -7,6 +7,7 @@ const MAP_FILTER_STORAGE_KEY = '@ATB_user_map_filters_v2';
 
 const fallback: MapFilterType = {
   mobility: {},
+  showZones: true,
 };
 
 /**

--- a/src/modules/map/hooks/use-map-filter.tsx
+++ b/src/modules/map/hooks/use-map-filter.tsx
@@ -7,7 +7,7 @@ const MAP_FILTER_STORAGE_KEY = '@ATB_user_map_filters_v2';
 
 const fallback: MapFilterType = {
   mobility: {},
-  showZones: true,
+  showTariffZones: true,
 };
 
 /**

--- a/src/modules/map/index.ts
+++ b/src/modules/map/index.ts
@@ -65,3 +65,5 @@ export {
 export {MapStateActionType} from './mapStateReducer.ts';
 export {useMapSelectionAnalytics} from './hooks/use-map-selection-analytics.tsx';
 export {MapButtons} from './components/MapButtons.tsx';
+export {TariffZoneLinesAndLabels} from './components/TariffZoneLinesAndLabels';
+export {mapZonesToPolygonCollection} from './zone-utils';

--- a/src/modules/map/types.ts
+++ b/src/modules/map/types.ts
@@ -101,6 +101,7 @@ export type MobilityMapFilterType = z.infer<typeof MobilityMapFilter>;
 
 export const MapFilter = z.object({
   mobility: MobilityMapFilter,
+  showZones: z.boolean().default(true),
 });
 export type MapFilterType = z.infer<typeof MapFilter>;
 

--- a/src/modules/map/types.ts
+++ b/src/modules/map/types.ts
@@ -101,7 +101,7 @@ export type MobilityMapFilterType = z.infer<typeof MobilityMapFilter>;
 
 export const MapFilter = z.object({
   mobility: MobilityMapFilter,
-  showZones: z.boolean().default(true),
+  showTariffZones: z.boolean().default(true),
 });
 export type MapFilterType = z.infer<typeof MapFilter>;
 

--- a/src/modules/map/zone-utils.ts
+++ b/src/modules/map/zone-utils.ts
@@ -1,0 +1,17 @@
+import {FareZone, getReferenceDataName} from '@atb/modules/configuration';
+import {Language} from '@atb/translations';
+import {decodePolylineEncodedGeometry} from '@atb/utils/decode-polyline-geometry';
+import {FeatureCollection, Polygon} from 'geojson';
+
+export const mapZonesToPolygonCollection = (
+  zones: FareZone[],
+  language: Language,
+): FeatureCollection<Polygon> => ({
+  type: 'FeatureCollection',
+  features: zones.map((t) => ({
+    type: 'Feature',
+    id: t.id,
+    properties: {name: getReferenceDataName(t, language)},
+    geometry: decodePolylineEncodedGeometry(t.geometry),
+  })),
+});

--- a/src/modules/mobility/components/filter/MapFilterSheet.tsx
+++ b/src/modules/mobility/components/filter/MapFilterSheet.tsx
@@ -9,6 +9,7 @@ import {
 } from '@atb/modules/map';
 import {StyleSheet} from '@atb/theme';
 import {MobilityFilters} from './MobilityFilters';
+import {ZoneFilters} from './ZoneFilters';
 import {
   BottomSheetHeaderType,
   MapBottomSheet,
@@ -46,6 +47,12 @@ export const MapFilterSheet = ({
     onFilterChanged(tempFilter);
   };
 
+  const onShowZonesChanged = (showZones: boolean) => {
+    const tempFilter = {...mapFilter, showZones};
+    setMapFilter(tempFilter);
+    onFilterChanged(tempFilter);
+  };
+
   return (
     <MapBottomSheet
       closeCallback={onClose}
@@ -60,6 +67,10 @@ export const MapFilterSheet = ({
         <MobilityFilters
           filter={initialFilterRef.current.mobility}
           onFilterChanged={onMobilityFilterChanged}
+        />
+        <ZoneFilters
+          showZones={initialFilterRef.current.showZones ?? true}
+          onFilterChanged={onShowZonesChanged}
         />
       </View>
     </MapBottomSheet>

--- a/src/modules/mobility/components/filter/MapFilterSheet.tsx
+++ b/src/modules/mobility/components/filter/MapFilterSheet.tsx
@@ -9,7 +9,7 @@ import {
 } from '@atb/modules/map';
 import {StyleSheet} from '@atb/theme';
 import {MobilityFilters} from './MobilityFilters';
-import {ZoneFilters} from './ZoneFilters';
+import {TariffZoneFilters} from './TariffZoneFilters';
 import {
   BottomSheetHeaderType,
   MapBottomSheet,
@@ -47,8 +47,8 @@ export const MapFilterSheet = ({
     onFilterChanged(tempFilter);
   };
 
-  const onShowZonesChanged = (showZones: boolean) => {
-    const tempFilter = {...mapFilter, showZones};
+  const onShowTariffZonesChanged = (showTariffZones: boolean) => {
+    const tempFilter = {...mapFilter, showTariffZones};
     setMapFilter(tempFilter);
     onFilterChanged(tempFilter);
   };
@@ -68,9 +68,9 @@ export const MapFilterSheet = ({
           filter={initialFilterRef.current.mobility}
           onFilterChanged={onMobilityFilterChanged}
         />
-        <ZoneFilters
-          showZones={initialFilterRef.current.showZones ?? true}
-          onFilterChanged={onShowZonesChanged}
+        <TariffZoneFilters
+          showTariffZones={initialFilterRef.current.showTariffZones ?? true}
+          onFilterChanged={onShowTariffZonesChanged}
         />
       </View>
     </MapBottomSheet>

--- a/src/modules/mobility/components/filter/MobilityFilters.tsx
+++ b/src/modules/mobility/components/filter/MobilityFilters.tsx
@@ -78,6 +78,5 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
   },
   contentHeading: {
     marginBottom: theme.spacing.small,
-    marginHorizontal: 0,
   },
 }));

--- a/src/modules/mobility/components/filter/TariffZoneFilters.tsx
+++ b/src/modules/mobility/components/filter/TariffZoneFilters.tsx
@@ -7,16 +7,19 @@ import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts'
 import {StyleSheet} from '@atb/theme';
 
 type Props = {
-  showZones: boolean;
-  onFilterChanged: (showZones: boolean) => void;
+  showTariffZones: boolean;
+  onFilterChanged: (showTariffZones: boolean) => void;
 };
 
-export const ZoneFilters = ({showZones, onFilterChanged}: Props) => {
+export const TariffZoneFilters = ({
+  showTariffZones,
+  onFilterChanged,
+}: Props) => {
   const {t} = useTranslation();
-  const [zonesFilter, setZonesFilter] = useState(showZones);
+  const [shouldShow, setShouldShow] = useState(showTariffZones);
 
-  const onShowZonesChanged = (value: boolean) => {
-    setZonesFilter(value);
+  const onShowTariffZonesChanged = (value: boolean) => {
+    setShouldShow(value);
     onFilterChanged(value);
   };
 
@@ -24,12 +27,12 @@ export const ZoneFilters = ({showZones, onFilterChanged}: Props) => {
 
   return (
     <View style={styles.container}>
-      <ContentHeading text={t(MobilityTexts.filter.sectionTitle.zones)} />
+      <ContentHeading text={t(MobilityTexts.filter.sectionTitle.tariffZones)} />
       <Section>
         <ToggleSectionItem
           text={t(MobilityTexts.filter.tariffZones)}
-          value={zonesFilter}
-          onValueChange={onShowZonesChanged}
+          value={shouldShow}
+          onValueChange={onShowTariffZonesChanged}
           testID="tariffZonesToggle"
         />
       </Section>

--- a/src/modules/mobility/components/filter/ZoneFilters.tsx
+++ b/src/modules/mobility/components/filter/ZoneFilters.tsx
@@ -1,0 +1,42 @@
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import {ContentHeading} from '@atb/components/heading';
+import {Section, ToggleSectionItem} from '@atb/components/sections';
+import {useTranslation} from '@atb/translations';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {StyleSheet} from '@atb/theme';
+
+type Props = {
+  showZones: boolean;
+  onFilterChanged: (showZones: boolean) => void;
+};
+
+export const ZoneFilters = ({showZones, onFilterChanged}: Props) => {
+  const {t} = useTranslation();
+  const [zonesFilter, setZonesFilter] = useState(showZones);
+
+  const onShowZonesChanged = (value: boolean) => {
+    setZonesFilter(value);
+    onFilterChanged(value);
+  };
+
+  const styles = useStyles();
+
+  return (
+    <View style={styles.container}>
+      <ContentHeading text={t(MobilityTexts.filter.sectionTitle.zones)} />
+      <Section>
+        <ToggleSectionItem
+          text={t(MobilityTexts.filter.tariffZones)}
+          value={zonesFilter}
+          onValueChange={onShowZonesChanged}
+          testID="tariffZonesToggle"
+        />
+      </Section>
+    </View>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {gap: theme.spacing.small},
+}));

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -104,7 +104,7 @@ export const Trip: React.FC<TripProps> = ({
         operators: [],
       },
     },
-    showZones: false,
+    showTariffZones: false,
   };
 
   const shouldShowDate =

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -104,6 +104,7 @@ export const Trip: React.FC<TripProps> = ({
         operators: [],
       },
     },
+    showZones: false,
   };
 
   const shouldShowDate =

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -318,7 +318,7 @@ export const MobilityTexts = {
         'Shared Mobility',
         'Delingsmobilitet',
       ),
-      zones: _('Soner', 'Zones', 'Soner'),
+      zones: _('Takstsoner', 'Fare zones', 'Takstsoner'),
     },
     tariffZones: _('Takstsoner', 'Fare zones', 'Takstsoner'),
   },

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -318,7 +318,7 @@ export const MobilityTexts = {
         'Shared Mobility',
         'Delingsmobilitet',
       ),
-      zones: _('Takstsoner', 'Fare zones', 'Takstsoner'),
+      tariffZones: _('Takstsoner', 'Fare zones', 'Takstsoner'),
     },
     tariffZones: _('Takstsoner', 'Fare zones', 'Takstsoner'),
   },

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -318,7 +318,9 @@ export const MobilityTexts = {
         'Shared Mobility',
         'Delingsmobilitet',
       ),
+      zones: _('Soner', 'Zones', 'Soner'),
     },
+    tariffZones: _('Takstsoner', 'Fare zones', 'Takstsoner'),
   },
   reportParkingViolation: _(
     'Rapporter som feilparkert',

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -331,7 +331,7 @@ const TripDetailsTexts = {
       _(
         `${publicCode} kjører på bestilling innenfor bestemte soner og tider.`,
         `${publicCode} runs on demand within specific zones and times.`,
-        `${publicCode} køyrer på bestilling innanfor bestemte sonar og tider.`,
+        `${publicCode} køyrer på bestilling innanfor bestemte soner og tider.`,
       ),
     steps: [
       _(


### PR DESCRIPTION
Add tariff zone boundary lines and labels to the main map, with a
toggle in the map filter sheet. Extract shared
TariffZoneLinesAndLabels component and mapZonesToPolygonCollection
utility to reuse across the fare zone selector map and the regular
map.

<img width="350" src="https://github.com/user-attachments/assets/b04901c1-f257-4e06-b1a2-9d62b6878a29" />
<img width="350" src="https://github.com/user-attachments/assets/e8d8c173-d2c9-4eed-97a8-3338efae5201" />
<img width="350" src="https://github.com/user-attachments/assets/e9d93c6b-5c36-499a-8d89-b4cd5d191e5a" />


- The new design on the zone lines is added to both general map and the existing zone selector map
- The new design on zone labels was not easy to implement, so the labels are kept as is in both places