### PR TITLE
refactor: replace individual margins with gap in trip search

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -121,6 +121,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
 
   const {from, to} = useLocations(currentLocation);
   const tripSearchEnabled = isValidTripLocations(from, to);
+  const hasLocations = !!from && !!to;
 
   const filtersState = useTravelSearchFiltersState();
 
@@ -379,9 +380,9 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
           </View>
         )}
       >
-        <View>
+        <View style={styles.contentContainer}>
           <ScreenReaderAnnouncement message={searchStateMessage} />
-          {(!from || !to) && (
+          {!hasLocations && (
             <ThemeText
               type="secondary"
               style={styles.missingLocationText}
@@ -390,73 +391,70 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
               {t(TripSearchTexts.searchState.noResultReason.MissingLocation)}
             </ThemeText>
           )}
-          <View style={styles.globalMessage}>
-            <GlobalMessage
-              textColor={theme.color.background.neutral[0]}
-              globalMessageContext={GlobalMessageContextEnum.appTripResults}
-              ruleVariables={{
-                transportModes: tripPatterns
-                  .flatMap((tp) => tp.legs)
-                  .map((leg) => leg.mode)
-                  .filter(isDefined)
-                  .filter(onlyUniques),
-                transportSubmodes: tripPatterns
-                  .flatMap((tp) => tp.legs)
-                  .map((leg) => leg.transportSubmode)
-                  .filter(isDefined)
-                  .filter(onlyUniques),
-                authorities: tripPatterns
-                  .flatMap((tp) => tp.legs)
-                  .map((leg) => leg.authority?.id)
-                  .filter(isDefined)
-                  .filter(onlyUniques),
-                publicCodes: tripPatterns
-                  .flatMap((tp) => tp.legs)
-                  .map((leg) => leg.line?.publicCode)
-                  .filter(isDefined)
-                  .filter(onlyUniques),
-              }}
-            />
-          </View>
-          {from && to && (
-            <View>
-              {isFlexibleTransportEnabled &&
-                !flexibleTransportInfoDismissed &&
-                (tripPatterns.length > 0 ||
-                  tripsSearchState === 'search-empty-result') &&
-                !tripsIsError && (
-                  <CityZoneMessage
-                    from={from}
-                    to={to}
-                    onDismiss={() => {
-                      setFlexibleTransportInfoDismissed(true);
-                      analytics.logEvent(
-                        'Flexible transport',
-                        'Message box dismissed',
-                      );
-                    }}
-                  />
-                )}
-              {tripSearchEnabled && (
-                <NonTransitResults
-                  tripsProps={tripsProps}
-                  onDetailsPressed={onPressed}
-                />
-              )}
-              <Results
-                tripPatterns={tripPatterns}
-                isSearching={isSearching}
-                showEmptyScreen={showEmptyScreen}
-                isEmptyResult={isEmptyResult}
-                resultReasons={noResultReasons}
-                onDetailsPressed={(tripPattern, resultIndex) =>
-                  onPressed(tripPattern, {analyticsMetadata: {resultIndex}})
-                }
-                tripsIsError={tripsIsError}
-                tripsIsNetworkError={tripsIsNetworkError}
-                searchTime={searchTime}
+          <GlobalMessage
+            textColor={theme.color.background.neutral[0]}
+            style={styles.globalMessage}
+            globalMessageContext={GlobalMessageContextEnum.appTripResults}
+            ruleVariables={{
+              transportModes: tripPatterns
+                .flatMap((tp) => tp.legs)
+                .map((leg) => leg.mode)
+                .filter(isDefined)
+                .filter(onlyUniques),
+              transportSubmodes: tripPatterns
+                .flatMap((tp) => tp.legs)
+                .map((leg) => leg.transportSubmode)
+                .filter(isDefined)
+                .filter(onlyUniques),
+              authorities: tripPatterns
+                .flatMap((tp) => tp.legs)
+                .map((leg) => leg.authority?.id)
+                .filter(isDefined)
+                .filter(onlyUniques),
+              publicCodes: tripPatterns
+                .flatMap((tp) => tp.legs)
+                .map((leg) => leg.line?.publicCode)
+                .filter(isDefined)
+                .filter(onlyUniques),
+            }}
+          />
+          {isFlexibleTransportEnabled &&
+            !flexibleTransportInfoDismissed &&
+            (tripPatterns.length > 0 ||
+              tripsSearchState === 'search-empty-result') &&
+            !tripsIsError && (
+              <CityZoneMessage
+                from={from}
+                to={to}
+                onDismiss={() => {
+                  setFlexibleTransportInfoDismissed(true);
+                  analytics.logEvent(
+                    'Flexible transport',
+                    'Message box dismissed',
+                  );
+                }}
               />
-            </View>
+            )}
+          {tripSearchEnabled && (
+            <NonTransitResults
+              tripsProps={tripsProps}
+              onDetailsPressed={onPressed}
+            />
+          )}
+          {hasLocations && (
+            <Results
+              tripPatterns={tripPatterns}
+              isSearching={isSearching}
+              showEmptyScreen={showEmptyScreen}
+              isEmptyResult={isEmptyResult}
+              resultReasons={noResultReasons}
+              onDetailsPressed={(tripPattern, resultIndex) =>
+                onPressed(tripPattern, {analyticsMetadata: {resultIndex}})
+              }
+              tripsIsError={tripsIsError}
+              tripsIsNetworkError={tripsIsNetworkError}
+              searchTime={searchTime}
+            />
           )}
           {!tripPatterns.length && <View style={styles.emptyResultsSpacer} />}
           {!tripsIsError && isValidLocations && (
@@ -703,7 +701,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     textAlign: 'center',
   },
   loadMoreButton: {
-    paddingVertical: theme.spacing.xLarge,
+    paddingVertical: theme.spacing.medium,
     marginBottom: theme.spacing.xLarge,
     flex: 1,
     flexDirection: 'row',
@@ -712,8 +710,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   emptyResultsSpacer: {
     marginTop: theme.spacing.xLarge * 3,
   },
+  contentContainer: {
+    gap: theme.spacing.medium,
+    marginTop: theme.spacing.medium,
+  },
   globalMessage: {
-    paddingHorizontal: theme.spacing.medium,
-    paddingTop: theme.spacing.medium,
+    marginHorizontal: theme.spacing.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
@@ -206,7 +206,6 @@ const useActionButtons = (cityZone?: CityZone) => {
 
 export const useStyle = StyleSheet.createThemeHook((theme) => ({
   cityZoneMessage: {
-    marginTop: theme.spacing.medium,
     marginHorizontal: theme.spacing.medium,
   },
   container: {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/DayLabel.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/DayLabel.tsx
@@ -51,7 +51,6 @@ export function DayLabel({
 const useDayTextStyle = StyleSheet.createThemeHook((theme) => ({
   title: {
     paddingHorizontal: theme.spacing.xLarge,
-    paddingTop: theme.spacing.medium,
     color: theme.color.foreground.dynamic.secondary,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults.tsx
@@ -37,7 +37,6 @@ export const NonTransitResults = ({tripsProps, onDetailsPressed}: Props) => {
   return (
     <ScrollView
       horizontal={true}
-      style={style.scrollView}
       contentContainerStyle={style.container}
       showsHorizontalScrollIndicator={false}
     >
@@ -93,9 +92,6 @@ const getMode = (
 };
 
 const useStyle = StyleSheet.createThemeHook((theme) => ({
-  scrollView: {
-    marginTop: theme.spacing.medium,
-  },
   container: {
     paddingHorizontal: theme.spacing.medium,
   },


### PR DESCRIPTION
Use gap and marginTop on the content container instead of
individual marginTop/paddingTop on child components
(GlobalMessage, CityZoneMessage, DayLabel, NonTransitResults).

Remove the inner wrapper View for from/to results — children
are now direct siblings in the gap layout. GlobalMessage is
rendered without a wrapper so it takes no space when empty.

**Before/After**
<div>
<img width="325" src="https://github.com/user-attachments/assets/741357c1-aed6-428f-8220-64207a5b0889" />
<img width="325" src="https://github.com/user-attachments/assets/d25cd634-b288-4acd-986b-db29ce6483bc" />
</div>

### Acceptance criteria
- [x] Should no longer be 36px margin above non transit results, but 24px instead.
- [x] Margins should look ok with other components on the trip search screen, like global message, empty results, city zone message.
