### PR TITLE
feat: use citybike illustrations

### DIFF
--- a/src/modules/mobility/components/BikeStationIntegrationView.tsx
+++ b/src/modules/mobility/components/BikeStationIntegrationView.tsx
@@ -31,6 +31,7 @@ import {
   MOCK_VEHICLE_ID,
 } from '../queries/use-vehicle-query';
 import {SupportButton} from './SupportButton';
+import {ThemedCityBikeStation} from '@atb/theme/ThemedAssets';
 
 type Props = {
   station: Station;
@@ -82,6 +83,9 @@ export const BikeStationIntegrationView = ({
       )}
 
       <View style={styles.container}>
+        <View style={styles.illustration}>
+          <ThemedCityBikeStation />
+        </View>
         <Section>
           {station?.vehicleTypesAvailable
             ?.filter((e) => {
@@ -183,6 +187,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       paddingHorizontal: theme.spacing.medium,
       paddingBottom: theme.spacing.medium,
       gap: theme.spacing.small,
+    },
+    illustration: {
+      alignItems: 'center',
     },
     freeParkingSection: {
       flexDirection: 'row',

--- a/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
+++ b/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
@@ -27,7 +27,8 @@ export const CityBikeStartTripOverlay = ({
   return (
     <View style={styles.overlay}>
       <ScrollView
-        contentContainerStyle={styles.contentWrapper}
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.title}>
@@ -47,7 +48,6 @@ export const CityBikeStartTripOverlay = ({
           <ThemeText typography="heading__xl" style={styles.contentText}>
             {t(MobilityTexts.cityBike.startTripView.title)}
           </ThemeText>
-
           <ThemeText style={styles.contentText}>
             {t(MobilityTexts.cityBike.startTripView.description)}
           </ThemeText>
@@ -81,11 +81,14 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     paddingBottom: theme.spacing.xLarge,
     zIndex: 100,
   },
-  contentWrapper: {
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 48,
+    gap: theme.spacing.xLarge,
   },
   title: {
     alignItems: 'center',
@@ -96,7 +99,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   content: {
     alignItems: 'center',
-    flexDirection: 'column',
     gap: theme.spacing.medium,
     padding: theme.spacing.large,
   },
@@ -109,6 +111,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   supportButton: {
     width: '100%',
-    marginTop: 'auto',
   },
 }));

--- a/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
+++ b/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
@@ -6,7 +6,7 @@ import {useTranslation} from '@atb/translations';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Parking} from '@atb/assets/svg/mono-icons/places';
 import {StyleSheet} from '@atb/theme';
-import {ThemedCityBike} from '@atb/theme/ThemedAssets';
+import {ThemedStartCityBike} from '@atb/theme/ThemedAssets';
 import {LinkSectionItem} from '@atb/components/sections';
 import {ShmoBooking} from '@atb/api/types/mobility';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
@@ -42,7 +42,7 @@ export const CityBikeStartTripOverlay = ({
             </ThemeText>
           )}
         </View>
-        <ThemedCityBike />
+        <ThemedStartCityBike />
         <View style={styles.content}>
           <ThemeText typography="heading__xl" style={styles.contentText}>
             {t(MobilityTexts.cityBike.startTripView.title)}

--- a/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
@@ -44,7 +44,7 @@ import {useOperators} from '../../use-operators';
 import {SupportButton} from '../SupportButton';
 import {BrandingImage} from '../BrandingImage';
 import {EndManualTripCard} from '../EndManualTripCard';
-import {ThemedCityBike} from '@atb/theme/ThemedAssets';
+import {ThemedCityBikeStation} from '@atb/theme/ThemedAssets';
 import {usePersistedBoolState} from '@atb/utils/use-persisted-bool-state';
 import {storage, StorageModelKeysEnum} from '@atb/modules/storage';
 
@@ -254,7 +254,7 @@ export const ActiveShmoSheet = ({
                         summary={t(
                           MobilityTexts.cityBike.endManualTrip.summary,
                         )}
-                        image={<ThemedCityBike height={54} width={50} />}
+                        image={<ThemedCityBikeStation height={54} width={90} />}
                         handleDismiss={() => setEndTripInfoClosed(true)}
                       />
                     )

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -46,7 +46,7 @@ import {
 import {TFunc} from '@leile/lobo-t';
 import {ErrorResponse, formatNumberToString} from '@atb-as/utils';
 import {FormattedRatePerUnit} from './types';
-import {ThemedCityBike, ThemedScooter} from '@atb/theme/ThemedAssets';
+import {ThemedElectricCityBike, ThemedScooter} from '@atb/theme/ThemedAssets';
 import {getCurrencySymbol} from '@atb/translations/currency';
 
 export const isStationCluster = (
@@ -388,7 +388,7 @@ export function getThemedIllustrationForFormFactor(formFactor: FormFactor) {
     case FormFactor.ScooterStanding:
       return ThemedScooter;
     case FormFactor.Bicycle:
-      return ThemedCityBike;
+      return ThemedElectricCityBike;
     default:
       return null;
   }


### PR DESCRIPTION
Added missing citybike illustrations

Closes https://github.com/AtB-AS/kundevendt/issues/23807

The start trip functionallity was down at entur, so showing the in-use sheet with the new illustration was not possible. So the last image with end trip was just forcefully put into a empty sheet just to show what the section would look like with the illustration.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/0ca44869-b893-4e7b-bb1b-770311745845" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/9bf8e688-2e32-41a8-8553-538e808d3f74" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/0cb3a5a9-a547-4cb7-a92e-c5ce4be81ddc" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/f83cb182-532d-4bfa-aa33-58f16f55bb8b" />
