### PR TITLE
Add app Feide-verification for Firebase-user in Profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "hex-to-rgba": "^2.0.1",
     "humanize-duration": "^3.33.1",
     "iso8601-duration": "^2.1.3",
+    "js-sha256": "^0.11.1",
     "libphonenumber-js": "^1.12.23",
     "lodash": "^4.18.1",
     "marked": "16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       iso8601-duration:
         specifier: ^2.1.3
         version: 2.1.3
+      js-sha256:
+        specifier: ^0.11.1
+        version: 0.11.1
       libphonenumber-js:
         specifier: ^1.12.23
         version: 1.12.23
@@ -5143,6 +5146,9 @@ packages:
 
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  js-sha256@0.11.1:
+    resolution: {integrity: sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -13268,6 +13274,8 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  js-sha256@0.11.1: {}
 
   js-tokens@4.0.0: {}
 

--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -19,6 +19,11 @@ export type FeideConnectResponse = {
   hasNin: boolean;
 };
 
+export type FeideConnectionStatus = {
+  connected: boolean;
+  feideSub?: string;
+};
+
 export const getServerTime = async () => {
   const response = await client.get('/identity/v1/time', {
     authWithIdToken: false,
@@ -211,6 +216,21 @@ export const connectFeide = async (
         ...opts,
       },
     )
+    .then((res) => res.data);
+};
+
+/**
+ * Whether the logged-in customer is connected to Feide (and with which sub).
+ * Mirrors getAgeVerification.
+ */
+export const getFeideConnection = (
+  opts?: AxiosRequestConfig,
+): Promise<FeideConnectionStatus> => {
+  return client
+    .get<FeideConnectionStatus>('/identity/v1/feide/connection', {
+      ...opts,
+      authWithIdToken: true,
+    })
     .then((res) => res.data);
 };
 

--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -175,31 +175,26 @@ async function generateNonce() {
 }
 
 /**
- * Start Feide-connection: Get authorization-URL from identity og open it in
- * in-app browser. Redirect catched via deep-link in screen which calls this.
- * Mirrors initAgeVerification (Vipps connect-while-logged-in).
+ * Start Feide-connection: Get authorization-URL from identity and return the
+ * full URL (with state, nonce and PKCE challenge) for the caller to open in an
+ * in-app browser. Redirect catched via deep-link in screen.
+ * Mirrors authorizeVippsUser (Vipps login).
  */
 export const initFeideConnect = async (
   opts?: AxiosRequestConfig,
-): Promise<void> => {
+): Promise<string> => {
   const state = await generateFeideState();
   const nonce = await generateFeideNonce();
   const {verifier, challenge} = generatePkcePair();
   await storage.set('feide_code_verifier', verifier);
-  return client
-    .get(
-      `/identity/v1/feide/authorization-url?callbackUrl=${FEIDE_CALLBACK_URL}`,
-      {
-        ...opts,
-      },
-    )
-    .then(async (response) => {
-      const authorisationUrl = response.data;
-      openInAppBrowser(
-        `${authorisationUrl}&state=${state}&nonce=${nonce}&code_challenge=${challenge}&code_challenge_method=S256`,
-        'cancel',
-      );
-    });
+  const response = await client.get(
+    `/identity/v1/feide/authorization-url?callbackUrl=${FEIDE_CALLBACK_URL}`,
+    {
+      ...opts,
+    },
+  );
+  const authorisationUrl = response.data;
+  return `${authorisationUrl}&state=${state}&nonce=${nonce}&code_challenge=${challenge}&code_challenge_method=S256`;
 };
 
 /**

--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -12,6 +12,12 @@ import {v4 as uuid} from 'uuid';
 import {DateResponse, DateResponseSchema} from './types/mobility';
 
 export const VIPPS_CALLBACK_URL = `${APP_SCHEME}://auth/vipps`;
+export const FEIDE_CALLBACK_URL = `${APP_SCHEME}://auth/feide`;
+
+export type FeideConnectResponse = {
+  name?: string;
+  hasNin: boolean;
+};
 
 export const getServerTime = async () => {
   const response = await client.get('/identity/v1/time', {
@@ -159,5 +165,63 @@ async function generateState() {
 async function generateNonce() {
   const nonce = uuid();
   await storage.set('vipps_nonce', nonce);
+  return nonce;
+}
+
+/**
+ * Start Feide-connection: Get authorization-URL from identity og open it in
+ * in-app browser. Redirect catched via deep-link in screen which calls this.
+ * Mirrors initAgeVerification (Vipps connect-while-logged-in).
+ */
+export const initFeideConnect = async (
+  opts?: AxiosRequestConfig,
+): Promise<void> => {
+  const state = await generateFeideState();
+  const nonce = await generateFeideNonce();
+  return client
+    .get(
+      `/identity/v1/feide/authorization-url?callbackUrl=${FEIDE_CALLBACK_URL}`,
+      {
+        ...opts,
+      },
+    )
+    .then(async (response) => {
+      const authorisationUrl = response.data;
+      openInAppBrowser(
+        `${authorisationUrl}&state=${state}&nonce=${nonce}`,
+        'cancel',
+      );
+    });
+};
+
+/**
+ * Complete Feide-connection: trade authorization code with userinfo server-side, and
+ * connect Feide-user to logged in Firebase-user
+ */
+export const connectFeide = async (
+  authorizationCode: string,
+  opts?: AxiosRequestConfig,
+): Promise<FeideConnectResponse> => {
+  return client
+    .post<FeideConnectResponse>(
+      `/identity/v1/feide/connect?callbackUrl=${FEIDE_CALLBACK_URL}`,
+      {authorizationCode},
+      {
+        authWithIdToken: true,
+        ...opts,
+      },
+    )
+    .then((res) => res.data);
+};
+
+async function generateFeideState() {
+  const state = uuid();
+  await storage.set('feide_state', state);
+  return state;
+}
+
+async function generateFeideNonce() {
+  const nonce = uuid();
+  await storage.set('feide_nonce', nonce);
   return nonce;
 }

--- a/src/api/identity.ts
+++ b/src/api/identity.ts
@@ -10,6 +10,7 @@ import {stringifyUrl} from './utils';
 import {AgeVerificationEnum} from '@atb/modules/mobility';
 import {v4 as uuid} from 'uuid';
 import {DateResponse, DateResponseSchema} from './types/mobility';
+import {generatePkcePair} from './pkce';
 
 export const VIPPS_CALLBACK_URL = `${APP_SCHEME}://auth/vipps`;
 export const FEIDE_CALLBACK_URL = `${APP_SCHEME}://auth/feide`;
@@ -183,6 +184,8 @@ export const initFeideConnect = async (
 ): Promise<void> => {
   const state = await generateFeideState();
   const nonce = await generateFeideNonce();
+  const {verifier, challenge} = generatePkcePair();
+  await storage.set('feide_code_verifier', verifier);
   return client
     .get(
       `/identity/v1/feide/authorization-url?callbackUrl=${FEIDE_CALLBACK_URL}`,
@@ -193,7 +196,7 @@ export const initFeideConnect = async (
     .then(async (response) => {
       const authorisationUrl = response.data;
       openInAppBrowser(
-        `${authorisationUrl}&state=${state}&nonce=${nonce}`,
+        `${authorisationUrl}&state=${state}&nonce=${nonce}&code_challenge=${challenge}&code_challenge_method=S256`,
         'cancel',
       );
     });
@@ -203,14 +206,20 @@ export const initFeideConnect = async (
  * Complete Feide-connection: trade authorization code with userinfo server-side, and
  * connect Feide-user to logged in Firebase-user
  */
+export type ConnectFeideParams = {
+  authorizationCode: string;
+  codeVerifier: string;
+  nonce: string;
+};
+
 export const connectFeide = async (
-  authorizationCode: string,
+  {authorizationCode, codeVerifier, nonce}: ConnectFeideParams,
   opts?: AxiosRequestConfig,
 ): Promise<FeideConnectResponse> => {
   return client
     .post<FeideConnectResponse>(
       `/identity/v1/feide/connect?callbackUrl=${FEIDE_CALLBACK_URL}`,
-      {authorizationCode},
+      {authorizationCode, codeVerifier, nonce},
       {
         authWithIdToken: true,
         ...opts,
@@ -227,7 +236,7 @@ export const getFeideConnection = (
   opts?: AxiosRequestConfig,
 ): Promise<FeideConnectionStatus> => {
   return client
-    .get<FeideConnectionStatus>('/identity/v1/feide/connection', {
+    .get<FeideConnectionStatus>(`/identity/v1/feide/connection`, {
       ...opts,
       authWithIdToken: true,
     })

--- a/src/api/pkce.test.ts
+++ b/src/api/pkce.test.ts
@@ -1,0 +1,39 @@
+import {sha256} from 'js-sha256';
+import {Buffer} from 'buffer';
+import {generatePkcePair} from './pkce';
+
+const isBase64Url = (s: string) => /^[A-Za-z0-9\-_]+$/.test(s);
+
+const base64UrlOfSha256 = (verifier: string) =>
+  Buffer.from(sha256.arrayBuffer(verifier))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+describe('generatePkcePair', () => {
+  it('produces a 43-char base64url verifier within the RFC 7636 range', () => {
+    const {verifier} = generatePkcePair();
+    expect(verifier).toHaveLength(43);
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+    expect(isBase64Url(verifier)).toBe(true);
+  });
+
+  it('produces a base64url challenge with no padding', () => {
+    const {challenge} = generatePkcePair();
+    expect(isBase64Url(challenge)).toBe(true);
+    expect(challenge).not.toContain('=');
+  });
+
+  it('challenge is the S256 hash of the verifier', () => {
+    const {verifier, challenge} = generatePkcePair();
+    expect(challenge).toEqual(base64UrlOfSha256(verifier));
+  });
+
+  it('generates a fresh verifier on each call', () => {
+    expect(generatePkcePair().verifier).not.toEqual(
+      generatePkcePair().verifier,
+    );
+  });
+});

--- a/src/api/pkce.ts
+++ b/src/api/pkce.ts
@@ -1,0 +1,37 @@
+import {sha256} from 'js-sha256';
+import {Buffer} from 'buffer';
+
+// RFC 7636 allows a verifier of 43-128 chars. 32 random bytes base64url-encoded
+// yields a 43-char verifier with 256 bits of entropy.
+const VERIFIER_BYTE_LENGTH = 32;
+
+export type PkcePair = {
+  verifier: string;
+  challenge: string;
+};
+
+/**
+ * Generate a PKCE (RFC 7636) verifier/challenge pair using the S256 method.
+ *
+ * The `verifier` stays on-device and is only sent to our backend when
+ * completing the flow; the `challenge` is placed on the authorization URL. This
+ * binds the authorization code to this app session, so an intercepted code
+ * cannot be redeemed without the verifier.
+ */
+export function generatePkcePair(): PkcePair {
+  const randomBytes = new Uint8Array(VERIFIER_BYTE_LENGTH);
+  crypto.getRandomValues(randomBytes);
+  const verifier = base64UrlEncode(randomBytes);
+  const challenge = base64UrlEncode(
+    new Uint8Array(sha256.arrayBuffer(verifier)),
+  );
+  return {verifier, challenge};
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -38,6 +38,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_experimental_features',
   },
   {
+    name: 'isFeideConnectionEnabled',
+    remoteConfigKey: 'enable_feide_connection',
+  },
+  {
     name: 'isFlexibleTransportEnabled',
     remoteConfigKey: 'enable_flexible_transport',
   },

--- a/src/modules/feide/index.ts
+++ b/src/modules/feide/index.ts
@@ -1,0 +1,2 @@
+export {useInitFeideConnectMutation} from './queries/use-init-feide-connect-mutation';
+export {useConnectFeideMutation} from './queries/use-connect-feide-mutation';

--- a/src/modules/feide/index.ts
+++ b/src/modules/feide/index.ts
@@ -1,2 +1,6 @@
 export {useInitFeideConnectMutation} from './queries/use-init-feide-connect-mutation';
 export {useConnectFeideMutation} from './queries/use-connect-feide-mutation';
+export {
+  useGetFeideConnectionQuery,
+  feideConnectionQueryKey,
+} from './queries/use-get-feide-connection-query';

--- a/src/modules/feide/queries/use-connect-feide-mutation.tsx
+++ b/src/modules/feide/queries/use-connect-feide-mutation.tsx
@@ -1,11 +1,11 @@
-import {connectFeide} from '@atb/api/identity';
+import {connectFeide, ConnectFeideParams} from '@atb/api/identity';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {feideConnectionQueryKey} from './use-get-feide-connection-query';
 
 export const useConnectFeideMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (authorizationCode: string) => connectFeide(authorizationCode),
+    mutationFn: (params: ConnectFeideParams) => connectFeide(params),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [feideConnectionQueryKey]});
     },

--- a/src/modules/feide/queries/use-connect-feide-mutation.tsx
+++ b/src/modules/feide/queries/use-connect-feide-mutation.tsx
@@ -1,0 +1,8 @@
+import {connectFeide} from '@atb/api/identity';
+import {useMutation} from '@tanstack/react-query';
+
+export const useConnectFeideMutation = () => {
+  return useMutation({
+    mutationFn: (authorizationCode: string) => connectFeide(authorizationCode),
+  });
+};

--- a/src/modules/feide/queries/use-connect-feide-mutation.tsx
+++ b/src/modules/feide/queries/use-connect-feide-mutation.tsx
@@ -1,8 +1,13 @@
 import {connectFeide} from '@atb/api/identity';
-import {useMutation} from '@tanstack/react-query';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {feideConnectionQueryKey} from './use-get-feide-connection-query';
 
 export const useConnectFeideMutation = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (authorizationCode: string) => connectFeide(authorizationCode),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: [feideConnectionQueryKey]});
+    },
   });
 };

--- a/src/modules/feide/queries/use-get-feide-connection-query.tsx
+++ b/src/modules/feide/queries/use-get-feide-connection-query.tsx
@@ -1,0 +1,20 @@
+import {useQuery} from '@tanstack/react-query';
+import {ONE_MINUTE_MS} from '@atb/utils/durations';
+import {getFeideConnection} from '@atb/api/identity';
+import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
+import {useAuthContext} from '@atb/modules/auth';
+
+export const feideConnectionQueryKey = 'getFeideConnection';
+
+export const useGetFeideConnectionQuery = () => {
+  const {isFeideConnectionEnabled} = useFeatureTogglesContext();
+  const {userId, authStatus} = useAuthContext();
+  return useQuery({
+    enabled: isFeideConnectionEnabled && authStatus === 'authenticated',
+    queryKey: [feideConnectionQueryKey, userId],
+    queryFn: ({signal}) => getFeideConnection({signal}),
+    staleTime: ONE_MINUTE_MS,
+    gcTime: ONE_MINUTE_MS,
+    refetchOnMount: 'always',
+  });
+};

--- a/src/modules/feide/queries/use-init-feide-connect-mutation.tsx
+++ b/src/modules/feide/queries/use-init-feide-connect-mutation.tsx
@@ -1,8 +1,10 @@
 import {initFeideConnect} from '@atb/api/identity';
 import {useMutation} from '@tanstack/react-query';
+import {openInAppBrowser} from '@atb/modules/in-app-browser';
 
 export const useInitFeideConnectMutation = () => {
   return useMutation({
     mutationFn: () => initFeideConnect(),
+    onSuccess: (url) => openInAppBrowser(url, 'cancel'),
   });
 };

--- a/src/modules/feide/queries/use-init-feide-connect-mutation.tsx
+++ b/src/modules/feide/queries/use-init-feide-connect-mutation.tsx
@@ -1,0 +1,8 @@
+import {initFeideConnect} from '@atb/api/identity';
+import {useMutation} from '@tanstack/react-query';
+
+export const useInitFeideConnectMutation = () => {
+  return useMutation({
+    mutationFn: () => initFeideConnect(),
+  });
+};

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -60,6 +60,7 @@ export type RemoteConfig = {
   enable_ticket_information: boolean;
   enable_ticket_transfer: boolean;
   enable_ticketing: boolean;
+  enable_feide_connection: boolean;
   enable_tips_and_information: boolean;
   enable_token_fallback_on_timeout: boolean;
   enable_token_fallback: boolean;
@@ -142,6 +143,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_ticket_information: false,
   enable_ticket_transfer: false,
   enable_ticketing: !!JSON.parse(ENABLE_TICKETING || 'false'),
+  enable_feide_connection: false,
   enable_event_stream: false,
   enable_event_stream_fare_contracts: false,
   enable_tips_and_information: false,
@@ -310,6 +312,9 @@ export function getConfig(): RemoteConfig {
     values['enable_ticket_transfer']?.asBoolean() ??
     defaultRemoteConfig.enable_ticket_transfer;
   const enable_ticketing = values['enable_ticketing']?.asBoolean() ?? false;
+  const enable_feide_connection =
+    values['enable_feide_connection']?.asBoolean() ??
+    defaultRemoteConfig.enable_feide_connection;
   const enable_tips_and_information =
     values['enable_tips_and_information']?.asBoolean() ??
     defaultRemoteConfig.enable_tips_and_information;
@@ -447,6 +452,7 @@ export function getConfig(): RemoteConfig {
     enable_ticket_information,
     enable_ticket_transfer,
     enable_ticketing,
+    enable_feide_connection,
     enable_tips_and_information,
     enable_token_fallback_on_timeout,
     enable_token_fallback,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
@@ -57,10 +57,17 @@ export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
         const initialState = await storage.get('feide_state');
 
         if (code && state && state === initialState) {
-          setLocalError(false);
-          connectFeide(code);
+          const codeVerifier = await storage.get('feide_code_verifier');
+          const nonce = await storage.get('feide_nonce');
+          if (codeVerifier && nonce) {
+            setLocalError(false);
+            connectFeide({authorizationCode: code, codeVerifier, nonce});
+          } else {
+            setLocalError(true);
+          }
           await storage.set('feide_state', '');
           await storage.set('feide_nonce', '');
+          await storage.set('feide_code_verifier', '');
         } else if (parsed.searchParams.get('error')) {
           setLocalError(true);
         }

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
@@ -18,6 +18,7 @@ import {closeInAppBrowseriOS} from '@atb/modules/in-app-browser';
 import {storage} from '@atb/modules/storage';
 import {
   useConnectFeideMutation,
+  useGetFeideConnectionQuery,
   useInitFeideConnectMutation,
 } from '@atb/modules/feide';
 import {ProfileScreenProps} from './navigation-types';
@@ -38,10 +39,11 @@ export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
   const {
     mutate: connectFeide,
     isPending: isConnecting,
-    isSuccess,
-    data,
     error: connectError,
   } = useConnectFeideMutation();
+
+  const {data: connection} = useGetFeideConnectionQuery();
+  const isConnected = !!connection?.connected;
 
   const hasError = localError || !!connectError;
 
@@ -86,15 +88,11 @@ export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
       <View style={style.container}>
         <ThemeText>{t(FeideConnectionTexts.description)}</ThemeText>
 
-        {isSuccess && (
+        {isConnected && (
           <MessageInfoBox
             type="valid"
-            title={t(FeideConnectionTexts.success.title)}
-            message={
-              data?.name
-                ? t(FeideConnectionTexts.success.message(data.name))
-                : t(FeideConnectionTexts.success.messageNoName)
-            }
+            title={t(FeideConnectionTexts.connected.title)}
+            message={t(FeideConnectionTexts.connected.message)}
           />
         )}
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
@@ -12,7 +12,6 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
-import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 import {FEIDE_CALLBACK_URL} from '@atb/api/identity';
 import {closeInAppBrowseriOS} from '@atb/modules/in-app-browser';
 import {storage} from '@atb/modules/storage';
@@ -28,7 +27,6 @@ type Props = ProfileScreenProps<'Profile_FeideConnectionScreen'>;
 export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
   const style = useStyle();
   const {t} = useTranslation();
-  const appStatus = useAppStateStatus();
   const focusRef = useFocusOnLoad(navigation);
 
   const [localError, setLocalError] = useState(false);
@@ -76,7 +74,7 @@ export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
 
     const subscription = Linking.addEventListener('url', handleUrl);
     return () => subscription.remove();
-  }, [appStatus, connectFeide]);
+  }, [connectFeide]);
 
   return (
     <FullScreenView

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
@@ -1,0 +1,133 @@
+import React, {useEffect, useState} from 'react';
+import {Linking, View} from 'react-native';
+import {FullScreenView} from '@atb/components/screen-view';
+import {ScreenHeading} from '@atb/components/heading';
+import {ThemeText} from '@atb/components/text';
+import {Button} from '@atb/components/button';
+import {MessageInfoBox} from '@atb/components/message-info-box';
+import {StyleSheet, Theme} from '@atb/theme';
+import {
+  dictionary,
+  FeideConnectionTexts,
+  useTranslation,
+} from '@atb/translations';
+import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {useAppStateStatus} from '@atb/utils/use-app-state-status';
+import {FEIDE_CALLBACK_URL} from '@atb/api/identity';
+import {closeInAppBrowseriOS} from '@atb/modules/in-app-browser';
+import {storage} from '@atb/modules/storage';
+import {
+  useConnectFeideMutation,
+  useInitFeideConnectMutation,
+} from '@atb/modules/feide';
+import {ProfileScreenProps} from './navigation-types';
+
+type Props = ProfileScreenProps<'Profile_FeideConnectionScreen'>;
+
+export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
+  const style = useStyle();
+  const {t} = useTranslation();
+  const appStatus = useAppStateStatus();
+  const focusRef = useFocusOnLoad(navigation);
+
+  const [localError, setLocalError] = useState(false);
+
+  const {mutateAsync: initFeideConnect, isPending: isInitting} =
+    useInitFeideConnectMutation();
+
+  const {
+    mutate: connectFeide,
+    isPending: isConnecting,
+    isSuccess,
+    data,
+    error: connectError,
+  } = useConnectFeideMutation();
+
+  const hasError = localError || !!connectError;
+
+  useEffect(() => {
+    const handleUrl = async ({url}: {url: string}) => {
+      if (url.includes(FEIDE_CALLBACK_URL)) {
+        closeInAppBrowseriOS();
+        const parsed = new URL(url);
+        const code = parsed.searchParams.get('code');
+        const state = parsed.searchParams.get('state');
+        const initialState = await storage.get('feide_state');
+
+        if (code && state && state === initialState) {
+          setLocalError(false);
+          connectFeide(code);
+          await storage.set('feide_state', '');
+          await storage.set('feide_nonce', '');
+        } else if (parsed.searchParams.get('error')) {
+          setLocalError(true);
+        }
+      }
+    };
+
+    const subscription = Linking.addEventListener('url', handleUrl);
+    return () => subscription.remove();
+  }, [appStatus, connectFeide]);
+
+  return (
+    <FullScreenView
+      focusRef={focusRef}
+      headerProps={{
+        title: t(FeideConnectionTexts.header.title),
+        leftButton: {type: 'back'},
+      }}
+      headerContent={(focusRef) => (
+        <ScreenHeading
+          ref={focusRef}
+          text={t(FeideConnectionTexts.header.title)}
+        />
+      )}
+    >
+      <View style={style.container}>
+        <ThemeText>{t(FeideConnectionTexts.description)}</ThemeText>
+
+        {isSuccess && (
+          <MessageInfoBox
+            type="valid"
+            title={t(FeideConnectionTexts.success.title)}
+            message={
+              data?.name
+                ? t(FeideConnectionTexts.success.message(data.name))
+                : t(FeideConnectionTexts.success.messageNoName)
+            }
+          />
+        )}
+
+        {hasError && (
+          <MessageInfoBox
+            type="error"
+            message={
+              connectError
+                ? t(dictionary.genericErrorMsg)
+                : t(FeideConnectionTexts.error)
+            }
+          />
+        )}
+
+        <Button
+          onPress={() => {
+            setLocalError(false);
+            initFeideConnect();
+          }}
+          text={t(FeideConnectionTexts.connectButton)}
+          expanded={true}
+          loading={isInitting || isConnecting}
+          disabled={isInitting || isConnecting}
+          testID="connectFeideButton"
+        />
+      </View>
+    </FullScreenView>
+  );
+};
+
+const useStyle = StyleSheet.createThemeHook((theme: Theme) => ({
+  container: {
+    margin: theme.spacing.medium,
+    rowGap: theme.spacing.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SettingsScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_SettingsScreen.tsx
@@ -10,7 +10,7 @@ import {ProfileScreenProps} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/T
 import {useRemoteConfigContext} from '@atb/modules/remote-config';
 import {useAuthContext} from '@atb/modules/auth';
 import {AccesstbilityCircle} from '@atb/assets/svg/mono-icons/miscellaneous';
-import {Travellers} from '@atb/assets/svg/mono-icons/ticketing';
+import {Student, Travellers} from '@atb/assets/svg/mono-icons/ticketing';
 import {Phone} from '@atb/assets/svg/mono-icons/devices';
 import {Profile} from '@atb/assets/svg/mono-icons/tab-bar';
 import {
@@ -30,6 +30,7 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
   const {isPushNotificationsEnabled} = useFeatureTogglesContext();
   const {disable_travelcard} = useRemoteConfigContext();
   const {isTravelAidEnabled} = useFeatureTogglesContext();
+  const {isFeideConnectionEnabled} = useFeatureTogglesContext();
   const {enable_ticketing} = useRemoteConfigContext();
   const {authenticationType} = useAuthContext();
 
@@ -109,6 +110,18 @@ export const Profile_SettingsScreen = ({navigation}: ProfileProps) => {
               )}
               leftIcon={{svg: Profile}}
               onPress={() => navigation.navigate('Profile_EditProfileScreen')}
+            />
+          )}
+          {isFeideConnectionEnabled && authenticationType === 'phone' && (
+            <LinkSectionItem
+              text={t(
+                ProfileTexts.sections.settings.linkSectionItems.feide.label,
+              )}
+              leftIcon={{svg: Student}}
+              onPress={() =>
+                navigation.navigate('Profile_FeideConnectionScreen')
+              }
+              testID="feideConnectionButton"
             />
           )}
         </Section>

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/TabNav_ProfileStack.tsx
@@ -29,6 +29,7 @@ import {Profile_BonusScreen} from './Profile_BonusScreen.tsx';
 import {Profile_BonusCouponCodesScreen} from './Profile_BonusCouponCodesScreen.tsx';
 import {Profile_SmartParkAndRideScreen} from './Profile_SmartParkAndRideScreen';
 import {Profile_SettingsScreen} from './Profile_SettingsScreen';
+import {Profile_FeideConnectionScreen} from './Profile_FeideConnectionScreen';
 import {Profile_FavoriteScreen} from './Profile_FavoriteScreen';
 import {Profile_InformationScreen} from './Profile_InformationScreen';
 import {Profile_HelpAndContactScreen} from './Profile_HelpAndContactScreen';
@@ -151,6 +152,10 @@ export const TabNav_ProfileStack = () => {
       <Stack.Screen
         name="Profile_SettingsScreen"
         component={Profile_SettingsScreen}
+      />
+      <Stack.Screen
+        name="Profile_FeideConnectionScreen"
+        component={Profile_FeideConnectionScreen}
       />
       <Stack.Screen
         name="Profile_FavoriteScreen"

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/navigation-types.ts
@@ -34,6 +34,7 @@ export type ProfileStackParams = StackParams<{
   Profile_TravelAidScreen: undefined;
   Profile_TravelAidInformationScreen: undefined;
   Profile_SettingsScreen: undefined;
+  Profile_FeideConnectionScreen: undefined;
   Profile_FavoriteScreen: undefined;
   Profile_InformationScreen: undefined;
   Profile_HelpAndContactScreen: undefined;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -43,6 +43,7 @@ export {default as BonusProgramTexts} from './screens/subscreens/BonusProgram';
 export {default as LanguageSettingsTexts} from './screens/subscreens/LanguageSettingsTexts';
 export {default as UserProfileSettingsTexts} from './screens/subscreens/UserProfileSettingsTexts';
 export {default as LoginTexts} from './screens/subscreens/Login';
+export {default as FeideConnectionTexts} from './screens/subscreens/FeideConnectionTexts';
 export {default as dictionary} from './dictionary';
 export {default as TravelTokenTexts} from './screens/subscreens/TravelToken';
 export {default as ConsiderTravelTokenChangeTexts} from './screens/ConsiderTravelTokenChangeScreen';

--- a/src/translations/screens/Profile.ts
+++ b/src/translations/screens/Profile.ts
@@ -106,6 +106,13 @@ const ProfileTexts = {
             'Standard reisande',
           ),
         },
+        feide: {
+          label: _(
+            'Feide og skoleskyss',
+            'Feide and school transport',
+            'Feide og skuleskyss',
+          ),
+        },
         travelToken: {
           label: _(
             'Flytt billett mellom t:kort og mobil',

--- a/src/translations/screens/subscreens/FeideConnectionTexts.ts
+++ b/src/translations/screens/subscreens/FeideConnectionTexts.ts
@@ -14,6 +14,14 @@ const FeideConnectionTexts = {
     'Koble til Feide for å hente skuleskyssbilletten din i appen. Du loggar inn med Feide, og vi koplar den til kontoen din.',
   ),
   connectButton: _('Koble til Feide', 'Connect with Feide', 'Koble til Feide'),
+  connected: {
+    title: _('Tilkoblet Feide', 'Connected to Feide', 'Tilkopla Feide'),
+    message: _(
+      'Kontoen din er koblet til Feide.',
+      'Your account is connected to Feide.',
+      'Kontoen din er kopla til Feide.',
+    ),
+  },
   success: {
     title: _('Feide tilkoblet', 'Feide connected', 'Feide tilkopla'),
     message: (name: string) =>

--- a/src/translations/screens/subscreens/FeideConnectionTexts.ts
+++ b/src/translations/screens/subscreens/FeideConnectionTexts.ts
@@ -1,0 +1,34 @@
+import {translation as _} from '../../commons';
+
+const FeideConnectionTexts = {
+  header: {
+    title: _('Feide og skoleskyss', 'Feide and school transport', 'Feide og skuleskyss'),
+  },
+  description: _(
+    'Koble til Feide for å hente skoleskyssbilletten din i appen. Du logger inn med Feide, og vi kobler den til kontoen din.',
+    'Connect with Feide to get your school transport ticket in the app. You log in with Feide, and we link it to your account.',
+    'Koble til Feide for å hente skuleskyssbilletten din i appen. Du loggar inn med Feide, og vi koplar den til kontoen din.',
+  ),
+  connectButton: _('Koble til Feide', 'Connect with Feide', 'Koble til Feide'),
+  success: {
+    title: _('Feide tilkoblet', 'Feide connected', 'Feide tilkopla'),
+    message: (name: string) =>
+      _(
+        `Du er nå koblet til Feide som ${name}.`,
+        `You are now connected with Feide as ${name}.`,
+        `Du er no kopla til Feide som ${name}.`,
+      ),
+    messageNoName: _(
+      'Du er nå koblet til Feide.',
+      'You are now connected with Feide.',
+      'Du er no kopla til Feide.',
+    ),
+  },
+  error: _(
+    'Vi klarte ikke å koble til Feide. Prøv igjen.',
+    'We could not connect with Feide. Please try again.',
+    'Vi klarte ikkje å koble til Feide. Prøv igjen.',
+  ),
+};
+
+export default FeideConnectionTexts;

--- a/src/translations/screens/subscreens/FeideConnectionTexts.ts
+++ b/src/translations/screens/subscreens/FeideConnectionTexts.ts
@@ -2,7 +2,11 @@ import {translation as _} from '../../commons';
 
 const FeideConnectionTexts = {
   header: {
-    title: _('Feide og skoleskyss', 'Feide and school transport', 'Feide og skuleskyss'),
+    title: _(
+      'Feide og skoleskyss',
+      'Feide and school transport',
+      'Feide og skuleskyss',
+    ),
   },
   description: _(
     'Koble til Feide for å hente skoleskyssbilletten din i appen. Du logger inn med Feide, og vi kobler den til kontoen din.',


### PR DESCRIPTION
Related to: https://github.com/AtB-AS/team-platform/issues/1080

Dependent on: https://github.com/AtB-AS/identity/pull/78 ✅ 
Dependent on: https://github.com/AtB-AS/identity/pull/79

## What
Adds the ability for a logged-in (phone-authenticated) pupil to connect their Firebase account to a Feide identity, so they can retrieve their school ticket (skoleskyss) in the app. This PR just introduces that verification-step towards Feide, and does not do anything with school ticket yet. This is coming in a later PR when work with `farecontract-admin` is done!

## Future work
- If the pupil has a ticket, we might want to go to the ticket screens to refresh after moving tickets to current ABT-account
- If they have a travelcard, do we want to initiate switching to mobile token?
- Lots of unknowns!

## Flow
The flow mirrors the existing Vipps "connect-while-logged-in" age verification:

1. The user starts the connection, which fetches a Feide authorization URL from the identity service. The app appends the `state`, `nonce` and PKCE-`challenge` to the authorization URL, and opens it in an in-app browser.
2. After login, Feide redirects back via the `atb://auth/feide` deep link. The screen validates the returned `state` against the locally stored value, then exchanges the authorization `code`, `nonce` and PKCE-`verifier` server-side to link the Feide user to the current Firebase user.
3. The screen reflects connection status (connected / error) to the user.

## Changes 
- A new **Feide og skoleskyss** entry appears under Profile → Settings.
- New `Profile_FeideConnectionScreen` handling the deep-link callback, state validation, connection status, and error display.
- Add API-endpoints in `src/api/identity.ts`:
    - `initFeideConnect` — fetches authorization URL and opens the in-app browser, generating/storing `state`, `nonce` and a PKCE-pair with `verifier` and a `challenge`.
    - `connectFeide` — trades the authorization `code`, `nonce` and `verifier` server-side and links Feide to the Firebase user.
    - `getFeideConnection` — returns whether the user is connected (and the sub).
- React Query hooks towards endpoints:
    - `useConnectFeideMutation` (invalidates the connection query on success),
    - `useGetFeideConnectionQuery` (gated by feature toggle + auth status).
- Remote flag / feature toggle `enable_feide_connection` & `isFeideConnectionEnabled` (defaults to `false`).

https://github.com/user-attachments/assets/85036185-342f-4a01-9143-7e582767b293