### PR TITLE
feat: add city bike illustrations and bonus star

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^11.0.0",
-    "@atb-as/generate-assets": "^18.14.0",
+    "@atb-as/generate-assets": "^18.15.0",
     "@atb-as/theme": "^15.2.0",
     "@atb-as/utils": "^6.1.0",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0(zod@4.1.11)
       '@atb-as/generate-assets':
-        specifier: ^18.14.0
-        version: 18.14.0
+        specifier: ^18.15.0
+        version: 18.15.0
       '@atb-as/theme':
         specifier: ^15.2.0
         version: 15.2.0
@@ -499,8 +499,8 @@ packages:
     peerDependencies:
       zod: ^4.1.11
 
-  '@atb-as/generate-assets@18.14.0':
-    resolution: {integrity: sha512-IyotQkhAfLIFq6JDz5n1YbiAe7+qq3WYqYg/dogQmhWf8bvjW08a5lSHhnkCgn2rI2Z4hdJbTvrzAuXl4uhvEg==}
+  '@atb-as/generate-assets@18.15.0':
+    resolution: {integrity: sha512-yPPeW1oSeT7THIN3e2ZpvWif154GHM+5x0iNr1huuQxO1G6lg1Od5XaoWgEozY4aN1vFdqDc0oqBP/tSQlqfqA==}
     hasBin: true
 
   '@atb-as/theme@14.0.1':
@@ -7319,7 +7319,7 @@ snapshots:
       yargs: 17.7.2
       zod: 4.1.11
 
-  '@atb-as/generate-assets@18.14.0':
+  '@atb-as/generate-assets@18.15.0':
     dependencies:
       '@atb-as/theme': 14.0.1
       commander: 9.5.0

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -46,6 +46,14 @@ import {
   BundlingCarSharingActive as BundlingCarSharingActiveDark,
   BundlingCityBikeActive as BundlingCityBikeActiveDark,
   CityBike as CityBikeDark,
+  CityBikeRide as CityBikeRideDark,
+  CityBikeStation as CityBikeStationDark,
+  CityBikeStationPerson as CityBikeStationPersonDark,
+  ElectricCityBike as ElectricCityBikeDark,
+  ElectricCityBikeRide as ElectricCityBikeRideDark,
+  ElectricCityBikeStation as ElectricCityBikeStationDark,
+  ElectricCityBikeStationPerson as ElectricCityBikeStationPersonDark,
+  StartCityBike as StartCityBikeDark,
   ParkAndRide as ParkAndRideDark,
   BabyOnScooter as BabyOnScooterDark,
   Scooter as ScooterDark,
@@ -55,6 +63,14 @@ import {
   BundlingCarSharingActive as BundlingCarSharingActiveLight,
   BundlingCityBikeActive as BundlingCityBikeActiveLight,
   CityBike as CityBikeLight,
+  CityBikeRide as CityBikeRideLight,
+  CityBikeStation as CityBikeStationLight,
+  CityBikeStationPerson as CityBikeStationPersonLight,
+  ElectricCityBike as ElectricCityBikeLight,
+  ElectricCityBikeRide as ElectricCityBikeRideLight,
+  ElectricCityBikeStation as ElectricCityBikeStationLight,
+  ElectricCityBikeStationPerson as ElectricCityBikeStationPersonLight,
+  StartCityBike as StartCityBikeLight,
   ParkAndRide as ParkAndRideLight,
   BabyOnScooter as BabyOnScooterLight,
   Scooter as ScooterLight,
@@ -64,6 +80,7 @@ import {
   BonusBagCarry as BonusBagCarryLight,
   BonusBagHug as BonusBagHugLight,
   BonusMap as BonusMapLight,
+  BonusStar as BonusStarLight,
   BonusTransaction as BonusTransactionLight,
   BonusTrashCan as BonusTrashCanLight,
 } from '@atb/assets/svg/color/images/bonus/light';
@@ -72,6 +89,7 @@ import {
   BonusBagCarry as BonusBagCarryDark,
   BonusBagHug as BonusBagHugDark,
   BonusMap as BonusMapDark,
+  BonusStar as BonusStarDark,
   BonusTransaction as BonusTransactionDark,
   BonusTrashCan as BonusTrashCanDark,
 } from '@atb/assets/svg/color/images/bonus/dark';
@@ -132,6 +150,38 @@ export const ThemedBundlingCityBikeActive = getThemedAsset(
   BundlingCityBikeActiveLight,
   BundlingCityBikeActiveDark,
 );
+export const ThemedElectricCityBike = getThemedAsset(
+  ElectricCityBikeLight,
+  ElectricCityBikeDark,
+);
+export const ThemedCityBikeRide = getThemedAsset(
+  CityBikeRideLight,
+  CityBikeRideDark,
+);
+export const ThemedElectricCityBikeRide = getThemedAsset(
+  ElectricCityBikeRideLight,
+  ElectricCityBikeRideDark,
+);
+export const ThemedCityBikeStation = getThemedAsset(
+  CityBikeStationLight,
+  CityBikeStationDark,
+);
+export const ThemedElectricCityBikeStation = getThemedAsset(
+  ElectricCityBikeStationLight,
+  ElectricCityBikeStationDark,
+);
+export const ThemedCityBikeStationPerson = getThemedAsset(
+  CityBikeStationPersonLight,
+  CityBikeStationPersonDark,
+);
+export const ThemedElectricCityBikeStationPerson = getThemedAsset(
+  ElectricCityBikeStationPersonLight,
+  ElectricCityBikeStationPersonDark,
+);
+export const ThemedStartCityBike = getThemedAsset(
+  StartCityBikeLight,
+  StartCityBikeDark,
+);
 export const ThemedFlexibleTransport = getThemedAsset(
   FlexibleTransportLight,
   FlexibleTransportDark,
@@ -171,6 +221,7 @@ export const ThemedBonusBagHug = getThemedAsset(
   BonusBagHugDark,
 );
 export const ThemedBonusMap = getThemedAsset(BonusMapLight, BonusMapDark);
+export const ThemedBonusStar = getThemedAsset(BonusStarLight, BonusStarDark);
 export const ThemedBonusTransaction = getThemedAsset(
   BonusTransactionLight,
   BonusTransactionDark,


### PR DESCRIPTION
## Summary
Wires up the new illustrations from `@atb-as/generate-assets` 18.15.0.

- Bump `@atb-as/generate-assets` `^18.14.0` → `^18.15.0`
- Add themed (light/dark) components in `ThemedAssets.tsx`:
  - `ThemedElectricCityBike`
  - `ThemedCityBikeRide`, `ThemedElectricCityBikeRide`
  - `ThemedCityBikeStation`, `ThemedElectricCityBikeStation`
  - `ThemedCityBikeStationPerson`, `ThemedElectricCityBikeStationPerson`
  - `ThemedStartCityBike`
  - `ThemedBonusStar`
