### PR TITLE
build: remove duplicate node_modules cache from build setup

### DIFF
--- a/.github/actions/ios-build-setup/action.yml
+++ b/.github/actions/ios-build-setup/action.yml
@@ -62,17 +62,7 @@ runs:
           ruby-version: 3.1.0
           cache-version: 2
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Get cached node_modules
-        uses: actions/cache@v4
-        if: inputs.force-build != 'true'
-        id: modules-cache
-        with:
-          path: '**/node_modules'
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/patches/**.patch') }}
-          restore-keys: |
-            node-modules-${{ runner.os }}-
       - name: Install node_modules
-        if: inputs.force-build == 'true' || steps.modules-cache.outputs.cache-hit != 'true'
         shell: bash
         run: pnpm install --frozen-lockfile
       - name: Setup Xcode version


### PR DESCRIPTION
## Issue Reference

https://github.com/AtB-AS/mittatb-app/pull/6107
https://github.com/AtB-AS/mittatb-app/actions/runs/26942959451/job/79490705646

## Description

The build failed after the pnpm upgrade because of file permission issues after node_modules was loaded from cache. This fixes it by removing the duplicated cache step (setup-node also has cache set to `pnpm`), and always running `pnpm install`. Since there is a cache it should be quick enough to do on every build.