### PR TITLE
fix: add missing key prop in LocationIcon list render

### DIFF
--- a/src/components/location-icon/LocationIcon.tsx
+++ b/src/components/location-icon/LocationIcon.tsx
@@ -43,7 +43,11 @@ export const LocationIcon = ({
 
       return multiple ? (
         <View style={styles.multipleIconsContainer}>
-          {venueIconTypes.map((it) => mapTypeToIconComponent(it))}
+          {venueIconTypes.map((it) => (
+            <React.Fragment key={it}>
+              {mapTypeToIconComponent(it)}
+            </React.Fragment>
+          ))}
         </View>
       ) : (
         mapTypeToIconComponent(venueIconTypes[0])
@@ -88,9 +92,7 @@ const mapTypeToIconComponent = (
       );
     case 'unknown':
     default:
-      return (
-        <ThemeIcon svg={Pin} accessibilityLabel="Lokasjon" key="unknown" />
-      );
+      return <ThemeIcon svg={Pin} accessibilityLabel="Lokasjon" />;
   }
 };
 


### PR DESCRIPTION
Wrap each mapped venue icon in React.Fragment with the icon
type as key, and remove the stale key="unknown" that was set
inside mapTypeToIconComponent.

Fixes this error:
```
console.js:662 Each child in a list should have a unique "key" prop.

Check the render method of `View`. It was passed a child from LocationIcon. See https://react.dev/link/warning-keys for more information. Error Stack:
    at mapTypeToIconComponent (LocationIcon.tsx:63:9)
    at _temp (LocationIcon.tsx:46:61)
    at map (native)
    at LocationIcon (LocationIcon.tsx:46:30)
    at _t (LocationResults.tsx:71:18)
    at map (native)
    at LocationResults (LocationResults.tsx:42:53)
    ...
```
