### PR TITLE
refactor: add MarginStyle for stricter style props

### DIFF
--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import {StyleProp, View, ViewStyle} from 'react-native';
-import {Statuses, StyleSheet, useThemeContext} from '@atb/theme';
+import {StyleProp, View} from 'react-native';
+import {
+  type MarginStyle,
+  Statuses,
+  StyleSheet,
+  useThemeContext,
+} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import MessageBoxTexts from '@atb/translations/components/MessageBox';
@@ -41,7 +46,7 @@ export type MessageInfoBoxProps = {
   noStatusIcon?: boolean;
   onDismiss?: () => void;
   isMarkdown?: boolean;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<MarginStyle>;
   onPressConfig?: OnPressConfig;
   a11yLiveRegion?: A11yLiveRegion;
   a11yLabel?: string;

--- a/src/components/message-info-text/MessageInfoText.tsx
+++ b/src/components/message-info-text/MessageInfoText.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import {ColorValue, StyleProp, View, ViewStyle} from 'react-native';
-import {Statuses, StyleSheet, useThemeContext} from '@atb/theme';
+import {ColorValue, StyleProp, View} from 'react-native';
+import {
+  type MarginStyle,
+  Statuses,
+  StyleSheet,
+  useThemeContext,
+} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
@@ -10,7 +15,7 @@ export type MessageInfoTextProps = {
   type: Statuses;
   message: string;
   a11yLabel?: string;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<MarginStyle>;
   testID?: string;
   iconPosition?: 'right' | 'left';
   textColor?: ContrastColor | ColorValue;

--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -218,7 +218,6 @@ export const DetailsContent: React.FC<Props> = ({
               }
               textColor={theme.color.background.neutral[0]}
               ruleVariables={globalMessageRuleVariables}
-              style={styles.globalMessages}
             />
           </View>
         </GenericSectionItem>

--- a/src/modules/global-messages/GlobalMessage.tsx
+++ b/src/modules/global-messages/GlobalMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useTranslation} from '@atb/translations';
 import {useGlobalMessagesContext} from './GlobalMessagesContext';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {StyleProp, ViewStyle} from 'react-native';
+import {StyleProp} from 'react-native';
 import {GlobalMessageContextEnum, GlobalMessageType} from './types';
 import {getTextForLanguage} from '@atb/translations';
 import {useNow} from '@atb/utils/use-now';
@@ -12,10 +12,11 @@ import {ContrastColor} from '@atb/theme/colors';
 import {ColorValue} from 'react-native';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {useAuthContext} from '@atb/modules/auth';
+import type {MarginStyle} from '@atb/theme';
 
 type Props = {
   globalMessageContext?: GlobalMessageContextEnum;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<MarginStyle>;
   includeDismissed?: boolean;
   ruleVariables?: RuleVariables;
   textColor?: ContrastColor | ColorValue;

--- a/src/modules/payment/SelectPaymentMethodSheet.tsx
+++ b/src/modules/payment/SelectPaymentMethodSheet.tsx
@@ -175,7 +175,6 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
 
         {authenticationType !== 'phone' && (
           <MessageInfoText
-            style={styles.warningMessageAnonym}
             message={t(AnonymousPurchases.consequences.select_payment_method)}
             type="warning"
           />
@@ -202,9 +201,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   confirmButton: {
     marginTop: theme.spacing.small,
-  },
-  warningMessageAnonym: {
-    paddingTop: theme.spacing.medium,
-    paddingLeft: theme.spacing.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -238,7 +238,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                   PurchaseOverviewTexts.errorMessageBox.productUnavailable
                     .message,
                 )}
-                style={styles.selectionComponent}
               />
             ) : (
               <MessageInfoBox
@@ -249,7 +248,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                   action: refreshOffer,
                   text: t(dictionary.retry),
                 }}
-                style={styles.selectionComponent}
               />
             ))}
 
@@ -336,7 +334,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             <MessageInfoBox
               type="valid"
               message={t(PurchaseOverviewTexts.summary.free)}
