### PR TITLE
fix: Add hentekode graphic for bottom sheet

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
@@ -15,6 +15,7 @@ import {
   BottomSheetModal,
 } from '@atb/components/bottom-sheet';
 import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
+import {ThemedTicketTilted} from '@atb/theme/ThemedAssets';
 
 const MIN_CODE_LENGTH = 8;
 
@@ -101,6 +102,7 @@ export const TransferCodeBottomSheet = ({
                   {t(TicketingTexts.transferCode.bottomSheet.infoBody)}
                 </ThemeText>
               </View>
+              <ThemedTicketTilted width={96} height={96} />
             </View>
           </GenericSectionItem>
         </Section>


### PR DESCRIPTION
Original from Figma (`TicketValid`) does not seem to be available in `design-system`. And unsure if other partners have it as well?

<img width="699" height="1345" alt="image" src="https://github.com/user-attachments/assets/98d6b7fd-bdad-46fc-becd-f387397d27e0" />

Original from Figma:
<img width="371" height="410" alt="image" src="https://github.com/user-attachments/assets/fe4754d7-0bd4-4a2a-b761-d44aa7750877" />
 