### PR TITLE
feat: Add keyboard avoiding behaviour to transfer code sheet

### DIFF
--- a/src/components/bottom-sheet/bottom-sheet-modal/BottomSheetModal.tsx
+++ b/src/components/bottom-sheet/bottom-sheet-modal/BottomSheetModal.tsx
@@ -44,6 +44,7 @@ type BottomSheetModalProps<T extends any> = {
   snapPoints?: Array<string | number>;
   enableDynamicSizing?: boolean;
   keyboardBehavior?: 'extend' | 'interactive' | 'fillParent';
+  keyboardBlurBehavior?: 'none' | 'restore';
   closeCallback?: () => void;
   fullyDismissedCallback?: () => void;
   Footer?: React.FC;
@@ -63,6 +64,7 @@ export const BottomSheetModal = <T extends any>({
   snapPoints,
   enableDynamicSizing = true,
   keyboardBehavior = Platform.OS === 'ios' ? 'interactive' : 'extend',
+  keyboardBlurBehavior,
   closeCallback,
   fullyDismissedCallback,
   Footer,
@@ -192,6 +194,7 @@ export const BottomSheetModal = <T extends any>({
       enableDismissOnClose={true}
       backdropComponent={renderBackdrop}
       keyboardBehavior={keyboardBehavior}
+      keyboardBlurBehavior={keyboardBlurBehavior}
       onAnimate={(_fromIndex, toIndex, _fromPosition, _toPosition) => {
         if (toIndex >= 0) {
           onOpen();

--- a/src/components/sections/items/TextInputSectionItem.tsx
+++ b/src/components/sections/items/TextInputSectionItem.tsx
@@ -27,6 +27,14 @@ type TextProps = SectionItemProps<
     showClear?: boolean;
     onClear?: () => void;
     errorText?: string;
+    /**
+     * The underlying text input component to render. Defaults to react-native's
+     * `TextInput`. Pass `@gorhom/bottom-sheet`'s `BottomSheetTextInput` when used
+     * inside a bottom sheet so the sheet reacts to the keyboard appearance.
+     */
+    InputComponent?: React.ComponentType<
+      InternalTextInputProps & React.RefAttributes<any>
+    >;
   }
 >;
 
@@ -41,6 +49,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
       showClear,
       onClear,
       style,
+      InputComponent = InternalTextInput,
       ...props
     },
     forwardedRef,
@@ -131,7 +140,7 @@ export const TextInputSectionItem = forwardRef<InternalTextInput, TextProps>(
             inlineLabel ? contentContainer : undefined,
           ]}
         >
-          <InternalTextInput
+          <InputComponent
             ref={combinedRef}
             style={[
               styles.input,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
@@ -14,7 +14,10 @@ import {
   BottomSheetHeaderType,
   BottomSheetModal,
 } from '@atb/components/bottom-sheet';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
+import {
+  BottomSheetModal as GorhomBottomSheetModal,
+  BottomSheetTextInput,
+} from '@gorhom/bottom-sheet';
 import {ThemedTicketTilted} from '@atb/theme/ThemedAssets';
 
 const MIN_CODE_LENGTH = 8;
@@ -55,6 +58,7 @@ export const TransferCodeBottomSheet = ({
       bottomSheetModalRef={bottomSheetModalRef}
       heading={t(TicketingTexts.transferCode.bottomSheet.heading)}
       bottomSheetHeaderType={BottomSheetHeaderType.Close}
+      keyboardBlurBehavior="restore"
       closeCallback={() => {
         giveFocus(onCloseFocusRef);
         setCode('');
@@ -65,6 +69,7 @@ export const TransferCodeBottomSheet = ({
       <View style={styles.container}>
         <Section>
           <TextInputSectionItem
+            InputComponent={BottomSheetTextInput}
             label={t(TicketingTexts.transferCode.bottomSheet.inputLabel)}
             placeholder={t(
               TicketingTexts.transferCode.bottomSheet.inputPlaceholder,


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/kundevendt/issues/23977#issuecomment-4715634548

Handle so bottom sheet avoids keyboard. The most stable way to do this is to use `BottomSheetTextInput` from `@gorhom/bottom-sheet`: https://gorhom.dev/react-native-bottom-sheet/components/bottomsheettextinput

https://github.com/user-attachments/assets/d2d47672-8d5c-41c8-8fbd-99ef4f280ce4