### PR TITLE
fix: show earned bonus points on tickets sent to others

### DIFF
--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -158,7 +158,9 @@ export const DetailsContent: React.FC<Props> = ({
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const shouldShowBonusAmountEarned =
-    isRelativeValidityStatus(validityStatus) && isBonusActiveForUser;
+    isBonusActiveForUser &&
+    !isReceived &&
+    (isRelativeValidityStatus(validityStatus) || validityStatus === 'sent');
 
   const accesses = getAccesses(fc);
 
@@ -247,14 +249,12 @@ export const DetailsContent: React.FC<Props> = ({
         />
       )}
 
-      {shouldShowBonusAmountEarned &&
-        !isReceived &&
-        !!bonusAmountEarned?.amount && (
-          <EarnedBonusPointsSectionItem
-            amount={bonusAmountEarned.amount}
-            navigateToBonusScreen={onNavigateToBonusScreen}
-          />
-        )}
+      {shouldShowBonusAmountEarned && !!bonusAmountEarned?.amount && (
+        <EarnedBonusPointsSectionItem
+          amount={bonusAmountEarned.amount}
+          navigateToBonusScreen={onNavigateToBonusScreen}
+        />
+      )}
       {!!usedAccesses?.length && (
         <UsedAccessesSectionItem usedAccesses={usedAccesses} />
       )}


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->

## Description
After #6147, the buyer should see earned bonus points on tickets sent to others, but `shouldShowBonusAmountEarned` only allowed relative validity statuses (`upcoming`/`valid`/`expired`), so the `sent` status never showed the earned bonus section. This adds `sent` as an allowed status.

Also folds the existing `!isReceived` render guard into `shouldShowBonusAmountEarned` so the whole show/hide condition lives in one place. No behavior change for receivers — they still never see the earned bonus section.