### PR TITLE
feat: update StartTimeSelection texts

### DIFF
--- a/src/components/date-selection/DatePickerSheet.tsx
+++ b/src/components/date-selection/DatePickerSheet.tsx
@@ -23,6 +23,7 @@ type Props<T extends string> = {
   initialDate?: string;
   initialOption?: T;
   options: DateOptionAndText<T>[];
+  heading?: string;
   onSave: (optionAndValue: DateOptionAndValue<T>) => void;
   bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
   onCloseFocusRef: RefObject<View | null>;
@@ -42,6 +43,7 @@ export const DatePickerSheet = <T extends string>({
   initialDate,
   initialOption,
   options,
+  heading,
   onSave,
   bottomSheetModalRef,
   onCloseFocusRef,
@@ -72,7 +74,7 @@ export const DatePickerSheet = <T extends string>({
   return (
     <BottomSheetModal
       bottomSheetModalRef={bottomSheetModalRef}
-      heading={t(DatePickerSheetTexts.heading)}
+      heading={heading ?? t(DatePickerSheetTexts.heading)}
       bottomSheetHeaderType={BottomSheetHeaderType.Confirm}
       closeCallback={() => {
         onSave({option: selectedOptionId, date});

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -9,7 +9,6 @@ import {
 } from '@atb/modules/purchase-selection';
 import {DatePickerSheet} from '@atb/components/date-selection';
 import {EditActionSectionItem, Section} from '@atb/components/sections';
-import {screenReaderPause} from '@atb/components/text';
 import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {Time} from '@atb/assets/svg/mono-icons/time';
 
@@ -49,22 +48,10 @@ export function StartTimeSelection({
             leftIcon={Time}
             text={
               selection.travelDate
-                ? t(PurchaseOverviewTexts.startTime.laterTime)
-                : t(PurchaseOverviewTexts.startTime.now)
-            }
-            subText={
-              selection.travelDate
                 ? formatToLongDateTime(selection.travelDate, language)
-                : undefined
+                : t(PurchaseOverviewTexts.startTime.now)
             }
             onPress={openDatePickerSheet}
-            accessibilityLabel={
-              selection.travelDate
-                ? t(PurchaseOverviewTexts.startTime.laterTime) +
-                  screenReaderPause +
-                  formatToLongDateTime(selection.travelDate, language)
-                : t(PurchaseOverviewTexts.startTime.now)
-            }
             accessibilityHint={t(PurchaseOverviewTexts.startTime.a11yLaterHint)}
             testID="startTimeButton"
           />
@@ -95,6 +82,7 @@ export function StartTimeSelection({
             .build();
           setSelection(newSelection);
         }}
+        heading={t(PurchaseOverviewTexts.startTime.bottomSheetTitle)}
         initialDate={selection.travelDate}
         onCloseFocusRef={onCloseFocusRef}
         bottomSheetModalRef={bottomSheetModalRef}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -1,5 +1,9 @@
 import React, {useRef} from 'react';
-import {PurchaseOverviewTexts, useTranslation} from '@atb/translations';
+import {
+  dictionary,
+  PurchaseOverviewTexts,
+  useTranslation,
+} from '@atb/translations';
 import {StyleProp, View, ViewStyle} from 'react-native';
 import {formatToLongDateTime, isInThePast} from '@atb/utils/date';
 import {ContentHeading} from '@atb/components/heading';
@@ -49,7 +53,7 @@ export function StartTimeSelection({
             text={
               selection.travelDate
                 ? formatToLongDateTime(selection.travelDate, language)
-                : t(PurchaseOverviewTexts.startTime.now)
+                : t(dictionary.date.units.now)
             }
             onPress={openDatePickerSheet}
             accessibilityHint={t(PurchaseOverviewTexts.startTime.a11yLaterHint)}
@@ -61,12 +65,12 @@ export function StartTimeSelection({
         options={[
           {
             option: 'now',
-            text: t(PurchaseOverviewTexts.startTime.now),
+            text: t(dictionary.date.units.now),
             selected: !selection.travelDate,
           },
           {
             option: 'later',
-            text: t(PurchaseOverviewTexts.startTime.laterOption),
+            text: t(dictionary.date.units.later),
             selected: !!selection.travelDate,
           },
         ]}

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -186,9 +186,13 @@ const PurchaseOverviewTexts = {
   },
   startTime: {
     title: _('Oppstartstidspunkt', 'Start time', 'Starttidspunkt'),
-    now: _('Oppstart nå', 'Start now', 'Oppstart no'),
-    laterTime: _('Oppstart senere', 'Start later', 'Start seinare'),
-    laterOption: _('Oppstart senere', 'Start later', 'Start seinare'),
+    bottomSheetTitle: _(
+      'Velg oppstartstidspunkt',
+      'Select start time',
+      'Vel oppstartstidspunkt',
+    ),
+    now: _('Nå', 'Now', 'No'),
+    laterOption: _('Senere', 'Later', 'Seinare'),
     a11yLaterHint: _(
       'Aktiver for å velge oppstartstidspunkt',
       'Activate to select start time',

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -191,8 +191,6 @@ const PurchaseOverviewTexts = {
       'Select start time',
       'Vel oppstartstidspunkt',
     ),
-    now: _('Nå', 'Now', 'No'),
-    laterOption: _('Senere', 'Later', 'Seinare'),
     a11yLaterHint: _(
       'Aktiver for å velge oppstartstidspunkt',
       'Activate to select start time',


### PR DESCRIPTION

## Issue Reference

follow up to https://github.com/AtB-AS/kundevendt/issues/23884

## Description

- "Start later" -> "Later"
- Shows the date only if later start date is selected (no subtext, just date as primary)
- Uses "Select start time" as header in the bottom sheet

Changes made based on input from @jennyluongg

## Acceptance criteria

- [x] Start time selection in ticket purchase has new texts, which works with screen reader etc.
- [x] Related change in planner web https://github.com/AtB-AS/planner-web/pull/738 ("Leave now" -> "Now")