### PR TITLE
fix: fix icon position in StartTripOverlay

### DIFF
--- a/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
+++ b/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
@@ -88,7 +88,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   title: {
     alignItems: 'center',
     flexDirection: 'row',
+    justifyContent: 'center',
     gap: theme.spacing.small,
+    width: '100%',
   },
   content: {
     alignItems: 'center',
@@ -97,7 +99,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     padding: theme.spacing.large,
   },
   titleText: {
-    flex: 1,
+    flexShrink: 1,
     textAlign: 'center',
   },
   contentText: {


### PR DESCRIPTION
Fixed bug reported by @hanne-at-atb from https://github.com/AtB-AS/kundevendt/issues/22834#issuecomment-4543817804