### PR TITLE
feat: add My coupon codes screen for AtB Bonus

### DIFF
--- a/src/modules/bonus/api/api.ts
+++ b/src/modules/bonus/api/api.ts
@@ -4,6 +4,8 @@ import {
   BonusProductGroupType,
   BonusProductSchema,
   BonusProductType,
+  BonusVoucher,
+  BonusVoucherSchema,
 } from '../types';
 import {z} from 'zod';
 
@@ -88,4 +90,12 @@ export const getActiveBonusProductGroups = async (): Promise<
   });
 
   return z.array(BonusProductGroupSchema).parse(response.data);
+};
+
+export const getBonusVouchers = async (): Promise<BonusVoucher[]> => {
+  const response = await client.get(`/bonus/v2/vouchers`, {
+    authWithIdToken: true,
+  });
+
+  return z.array(BonusVoucherSchema).parse(response.data);
 };

--- a/src/modules/bonus/components/UserBonusBalanceContent.tsx
+++ b/src/modules/bonus/components/UserBonusBalanceContent.tsx
@@ -61,7 +61,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   currentBalanceDisplay: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: theme.spacing.medium,
+    gap: theme.spacing.xSmall,
     minHeight: theme.typography['heading__xl'].lineHeight,
   },
 }));

--- a/src/modules/bonus/index.ts
+++ b/src/modules/bonus/index.ts
@@ -17,12 +17,14 @@ export {
   useProductPointsQuery,
   useActiveBonusProductsQuery,
   useActiveBonusProductGroupsQuery,
+  useBonusVouchersQuery,
 } from './queries';
 export {BonusProductTypeEnum} from './types';
 export type {
   BonusProductType,
   BonusProductGroupType,
   TicketRuleType,
+  BonusVoucher,
 } from './types';
 export {
   bonusOnboardingCarouselConfig,

--- a/src/modules/bonus/queries/index.tsx
+++ b/src/modules/bonus/queries/index.tsx
@@ -7,3 +7,4 @@ export {
 export {useProductPointsQuery} from './use-product-points-query';
 export {useActiveBonusProductsQuery} from './use-active-bonus-products-query';
 export {useActiveBonusProductGroupsQuery} from './use-active-bonus-product-groups-query';
+export {useBonusVouchersQuery} from './use-bonus-vouchers-query';

--- a/src/modules/bonus/queries/use-bonus-vouchers-query.tsx
+++ b/src/modules/bonus/queries/use-bonus-vouchers-query.tsx
@@ -1,0 +1,23 @@
+import {useQuery} from '@tanstack/react-query';
+import {useAuthContext} from '@atb/modules/auth';
+import {getBonusVouchers} from '../api/api';
+import {useIsBonusActiveForUser} from '../use-is-bonus-active-for-user';
+
+export const getBonusVouchersQueryKey = (userId: string | undefined) => {
+  return ['bonusVouchers', userId];
+};
+
+export const useBonusVouchersQuery = () => {
+  const {userId, authStatus, authenticationType} = useAuthContext();
+  const isBonusActiveForUser = useIsBonusActiveForUser();
+  const isEnabled =
+    authStatus === 'authenticated' &&
+    authenticationType === 'phone' &&
+    isBonusActiveForUser;
+
+  return useQuery({
+    enabled: isEnabled,
+    queryKey: getBonusVouchersQueryKey(userId),
+    queryFn: getBonusVouchers,
+  });
+};

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -64,3 +64,11 @@ export const BonusProductGroupSchema = z.object({
 });
 
 export type BonusProductGroupType = z.infer<typeof BonusProductGroupSchema>;
+
+export const BonusVoucherSchema = z.object({
+  operator: z.string(),
+  code: z.string(),
+  claimDate: z.string(),
+});
+
+export type BonusVoucher = z.infer<typeof BonusVoucherSchema>;

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
@@ -1,8 +1,8 @@
 import React, {useMemo} from 'react';
-import {SectionList, View} from 'react-native';
+import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {BonusProgramTexts, useTranslation} from '@atb/translations';
-import {getTranslatedModeName} from '@atb/utils/transportation-names';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ScreenHeading} from '@atb/components/heading';
 import {ThemeText} from '@atb/components/text';
@@ -14,7 +14,7 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {ThemedBonusTransaction, ThemedBonusBag} from '@atb/theme/ThemedAssets';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
-import {formatToVerboseFullDate} from '@atb/utils/date';
+import {formatToDate} from '@atb/utils/date';
 import {BonusVoucher, useBonusVouchersQuery} from '@atb/modules/bonus';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {getTransportModeAndSubMode} from '@atb/modules/mobility';
@@ -86,19 +86,26 @@ export const Profile_BonusCouponCodesScreen = ({navigation}: Props) => {
               onPress={() => refetch()}
             />
           </View>
+        ) : sections.length === 0 ? (
+          <>
+            <EmptyState />
+            <HowItWorksCard />
+          </>
         ) : (
-          <SectionList
-            contentContainerStyle={styles.sectionListContent}
-            sections={sections}
-            keyExtractor={(item) => `${item.claimDate}-${item.code}`}
-            renderItem={({item}) => <VoucherCard voucher={item} />}
-            renderSectionHeader={({section}) => (
-              <VoucherSectionHeading date={section.date} />
-            )}
-            stickySectionHeadersEnabled={false}
-            ListEmptyComponent={<EmptyState />}
-            ListFooterComponent={<HowItWorksCard />}
-          />
+          <>
+            {sections.map((section) => (
+              <View key={section.date} style={styles.voucherSection}>
+                <VoucherSectionHeading date={section.date} />
+                {section.data.map((voucher) => (
+                  <VoucherCard
+                    key={`${voucher.claimDate}-${voucher.code}`}
+                    voucher={voucher}
+                  />
+                ))}
+              </View>
+            ))}
+            <HowItWorksCard />
+          </>
         )}
       </View>
     </FullScreenView>
