### PR TITLE
fix: hide status text when it's a walk or bike trips

### DIFF
--- a/src/screen-components/travel-card/hooks.ts
+++ b/src/screen-components/travel-card/hooks.ts
@@ -49,11 +49,13 @@ export const useTripPatternInfo = (tripPattern: TripPattern) => {
   const hasStarted = isInThePast(expectedStartTime);
   const isEnded = isInThePast(expectedEndTime);
 
-  const statusTextConfig = getStatusTextConfig(
-    tripPattern,
-    t,
-    theme.color.foreground.emphasis,
+  const isOnlyFootOrBicycle = tripPattern.legs.every(
+    (leg) => leg.mode === 'foot' || leg.mode === 'bicycle',
   );
+
+  const statusTextConfig = isOnlyFootOrBicycle
+    ? undefined
+    : getStatusTextConfig(tripPattern, t, theme.color.foreground.emphasis);
 
   return {
     fromName,


### PR DESCRIPTION
## Description
Should not say any status for walk or bike trips, because these are user-initiated and doesn't depend on any timing-related transport mode.