### PR TITLE
fix: get fare contracts from context instead of query

### DIFF
--- a/src/modules/ticketing/use-get-has-reservation-or-available-fare-contract.ts
+++ b/src/modules/ticketing/use-get-has-reservation-or-available-fare-contract.ts
@@ -1,20 +1,18 @@
 import {useMemo} from 'react';
 import {useTicketingContext} from '@atb/modules/ticketing';
 import {getReservationStatus} from '@atb/modules/fare-contracts';
-import {
-  getFilterdFareContracts,
-  useGetFareContractsQuery,
-} from './use-fare-contracts';
+import {getFilterdFareContracts, useFareContracts} from './use-fare-contracts';
 import {FareContractType} from '@atb-as/utils';
 import {isDefined} from '@atb/utils/presence';
+import {useTimeContext} from '../time';
 
 export const useGetHasReservationOrAvailableFareContract = () => {
   const {reservations} = useTicketingContext();
-
-  const {data: fareContracts} = useGetFareContractsQuery({
-    enabled: true,
-    availability: 'available',
-  });
+  const {serverNow} = useTimeContext();
+  const {fareContracts} = useFareContracts(
+    {availability: 'available', status: 'valid'},
+    serverNow,
+  );
 
   const hasReservationOrAvailableFareContract = useMemo(
     () => () => {


### PR DESCRIPTION
This fixes a bug where the fare contract warning screen doesn't appear when stream service is disabled and there haven't been any reloads of the fare contract list data since purchase of a ticket.