@@ -151,8 +158,12 @@ const VoucherSectionHeading = ({date}: {date: number}) => {
   const {language} = useTranslation();
   const styles = useStyles();
   return (
-    <ThemeText typography="body__s__strong" style={styles.sectionHeading}>
-      {formatToVerboseFullDate(new Date(date), language)}
+    <ThemeText
+      typography="body__s"
+      type="secondary"
+      style={styles.sectionHeading}
+    >
+      {formatToDate(new Date(date), language)}
     </ThemeText>
   );
 };
@@ -165,7 +176,9 @@ const VoucherCard = ({voucher}: {voucher: BonusVoucher}) => {
   const operator = mobilityOperators?.find((op) => op.id === voucher.operator);
   const formFactor = operator?.formFactors[0] as FormFactor | undefined;
   const {mode, subMode} = getTransportModeAndSubMode(formFactor);
-  const modeName = t(getTranslatedModeName(mode, subMode));
+  const modeName = formFactor
+    ? t(MobilityTexts.vehicleName(formFactor))
+    : (operator?.name ?? voucher.operator);
 
   return (
     <Section>
@@ -190,15 +203,20 @@ const VoucherCard = ({voucher}: {voucher: BonusVoucher}) => {
                   <ScreenReaderAnnouncement
                     message={t(BonusProgramTexts.myCouponCodes.copied)}
                   />
-                  <ThemeText typography="body__s" type="secondary">
-                    {t(BonusProgramTexts.myCouponCodes.copied)}
-                  </ThemeText>
+
+                  <View style={styles.copyButton}>
+                    <ThemeText typography="body__s">
+                      {t(BonusProgramTexts.myCouponCodes.copied)}
+                    </ThemeText>
+                  </View>
                 </>
               }
             >
-              <ThemeText typography="body__s" type="secondary">
-                {t(BonusProgramTexts.myCouponCodes.copy)}
-              </ThemeText>
+              <View style={styles.copyButton}>
+                <ThemeText typography="body__s">
+                  {t(BonusProgramTexts.myCouponCodes.copy)}
+                </ThemeText>
+              </View>
             </ClickableCopy>
           </View>
         </View>
@@ -210,19 +228,15 @@ const VoucherCard = ({voucher}: {voucher: BonusVoucher}) => {
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-    rowGap: theme.spacing.small,
-    marginTop: theme.spacing.large,
+    gap: theme.spacing.medium,
     margin: theme.spacing.medium,
+    marginTop: 0,
   },
   message: {
     rowGap: theme.spacing.small,
   },
   retryButton: {
     marginTop: theme.spacing.small,
-  },
-  sectionListContent: {
-    gap: theme.spacing.medium,
-    flexGrow: 1,
   },
   emptyState: {
     alignItems: 'center',
@@ -235,21 +249,25 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   emptySubtitle: {
     textAlign: 'center',
   },
-  howItWorksSection: {
-    marginTop: theme.spacing.medium,
-  },
   horizontalContainer: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: theme.spacing.large,
   },
+  howItWorksSection: {
+    marginTop: theme.spacing.large,
+  },
   howItWorksText: {
     flex: 1,
     gap: theme.spacing.xSmall,
   },
+  voucherSection: {
+    gap: theme.spacing.xSmall,
+  },
   sectionHeading: {
-    marginTop: theme.spacing.medium,
+    marginTop: theme.spacing.small,
+    marginLeft: theme.spacing.medium,
   },
   cardRow: {
     flexDirection: 'row',
@@ -267,7 +285,15 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
   },
   cardCode: {
-    alignItems: 'flex-end',
-    gap: theme.spacing.xSmall,
+    alignItems: 'center',
+    gap: theme.spacing.medium,
+    flexDirection: 'row',
+  },
+  copyButton: {
+    borderRadius: theme.border.radius.circle,
+    borderWidth: theme.border.width.slim,
+    borderColor: theme.color.background.neutral[2].foreground.primary,
+    paddingHorizontal: theme.spacing.medium,
+    paddingVertical: theme.spacing.xSmall,
   },
 }));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
