### PR TITLE
build: fix missing flag on build staging iOS

### DIFF
--- a/.github/workflows/build-staging-ios.yml
+++ b/.github/workflows/build-staging-ios.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Add Entur private registry credentials
         shell: bash
-        if: steps.modules-cache.outputs.cache-hit != 'true'
+        if: inputs.force-build == 'true' || steps.modules-cache.outputs.cache-hit != 'true'
         run: bash ./scripts/add-entur-private-registry.sh
         env:
           ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}


### PR DESCRIPTION
## Description
Match the Android setup, the `inputs.force-build == 'true'` is missing on build iOS Staging.

```
      - name: Add Entur private registry credentials
        shell: bash
        if: inputs.force-build == 'true' || steps.modules-cache.outputs.cache-hit != 'true'
        run: bash ./scripts/add-entur-private-registry.sh
        env:
          ENTUR_REGISTRY_USER: ${{ vars.ENTUR_REGISTRY_USER }}
          ENTUR_REGISTRY_TOKEN: ${{ secrets.ENTUR_REGISTRY_TOKEN }}
```