### PR TITLE
fix: travel card and trip details UI tweaks after demo

### DIFF
--- a/src/modules/experimental-store-trip-patterns/SaveableTripSearchResultRow.tsx
+++ b/src/modules/experimental-store-trip-patterns/SaveableTripSearchResultRow.tsx
@@ -11,11 +11,10 @@ import {getTripPatternAnalytics} from '@atb/screen-components/travel-details-scr
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
 import {useTimeContext} from '../time';
 
-export const SaveableTripSearchResultRow: React.FC<
-  React.PropsWithChildren<{
-    tripPattern: TripPattern;
-  }>
-> = ({children, tripPattern}) => {
+export const SaveableTripSearchResultRow: React.FC<{
+  tripPattern: TripPattern;
+  children: (isStored: boolean) => React.ReactNode;
+}> = ({children, tripPattern}) => {
   const {isSaveTripsEnabled} = useFeatureTogglesContext();
   const {tripPatterns, addTripPattern, removeTripPattern, canAddTripPattern} =
     useStoredTripPatterns();
@@ -69,7 +68,7 @@ export const SaveableTripSearchResultRow: React.FC<
   );
 
   if (!isSaveTripsEnabled || !canAdd) {
-    return children;
+    return children(false);
   }
 
   return (
@@ -77,7 +76,7 @@ export const SaveableTripSearchResultRow: React.FC<
       onRightAction={onRightAction}
       rightActionKind={rightActionKind}
     >
-      {children}
+      {children(isStored)}
       {isStored && (
         <ThemeIcon
           svg={SaveFill}

--- a/src/screen-components/travel-card/StatusText.tsx
+++ b/src/screen-components/travel-card/StatusText.tsx
@@ -6,7 +6,7 @@ import {StyleSheet} from '@atb/theme';
 import {SvgProps} from 'react-native-svg';
 
 type StatusTextProps = {
-  svg: (props: SvgProps) => React.JSX.Element;
+  svg?: (props: SvgProps) => React.JSX.Element;
   color: IconColor;
   text: string;
 };
@@ -15,7 +15,7 @@ export const StatusText: React.FC<StatusTextProps> = ({svg, color, text}) => {
   const styles = useStyles();
   return (
     <View style={styles.container}>
-      <ThemeIcon svg={svg} color={color} size="xSmall" />
+      {svg && <ThemeIcon svg={svg} color={color} size="xSmall" />}
       <ThemeText typography="body__s__strong" color={color}>
         {text}
       </ThemeText>

--- a/src/screen-components/travel-card/TravelCard.tsx
+++ b/src/screen-components/travel-card/TravelCard.tsx
@@ -25,6 +25,7 @@ type TravelCardProps = {
   includeSituationsAndNotices?: boolean;
   includeTransportInfo?: boolean;
   isDisabled?: boolean;
+  isSaved?: boolean;
   tag?: {label: string; type: Statuses};
 };
 
@@ -39,6 +40,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
   includeSituationsAndNotices = false,
   includeTransportInfo = false,
   isDisabled = false,
+  isSaved = false,
   tag,
 }) => {
   const styles = useThemeStyles();
@@ -83,6 +85,7 @@ export const TravelCard: React.FC<TravelCardProps> = ({
               tripPattern={tripPattern}
               includeDayInfo={includeDayInfo}
               includeFromToInfo={includeFromToInfo}
+              isSaved={isSaved}
             />
             <View style={styles.legsContainer}>
               <View

--- a/src/screen-components/travel-card/TravelCardHeader.tsx
+++ b/src/screen-components/travel-card/TravelCardHeader.tsx
@@ -99,7 +99,6 @@ export const TravelCardHeader: React.FC<
         <View style={styles.timeContainer}>
           {statusTextConfig && (
             <StatusText
-              svg={statusTextConfig.svg}
               color={statusTextConfig.color}
               text={statusTextConfig.text}
             />

--- a/src/screen-components/travel-card/TravelCardHeader.tsx
+++ b/src/screen-components/travel-card/TravelCardHeader.tsx
@@ -22,12 +22,14 @@ export const TravelCardHeader: React.FC<
     size?: TravelCardHeaderSize;
     includeDayInfo?: boolean;
     includeFromToInfo?: boolean;
+    isSaved?: boolean;
   }
 > = ({
   tripPattern,
   size = 'standard',
   includeDayInfo = true,
   includeFromToInfo = true,
+  isSaved = false,
   ...accessibilityProps
 }) => {
   const styles = useThemeStyles();
@@ -116,7 +118,12 @@ export const TravelCardHeader: React.FC<
           )}
         </View>
 
-        <View style={styles.durationContainer}>
+        <View
+          style={[
+            styles.durationContainer,
+            isSaved && styles.durationContainerSaved,
+          ]}
+        >
           <ThemeText
             typography="body__m"
             type="secondary"
@@ -151,6 +158,9 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
   durationContainer: {
     flexShrink: 0,
     alignItems: 'flex-end',
+  },
+  durationContainerSaved: {
+    paddingTop: theme.spacing.medium,
   },
   fromToContainer: {
     flexDirection: 'row',

--- a/src/screen-components/travel-card/types.ts
+++ b/src/screen-components/travel-card/types.ts
@@ -1,6 +1,4 @@
 import type {IconColor} from '@atb/components/theme-icon';
-import type {SvgProps} from 'react-native-svg';
-import {JSX} from 'react';
 
 export type TripPatternStatus =
   | 'started'
@@ -13,7 +11,6 @@ export type TripPatternStatus =
 
 export type StatusTextConfig = {
   type: TripPatternStatus;
-  svg: (props: SvgProps) => JSX.Element;
   color: IconColor;
   text: string;
 };

--- a/src/screen-components/travel-card/utils.ts
+++ b/src/screen-components/travel-card/utils.ts
@@ -15,15 +15,6 @@ import {Statuses} from '@atb/theme';
 import type {StatusTextConfig, TripPatternStatus} from './types';
 import type {TranslateFunction} from '@atb/translations';
 import {TravelCardTexts} from '@atb/translations';
-import {Close} from '@atb/assets/svg/mono-icons/actions';
-import SvgError from '@atb/assets/svg/color/icons/status/light/Error';
-import {
-  BookingClosed,
-  BookingRequired,
-  Check,
-  Warning,
-} from '@atb/assets/svg/mono-icons/status';
-import {Duration} from '@atb/assets/svg/mono-icons/time';
 import {isInThePast, secondsBetween} from '@atb/utils/date';
 
 type StatusColors = {
@@ -81,49 +72,42 @@ export function getStatusTextConfig(
     case 'cancelled':
       return {
         type: 'cancelled',
-        svg: SvgError,
         color: colors.error,
         text: t(TravelCardTexts.header.cancelled),
       };
     case 'impossible':
       return {
         type: 'impossible',
-        svg: Close,
         color: 'error',
         text: t(TravelCardTexts.header.notPossible),
       };
     case 'ended':
       return {
         type: 'ended',
-        svg: Check,
         color: colors.error,
         text: t(TravelCardTexts.header.tripEnded),
       };
     case 'started':
       return {
         type: 'started',
-        svg: Duration,
         color: colors.info,
         text: t(TravelCardTexts.header.tripStarted),
       };
     case 'bookingDeadlineExceeded':
       return {
         type: 'bookingDeadlineExceeded',
-        svg: BookingClosed,
         color: colors.interactive,
         text: t(TravelCardTexts.header.bookingDeadlineExceeded),
       };
     case 'requiresBooking':
       return {
         type: 'requiresBooking',
-        svg: BookingRequired,
         color: colors.info,
         text: t(TravelCardTexts.header.requiresBooking),
       };
     case 'stale':
       return {
         type: 'stale',
-        svg: Warning,
         color: colors.info,
         text: t(TravelCardTexts.header.staleTrip),
       };

--- a/src/screen-components/travel-details-screens/components/TripRow.tsx
+++ b/src/screen-components/travel-details-screens/components/TripRow.tsx
@@ -6,12 +6,14 @@ import {NativeBlockButton} from '@atb/components/native-button';
 export type DimensionOverrides = {
   labelWidth?: number;
   decorationContainerWidth?: number;
+  labelAlignment?: 'flex-start' | 'flex-end';
 };
 
 // TODO: Remove / rename once old trip details are removed
 export const NEW_TRIP_DIMENSIONS: DimensionOverrides = {
-  labelWidth: 64,
+  labelWidth: 42,
   decorationContainerWidth: 42,
+  labelAlignment: 'flex-start',
 };
 
 type TripRowProps = {
@@ -40,6 +42,9 @@ export const TripRow: React.FC<TripRowProps> = ({
           styles.leftColumn,
           dimensionOverrides?.labelWidth != null && {
             minWidth: dimensionOverrides.labelWidth,
+          },
+          dimensionOverrides?.labelAlignment != null && {
+            justifyContent: dimensionOverrides.labelAlignment,
           },
         ]}
       >

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/Results.tsx
@@ -101,28 +101,31 @@ export const Results: React.FC<Props> = ({
               previousDepartureTime={tripPatterns[i - 1]?.expectedStartTime}
             />
             <SaveableTripSearchResultRow tripPattern={tripPattern}>
-              {isExperimentalEnabled ? (
-                <TravelCard
-                  tripPattern={tripPattern}
-                  onDetailsPressed={onDetailsPressed}
-                  testID={'tripSearchSearchResult' + i}
-                  a11yLabelPrefix={t(
-                    TravelCardTexts.card.a11yPrefix.tripSuggestion(
-                      i,
-                      tripPatterns.length,
-                    ),
-                  )}
-                  a11yHint={t(TravelCardTexts.card.a11yHint.tripDetails)}
-                />
-              ) : (
-                <ResultRow
-                  tripPattern={tripPattern}
-                  onDetailsPressed={onDetailsPressed}
-                  resultIndex={i}
-                  searchTime={searchTime}
-                  testID={'tripSearchSearchResult' + i}
-                />
-              )}
+              {(isSaved) =>
+                isExperimentalEnabled ? (
+                  <TravelCard
+                    tripPattern={tripPattern}
+                    onDetailsPressed={onDetailsPressed}
+                    testID={'tripSearchSearchResult' + i}
+                    a11yLabelPrefix={t(
+                      TravelCardTexts.card.a11yPrefix.tripSuggestion(
+                        i,
+                        tripPatterns.length,
+                      ),
+                    )}
+                    a11yHint={t(TravelCardTexts.card.a11yHint.tripDetails)}
+                    isSaved={isSaved}
+                  />
+                ) : (
+                  <ResultRow
+                    tripPattern={tripPattern}
+                    onDetailsPressed={onDetailsPressed}
+                    resultIndex={i}
+                    searchTime={searchTime}
+                    testID={'tripSearchSearchResult' + i}
+                  />
+                )
+              }
             </SaveableTripSearchResultRow>
           </Fragment>
         ))}


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->

## Description

Three small UI fixes to the new travel card / trip details design:

- **Status text without icon** — `StatusText` now supports rendering without an icon, and the icons currently used on the status configs are removed. The text renders where the icon would otherwise sit.
- **Saved-trip icon overlap** — the bookmark icon on a saved trip in search results no longer overlaps the duration. The saved state is passed through `SaveableTripSearchResultRow`, and the duration drops below the icon when a trip is saved.
- **Timestamp alignment** — trip-leg timestamps in trip details are left-aligned so they line up with the time in the travel card header above them, instead of being indented by the right-aligned label column.

## Notes for reviewers

- The trip-leg label column (`NEW_TRIP_DIMENSIONS.labelWidth` in `TripRow.tsx`) is a fixed, reserved gutter — it has to be predetermined because rows without a timestamp (transport, walk, wait, "X mellomstopp") still need their content to align, and the timeline line is absolutely positioned at `labelWidth + decorationContainerWidth/2`. This is the existing pattern (`theme.tripLegDetail.labelWidth`); the value was just retuned for the left-aligned layout. Trade-off: it's sized for `HH:mm` at default font, so very large accessibility font sizes / the `ca.` approximate-time prefix have less headroom than before. Can follow up with a font-scale-aware version if we want.

## Screenshots

### Status text without icon


| Before | After |
|--------|-------|
| <img width="350" src="https://github.com/user-attachments/assets/3da0f058-1589-457c-a1a6-9dfc0d9ff25b" /> | <img width="350" src="https://github.com/user-attachments/assets/a54ad10f-5828-49ce-867d-1ccb0b2e5c08" /> |

### Saved-trip icon overlap

| Before | After |
|--------|-------|
| <img width="350" src="https://github.com/user-attachments/assets/a81b2eca-515f-4245-be7b-4af989fe0e74" /> | <img width="350" src="https://github.com/user-attachments/assets/fbf72d5c-f535-4d72-a633-6b46c70ff0a3" /> |

### Trip details timestamp alignment

| Before | After |
|--------|-------|
| <img width="350" src="https://github.com/user-attachments/assets/59976bf7-fb71-4a90-931b-4d6710d945e8" /> | <img width="350" src="https://github.com/user-attachments/assets/02498649-b02e-422b-a308-1f4517a1d1b9" /> |
