### PR TITLE
chore: add yarn doctor environment health-check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Since iOS development is only supported on MacOS, using MacOS for development is
 
 1. Ruby v3.1.0: With something like [rbenv](https://github.com/rbenv/rbenv)
 2. See [React Native: Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment)
-   > ⓘ If bundler fails or not installed, use `gem install bundler -v <version>`, where `<version>` is the one listed at the bottom of [Podfile.lock](./ios/Podfile.lock) (`BUNDLED WITH: 2.x.x`).
+   > ⓘ If bundler fails or not installed, use `gem install bundler -v <version>`, where `<version>` is the one listed at the bottom of [Gemfile.lock](./ios/Podfile.lock) (`BUNDLED WITH: 2.x.x`).
    > If encountering errors, following the suggested gem installs might solve it.
    >
    > If you experience various mysterious errors when running `yarn android` you probably have the wrong JDK. See **Common errors**** below for fix. 
@@ -60,7 +60,6 @@ Since iOS development is only supported on MacOS, using MacOS for development is
    ```
 
    > ⓘ Access token from jfrog has a one-year expiry
-
 2. Install dependencies:
 
    a. React Native: `yarn`
@@ -89,6 +88,10 @@ Since iOS development is only supported on MacOS, using MacOS for development is
 - Android: Run `yarn android`
   - You may select which device/emulator to use from Android Studio. You may also use Android Debug Bridge (adb).
   - When deploying on device you should check that the device is listed as `device` with `adb devices`. You may also need to use the command `adb -s <device-id> reverse tcp:8081 tcp:8081` to reverse the port needed for metro.
+
+### Verifying your environment
+
+Run `yarn doctor` at any time to check that all requirements and setup steps are in place — useful after OS upgrades, tool updates, or when something suddenly stops working.
 
 ### Common errors
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Since iOS development is only supported on MacOS, using MacOS for development is
 
 1. Ruby v3.1.0: With something like [rbenv](https://github.com/rbenv/rbenv)
 2. See [React Native: Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment)
-   > ⓘ If bundler fails or not installed, use `gem install bundler -v <version>`, where `<version>` is the one listed at the bottom of [Gemfile.lock](./ios/Podfile.lock) (`BUNDLED WITH: 2.x.x`).
+   > ⓘ If bundler fails or not installed, use `gem install bundler -v <version>`, where `<version>` is the one listed at the bottom of [Gemfile.lock](./Gemfile.lock) (`BUNDLED WITH: 2.x.x`).
    > If encountering errors, following the suggested gem installs might solve it.
    >
    > If you experience various mysterious errors when running `yarn android` you probably have the wrong JDK. See **Common errors**** below for fix. 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "EUPL-1.2",
   "scripts": {
+    "doctor": "sh scripts/doctor.sh",
     "android": "sh ./scripts/android/run-android.sh",
     "ios": "react-native run-ios",
     "start": "react-native start",

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,242 @@
+#!/bin/sh
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+
+pass() { printf "  ${GREEN}✓${NC} %s\n" "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf "  ${RED}✗${NC} %s\n" "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+warn() { printf "  ${YELLOW}⚠${NC} %s\n" "$1"; WARN_COUNT=$((WARN_COUNT + 1)); }
+section() { printf "\n${BOLD}%s${NC}\n" "$1"; }
+
+is_integer() { expr "$1" : '^[0-9][0-9]*$' >/dev/null 2>&1; }
+
+printf "\n${BOLD}AtB App – Environment Doctor${NC}\n"
+echo "Checking your development environment..."
+
+REPO_ROOT="$(git rev-parse --show-toplevel)" || { echo "Not in a git repo"; exit 1; }
+
+# --- Requirements ---
+
+# Ruby (README requirement 1)
+section "Ruby"
+REQUIRED_RUBY=$(tr -d '[:space:]' < "$REPO_ROOT/.ruby-version")
+if command -v ruby >/dev/null 2>&1; then
+  RUBY_VERSION=$(ruby --version | awk '{print $2}' | sed 's/p.*//')
+  if [ "$RUBY_VERSION" = "$REQUIRED_RUBY" ]; then
+    pass "ruby $RUBY_VERSION"
+  else
+    fail "ruby $RUBY_VERSION (required: $REQUIRED_RUBY) – see README"
+  fi
+else
+  fail "ruby not found (required: $REQUIRED_RUBY) – see README"
+fi
+
+# Node.js (README requirement 2 – React Native environment)
+section "Node.js"
+if command -v node >/dev/null 2>&1; then
+  NODE_VERSION=$(node --version | sed 's/v//')
+  NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+  if is_integer "$NODE_MAJOR" && [ "$NODE_MAJOR" -ge 22 ]; then
+    pass "node $NODE_VERSION"
+  else
+    fail "node $NODE_VERSION (required: >=22) – see README"
+  fi
+else
+  fail "node not found (required: >=22) – see README"
+fi
+
+# iOS toolchain – requirements (macOS only)
+case "$OSTYPE" in darwin*)
+  section "Xcode"
+  if command -v xcodebuild >/dev/null 2>&1; then
+    XCODE_VERSION=$(xcodebuild -version 2>/dev/null | head -1 | awk '{print $2}')
+    pass "Xcode $XCODE_VERSION"
+    if xcode-select -p >/dev/null 2>&1; then
+      pass "Xcode Command Line Tools"
+    else
+      fail "Xcode Command Line Tools not installed – see README"
+    fi
+  else
+    fail "Xcode not found – see README"
+  fi
+
+  section "CocoaPods"
+  REQUIRED_POD=$(awk '/^COCOAPODS:/{print $2}' "$REPO_ROOT/ios/Podfile.lock")
+  if command -v pod >/dev/null 2>&1; then
+    POD_VERSION=$(pod --version)
+    if [ "$POD_VERSION" = "$REQUIRED_POD" ]; then
+      pass "cocoapods $POD_VERSION"
+    else
+      warn "cocoapods $POD_VERSION (required: $REQUIRED_POD) – see README"
+    fi
+  else
+    warn "cocoapods not found – see README"
+  fi
+esac
+
+# Android SDK (README requirement 2 – React Native environment)
+section "Android SDK"
+case "$OSTYPE" in
+  darwin*) ANDROID_SDK="${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}" ;;
+  *)       ANDROID_SDK="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}" ;;
+esac
+if [ -d "$ANDROID_SDK" ]; then
+  pass "Android SDK at $ANDROID_SDK"
+  if ls "$ANDROID_SDK/build-tools/" >/dev/null 2>&1; then
+    LATEST_BUILD_TOOLS=$(ls "$ANDROID_SDK/build-tools/" | sort -V | tail -1)
+    pass "build-tools $LATEST_BUILD_TOOLS"
+  else
+    fail "Android build tools not found – see README"
+  fi
+else
+  warn "Android SDK not found – see README"
+fi
+
+# Java (README requirement 2 – React Native environment)
+section "Java"
+if command -v java >/dev/null 2>&1; then
+  JAVA_VERSION=$(java -XshowSettings:property -version 2>&1 | awk '/java.version =/{print $3}')
+  JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d. -f1)
+  if is_integer "$JAVA_MAJOR" && [ "$JAVA_MAJOR" -ge 17 ]; then
+    pass "java $JAVA_VERSION"
+  else
+    fail "java $JAVA_VERSION (required: >=17) – see README"
+  fi
+else
+  fail "java not found (required: >=17) – see README"
+fi
+
+# Yarn (README requirement 3)
+section "Yarn"
+if command -v yarn >/dev/null 2>&1; then
+  YARN_VERSION=$(yarn --version)
+  YARN_MAJOR=$(echo "$YARN_VERSION" | cut -d. -f1)
+  YARN_MINOR=$(echo "$YARN_VERSION" | cut -d. -f2)
+  if [ "$YARN_MAJOR" = "1" ] && is_integer "$YARN_MINOR" && [ "$YARN_MINOR" -ge 22 ]; then
+    pass "yarn $YARN_VERSION"
+  else
+    fail "yarn $YARN_VERSION (required: >=1.22, <2) – see README"
+  fi
+else
+  fail "yarn not found (required: >=1.22, <2) – see README"
+fi
+
+# git-crypt installed + unlocked (README requirement 4 / setup step 3)
+section "git-crypt"
+if command -v git-crypt >/dev/null 2>&1; then
+  pass "git-crypt installed"
+  GIT_CRYPT_PROBE="$REPO_ROOT/env/atb/dev/google-services.json"
+  if [ -f "$GIT_CRYPT_PROBE" ]; then
+    if grep -q "GITCRYPT" "$GIT_CRYPT_PROBE" 2>/dev/null; then
+      fail "git-crypt: repo is locked – see README"
+    else
+      pass "git-crypt: repo is unlocked"
+    fi
+  fi
+else
+  fail "git-crypt not found – see README"
+fi
+
+# --- Setup steps (README first time setup order) ---
+
+# Entur JFrog npm registry (setup step 1)
+section "Entur JFrog Registry (npm)"
+NPMRC="$HOME/.npmrc"
+if [ -f "$NPMRC" ] && grep -q "@entur-private:registry" "$NPMRC"; then
+  pass "@entur-private:registry configured"
+  if grep -q "entur2.jfrog.io.*_authToken" "$NPMRC"; then
+    pass "JFrog auth token configured"
+  else
+    fail "JFrog auth token not configured – see README"
+  fi
+else
+  fail "@entur-private:registry not configured – see README"
+fi
+
+# Entur JFrog Gradle registry (setup step 1)
+section "Entur JFrog Registry (Gradle)"
+GRADLE_PROPS="$HOME/.gradle/gradle.properties"
+if [ -f "$GRADLE_PROPS" ] && grep -q "entur_artifactory_user" "$GRADLE_PROPS"; then
+  pass "Gradle credentials configured"
+else
+  warn "Gradle credentials not configured – see README"
+fi
+
+# Bundler (setup step 2b – bundle install)
+section "Bundler"
+REQUIRED_BUNDLER=$(awk '/BUNDLED WITH/{getline; print $1}' "$REPO_ROOT/Gemfile.lock")
+if command -v bundle >/dev/null 2>&1; then
+  BUNDLER_VERSION=$(bundle --version | awk '{print $3}')
+  if [ "$BUNDLER_VERSION" = "$REQUIRED_BUNDLER" ]; then
+    pass "bundler $BUNDLER_VERSION"
+  else
+    fail "bundler $BUNDLER_VERSION (required: $REQUIRED_BUNDLER) – see README"
+  fi
+else
+  fail "bundler not found (required: $REQUIRED_BUNDLER) – see README"
+fi
+
+# ImageMagick (setup step 2c)
+section "ImageMagick"
+if command -v magick >/dev/null 2>&1 || command -v convert >/dev/null 2>&1; then
+  if command -v magick >/dev/null 2>&1; then
+    IM_VERSION=$(magick --version 2>/dev/null | awk 'NR==1{print $3}')
+  else
+    IM_VERSION=$(convert --version 2>/dev/null | awk 'NR==1{print $3}')
+  fi
+  pass "imagemagick $IM_VERSION"
+else
+  fail "imagemagick not found – see README"
+fi
+
+# MapBox .netrc (setup step 4a – requires git-crypt unlock)
+section "MapBox (.netrc)"
+NETRC="$HOME/.netrc"
+if [ -f "$NETRC" ] && grep -q "api.mapbox.com" "$NETRC"; then
+  pass "MapBox credentials configured"
+else
+  fail "MapBox credentials not configured – see README"
+fi
+
+# App setup (setup step 5 – requires git-crypt unlock)
+section "App setup (yarn setup dev <org>)"
+if [ -f "$REPO_ROOT/.env" ] && [ -f "$REPO_ROOT/android/app/google-services.json" ] && [ -f "$REPO_ROOT/ios/atb/GoogleService-Info.plist" ]; then
+  pass "app environment configured"
+else
+  fail "app environment not configured – see README"
+fi
+
+# iOS Certificates (setup step 6 – macOS only)
+case "$OSTYPE" in darwin*)
+  section "iOS Certificates (get_ios_certs)"
+  IOS_CERT_COUNT=$(security find-identity -v -p codesigning 2>/dev/null | grep -c "valid identit")
+  if is_integer "$IOS_CERT_COUNT" && [ "$IOS_CERT_COUNT" -gt 0 ]; then
+    pass "$IOS_CERT_COUNT codesigning identity/identities"
+  else
+    warn "no codesigning identities found – see README"
+  fi
+esac
+
+# Summary
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+TOTAL=$((PASS_COUNT + FAIL_COUNT + WARN_COUNT))
+printf "${BOLD}Results:${NC} %s checks — ${GREEN}%s passed${NC}, ${RED}%s failed${NC}, ${YELLOW}%s warnings${NC}\n" "$TOTAL" "$PASS_COUNT" "$FAIL_COUNT" "$WARN_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf "\n${RED}${BOLD}Environment is not ready.${NC} Fix the failing checks above.\n"
+  exit 1
+elif [ "$WARN_COUNT" -gt 0 ]; then
+  printf "\n${YELLOW}${BOLD}Environment mostly ready.${NC} Review warnings above.\n"
+  exit 0
+else
+  printf "\n${GREEN}${BOLD}Environment is ready!${NC} You should be able to build the app.\n"
+  exit 0
+fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -47,10 +47,19 @@ if command -v node >/dev/null 2>&1; then
   if is_integer "$NODE_MAJOR" && [ "$NODE_MAJOR" -ge 22 ]; then
     pass "node $NODE_VERSION"
   else
-    fail "node $NODE_VERSION (required: >=22) – see README"
+    fail "node $NODE_VERSION (required: >=22) – see https://reactnative.dev/docs/set-up-your-environment"
   fi
 else
-  fail "node not found (required: >=22) – see README"
+  fail "node not found (required: >=22) – see https://reactnative.dev/docs/set-up-your-environment"
+fi
+
+# Watchman (recommended by React Native for both platforms)
+section "Watchman"
+if command -v watchman >/dev/null 2>&1; then
+  WATCHMAN_VERSION=$(watchman --version 2>/dev/null)
+  pass "watchman $WATCHMAN_VERSION"
+else
+  warn "watchman not found (recommended) – see https://reactnative.dev/docs/set-up-your-environment"
 fi
 
 # iOS toolchain – requirements (macOS only)
@@ -62,10 +71,16 @@ case "$OS" in Darwin)
     if xcode-select -p >/dev/null 2>&1; then
       pass "Xcode Command Line Tools"
     else
-      fail "Xcode Command Line Tools not installed – see README"
+      fail "Xcode Command Line Tools not installed – see https://reactnative.dev/docs/set-up-your-environment"
+    fi
+    if grep -q "NODE_BINARY" "$REPO_ROOT/ios/.xcode.env" 2>/dev/null || \
+       grep -q "NODE_BINARY" "$REPO_ROOT/ios/.xcode.env.local" 2>/dev/null; then
+      pass ".xcode.env NODE_BINARY configured"
+    else
+      warn ".xcode.env missing NODE_BINARY – Xcode builds may fail with NVM (see React Native docs)"
     fi
   else
-    fail "Xcode not found – see README"
+    fail "Xcode not found – see https://reactnative.dev/docs/set-up-your-environment"
   fi
 
   section "CocoaPods"
@@ -75,10 +90,10 @@ case "$OS" in Darwin)
     if [ "$POD_VERSION" = "$REQUIRED_POD" ]; then
       pass "cocoapods $POD_VERSION"
     else
-      warn "cocoapods $POD_VERSION (required: $REQUIRED_POD) – see README"
+      warn "cocoapods $POD_VERSION (required: $REQUIRED_POD) – see https://reactnative.dev/docs/set-up-your-environment"
     fi
   else
-    warn "cocoapods not found – see README"
+    warn "cocoapods not found – see https://reactnative.dev/docs/set-up-your-environment"
   fi
 esac
 
@@ -94,10 +109,16 @@ if [ -d "$ANDROID_SDK" ]; then
   if [ -n "$LATEST_BUILD_TOOLS" ]; then
     pass "build-tools $LATEST_BUILD_TOOLS"
   else
-    fail "Android build tools not found – see README"
+    fail "Android build tools not found – see https://reactnative.dev/docs/set-up-your-environment"
+  fi
+  REQUIRED_SDK=$(grep 'compileSdkVersion\s*=' "$REPO_ROOT/android/build.gradle" 2>/dev/null | awk -F'= ' '{print $2}' | tr -d ' ')
+  if [ -n "$REQUIRED_SDK" ] && [ -d "$ANDROID_SDK/platforms/android-$REQUIRED_SDK" ]; then
+    pass "Android SDK Platform $REQUIRED_SDK"
+  elif [ -n "$REQUIRED_SDK" ]; then
+    fail "Android SDK Platform $REQUIRED_SDK not found – see https://reactnative.dev/docs/set-up-your-environment"
   fi
 else
-  warn "Android SDK not found – see README"
+  warn "Android SDK not found – see https://reactnative.dev/docs/set-up-your-environment"
 fi
 
 # Java (README requirement 2 – React Native environment)
@@ -110,10 +131,10 @@ if command -v java >/dev/null 2>&1; then
   elif [ "$JAVA_MAJOR" -ge 17 ]; then
     pass "java $JAVA_VERSION"
   else
-    fail "java $JAVA_VERSION (required: >=17) – see README"
+    fail "java $JAVA_VERSION (required: >=17) – see https://reactnative.dev/docs/set-up-your-environment"
   fi
 else
-  fail "java not found (required: >=17) – see README"
+  fail "java not found (required: >=17) – see https://reactnative.dev/docs/set-up-your-environment"
 fi
 
 # Yarn (README requirement 3)

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -105,11 +105,16 @@ case "$OS" in
 esac
 if [ -d "$ANDROID_SDK" ]; then
   pass "Android SDK at $ANDROID_SDK"
+  REQUIRED_BUILD_TOOLS=$(grep 'buildToolsVersion' "$REPO_ROOT/android/build.gradle" 2>/dev/null | awk -F'"' '{print $2}')
   LATEST_BUILD_TOOLS=$(ls "$ANDROID_SDK/build-tools/" 2>/dev/null | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-  if [ -n "$LATEST_BUILD_TOOLS" ]; then
-    pass "build-tools $LATEST_BUILD_TOOLS"
-  else
+  if [ -z "$LATEST_BUILD_TOOLS" ]; then
     fail "Android build tools not found – see https://reactnative.dev/docs/set-up-your-environment"
+  elif [ -n "$REQUIRED_BUILD_TOOLS" ] && [ -d "$ANDROID_SDK/build-tools/$REQUIRED_BUILD_TOOLS" ]; then
+    pass "build-tools $REQUIRED_BUILD_TOOLS"
+  elif [ -n "$REQUIRED_BUILD_TOOLS" ]; then
+    fail "build-tools $REQUIRED_BUILD_TOOLS not found (latest installed: $LATEST_BUILD_TOOLS) – see https://reactnative.dev/docs/set-up-your-environment"
+  else
+    pass "build-tools $LATEST_BUILD_TOOLS"
   fi
   REQUIRED_SDK=$(grep 'compileSdkVersion\s*=' "$REPO_ROOT/android/build.gradle" 2>/dev/null | awk -F'= ' '{print $2}' | tr -d ' ')
   if [ -n "$REQUIRED_SDK" ] && [ -d "$ANDROID_SDK/platforms/android-$REQUIRED_SDK" ]; then
@@ -240,7 +245,7 @@ fi
 # iOS Certificates (setup step 6 – macOS only)
 case "$OS" in Darwin)
   section "iOS Certificates (get_ios_certs)"
-  IOS_CERT_COUNT=$(security find-identity -v -p codesigning 2>/dev/null | grep -c "valid identit")
+  IOS_CERT_COUNT=$(security find-identity -v -p codesigning 2>/dev/null | awk '/valid identit/{print $1}')
   if is_integer "$IOS_CERT_COUNT" && [ "$IOS_CERT_COUNT" -gt 0 ]; then
     pass "$IOS_CERT_COUNT codesigning identity/identities"
   else

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -103,9 +103,11 @@ fi
 # Java (README requirement 2 – React Native environment)
 section "Java"
 if command -v java >/dev/null 2>&1; then
-  JAVA_VERSION=$(java -XshowSettings:property -version 2>&1 | awk '/java.version =/{print $3}')
+  JAVA_VERSION=$(java -version 2>&1 | awk -F '"' 'NR==1{print $2}')
   JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d. -f1)
-  if is_integer "$JAVA_MAJOR" && [ "$JAVA_MAJOR" -ge 17 ]; then
+  if ! is_integer "$JAVA_MAJOR"; then
+    fail "java: could not parse version"
+  elif [ "$JAVA_MAJOR" -ge 17 ]; then
     pass "java $JAVA_VERSION"
   else
     fail "java $JAVA_VERSION (required: >=17) – see README"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -21,6 +21,7 @@ printf "\n${BOLD}AtB App – Environment Doctor${NC}\n"
 echo "Checking your development environment..."
 
 REPO_ROOT="$(git rev-parse --show-toplevel)" || { echo "Not in a git repo"; exit 1; }
+OS="$(uname -s)"
 
 # --- Requirements ---
 
@@ -53,7 +54,7 @@ else
 fi
 
 # iOS toolchain – requirements (macOS only)
-case "$OSTYPE" in darwin*)
+case "$OS" in Darwin)
   section "Xcode"
   if command -v xcodebuild >/dev/null 2>&1; then
     XCODE_VERSION=$(xcodebuild -version 2>/dev/null | head -1 | awk '{print $2}')
@@ -83,14 +84,14 @@ esac
 
 # Android SDK (README requirement 2 – React Native environment)
 section "Android SDK"
-case "$OSTYPE" in
-  darwin*) ANDROID_SDK="${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}" ;;
-  *)       ANDROID_SDK="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}" ;;
+case "$OS" in
+  Darwin) ANDROID_SDK="${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}" ;;
+  *)      ANDROID_SDK="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}" ;;
 esac
 if [ -d "$ANDROID_SDK" ]; then
   pass "Android SDK at $ANDROID_SDK"
-  if ls "$ANDROID_SDK/build-tools/" >/dev/null 2>&1; then
-    LATEST_BUILD_TOOLS=$(ls "$ANDROID_SDK/build-tools/" | sort -V | tail -1)
+  LATEST_BUILD_TOOLS=$(ls "$ANDROID_SDK/build-tools/" 2>/dev/null | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+  if [ -n "$LATEST_BUILD_TOOLS" ]; then
     pass "build-tools $LATEST_BUILD_TOOLS"
   else
     fail "Android build tools not found – see README"
@@ -214,7 +215,7 @@ else
 fi
 
 # iOS Certificates (setup step 6 – macOS only)
-case "$OSTYPE" in darwin*)
+case "$OS" in Darwin)
   section "iOS Certificates (get_ios_certs)"
   IOS_CERT_COUNT=$(security find-identity -v -p codesigning 2>/dev/null | grep -c "valid identit")
   if is_integer "$IOS_CERT_COUNT" && [ "$IOS_CERT_COUNT" -gt 0 ]; then


### PR DESCRIPTION
Adds scripts/doctor.sh — a POSIX sh script that checks all
requirements and setup steps (Ruby, Node, Java, Yarn, Android SDK,
Xcode, CocoaPods, git-crypt, registries, MapBox, etc.) and prints
a color-coded pass/warn/fail summary.

Invoked via `yarn doctor`. Documented in README under a new
"Verifying your environment" section.
