### PR TITLE
fix: various booking travel card fixes

### DIFF
--- a/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
+++ b/src/modules/experimental-store-trip-patterns/StoredTripPatternsDashboardComponent.tsx
@@ -148,6 +148,7 @@ const StoredTripPatternRow: React.FC<{
         a11yLabelPrefix={t(
           TravelCardTexts.card.a11yPrefix.savedTrip(resultIndex, length),
         )}
+        a11yHint={t(TravelCardTexts.card.a11yHint.tripDetails)}
         includeDayInfo
         includeFromToInfo
         includeLegNotifications

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -23,6 +23,7 @@ type TravelCardProps = {
   onDetailsPressed(tripPattern: TripPattern): void;
   testID?: string;
   a11yLabelPrefix: string;
+  a11yHint: string;
   includeDayInfo?: boolean;
   includeFromToInfo?: boolean;
   includeLegNotifications?: boolean;
@@ -36,6 +37,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   onDetailsPressed,
   testID,
   a11yLabelPrefix,
+  a11yHint,
   includeDayInfo = false,
   includeFromToInfo = false,
   includeLegNotifications = false,
@@ -65,7 +67,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
       : undefined;
 
   const tagA11yLabel = tag
-    ? `. ${t(dictionary.messageTypes[tag.type])}. ${tag.label}`
+    ? `${t(dictionary.messageTypes[tag.type])}. ${tag.label}`
     : undefined;
 
   return (
@@ -79,11 +81,11 @@ export const TravelCard: React.FC<TravelCardProps> = ({
         }}
         order={[
           'cardPrefix',
+          'tag',
           'header',
           'legs',
           'situationOrNotice',
           'legNotifications',
-          'tag',
         ]}
       >
         {(accessibilityProps) => (
@@ -92,9 +94,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
             testID={testID}
             style={[styles.container, isDisabled && styles.containerDisabled]}
             accessibilityRole={isDisabled ? 'none' : 'button'}
-            accessibilityHint={
-              isDisabled ? undefined : t(TravelCardTexts.card.a11yHint)
-            }
+            accessibilityHint={isDisabled ? undefined : a11yHint}
             {...accessibilityProps}
           >
             {tag && (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -110,6 +110,7 @@ export const Results: React.FC<Props> = ({
                       tripPatterns.length,
                     ),
                   )}
+                  a11yHint={t(TravelCardTexts.card.a11yHint.tripDetails)}
                   includeDayInfo
                   includeFromToInfo
                 />

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/components/TripSelection.tsx
@@ -95,6 +95,11 @@ export function BookingTripSelection({
                   tripPatterns.length,
                 ),
               )}
+              a11yHint={t(
+                selection.isOnBehalfOf
+                  ? TravelCardTexts.card.a11yHint.chooseRecipient
+                  : TravelCardTexts.card.a11yHint.ticketSummary,
+              )}
               includeLegNotifications
               includeSituationNotices
               isDisabled={
@@ -202,7 +207,9 @@ function BookingTrip({tripPattern, onSelect}: BookingTripProps) {
               mode="tertiary"
               onPress={onPress}
               backgroundColor={theme.color.interactive[2].default}
-              style={{marginLeft: 'auto'}}
+              style={{
+                marginLeft: 'auto',
+              }}
               rightIcon={{svg: ChevronRight}}
             />
           </View>
@@ -300,6 +307,8 @@ function TripSelectionTag({
 const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
   return {
     container: {
+      marginHorizontal: theme.spacing.medium,
+      marginVertical: theme.spacing.small,
       borderRadius: theme.border.radius.regular,
       overflow: 'hidden',
     },
@@ -318,6 +327,7 @@ const useBookingTripStyles = StyleSheet.createThemeHook((theme) => {
       paddingVertical: theme.spacing.small,
       justifyContent: 'space-between',
       alignItems: 'center',
+      borderRadius: theme.border.radius.regular,
     },
     footerAvailable: {
       backgroundColor: theme.color.interactive[2].default.background,

--- a/src/translations/components/TravelCard.ts
+++ b/src/translations/components/TravelCard.ts
@@ -2,34 +2,46 @@ import {translation as _} from '../commons';
 
 const TravelCardTexts = {
   card: {
-    a11yHint: _(
-      'Aktivér for å se detaljer om reisen.',
-      'Activate to see trip details.',
-      'Aktivér for å se detaljer om reisen.',
-    ),
+    a11yHint: {
+      tripDetails: _(
+        'Aktivér for å se reisedetaljer.',
+        'Activate to see trip details.',
+        'Aktivér for å sjå reisedetaljar.',
+      ),
+      ticketSummary: _(
+        'Aktivér for å se billettsammendrag.',
+        'Activate to see ticket summary.',
+        'Aktivér for å sjå billettsamandrag.',
+      ),
+      chooseRecipient: _(
+        'Aktivér for å velge mottaker.',
+        'Activate to choose recipient.',
+        'Aktivér for å velje mottakar.',
+      ),
+    },
     a11yPrefix: {
       tripSuggestion: (cardIndex: number, numberOfCards: number) => {
         const index = numberOfCards === 1 ? '' : ` ${cardIndex + 1}`;
         return _(
-          `Reiseforslag${index}.`,
-          `Trip suggestion${index}.`,
-          `Reiseforslag${index}.`,
+          `Reiseforslag${index}`,
+          `Trip suggestion${index}`,
+          `Reiseforslag${index}`,
         );
       },
       savedTrip: (cardIndex: number, numberOfCards: number) => {
         const index = numberOfCards === 1 ? '' : ` ${cardIndex + 1}`;
         return _(
-          `Lagret reise${index}.`,
-          `Saved trip${index}.`,
-          `Lagret reise${index}.`,
+          `Lagret reise${index}`,
+          `Saved trip${index}`,
+          `Lagret reise${index}`,
         );
       },
       bookingOption: (cardIndex: number, numberOfCards: number) => {
         const index = numberOfCards === 1 ? '' : ` ${cardIndex + 1}`;
         return _(
-          `Bestillingsalternativ${index}.`,
-          `Booking option${index}.`,
-          `Bestillingsalternativ${index}.`,
+          `Bestillingsalternativ${index}`,
+          `Booking option${index}`,
+          `Bestillingsalternativ${index}`,
         );
       },
     },


### PR DESCRIPTION
## Issue Reference
related to https://github.com/AtB-AS/kundevendt/issues/23646

## Description
- Reorder a11y text screenreader for `Travel Card`, now the trip status inside "Tag" will be read earlier, rather than later, so the user gets the availability information earlier before the trip detail information.
- Fixes margin on the old booking layout
- Improves a11y text hint, `Travel Card` is used for:
  - Saved Trips -> activate to Trip Details
  - Trip Search ->  activate to Trip Details
  - Booking Option ->
    - activate to Ticket Summary if purchasing for self
    - activate to Choose Recipient if purchasing for others