### PR TITLE
chore: add PostHog events for swap and my location buttons

### DIFF
--- a/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
+++ b/src/screen-components/nearby-stop-places/NearbyStopPlacesScreenComponent.tsx
@@ -1,5 +1,6 @@
 import {StopPlace} from '@atb/api/types/departures';
 import {Location as LocationIcon} from '@atb/assets/svg/mono-icons/places';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {LocationInputSectionItem, Section} from '@atb/components/sections';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -205,8 +206,10 @@ const Header = React.memo(function Header({
   const {theme} = useThemeContext();
   const {location: geolocation, requestLocationPermission} =
     useGeolocationContext();
+  const analytics = useAnalyticsContext();
 
   const setCurrentLocationOrRequest = () => {
+    analytics.logEvent('Departures', 'My location button clicked');
     if (geolocation) {
       setLocation({...geolocation, resultType: 'geolocation'});
     } else {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/Dashboard_RootScreen.tsx
@@ -148,6 +148,7 @@ export const Dashboard_RootScreen: React.FC<RootProps> = ({navigation}) => {
       newFrom: translateLocation(to),
       newTo: translateLocation(from),
     });
+    analytics.logEvent('Trip search', 'Locations to/from swapped');
     navigation.setParams({fromLocation: to, toLocation: from});
   }
 


### PR DESCRIPTION
Track 'Locations to/from swapped' on the Dashboard_RootScreen swap
button (Dashboard_TripSearchScreen already tracked this event).
Track 'My location button clicked' on the my location button in
the departures search (NearbyStopPlacesScreenComponent).
