### PR TITLE
feat: update PurchaseOverview input components

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -28,17 +28,10 @@ import {useFocusRefs} from '@atb/utils/use-focus-refs';
 import {FullScreenView} from '@atb/components/screen-view';
 import {FareProductHeader} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader';
 import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen';
-import {ToggleSectionItem} from '@atb/components/sections';
 import {useProductAlternatives} from '@atb/modules/ticketing';
 import {useOtherDeviceIsInspectableWarning} from '@atb/modules/fare-contracts';
 import {useParamAsState} from '@atb/utils/use-param-as-state';
-import {
-  usePurchaseSelectionBuilder,
-  useSelectableUserProfiles,
-} from '@atb/modules/purchase-selection';
-import {ContentHeading} from '@atb/components/heading';
-import {isUserProfileSelectable} from './utils';
-import {useOnBehalfOf} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/use-on-behalf-of';
+import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
 import {useBookingTrips} from '@atb/modules/booking';
 import {isValidSelection} from '@atb/modules/booking';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
@@ -61,15 +54,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const isFree = params.selection.stopPlaces?.to?.isFree || false;
 
   const preassignedFareProductAlternatives = useProductAlternatives(selection);
-  const selectableUserProfiles = useSelectableUserProfiles(
-    selection.preassignedFareProduct,
-  );
   const inspectableTokenWarningText = useOtherDeviceIsInspectableWarning();
 
   const analytics = useAnalyticsContext();
 
-  const {travellerSelectionMode, zoneSelectionMode} =
-    selection.fareProductTypeConfig.configuration;
+  const {zoneSelectionMode} = selection.fareProductTypeConfig.configuration;
 
   const {
     isSearchingOffer,
@@ -101,11 +90,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       tripAnalytics: params.tripAnalytics,
     };
 