@@ -1,0 +1,210 @@
+import React, {useMemo} from 'react';
+import {SectionList, View} from 'react-native';
+import {StyleSheet} from '@atb/theme';
+import {BonusProgramTexts, useTranslation} from '@atb/translations';
+import {getTranslatedModeName} from '@atb/utils/transportation-names';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ScreenHeading} from '@atb/components/heading';
+import {ThemeText} from '@atb/components/text';
+import {GenericSectionItem, Section} from '@atb/components/sections';
+import {TransportationIconBox} from '@atb/components/icon-box';
+import {Loading} from '@atb/components/loading';
+import {Button} from '@atb/components/button';
+import {MessageInfoBox} from '@atb/components/message-info-box';
+import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {formatToVerboseFullDate} from '@atb/utils/date';
+import {BonusVoucher, useBonusVouchersQuery} from '@atb/modules/bonus';
+import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
+import {getTransportModeAndSubMode} from '@atb/modules/mobility';
+import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {startOfDay} from 'date-fns';
+import {ProfileScreenProps} from './navigation-types';
+import {ClickableCopy} from './components/ClickableCopy';
+
+type Props = ProfileScreenProps<'Profile_BonusCouponCodesScreen'>;
+
+type VoucherSection = {
+  date: number;
+  data: BonusVoucher[];
+};
+
+export const Profile_BonusCouponCodesScreen = ({navigation}: Props) => {
+  const focusRef = useFocusOnLoad(navigation);
+  const {t} = useTranslation();
+  const styles = useStyles();
+  const {data: vouchers, isLoading, isError, refetch} = useBonusVouchersQuery();
+
+  const sections = useMemo<VoucherSection[]>(() => {
+    if (!vouchers) return [];
+    const sorted = [...vouchers].sort(
+      (a, b) =>
+        new Date(b.claimDate).getTime() - new Date(a.claimDate).getTime(),
+    );
+
+    const result: VoucherSection[] = [];
+    let currentSection: VoucherSection | null = null;
+    for (const voucher of sorted) {
+      const date = startOfDay(new Date(voucher.claimDate)).getTime();
+      if (!currentSection || currentSection.date !== date) {
+        currentSection = {date, data: []};
+        result.push(currentSection);
+      }
+      currentSection.data.push(voucher);
+    }
+    return result;
+  }, [vouchers]);
+
+  return (
+    <FullScreenView
+      focusRef={focusRef}
+      headerProps={{
+        title: t(BonusProgramTexts.myCouponCodes.title),
+        leftButton: {type: 'back'},
+      }}
+      headerContent={(focusRef) => (
+        <ScreenHeading
+          ref={focusRef}
+          text={t(BonusProgramTexts.myCouponCodes.title)}
+        />
+      )}
+    >
+      <View style={styles.container}>
+        {isLoading ? (
+          <Loading size="large" />
+        ) : isError ? (
+          <View style={styles.message}>
+            <MessageInfoBox
+              type="error"
+              message={t(BonusProgramTexts.myCouponCodes.errorMessage)}
+            />
+            <Button
+              expanded
+              style={styles.retryButton}
+              text={t(BonusProgramTexts.myCouponCodes.retry)}
+              onPress={() => refetch()}
+            />
+          </View>
+        ) : sections.length === 0 ? (
+          <View style={styles.message}>
+            <MessageInfoBox
+              type="info"
+              message={t(BonusProgramTexts.myCouponCodes.emptyState)}
+            />
+          </View>
+        ) : (
+          <SectionList
+            contentContainerStyle={styles.sectionListContent}
+            sections={sections}
+            keyExtractor={(item) => `${item.claimDate}-${item.code}`}
+            renderItem={({item}) => <VoucherCard voucher={item} />}
+            renderSectionHeader={({section}) => (
+              <VoucherSectionHeading date={section.date} />
+            )}
+            stickySectionHeadersEnabled={false}
+          />
+        )}
+      </View>
+    </FullScreenView>
+  );
+};
+
+const VoucherSectionHeading = ({date}: {date: number}) => {
+  const {language} = useTranslation();
+  const styles = useStyles();
+  return (
+    <ThemeText typography="body__s__strong" style={styles.sectionHeading}>
+      {formatToVerboseFullDate(new Date(date), language)}
+    </ThemeText>
+  );
+};
+
+const VoucherCard = ({voucher}: {voucher: BonusVoucher}) => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+  const {mobilityOperators} = useFirestoreConfigurationContext();
+
+  const operator = mobilityOperators?.find((op) => op.id === voucher.operator);
+  const formFactor = operator?.formFactors[0] as FormFactor | undefined;
+  const {mode, subMode} = getTransportModeAndSubMode(formFactor);
+  const modeName = t(getTranslatedModeName(mode, subMode));
+
+  return (
+    <Section>
+      <GenericSectionItem>
+        <View style={styles.cardRow}>
+          <View style={styles.cardInfo}>
+            <TransportationIconBox mode={mode} subMode={subMode} rounded />
+            <View style={styles.cardText} accessible={true}>
+              <ThemeText typography="body__s__strong">{modeName}</ThemeText>
+              <ThemeText typography="body__s" type="secondary">
+                {operator?.name ?? voucher.operator}
+              </ThemeText>
+            </View>
+          </View>
+          <View style={styles.cardCode}>
+            <ThemeText typography="body__s__strong">{voucher.code}</ThemeText>
+            <ClickableCopy
+              copyContent={voucher.code}
+              accessibilityLabel={t(BonusProgramTexts.myCouponCodes.copy)}
+              successElement={
+                <>
+                  <ScreenReaderAnnouncement
+                    message={t(BonusProgramTexts.myCouponCodes.copied)}
+                  />
+                  <ThemeText typography="body__s" type="secondary">
+                    {t(BonusProgramTexts.myCouponCodes.copied)}
+                  </ThemeText>
+                </>
+              }
+            >
+              <ThemeText typography="body__s" type="secondary">
+                {t(BonusProgramTexts.myCouponCodes.copy)}
+              </ThemeText>
+            </ClickableCopy>
+          </View>
+        </View>
+      </GenericSectionItem>
+    </Section>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    flex: 1,
+    rowGap: theme.spacing.small,
+    marginTop: theme.spacing.large,
+    margin: theme.spacing.medium,
+  },
+  message: {
+    rowGap: theme.spacing.small,
+  },
+  retryButton: {
+    marginTop: theme.spacing.small,
+  },
+  sectionListContent: {
+    gap: theme.spacing.medium,
+  },
+  sectionHeading: {
+    marginTop: theme.spacing.medium,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing.medium,
+  },
+  cardInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.medium,
+    flex: 1,
+  },
+  cardText: {
+    flex: 1,
+  },
+  cardCode: {
+    alignItems: 'flex-end',
+    gap: theme.spacing.xSmall,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
@@ -11,6 +11,7 @@ import {TransportationIconBox} from '@atb/components/icon-box';
 import {Loading} from '@atb/components/loading';
 import {Button} from '@atb/components/button';
 import {MessageInfoBox} from '@atb/components/message-info-box';
+import {ThemedBonusTransaction, ThemedBonusBag} from '@atb/theme/ThemedAssets';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {formatToVerboseFullDate} from '@atb/utils/date';
@@ -85,13 +86,6 @@ export const Profile_BonusCouponCodesScreen = ({navigation}: Props) => {
               onPress={() => refetch()}
             />
           </View>
-        ) : sections.length === 0 ? (
-          <View style={styles.message}>
-            <MessageInfoBox
-              type="info"
-              message={t(BonusProgramTexts.myCouponCodes.emptyState)}
-            />
-          </View>
         ) : (
           <SectionList
             contentContainerStyle={styles.sectionListContent}
@@ -102,10 +96,54 @@ export const Profile_BonusCouponCodesScreen = ({navigation}: Props) => {
               <VoucherSectionHeading date={section.date} />
             )}
             stickySectionHeadersEnabled={false}
+            ListEmptyComponent={<EmptyState />}
+            ListFooterComponent={<HowItWorksCard />}
           />
         )}
       </View>
     </FullScreenView>
