### PR TITLE
fix: trigger ThemeText re-renders on fontScale changes

### DIFF
--- a/src/components/text/ThemeText.tsx
+++ b/src/components/text/ThemeText.tsx
@@ -81,8 +81,17 @@ export const ThemeText: React.FC<ThemeTextProps> = ({
   // If markdown is enabled, we need to wrap the content in a <View></View> to properly align the <Text></Text> elements,
   // by doing this we also avoid to wrap the list elements inside the markdown render in a Text component, which is not allowed.
   if (isMarkdown) {
-    return <View>{content}</View>;
+    return <View key={fontScale}>{content}</View>;
   }
 
-  return <Text {...textProps}>{content}</Text>;
+  return (
+    <Text
+      {...textProps}
+      // Trigger re-renders on `fontScale` changes to avoid a react-native bug
+      // where text size is updated, but the text container isn't.
+      key={fontScale}
+    >
+      {content}
+    </Text>
+  );
 };


### PR DESCRIPTION
## Description

After the new architecture update, changing font size updates text size without updating its container. This causes clipping when it is increased, and excessive padding when it is decreased. Re-rendering text nodes on changes fixes this.

## Acceptance criteria

- [ ] Increasing and decreasing font size doesn't cause clipping or broken padding around text.