### PR TITLE
fix: map onPress handling with geofencingZonesAsTiles

### DIFF
--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -214,21 +214,6 @@ export const Map = (props: MapProps) => {
     [showSnackbar, getGeofencingZoneContent],
   );
 
-  const geofencingZoneOnPress = useCallback(
-    (e: OnPressEvent) => {
-      const featuresAtClick = e.features;
-      if (!featuresAtClick || featuresAtClick.length === 0) return;
-      const featureToSelect = featuresAtClick[0]; // currently ignore the ones behind
-
-      const code = featureToSelect.properties?.code ?? 'allowed';
-      const stationParking =
-        featureToSelect.properties?.stationParking ?? false;
-
-      showGeofencingZoneSnackbar(code, stationParking);
-    },
-    [showGeofencingZoneSnackbar],
-  );
-
   const locationArrowOnPress = useCallback(async () => {
     const coordinates = await getCurrentCoordinates(true);
     if (
@@ -470,7 +455,6 @@ export const Map = (props: MapProps) => {
               <GeofencingZonesAsTiles
                 systemId={systemId}
                 vehicleTypeId={vehicleTypeId}
-                geofencingZoneOnPress={geofencingZoneOnPress}
               />
             ) : (
               <GeofencingZones

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -30,6 +30,7 @@ import {
   isParkAndRide,
   isStopPlace,
   isFeatureGeofencingZone,
+  isFeatureGeofencingZoneAsTiles,
   isClusterFeature,
 } from './utils';
 
@@ -288,10 +289,13 @@ export const Map = (props: MapProps) => {
         // - select a stop place with the clicked quay sorted on top
         // - have a bottom sheet with departures just for the clicked quay
         return; // currently - do nothing
+      } else if (isFeatureGeofencingZoneAsTiles(featureToSelect)) {
+        const {code, station_parking} = featureToSelect.properties;
+        showGeofencingZoneSnackbar(code, station_parking);
       } else if (isFeatureGeofencingZone(featureToSelect)) {
-        if (isGeofencingZonesAsTilesEnabled) return; // Handled directly with geofencingZoneOnPress instead in this case
-        const gfzProps = featureToSelect?.properties?.geofencingZoneCustomProps;
-        showGeofencingZoneSnackbar(gfzProps?.code, gfzProps.isStationParking);
+        const {code, isStationParking} =
+          featureToSelect.properties.geofencingZoneCustomProps;
+        showGeofencingZoneSnackbar(code, isStationParking);
       } else if (isScooter(selectedFeature) && !isActiveTrip) {
         // outside of operational area, rules unspecified
         showGeofencingZoneSnackbar(undefined);
@@ -301,7 +305,6 @@ export const Map = (props: MapProps) => {
       activeShmoBooking?.state,
       showGeofencingZones,
       hideSnackbar,
-      isGeofencingZonesAsTilesEnabled,
       selectedFeature,
       showGeofencingZoneSnackbar,
     ],

--- a/src/modules/map/components/mobility/GeofencingZonesAsTiles.tsx
+++ b/src/modules/map/components/mobility/GeofencingZonesAsTiles.tsx
@@ -148,54 +148,15 @@ export const GeofencingZonesAsTiles = ({
   }
 
   return (
-    <MapboxGL.VectorSource
-      id={geofencingZonesVectorSourceId}
-      tileUrlTemplates={tileUrlTemplates}
-      minZoomLevel={minZoomLevel}
-      maxZoomLevel={maxZoomLevel}
-      hitbox={hitboxCoveringIconOnly} // to not be able to hit multiple zones with one click
-      onPress={geofencingZoneOnPress}
-    >
-      <>
-        <MapboxGL.FillLayer
-          id="GeofencingZones_Fill_Consolidated"
-          sourceID={geofencingZonesVectorSourceId}
-          sourceLayerID={geofencingZonesFeaturesLayerId}
-          aboveLayerID={MapSlotLayerId.GeofencingZones}
-          minZoomLevel={minZoomLevel}
-          slot="middle"
-          style={{
-            fillSortKey: sortKey,
-            fillColor,
-            fillOpacity,
-            fillAntialias: true,
-            fillEmissiveStrength: 1,
-          }}
-        />
-
-        {lineLayerConfigs.map(({id, filter, dashArray}) => (
-          <MapboxGL.LineLayer
-            key={id}
-            id={id}
-            aboveLayerID={MapSlotLayerId.GeofencingZones}
-            sourceID={geofencingZonesVectorSourceId}
-            sourceLayerID={geofencingZonesFeaturesLayerId}
-            minZoomLevel={minZoomLevel}
-            slot="middle"
-            filter={filter}
-            style={{
-              lineSortKey: sortKey,
-              lineColor: fillColor,
-              lineOpacity: lineOpacity,
-              lineEmissiveStrength: 1,
-              lineCap: 'round',
-              lineJoin: 'round',
-              lineWidth: lineWidth,
-              lineDasharray: dashArray,
-            }}
-          />
-        ))}
-
+    <>
+      <MapboxGL.VectorSource
+        id={geofencingZonesVectorSourceId}
+        tileUrlTemplates={tileUrlTemplates}
+        minZoomLevel={minZoomLevel}
+        maxZoomLevel={maxZoomLevel}
+        hitbox={hitboxCoveringIconOnly} // to not be able to hit multiple zones with one click
+        onPress={geofencingZoneOnPress}
+      >
         <MapboxGL.SymbolLayer
           id="geofencing-zone-icon-layer"
           sourceID={geofencingZonesVectorSourceId}
@@ -213,7 +174,46 @@ export const GeofencingZonesAsTiles = ({
           filter={iconFilter}
           aboveLayerID={MapSlotLayerId.GeofencingZonesIcons}
         />
-      </>
-    </MapboxGL.VectorSource>
+      </MapboxGL.VectorSource>
+
+      <MapboxGL.FillLayer
+        id="GeofencingZones_Fill_Consolidated"
+        sourceID={geofencingZonesVectorSourceId}
+        sourceLayerID={geofencingZonesFeaturesLayerId}
+        aboveLayerID={MapSlotLayerId.GeofencingZones}
+        minZoomLevel={minZoomLevel}
+        slot="middle"
+        style={{
+          fillSortKey: sortKey,
+          fillColor,
+          fillOpacity,
+          fillAntialias: true,
+          fillEmissiveStrength: 1,
+        }}
+      />
+
+      {lineLayerConfigs.map(({id, filter, dashArray}) => (
+        <MapboxGL.LineLayer
+          key={id}
+          id={id}
+          aboveLayerID={MapSlotLayerId.GeofencingZones}
+          sourceID={geofencingZonesVectorSourceId}
+          sourceLayerID={geofencingZonesFeaturesLayerId}
+          minZoomLevel={minZoomLevel}
+          slot="middle"
+          filter={filter}
+          style={{
+            lineSortKey: sortKey,
+            lineColor: fillColor,
+            lineOpacity: lineOpacity,
+            lineEmissiveStrength: 1,
+            lineCap: 'round',
+            lineJoin: 'round',
+            lineWidth: lineWidth,
+            lineDasharray: dashArray,
+          }}
+        />
+      ))}
+    </>
   );
 };

--- a/src/modules/map/components/mobility/GeofencingZonesAsTiles.tsx
+++ b/src/modules/map/components/mobility/GeofencingZonesAsTiles.tsx
@@ -1,7 +1,6 @@
 import MapboxGL from '@rnmapbox/maps';
 import {useMemo} from 'react';
 
-import {hitboxCoveringIconOnly} from '@atb/modules/map';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {useThemeContext} from '@atb/theme';
 
@@ -13,7 +12,6 @@ import {geofencingZoneCodes, getIconZoomTransitionStyle} from '../../utils';
 import {MapSlotLayerId} from '../../hooks/use-mapbox-json-style';
 
 import {Expression} from 'node_modules/@rnmapbox/maps/src/utils/MapboxStyles';
-import {OnPressEvent} from 'node_modules/@rnmapbox/maps/src/types/OnPressEvent';
 
 const geofencingZonesVectorSourceId = 'geofencing-zones-source';
 const geofencingZonesFeaturesLayerId = 'geofencing_zones_features';
@@ -53,13 +51,11 @@ const {iconOpacity, iconSize} = getIconZoomTransitionStyle(
 type GeofencingZonesAsTilesProps = {
   systemId: string | null;
   vehicleTypeId: string | null;
-  geofencingZoneOnPress: (e: OnPressEvent) => void;
 };
 
 export const GeofencingZonesAsTiles = ({
   systemId,
   vehicleTypeId,
-  geofencingZoneOnPress,
 }: GeofencingZonesAsTilesProps) => {
   const {isGeofencingZonesEnabled, isGeofencingZonesAsTilesEnabled} =
     useFeatureTogglesContext();
@@ -148,15 +144,52 @@ export const GeofencingZonesAsTiles = ({
   }
 
   return (
-    <>
-      <MapboxGL.VectorSource
-        id={geofencingZonesVectorSourceId}
-        tileUrlTemplates={tileUrlTemplates}
-        minZoomLevel={minZoomLevel}
-        maxZoomLevel={maxZoomLevel}
-        hitbox={hitboxCoveringIconOnly} // to not be able to hit multiple zones with one click
-        onPress={geofencingZoneOnPress}
-      >
+    <MapboxGL.VectorSource
+      id={geofencingZonesVectorSourceId}
+      tileUrlTemplates={tileUrlTemplates}
+      minZoomLevel={minZoomLevel}
+      maxZoomLevel={maxZoomLevel}
+    >
+      <>
+        <MapboxGL.FillLayer
+          id="GeofencingZones_Fill_Consolidated"
+          sourceID={geofencingZonesVectorSourceId}
+          sourceLayerID={geofencingZonesFeaturesLayerId}
+          aboveLayerID={MapSlotLayerId.GeofencingZones}
+          minZoomLevel={minZoomLevel}
+          slot="middle"
+          style={{
+            fillSortKey: sortKey,
+            fillColor,
+            fillOpacity,
+            fillAntialias: true,
+            fillEmissiveStrength: 1,
+          }}
+        />
+
+        {lineLayerConfigs.map(({id, filter, dashArray}) => (
+          <MapboxGL.LineLayer
+            key={id}
+            id={id}
+            aboveLayerID={MapSlotLayerId.GeofencingZones}
+            sourceID={geofencingZonesVectorSourceId}
+            sourceLayerID={geofencingZonesFeaturesLayerId}
+            minZoomLevel={minZoomLevel}
+            slot="middle"
+            filter={filter}
+            style={{
+              lineSortKey: sortKey,
+              lineColor: fillColor,
+              lineOpacity: lineOpacity,
+              lineEmissiveStrength: 1,
+              lineCap: 'round',
+              lineJoin: 'round',
+              lineWidth: lineWidth,
+              lineDasharray: dashArray,
+            }}
+          />
+        ))}
+
         <MapboxGL.SymbolLayer
           id="geofencing-zone-icon-layer"
           sourceID={geofencingZonesVectorSourceId}
@@ -174,46 +207,7 @@ export const GeofencingZonesAsTiles = ({
           filter={iconFilter}
           aboveLayerID={MapSlotLayerId.GeofencingZonesIcons}
         />
-      </MapboxGL.VectorSource>
-
-      <MapboxGL.FillLayer
-        id="GeofencingZones_Fill_Consolidated"
-        sourceID={geofencingZonesVectorSourceId}
-        sourceLayerID={geofencingZonesFeaturesLayerId}
-        aboveLayerID={MapSlotLayerId.GeofencingZones}
-        minZoomLevel={minZoomLevel}
-        slot="middle"
-        style={{
-          fillSortKey: sortKey,
-          fillColor,
-          fillOpacity,
-          fillAntialias: true,
-          fillEmissiveStrength: 1,
-        }}
-      />
-
-      {lineLayerConfigs.map(({id, filter, dashArray}) => (
-        <MapboxGL.LineLayer
-          key={id}
-          id={id}
-          aboveLayerID={MapSlotLayerId.GeofencingZones}
-          sourceID={geofencingZonesVectorSourceId}
-          sourceLayerID={geofencingZonesFeaturesLayerId}
-          minZoomLevel={minZoomLevel}
-          slot="middle"
-          filter={filter}
-          style={{
-            lineSortKey: sortKey,
-            lineColor: fillColor,
-            lineOpacity: lineOpacity,
-            lineEmissiveStrength: 1,
-            lineCap: 'round',
-            lineJoin: 'round',
-            lineWidth: lineWidth,
-            lineDasharray: dashArray,
-          }}
-        />
-      ))}
-    </>
+      </>
+    </MapboxGL.VectorSource>
   );
 };

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -298,15 +298,19 @@ export function getFeatureWeight(
   positionClicked: Position,
 ): number {
   if (isFeaturePoint(feature)) {
-    return isStopPlace(feature) ||
+    if (
+      isStopPlace(feature) ||
       isVehicleCluster(feature) ||
       isScooter(feature) ||
       isBicycle(feature) ||
       isStation(feature) ||
       isCarStation(feature) ||
       isParkAndRide(feature)
-      ? 3
-      : 1;
+    ) {
+      return 4;
+    }
+    if (isFeatureGeofencingZoneAsTiles(feature)) return 3;
+    return 1;
   } else if (isFeatureGeofencingZoneAsTiles(feature)) {
     return 2;
   } else if (isFeatureGeofencingZone(feature)) {

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -81,10 +81,13 @@ export const geofencingZoneCodes: GeofencingZoneCode[] = [
 ];
 const GeofencingZonePropsSchema = z.object({
   code: z.enum(geofencingZoneCodes),
-  systemId: z.string(),
+  system_id: z.string(),
+  station_parking: z.boolean().optional(),
 });
 export type GeofencingZoneProps = z.infer<typeof GeofencingZonePropsSchema>;
-export const isFeatureGeofencingZoneAsTiles = (feature: Feature) =>
+export const isFeatureGeofencingZoneAsTiles = (
+  feature: Feature,
+): feature is Feature<Geometry, GeofencingZoneProps> =>
   GeofencingZonePropsSchema.safeParse(feature.properties).success;
 
 export const isClusterFeatureV2 = (
@@ -304,9 +307,9 @@ export function getFeatureWeight(
       isParkAndRide(feature)
       ? 3
       : 1;
+  } else if (isFeatureGeofencingZoneAsTiles(feature)) {
+    return 2;
   } else if (isFeatureGeofencingZone(feature)) {
-    // note: This case never happens when enable_geofencing_zones_as_tiles is true.
-    // Can just return 0 after removing the old solution
     const positionClickedIsInsideGeofencingZone = turfBooleanPointInPolygon(
       positionClicked,
       feature.geometry,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DebugInfoScreen.tsx
@@ -55,6 +55,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {useDebugUserInfoHeader} from '@atb/api';
 import {DebugServerOverrides} from '@atb/modules/debug';
 import {useScrollBorder} from '@atb/utils/use-scroll-border';
+import MapboxGL from '@rnmapbox/maps';
 
 function setClipboard(content: string) {
   Clipboard.setString(content);
@@ -311,6 +312,34 @@ export const Profile_DebugInfoScreen = () => {
           <LinkSectionItem
             text="Reset user map filters"
             onPress={() => storage.set('@ATB_user_map_filters', '')}
+          />
+
+          <LinkSectionItem
+            text="Clear locally stored map tiles"
+            onPress={() =>
+              Alert.alert(
+                'Clear locally stored map tiles?',
+                'Clears the Mapbox disk tile cache.',
+                [
+                  {text: 'Cancel', style: 'cancel'},
+                  {
+                    text: 'Clear',
+                    style: 'destructive',
+                    onPress: async () => {
+                      try {
+                        await MapboxGL.clearData();
+                        Alert.alert('Cleared', 'Map tile cache cleared.');
+                      } catch (e: any) {
+                        Alert.alert(
+                          'Failed',
+                          e?.message ?? 'Could not clear tile cache.',
+                        );
+                      }
+                    },
+                  },
+                ],
+              )
+            }
           />
 
           <LinkSectionItem


### PR DESCRIPTION
After https://github.com/AtB-AS/mittatb-app/pull/6033, the geofencingZones would always capture the onPress events when shown. This meant you couldn't go directly from one scooter to another.

Fixed by handling it the same way as for GeofencingZones (geojson) -> using the onFeatureClick handler instead.

Also
- fixed an incorrectly named prop in GeofencingZonePropsSchema. This likely also fixes the missing shmo warnings in the bottom sheet during an active trip.
- added a debug util to clear locally cached tiles.

**Acceptance Criteria:**
- [x] You can click on map items also when a vehicle with geofencingZones as tiles is selected
- [x] Clicks on geofencing zones should show the snackbar correctly
- [x] Warning messages in the active scooter sheet should show correctly
- [x] Still working with the old geojson gfz as well