+  );
+};
+
+const EmptyState = () => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+  return (
+    <View style={styles.emptyState}>
+      <ThemedBonusTransaction height={120} width={120} />
+      <ThemeText typography="heading__m" style={styles.emptyTitle}>
+        {t(BonusProgramTexts.myCouponCodes.emptyTitle)}
+      </ThemeText>
+      <ThemeText
+        typography="body__m"
+        type="secondary"
+        style={styles.emptySubtitle}
+      >
+        {t(BonusProgramTexts.myCouponCodes.emptyState)}
+      </ThemeText>
+    </View>
+  );
+};
+
+const HowItWorksCard = () => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+  return (
+    <Section style={styles.howItWorksSection}>
+      <GenericSectionItem>
+        <View style={styles.horizontalContainer}>
+          <View style={styles.howItWorksText}>
+            <ThemeText typography="body__m__strong">
+              {t(BonusProgramTexts.myCouponCodes.howItWorksTitle)}
+            </ThemeText>
+            <ThemeText typography="body__s" type="secondary">
+              {t(BonusProgramTexts.myCouponCodes.howItWorksBody)}
+            </ThemeText>
+          </View>
+          <ThemedBonusBag height={60} width={60} />
+        </View>
+      </GenericSectionItem>
+    </Section>
   );
 };
 
