### PR TITLE
fix: include short wait time in travel card overflow badge

### DIFF
--- a/src/modules/situations/index.tsx
+++ b/src/modules/situations/index.tsx
@@ -12,7 +12,6 @@ export {
   findAllNotices,
   findAllSituationsFromLeg,
   findAllSituations,
-  getNotificationSvgForLegs,
   getMsgTypeForLeg,
   getA11yLabelForLeg,
   getDetailedSituationOrNoticeA11yLabel,

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -165,18 +165,6 @@ export const getMsgTypeForLeg = (
 };
 
 /**
- * Get the most critical notification SVG across multiple legs.
- */
-export const getNotificationSvgForLegs = (legs: Leg[], themeName: Mode) => {
-  const msgType = legs
-    .map(getMsgTypeForLeg)
-    .reduce<
-      Exclude<Statuses, 'valid'> | undefined
-    >(toMostCriticalStatus, undefined);
-  return msgType && statusTypeToIcon(msgType, true, themeName);
-};
-
-/**
  * Get an accessibility label describing situations, notices, or special
  * transport submodes (e.g. RailReplacementBus) for a single leg.
  * Returns undefined if there is nothing to announce.

--- a/src/screen-components/travel-card/TravelCardLegs.tsx
+++ b/src/screen-components/travel-card/TravelCardLegs.tsx
@@ -1,20 +1,16 @@
 import {CounterIconBox} from '@atb/components/icon-box';
 import {StyleSheet, useThemeContext, Statuses} from '@atb/theme';
-import {Mode} from '@atb-as/theme';
 import React from 'react';
 import {View} from 'react-native';
 import {Leg, TripPattern} from '@atb/api/types/trips';
 import {getFilteredLegsByWalkOrWaitTime} from '@atb/screen-components/travel-details-screens';
 import {OverflowContainer} from '@atb/components/overflow-container';
-import {
-  getNotificationSvgForLegs,
-  getMsgTypeForLeg,
-  toMostCriticalStatus,
-} from '@atb/modules/situations';
+import {toMostCriticalStatus} from '@atb/modules/situations';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
-import {isShortWaitTime, significantWaitTime} from '@atb/modules/trip-patterns';
+import {significantWaitTime} from '@atb/modules/trip-patterns';
 import {secondsBetween} from '@atb/utils/date';
 import {TransportationLeg, FootLeg} from './legs';
+import {getMsgTypeForTravelCardLeg} from './utils';
 import {TravelCardTexts, useTranslation} from '@atb/translations';
 import {secondsToDuration} from '@atb/utils/date';
 import {useAccessibilityLabelContribution} from '@atb/modules/composite-accessibility';
@@ -41,6 +37,10 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
   const a11yLabel = useA11yLabel(filteredLegs);
   useAccessibilityLabelContribution('legs', a11yLabel);
 
+  const legMsgTypes = filteredLegs.map((_, i) =>
+    getMsgTypeForTravelCardLeg(filteredLegs, i),
+  );
+
   return (
     <View style={styles.detailsContainer}>
       <View style={styles.flexRow}>
@@ -50,10 +50,14 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
               maxWidth={maxWidth}
               gap={theme.spacing.xSmall}
               overflow={(n) => {
-                const overflowNotification = getNotificationSvgForLegs(
-                  filteredLegs.slice(-n),
-                  themeName,
-                );
+                const overflowMsgType = legMsgTypes
+                  .slice(-n)
+                  .reduce<
+                    Exclude<Statuses, 'valid'> | undefined
+                  >(toMostCriticalStatus, undefined);
+                const overflowNotification =
+                  overflowMsgType &&
+                  statusTypeToIcon(overflowMsgType, true, themeName);
                 return (
                   <CounterIconBox
                     count={n}
@@ -65,23 +69,23 @@ export const TravelCardLegs: React.FC<TravelCardContentProps> = ({
                 );
               }}
             >
-              {filteredLegs.map((leg, i) => (
-                <View key={`leg-${leg.id ?? i}`}>
-                  {leg.mode === 'foot' ? (
-                    <FootLeg leg={leg} />
-                  ) : staySeated(i) ? null : (
-                    <TransportationLeg
-                      leg={leg}
-                      notification={getNotificationForLeg(
-                        leg,
-                        filteredLegs,
-                        i,
-                        themeName,
-                      )}
-                    />
-                  )}
-                </View>
-              ))}
+              {filteredLegs.map((leg, i) => {
+                const msgType = legMsgTypes[i];
+                return (
+                  <View key={`leg-${leg.id ?? i}`}>
+                    {leg.mode === 'foot' ? (
+                      <FootLeg leg={leg} />
+                    ) : staySeated(i) ? null : (
+                      <TransportationLeg
+                        leg={leg}
+                        notification={
+                          msgType && statusTypeToIcon(msgType, true, themeName)
+                        }
+                      />
+                    )}
+                  </View>
+                );
+              })}
             </OverflowContainer>
           </View>
         </View>
@@ -148,25 +152,6 @@ const getWaitTime = (leg: Leg, nextLeg?: Leg) => {
     mustWait: significantWaitTime(waitTimeInSeconds),
   };
 };
-
-function getNotificationForLeg(
-  leg: Leg,
-  legs: Leg[],
-  index: number,
-  themeName: Mode,
-) {
-  const previousLeg = legs[index - 1];
-  const waitTimeInSeconds = previousLeg
-    ? secondsBetween(previousLeg.expectedEndTime, leg.expectedStartTime)
-    : 0;
-  const shortTransferMsgType: Exclude<Statuses, 'valid'> | undefined =
-    isShortWaitTime(waitTimeInSeconds) ? 'info' : undefined;
-  const msgType = toMostCriticalStatus(
-    getMsgTypeForLeg(leg),
-    shortTransferMsgType,
-  );
-  return msgType && statusTypeToIcon(msgType, true, themeName);
-}
 
 const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   detailsContainer: {

--- a/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
+++ b/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
@@ -1,0 +1,170 @@
+import {Leg} from '@atb/api/types/trips';
+import type {SituationFragment} from '@atb/api/types/generated/fragments/situations';
+import {
+  ReportType,
+  TransportSubmode,
+} from '@atb/api/types/generated/journey_planner_v3_types';
+import {getMsgTypeForTravelCardLeg} from '../utils';
+
+jest.mock('@atb/screen-components/travel-details-screens', () => ({
+  getTripPatternBookingStatus: (...args: unknown[]) =>
+    require('@atb/screen-components/travel-details-screens/utils').getTripPatternBookingStatus(
+      ...args,
+    ),
+}));
+
+const baseTime = new Date('2026-06-03T12:00:00Z');
+const atSeconds = (seconds: number) =>
+  new Date(baseTime.getTime() + seconds * 1000).toISOString();
+
+const makeSituation = (
+  overrides: Partial<SituationFragment> = {},
+): SituationFragment => ({
+  id: overrides.id ?? 'sit-1',
+  summary: overrides.summary ?? [],
+  description: overrides.description ?? [],
+  advice: overrides.advice ?? [],
+  reportType: overrides.reportType ?? ReportType.General,
+  validityPeriod: overrides.validityPeriod,
+  situationNumber: overrides.situationNumber,
+  infoLinks: overrides.infoLinks,
+});
+
+const makeLeg = (overrides: Partial<Leg> = {}): Leg =>
+  ({
+    mode: 'bus',
+    expectedStartTime: atSeconds(0),
+    expectedEndTime: atSeconds(600),
+    fromPlace: {quay: null},
+    toPlace: {quay: null},
+    fromEstimatedCall: null,
+    toEstimatedCall: null,
+    situations: [],
+    bookingArrangements: null,
+    transportSubmode: null,
+    line: null,
+    ...overrides,
+  }) as unknown as Leg;
+
+/** A pair of transit legs with the given wait time (in seconds) between them. */
+const makeLegPair = (
+  waitTimeInSeconds: number,
+  secondLegOverrides: Partial<Leg> = {},
+): Leg[] => [
+  makeLeg({expectedStartTime: atSeconds(0), expectedEndTime: atSeconds(600)}),
+  makeLeg({
+    expectedStartTime: atSeconds(600 + waitTimeInSeconds),
+    expectedEndTime: atSeconds(1200 + waitTimeInSeconds),
+    ...secondLegOverrides,
+  }),
+];
+
+describe('getMsgTypeForTravelCardLeg', () => {
+  describe('leg-specific notifications', () => {
+    it('returns undefined for a leg without notifications', () => {
+      expect(getMsgTypeForTravelCardLeg([makeLeg()], 0)).toBeUndefined();
+    });
+
+    it('returns warning for a leg with an incident situation', () => {
+      const leg = makeLeg({
+        situations: [makeSituation({reportType: ReportType.Incident})],
+      });
+      expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('warning');
+    });
+
+    it('returns info for a leg with a general situation', () => {
+      const leg = makeLeg({
+        situations: [makeSituation({reportType: ReportType.General})],
+      });
+      expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('info');
+    });
+
+    it('returns info for a leg with a notice', () => {
+      const leg = makeLeg({
+        fromEstimatedCall: {
+          aimedDepartureTime: atSeconds(0),
+          expectedDepartureTime: atSeconds(0),
+          stopPositionInPattern: 0,
+          cancellation: false,
+          quay: {name: 'A'},
+          notices: [{id: 'notice-1', text: 'Some notice'}],
+          situations: [],
+        },
+      });
+      expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('info');
+    });
+
+    it('returns warning for a rail replacement bus leg', () => {
+      const leg = makeLeg({
+        transportSubmode: TransportSubmode.RailReplacementBus,
+      });
+      expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('warning');
+    });
+
+    it('returns warning for a leg with booking arrangements', () => {
+      const leg = makeLeg({bookingArrangements: {}} as Partial<Leg>);
+      expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('warning');
+    });
+  });
+
+  describe('short transfer time', () => {
+    it('returns info for a short wait time from the previous leg', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(120), 1)).toBe('info');
+    });
+
+    it('returns undefined for an insignificant wait time (30s or less)', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(30), 1)).toBeUndefined();
+    });
+
+    it('returns info just above the insignificant wait time limit', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(31), 1)).toBe('info');
+    });
+
+    it('returns info at the short transfer time limit (180s)', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(180), 1)).toBe('info');
+    });
+
+    it('returns undefined just above the short transfer time limit', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(181), 1)).toBeUndefined();
+    });
+
+    it('returns undefined for a negative wait time', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(-60), 1)).toBeUndefined();
+    });
+
+    it('returns undefined for the first leg regardless of times', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(120), 0)).toBeUndefined();
+    });
+  });
+
+  describe('foot legs', () => {
+    it('returns undefined for a foot leg even with short wait from the previous leg', () => {
+      const legs = makeLegPair(120, {mode: 'foot'} as Partial<Leg>);
+      expect(getMsgTypeForTravelCardLeg(legs, 1)).toBeUndefined();
+    });
+
+    it('returns the leg-specific notification for a foot leg', () => {
+      const legs = makeLegPair(120, {
+        mode: 'foot',
+        situations: [makeSituation({reportType: ReportType.Incident})],
+      } as Partial<Leg>);
+      expect(getMsgTypeForTravelCardLeg(legs, 1)).toBe('warning');
+    });
+  });
+
+  describe('combined notifications', () => {
+    it('returns the most critical when combining short wait (info) with an incident (warning)', () => {
+      const legs = makeLegPair(120, {
+        situations: [makeSituation({reportType: ReportType.Incident})],
+      });
+      expect(getMsgTypeForTravelCardLeg(legs, 1)).toBe('warning');
+    });
+
+    it('returns info when combining short wait with a general situation', () => {
+      const legs = makeLegPair(120, {
+        situations: [makeSituation({reportType: ReportType.General})],
+      });
+      expect(getMsgTypeForTravelCardLeg(legs, 1)).toBe('info');
+    });
+  });
+});

