### PR TITLE
fix: Require login to use transfer code

### DIFF
--- a/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
+++ b/src/stacks-hierarchy/Root_LoginRequiredForFareProductScreen.tsx
@@ -16,7 +16,10 @@ const getThemeColor = (theme: Theme) => theme.color.background.accent[0];
 
 type Props = RootStackScreenProps<'Root_LoginRequiredForFareProductScreen'>;
 
-export const Root_LoginRequiredForFareProductScreen = ({navigation}: Props) => {
+export const Root_LoginRequiredForFareProductScreen = ({
+  navigation,
+  route,
+}: Props) => {
   const {enable_vipps_login} = useRemoteConfigContext();
   const {t} = useTranslation();
   const styles = useThemeStyles();
@@ -27,6 +30,8 @@ export const Root_LoginRequiredForFareProductScreen = ({navigation}: Props) => {
 
   const getHasReservationOrAvailableFareContract =
     useGetHasReservationOrAvailableFareContract();
+
+  const {title, text} = route.params;
 
   const onNext = () => {
     if (getHasReservationOrAvailableFareContract()) {
@@ -55,7 +60,7 @@ export const Root_LoginRequiredForFareProductScreen = ({navigation}: Props) => {
             style={styles.title}
             color={themeColor}
           >
-            {t(LoginTexts.onboarding.title)}
+            {title ?? t(LoginTexts.onboarding.title)}
           </ThemeText>
         </View>
         <View accessible={true}>
@@ -64,7 +69,7 @@ export const Root_LoginRequiredForFareProductScreen = ({navigation}: Props) => {
             color={themeColor}
             testID="logInPurchaseDescription"
           >
-            {t(LoginTexts.onboarding.description)}
+            {text ?? t(LoginTexts.onboarding.description)}
           </ThemeText>
         </View>
       </View>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -61,6 +61,18 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
     });
   };
 
+  const onOpenTransferCodeSheet = () => {
+    if (authenticationType !== 'phone') {
+      navigation.navigate('Root_LoginRequiredForFareProductScreen', {
+        title: t(TicketingTexts.transferCode.loginRequired.title),
+        text: t(TicketingTexts.transferCode.loginRequired.text),
+      });
+      return;
+    } else {
+      transferCodeSheetRef.current?.present();
+    }
+  };
+
   const onProductSelect = (fareProductTypeConfig: FareProductTypeConfig) => {
     analytics.logEvent('Ticketing', 'Fare product selected', {
       type: fareProductTypeConfig.type,
@@ -74,9 +86,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
       authenticationType !== 'phone' &&
       fareProductTypeConfig.configuration.requiresLogin
     ) {
-      navigation.navigate('Root_LoginRequiredForFareProductScreen', {
-        selection,
-      });
+      navigation.navigate('Root_LoginRequiredForFareProductScreen', {});
       return;
     }
 
@@ -196,7 +206,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
                     TicketingTexts.transferCode.link.a11yLabel,
                   ),
                 }}
-                onPress={() => transferCodeSheetRef.current?.present()}
+                onPress={onOpenTransferCodeSheet}
               />
             </Section>
             <TransferCodeBottomSheet

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -60,7 +60,8 @@ export type Root_LoginConfirmCodeScreenParams = {
 };
 
 export type Root_LoginRequiredForFareProductScreenParams = {
-  selection: PurchaseSelectionType;
+  title?: string;
+  text?: string;
 };
 
 type Root_ParkingViolationsPhotoParams = {

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -90,6 +90,14 @@ const TicketingTexts = {
         'Ein hentekode kan brukast til å hente ein billett i appen. Vanlegvis er det nokon andre som har sendt deg koden, til dømes skulen eller arbeidsgivaren din.',
       ),
     },
+    loginRequired: {
+      title: _('Du må logge inn', 'You must log in', 'Du må logge inn'),
+      text: _(
+        'Du må logge inn for å bruke en hentekode.',
+        'You must log in to use a transfer code.',
+        'Du må logge inn for å bruke en hentekode.',
+      ),
+    },
     successMessage: _(
       'Vi har lagt til billetten din!',
       'We have added your ticket!',


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/kundevendt/issues/23977

Must be verified as a requirement first, but seems like a sensible one so pupils do not accidentally add school tickets to an anonymous account and lose them.

CC @Aliaaen & @Sebstorvik 

## Changes
- Re-use `Root_LoginRequiredForFareProductScreen` to gate usage of transfer code
- Made title/text on `Root_LoginRequiredForFareProductScreen` route params so they can be overridden

<img width="699" height="1345" alt="image" src="https://github.com/user-attachments/assets/8f09d4de-0047-45f1-91c5-90944d14d450" />
