### PR TITLE
feat: add edit button to recent ticket confirmation

### DIFF
--- a/src/modules/payment/PaymentSelectionSectionItem.tsx
+++ b/src/modules/payment/PaymentSelectionSectionItem.tsx
@@ -1,7 +1,7 @@
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
 import {humanizePaymentType} from '@atb/modules/ticketing';
-import {useTranslation} from '@atb/translations';
+import {dictionary, useTranslation} from '@atb/translations';
 import React, {forwardRef} from 'react';
 import PaymentMethodsTexts from '@atb/translations/screens/subscreens/PaymentMethods';
 import SelectPaymentMethodTexts from '@atb/translations/screens/subscreens/SelectPaymentMethodTexts';
@@ -81,7 +81,7 @@ export const PaymentSelectionSectionItem = forwardRef<
             )}
         </View>
         <View style={style.actionButton}>
-          <ThemeText>{t(PaymentMethodsTexts.editPaymentMethod)}</ThemeText>
+          <ThemeText>{t(dictionary.edit)}</ThemeText>
           <ThemeIcon svg={SvgEdit} />
         </View>
       </View>

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -308,6 +308,18 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
           }
           validDurationSeconds={validDurationSeconds}
           legs={selection.legs}
+          onEdit={
+            params.allowEdit
+              ? () => {
+                  navigation.navigate('Root_PurchaseOverviewScreen', {
+                    selection,
+                    mode: params.mode,
+                    tripAnalytics: params.tripAnalytics,
+                    transitionOverride: 'slide-from-right',
+                  });
+                }
+              : undefined
+          }
         />
         <PriceSummary
           fareProductTypeConfig={selection.fareProductTypeConfig}

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/components/PreassignedFareProductSummary.tsx
@@ -12,21 +12,25 @@ import {
   GlobalMessage,
   GlobalMessageContextEnum,
 } from '@atb/modules/global-messages';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
   Language,
   PurchaseConfirmationTexts,
   getTextForLanguage,
   useTranslation,
+  dictionary,
 } from '@atb/translations';
 import {formatToLongDateTime, secondsToDuration} from '@atb/utils/date';
 import {formatPhoneNumber} from '@atb/utils/phone-number-utils';
 import React from 'react';
 import {View} from 'react-native';
+import {NativeBlockButton} from '@atb/components/native-button';
 import {TicketRecipientType} from '@atb/modules/ticketing';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {LegsSummary} from '@atb/components/journey-legs-summary';
 import type {Leg} from '@atb/api/types/trips';