@@ -184,6 +222,31 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   sectionListContent: {
     gap: theme.spacing.medium,
+    flexGrow: 1,
+  },
+  emptyState: {
+    alignItems: 'center',
+    gap: theme.spacing.medium,
+    paddingVertical: theme.spacing.xLarge,
+  },
+  emptyTitle: {
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    textAlign: 'center',
+  },
+  howItWorksSection: {
+    marginTop: theme.spacing.medium,
+  },
+  horizontalContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing.large,
+  },
+  howItWorksText: {
+    flex: 1,
+    gap: theme.spacing.xSmall,
   },
   sectionHeading: {
     marginTop: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -207,6 +207,13 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
               <GenericSectionItem>
                 <UserBonusBalanceContent />
               </GenericSectionItem>
+              <LinkSectionItem
+                text={t(BonusProgramTexts.myCouponCodes.linkText)}
+                onPress={() => {
+                  analytics.logEvent('Bonus', 'My coupon codes clicked');
+                  navigation.navigate('Profile_BonusCouponCodesScreen');
+                }}
+              />
             </Section>
             {isBonusBalanceError && (
               <MessageInfoBox

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -26,6 +26,7 @@ import {screenOptions} from '@atb/stacks-hierarchy/navigation-utils';
 import {Profile_TravelAidScreen} from './Profile_TravelAidScreen';
 import {Profile_TravelAidInformationScreen} from './Profile_TravelAidInformationScreen.tsx';
 import {Profile_BonusScreen} from './Profile_BonusScreen.tsx';
+import {Profile_BonusCouponCodesScreen} from './Profile_BonusCouponCodesScreen.tsx';
 import {Profile_SmartParkAndRideScreen} from './Profile_SmartParkAndRideScreen';
 import {Profile_SettingsScreen} from './Profile_SettingsScreen';
 import {Profile_FavoriteScreen} from './Profile_FavoriteScreen';
@@ -50,6 +51,10 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_BonusScreen"
         component={Profile_BonusScreen}
+      />
+      <Stack.Screen
+        name="Profile_BonusCouponCodesScreen"
+        component={Profile_BonusCouponCodesScreen}
       />
       <Stack.Screen
         name="Profile_SmartParkAndRideScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -11,6 +11,7 @@ export type ProfileStackParams = StackParams<{
   Profile_PaymentMethodsScreen: undefined;
   Profile_PurchaseHistoryScreen: undefined;
   Profile_BonusScreen: undefined;
+  Profile_BonusCouponCodesScreen: undefined;
   Profile_SmartParkAndRideScreen: SmartParkAndRideScreenParams;
   Profile_DeleteProfileScreen: undefined;
   Profile_EditProfileScreen: undefined;

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -266,5 +266,23 @@ const BonusProgramTexts = {
       ),
     },
   },
+
+  myCouponCodes: {
+    linkText: _('Mine kampanjekoder', 'My coupon codes', 'Mine kampanjekodar'),
+    title: _('Mine kampanjekoder', 'My coupon codes', 'Mine kampanjekodar'),
+    emptyState: _(
+      'Du har ingen kampanjekoder enda. Bruk poengene dine for å få en kampanjekode.',
+      "You don't have any coupon codes yet. Use your points to get a coupon code.",
+      'Du har ingen kampanjekodar enno. Bruk poenga dine for å få ein kampanjekode.',
+    ),
+    copy: _('Kopier', 'Copy', 'Kopier'),
+    copied: _('Kopiert!', 'Copied!', 'Kopiert!'),
+    errorMessage: _(
+      'Vi klarte ikke å hente kampanjekodene dine. Prøv igjen senere.',
+      'We could not load your coupon codes. Please try again later.',
+      'Vi klarte ikkje å hente kampanjekodane dine. Prøv igjen seinare.',
+    ),
+    retry: _('Prøv igjen', 'Try again', 'Prøv igjen'),
+  },
 };
 export default BonusProgramTexts;

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -270,10 +270,25 @@ const BonusProgramTexts = {
   myCouponCodes: {
     linkText: _('Mine kampanjekoder', 'My coupon codes', 'Mine kampanjekodar'),
     title: _('Mine kampanjekoder', 'My coupon codes', 'Mine kampanjekodar'),
+    emptyTitle: _(
+      'Ingen kampanjekoder',
+      'No coupon codes',
+      'Ingen kampanjekodar',
+    ),
     emptyState: _(
-      'Du har ingen kampanjekoder enda. Bruk poengene dine for å få en kampanjekode.',
-      "You don't have any coupon codes yet. Use your points to get a coupon code.",
-      'Du har ingen kampanjekodar enno. Bruk poenga dine for å få ein kampanjekode.',
+      'Når du aktiverer en kampanjekode, vil den vises her.',
+      'When you activate a coupon code, it will appear here.',
+      'Når du aktiverer ein kampanjekode, vil den visast her.',
+    ),
+    howItWorksTitle: _(
+      'Hvordan fungerer kampanjekoden?',
+      'How does the coupon code work?',
+      'Korleis fungerer kampanjekoden?',
+    ),
+    howItWorksBody: _(
+      'Når du huker av for å bruke poeng, legges kampanjekoden automatisk til i Hyre- eller Bysykkelappen. Hvis dette ikke skjer, for eksempel fordi du ikke var logget inn, kan du legge den til manuelt i deres app eller prøve å aktivere den på nytt.',
+      "When you choose to use points, the coupon code is automatically added to the Hyre or City Bike app. If this doesn't happen, for example because you weren't logged in, you can add it manually in their app or try to activate it again.",
+      'Når du hukar av for å bruke poeng, blir kampanjekoden automatisk lagt til i Hyre- eller Bysykkelappen. Viss dette ikkje skjer, til dømes fordi du ikkje var logga inn, kan du leggje den til manuelt i appen deira eller prøve å aktivere den på nytt.',
     ),
     copy: _('Kopier', 'Copy', 'Kopier'),
     copied: _('Kopiert!', 'Copied!', 'Kopiert!'),


### PR DESCRIPTION
## Summary
- New "Mine kampanjekoder" (My coupon codes) screen showing a user's redeemed AtB Bonus vouchers, grouped by claim day under verbose date headers (e.g. "3. juni 2026"), newest first.
- Each card shows the operator icon + transport mode name + operator name, the voucher code, and a copy-to-clipboard button (no status badges, no re-activate button — matches the Figma sketch).
- New `getBonusVouchers` API call (`GET /bonus/v2/vouchers`) with a zod-parsed `BonusVoucher` schema, and a `useBonusVouchersQuery` hook (enabled when authenticated + phone + bonus active).
- Entry point added as a `LinkSectionItem` inside the bonus balance section on the bonus profile screen, with analytics logging.
- Handles loading, empty, and error + retry states, plus Bokmål/English/Nynorsk translations.

Operator resolution matches `mobilityOperators` by netex ref (`op.id`); mode/icon derived from the operator's first form factor via `getTransportModeAndSubMode`. Falls back to the raw operator ref if no operator match.

Ref: AtB-AS/kundevendt#23925

## Test plan
- [ ] Redeem a voucher, open the bonus profile screen, tap "Mine kampanjekoder"
- [ ] Verify cards group by day with correct date headers, newest first
- [ ] Verify operator icon, mode name, operator name, and code render correctly
- [ ] Verify copy button copies the code and shows "Kopiert!" feedback
- [ ] Verify empty, loading, and error + retry states