### PR TITLE
fix: only buyer sees earned bonus on ticket sent to others

### DIFF
--- a/src/modules/fare-contracts/FareContractView.tsx
+++ b/src/modules/fare-contracts/FareContractView.tsx
@@ -11,6 +11,7 @@ import {useMobileTokenContext} from '@atb/modules/mobile-token';
 import {useOperatorBenefitsForFareProduct} from '@atb/modules/mobility';
 import {
   isCanBeConsumedNowFareContract,
+  isSentOrReceivedFareContract,
   useGetFareProductsQuery,
   useSchoolCarnetInfoQuery,
 } from '@atb/modules/ticketing';
@@ -85,9 +86,14 @@ export const FareContractView: React.FC<Props> = ({
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
 
+  const isReceived =
+    isSentOrReceivedFareContract(fareContract) &&
+    fareContract.purchasedBy != currentUserId;
+
   const shouldGetBonusAmountEarned =
     (validityStatus === 'valid' || validityStatus === 'upcoming') &&
-    isBonusActiveForUser;
+    isBonusActiveForUser &&
+    !isReceived;
 
   const shouldShowLegs =
     preassignedFareProduct?.isBookingEnabled && !!legs?.length;

--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -240,7 +240,7 @@ export const DetailsContent: React.FC<Props> = ({
           onNavigateToMap={onNavigateToMap}
         />
       )}
-      {isBonusActiveForUser && !!bonusAmountEarned?.amount && (
+      {isBonusActiveForUser && !isReceived && !!bonusAmountEarned?.amount && (
         <EarnedBonusPointsSectionItem
           amount={bonusAmountEarned.amount}
           navigateToBonusScreen={onNavigateToBonusScreen}


### PR DESCRIPTION
## Description
When a ticket is sent to others:
Only the user who has bought the ticket should be able to see how many points was earned for the purchase, as they are the one who received the point(s)

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/6ae7eccd-e445-4749-b1c8-4406820edf34" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/080f7eb0-10f3-435c-aaee-354d172a289f" />
