### PR TITLE
fix: Set saved trips remote config default to true

### DIFF
--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -132,7 +132,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_posthog: false,
   enable_push_notifications: false,
   enable_refunds: true,
-  enable_save_trips: false,
+  enable_save_trips: true,
   enable_server_time: true,
   enable_shmo_deep_integration: false,
   enable_shmo_deep_integration_citybike: false,


### PR DESCRIPTION
## Description
Set's the default value to `true` for `enable_save_trips` Remote Config which improves [this situation](https://mittatb.slack.com/archives/CS3JNRXEV/p1779783128025559)

## Test input
- [x] Can be verified by setting [minimumFetchInterval](https://github.com/AtB-AS/mittatb-app/blob/master/src/modules/remote-config/RemoteConfigContext.tsx#L93) to something low (i.e. 10 seconds), and trying with the default set to true and false