### PR TITLE
fix: gate parking report link by feature toggle

### DIFF
--- a/src/stacks-hierarchy/Root_ShmoHelp/components/ShmoContactSection.tsx
+++ b/src/stacks-hierarchy/Root_ShmoHelp/components/ShmoContactSection.tsx
@@ -15,6 +15,7 @@ import {ArrowRight, ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {openUrl} from '@atb/utils/open-url';
 import {MobilityOperatorType} from '@atb/modules/configuration';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 type Props = {
   operatorName: string | undefined;
@@ -35,6 +36,7 @@ export const ShmoContactSection = ({
 }: Props) => {
   const {t} = useTranslation();
   const style = useStyles();
+  const {isParkingViolationsReportingEnabled} = useFeatureTogglesContext();
 
   const isBicycle = formFactor === FormFactor.Bicycle;
 
@@ -92,7 +94,7 @@ export const ShmoContactSection = ({
           />
         )}
 
-        {!isBicycle && (
+        {!isBicycle && isParkingViolationsReportingEnabled && (
           <LinkSectionItem
             text={t(ShmoHelpTexts.reportParking)}
             rightIcon={{svg: ArrowRight}}


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->

## Description
The "Report parking" link on the shmo help screen (`ShmoContactSection`) was shown for all non-bicycle form factors regardless of the `enable_parking_violations_reporting` remote config flag. The map vehicle sheet entry point is already gated by `isParkingViolationsReportingEnabled` — this gates the second (and only other) entry point into the parking violations reporting flow with the same toggle.