### PR TITLE
fix: prevent wrapping of zone texts

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ZonesSelection.tsx
@@ -199,7 +199,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     gap: theme.spacing.small,
     flex: 1,
     flexShrink: 1,
-    flexWrap: 'wrap',
   },
   zoneContainer: {
     gap: theme.spacing.small,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -188,7 +188,7 @@ const PurchaseOverviewTexts = {
     title: _('Oppstartstidspunkt', 'Start time', 'Starttidspunkt'),
     now: _('Oppstart nå', 'Start now', 'Oppstart no'),
     laterTime: _('Oppstart senere', 'Start later', 'Start seinare'),
-    laterOption: _('Senere', 'Later', 'Seinare'),
+    laterOption: _('Oppstart senere', 'Start later', 'Start seinare'),
     a11yLaterHint: _(
       'Aktiver for å velge oppstartstidspunkt',
       'Activate to select start time',


### PR DESCRIPTION
## Issue Reference

Fixes feedback in https://github.com/AtB-AS/kundevendt/issues/23888

## Description

Fixes a wrapping issue, and updates the option text for later start time.