### PR TITLE
fix: improve coupon codes screen accessibility and zoom layout

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusCouponCodesScreen.tsx
@@ -194,10 +194,22 @@ const VoucherCard = ({voucher}: {voucher: BonusVoucher}) => {
             </View>
           </View>
           <View style={styles.cardCode}>
-            <ThemeText typography="body__s__strong">{voucher.code}</ThemeText>
+            <ThemeText
+              typography="body__s__strong"
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+            >
+              {voucher.code}
+            </ThemeText>
             <ClickableCopy
               copyContent={voucher.code}
-              accessibilityLabel={t(BonusProgramTexts.myCouponCodes.copy)}
+              accessibilityRole="button"
+              accessibilityLabel={t(
+                BonusProgramTexts.myCouponCodes.codeA11yLabel(voucher.code),
+              )}
+              accessibilityHint={t(
+                BonusProgramTexts.myCouponCodes.copyA11yHint,
+              )}
               successElement={
                 <>
                   <ScreenReaderAnnouncement
@@ -271,6 +283,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   cardRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: theme.spacing.medium,
@@ -279,7 +292,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     gap: theme.spacing.medium,
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
+    minWidth: '40%',
   },
   cardText: {
     flex: 1,
@@ -288,6 +303,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     alignItems: 'center',
     gap: theme.spacing.medium,
     flexDirection: 'row',
+    flexShrink: 0,
   },
   copyButton: {
     borderRadius: theme.border.radius.circle,

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -1,3 +1,4 @@
+import {spellOut} from '@atb/utils/accessibility';
 import {translation as _} from '../../commons';
 
 const BonusProgramTexts = {
@@ -286,6 +287,17 @@ const BonusProgramTexts = {
       'Når du hukar av for å bruke poeng, blir kampanjekoden automatisk lagt til i Hyre- eller Bysykkelappen. Viss dette ikkje skjer, til dømes fordi du ikkje var logga inn, kan du leggje den til manuelt i appen deira.',
     ),
     copy: _('Kopier', 'Copy', 'Kopier'),
+    copyA11yHint: _(
+      'Klikk for å kopiere kampanjekoden',
+      'Press to copy the coupon code',
+      'Klikk for å kopiere kampanjekoden',
+    ),
+    codeA11yLabel: (code: string) =>
+      _(
+        `Kode ${spellOut(code)}`,
+        `Code ${spellOut(code)}`,
+        `Kode ${spellOut(code)}`,
+      ),
     copied: _('Kopiert!', 'Copied!', 'Kopiert!'),
     errorMessage: _(
       'Vi klarte ikke å hente kampanjekodene dine. Prøv igjen senere.',


### PR DESCRIPTION
## Issue Reference
<!-- No linked issue — tester/QA feedback on the My coupon codes screen. -->
closes https://github.com/AtB-AS/kundevendt/issues/23925

## Description
Accessibility and layout fixes for the AtB Bonus **My coupon codes** screen (`Profile_BonusCouponCodesScreen`):

- **Spell out the code** in the copy button's accessibility label (`spellOut`), so screen readers read it character-by-character instead of mispronouncing it as a word.
- **Add an accessibility hint** on the copy button ("Press to copy the coupon code"), mirroring the existing `installId` copy pattern.
- **Add `accessibilityRole="button"`** so the copy control is exposed as a button (surfaces label + hint correctly in the Accessibility Inspector / VoiceOver).
- **Hide the duplicate visual code** `ThemeText` from the screen reader (`accessibilityElementsHidden` / `importantForAccessibility`), so the code is announced once (spelled out) instead of twice.
- **Reflow the voucher card on zoom**: with large font scale the code + Copy button now wrap below the operator name (`flexWrap` + `minWidth` floor on the info column) instead of crushing the name text to one character per line.

New translation keys added under `BonusProgramTexts.myCouponCodes`: `copyA11yHint`, `codeA11yLabel` (nb/en/nn).