--- a/src/screen-components/travel-card/utils.ts
+++ b/src/screen-components/travel-card/utils.ts
@@ -1,5 +1,17 @@
-import {TripPattern} from '@atb/api/types/trips';
+import {Leg, TripPattern} from '@atb/api/types/trips';
 import {getTripPatternBookingStatus} from '@atb/screen-components/travel-details-screens';
+// Import directly from the modules' utils instead of their index files, since
+// the index files pull in React components whose import chains require native
+// modules, which are not available in the Jest environment. Going through the
+// index files would break every test importing from this file.
+// eslint-disable-next-line no-restricted-imports
+import {
+  getMsgTypeForLeg,
+  toMostCriticalStatus,
+} from '@atb/modules/situations/utils';
+// eslint-disable-next-line no-restricted-imports
+import {isShortWaitTime} from '@atb/modules/trip-patterns/utils';
+import {Statuses} from '@atb/theme';
 import type {StatusTextConfig, TripPatternStatus} from './types';
 import type {TranslateFunction} from '@atb/translations';
 import {TravelCardTexts} from '@atb/translations';
@@ -12,7 +24,7 @@ import {
   Warning,
 } from '@atb/assets/svg/mono-icons/status';
 import {Duration} from '@atb/assets/svg/mono-icons/time';
