### PR TITLE
fix: new trip details screen fixes

### DIFF
--- a/src/components/message-info-box/MessageInfoBox.tsx
+++ b/src/components/message-info-box/MessageInfoBox.tsx
@@ -98,7 +98,17 @@ export const MessageInfoBox = ({
     <NativeButtonOrView
       onClick={onPress}
       style={[styles.container, style]}
-      accessible={false}
+      accessible={onPressConfig ? true : false}
+      accessibilityRole={
+        onPressConfig && ('action' in onPressConfig ? 'button' : 'link')
+      }
+      accessibilityLabel={onPressConfig ? a11yLabelInternal : undefined}
+      accessibilityHint={
+        onPressConfig &&
+        ('action' in onPressConfig
+          ? t(MessageBoxTexts.a11yHintActionPrefix)
+          : t(MessageBoxTexts.a11yHintUrlPrefix)) + onPressConfig.text
+      }
       testID={testID}
       focusRef={focusRef}
       type="block"
@@ -110,19 +120,7 @@ export const MessageInfoBox = ({
           {...iconColorProps}
         />
       )}
-      <View
-        style={styles.content}
-        accessibilityRole={
-          onPressConfig && ('action' in onPressConfig ? 'button' : 'link')
-        }
-        accessibilityHint={
-          onPressConfig &&
-          ('action' in onPressConfig
-            ? t(MessageBoxTexts.a11yHintActionPrefix)
-            : t(MessageBoxTexts.a11yHintUrlPrefix)) + onPressConfig.text
-        }
-        {...liveRegionA11yProps}
-      >
+      <View style={styles.content} {...liveRegionA11yProps}>
         {title && (
           <ThemeText
             typography="body__m__strong"

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -386,12 +386,20 @@ export const TripSection: React.FC<TripSectionProps> = ({
           </TripRow>
         )}
         {leg.situations.map((situation) => (
-          <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS} key={situation.id}>
+          <TripRow
+            dimensionOverrides={NEW_TRIP_DIMENSIONS}
+            key={situation.id}
+            accessible={false}
+          >
             <SituationMessageBox situation={situation} />
           </TripRow>
         ))}
         {notices.map((notice) => (
-          <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS} key={notice.id}>
+          <TripRow
+            dimensionOverrides={NEW_TRIP_DIMENSIONS}
+            key={notice.id}
+            accessible={false}
+          >
             <MessageInfoBox type="info" message={notice.text} />
           </TripRow>
         ))}

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -611,7 +611,7 @@ const IntermediateInfo = ({
       <TripRow
         dimensionOverrides={NEW_TRIP_DIMENSIONS}
         testID={`${testID}IntermediateStops`}
-        accessible={true}
+        accessible={false}
       >
         <Button
           type="small"
@@ -635,8 +635,9 @@ const IntermediateInfo = ({
             ) + screenReaderPause
           }
           accessibilityHint={t(
-            TripDetailsTexts.trip.leg.intermediateStops.a11yHint,
+            TripDetailsTexts.trip.leg.intermediateStops.a11yHint(expanded),
           )}
+          accessibilityState={{expanded}}
         />
       </TripRow>
       {expanded &&

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -365,9 +365,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
                 spacious
                 rounded
               />
-              <ThemeText>
-                {getLineDestinationName(t, leg)}
-              </ThemeText>
+              <ThemeText>{getLineDestinationName(t, leg)}</ThemeText>
             </View>
             {isFlexible && (
               <ThemeText

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -365,7 +365,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
                 spacious
                 rounded
               />
-              <ThemeText typography="body__m__strong">
+              <ThemeText>
                 {getLineDestinationName(t, leg)}
               </ThemeText>
             </View>

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -881,9 +881,11 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   return (
     <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS} accessible={false}>
       <View style={style.authoritySection}>
-        <ThemeText typography="body__s" type="secondary" accessible={false}>
-          {t(TripDetailsTexts.trip.leg.buyTicketFrom)}
-        </ThemeText>
+        <View aria-hidden accessible={false}>
+          <ThemeText typography="body__s" type="secondary">
+            {t(TripDetailsTexts.trip.leg.buyTicketFrom)}
+          </ThemeText>
+        </View>
         <Button
           accessibilityRole="link"
           accessibilityLabel={t(

--- a/src/screen-components/travel-details-screens/legacy/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/legacy/TripSection.tsx
@@ -452,7 +452,7 @@ const IntermediateInfo = ({
         ) + screenReaderPause
       }
       accessibilityHint={t(
-        TripDetailsTexts.trip.leg.intermediateStops.a11yHint,
+        TripDetailsTexts.trip.leg.intermediateStops.a11yHint(false),
       )}
     >
       <ThemeText typography="body__s" type="secondary">

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -277,11 +277,18 @@ const TripDetailsTexts = {
               : `${count} intermediate stop (${duration})`,
             `${count} mellomstopp (${duration})`,
           ),
-        a11yHint: _(
-          'Aktivér for å vise alle mellomstopp.',
-          'Activate to show intermediate stops',
-          'Aktiver for å vise alle mellomstopp',
-        ),
+        a11yHint: (expanded: boolean) =>
+          expanded
+            ? _(
+                'Aktivér for å skjule alle mellomstopp.',
+                'Activate to hide intermediate stops',
+                'Aktiver for å skjule alle mellomstopp',
+              )
+            : _(
+                'Aktivér for å vise alle mellomstopp.',
+                'Activate to show intermediate stops',
+                'Aktiver for å vise alle mellomstopp',
+              ),
       },
       walk: {
         label: (duration: string) =>


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/22871#issuecomment-4554385940

## Description
Addresses the following issues:
- [x] Should line name be in bold or not? Seems like it's not in bold in the sketches
  **Updated to use regular text**
- [x] The info "Passed X at 12:35" is not focused and thus not read by screen reader
  **The information is included in the bus line when it is focused by the screen reader**
- [x] Different behaviour for "Ticket can be bought from" in VoiceOver (focuses on link and read the label with it) vs TalkBack (focuses on label and then focus on link where it also reads the label)
  **Updated to have the same behavior**
- [x] VoiceOver only reads the text on the intermediate stops button. No role is read. TalkBack reads "button". However, TalkBack still reads "activate to show intermediate stops" when it's not collapsed.
  **Updated the intermediate stops button a11y**
- [x] VoiceOver does not read role "button" on notifications that contains a link
  **Updated the MessageInfoBox to have better a11y interaction**
- [x] With TalkBack it seems that it skips to focus (and thus read) the reservation warning for AtB Bestill.
  **Different behavior between android devices, can't reproduce.**
- [x] Possible to align the text within the border for intermediate stops on large zoom (190% on iOS). See screenshot.
  **Requires major overhaul, so we let it slide for now**