### PR TITLE
fix: don't re-enroll already enrolled users in bonus onboarding

### DIFF
--- a/src/modules/bonus/onboarding/BonusOnboarding_JoinScreen.tsx
+++ b/src/modules/bonus/onboarding/BonusOnboarding_JoinScreen.tsx
@@ -20,22 +20,28 @@ import {ThemeIcon} from '@atb/components/theme-icon';
 import {
   KnownProgramId,
   useEnrollIntoProgramWithIdMutation,
+  useIsEnrolled,
 } from '@atb/modules/enrollment';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useNavigation} from '@react-navigation/native';
 import {RootNavigationProps} from '@atb/stacks-hierarchy';
 import {Activity} from '@atb/assets/svg/mono-icons/miscellaneous';
+import {useNestedProfileScreenParams} from '@atb/utils/use-nested-profile-screen-params';
 
 export const BonusOnboarding_JoinScreen = () => {
   const focusRef = useFocusOnLoad();
   const {t} = useTranslation();
   const navigation = useNavigation<RootNavigationProps>();
   const enrollMutation = useEnrollIntoProgramWithIdMutation();
+  const isEnrolled = useIsEnrolled(KnownProgramId.BONUS);
+  const bonusScreenParams = useNestedProfileScreenParams('Profile_BonusScreen');
 
   const onPress = async () => {
     try {
-      await enrollMutation.mutateAsync(KnownProgramId.BONUS);
-      navigation.goBack();
+      if (!isEnrolled) {
+        await enrollMutation.mutateAsync(KnownProgramId.BONUS);
+      }
+      navigation.navigate('Root_TabNavigatorStack', bonusScreenParams);
     } catch {
       // Error state is handled via enrollMutation.error and shown in the UI
     }


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->
N/A

## Description

<details><summary>Screen recording</summary>
<p>

https://github.com/user-attachments/assets/e9bca69a-4d4d-4116-ab01-75e72e72f913




</p>
</details> 

When a user enrolls in the bonus program with an invite code on the enrollment screen, they are enrolled immediately via `POST enrollment/v2/enroll`. On success the app navigates to the bonus onboarding (`BonusOnboarding_JoinScreen`), where the accept button unconditionally fired a second enroll (`POST enrollment/v2/enroll/bonus`). Since the user was already enrolled, this call failed and the screen showed the misleading error "You were not enrolled in AtB Bonus" — even though the enrollment had succeeded.

Changes:
- Skip the enroll-by-id call when the user is already enrolled (`useIsEnrolled`). The enrollments cache is already invalidated by the code enrollment, so the guard is in place by the time the user accepts the terms.
- Navigate to `Profile_BonusScreen` after accepting (instead of `goBack()`), using the same nested-params pattern as `Root_FareContractDetailsScreen`. Both entry points (invite code flow and the join button on the bonus screen) now land on the bonus screen.

The join flow from `Profile_BonusScreen` for not-yet-enrolled users is unchanged — they are still enrolled when pressing accept.