-import {isInThePast} from '@atb/utils/date';
+import {isInThePast, secondsBetween} from '@atb/utils/date';
 
 type StatusColors = {
   error: string;
@@ -36,6 +48,28 @@ export function getTripPatternStatus(
   }
   if (tripPattern.status === 'stale') return 'stale';
   return undefined;
+}
+
+/**
+ * Get the most critical message type for a leg in the travel card, considering
+ * both leg-specific notifications (situations, notices, etc.) and short
+ * transfer time from the previous leg. Transfer time is only considered for
+ * transit legs.
+ */
+export function getMsgTypeForTravelCardLeg(
+  legs: Leg[],
+  index: number,
+): Exclude<Statuses, 'valid'> | undefined {
+  const leg = legs[index];
+  const legMsgType = getMsgTypeForLeg(leg);
+  if (leg.mode === 'foot') return legMsgType;
+  const previousLeg = legs[index - 1];
+  const waitTimeInSeconds = previousLeg
+    ? secondsBetween(previousLeg.expectedEndTime, leg.expectedStartTime)
+    : 0;
+  const shortTransferMsgType: Exclude<Statuses, 'valid'> | undefined =
+    isShortWaitTime(waitTimeInSeconds) ? 'info' : undefined;
+  return toMostCriticalStatus(legMsgType, shortTransferMsgType);
 }
 
 export function getStatusTextConfig(


### PR DESCRIPTION
## Description
The `+n` overflow counter on TravelCard only showed notification badges for situations and notices on hidden legs — short wait time notifications were lost when the affected leg was collapsed into the counter.

<img width="350" src="https://github.com/user-attachments/assets/5da0f2f8-ca8b-4efa-9326-868861e6dbd4" />

Per-leg message types are now computed once in `getMsgTypeForTravelCardLeg` (moved to `travel-card/utils.ts`, with tests) and reused for both the visible leg badges and the overflow badge. `getNotificationSvgForLegs` is removed from the situations module — this was its only consumer.

## Test Input
- Requires the new trip search UI (`isNewTripSearchEnabled`).
- Search for a trip with enough legs that the travel card collapses some into the `+n` box (long trip and/or narrow screen, e.g. large font scale).
- One of the *hidden* legs must have a short transfer (31–180 s wait from the previous leg) — the `+n` box should now show an info badge.
- Visible leg badges should behave exactly as before.