### PR TITLE
feat: add geocoder v3 BFF API support

### DIFF
--- a/src/api/bff/geocoder.ts
+++ b/src/api/bff/geocoder.ts
@@ -4,7 +4,7 @@ import {client} from '../client';
 import qs from 'query-string';
 import {stringifyUrl} from '../utils';
 import {AxiosRequestConfig} from 'axios';
-import {Feature} from './types';
+import {Feature, FeatureCategory, FeatureV3} from './types';
 import {SearchLocation} from '@atb/modules/favorites';
 
 export const FOCUS_ORIGIN: Coordinates = {
@@ -72,5 +72,71 @@ const mapFeatureToSearchLocation = ({
 }: Feature): SearchLocation => ({
   ...properties,
   coordinates: {latitude, longitude},
+  resultType: 'search',
+});
+
+export async function autocompleteV3(
+  text: string,
+  coordinates: Coordinates | null,
+  onlyLocalFareZoneAuthority: boolean = false,
+  onlyStopPlaces: boolean = false,
+  config?: AxiosRequestConfig,
+): Promise<SearchLocation[]> {
+  const url = 'bff/v2/geocoder/features';
+  const query = qs.stringify(
+    {
+      query: text,
+      lat: coordinates?.latitude ?? FOCUS_ORIGIN.latitude,
+      lon: coordinates?.longitude ?? FOCUS_ORIGIN.longitude,
+      limit: 10,
+      fareZoneAuthorities: onlyLocalFareZoneAuthority
+        ? TARIFF_ZONE_AUTHORITY
+        : null,
+      layers: onlyStopPlaces ? ['stopPlace'] : undefined,
+      multimodal: 'parent',
+    },
+    {skipNull: true},
+  );
+
+  const response = await client.get<FeatureV3[]>(
+    stringifyUrl(url, query),
+    config,
+  );
+  return response.data.map(mapFeatureV3ToSearchLocation);
+}
+
+export async function reverseV3(
+  coordinates: Coordinates | null,
+  config?: AxiosRequestConfig,
+): Promise<SearchLocation[]> {
+  const url = 'bff/v2/geocoder/reverse';
+  const query = qs.stringify({
+    lat: coordinates?.latitude,
+    lon: coordinates?.longitude,
+  });
+
+  const response = await client.get<FeatureV3[]>(
+    stringifyUrl(url, query),
+    config,
+  );
+  return response.data.map(mapFeatureV3ToSearchLocation);
+}
+
+const mapFeatureV3ToSearchLocation = ({
+  geometry: {
+    coordinates: [longitude, latitude],
+  },
+  properties,
+}: FeatureV3): SearchLocation => ({
+  id: properties.id,
+  name: properties.name.default,
+  label: properties.name.display,
+  layer: properties.layer === 'stopPlace' ? 'venue' : 'address',
+  coordinates: {latitude, longitude},
+  locality: properties.address?.locality ?? '',
+  postalcode: properties.address?.postalCode ?? '',
+  housenumber: properties.address?.housenumber,
+  fare_zones: properties.fareZones,
+  category: (properties.stopPlaceTypes ?? []) as FeatureCategory[],
   resultType: 'search',
 });

--- a/src/api/bff/geocoder.ts
+++ b/src/api/bff/geocoder.ts
@@ -73,6 +73,7 @@ const mapFeatureToSearchLocation = ({
   ...properties,
   coordinates: {latitude, longitude},
   resultType: 'search',
+  fare_zones: properties.tariff_zones,
 });
 
 export async function autocompleteV3(
@@ -122,6 +123,8 @@ export async function reverseV3(
   return response.data.map(mapFeatureV3ToSearchLocation);
 }
 
+const featureCategories = new Set<string>(Object.values(FeatureCategory));
+
 const mapFeatureV3ToSearchLocation = ({
   geometry: {
     coordinates: [longitude, latitude],
@@ -133,10 +136,12 @@ const mapFeatureV3ToSearchLocation = ({
   label: properties.name.display,
   layer: properties.layer === 'stopPlace' ? 'venue' : 'address',
   coordinates: {latitude, longitude},
-  locality: properties.address?.locality ?? '',
-  postalcode: properties.address?.postalCode ?? '',
+  locality: properties.address?.locality,
+  postalcode: properties.address?.postalCode,
   housenumber: properties.address?.housenumber,
   fare_zones: properties.fareZones,
-  category: (properties.stopPlaceTypes ?? []) as FeatureCategory[],
+  category: (properties.stopPlaceTypes ?? []).filter(
+    (t): t is FeatureCategory => featureCategories.has(t),
+  ),
   resultType: 'search',
 });

--- a/src/api/bff/types.ts
+++ b/src/api/bff/types.ts
@@ -146,7 +146,7 @@ export type Feature = {
     source: string;
     source_id: string;
     street: string;
-    fare_zones?: string[];
+    tariff_zones?: string[];
   };
 };
 

--- a/src/api/bff/types.ts
+++ b/src/api/bff/types.ts
@@ -146,6 +146,51 @@ export type Feature = {
     source: string;
     source_id: string;
     street: string;
-    tariff_zones?: string[];
+    fare_zones?: string[];
+  };
+};
+
+export const geocoderV3Layers = [
+  'stopPlace',
+  'address',
+  'street',
+  'groupOfStopPlaces',
+  'poi',
+  'place',
+] as const;
+
+export type GeocoderV3Layer = (typeof geocoderV3Layers)[number];
+
+export type FeatureV3 = {
+  geometry: {
+    coordinates: [number, number];
+    type: 'Point';
+  };
+  properties: {
+    id: string;
+    name: {
+      default: string;
+      display: string;
+    };
+    layer: GeocoderV3Layer;
+    address?: {
+      street?: string;
+      housenumber?: string;
+      postalCode?: string;
+      locality?: string;
+      localityId?: string;
+      county?: string;
+      countyId?: string;
+      countryCode?: string;
+    };
+    transportModes?: Array<{
+      mode: string;
+      subMode?: string;
+    }>;
+    stopPlaceTypes?: string[];
+    categories?: string[];
+    fareZones?: string[];
+    source?: string;
+    distance?: number;
   };
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,3 @@
 export {CancelToken, client, useDebugUserInfoHeader} from './client';
-export {autocomplete, reverse} from './bff/geocoder';
+export {autocomplete, reverse, autocompleteV3, reverseV3} from './bff/geocoder';
 export {getProfile, updateProfile, deleteProfile} from './profile';

--- a/src/modules/favorites/types.ts
+++ b/src/modules/favorites/types.ts
@@ -23,7 +23,7 @@ export type SearchLocation = {
   category: FeatureCategory[];
   label?: string;
   postalcode?: string;
-  tariff_zones?: string[];
+  fare_zones?: string[];
   housenumber?: string;
 } & (
   | {resultType: 'search'}

--- a/src/modules/favorites/types.ts
+++ b/src/modules/favorites/types.ts
@@ -19,7 +19,7 @@ export type SearchLocation = {
   name: string;
   layer: 'venue' | 'address';
   coordinates: Coordinates;
-  locality: string;
+  locality?: string;
   category: FeatureCategory[];
   label?: string;
   postalcode?: string;

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -189,6 +189,10 @@ export const toggleSpecifications = [
     name: 'isHarborDistancesApiEnabled',
     remoteConfigKey: 'enable_harbor_distances_api',
   },
+  {
+    name: 'isGeocoderV3Enabled',
+    remoteConfigKey: 'use_geocoder_v3',
+  },
 ] as const satisfies readonly FeatureToggleSpecification[];
 
 /**

--- a/src/modules/geocoder/use-geocoder-query.ts
+++ b/src/modules/geocoder/use-geocoder-query.ts
@@ -1,6 +1,7 @@
 import {Coordinates} from '@atb/utils/coordinates';
-import {autocomplete} from '@atb/api';
+import {autocomplete, autocompleteV3} from '@atb/api';
 import {useQuery} from '@tanstack/react-query';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export function useGeocoderQuery(
   text: string | null,
@@ -8,22 +9,32 @@ export function useGeocoderQuery(
   onlyLocalTariffZoneAuthority?: boolean,
   onlyStopPlaces?: boolean,
 ) {
+  const {isGeocoderV3Enabled} = useFeatureTogglesContext();
   return useQuery({
     queryKey: [
       'geocoder',
+      isGeocoderV3Enabled,
       text,
       coords,
       onlyLocalTariffZoneAuthority,
       onlyStopPlaces,
     ],
     queryFn: ({signal}) =>
-      autocomplete(
-        text ?? '',
-        coords,
-        onlyLocalTariffZoneAuthority,
-        onlyStopPlaces,
-        {signal},
-      ),
+      isGeocoderV3Enabled
+        ? autocompleteV3(
+            text ?? '',
+            coords,
+            onlyLocalTariffZoneAuthority,
+            onlyStopPlaces,
+            {signal},
+          )
+        : autocomplete(
+            text ?? '',
+            coords,
+            onlyLocalTariffZoneAuthority,
+            onlyStopPlaces,
+            {signal},
+          ),
     enabled: !!text,
   });
 }

--- a/src/modules/geocoder/use-reverse-geocoder-query.ts
+++ b/src/modules/geocoder/use-reverse-geocoder-query.ts
@@ -1,11 +1,16 @@
 import {Coordinates} from '@atb/utils/coordinates';
-import {reverse} from '@atb/api';
+import {reverse, reverseV3} from '@atb/api';
 import {useQuery} from '@tanstack/react-query';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export function useReverseGeocoderQuery(coords: Coordinates | null) {
+  const {isGeocoderV3Enabled} = useFeatureTogglesContext();
   return useQuery({
-    queryKey: ['reverseGeocoder', coords],
-    queryFn: ({signal}) => reverse(coords, {signal}),
+    queryKey: ['reverseGeocoder', isGeocoderV3Enabled, coords],
+    queryFn: ({signal}) =>
+      isGeocoderV3Enabled
+        ? reverseV3(coords, {signal})
+        : reverse(coords, {signal}),
     enabled: !!coords,
   });
 }

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -85,6 +85,7 @@ export type RemoteConfig = {
   service_disruption_url: string;
   save_trip_swipe_threshold: number;
   token_timeout_in_seconds: number;
+  use_geocoder_v3: boolean;
   use_product_api_v2: boolean;
   use_trygg_overgang_qr_code: boolean;
 };
@@ -168,6 +169,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   service_disruption_url: '',
   save_trip_swipe_threshold: 40,
   token_timeout_in_seconds: 10,
+  use_geocoder_v3: false,
   use_product_api_v2: false,
   use_trygg_overgang_qr_code: false,
 };
@@ -387,6 +389,9 @@ export function getConfig(): RemoteConfig {
   const token_timeout_in_seconds =
     values['token_timeout_in_seconds']?.asNumber() ??
     defaultRemoteConfig.token_timeout_in_seconds;
+  const use_geocoder_v3 =
+    values['use_geocoder_v3']?.asBoolean() ??
+    defaultRemoteConfig.use_geocoder_v3;
   const use_product_api_v2 =
     values['use_product_api_v2']?.asBoolean() ??
     defaultRemoteConfig.use_product_api_v2;
@@ -467,6 +472,7 @@ export function getConfig(): RemoteConfig {
     service_disruption_url,
     save_trip_swipe_threshold,
     token_timeout_in_seconds,
+    use_geocoder_v3,
     use_product_api_v2,
     use_trygg_overgang_qr_code,
   };

--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/Root_PurchaseFareZonesSearchByTextScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/Root_PurchaseFareZonesSearchByTextScreen.tsx
@@ -52,9 +52,7 @@ export const Root_PurchaseFareZonesSearchByTextScreen: React.FC<Props> = ({
   const fareZones = useSelectableFareZones(selection.preassignedFareProduct);
   const getMatchingFareZone = useCallback(
     (location: SearchLocation) =>
-      fareZones.find((fareZone) =>
-        location.tariff_zones?.includes(fareZone.id),
-      ),
+      fareZones.find((fareZone) => location.fare_zones?.includes(fareZone.id)),
     [fareZones],
   );
 


### PR DESCRIPTION
Integrates the new /bff/v2/geocoder endpoints backed by Entur's
geocoder v3. A feature toggle (use_geocoder_v3) switches between
the existing v1 and new v3 endpoints at runtime.

Also renames tariff_zones to fare_zones to align with the updated
API response shape.
