### PR TITLE
feat: improved a11y in happypath vehicles

### DIFF
--- a/src/modules/mobility/components/ShmoTripDetailsSectionItem.tsx
+++ b/src/modules/mobility/components/ShmoTripDetailsSectionItem.tsx
@@ -94,12 +94,15 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    gap: theme.spacing.medium,
   },
   leftSection: {
+    flex: 1,
     flexDirection: 'column',
     gap: theme.spacing.medium,
   },
   rightSection: {
+    flex: 1,
     flexDirection: 'column',
     gap: theme.spacing.medium,
     alignItems: 'flex-end',

--- a/src/modules/mobility/components/VehicleCardStat.tsx
+++ b/src/modules/mobility/components/VehicleCardStat.tsx
@@ -31,7 +31,7 @@ export const VehicleCardStat = ({
       ]}
     >
       <ThemeIcon svg={icon} color="primary" size="large" />
-      <View>
+      <View style={styles.textContainer}>
         <ThemeText typography="body__m__strong" type="primary">
           {stat}
         </ThemeText>
@@ -52,6 +52,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       gap: theme.spacing.small,
       padding: theme.spacing.small,
       borderRadius: theme.border.radius.small,
+    },
+    textContainer: {
+      flex: 1,
     },
   };
 });


### PR DESCRIPTION
There was a issue with textsize in vehicleCards during vehicletrips, that is now fixed. Also gave more space between counter in active trip.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/ba5ce8ca-5984-448c-8b8d-db18c5db7c67" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/df65cea8-f72c-4c01-8ffd-93bdaaed1d21" />


<img width="250" alt="image" src="https://github.com/user-attachments/assets/c46f08b8-4680-427b-a311-81f4634dd0ac" />