-  const canSelectUserProfile = isUserProfileSelectable(
-    travellerSelectionMode,
-    selectableUserProfiles,
-  );
-
   const handleTicketInfoButtonPress = () => {
     const parameters: RootStackParamList['Root_TicketInformationScreen'] = {
       preassignedFareProductId: preassignedFareProduct.id,
@@ -134,8 +118,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const userTypeStrings = userProfilesWithCountAndOffer
     .filter((u) => u.count > 0)
     .map((u) => u.userTypeString);
-
-  const {isAllowed: isOnBehalfOfAllowed} = useOnBehalfOf(selection);
 
   const {isBookingRequired, isError: isBookingError} = useBookingTrips({
     selection,
@@ -266,31 +248,6 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             }}
             style={styles.selectionComponent}
           />
-
-          {isOnBehalfOfAllowed && (
-            <View style={styles.selectionComponent}>
-              {!canSelectUserProfile && (
-                <ContentHeading
-                  text={t(PurchaseOverviewTexts.onBehalfOf.sectionTitle)}
-                />
-              )}
-              <ToggleSectionItem
-                text={t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
-                value={selection.isOnBehalfOf}
-                onValueChange={(newValue) => {
-                  const newSelection = builder
-                    .fromSelection(selection)
-                    .isOnBehalfOf(newValue)
-                    .build();
-                  setSelection(newSelection);
-                }}
-                testID="onBehalfOfToggle"
-                type="slim"
-                radiusSize="regular"
-                radius="top-bottom"
-              />
-            </View>
-          )}
 
           <FromToSelection
             selection={selection}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -8,11 +8,8 @@ import {
   usePurchaseSelectionBuilder,
 } from '@atb/modules/purchase-selection';
 import {DatePickerSheet} from '@atb/components/date-selection';
-import {GenericClickableSectionItem, Section} from '@atb/components/sections';
-import {screenReaderPause, ThemeText} from '@atb/components/text';
-import {Edit} from '@atb/assets/svg/mono-icons/actions';
-import {ThemeIcon} from '@atb/components/theme-icon';
-import {StyleSheet, useThemeContext} from '@atb/theme';
+import {EditActionSectionItem, Section} from '@atb/components/sections';
+import {screenReaderPause} from '@atb/components/text';
 import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {Time} from '@atb/assets/svg/mono-icons/time';
 
@@ -28,8 +25,6 @@ export function StartTimeSelection({
   style,
 }: StartTimeSelectionProps) {
   const {t, language} = useTranslation();
-  const {theme} = useThemeContext();
-  const styles = useStyles();
   const selectionBuilder = usePurchaseSelectionBuilder();
   const onCloseFocusRef = useRef<View | null>(null);
   const bottomSheetModalRef = useRef<GorhomBottomSheetModal | null>(null);
@@ -49,8 +44,19 @@ export function StartTimeSelection({
       <View style={style}>
         <ContentHeading text={t(PurchaseOverviewTexts.startTime.title)} />
         <Section>
-          <GenericClickableSectionItem
+          <EditActionSectionItem
             ref={onCloseFocusRef}
+            leftIcon={Time}
+            text={
+              selection.travelDate
+                ? t(PurchaseOverviewTexts.startTime.laterTime)
+                : t(PurchaseOverviewTexts.startTime.now)
+            }
+            subText={
+              selection.travelDate
+                ? formatToLongDateTime(selection.travelDate, language)
+                : undefined
+            }
             onPress={openDatePickerSheet}
             accessibilityLabel={
               selection.travelDate
@@ -61,28 +67,7 @@ export function StartTimeSelection({
             }
             accessibilityHint={t(PurchaseOverviewTexts.startTime.a11yLaterHint)}
             testID="startTimeButton"
-          >
-            <View style={styles.sectionContent}>
-              <ThemeIcon svg={Time} />
-              <View style={styles.textContainer}>
-                <ThemeText typography="body__m__strong">
-                  {selection.travelDate
-                    ? t(PurchaseOverviewTexts.startTime.laterTime)
-                    : t(PurchaseOverviewTexts.startTime.now)}
-                </ThemeText>
-                {selection.travelDate && (
-                  <ThemeText>
-                    {formatToLongDateTime(selection.travelDate, language)}
-                  </ThemeText>
-                )}
-              </View>
-              <ThemeIcon
-                svg={Edit}
-                size="normal"
-                color={theme.color.interactive[0].default.background}
-              />
-            </View>
-          </GenericClickableSectionItem>
+          />
         </Section>
       </View>
       <DatePickerSheet
@@ -117,18 +102,3 @@ export function StartTimeSelection({
     </>
   );
 }
-
-const useStyles = StyleSheet.createThemeHook((theme) => ({
-  sectionContent: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: theme.spacing.small,
-  },
-  textContainer: {
-    flex: 1,
-    flexDirection: 'row',
-    gap: theme.spacing.xSmall,
-    flexWrap: 'wrap',
-  },
-}));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -9,11 +9,12 @@ import {
 } from '@atb/modules/purchase-selection';
 import {DatePickerSheet} from '@atb/components/date-selection';
 import {GenericClickableSectionItem, Section} from '@atb/components/sections';
-import {ThemeText} from '@atb/components/text';
+import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
+import {Time} from '@atb/assets/svg/mono-icons/time';
 
 type StartTimeSelectionProps = {
   selection: PurchaseSelectionType;
@@ -51,25 +52,30 @@ export function StartTimeSelection({
           <GenericClickableSectionItem
             ref={onCloseFocusRef}
             onPress={openDatePickerSheet}
-            accessibilityLabel={t(
-              PurchaseOverviewTexts.startTime.a11yLabel(
-                selection.travelDate &&
-                  formatToLongDateTime(selection.travelDate, language),
-              ),
-            )}
+            accessibilityLabel={
+              selection.travelDate
+                ? t(PurchaseOverviewTexts.startTime.laterTime) +
+                  screenReaderPause +
+                  formatToLongDateTime(selection.travelDate, language)
+                : t(PurchaseOverviewTexts.startTime.now)
+            }
             accessibilityHint={t(PurchaseOverviewTexts.startTime.a11yLaterHint)}
             testID="startTimeButton"
           >
             <View style={styles.sectionContent}>
-              <ThemeText typography="body__m__strong">
-                {selection.travelDate
-                  ? t(
-                      PurchaseOverviewTexts.startTime.laterTime(
-                        formatToLongDateTime(selection.travelDate, language),
-                      ),
-                    )
-                  : t(PurchaseOverviewTexts.startTime.now)}
-              </ThemeText>
+              <ThemeIcon svg={Time} />
+              <View style={styles.textContainer}>
+                <ThemeText typography="body__m__strong">
+                  {selection.travelDate
+                    ? t(PurchaseOverviewTexts.startTime.laterTime)
+                    : t(PurchaseOverviewTexts.startTime.now)}
+                </ThemeText>
+                {selection.travelDate && (
+                  <ThemeText>
+                    {formatToLongDateTime(selection.travelDate, language)}
+                  </ThemeText>
+                )}
+              </View>
               <ThemeIcon
                 svg={Edit}
                 size="normal"
@@ -112,11 +118,17 @@ export function StartTimeSelection({
   );
 }
 
-const useStyles = StyleSheet.createThemeHook(() => ({
+const useStyles = StyleSheet.createThemeHook((theme) => ({
   sectionContent: {
     display: 'flex',
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
+    gap: theme.spacing.small,
+  },
+  textContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: theme.spacing.xSmall,
+    flexWrap: 'wrap',
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -121,8 +121,8 @@ export function TravellerSelection({
 
   const content = (
     <View style={styles.sectionContentContainer}>
-      <ThemeIcon svg={Travellers} />
-      <View style={{flex: 1}}>
+      {canSelectUserProfile && <ThemeIcon svg={Travellers} />}
+      <View style={styles.textDescriptionWrapper}>
         <View style={styles.textWrapper}>
           <ThemeText typography="body__m__strong">
             {t(
@@ -213,6 +213,10 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     gap: theme.spacing.small,
+  },
+  textDescriptionWrapper: {
+    flex: 1,
+    gap: theme.spacing.xSmall,
   },
   textWrapper: {
     flexDirection: 'row',

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -10,6 +10,7 @@ import {
   GenericClickableSectionItem,
   GenericSectionItem,
   Section,
+  ToggleSectionItem,
 } from '@atb/components/sections';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -20,11 +21,13 @@ import {ContentHeading} from '@atb/components/heading';
 import {isUserProfileSelectable} from '../utils';
 import {
   type PurchaseSelectionType,
+  usePurchaseSelectionBuilder,
   useSelectableUserProfiles,
 } from '@atb/modules/purchase-selection';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {formatToNonBreakingSpaces} from '@atb/utils/text';
 import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
+import {useOnBehalfOf} from '../use-on-behalf-of';
 
 type TravellerSelectionProps = {
   selection: PurchaseSelectionType;
@@ -42,6 +45,7 @@ export function TravellerSelection({
   const styles = useStyles();
   const onCloseFocusRef = useRef<View | null>(null);
   const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const builder = usePurchaseSelectionBuilder();
 
   const selectionMode =
     selection.fareProductTypeConfig.configuration.travellerSelectionMode;
@@ -50,12 +54,13 @@ export function TravellerSelection({
     selection.preassignedFareProduct,
   );
 
+  const {isAllowed: isOnBehalfOfAllowed} = useOnBehalfOf(selection);
   const canSelectUserProfile = isUserProfileSelectable(
     selectionMode,
     selectableUserProfiles,
   );
 
-  if (selectionMode === 'none') {
+  if (selectionMode === 'none' && !isOnBehalfOfAllowed) {
     return null;
   }
 
@@ -147,17 +152,20 @@ export function TravellerSelection({
     </View>
   );
 
+  const heading = (() => {
+    if (selectionMode === 'none') {
+      return t(PurchaseOverviewTexts.onBehalfOf.sectionTitle);
+    }
+    return selectionMode == 'multiple'
+      ? t(PurchaseOverviewTexts.travellerSelection.titleMultiple)
+      : t(PurchaseOverviewTexts.travellerSelection.titleSingle);
+  })();
+
   return (
     <View style={style}>
-      <ContentHeading
-        text={
-          selectionMode == 'multiple'
-            ? t(PurchaseOverviewTexts.travellerSelection.titleMultiple)
-            : t(PurchaseOverviewTexts.travellerSelection.titleSingle)
-        }
-      />
+      <ContentHeading text={heading} />
       <Section {...accessibility}>
-        {canSelectUserProfile ? (
+        {selectionMode === 'none' ? undefined : canSelectUserProfile ? (
           <GenericClickableSectionItem
             onPress={travellerSelectionOnPress}
             ref={onCloseFocusRef}
@@ -168,6 +176,19 @@ export function TravellerSelection({
         ) : (
           <GenericSectionItem>{content}</GenericSectionItem>
         )}
+        <ToggleSectionItem
+          text={t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
+          value={selection.isOnBehalfOf}
+          onValueChange={(newValue) => {
+            const newSelection = builder
+              .fromSelection(selection)
+              .isOnBehalfOf(newValue)
+              .build();
+            onSave(newSelection);
+          }}
+          testID="onBehalfOfToggle"
+          type="slim"
+        />
       </Section>
       <TravellerSelectionSheet
         selection={selection}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -14,7 +14,6 @@ import {
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {TravellerSelectionSheet} from './TravellerSelectionSheet';
-
 import {Edit} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ContentHeading} from '@atb/components/heading';
@@ -25,6 +24,7 @@ import {
 } from '@atb/modules/purchase-selection';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {formatToNonBreakingSpaces} from '@atb/utils/text';
+import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
 
 type TravellerSelectionProps = {
   selection: PurchaseSelectionType;
@@ -63,9 +63,22 @@ export function TravellerSelection({
     ...selection.userProfilesWithCount,
     ...selection.supplementProductsWithCount,
   ]
-    .map((t) => `${t.count} ${getReferenceDataName(t, language)}`)
+    .map(
+      (t) =>
+        `${t.count > 1 ? t.count + ' ' : ''}${getReferenceDataName(t, language)}`,
+    )
     .map((t) => formatToNonBreakingSpaces(t))
     .join(', ');
+
+  const travellerCount =
+    selection.userProfilesWithCount.reduce(
+      (sum, current) => sum + current.count,
+      0,
+    ) +
+    selection.supplementProductsWithCount.reduce(
+      (sum, current) => sum + current.count,
+      0,
+    );
 
   const travellerInfo = !canSelectUserProfile
     ? getTextForLanguage(
@@ -103,10 +116,20 @@ export function TravellerSelection({
 
   const content = (
     <View style={styles.sectionContentContainer}>
+      <ThemeIcon svg={Travellers} />
       <View style={{flex: 1}}>
-        <ThemeText typography="body__m__strong" testID="selectedTravellers">
-          {travellersDetailsText}
-        </ThemeText>
+        <View style={styles.textWrapper}>
+          <ThemeText typography="body__m__strong">
+            {t(
+              PurchaseOverviewTexts.travellerSelection.travellerCount(
+                travellerCount,
+              ),
+            )}
+          </ThemeText>
+          <ThemeText typography="body__m" testID="selectedTravellers">
+            ({travellersDetailsText})
+          </ThemeText>
+        </View>
         {!canSelectUserProfile && (
           <ThemeText typography="body__s" type="secondary">
             {travellerInfo}
@@ -168,5 +191,11 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    gap: theme.spacing.small,
+  },
+  textWrapper: {
+    flexDirection: 'row',
+    gap: theme.spacing.xSmall,
+    flexWrap: 'wrap',
   },
 }));

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -22,6 +22,7 @@ import {FocusRefsType} from '@atb/utils/use-focus-refs';
 import {ContentHeading} from '@atb/components/heading';
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import {NativeBlockButton} from '@atb/components/native-button';
+import {MapPin} from '@atb/assets/svg/mono-icons/tab-bar';
 
 type ZonesSelectionProps = {
   selection: PurchaseSelectionType;
@@ -71,12 +72,15 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
 
     const content = (
       <View style={styles.sectionContentContainer}>
-        <View>
+        <View style={styles.zoneRows}>
           {displayAsOneZone ? (
-            <ZoneLabel fareZone={fromFareZone} />
+            <View style={styles.zoneContainer}>
+              <ThemeIcon svg={MapPin} />
+              <ZoneLabel fareZone={fromFareZone} />
+            </View>
           ) : (
             <>
-              <View style={styles.fromZone}>
+              <View style={styles.zoneContainer}>
                 <ThemeText
                   type="secondary"
                   typography="body__s"
@@ -86,7 +90,7 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
                 </ThemeText>
                 <ZoneLabel fareZone={fromFareZone} />
               </View>
-              <View style={styles.toZone}>
+              <View style={styles.zoneContainer}>
                 <ThemeText
                   type="secondary"
                   typography="body__s"
@@ -143,16 +147,17 @@ export const ZonesSelection = forwardRef<FocusRefsType, ZonesSelectionProps>(
 
 const ZoneLabel = ({fareZone}: {fareZone: FareZoneWithMetadata}) => {
   const {t, language} = useTranslation();
+  const styles = useStyles();
   const zoneName = getReferenceDataName(fareZone, language);
   const zoneLabel = t(PurchaseOverviewTexts.zones.zoneName(zoneName));
 
   return fareZone.venueName ? (
-    <ThemeText style={{flexShrink: 1}} testID="selectedStationAndZone">
+    <View style={styles.zoneLabel} testID="selectedStationAndZone">
       <ThemeText typography="body__m__strong" testID="selectedStation">
-        {fareZone.venueName + ' '}
+        {fareZone.venueName}
       </ThemeText>
-      ({zoneLabel})
-    </ThemeText>
+      <ThemeText style={{flexWrap: 'wrap'}}>({zoneLabel})</ThemeText>
+    </View>
   ) : (
     <ThemeText typography="body__m__strong" testID="selectedZone">
       {zoneLabel}
@@ -190,25 +195,26 @@ const a11yLabel = (
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
-  subtitleStyle: {
-    paddingTop: theme.spacing.xSmall,
+  zoneRows: {
+    gap: theme.spacing.small,
+    flex: 1,
+    flexShrink: 1,
+    flexWrap: 'wrap',
   },
-  sectionText: {
-    marginBottom: theme.spacing.medium,
-  },
-  fromZone: {
+  zoneContainer: {
+    gap: theme.spacing.small,
     flexDirection: 'row',
   },
-  toZone: {
+  zoneLabel: {
+    flex: 1,
     flexDirection: 'row',
-    marginTop: theme.spacing.small,
+    flexWrap: 'wrap',
+    gap: theme.spacing.xSmall,
   },
   toFromLabel: {
     minWidth: 40,
-    marginRight: theme.spacing.small,
   },
   sectionContentContainer: {
-    display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -150,6 +150,12 @@ const PurchaseOverviewTexts = {
   travellerSelection: {
     titleSingle: _('Reisende', 'Traveller', 'Reisande'),
     titleMultiple: _('Reisende', 'Travellers', 'Reisande'),
+    travellerCount: (count: number) =>
+      _(
+        `${count} reisende`,
+        count === 1 ? `${count} traveller` : `${count} travellers`,
+        `${count} reisande`,
+      ),
     a11yLabelPrefixSingle: _(
       'Valgt reisende:',
       'Selected traveller:',

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -186,16 +186,9 @@ const PurchaseOverviewTexts = {
   },
   startTime: {
     title: _('Oppstartstidspunkt', 'Start time', 'Starttidspunkt'),
-    now: _('Nå', 'Now', 'No'),
-    laterTime: (time: string) =>
-      _(`Oppstart ${time}`, `Start ${time}`, `Start ${time}`),
+    now: _('Oppstart nå', 'Start now', 'Oppstart no'),
+    laterTime: _('Oppstart senere', 'Start later', 'Start seinare'),
     laterOption: _('Senere', 'Later', 'Seinare'),
-    a11yLabel: (time?: string) =>
-      _(
-        `Valgt oppstartstidspunkt: ${time || 'nå'}`,
-        `Selected start time:  ${time || 'now'}`,
-        `Vald starttidspunkt:  ${time || 'no'}`,
-      ),
     a11yLaterHint: _(
       'Aktiver for å velge oppstartstidspunkt',
       'Activate to select start time',


### PR DESCRIPTION
## Issue Reference

closes https://github.com/AtB-AS/kundevendt/issues/23888

## Description

Updates some of the purchase selection input components with icons, and updated display logic
- TravellerSelection: Left icon, new summary texts
- StartTimeSelection: Left icon, new summary text when time is changed
- ZonesSelection: Left icon when only one zone is selected
- On behalf of toggle: Moved into TravellerSelection

Some examples:

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-03 at 15 32 52" src="https://github.com/user-attachments/assets/b1a58d5b-84b1-4563-99bc-7e0ae1ece439" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-03 at 15 33 05" src="https://github.com/user-attachments/assets/9b0022b2-fed4-42f1-b40b-06c92471e7b2" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-03 at 15 33 12" src="https://github.com/user-attachments/assets/8cb0e286-3eb4-464e-801e-6671145d0cee" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-03 at 15 34 28" src="https://github.com/user-attachments/assets/1dd494b2-d73c-486f-af9a-27db1cd12517" />
