### PR TITLE
fix: walk leg can use expected time

### DIFF
--- a/src/screen-components/travel-details-screens/components/Time.tsx
+++ b/src/screen-components/travel-details-screens/components/Time.tsx
@@ -64,7 +64,7 @@ export const Time: React.FC<{
     case 'no-realtime': {
       return (
         <ThemeText typography="body__m__strong" testID="schCaTime">
-          {scheduled}
+          {expected || scheduled}
         </ThemeText>
       );
     }

--- a/src/screen-components/travel-details-screens/components/Time.tsx
+++ b/src/screen-components/travel-details-screens/components/Time.tsx
@@ -61,20 +61,11 @@ export const Time: React.FC<{
         </View>
       );
     }
-    case 'no-realtime': {
-      return (
-        <ThemeText typography="body__m__strong" testID="schCaTime">
-          {expected || scheduled}
-        </ThemeText>
-      );
-    }
     default: {
       return (
-        <View style={styles.rowContainer}>
-          <ThemeText typography="body__m__strong" testID="schTime">
-            {expected}
-          </ThemeText>
-        </View>
+        <ThemeText typography="body__m__strong" testID="schTime">
+          {expected || scheduled}
+        </ThemeText>
       );
     }
   }

--- a/src/screen-components/travel-details-screens/legacy/Time.tsx
+++ b/src/screen-components/travel-details-screens/legacy/Time.tsx
@@ -57,15 +57,8 @@ export const Time: React.FC<{
         </View>
       );
     }
-    case 'no-realtime': {
-      return <ThemeText testID="schCaTime">{expected || scheduled}</ThemeText>;
-    }
     default: {
-      return (
-        <View style={{flexDirection: 'row', alignItems: 'center'}}>
-          <ThemeText testID="schTime">{expected}</ThemeText>
-        </View>
-      );
+      return <ThemeText testID="schTime">{expected || scheduled}</ThemeText>;
     }
   }
 };

--- a/src/screen-components/travel-details-screens/legacy/Time.tsx
+++ b/src/screen-components/travel-details-screens/legacy/Time.tsx
@@ -58,7 +58,7 @@ export const Time: React.FC<{
       );
     }
     case 'no-realtime': {
-      return <ThemeText testID="schCaTime">{scheduled}</ThemeText>;
+      return <ThemeText testID="schCaTime">{expected || scheduled}</ThemeText>;
     }
     default: {
       return (


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/22871#issuecomment-4543787406

## Description
In a trip pattern which involves a transit, the walk leg has `expected` time and not just `aimed` time, even though it is a `no-realtime` part of the trip.

Currently, when the time is updated due to a delayed bus trip, the start of walk leg is not updated according to the schedule, because it kept on using the `aimed` time, which is the original time.

This PR attempts to fix it by using `expected` time whenever available, so the trip timing is consistent across legs.