### PR TITLE
fix: Naming of some geocoder v3 props

### DIFF
--- a/src/api/bff/geocoder.ts
+++ b/src/api/bff/geocoder.ts
@@ -138,7 +138,7 @@ const mapFeatureV3ToSearchLocation = ({
   coordinates: {latitude, longitude},
   locality: properties.address?.locality,
   postalcode: properties.address?.postalCode,
-  housenumber: properties.address?.housenumber,
+  housenumber: properties.address?.houseNumber,
   fare_zones: properties.fareZones,
   category: (properties.stopPlaceTypes ?? []).filter(
     (t): t is FeatureCategory => featureCategories.has(t),

--- a/src/api/bff/types.ts
+++ b/src/api/bff/types.ts
@@ -174,8 +174,8 @@ export type FeatureV3 = {
     };
     layer: GeocoderV3Layer;
     address?: {
-      street?: string;
-      housenumber?: string;
+      streetName?: string;
+      houseNumber?: string;
       postalCode?: string;
       locality?: string;
       localityId?: string;


### PR DESCRIPTION
Misnamed houseNumber made the pin/house icon logic in location
search results not work as expected.
