### PR TITLE
feat: track bonus points usage in Shmo booking started event

### DIFF
--- a/src/modules/mobility/components/ShmoActionButton.tsx
+++ b/src/modules/mobility/components/ShmoActionButton.tsx
@@ -77,6 +77,7 @@ export const ShmoActionButton = ({
     logEvent('Mobility', 'Shmo booking started', {
       operatorId,
       bookingId: res.bookingId,
+      paidWithBonusPoints: !!bonusProductId,
     });
     if (res.bookingId) {
       savePreviousPayment(


### PR DESCRIPTION
## What

Add `paidWithBonusPoints` property to the `Mobility: Shmo booking started` PostHog event.

## Why

Lets us measure how often Shmo bookings are paid with bonus points vs regular payment.

## How

`paidWithBonusPoints: !!bonusProductId` — `bonusProductId` is already available at the booking-start call site (set when user toggles the "Pay with Bonus Points" checkbox) and already in the `useCallback` deps.