### PR TITLE
fix: bonus product title position when no mobility operator

### DIFF
--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -66,9 +66,9 @@ export const BonusProductList = ({
         const operatorNames = memberProducts
           .map(
             (bp) =>
-              mobilityOperators?.find((op) => op.id === bp.operatorId)?.name ??
-              bp.operatorId,
+              mobilityOperators?.find((op) => op.id === bp.operatorId)?.name,
           )
+          .filter(Boolean)
           .join(', ');
         const showMapButton =
           !!onNavigateToMap &&
@@ -102,9 +102,11 @@ export const BonusProductList = ({
                         ),
                       )}
                     </ThemeText>
-                    <ThemeText typography="body__s" type="secondary">
-                      {operatorNames}
-                    </ThemeText>
+                    {!!operatorNames && (
+                      <ThemeText typography="body__s" type="secondary">
+                        {operatorNames}
+                      </ThemeText>
+                    )}
                   </View>
                   {showMapButton && (
                     <Pressable


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23893

## Description
Updates so that when there is no matching operatorId, the operator field is not present (title text is centered vertically.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8a19adf2-1c49-4cd2-9f46-8b07ae6ad6bb" />
