### PR TITLE
fix: clarify impossible trip status text with transfer cause

### DIFF
--- a/src/translations/components/TravelCard.ts
+++ b/src/translations/components/TravelCard.ts
@@ -69,9 +69,9 @@ const TravelCardTexts = {
     originalTime: _('Opprinnelig', 'Original', 'Opprinnelig'),
     pastTime: _('Avreise passert', 'Departure passed', 'Avreise passert'),
     notPossible: _(
-      'Ikke lenger mulig',
-      'No longer possible',
-      'Ikkje lenger mogleg',
+      'Ikke lenger mulig pga. overgang',
+      'No longer possible due to transfer',
+      'Ikkje lenger mogleg pga. overgang',
     ),
     cancelled: _('Innstilt', 'Cancelled', 'Innstilt'),
     tripStarted: _('Reisen har begynt', 'Trip has started', 'Reisa har begynt'),

--- a/src/translations/components/TravelCard.ts
+++ b/src/translations/components/TravelCard.ts
@@ -69,9 +69,9 @@ const TravelCardTexts = {
     originalTime: _('Opprinnelig', 'Original', 'Opprinnelig'),
     pastTime: _('Avreise passert', 'Departure passed', 'Avreise passert'),
     notPossible: _(
-      'Ikke lenger mulig pga. overgang',
-      'No longer possible due to transfer',
-      'Ikkje lenger mogleg pga. overgang',
+      'Overgang ikke lenger mulig',
+      'Transfer no longer possible',
+      'Overgang ikkje lenger mogleg',
     ),
     cancelled: _('Innstilt', 'Cancelled', 'Innstilt'),
     tripStarted: _('Reisen har begynt', 'Trip has started', 'Reisa har begynt'),


### PR DESCRIPTION
## Description
When the journey planner marks a trip pattern as `impossible` — meaning a transfer can no longer be made, e.g. due to delays — the TravelCard status text just said *"Ikke lenger mulig"* without explaining why. This change updates the text to *"Overgang ikke lenger mulig"* (with matching English and Nynorsk variants) so it's clear that the transfer is the cause.

## Screenshot
<img width="350" src="https://github.com/user-attachments/assets/ee639eb7-280e-4430-90e3-b86227bf9bee" />

