### PR TITLE
fix: Better Keyboard-handling in transfer code bottomsheet for Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@dr.pogodin/react-native-fs": "^2.37.0",
     "@entur-private/abt-mobile-barcode-javascript-lib": "3.4.8",
     "@entur-private/abt-mobile-client-sdk": "3.4.8",
-    "@gorhom/bottom-sheet": "^5.2.8",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@intercom/intercom-react-native": "9.4.0",
     "@leile/lobo-t": "^1.0.5",
     "@mapbox/polyline": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 3.4.8
         version: 3.4.8(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       '@gorhom/bottom-sheet':
-        specifier: ^5.2.8
-        version: 5.2.8(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
+        specifier: ^5.2.14
+        version: 5.2.14(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       '@intercom/intercom-react-native':
         specifier: 9.4.0
         version: 9.4.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
@@ -335,13 +335,13 @@ importers:
         version: 10.3.2(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0))
       '@storybook/addon-ondevice-controls':
         specifier: ^10.3.2
-        version: 10.3.2(263aa3ed3fd15c7ba10ed2b50b13c689)
+        version: 10.3.2(108e78b54c63cf5cefbe7eb79e9af620)
       '@storybook/react':
         specifier: ^10.3.5
         version: 10.3.5(react-dom@19.1.1(react@19.2.0))(react@19.2.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       '@storybook/react-native':
         specifier: ^10.3.2
-        version: 10.3.2(4d99b1525fcaeb8fac82dc92643b9643)
+        version: 10.3.2(eb009814e9920927791d9b112442d53b)
       '@svgr/cli':
         specifier: ^6.5.1
         version: 6.5.1
@@ -521,6 +521,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -538,6 +542,10 @@ packages:
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -567,6 +575,10 @@ packages:
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.27.1':
@@ -611,8 +623,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -633,6 +653,11 @@ packages:
 
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1167,16 +1192,32 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bam.tech/react-native-image-resizer@3.0.11':
@@ -1705,8 +1746,8 @@ packages:
   '@firebase/webchannel-wrapper@1.0.5':
     resolution: {integrity: sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==}
 
-  '@gorhom/bottom-sheet@5.2.8':
-    resolution: {integrity: sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==}
+  '@gorhom/bottom-sheet@5.2.14':
+    resolution: {integrity: sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-native': '*'
@@ -1885,6 +1926,9 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/source-map@0.3.5':
     resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
 
@@ -1893,6 +1937,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@leile/lobo-t@1.0.5':
     resolution: {integrity: sha512-A2OaWFEFfs9Gvs5K8IhMgGeHvve+zABWM4kWs849ypvOKDNlWzUFp6rGe6SDAPdUyl3D/9zSNSm5WcKzsqpy1w==}
@@ -2731,6 +2778,9 @@ packages:
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
 
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -2973,8 +3023,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3011,6 +3061,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -3286,8 +3339,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.31:
-    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+  baseline-browser-mapping@2.10.37:
+    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3394,8 +3447,8 @@ packages:
   caniuse-lite@1.0.30001739:
     resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
 
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   canvaskit-wasm@0.40.0:
     resolution: {integrity: sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==}
@@ -3744,6 +3797,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize-keys@1.1.0:
     resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
     engines: {node: '>=0.10.0'}
@@ -3907,8 +3969,8 @@ packages:
   electron-to-chromium@1.5.213:
     resolution: {integrity: sha512-xr9eRzSLNa4neDO0xVFrkXu3vyIzG4Ay08dApecw42Z1NbmCt+keEpXdvlYGVe0wtvY5dhW0Ay0lY0IOfsCg0Q==}
 
-  electron-to-chromium@1.5.360:
-    resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -3934,8 +3996,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.21.5:
-    resolution: {integrity: sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==}
+  enhanced-resolve@5.24.0:
+    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
     engines: {node: '>=10.13.0'}
 
   entities@2.2.0:
@@ -4282,6 +4344,9 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-parser@4.5.3:
     resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
@@ -5476,6 +5541,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -5513,8 +5583,9 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  node-releases@2.0.44:
-    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   node-stream-zip@1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
@@ -6682,8 +6753,8 @@ packages:
     resolution: {integrity: sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==}
     engines: {node: '>=14.18'}
 
-  terser-webpack-plugin@5.6.0:
-    resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@minify-html/node': '*'
@@ -6730,8 +6801,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  terser@5.47.1:
-    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6929,6 +7000,9 @@ packages:
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -7056,8 +7130,8 @@ packages:
   warn-once@0.1.1:
     resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   wcwidth@1.0.1:
@@ -7074,8 +7148,8 @@ packages:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
 
-  webpack-sources@3.4.1:
-    resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
 
   webpack@5.107.0:
@@ -7355,6 +7429,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -7391,6 +7471,14 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.1.0
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -7437,6 +7525,8 @@ snapshots:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
@@ -7494,7 +7584,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -7521,6 +7615,10 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -8161,11 +8259,19 @@ snapshots:
 
   '@babel/runtime@7.28.4': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -8179,10 +8285,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bam.tech/react-native-image-resizer@3.0.11(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -8766,7 +8889,7 @@ snapshots:
 
   '@firebase/webchannel-wrapper@1.0.5': {}
 
-  '@gorhom/bottom-sheet@5.2.8(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)':
+  '@gorhom/bottom-sheet@5.2.14(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       invariant: 2.2.4
@@ -8779,7 +8902,7 @@ snapshots:
 
   '@gorhom/portal@1.0.14(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       react: 19.2.0
       react-native: 0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0)
 
@@ -9062,6 +9185,11 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/source-map@0.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -9070,6 +9198,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.30':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9664,7 +9797,7 @@ snapshots:
       react-native: 0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-ondevice-controls@10.3.2(263aa3ed3fd15c7ba10ed2b50b13c689)':
+  '@storybook/addon-ondevice-controls@10.3.2(108e78b54c63cf5cefbe7eb79e9af620)':
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       '@react-native-community/datetimepicker': 8.4.5(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
@@ -9678,7 +9811,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0)
       tinycolor2: 1.6.0
     optionalDependencies:
-      '@gorhom/bottom-sheet': 5.2.8(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
+      '@gorhom/bottom-sheet': 5.2.14(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - react-dom
       - supports-color
@@ -9729,9 +9862,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react-native-ui@10.3.2(3c4afea1cec0a55a6bc2804303c2c871)':
+  '@storybook/react-native-ui@10.3.2(469a4812e675079520fde1861f9d2f54)':
     dependencies:
-      '@gorhom/bottom-sheet': 5.2.8(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
+      '@gorhom/bottom-sheet': 5.2.14(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       '@gorhom/portal': 1.0.14(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       '@nozbe/microfuzz': 1.0.0
       '@storybook/react': 10.3.5(react-dom@19.1.1(react@19.2.0))(react@19.2.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
@@ -9750,12 +9883,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react-native@10.3.2(4d99b1525fcaeb8fac82dc92643b9643)':
+  '@storybook/react-native@10.3.2(eb009814e9920927791d9b112442d53b)':
     dependencies:
       '@storybook/mcp': 0.6.2(typescript@5.9.3)
       '@storybook/react': 10.3.5(react-dom@19.1.1(react@19.2.0))(react@19.2.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       '@storybook/react-native-theming': 10.3.2(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
-      '@storybook/react-native-ui': 10.3.2(3c4afea1cec0a55a6bc2804303c2c871)
+      '@storybook/react-native-ui': 10.3.2(469a4812e675079520fde1861f9d2f54)
       '@storybook/react-native-ui-common': 10.3.2(react-dom@19.1.1(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.1.1(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.3.1(typescript@5.9.3))
       '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.9.3))
@@ -9773,7 +9906,7 @@ snapshots:
       valibot: 1.3.1(typescript@5.9.3)
       ws: 8.20.0
     optionalDependencies:
-      '@gorhom/bottom-sheet': 5.2.8(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
+      '@gorhom/bottom-sheet': 5.2.14(@types/react@19.2.7)(react-native-gesture-handler@2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       react-native-gesture-handler: 2.30.0(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       react-native-reanimated: 4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0))(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       react-native-safe-area-context: 5.6.2(react-native@0.83.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
@@ -9930,8 +10063,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -10236,6 +10369,10 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -10335,7 +10472,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.0
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.0(eslint@8.47.0)(typescript@5.9.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.47.0
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -10350,7 +10487,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
@@ -10543,9 +10680,9 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-phases@1.0.4(acorn@8.16.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -10553,23 +10690,23 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   add-stream@1.0.0: {}
 
   agent-base@7.1.4: {}
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -10583,6 +10720,13 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10934,7 +11078,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.31: {}
+  baseline-browser-mapping@2.10.37: {}
 
   big-integer@1.6.52: {}
 
@@ -10999,10 +11143,10 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.31
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.360
-      node-releases: 2.0.44
+      baseline-browser-mapping: 2.10.37
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bs-logger@0.2.6:
@@ -11062,7 +11206,7 @@ snapshots:
 
   caniuse-lite@1.0.30001739: {}
 
-  caniuse-lite@1.0.30001793: {}
+  caniuse-lite@1.0.30001799: {}
 
   canvaskit-wasm@0.40.0:
     dependencies:
@@ -11443,6 +11587,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.0:
     dependencies:
       decamelize: 1.2.0
@@ -11579,7 +11727,7 @@ snapshots:
 
   electron-to-chromium@1.5.213: {}
 
-  electron-to-chromium@1.5.360: {}
+  electron-to-chromium@1.5.372: {}
 
   emittery@0.13.1: {}
 
@@ -11597,7 +11745,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.21.5:
+  enhanced-resolve@5.24.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -12065,6 +12213,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.0: {}
+
+  fast-uri@3.1.2: {}
 
   fast-xml-parser@4.5.3:
     dependencies:
@@ -13080,7 +13230,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 25.9.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13413,7 +13563,7 @@ snapshots:
   metro-source-map@0.83.3:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.0'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.7'
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -13581,6 +13731,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
@@ -13608,7 +13760,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  node-releases@2.0.44: {}
+  node-releases@2.0.47: {}
 
   node-stream-zip@1.15.0: {}
 
@@ -13804,7 +13956,7 @@ snapshots:
 
   parse-json@8.1.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       index-to-position: 0.1.2
       type-fest: 4.41.0
 
@@ -14496,9 +14648,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   search-params@4.0.1: {}
 
@@ -14932,12 +15084,12 @@ snapshots:
     dependencies:
       temp-dir: 3.0.0
 
-  terser-webpack-plugin@5.6.0(esbuild@0.27.7)(webpack@5.107.0(esbuild@0.27.7)):
+  terser-webpack-plugin@5.6.1(esbuild@0.27.7)(webpack@5.107.0(esbuild@0.27.7)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.47.1
+      terser: 5.48.0
       webpack: 5.107.0(esbuild@0.27.7)
     optionalDependencies:
       esbuild: 0.27.7
@@ -14949,10 +15101,10 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  terser@5.47.1:
+  terser@5.48.0:
     dependencies:
-      '@jridgewell/source-map': 0.3.5
-      acorn: 8.16.0
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -15131,6 +15283,8 @@ snapshots:
 
   undici-types@7.10.0: {}
 
+  undici-types@7.24.6: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -15221,9 +15375,8 @@ snapshots:
 
   warn-once@0.1.1: {}
 
-  watchpack@2.5.1:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   wcwidth@1.0.1:
@@ -15236,7 +15389,7 @@ snapshots:
 
   webidl-conversions@5.0.0: {}
 
-  webpack-sources@3.4.1: {}
+  webpack-sources@3.5.0: {}
 
   webpack@5.107.0(esbuild@0.27.7):
     dependencies:
@@ -15245,11 +15398,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.5
+      enhanced-resolve: 5.24.0
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -15260,9 +15413,9 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.27.7)(webpack@5.107.0(esbuild@0.27.7))
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
+      terser-webpack-plugin: 5.6.1(esbuild@0.27.7)(webpack@5.107.0(esbuild@0.27.7))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9193,7 +9193,7 @@ snapshots:
   '@jridgewell/source-map@0.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 

--- a/src/components/PhotoCapture/ImageConfirmationBottomSheet.tsx
+++ b/src/components/PhotoCapture/ImageConfirmationBottomSheet.tsx
@@ -5,15 +5,18 @@ import {Image, View} from 'react-native';
 import {Coordinates} from '@atb/utils/coordinates';
 import {UserCoordinatesMap} from '../../stacks-hierarchy/Root_ShmoHelp/components/UserCoordinatesMap';
 import {ParkingViolationTexts} from '@atb/translations/screens/ParkingViolations';
-import {BottomSheetHeaderType, BottomSheetModal} from '../bottom-sheet';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
+import {
+  BottomSheetHeaderType,
+  BottomSheetModal,
+  BottomSheetModalMethods,
+} from '../bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 
 type Props = {
   file: string;
   coordinates: Coordinates | undefined;
   onConfirm: () => void;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
 

--- a/src/components/PhotoCapture/PhotoCapture.tsx
+++ b/src/components/PhotoCapture/PhotoCapture.tsx
@@ -5,7 +5,7 @@ import {ImageConfirmationBottomSheet} from './ImageConfirmationBottomSheet';
 import {Coordinates} from '@atb/utils/coordinates';
 import {getCurrentCoordinatesGlobal} from '@atb/modules/geolocation';
 import {View} from 'react-native';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 
 type PhotoCaptureProps = {
   onConfirmImage: (file: PhotoFile) => void;
@@ -29,7 +29,7 @@ export const PhotoCapture = ({
   const isFocused = useIsFocusedAndActive();
 
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
   const [file, setFile] = useState<PhotoFile | null>(null);
   const userCoordinates = getCurrentCoordinatesGlobal();
 

--- a/src/components/bottom-sheet/index.ts
+++ b/src/components/bottom-sheet/index.ts
@@ -2,3 +2,7 @@ export {BottomSheetModal} from './bottom-sheet-modal/BottomSheetModal';
 export {MapBottomSheet} from './bottom-sheet-map/MapBottomSheet';
 export {useBottomSheetContext} from './BottomSheetContext';
 export {BottomSheetHeaderType} from './use-bottom-sheet-header-type';
+// The type of the ref methods (present/dismiss/etc.) for a bottom sheet modal.
+// Re-exported here so consumers don't reach into @gorhom internals, and because
+// @gorhom no longer exports it from its package root.
+export type {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';

--- a/src/components/camera/Camera.tsx
+++ b/src/components/camera/Camera.tsx
@@ -1,6 +1,6 @@
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {RefObject, useRef, useState} from 'react';
-import {Dimensions, Linking, Platform, View} from 'react-native';
+import {Linking, Platform, View} from 'react-native';
 import {Processing} from '../loading';
 import {MessageInfoBox} from '../message-info-box';
 import {CaptureButton} from './CaptureButton';
@@ -168,7 +168,7 @@ export const Camera = ({
   }
 };
 
-const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => {
+const useStyles = StyleSheet.createThemeHook((theme, {bottom}, {height}) => {
   return {
     container: {
       flex: 1,
@@ -181,7 +181,7 @@ const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => {
     qrFrame: {
       position: 'absolute',
       alignSelf: 'center',
-      bottom: Dimensions.get('window').height / 2,
+      bottom: height / 2,
       transform: [{translateY: 100}],
       width: 200,
       height: 200,

--- a/src/components/camera/Camera.tsx
+++ b/src/components/camera/Camera.tsx
@@ -1,6 +1,6 @@
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {RefObject, useRef, useState} from 'react';
-import {Linking, Platform, View} from 'react-native';
+import {Dimensions, Linking, Platform, View} from 'react-native';
 import {Processing} from '../loading';
 import {MessageInfoBox} from '../message-info-box';
 import {CaptureButton} from './CaptureButton';
@@ -17,7 +17,6 @@ import {
 } from 'react-native-vision-camera';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Flash, NoFlash} from '@atb/assets/svg/mono-icons/miscellaneous';
-import {SCREEN_HEIGHT} from '@gorhom/bottom-sheet';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {errorToMetadata, logToBugsnag} from '@atb/utils/bugsnag-utils';
 import DeviceInfo from 'react-native-device-info';
@@ -182,7 +181,7 @@ const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => {
     qrFrame: {
       position: 'absolute',
       alignSelf: 'center',
-      bottom: SCREEN_HEIGHT / 2,
+      bottom: Dimensions.get('window').height / 2,
       transform: [{translateY: 100}],
       width: 200,
       height: 200,

--- a/src/components/date-selection/DatePickerSheet.tsx
+++ b/src/components/date-selection/DatePickerSheet.tsx
@@ -12,10 +12,9 @@ import type {
 import {default as RNDatePicker} from 'react-native-date-picker';
 import {getTimeZoneOffsetInMinutes, parseDate} from '@atb/utils/date';
 import {useLocaleContext} from '@atb/modules/locale';
-import {BottomSheetModal} from '../bottom-sheet';
+import {BottomSheetModal, BottomSheetModalMethods} from '../bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {RefObject} from '@testing-library/react-native/build/types';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {BottomSheetHeaderType} from '../bottom-sheet/use-bottom-sheet-header-type';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 
@@ -25,7 +24,7 @@ type Props<T extends string> = {
   options: DateOptionAndText<T>[];
   heading?: string;
   onSave: (optionAndValue: DateOptionAndValue<T>) => void;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: RefObject<View | null>;
 };
 

--- a/src/components/date-selection/DateSelection.tsx
+++ b/src/components/date-selection/DateSelection.tsx
@@ -13,7 +13,7 @@ import React, {useRef} from 'react';
 import {View} from 'react-native';
 import {DatePickerSheet} from './DatePickerSheet';
 import {DepartureDateOptions, type DepartureSearchTime} from './types';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {EditActionSectionItem, Section} from '../sections';
 
 type DateSelectionProps = {
@@ -32,7 +32,7 @@ export const DateSelection = ({
     parseISOFromCET(searchTime.date),
   );
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const onSetSearchTime = (time: DepartureSearchTime) => {
     if (isInThePast(time.date)) {

--- a/src/departure-list/section-items/FavoriteDialogSheet.tsx
+++ b/src/departure-list/section-items/FavoriteDialogSheet.tsx
@@ -14,8 +14,8 @@ import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 type Props = {
   lineNumber: string;
@@ -23,7 +23,7 @@ type Props = {
   addFavorite: (forSpecificLineName: boolean) => void;
   quayName: string;
   onCloseFocusRef: React.RefObject<View | null>;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseCallback?: () => void;
 };
 

--- a/src/modules/debug/DebugServerOverrides.tsx
+++ b/src/modules/debug/DebugServerOverrides.tsx
@@ -5,6 +5,7 @@ import {Button} from '@atb/components/button';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {
   SectionSeparator,
@@ -23,7 +24,6 @@ import Swipeable, {
 } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import Animated, {SharedValue, useAnimatedStyle} from 'react-native-reanimated';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import type {DebugServerOverride, HeaderOverride} from './types';
 
 type OftenUsedOverride = DebugServerOverride & {label: string};
@@ -50,8 +50,8 @@ const oftenUsedOverrides: OftenUsedOverride[] = [
 export function DebugServerOverrides() {
   const [overrides, setOverrides] = React.useState<DebugServerOverride[]>([]);
   const focusRef = useRef<View>(null);
-  const editBottomSheetRef = useRef<GorhomBottomSheetModal>(null);
-  const addBottomSheetRef = useRef<GorhomBottomSheetModal>(null);
+  const editBottomSheetRef = useRef<BottomSheetModalMethods>(null);
+  const addBottomSheetRef = useRef<BottomSheetModalMethods>(null);
   const [selectedOverride, setSelectedOverride] = useState<
     DebugServerOverride | undefined
   >(undefined);

--- a/src/modules/fare-contracts/components/ActivateNowBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowBottomSheet.tsx
@@ -10,8 +10,8 @@ import React, {RefObject} from 'react';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {View} from 'react-native';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {useAnalyticsContext} from '@atb/modules/analytics';
@@ -19,7 +19,7 @@ import {useAnalyticsContext} from '@atb/modules/analytics';
 type Props = {
   fareContractId: string;
   fareProductType: string | undefined;
-  bottomSheetModalRef: RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: RefObject<View | null>;
 };
 

--- a/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
+++ b/src/modules/fare-contracts/components/ActivateNowSectionItem.tsx
@@ -3,7 +3,7 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {useRef} from 'react';
 import {ActivateNowBottomSheet} from './ActivateNowBottomSheet';
 import {useThemeContext} from '@atb/theme';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {View} from 'react-native';
 import {Button} from '@atb/components/button';
 import {
@@ -23,7 +23,7 @@ export function ActivateNowButton({
   const {t} = useTranslation();
   const {theme} = useThemeContext();
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const onPress = () => {
     bottomSheetModalRef.current?.present();

--- a/src/modules/fare-contracts/components/ConsumeCarnetBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetBottomSheet.tsx
@@ -12,17 +12,17 @@ import React, {useState} from 'react';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {View} from 'react-native';
 import {RefObject} from '@testing-library/react-native/build/types';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 
 type Props = {
   fareContractId: string;
   fareProductType: string | undefined;
-  bottomSheetModalRef: RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: RefObject<View | null>;
 };
 

--- a/src/modules/fare-contracts/components/ConsumeCarnetSectionitem.tsx
+++ b/src/modules/fare-contracts/components/ConsumeCarnetSectionitem.tsx
@@ -4,7 +4,7 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {useRef} from 'react';
 import {ConsumeCarnetBottomSheet} from './ConsumeCarnetBottomSheet';
 import {View} from 'react-native';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {Button} from '@atb/components/button';
 import {
   GenericSectionItem,
@@ -25,7 +25,7 @@ export function ConsumeCarnetSectionitem({
   const {theme} = useThemeContext();
   const interactiveColor = theme.color.interactive[0];
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const onPress = () => {
     bottomSheetModalRef.current?.present();

--- a/src/modules/fare-contracts/components/RefundBottomSheet.tsx
+++ b/src/modules/fare-contracts/components/RefundBottomSheet.tsx
@@ -19,9 +19,9 @@ import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {RefObject} from '@testing-library/react-native/build/types';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {openInAppBrowser} from '@atb/modules/in-app-browser';
 
@@ -29,7 +29,7 @@ type Props = {
   orderId: string;
   fareProductType: string | undefined;
   state: FareContractState;
-  bottomSheetModalRef: RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: RefObject<View | null>;
 };
 

--- a/src/modules/fare-contracts/components/RefundSectionItem.tsx
+++ b/src/modules/fare-contracts/components/RefundSectionItem.tsx
@@ -4,7 +4,7 @@ import {FareContractTexts, useTranslation} from '@atb/translations';
 import React, {useRef} from 'react';
 import {RefundBottomSheet} from './RefundBottomSheet';
 import {FareContractState} from '@atb-as/utils';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {View} from 'react-native';
 
 type RefundSectionItemProps = SectionItemProps<{
@@ -21,7 +21,7 @@ export function RefundSectionItem({
 }: RefundSectionItemProps): React.JSX.Element {
   const {t} = useTranslation();
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const onPress = () => {
     bottomSheetModalRef.current?.present();

--- a/src/modules/fare-contracts/details/Barcode.tsx
+++ b/src/modules/fare-contracts/details/Barcode.tsx
@@ -23,11 +23,11 @@ import {
 } from '@entur-private/abt-token-state-react-native-lib';
 import {CONTEXT_ID} from '@atb/modules/mobile-token';
 import {notifyBugsnag} from '@atb/utils/bugsnag-utils';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {Loading} from '@atb/components/loading';
 
@@ -231,7 +231,7 @@ const StaticAztec = ({fc}: {fc: FareContractType}) => {
   const {t} = useTranslation();
   const [aztecXml, setAztecXml] = useState<string>();
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<GorhomBottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   useEffect(() => {
     if (fc.qrCode) {
@@ -270,7 +270,7 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
   const {t} = useTranslation();
   const [qrCodeSvg, setQrCodeSvg] = useState<string>();
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<GorhomBottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   useEffect(() => {
     if (fc.qrCode) {
@@ -348,7 +348,7 @@ const StaticBarcodeBottomSheet = ({
 }: {
   qrCodeSvg: string | undefined;
   onCloseFocusRef: RefObject<View | null>;
-  bottomSheetModalRef: RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: RefObject<BottomSheetModalMethods | null>;
 }) => {
   const styles = useStyles();
   const {t} = useTranslation();

--- a/src/modules/payment/SelectPaymentMethodSheet.tsx
+++ b/src/modules/payment/SelectPaymentMethodSheet.tsx
@@ -23,8 +23,8 @@ import {MultiplePaymentMethodsRadioSection} from './MultiplePaymentMethodsRadioS
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {isNonRecurringPaymentType} from './utils';
 
@@ -38,7 +38,7 @@ type Props = {
     paymentMethod?: PaymentMethod;
   };
   recurringPaymentMethods?: PaymentMethod[];
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
 

--- a/src/modules/situations/SituationBottomSheet.tsx
+++ b/src/modules/situations/SituationBottomSheet.tsx
@@ -22,13 +22,13 @@ import {openInAppBrowser} from '../in-app-browser';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 type Props = {
   situation: SituationType;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
 

--- a/src/modules/situations/SituationMessageBox.tsx
+++ b/src/modules/situations/SituationMessageBox.tsx
@@ -8,7 +8,7 @@ import {dictionary, useTranslation} from '@atb/translations';
 import {SituationType} from './types';
 import type {A11yLiveRegion} from '@atb/components/screen-reader-announcement';
 import {SituationBottomSheet} from './SituationBottomSheet';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 
 export type Props = {
   situation: SituationType;
@@ -25,7 +25,9 @@ export const SituationMessageBox = ({
 }: Props) => {
   const {language} = useTranslation();
   const onCloseFocusRef = React.useRef(null);
-  const bottomSheetModalRef = React.useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = React.useRef<BottomSheetModalMethods | null>(
+    null,
+  );
   const messageType = getMessageTypeForSituation(situation);
   const text = getSituationSummary(situation, language);
   const {t} = useTranslation();

--- a/src/modules/situations/SituationSectionItem.tsx
+++ b/src/modules/situations/SituationSectionItem.tsx
@@ -5,7 +5,7 @@ import {getMessageTypeForSituation, getSituationSummary} from './utils';
 import {SituationType} from './types';
 import {SituationBottomSheet} from './SituationBottomSheet';
 import {View} from 'react-native';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 
 type Props = SectionItemProps<{
   situation: SituationType;
@@ -15,7 +15,9 @@ export const SituationSectionItem = ({situation, ...sectionProps}: Props) => {
   const {t, language} = useTranslation();
   const situationText = getSituationSummary(situation, language);
   const onCloseFocusRef = React.useRef<View | null>(null);
-  const bottomSheetModalRef = React.useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = React.useRef<BottomSheetModalMethods | null>(
+    null,
+  );
 
   if (!situationText) return null;
 

--- a/src/screen-components/favorite-departures/components/FavoriteLineList.tsx
+++ b/src/screen-components/favorite-departures/components/FavoriteLineList.tsx
@@ -28,7 +28,7 @@ import {
   StoredFavoriteDeparture,
   useOnMarkFavouriteDepartures,
 } from '@atb/modules/favorites';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {Loading} from '@atb/components/loading';
@@ -141,7 +141,7 @@ export function QuayLineSection({
   const styles = useStyles();
   const departures = getDeparturesForQuay(data, quay);
   const {t} = useTranslation();
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const sortedDepartures = departures.sort((a, b) =>
     compareByLineNameAndDesc(t, a, b),

--- a/src/screen-components/place-screen/components/EstimatedCallList.tsx
+++ b/src/screen-components/place-screen/components/EstimatedCallList.tsx
@@ -18,7 +18,7 @@ import {
 } from '@atb/modules/favorites';
 import {QuaySectionProps} from './QuaySection';
 import {secondsBetween} from '@atb/utils/date';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
 
 type EstimatedCallRenderItem = {
@@ -48,7 +48,7 @@ export const EstimatedCallList = ({
   testID,
 }: Props) => {
   const {t} = useTranslation();
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
   const [selectedDeparture, setSelectedDeparture] = useState<{
     departure: EstimatedCall;
     existingFavorite: StoredFavoriteDeparture | undefined;

--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -86,7 +86,7 @@ import {
 // eslint-disable-next-line rulesdir/navigation-only-in-screens
 import {useFocusEffect} from '@react-navigation/native';
 import {EstimatedCallWithQuayFragment} from '@atb/api/types/generated/fragments/estimated-calls';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {FavoriteDialogSheet} from '@atb/departure-list/section-items/FavoriteDialogSheet';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {Loading} from '@atb/components/loading';
@@ -790,7 +790,7 @@ const FavoriteButton = ({
   const {t} = useTranslation();
   const {theme} = useThemeContext();
   const analytics = useAnalyticsContext();
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const {getFavoriteDeparture} = useFavoritesContext();
 

--- a/src/screen-components/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
+++ b/src/screen-components/travel-details-screens/components/FlexibleTransportBookingDetailsSheet.tsx
@@ -20,16 +20,16 @@ import {openInAppBrowser} from '@atb/modules/in-app-browser';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 const {width, height} = Dimensions.get('window');
 const isSmallScreen = width < 320 || height < 568;
 
 type FlexibleTransportBookingDetailsProps = {
   leg: Leg;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
 

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -65,7 +65,7 @@ import {
 import {animateNextChange} from '@atb/utils/animation';
 import {AUTHORITY} from '@env';
 import {AuthorityFragment} from '@atb/api/types/generated/fragments/authority';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {CancelledDepartureMessage} from './CancelledDepartureMessage';
 import {WalkFill} from '@atb/assets/svg/mono-icons/transportation';
 
@@ -103,7 +103,9 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const style = useSectionStyles();
   const {theme, themeName} = useThemeContext();
   const onCloseFocusRef = React.useRef(null);
-  const bottomSheetModalRef = React.useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = React.useRef<BottomSheetModalMethods | null>(
+    null,
+  );
 
   const isWalkSection = leg.mode === Mode.Foot;
   const isBikeSection = leg.mode === Mode.Bicycle;

--- a/src/screen-components/travel-details-screens/legacy/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/legacy/TripSection.tsx
@@ -60,7 +60,7 @@ import {ExternalLink} from '@atb/assets/svg/mono-icons/navigation';
 import {AUTHORITY} from '@env';
 import {AuthorityFragment} from '@atb/api/types/generated/fragments/authority';
 import {getRealtimeState, type TimeValues} from '@atb/utils/realtime';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {CancelledDepartureMessage} from '../components/CancelledDepartureMessage';
 
 type TripSectionProps = {
@@ -97,7 +97,9 @@ export const LegacyTripSection: React.FC<TripSectionProps> = ({
   const style = useSectionStyles();
   const {theme, themeName} = useThemeContext();
   const onCloseFocusRef = React.useRef(null);
-  const bottomSheetModalRef = React.useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = React.useRef<BottomSheetModalMethods | null>(
+    null,
+  );
 
   const isWalkSection = leg.mode === Mode.Foot;
   const isBikeSection = leg.mode === Mode.Bicycle;

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/EmojiSheet.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/EmojiSheet.tsx
@@ -21,9 +21,9 @@ import {AddEditFavoriteTexts, useTranslation} from '@atb/translations';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 // Polyfill for Android
 require('string.fromcodepoint');
@@ -180,7 +180,7 @@ type Props = Omit<EmojiCategory, 'category'> & {
   clearButtonStyle?: ViewStyle;
   clearButtonText?: string;
   value: string | null;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
 export const EmojiSheet = ({

--- a/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
+++ b/src/stacks-hierarchy/Root_AddEditFavoritePlaceScreen/Root_AddEditFavoritePlaceScreen.tsx
@@ -26,7 +26,7 @@ import {
   TextInputSectionItem,
 } from '@atb/components/sections';
 import {FullScreenFooter} from '@atb/components/screen-footer';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 
 export type Props = RootStackScreenProps<'Root_AddEditFavoritePlaceScreen'>;
 
@@ -57,7 +57,7 @@ export const Root_AddEditFavoritePlaceScreen = ({navigation, route}: Props) => {
     'searchLocation',
     editItem?.location,
   );
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
   const onCloseFocusRef = useRef<View | null>(null);
   const {pendingResult, clearPendingResult} = usePendingLocationSearchStore();
 

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -54,7 +54,7 @@ import {PaymentSelectionSectionItem} from '@atb/modules/payment';
 import {useDoOnceWhen} from '@atb/utils/use-do-once-when';
 import {formatNumberToString} from '@atb-as/utils';
 import {ScreenHeading} from '@atb/components/heading';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {useProductAlternatives} from '@atb/modules/ticketing';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {isNonRecurringPaymentType} from '@atb/modules/payment';
@@ -91,7 +91,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
   const paymentMethod = selectedPaymentMethod ?? previousPaymentMethod;
   const [vippsNotInstalledError, setVippsNotInstalledError] = useState(false);
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
   const focusRef = useFocusOnLoad(navigation);
 
   const [selection, setSelection] = useParamAsState(params.selection);

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -13,7 +13,7 @@ import {
 } from '@atb/modules/purchase-selection';
 import {DatePickerSheet} from '@atb/components/date-selection';
 import {EditActionSectionItem, Section} from '@atb/components/sections';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {Time} from '@atb/assets/svg/mono-icons/time';
 
 type StartTimeSelectionProps = {
@@ -30,7 +30,7 @@ export function StartTimeSelection({
   const {t, language} = useTranslation();
   const selectionBuilder = usePurchaseSelectionBuilder();
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<GorhomBottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   if (
     selection.fareProductTypeConfig.configuration.timeSelectionMode === 'none'

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -24,7 +24,7 @@ import {
   usePurchaseSelectionBuilder,
   useSelectableUserProfiles,
 } from '@atb/modules/purchase-selection';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {formatToNonBreakingSpaces} from '@atb/utils/text';
 import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
 import {useOnBehalfOf} from '../use-on-behalf-of';
@@ -44,7 +44,7 @@ export function TravellerSelection({
   const {theme} = useThemeContext();
   const styles = useStyles();
   const onCloseFocusRef = useRef<View | null>(null);
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
   const builder = usePurchaseSelectionBuilder();
 
   const selectionMode =

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -9,8 +9,8 @@ import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {TravellerSelectionSheetContent} from './TravellerSelectionSheetContent';
 import {UniqueWithCount} from '@atb/utils/unique-with-count';
 import {BaggageProduct, UserProfile} from '@atb-as/config-specs';
@@ -18,7 +18,7 @@ import {BaggageProduct, UserProfile} from '@atb-as/config-specs';
 type TravellerSelectionSheetProps = {
   selection: PurchaseSelectionType;
   onSave: (selection: PurchaseSelectionType) => void;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
 export const TravellerSelectionSheet = ({

--- a/src/stacks-hierarchy/Root_ShmoHelp/Root_ParkingViolationsQrScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoHelp/Root_ParkingViolationsQrScreen.tsx
@@ -18,7 +18,7 @@ import {RootStackScreenProps} from '@atb/stacks-hierarchy';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {compressImageToBase64} from '@atb/utils/image';
 import {View} from 'react-native';
-import {BottomSheetModal as GorhamBottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {ViolationsReportingProvider} from '@atb/api/types/mobility';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 
@@ -44,9 +44,9 @@ export const Root_ParkingViolationsQrScreen = ({
   const {userId} = useAuthContext();
   const onCloseFocusRef = useRef<View | null>(null);
   const providerAndVehicleBottomSheetModalRef =
-    useRef<GorhamBottomSheetModal | null>(null);
+    useRef<BottomSheetModalMethods | null>(null);
   const selectProviderBottomSheetModalRef =
-    useRef<GorhamBottomSheetModal | null>(null);
+    useRef<BottomSheetModalMethods | null>(null);
   const [providerAndVehicleId, setProviderAndVehicleId] = useState<{
     provider: ViolationsReportingProvider;
     vehicle_id: string | undefined;

--- a/src/stacks-hierarchy/Root_ShmoHelp/bottom-sheets/SelectProviderBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_ShmoHelp/bottom-sheets/SelectProviderBottomSheet.tsx
@@ -11,9 +11,9 @@ import {SelectGroup} from '../components/SelectGroup';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 type Props = {
   providers: ViolationsReportingProvider[];
@@ -21,7 +21,7 @@ type Props = {
   onSelect: (provider: ViolationsReportingProvider) => void;
   qrScanFailed: boolean | undefined;
   onCloseFocusRef: React.RefObject<View | null>;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
 };
 
 export const SelectProviderBottomSheet = ({

--- a/src/stacks-hierarchy/Root_ShmoHelp/bottom-sheets/VehicleLookupBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_ShmoHelp/bottom-sheets/VehicleLookupBottomSheet.tsx
@@ -9,9 +9,9 @@ import {ProviderLogo} from '../components/ProviderLogo';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 
 type Props = {
   provider: ViolationsReportingProvider;
@@ -19,7 +19,7 @@ type Props = {
   onReportSubmit: (providerId: number) => void;
   onClose: () => void;
   onCloseFocusRef: React.RefObject<View | null>;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
 };
 
 export const VehicleLookupConfirmationBottomSheet = ({

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/AnnouncementSection.tsx
@@ -24,7 +24,7 @@ import {animateNextChange} from '@atb/utils/animation';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useActionButtonProps} from './hooks';
 import {useRef} from 'react';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {AnnouncementSheet} from './AnnouncementSheet';
 
 type Props = {
@@ -39,7 +39,7 @@ export const AnnouncementSection = ({announcement, style}: Props) => {
   const {theme} = useThemeContext();
   const analytics = useAnalyticsContext();
   const {dismissAnnouncement} = useAnnouncementsContext();
-  const bottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModalMethods | null>(null);
 
   const actionButtonProps = useActionButtonProps(
     announcement,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -88,7 +88,7 @@ export const Announcements = ({style, isFocused}: Props) => {
   );
 };
 
-const useStyle = StyleSheet.createThemeHook((theme) => ({
+const useStyle = StyleSheet.createThemeHook((theme, _, {width}) => ({
   container: {
     rowGap: theme.spacing.small,
   },
@@ -100,7 +100,7 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
     gap: theme.spacing.medium,
   },
   announcement: {
-    width: Dimensions.get('window').width * 0.9 - 2 * theme.spacing.medium,
+    width: width * 0.9 - 2 * theme.spacing.medium,
   },
 }));
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/Announcements.tsx
@@ -1,4 +1,4 @@
-import {Dimensions, StyleProp, View, ViewStyle} from 'react-native';
+import {StyleProp, View, ViewStyle} from 'react-native';
 import {useAnnouncementsContext} from '@atb/modules/announcements';
 import {ScrollView} from 'react-native-gesture-handler';
 import {AnnouncementSection} from './AnnouncementSection';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/DeparturesWidget.tsx
@@ -27,7 +27,7 @@ import {
   Section,
 } from '@atb/components/sections';
 import {ContentHeading} from '@atb/components/heading';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {Loading} from '@atb/components/loading';
 import {useNow} from '@atb/utils/use-now';
@@ -58,7 +58,7 @@ export const DeparturesWidget = ({
   const {data: favoriteDeparturesData, isLoading: favoriteDeparturesIsLoading} =
     useFavoriteDeparturesQuery(isFocused);
   const onCloseFocusRef = useRef<View>(null);
-  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const bottomSheetRef = useRef<BottomSheetModalMethods>(null);
 
   async function openFrontpageFavouritesBottomSheet() {
     bottomSheetRef.current?.present();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/SelectFavouritesBottomSheet.tsx
@@ -15,10 +15,10 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {getTranslatedModeName} from '@atb/utils/transportation-names';
 import {formatDestinationDisplay} from '@atb/screen-components/travel-details-screens';
 import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {FullScreenFooter} from '@atb/components/screen-footer';
 import {Button} from '@atb/components/button';
@@ -83,7 +83,7 @@ const SelectableFavouriteDeparture = ({
 
 type SelectFavouritesBottomSheetProps = {
   onEditFavouriteDeparture: () => void;
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: RefObject<View | null>;
 };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_RootScreen/components/hooks.ts
@@ -18,7 +18,7 @@ import {
 } from '@atb/modules/announcements';
 import {AnalyticsEventContext} from '@atb/modules/analytics';
 import {useAnalyticsContext} from '@atb/modules/analytics';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {openInAppBrowser} from '@atb/modules/in-app-browser';
 
 type ActionButtonProps = {
@@ -33,7 +33,7 @@ export const useActionButtonProps = (
   announcement: Announcement,
   button: UrlActionButton | BottomSheetActionButton | undefined,
   logContext: AnalyticsEventContext,
-  bottomSheetModalRef: RefObject<BottomSheetModal | null>,
+  bottomSheetModalRef: RefObject<BottomSheetModalMethods | null>,
 ): ActionButtonProps | undefined => {
   const {language, t} = useTranslation();
   const analytics = useAnalyticsContext();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -59,7 +59,7 @@ import {onlyUniques} from '@atb/utils/only-uniques';
 import {DatePickerSheet} from '@atb/components/date-selection';
 import SharedTexts from '@atb/translations/shared';
 import {TravelSearchFiltersBottomSheet} from './components/TravelSearchFiltersBottomSheet';
-import {BottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {WithOverlayButton} from '@atb/components/overlay-button';
 import {Loading} from '@atb/components/loading';
@@ -94,8 +94,11 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const analytics = useAnalyticsContext();
   const filterButtonWrapperRef = useRef(null);
   const filterButtonRef = useRef(null);
-  const travelSearchBottomSheetModalRef = useRef<BottomSheetModal | null>(null);
-  const timePickerBottomSheetModalRef = useRef<BottomSheetModal | null>(null);
+  const travelSearchBottomSheetModalRef =
+    useRef<BottomSheetModalMethods | null>(null);
+  const timePickerBottomSheetModalRef = useRef<BottomSheetModalMethods | null>(
+    null,
+  );
   const timePickerCloseRef = useRef<View | null>(null);
 
   const {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/TravelSearchFiltersBottomSheet.tsx
@@ -20,9 +20,9 @@ import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
-import {BottomSheetModal as GorhamBottomSheetModal} from '@gorhom/bottom-sheet';
 
 export const TravelSearchFiltersBottomSheet = ({
   filtersSelection,
@@ -32,7 +32,7 @@ export const TravelSearchFiltersBottomSheet = ({
 }: {
   filtersSelection: TravelSearchFiltersSelectionType;
   onSave: (t: TravelSearchFiltersSelectionType) => void;
-  bottomSheetModalRef: React.RefObject<GorhamBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 }) => {
   const {t, language} = useTranslation();

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
@@ -13,17 +13,15 @@ import {useThemeContext} from '@atb/theme';
 import {
   BottomSheetHeaderType,
   BottomSheetModal,
+  BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
-import {
-  BottomSheetModal as GorhomBottomSheetModal,
-  BottomSheetTextInput,
-} from '@gorhom/bottom-sheet';
+import {BottomSheetTextInput} from '@gorhom/bottom-sheet';
 import {ThemedTicketTilted} from '@atb/theme/ThemedAssets';
 
 const MIN_CODE_LENGTH = 8;
 
 type Props = {
-  bottomSheetModalRef: React.RefObject<GorhomBottomSheetModal | null>;
+  bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
   onTicketsReceived: () => void;
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/Components/TransferCodeBottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {View} from 'react-native';
+import {Keyboard, View} from 'react-native';
 import {isErrorResponse} from '@atb/api/utils';
 import {StyleSheet} from '@atb/theme';
 import {TicketingTexts, useTranslation} from '@atb/translations';
@@ -37,6 +37,7 @@ export const TransferCodeBottomSheet = ({
   const {theme} = useThemeContext();
   const styles = useStyles();
   const [code, setCode] = useState('');
+  const [isInputFocused, setIsInputFocused] = useState(false);
   const {mutate, isPending, error, reset} = useAcceptTicketTransferMutation();
 
   const onSubmit = () =>
@@ -58,8 +59,10 @@ export const TransferCodeBottomSheet = ({
       bottomSheetModalRef={bottomSheetModalRef}
       heading={t(TicketingTexts.transferCode.bottomSheet.heading)}
       bottomSheetHeaderType={BottomSheetHeaderType.Close}
+      keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
       closeCallback={() => {
+        Keyboard.dismiss();
         giveFocus(onCloseFocusRef);
         setCode('');
         reset();
@@ -84,6 +87,8 @@ export const TransferCodeBottomSheet = ({
             autoCapitalize="none"
             autoCorrect={false}
             errorText={errorText}
+            onFocus={() => setIsInputFocused(true)}
+            onBlur={() => setIsInputFocused(false)}
             testID="transferCodeInput"
           />
         </Section>
@@ -96,21 +101,23 @@ export const TransferCodeBottomSheet = ({
           loading={isPending}
           testID="transferCodeSubmitButton"
         />
-        <Section>
-          <GenericSectionItem>
-            <View style={styles.infoContainer}>
-              <View style={styles.infoText}>
-                <ThemeText typography="body__m__strong">
-                  {t(TicketingTexts.transferCode.bottomSheet.infoTitle)}
-                </ThemeText>
-                <ThemeText typography="body__s" type="secondary">
-                  {t(TicketingTexts.transferCode.bottomSheet.infoBody)}
-                </ThemeText>
+        {!isInputFocused && (
+          <Section>
+            <GenericSectionItem>
+              <View style={styles.infoContainer}>
+                <View style={styles.infoText}>
+                  <ThemeText typography="body__m__strong">
+                    {t(TicketingTexts.transferCode.bottomSheet.infoTitle)}
+                  </ThemeText>
+                  <ThemeText typography="body__s" type="secondary">
+                    {t(TicketingTexts.transferCode.bottomSheet.infoBody)}
+                  </ThemeText>
+                </View>
+                <ThemedTicketTilted width={96} height={96} />
               </View>
-              <ThemedTicketTilted width={96} height={96} />
-            </View>
-          </GenericSectionItem>
-        </Section>
+            </GenericSectionItem>
+          </Section>
+        )}
       </View>
     </BottomSheetModal>
   );

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -4,7 +4,7 @@ import {FareProducts} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_
 import {StyleSheet} from '@atb/theme';
 import React, {useRef} from 'react';
 import {RefreshControl, View} from 'react-native';
-import {BottomSheetModal as GorhomBottomSheetModal} from '@gorhom/bottom-sheet';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {TicketingTexts, useTranslation} from '@atb/translations';
 import {TransferCodeBottomSheet} from './Components/TransferCodeBottomSheet';
@@ -51,7 +51,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
   const {scrollHandler} = useTabScrollHandler(0);
   const {isTicketTransferEnabled} = useFeatureTogglesContext();
   const transferCodeButtonRef = useRef<View>(null);
-  const transferCodeSheetRef = useRef<GorhomBottomSheetModal>(null);
+  const transferCodeSheetRef = useRef<BottomSheetModalMethods>(null);
 
   const onTicketsReceived = () => {
     analytics.logEvent('Ticketing', 'Ticket received with transfer code');

--- a/src/theme/StyleSheet.ts
+++ b/src/theme/StyleSheet.ts
@@ -9,6 +9,7 @@ import {
 import {Theme} from './colors';
 import {useThemeContext} from './ThemeContext';
 import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
+import {MAX_FONT_SCALE} from '@atb/components/text';
 
 export type NamedStyles<T> = {
   [P in keyof T]: ViewStyle | TextStyle | ImageStyle;
@@ -38,6 +39,7 @@ export function useStyle<T extends NamedStyles<T>>(
   const {theme} = useThemeContext();
   const insets = useSafeAreaInsets();
   const dimensions = useWindowDimensions();
+  dimensions.fontScale = Math.min(dimensions.fontScale, MAX_FONT_SCALE);
   if (!isThemedStyles<T>(style)) {
     return style;
   }

--- a/src/theme/StyleSheet.ts
+++ b/src/theme/StyleSheet.ts
@@ -3,6 +3,8 @@ import {
   ViewStyle,
   TextStyle,
   ImageStyle,
+  useWindowDimensions,
+  ScaledSize,
 } from 'react-native';
 import {Theme} from './colors';
 import {useThemeContext} from './ThemeContext';
@@ -11,7 +13,11 @@ import {useSafeAreaInsets, EdgeInsets} from 'react-native-safe-area-context';
 export type NamedStyles<T> = {
   [P in keyof T]: ViewStyle | TextStyle | ImageStyle;
 };
-export type ThemedStyles<T> = (theme: Theme, insets: EdgeInsets) => T;
+export type ThemedStyles<T> = (
+  theme: Theme,
+  insets: EdgeInsets,
+  dimensions: ScaledSize,
+) => T;
 
 // MarginStyle is a subset of ViewStyle containing only margin-related
 // fields, e.g. 'margin', 'marginTop', 'marginHorizontal', etc. All other
@@ -31,10 +37,11 @@ export function useStyle<T extends NamedStyles<T>>(
 ): T {
   const {theme} = useThemeContext();
   const insets = useSafeAreaInsets();
+  const dimensions = useWindowDimensions();
   if (!isThemedStyles<T>(style)) {
     return style;
   }
-  return style(theme, insets);
+  return style(theme, insets, dimensions);
 }
 
 function isThemedStyles<T>(style: any): style is ThemedStyles<T> {


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/kundevendt/issues/23977

Attempted fix for: https://github.com/AtB-AS/mittatb-app/pull/6164#issuecomment-4716457595

## Changes

- `@gorhom/bottom-sheet` upgraded from `5.2.8` to `5.2.14` which is what made the transfer-code sheet's re-focus behavior more robust on Android
- Hide info-box when input is focused, it just takes up space then
- The `SCREEN_HEIGHT` export has been removed from `@gorhom/bottom-sheet` in newer versions. So `Camera.tsx` now uses Dimensions.get('window').height instead: https://github.com/AtB-AS/mittatb-app/pull/6166/changes#diff-c0f30694373e57820d753d34e9c94cc582f77bb167b701da4935900598762f4b
- Modal ref type has been changed in `@gorhom/bottom-sheet` (`BottomSheetModal` component no longer assignable as a ref to `BottomSheetModalMethods`). Instead I re-exported `BottomSheetModalMethods` once from `@atb/components/bottom-sheet`, and changed all the component files that also uses it.
- Add `window`-dimensions to theme hook to more easily calculate styles based on window dimensions.

See https://github.com/AtB-AS/mittatb-app/pull/6166/changes#diff-4abbb2c912ea456de79ac05b0532274ae501917adaba2dd46f4fd2d1fbf307d9 for the "non-cosmetic" changes.