### PR TITLE
fix: prevent intermittent blank travel card legs

### DIFF
--- a/src/components/overflow-container/OverflowContainer.tsx
+++ b/src/components/overflow-container/OverflowContainer.tsx
@@ -91,8 +91,11 @@ export const OverflowContainer: React.FC<Props> = ({
   return (
     <View style={[styles.row, {gap}]}>
       {!fitResult && (
+        // Key includes the child count so a count change remounts this pass and
+        // every child re-fires onLayout — reused views don't re-measure, which
+        // would otherwise leave the row blank.
         <View
-          key={maxWidth}
+          key={`${maxWidth}-${children.length}`}
           style={[styles.measureWrapper, {width: maxWidth}]}
           pointerEvents="none"
         >

--- a/src/components/overflow-container/__tests__/OverflowContainer.test.tsx
+++ b/src/components/overflow-container/__tests__/OverflowContainer.test.tsx
@@ -1,0 +1,123 @@
+import React, {useEffect} from 'react';
+import {View} from 'react-native';
+import {
+  fireEvent,
+  render,
+  type RenderResult,
+} from '@testing-library/react-native';
+import {OverflowContainer} from '../OverflowContainer';
+
+// Minimal mock for the reveal animation OverflowContainer imports from reanimated.
+jest.mock('react-native-reanimated', () => {
+  const RN = require('react-native');
+  const entering = {duration: () => entering, easing: () => entering};
+  return {
+    __esModule: true,
+    default: {View: RN.View},
+    FadeIn: entering,
+    Easing: {out: () => 0, ease: 0},
+  };
+});
+
+/**
+ * What OverflowContainer does, and what these tests pin down.
+ *
+ * OverflowContainer shows as many children as fit in `maxWidth`, plus a "+N"
+ * overflow badge when some don't. Deciding how many fit needs each child's pixel
+ * width, which isn't known until it has been rendered and laid out — so it works
+ * in two phases:
+ *
+ *  1. Measure pass: while `fitResult` is null it renders every child and the
+ *     badge invisibly (opacity 0, clipped), purely so React Native fires
+ *     `onLayout` for each and reports its width. Widths accumulate in refs; once
+ *     every child and the badge have reported, it computes how many fit and sets
+ *     `fitResult`.
+ *  2. Reveal: with `fitResult` set it renders the real, visible row — the
+ *     children that fit, plus the badge if needed.
+ *
+ * If `fitResult` is never set, only the invisible measure pass renders and the
+ * row looks blank. Each shown child therefore mounts twice in the normal flow:
+ * once to be measured, then again when the row is revealed.
+ *
+ * The subtlety these tests guard: React Native delivers `onLayout` when a view
+ * mounts (or its layout changes), but not when a view is merely reconciled in
+ * place. When the child set changes, OverflowContainer resets its measurement and
+ * re-measures — which only completes if the measure pass remounts the children.
+ * If the measure pass is reused instead, the surviving children never report
+ * layout again, measurement can't finish, and the row stays blank.
+ *
+ * These tests rely on real React behaviour rather than re-simulating onLayout
+ * timing: the "measuring" state is reproduced simply by not firing onLayout, and
+ * a child re-running its mount effect is how we observe a remount.
+ */
+
+let legMounts: Record<string, number> = {};
+
+// Records its own mounts through the real React lifecycle: a reconciled-in-place
+// instance does not re-run this effect, a remounted one does.
+function Leg({id}: {id: string}) {
+  useEffect(() => {
+    legMounts[id] = (legMounts[id] ?? 0) + 1;
+  }, [id]);
+  return <View testID={id} />;
+}
+
+const legs = (count: number) =>
+  Array.from({length: count}, (_, i) => <Leg key={i} id={`leg-${i}`} />);
+const overflowNode = () => <Leg id="overflow" />;
+
+// In the measure pass every child is wrapped in a View carrying onLayout; the
+// settled row carries none, so these nodes also report whether measurement is
+// still in progress.
+const measureChildren = (view: RenderResult) =>
+  view.UNSAFE_root.findAll((n) => typeof n.props?.onLayout === 'function');
+
+describe('OverflowContainer', () => {
+  beforeEach(() => {
+    legMounts = {};
+  });
+
+  it('shows its children once a layout pass reports every width', () => {
+    const view = render(
+      <OverflowContainer maxWidth={200} overflow={overflowNode}>
+        {legs(3)}
+      </OverflowContainer>,
+    );
+
+    // One layout pass: report a width for every measure child.
+    measureChildren(view).forEach((node) =>
+      fireEvent(node, 'layout', {
+        nativeEvent: {layout: {x: 0, y: 0, width: 30, height: 20}},
+      }),
+    );
+
+    expect(view.getByTestId('leg-0')).toBeTruthy();
+    expect(measureChildren(view)).toHaveLength(0);
+
+    // Each shown leg mounts twice in the normal flow: once in the hidden measure
+    // pass, then again when the measured row is revealed.
+    [0, 1, 2].forEach((i) => expect(legMounts[`leg-${i}`]).toBe(2));
+  });
+
+  // Expected behaviour: a change to the child set re-runs the measure pass,
+  // remounting the children so their new widths can be measured.
+  //
+  // TODO: remove `.failing` once OverflowContainer remounts its measure pass on
+  // child-count changes.
+  it.failing('remounts the measure pass when the child count changes', () => {
+    const view = render(
+      <OverflowContainer maxWidth={200} overflow={overflowNode}>
+        {legs(4)}
+      </OverflowContainer>,
+    );
+    const mountsBefore = legMounts['leg-0'];
+
+    view.rerender(
+      <OverflowContainer maxWidth={200} overflow={overflowNode}>
+        {legs(3)}
+      </OverflowContainer>,
+    );
+
+    expect(legMounts['leg-0']).toBeGreaterThan(mountsBefore);
+  });
+});

--- a/src/components/overflow-container/__tests__/OverflowContainer.test.tsx
+++ b/src/components/overflow-container/__tests__/OverflowContainer.test.tsx
@@ -101,10 +101,7 @@ describe('OverflowContainer', () => {
 
   // Expected behaviour: a change to the child set re-runs the measure pass,
   // remounting the children so their new widths can be measured.
-  //
-  // TODO: remove `.failing` once OverflowContainer remounts its measure pass on
-  // child-count changes.
-  it.failing('remounts the measure pass when the child count changes', () => {
+  it('remounts the measure pass when the child count changes', () => {
     const view = render(
       <OverflowContainer maxWidth={200} overflow={overflowNode}>
         {legs(4)}


### PR DESCRIPTION
## Description
This is a difficult one to explain and reproduce, and I have struggled with understanding exactly what happens myself, but I will give it a try. I think that the render-invisible-to-measure-then-render-properly approach in `OverflowContainer` has a bug, where the faulty assumption is that the following holds: 

**Invariant:** The `tryCompute` function will always be called after `setFitResult(null)` is called in the `useEffect`

Counterexample where that doesn't hold: 

1. Overflow container renders one `TripPattern` with 1 foot leg, and two bus legs. `maxWidth` is stable, because the `View` wrapping `TravelCardLegs` has a settled size.
2. The `TripPattern` is updated, but only times changes such that the foot leg is no longer significant according to [isSignificantFootLegOrWalkTime](https://github.com/AtB-AS/mittatb-app/blob/5236123d158c9f8326b1bea7d61a683d3c76fa92/src/screen-components/travel-details-screens/utils.ts#L202) and thus gets filtered out of [TravelCardLegs](https://github.com/AtB-AS/mittatb-app/blob/master/src/screen-components/travel-card/TravelCardLegs.tsx#L31)
3. That means the number of `children` to [OverflowContainer](https://github.com/AtB-AS/mittatb-app/blob/master/src/screen-components/travel-card/TravelCardLegs.tsx#L72) has changed, which in turn triggers the [useEffect of OverflowContainer](https://github.com/AtB-AS/mittatb-app/blob/master/src/components/overflow-container/OverflowContainer.tsx#L33-L39), which sets `fitResult` to `null` since `maxWidth` is not 0. 
4. But since the [View wrapping children in OverflowContainer](https://github.com/AtB-AS/mittatb-app/blob/master/src/components/overflow-container/OverflowContainer.tsx#L94-L98) is keyed only off of `maxWidth` (which is stable) the `onLayout` function is never called --> `tryCompute` is never called on its children (or called less times than the number of children, which means `fitResult` is [never set](https://github.com/AtB-AS/mittatb-app/blob/master/src/components/overflow-container/OverflowContainer.tsx#L45))
5. I.e. the invariant does not hold. QED.

This PR tries to fix that, by keeping the useEffect and the `View wrapping children in OverflowContainer` in sync. It also adds a test that tries to communicate how `OverflowContainer` works, the nuance of the issue, and tries to catch the issue if it ever happens again. 


## Example 

Bug report from [Slack](https://mittatb.slack.com/archives/C09CJU3JUH5/p1781185740199769): 

```
I'we experienced the bug where the transport icon is missing/invisible in the 
trip search a couple of times now. Think we should prioritize to look into it. 
See pictures in :thread:.

Can't replicate it consistently, but i have seen it a couple of times when i keep 
loading in more results by continuing to press "load more results" at the bottom
```

<img width="250"  src="https://github.com/user-attachments/assets/9e99b6a7-4f07-46fd-9be9-a03fbeb0661b" />
