### PR TITLE
fix: render bonus product groups from transport mode

### DIFF
--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -10,9 +10,8 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {StyleSheet} from '@atb/theme';
-import {getTransportModeAndSubMode} from '@atb/modules/mobility';
+import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {TransportationIconBox} from '@atb/components/icon-box';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -89,23 +88,19 @@ export const BonusProductList = ({
             <Section>
               <GenericSectionItem>
                 <View style={styles.horizontalContainer}>
-                  {(() => {
-                    const {mode, subMode} = getTransportModeAndSubMode(
-                      formFactors[0],
-                    );
-                    return (
-                      <TransportationIconBox
-                        mode={mode}
-                        subMode={subMode}
-                        rounded
-                      />
-                    );
-                  })()}
+                  <TransportationIconBox
+                    mode={group.transportMode}
+                    subMode={group.transportSubMode ?? undefined}
+                    rounded
+                  />
                   <View style={{flex: 1}} accessible={true}>
                     <ThemeText typography="body__s__strong">
-                      {formFactors
-                        .map((ff) => t(MobilityTexts.vehicleName(ff)))
-                        .join(', ')}
+                      {t(
+                        getTranslatedModeName(
+                          group.transportMode,
+                          group.transportSubMode ?? undefined,
+                        ),
+                      )}
                     </ThemeText>
                     <ThemeText typography="body__s" type="secondary">
                       {operatorNames}

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -1,6 +1,10 @@
 import {FormFactorSchema} from '@atb/api/types/mobility';
 import {LanguageAndTextTypeArray} from '@atb/modules/configuration';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
+import {
+  TransportModeType,
+  TransportSubmodeType,
+} from '@atb-as/config-specs/lib/common';
 import {z} from 'zod';
 import {optionalNullish} from '@atb-as/config-specs/lib/utils/nullish';
 
@@ -55,6 +59,8 @@ export const BonusProductGroupSchema = z.object({
   id: z.string(),
   description: LanguageAndTextTypeArray,
   price: PriceSchema,
+  transportMode: TransportModeType,
+  transportSubMode: optionalNullish(TransportSubmodeType),
 });
 
 export type BonusProductGroupType = z.infer<typeof BonusProductGroupSchema>;

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -62,6 +62,10 @@ const dictionary = {
         ..._('Sykkel', 'Bicycle', `Sykkel`),
         definite: _('Sykkelen', 'The bicycle', 'Sykkelen'),
       },
+      scooter: {
+        ..._('Sparkesykkel', 'Scooter', `Sparkesykkel`),
+        definite: _('Sparkesykkelen', 'The scooter', 'Sparkesykkelen'),
+      },
       unknown: {
         ..._(
           'Ukjent transportmiddel',
@@ -79,6 +83,30 @@ const dictionary = {
       nightBus: {
         ..._('Nattbuss', 'Night bus', `Nattbuss`),
         definite: _('Nattbussen', 'The night bus', 'Nattbussen'),
+      },
+      escooter: {
+        ..._(
+          'Elektrisk sparkesykkel',
+          'Electric scooter',
+          'Elektrisk sparkesykkel',
+        ),
+        definite: _(
+          'Den elektriske sparkesykkelen',
+          'The electric scooter',
+          'Den elektriske sparkesykkelen',
+        ),
+      },
+      ebicycle: {
+        ..._('Elektrisk bysykkel', 'Electric city bike', 'Elektrisk bysykkel'),
+        definite: _(
+          'Den elektriske bysykkelen',
+          'The electric city bike',
+          'Den elektriske bysykkelen',
+        ),
+      },
+      hireCycle: {
+        ..._('Bysykkel', 'City bike', 'Bysykkel'),
+        definite: _('Bysykkelen', 'The city bike', 'Bysykkelen'),
       },
     },
     line: _('Linje', 'Line', 'Linje'),

--- a/src/utils/transportation-names.ts
+++ b/src/utils/transportation-names.ts
@@ -42,7 +42,22 @@ export function getTranslatedModeName(
       result = legModeNames.metro;
       break;
     case 'bicycle':
+      if (subMode === 'ebicycle') {
+        result = legSubModeNames.ebicycle;
+        break;
+      }
+      if (subMode === 'hireCycle') {
+        result = legSubModeNames.hireCycle;
+        break;
+      }
       result = legModeNames.bicycle;
+      break;
+    case 'scooter':
+      if (subMode === 'escooter') {
+        result = legSubModeNames.escooter;
+        break;
+      }
+      result = legModeNames.scooter;
       break;
     case 'car':
       result = legModeNames.car;


### PR DESCRIPTION
## Summary
- `BonusProductList` now renders each group's icon + heading from a backend-supplied `(transportMode, transportSubMode)` pair via `TransportationIconBox` + `getTranslatedModeName`, instead of deriving from member-product `formFactors`.
- Fixes TICKET-type groups (empty `form_factors` → "unknown" icon + blank heading) and the SCOOTER/SCOOTER_STANDING "Scooter, Scooter" duplicity.
- Adds `legModes.scooter` and `legSubModes` `escooter`/`ebicycle`/`hireCycle`; extends `getTranslatedModeName` (scooter + electric/city-bike variants). Shared journey-planner mode strings untouched.
- `formFactors`/`operatorId` still drive the map button + operator subtitle (mobility only).

Fixes AtB-AS/kundevendt#23893. Backend: AtB-AS/bonus#37.

## Note
Wording strings (esp. bicycle "Bysykkel" vs "Sykkel") use existing `MobilityTexts.vehicleName` values — confirm with design.

## Test plan
- [ ] `yarn tsc` clean (no casts)
- [ ] Poeng screen: TICKET group → transit icon + label, no operator/map row
- [ ] Scooter group → single icon + "Electric scooter"
- [ ] Bicycle group → "Electric city bike" / "City bike"; other mobility unchanged