### PR TITLE
fix: use correct screen transition after zone selection

### DIFF
--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByMapScreen.tsx
@@ -41,11 +41,15 @@ export const Root_PurchaseFareZonesSearchByMapScreen = ({
         to: selection.zones.to.id,
       });
     }
-    navigation.popTo('Root_PurchaseOverviewScreen', {
-      mode: 'Ticket',
-      selection,
-      onFocusElement: 'zones',
-    });
+    navigation.popTo(
+      'Root_PurchaseOverviewScreen',
+      {
+        mode: 'Ticket',
+        selection,
+        onFocusElement: 'zones',
+      },
+      {merge: true},
+    );
   };
 
   const onVenueSearchClick = (fromOrTo: 'from' | 'to') =>


### PR DESCRIPTION
There was a small bug with screen transitions after zone selection was done during ticket purchase. If the user entered the zone selection screen and navigated back, the transition setting wasn't remembered, and it would navigate with the `slide-from-bottom` animation instead of `slide-from-right`.

https://github.com/user-attachments/assets/37148b07-2657-4028-bf71-b78ac79bab37

## Acceptance criteria

- [ ] Exiting the ticket purchase flow has the same animation as going in, also after changing zones