### PR TITLE
fix(purchase): keep pay button above android navigation bar

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -553,10 +553,11 @@ const PaymentButton = ({
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => ({
   container: {
     padding: theme.spacing.medium,
     rowGap: theme.spacing.medium,
+    paddingBottom: bottom + theme.spacing.medium,
   },
   waitingForPayment: {
     flexDirection: 'row',


### PR DESCRIPTION
## Description

On the purchase confirmation screen the Pay button sits at the end of the scrollable content. The scroll container had no bottom safe-area inset, so when a trip's legs carry several notices/situations (LegsSummary renders them all inline) the content grows tall enough that, on Android with on-screen navigation buttons, the Pay button ends up behind the system nav bar. See Slack: https://oms-yzc6053.slack.com/archives/C08MK828GV7/p1780555927215539

Add `paddingBottom: bottom + theme.spacing.medium` to the scroll container so the button clears the system bar. `bottom` comes from the safe-area insets, so it adapts to Android on-screen buttons, Android gesture nav, and the iOS home indicator — matching how the sibling Root_PurchaseOverviewScreen and Root_TicketInformationScreen already handle their bottom inset.

## Test Input

- Android device/emulator with on-screen navigation buttons (not gesture nav).
- Start a ticket purchase for a journey whose legs have several notices/situations, so LegsSummary is long enough to require scrolling.
- On the confirmation screen, scroll to the bottom and confirm the Pay button is fully tappable above the system nav buttons. Also spot-check gesture nav and iOS (home indicator) for no regression.