-              style={styles.messages}
+              style={styles.isFreeMessage}
             />
           ) : (
             <View style={styles.messages}>
@@ -416,6 +414,9 @@ const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => {
       rowGap: theme.spacing.medium,
       margin: theme.spacing.medium,
       marginBottom: bottom + theme.spacing.medium,
+    },
+    isFreeMessage: {
+      marginTop: theme.spacing.medium,
     },
     messages: {
       rowGap: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/ErrorWithAccountMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/ErrorWithAccountMessage.tsx
@@ -1,10 +1,11 @@
 import {useAuthContext} from '@atb/modules/auth';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import {MessageInfoBox} from '@atb/components/message-info-box';
-import {StyleProp, ViewStyle} from 'react-native';
+import {StyleProp} from 'react-native';
 import {useAnalyticsContext} from '@atb/modules/analytics';
+import type {MarginStyle} from '@atb/theme';
 
-type Props = {style?: StyleProp<ViewStyle>};
+type Props = {style?: StyleProp<MarginStyle>};
 
 export const ErrorWithAccountMessage = ({style}: Props) => {
   const {authStatus, retryAuth} = useAuthContext();

--- a/src/theme/StyleSheet.ts
+++ b/src/theme/StyleSheet.ts
@@ -13,6 +13,9 @@ export type NamedStyles<T> = {
 };
 export type ThemedStyles<T> = (theme: Theme, insets: EdgeInsets) => T;
 
+// MarginStyle is a subset of ViewStyle containing only margin-related
+// fields, e.g. 'margin', 'marginTop', 'marginHorizontal', etc. All other
+// ViewStyle fields are typed as `never`, so they cannot be set.
 type MarginKeys = Extract<keyof ViewStyle, `margin${string}`>;
 export type MarginStyle = Pick<ViewStyle, MarginKeys> & {
   [K in Exclude<keyof ViewStyle, MarginKeys>]?: never;

--- a/src/theme/StyleSheet.ts
+++ b/src/theme/StyleSheet.ts
@@ -13,9 +13,14 @@ export type NamedStyles<T> = {
 };
 export type ThemedStyles<T> = (theme: Theme, insets: EdgeInsets) => T;
 
+type MarginKeys = Extract<keyof ViewStyle, `margin${string}`>;
+export type MarginStyle = Pick<ViewStyle, MarginKeys> & {
+  [K in Exclude<keyof ViewStyle, MarginKeys>]?: never;
+};
+
 type StyleSheetType = typeof StyleSheetNative;
 interface ExtendedStyleSheet extends StyleSheetType {
-  createThemeHook<T>(input: ThemedStyles<NamedStyles<T>>): () => NamedStyles<T>;
+  createThemeHook<T extends NamedStyles<T>>(input: ThemedStyles<T>): () => T;
 }
 
 export function useStyle<T extends NamedStyles<T>>(
@@ -35,9 +40,7 @@ function isThemedStyles<T>(style: any): style is ThemedStyles<T> {
 
 export const StyleSheet: ExtendedStyleSheet = {
   ...StyleSheetNative,
-  createThemeHook<T>(
-    input: ThemedStyles<NamedStyles<T>>,
-  ): () => NamedStyles<T> {
+  createThemeHook<T extends NamedStyles<T>>(input: ThemedStyles<T>): () => T {
     return function useThemeStyle() {
       return useStyle(input);
     };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,4 @@
 export * from './colors';
 
-export {StyleSheet, useStyle} from './StyleSheet';
+export {StyleSheet, useStyle, type MarginStyle} from './StyleSheet';
 export {useThemeContext} from './ThemeContext';


### PR DESCRIPTION
Introduce MarginStyle which only allows margin-related ViewStyle
keys, and apply it to MessageInfoBox, MessageInfoText, and
GlobalMessage so callers can only pass margins via style.

Update createThemeHook to preserve narrow inferred types, so
styles created via useStyles flow through without casts. Clean
up callers that previously passed non-margin properties.

This is done kinda as a PoC because of [this comment](https://github.com/AtB-AS/mittatb-app/pull/6118#discussion_r3317384262), which correctly pinpoints that the ability to send in styles from outside to components is a risk factor. But trying to remove the style on MessageBox is too large a change, so making a more narrow MarginStyle was more manageable.

### Acceptance criteria
Verify some message boxes/texts in the app that they look as intended:
- [x] Message-boxes on the purchase overview screen (just check some of them, not necessary with all)
- [x] The anonymous warning message info text on select payment method bottom sheet
- [x] Global message on fare contract details
