### PR TITLE
fix: paging bug when arriveBy: true

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
@@ -49,7 +49,10 @@ export const useTripsInfiniteQuery = (
     staleTime: 30 * ONE_MINUTE_MS,
     gcTime: 30 * ONE_MINUTE_MS,
     initialPageParam: undefined,
-    getNextPageParam: (lastPage) => lastPage?.trip?.nextPageCursor,
+    getNextPageParam: (lastPage) =>
+      tripsInfiniteQueryProps.arriveBy
+        ? lastPage.trip.previousPageCursor
+        : lastPage?.trip?.nextPageCursor,
   });
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/use-trips-infinite-query.ts
@@ -51,7 +51,7 @@ export const useTripsInfiniteQuery = (
     initialPageParam: undefined,
     getNextPageParam: (lastPage) =>
       tripsInfiniteQueryProps.arriveBy
-        ? lastPage.trip.previousPageCursor
+        ? lastPage?.trip?.previousPageCursor
         : lastPage?.trip?.nextPageCursor,
   });
 };


### PR DESCRIPTION
## Issue Reference
Not an issue, but a bug report in Slack: https://mittatb.slack.com/archives/C0116FMPX4Y/p1779427611851349

## Description
When `arriveBy: true` we should not use `nextPageCursor` to fetch more result. Instead we should use ´previousPageCursor`