### PR TITLE
fix: update bonus join copy per tester feedback

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusFaqSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/BonusFaqSection.tsx
@@ -2,18 +2,9 @@ import {BonusProgramTexts, useTranslation} from '@atb/translations';
 import {ThemeText} from '@atb/components/text';
 import React from 'react';
 import {ExpandableSectionItem, Section} from '@atb/components/sections';
-import {useProgramQuery, KnownProgramId} from '@atb/modules/enrollment';
-import {formatToVerboseFullDate} from '@atb/utils/date';
 
 export const BonusFaqSection = () => {
-  const {t, language} = useTranslation();
-  const bonusProgram = useProgramQuery(KnownProgramId.BONUS);
-  const endDateString = bonusProgram?.endAt
-    ? formatToVerboseFullDate(bonusProgram.endAt, language)
-    : '';
-  const faqContext = {
-    endDate: endDateString,
-  };
+  const {t} = useTranslation();
 
   return (
     <Section>
@@ -27,7 +18,7 @@ export const BonusFaqSection = () => {
               showIconText={false}
               expandContent={
                 <ThemeText isMarkdown={false} type="secondary">
-                  {t(answer(faqContext))}
+                  {t(answer())}
                 </ThemeText>
               }
             />

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -22,11 +22,7 @@ import {
   useActiveBonusProductGroupsQuery,
   BonusProductList,
 } from '@atb/modules/bonus';
-import {
-  useIsEnrolled,
-  useProgramQuery,
-  KnownProgramId,
-} from '@atb/modules/enrollment';
+import {useIsEnrolled, KnownProgramId} from '@atb/modules/enrollment';
 import {useAuthContext} from '@atb/modules/auth';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {isDefined} from '@atb/utils/presence';
@@ -40,7 +36,6 @@ import {Loading} from '@atb/components/loading';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {ProfileScreenProps} from './navigation-types';
 import {useGetHasReservationOrAvailableFareContract} from '@atb/modules/ticketing';
-import {formatToDate} from '@atb/utils/date';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {
   GlobalMessage,
@@ -55,7 +50,7 @@ type Props = ProfileScreenProps<'Profile_BonusScreen'>;
 
 export const Profile_BonusScreen = ({navigation}: Props) => {
   const focusRef = useFocusOnLoad(navigation);
-  const {t, language} = useTranslation();
+  const {t} = useTranslation();
   const styles = useStyles();
   const {theme} = useThemeContext();
   const {authenticationType} = useAuthContext();
@@ -85,10 +80,6 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
     wasEnrolledRef.current = isEnrolled;
   }, [isEnrolled]);
 
-  const bonusProgram = useProgramQuery(KnownProgramId.BONUS);
-  const endDateString = bonusProgram?.endAt
-    ? formatToDate(bonusProgram.endAt, language)
-    : '';
   const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
 
@@ -134,11 +125,7 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
                   {t(BonusProgramTexts.bonusProfile.joinProgram.description)}
                 </ThemeText>
                 <ThemeText typography="body__m" type="primary">
-                  {t(
-                    BonusProgramTexts.bonusProfile.joinProgram.footer(
-                      endDateString,
-                    ),
-                  )}
+                  {t(BonusProgramTexts.bonusProfile.joinProgram.footer)}
                 </ThemeText>
               </GenericSectionItem>
             </Section>

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -70,16 +70,15 @@ const BonusProgramTexts = {
         'Reis billegare med AtB Bonus!',
       ),
       description: _(
-        'Bli med og tjen poeng hver gang du kjøper en enkeltbillett (voksen/student, sone A). Bruk poengene dine og få kampanjepris på enkeltbilletter, bysykler, elsparkesykler og Hyrebiler.',
-        'Sign up and earn points every time you buy a single ticket (adult/student, zone A). Use your points and get campaign prices on single tickets, city bikes, electric scooters and Hyre cars.',
-        'Bli med og ten poeng kvar gong du kjøper ein enkeltbillett (vaksen/student, sone A). Bruk poenga dine og få kampanjepris på enkeltbillettar, bysyklar, elsparkesyklar og Hyrebilar.',
+        'Bli med og tjen poeng hver gang du kjøper en enkeltbillett (voksen/student, sone A). Bruk poengene dine og få kampanjepris på bysykler og Hyrebiler.',
+        'Sign up and earn points every time you buy a single ticket (adult/student, zone A). Use your points and get campaign prices on city bikes and Hyre cars.',
+        'Bli med og ten poeng kvar gong du kjøper ein enkeltbillett (vaksen/student, sone A). Bruk poenga dine og få kampanjepris på bysyklar og Hyrebilar.',
       ),
-      footer: (endDate: string) =>
-        _(
-          `Dette er et prøveprosjekt som varer til ${endDate}.`,
-          `This is a pilot project that runs until ${endDate}.`,
-          `Dette er eit prøveprosjekt som varer til ${endDate}.`,
-        ),
+      footer: _(
+        'Dette er et prøveprosjekt.',
+        'This is a pilot project.',
+        'Dette er eit prøveprosjekt.',
+      ),
       button: {
         text: _('Bli med', 'Join', 'Bli med'),
       },

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -53,9 +53,9 @@ const BonusProgramTexts = {
 
   log_in_operator_app_warning: (operatorName: string) =>
     _(
-      `Du må være logget inn i ${operatorName}-appen før du bruker kampanjeprisen.`,
-      `You must be logged in to the ${operatorName} app before using the campaign price.`,
-      `Du må vera logga inn i ${operatorName}-appen før du brukar kampanjeprisen.`,
+      `Du må være logget inn i ${operatorName}-appen for å få kampanjeprisen.`,
+      `You must be logged in to the ${operatorName} app to get the campaign price.`,
+      `Du må vera logga inn i ${operatorName}-appen for å få kampanjeprisen.`,
     ),
 
   bonusProfile: {
@@ -70,14 +70,14 @@ const BonusProgramTexts = {
         'Reis billegare med AtB Bonus!',
       ),
       description: _(
-        'Bli med og tjen poeng hver gang du kjøper en enkeltbillett (voksen/student, sone A). Bruk poengene dine og få kampanjepris på bysykler og Hyrebiler.',
-        'Sign up and earn points every time you buy a single ticket (adult/student, zone A). Use your points and get campaign prices on city bikes and Hyre cars.',
-        'Bli med og ten poeng kvar gong du kjøper ein enkeltbillett (vaksen/student, sone A). Bruk poenga dine og få kampanjepris på bysyklar og Hyrebilar.',
+        'Bli med og tjen poeng hver gang du kjøper en enkeltbillett (voksen/student, sone A). Bruk poengene dine og få kampanjepris på ulike transportmidler i AtB-appen.',
+        'Join and earn points every time you buy a single ticket (adult/student, zone A). Use your points and get campaign prices on various means of transport in the AtB app.',
+        'Bli med og ten poeng kvar gong du kjøper ein enkeltbillett (vaksen/student, sone A). Bruk poenga dine og få kampanjepris på ulike transportmiddel i AtB-appen.',
       ),
       footer: _(
-        'Dette er et prøveprosjekt.',
-        'This is a pilot project.',
-        'Dette er eit prøveprosjekt.',
+        'Dette er et prøveprosjekt som varer til slutten av året.',
+        'This is a pilot project that will last until the end of the year.',
+        'Dette er eit prøveprosjekt som varer til slutten av året.',
       ),
       button: {
         text: _('Bli med', 'Join', 'Bli med'),
@@ -163,9 +163,9 @@ const BonusProgramTexts = {
       spendPoints: {
         title: _('Bruk poeng', 'Spend points', 'Bruk poeng'),
         description: _(
-          'Du kan bruke poeng på turer med bysykler og Hyre-biler.',
-          'You may use points on trips with city bikes and Hyre cars.',
-          'Du kan bruke poeng på turer med bysykler og Hyre-biler.',
+          'Du kan bruke poeng på turer med ulike transportmidler. Se listen under.',
+          'You may use points on trips with different transport modes. See the list below.',
+          'Du kan bruka poeng på turar med ulike transportmiddel. Sjå lista under.',
         ),
       },
       downloadOperator: (operator: string) =>
@@ -192,15 +192,15 @@ const BonusProgramTexts = {
       faqs: [
         {
           question: _(
-            'Hvordan bruker jeg poengene?',
-            'How do I use the points?',
-            'Korleis brukar eg poenga?',
+            'Hvordan bruker jeg poengene mine?',
+            'How do I use my points?',
+            'Korleis brukar eg poenga mine?',
           ),
           answer: () =>
             _(
-              'På bysykkel, elsparkesykkel eller Hyrebil:\nFinn kjøretøyet i kartet, trykk på ikonet og huk av for at du vil bruke poeng før du starter turen.',
-              'On city bikes, electric scooters, or Hyre cars:\nFind the vehicle on the map, tap the icon, and check the box to use points before starting the trip.',
-              'På bysykkel, elsparkesykkel eller Hyrebil:\nFinn kjøretøyet i kartet, trykk på ikonet og huk av for at du vil bruke poeng før du starter turen.',
+              'Når du er inne på et transportmiddel som støtter poeng, kan du velge å bruke poengene dine og få kampanjepris.',
+              'When you are on a mode of transportation that supports points, you can choose to use your points and get campaign price.',
+              'Når du er inne på eit transportmiddel som støttar poeng, kan du velja å bruka poenga dine og få kampanjepris.',
             ),
         },
         {
@@ -209,11 +209,11 @@ const BonusProgramTexts = {
             'How long does the pilot project last?',
             'Kor lenge varer prøveprosjektet?',
           ),
-          answer: ({endDate}: BonusFaqContext) =>
+          answer: () =>
             _(
-              `Prøveprosjektet varer frem til ${endDate}. Etter dette slettes resten av poengene dine.`,
-              `The pilot project lasts until ${endDate}. After this, the remaining points will be deleted.`,
-              `Prøveprosjektet varer fram til ${endDate}. Etter dette slettes resten av poenga dine.`,
+              `Prøveprosjektet varer frem til slutten av året. Etter dette slettes resten av poengene dine.`,
+              `The pilot project lasts until the end of the year. After this, the remaining points will be deleted.`,
+              `Prøveprosjektet varer fram til slutten av året. Etter dette slettes resten av poenga dine.`,
             ),
         },
       ],

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -1,9 +1,5 @@
 import {translation as _} from '../../commons';
 
-export type BonusFaqContext = {
-  endDate: string;
-};
-
 const BonusProgramTexts = {
   points: _('poeng', 'points', 'poeng'),
   costA11yLabel: (amount: number) =>


### PR DESCRIPTION
## Summary
Addresses tester findings on AtB-AS/kundevendt#23803 (AtB Bonus copy reword, merged #6121).

- `joinProgram.description`: spend list now "bysykler og Hyrebiler" only — dropped single ticket + scooter (Finding 3).
- `joinProgram.footer`: now static "Dette er et prøveprosjekt." with no end date (Finding 3). Removed now-unused end-date plumbing in `Profile_BonusScreen.tsx`.

Not in this PR:
- Finding 1 (Hyre "opplåsning" → Figma copy): operator-benefit config text, updated in remote/Firestore config, not in app code.
- Finding 2 ("Fjerne dobbel tekst"): fixed by #6125.

## Test plan
- [ ] Profile → AtB Bonus, not enrolled: description reads "…kampanjepris på bysykler og Hyrebiler"; footer "Dette er et prøveprosjekt." (no date). Check NB/EN/NN.
- [ ] FAQ "Hvor lenge varer prøveprosjektet?" still shows end date.
- [x] tsc + eslint pass