### PR TITLE
fix: remove welcome gift message from joined Bonus

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_BonusScreen.tsx
@@ -9,7 +9,7 @@ import {
   ProfileTexts,
   useTranslation,
 } from '@atb/translations';
-import React, {useEffect, useRef, useState} from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import {FullScreenView} from '@atb/components/screen-view';
 import {ThemeText} from '@atb/components/text';
@@ -70,15 +70,6 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
     useGetHasReservationOrAvailableFareContract();
 
   const isEnrolled = useIsEnrolled(KnownProgramId.BONUS);
-  const wasEnrolledRef = useRef(isEnrolled);
-  const [hasJustEnrolled, setHasJustEnrolled] = useState(false);
-
-  useEffect(() => {
-    if (!wasEnrolledRef.current && isEnrolled) {
-      setHasJustEnrolled(true);
-    }
-    wasEnrolledRef.current = isEnrolled;
-  }, [isEnrolled]);
 
   const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
@@ -173,23 +164,6 @@ export const Profile_BonusScreen = ({navigation}: Props) => {
 
         {isEnrolled && (
           <>
-            {hasJustEnrolled && (
-              <MessageInfoBox
-                type="valid"
-                title={
-                  !!userBonusBalance
-                    ? t(BonusProgramTexts.bonusProfile.joined.title)
-                    : undefined
-                }
-                message={t(
-                  !!userBonusBalance
-                    ? BonusProgramTexts.bonusProfile.joined.welcomeGiftDescription(
-                        userBonusBalance,
-                      )
-                    : BonusProgramTexts.bonusProfile.joined.title,
-                )}
-              />
-            )}
             <Section>
               <GenericSectionItem>
                 <UserBonusBalanceContent />

--- a/src/translations/screens/subscreens/BonusProgram.ts
+++ b/src/translations/screens/subscreens/BonusProgram.ts
@@ -114,19 +114,6 @@ const BonusProgramTexts = {
       'We are unable to display your points right now. You will still earn points as usual.',
       'Me klarer ikkje visa poenga dine akkurat no. Du vil framleis tena poeng som vanleg.',
     ),
-    joined: {
-      title: _(
-        'Du er med i AtB Bonus!',
-        'You have joined AtB Bonus!',
-        'Du er med i AtB Bonus!',
-      ),
-      welcomeGiftDescription: (points: number) =>
-        _(
-          `Du har fått ${points} p i velkomstgave!`,
-          `You have received ${points} points as a welcome gift!`,
-          `Du har fått ${points} poeng i velkomstgåve!`,
-        ),
-    },
     noBonusProducts: _(
       'Vi klarer ikke dette akkurat nå. Du vil fortsatt tjene poeng som vanlig.',
       'We are unable to display this right now. You will still earn points as usual.',


### PR DESCRIPTION
## Description
Welcome gifts for joining Bonus are no longer relevant. Therefore the logic to show welcome gift message is removed.