### PR TITLE
fix: Fix bug with originalTime in TravelCard Header

### DIFF
--- a/src/screen-components/travel-card/TravelCardHeader.tsx
+++ b/src/screen-components/travel-card/TravelCardHeader.tsx
@@ -45,6 +45,14 @@ export const TravelCardHeader: React.FC<
     endTimeLabel: expectedEndTimeLabel,
   } = useTimeLabels(expectedStartTime, expectedEndTime, includeDayInfo);
 
+  /**
+   * If the start time of a trip is in the past (hasStarted), and the
+   * includeDayInfo flag is true, we want to include day info in the
+   * time label.
+   *
+   * See documentation in useTimeLabels for details about special
+   * handling of the current day.
+   */
   const {startTimeLabel: aimedStartTimeLabel, endTimeLabel: aimedEndTimeLabel} =
     useTimeLabels(aimedStartTime, aimedEndTime, hasStarted && includeDayInfo);
 

--- a/src/screen-components/travel-card/TravelCardHeader.tsx
+++ b/src/screen-components/travel-card/TravelCardHeader.tsx
@@ -46,10 +46,6 @@ export const TravelCardHeader: React.FC<
   } = useTimeLabels(expectedStartTime, expectedEndTime, includeDayInfo);
 
   /**
-   * If the start time of a trip is in the past (hasStarted), and the
-   * includeDayInfo flag is true, we want to include day info in the
-   * time label.
-   *
    * See documentation in useTimeLabels for details about special
    * handling of the current day.
    */

--- a/src/screen-components/travel-card/TravelCardHeader.tsx
+++ b/src/screen-components/travel-card/TravelCardHeader.tsx
@@ -36,7 +36,7 @@ export const TravelCardHeader: React.FC<
     expectedEndTime,
     aimedStartTime,
     aimedEndTime,
-    isInPast,
+    hasStarted,
     statusTextConfig,
   } = useTripPatternInfo(tripPattern);
 
@@ -46,13 +46,13 @@ export const TravelCardHeader: React.FC<
   } = useTimeLabels(expectedStartTime, expectedEndTime, includeDayInfo);
 
   const {startTimeLabel: aimedStartTimeLabel, endTimeLabel: aimedEndTimeLabel} =
-    useTimeLabels(aimedStartTime, aimedEndTime, isInPast && includeDayInfo);
+    useTimeLabels(aimedStartTime, aimedEndTime, hasStarted && includeDayInfo);
 
   const areTimesEquivalentInMinutes =
-    differenceInMinutes(expectedStartTime, aimedStartTime) < 1 &&
-    differenceInMinutes(expectedEndTime, aimedEndTime) < 1;
+    Math.abs(differenceInMinutes(expectedStartTime, aimedStartTime)) < 1 &&
+    Math.abs(differenceInMinutes(expectedEndTime, aimedEndTime)) < 1;
 
-  const showAimedTime = !areTimesEquivalentInMinutes || isInPast;
+  const showAimedTime = !areTimesEquivalentInMinutes;
 
   const a11yLabel = [
     includeFromToInfo
@@ -99,7 +99,7 @@ export const TravelCardHeader: React.FC<
           <ThemeText typography="body__m__strong">
             {`${expectedStartTimeLabel} - ${expectedEndTimeLabel}`}
           </ThemeText>
-          {(!areTimesEquivalentInMinutes || isInPast) && (
+          {!areTimesEquivalentInMinutes && (
             <ThemeText typography="body__s" type="secondary">
               {t(TravelCardTexts.header.originalTime)} {aimedStartTimeLabel} -{' '}
               {aimedEndTimeLabel}

--- a/src/screen-components/travel-card/hooks.ts
+++ b/src/screen-components/travel-card/hooks.ts
@@ -46,7 +46,7 @@ export const useTripPatternInfo = (tripPattern: TripPattern) => {
     tripPattern.aimedEndTime ??
     tripPattern.legs[tripPattern.legs.length - 1].aimedEndTime;
 
-  const isInPast = isInThePast(expectedStartTime);
+  const hasStarted = isInThePast(expectedStartTime);
   const isEnded = isInThePast(expectedEndTime);
 
   const statusTextConfig = getStatusTextConfig(
@@ -62,7 +62,7 @@ export const useTripPatternInfo = (tripPattern: TripPattern) => {
     expectedEndTime,
     aimedStartTime,
     aimedEndTime,
-    isInPast,
+    hasStarted,
     isEnded,
     statusTextConfig,
   };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -111,7 +111,6 @@ export const Results: React.FC<Props> = ({
                     ),
                   )}
                   a11yHint={t(TravelCardTexts.card.a11yHint.tripDetails)}
-                  includeDayInfo
                 />
               ) : (
                 <ResultRow


### PR DESCRIPTION
## Issue Reference
Fixes a bug related to https://github.com/AtB-AS/kundevendt/issues/23634

## Description
Currently, we show the "Opprinnelig xx.xx - yy.yy" text for all tripPatterns that has started. This PR changes so that we only show Opprinnelige if they actually are different. 