+import SvgEdit from '@atb/assets/svg/mono-icons/actions/Edit';
+import {ThemeIcon} from '@atb/components/theme-icon';
 
 type Props = {
   preassignedFareProduct: PreassignedFareProduct;
@@ -37,6 +41,7 @@ type Props = {
   validDurationSeconds?: number;
   travelDate?: string;
   legs?: Leg[];
+  onEdit?: () => void;
 };
 
 export const PreassignedFareContractSummary = ({
@@ -48,6 +53,7 @@ export const PreassignedFareContractSummary = ({
   validDurationSeconds,
   travelDate,
   legs,
+  onEdit,
 }: Props) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
@@ -65,6 +71,8 @@ export const PreassignedFareContractSummary = ({
         ),
       )
     : t(PurchaseConfirmationTexts.travelDate.now);
+
+  const {theme} = useThemeContext();
 
   function summary(text?: string) {
     if (!text) return null;
@@ -116,60 +124,80 @@ export const PreassignedFareContractSummary = ({
   return (
     <Section>
       <GenericSectionItem>
-        <View accessible={true} style={styles.ticketInfoContainer}>
-          <ThemeText>
-            {getReferenceDataName(preassignedFareProduct, language)}
-          </ThemeText>
-          {recipient && (
-            <ThemeText
-              typography="body__s"
-              type="secondary"
-              style={styles.sendingToText}
-              testID="onBehalfOfText"
-            >
-              {t(
-                PurchaseConfirmationTexts.sendingTo(
-                  recipient.name || formatPhoneNumber(recipient.phoneNumber),
+        <View style={styles.ticketInfoContainer}>
+          <View style={styles.headerRow}>
+            <ThemeText>
+              {getReferenceDataName(preassignedFareProduct, language)}
+            </ThemeText>
+            {onEdit && (
+              <NativeBlockButton
+                onPress={onEdit}
+                style={styles.editButton}
+                accessibilityRole="button"
+                accessibilityLabel={t(dictionary.edit)}
+              >
+                <ThemeText color={theme.color.foreground.emphasis.interactive}>
+                  {t(dictionary.edit)}
+                </ThemeText>
+                <ThemeIcon
+                  svg={SvgEdit}
+                  color={theme.color.foreground.emphasis.interactive}
+                />
+              </NativeBlockButton>
+            )}
+          </View>
+          <View accessible={true}>
+            {recipient && (
+              <ThemeText
+                typography="body__s"
+                type="secondary"
+                style={styles.sendingToText}
+                testID="onBehalfOfText"
+              >
+                {t(
+                  PurchaseConfirmationTexts.sendingTo(
+                    recipient.name || formatPhoneNumber(recipient.phoneNumber),
+                  ),
+                )}
+              </ThemeText>
+            )}
+            {fareProductTypeConfig.direction &&
+              summary(
+                t(
+                  PurchaseConfirmationTexts.validityTexts.direction[
+                    fareProductTypeConfig.direction
+                  ](fromPlaceName, toPlaceName),
                 ),
               )}
-            </ThemeText>
-          )}
-          {fareProductTypeConfig.direction &&
-            summary(
-              t(
-                PurchaseConfirmationTexts.validityTexts.direction[
-                  fareProductTypeConfig.direction
-                ](fromPlaceName, toPlaceName),
-              ),
-            )}
-          <SummaryText />
-          {!!validDurationSeconds &&
-            isShowValidTimeInfoEnabled &&
-            summary(
-              t(
-                PurchaseConfirmationTexts.validityTexts.time(
-                  secondsToDuration(validDurationSeconds, language),
+            <SummaryText />
+            {!!validDurationSeconds &&
+              isShowValidTimeInfoEnabled &&
+              summary(
+                t(
+                  PurchaseConfirmationTexts.validityTexts.time(
+                    secondsToDuration(validDurationSeconds, language),
+                  ),
                 ),
-              ),
-            )}
-          <GlobalMessage
-            style={styles.globalMessage}
-            globalMessageContext={
-              GlobalMessageContextEnum.appPurchaseConfirmation
-            }
-            textColor="secondary"
-            ruleVariables={{
-              preassignedFareProductType: preassignedFareProduct.type,
-            }}
-          />
-          {!fareProductTypeConfig.isCollectionOfAccesses && (
-            <MessageInfoText
-              style={styles.smallTopMargin}
-              type="info"
-              message={travelDateText}
+              )}
+            <GlobalMessage
+              style={styles.globalMessage}
+              globalMessageContext={
+                GlobalMessageContextEnum.appPurchaseConfirmation
+              }
               textColor="secondary"
+              ruleVariables={{
+                preassignedFareProductType: preassignedFareProduct.type,
+              }}
             />
-          )}
+            {!fareProductTypeConfig.isCollectionOfAccesses && (
+              <MessageInfoText
+                style={styles.smallTopMargin}
+                type="info"
+                message={travelDateText}
+                textColor="secondary"
+              />
+            )}
+          </View>
         </View>
       </GenericSectionItem>
       {!!legs?.length && (
@@ -193,6 +221,14 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   ticketInfoContainer: {
     flex: 1,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  editButton: {
+    flexDirection: 'row',
+    gap: theme.spacing.small,
   },
   globalMessage: {
     marginTop: theme.spacing.small,

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/navigation-types.ts
@@ -7,4 +7,5 @@ export type Root_PurchaseConfirmationScreenParams = {
   mode?: 'TravelSearch' | 'Ticket';
   recipient?: TicketRecipientType;
   tripAnalytics?: TripAnalytics;
+  allowEdit?: boolean;
 };

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -111,7 +111,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params?.refreshOffer]);
 
-  const closeModal = () => navigation.popToTop();
+  const closeModal = () => navigation.pop();
 
   const focusRefs = useFocusRefs(params.onFocusElement);
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -110,15 +110,20 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
      *  If booking is enabled we need the user to select a departure, and
      *  thus cannot send them directly to the confirmation screen.
      */
-    const targetScreen = rfc.preassignedFareProduct.isBookingEnabled
-      ? 'Root_PurchaseOverviewScreen'
-      : 'Root_PurchaseConfirmationScreen';
-
-    navigation.navigate(targetScreen, {
-      selection,
-      mode: 'Ticket',
-      transitionOverride: 'slide-from-right',
-    });
+    if (rfc.preassignedFareProduct.isBookingEnabled) {
+      navigation.navigate('Root_PurchaseOverviewScreen', {
+        selection,
+        mode: 'Ticket',
+        transitionOverride: 'slide-from-right',
+      });
+    } else {
+      navigation.navigate('Root_PurchaseConfirmationScreen', {
+        selection,
+        mode: 'Ticket',
+        transitionOverride: 'slide-from-right',
+        allowEdit: true,
+      });
+    }
   };
 
   const refreshControlProps = useManualRefreshControlProps({

--- a/src/translations/dictionary.ts
+++ b/src/translations/dictionary.ts
@@ -202,6 +202,7 @@ const dictionary = {
   },
   confirm: _('Bekreft', 'Confirm', `Bekreft`),
   retry: _('Prøv på nytt', 'Try again', `Prøv på nytt`),
+  edit: _('Endre', 'Edit', 'Endre'),
   cancel: _('Avbryt', 'Cancel', `Avbryt`),
   remove: _('Fjern', 'Remove', `Fjern`),
   seeMore: _('Vis mer', 'See more', `Vis meir`),

--- a/src/translations/screens/subscreens/PaymentMethods.ts
+++ b/src/translations/screens/subscreens/PaymentMethods.ts
@@ -75,7 +75,6 @@ const PaymentMethodsTexts = {
     'When you buy a ticket you can also pay with Vipps or Apple Pay',
     'Når du kjøper billettar kan du også betale med Vipps eller Apple Pay',
   ),
-  editPaymentMethod: _('Endre', 'Edit', 'Endre'),
   expiryMessages: {
     cardExpired: _(
       'Kortet er utløpt',


### PR DESCRIPTION
When buying a recent ticket, the purchase confirmation
screen now shows an edit button that navigates to the
purchase overview so the user can adjust the selection.

This is done as a more short term solution to try to
decrease ticket purchase refunds, while there is an
ongoing initiative looking at it in the bigger picture.

<img width="400" src="https://github.com/user-attachments/assets/413703ef-5761-43b5-babf-89c5eb35558b" />


### Acceptance criteria
- [x] When selecting recent purchase (non booking), there should be an edit option which goes to the overview screen
- [x] When coming to confirmation screen through other sources there should be no edit option
- [x] The edit action should be reachable for screen readers