### PR TITLE
refactor: select shmo bonus product and price adjustments by vehicleTypeId

### DIFF
--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -62,9 +62,8 @@ export const BonusProductList = ({
               <GenericSectionItem>
                 <View style={styles.horizontalContainer}>
                   {(() => {
-                    const {mode, subMode} = getTransportModeAndSubMode(
-                      undefined,
-                    );
+                    const {mode, subMode} =
+                      getTransportModeAndSubMode(undefined);
                     return (
                       <TransportationIconBox
                         mode={mode}

--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import {Pressable, View} from 'react-native';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
@@ -10,15 +10,11 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {StyleSheet} from '@atb/theme';
 import {getTransportModeAndSubMode} from '@atb/modules/mobility';
-import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {TransportationIconBox} from '@atb/components/icon-box';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
-import {MapPin} from '@atb/assets/svg/mono-icons/tab-bar';
-import {MapFilterType, useMapContext} from '@atb/modules/map';
+import {MapFilterType} from '@atb/modules/map';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 
 type Props = {
@@ -30,30 +26,12 @@ type Props = {
 export const BonusProductList = ({
   bonusProductGroups,
   bonusProducts,
-  onNavigateToMap,
+  onNavigateToMap: _onNavigateToMap,
 }: Props) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {mobilityOperators} = useFirestoreConfigurationContext();
-  const {mapFilter, setMapFilter} = useMapContext();
   const analytics = useAnalyticsContext();
-
-  const handleNavigateToMap = useCallback(
-    (formFactors: FormFactor[]) => {
-      if (!onNavigateToMap || !mapFilter?.mobility) return;
-      const updatedMobility = {...mapFilter.mobility};
-      formFactors.forEach((ff) => {
-        updatedMobility[ff] = {
-          operators: updatedMobility[ff]?.operators ?? [],
-          showAll: true,
-        };
-      });
-      const updatedFilter = {...mapFilter, mobility: updatedMobility};
-      setMapFilter(updatedFilter);
-      onNavigateToMap(updatedFilter);
-    },
-    [onNavigateToMap, mapFilter, setMapFilter],
-  );
 
   return (
     <View style={styles.container}>
@@ -61,9 +39,6 @@ export const BonusProductList = ({
         const memberProducts = bonusProducts.filter(
           (bp) => bp.bonusProductGroupId === group.id,
         );
-        const formFactors = [
-          ...new Set(memberProducts.flatMap((bp) => bp.formFactors)),
-        ] as FormFactor[];
         const operatorNames = memberProducts
           .map(
             (bp) =>
@@ -71,9 +46,6 @@ export const BonusProductList = ({
               bp.operatorId,
           )
           .join(', ');
-        const showMapButton =
-          !!onNavigateToMap &&
-          formFactors.some((ff) => ff !== FormFactor.Other);
 
         return (
           <Pressable
@@ -91,7 +63,7 @@ export const BonusProductList = ({
                 <View style={styles.horizontalContainer}>
                   {(() => {
                     const {mode, subMode} = getTransportModeAndSubMode(
-                      formFactors[0],
+                      undefined,
                     );
                     return (
                       <TransportationIconBox
@@ -103,39 +75,9 @@ export const BonusProductList = ({
                   })()}
                   <View style={{flex: 1}} accessible={true}>
                     <ThemeText typography="body__s__strong">
-                      {formFactors
-                        .map((ff) => t(MobilityTexts.vehicleName(ff)))
-                        .join(', ')}
-                    </ThemeText>
-                    <ThemeText typography="body__s" type="secondary">
                       {operatorNames}
                     </ThemeText>
                   </View>
-                  {showMapButton && (
-                    <Pressable
-                      onPress={() => {
-                        analytics.logEvent(
-                          'Bonus',
-                          'Map button on bonus product group clicked',
-                          {
-                            bonusProductGroupId: group.id,
-                          },
-                        );
-                        handleNavigateToMap(formFactors);
-                      }}
-                      style={styles.mapButton}
-                      accessibilityRole="button"
-                      accessibilityLabel={t(
-                        BonusProgramTexts.bonusProfile.mapButton.a11yLabel,
-                      )}
-                      accessibilityHint={t(
-                        BonusProgramTexts.bonusProfile.mapButton.a11yHint,
-                      )}
-                    >
-                      <ThemeIcon svg={MapPin} />
-                      <ThemeIcon svg={ChevronRight} />
-                    </Pressable>
-                  )}
                 </View>
               </GenericSectionItem>
               <GenericSectionItem>

--- a/src/modules/bonus/index.ts
+++ b/src/modules/bonus/index.ts
@@ -7,7 +7,10 @@ export {
   UserBonusBalance,
   UserBonusBalanceContent,
 } from './components';
-export {useRelevantBonusProduct} from './use-relevant-bonus-product';
+export {
+  useRelevantSharedMobilityBonusProduct,
+  useRelevantVoucherBonusProduct,
+} from './use-relevant-bonus-product';
 export {useRelevantTicketBonusProduct} from './use-relevant-ticket-bonus-product';
 export type {ProductPointsItem} from './api/api';
 export {

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -1,4 +1,3 @@
-import {FormFactorSchema} from '@atb/api/types/mobility';
 import {LanguageAndTextTypeArray} from '@atb/modules/configuration';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import {z} from 'zod';
@@ -40,7 +39,7 @@ export const BonusProductSchema = z.object({
   isActive: z.boolean(),
   bonusProductGroupId: z.string(),
   operatorId: z.string(),
-  formFactors: z.array(FormFactorSchema),
+  vehicleTypeIds: z.array(z.string()),
   price: PriceSchema,
   productType: z.enum(BonusProductTypeEnum),
   description: LanguageAndTextTypeArray,

--- a/src/modules/bonus/use-relevant-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-bonus-product.ts
@@ -1,9 +1,8 @@
 import {useActiveBonusProductsQuery} from './queries';
 import {BonusProductTypeEnum} from './types';
 
-export const useRelevantBonusProduct = (
+export const useRelevantSharedMobilityBonusProduct = (
   vehicleTypeId: string | undefined,
-  productType?: BonusProductTypeEnum,
 ) => {
   const {data: activeBonusProducts} = useActiveBonusProductsQuery(
     Boolean(vehicleTypeId),
@@ -11,7 +10,21 @@ export const useRelevantBonusProduct = (
   if (!vehicleTypeId) return undefined;
   return activeBonusProducts?.find(
     (bonusProduct) =>
-      bonusProduct.vehicleTypeIds.includes(vehicleTypeId) &&
-      (!productType || bonusProduct.productType === productType),
+      bonusProduct.productType === BonusProductTypeEnum.SHARED_MOBILITY &&
+      bonusProduct.vehicleTypeIds.includes(vehicleTypeId),
+  );
+};
+
+export const useRelevantVoucherBonusProduct = (
+  operatorId: string | undefined,
+) => {
+  const {data: activeBonusProducts} = useActiveBonusProductsQuery(
+    Boolean(operatorId),
+  );
+  if (!operatorId) return undefined;
+  return activeBonusProducts?.find(
+    (bonusProduct) =>
+      bonusProduct.productType === BonusProductTypeEnum.VOUCHER &&
+      bonusProduct.operatorId === operatorId,
   );
 };

--- a/src/modules/bonus/use-relevant-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-bonus-product.ts
@@ -1,20 +1,17 @@
-import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {useActiveBonusProductsQuery} from './queries';
 import {BonusProductTypeEnum} from './types';
 
 export const useRelevantBonusProduct = (
-  operatorId: string | undefined,
-  formFactor: FormFactor,
+  vehicleTypeId: string | undefined,
   productType?: BonusProductTypeEnum,
 ) => {
   const {data: activeBonusProducts} = useActiveBonusProductsQuery(
-    Boolean(operatorId),
+    Boolean(vehicleTypeId),
   );
-  if (!operatorId) return undefined;
+  if (!vehicleTypeId) return undefined;
   return activeBonusProducts?.find(
     (bonusProduct) =>
-      bonusProduct.formFactors.includes(formFactor) &&
-      bonusProduct.operatorId === operatorId &&
+      bonusProduct.vehicleTypeIds.includes(vehicleTypeId) &&
       (!productType || bonusProduct.productType === productType),
   );
 };

--- a/src/modules/configuration/FirestoreConfigurationContext.tsx
+++ b/src/modules/configuration/FirestoreConfigurationContext.tsx
@@ -48,7 +48,9 @@ import {
   mapToConsentLines,
   mapToAppVersionedConfigurableLinks,
   mapToKnownQrCodeUrls,
+  mapToMobilityPriceAdjustments,
 } from './converters';
+import {type PriceAdjustmentType} from '@atb-as/config-specs/lib/mobility';
 import {LanguageAndTextType} from '@atb/translations';
 import {useResubscribeToggle} from '@atb/utils/use-resubscribe-toggle';
 import {
@@ -85,6 +87,7 @@ type ConfigurationContextState = {
   bonusTexts: BonusTextsType | undefined;
   benefitIdsRequiringValueCode: OperatorBenefitIdType[] | undefined;
   harborConnectionOverrides: HarborConnectionOverrideType[] | undefined;
+  mobilityPriceAdjustments: Record<string, PriceAdjustmentType[]> | undefined;
   firestoreConfigStatus: FirestoreConfigStatus;
   notificationConfig: NotificationConfigType | undefined;
   stopSignalButtonConfig: StopSignalButtonConfigType;
@@ -140,6 +143,9 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
   const [harborConnectionOverrides, setHarborConnectionOverrides] = useState<
     HarborConnectionOverrideType[]
   >([]);
+  const [mobilityPriceAdjustments, setMobilityPriceAdjustments] = useState<
+    Record<string, PriceAdjustmentType[]> | undefined
+  >(undefined);
   const [notificationConfig, setNotificationConfig] = useState<
     NotificationConfigType | undefined
   >();
@@ -262,6 +268,11 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
           if (harborConnectionOverrides) {
             setHarborConnectionOverrides(harborConnectionOverrides);
           }
+
+          setMobilityPriceAdjustments(
+            getMobilityPriceAdjustmentsFromSnapshot(snapshot),
+          );
+
           setFirestoreConfigStatus(!snapshot.empty ? 'success' : 'loading');
 
           const notificationConfig =
@@ -339,6 +350,7 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
       bonusTexts,
       benefitIdsRequiringValueCode,
       harborConnectionOverrides,
+      mobilityPriceAdjustments,
       notificationConfig,
       stopSignalButtonConfig,
       knownQrCodeUrls,
@@ -365,6 +377,7 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
     bonusTexts,
     benefitIdsRequiringValueCode,
     harborConnectionOverrides,
+    mobilityPriceAdjustments,
     notificationConfig,
     stopSignalButtonConfig,
     knownQrCodeUrls,
@@ -738,4 +751,11 @@ function getKnownQrCodeUrlsFromSnapshot(
 ): CompiledKnownQrCodeUrl[] {
   const config = snapshot.docs.find((doc) => doc.id == 'knownQrCodeUrls');
   return mapToKnownQrCodeUrls(config?.data());
+}
+
+function getMobilityPriceAdjustmentsFromSnapshot(
+  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
+): Record<string, PriceAdjustmentType[]> | undefined {
+  const mobilityDoc = snapshot.docs.find((doc) => doc.id == 'mobility');
+  return mapToMobilityPriceAdjustments(mobilityDoc?.get('priceAdjustments'));
 }

--- a/src/modules/configuration/converters.ts
+++ b/src/modules/configuration/converters.ts
@@ -27,6 +27,11 @@ import {
   TransportModeFilterOption,
   TravelSearchPreference,
 } from '@atb-as/config-specs';
+import {
+  PriceAdjustment,
+  type PriceAdjustmentType,
+} from '@atb-as/config-specs/lib/mobility';
+import {z} from 'zod';
 
 export function mapToFareProductTypeConfigs(
   config: any,
@@ -283,6 +288,26 @@ export const mapToStopSignalButtonConfig = (
     ? parseResult.data
     : StopSignalButtonConfig.parse({});
 };
+
+const PriceAdjustmentsByVehicleTypeId = z.record(
+  z.string(),
+  z.array(PriceAdjustment),
+);
+
+export function mapToMobilityPriceAdjustments(
+  data: unknown,
+): Record<string, PriceAdjustmentType[]> | undefined {
+  if (!data) return undefined;
+  const result = PriceAdjustmentsByVehicleTypeId.safeParse(data);
+  if (!result.success) {
+    console.warn(
+      `mapToMobilityPriceAdjustments failed safeParsing:\n`,
+      result.error,
+    );
+    return undefined;
+  }
+  return result.data;
+}
 
 export function mapToKnownQrCodeUrls(config?: any): CompiledKnownQrCodeUrl[] {
   if (!config) return [];

--- a/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
+++ b/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
@@ -53,8 +53,7 @@ export const BikeStationNotIntegratedView = ({
   const {operatorBenefit} = useOperatorBenefit(operatorId);
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const bonusProduct = useRelevantBonusProduct(
-    operatorId,
-    FormFactor.Bicycle,
+    undefined,
     BonusProductTypeEnum.VOUCHER,
   );
   const {logEvent} = useAnalyticsContext();

--- a/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
+++ b/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
@@ -6,9 +6,8 @@ import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {
-  BonusProductTypeEnum,
   PayWithBonusPointsCheckbox,
-  useRelevantBonusProduct,
+  useRelevantVoucherBonusProduct,
 } from '@atb/modules/bonus';
 import {StyleSheet} from '@atb/theme';
 import {ThemedCityBike} from '@atb/theme/ThemedAssets';
@@ -52,10 +51,7 @@ export const BikeStationNotIntegratedView = ({
 
   const {operatorBenefit} = useOperatorBenefit(operatorId);
   const isBonusActiveForUser = useIsBonusActiveForUser();
-  const bonusProduct = useRelevantBonusProduct(
-    undefined,
-    BonusProductTypeEnum.VOUCHER,
-  );
+  const bonusProduct = useRelevantVoucherBonusProduct(operatorId);
   const {logEvent} = useAnalyticsContext();
 
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);

--- a/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
@@ -22,10 +22,9 @@ import {WalkingDistance} from '@atb/components/walking-distance';
 import {MobilityStat} from './MobilityStat';
 import {useDoOnceOnItemReceived} from '../use-do-once-on-item-received';
 import {
-  BonusProductTypeEnum,
   PayWithBonusPointsCheckbox,
   useIsBonusActiveForUser,
-  useRelevantBonusProduct,
+  useRelevantVoucherBonusProduct,
 } from '@atb/modules/bonus';
 import {
   BottomSheetHeaderType,
@@ -68,12 +67,7 @@ export const CarSharingStationBottomSheet = ({
   const {operatorBenefit} = useOperatorBenefit(operatorId);
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
-  const vehicleTypeId =
-    station?.vehicleTypesAvailable?.[0]?.vehicleType.id ?? undefined;
-  const bonusProduct = useRelevantBonusProduct(
-    vehicleTypeId,
-    BonusProductTypeEnum.VOUCHER,
-  );
+  const bonusProduct = useRelevantVoucherBonusProduct(operatorId);
 
   const {logEvent} = useAnalyticsContext();
 

--- a/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
@@ -68,9 +68,10 @@ export const CarSharingStationBottomSheet = ({
   const {operatorBenefit} = useOperatorBenefit(operatorId);
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
+  const vehicleTypeId =
+    station?.vehicleTypesAvailable?.[0]?.vehicleType.id ?? undefined;
   const bonusProduct = useRelevantBonusProduct(
-    operatorId,
-    FormFactor.Car,
+    vehicleTypeId,
     BonusProductTypeEnum.VOUCHER,
   );
 

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -43,10 +43,9 @@ import {TransportationIconBox} from '@atb/components/icon-box';
 import {BrandingImage} from '../BrandingImage';
 import {getTransportModeAndSubMode} from '../../utils';
 import {
-  BonusProductTypeEnum,
   PayWithBonusPointsCheckbox,
   useIsBonusActiveForUser,
-  useRelevantBonusProduct,
+  useRelevantSharedMobilityBonusProduct,
 } from '@atb/modules/bonus';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
@@ -133,10 +132,7 @@ export const VehicleSheet = ({
   } = useFeatureTogglesContext();
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
-  const bonusProduct = useRelevantBonusProduct(
-    vehicleTypeId,
-    BonusProductTypeEnum.SHARED_MOBILITY,
-  );
+  const bonusProduct = useRelevantSharedMobilityBonusProduct(vehicleTypeId);
   const {logEvent} = useAnalyticsContext();
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
 

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -49,6 +49,7 @@ import {
   useRelevantBonusProduct,
 } from '@atb/modules/bonus';
 import {useAnalyticsContext} from '@atb/modules/analytics';
+import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 
 type Props = {
   selectPaymentMethod: () => void;
@@ -103,17 +104,11 @@ export const VehicleSheet = ({
 
   const operator = useOperators().byId(operatorId);
   const operatorIsIntegrationEnabled = operator?.isDeepIntegrationEnabled;
-  const priceAdjustments = (() => {
-    switch (formFactor) {
-      case FormFactor.Bicycle:
-      case FormFactor.Car:
-      case FormFactor.Scooter:
-      case FormFactor.ScooterStanding:
-        return operator?.priceAdjustments?.[formFactor];
-      default:
-        return undefined;
-    }
-  })();
+  const {mobilityPriceAdjustments} = useFirestoreConfigurationContext();
+  const vehicleTypeId = vehicle?.vehicleType.id;
+  const priceAdjustments = vehicleTypeId
+    ? mobilityPriceAdjustments?.[vehicleTypeId]
+    : undefined;
   const operatorLogo = operator?.brandAssets?.brandImageUrl;
 
   const {mode, subMode} = getTransportModeAndSubMode(
@@ -139,8 +134,7 @@ export const VehicleSheet = ({
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const bonusProduct = useRelevantBonusProduct(
-    operatorId,
-    formFactor,
+    vehicleTypeId,
     BonusProductTypeEnum.SHARED_MOBILITY,
   );
   const {logEvent} = useAnalyticsContext();


### PR DESCRIPTION
Resolves AtB-AS/kundevendt#23889

## Summary

Full change overview: https://htmlpreview.github.io/?https://gist.githubusercontent.com/adriansberg/c2b51ea01ae21f4da079342b8ef493bd/raw/explanation.html

Switch shared-mobility bonus product selection and price adjustment display from `operatorId + formFactor` to `vehicleTypeId`. This allows differentiating e.g. manual bikes from e-bikes at the same station.

## Changes

**Bonus product selection:**
- `BonusProduct` type: replace `formFactors: FormFactor[]` with `vehicleTypeIds: string[]`
- Split `useRelevantBonusProduct` into two dedicated hooks — VOUCHER and SHARED_MOBILITY have different match keys in the backend:
  - `useRelevantSharedMobilityBonusProduct(vehicleTypeId)` → matches `productType===SHARED_MOBILITY && vehicleTypeIds.includes(vehicleTypeId)`
  - `useRelevantVoucherBonusProduct(operatorId)` → matches `productType===VOUCHER && operatorId===operatorId`
- `VehicleSheet`: uses `useRelevantSharedMobilityBonusProduct` with `vehicle.vehicleType.id`
- `CarSharingStationBottomSheet` (Hyre): uses `useRelevantVoucherBonusProduct(operatorId)`
- `BicycleSheetNotIntegratedView` (Trondheim Bysykkel): uses `useRelevantVoucherBonusProduct(operatorId)`
- `BonusProductList`: remove now-unused `formFactor` prop

**Price adjustments:**
- `FirestoreConfigurationContext`: add `mobilityPriceAdjustments` state — reads new top-level `priceAdjustments` map from Firestore mobility doc
- `converters.ts`: add `mapToMobilityPriceAdjustments` using `PriceAdjustmentsByVehicleTypeId` zod schema
- `VehicleSheet`: look up price adjustments by `vehicle.vehicleType.id` from the new top-level map instead of `operator.priceAdjustments[formFactor]`

## Dependencies

- Requires config-specs v11 (breaking schema change) — dep bump needed after publish
- Requires firestore-configuration PR merged and deployed
- Requires bonus service PR merged and deployed (for claim endpoint change)

## Test plan

- [ ] `yarn tsc` clean
- [ ] Open vehicle sheet for e-bike vs manual bike at same station → different price adjustments shown
- [ ] Correct shmo bonus product (or none) offered per vehicle type
- [ ] Trondheim Bysykkel non-integrated bike sheet → "pay with bonus points" renders and voucher claim works
- [ ] Hyre car-sharing station sheet → "pay with bonus points" renders and voucher claim works
- [ ] Scooter flow unchanged