### PR TITLE
feat: redesign interchange section in trip details

### DIFF
--- a/src/api/types/generated/fragments/interchanges.ts
+++ b/src/api/types/generated/fragments/interchanges.ts
@@ -1,0 +1,15 @@
+export type InterchangeFragment = {
+  guaranteed?: boolean;
+  maximumWaitTime?: number;
+  staySeated?: boolean;
+  fromServiceJourney?: {
+    id: string;
+    publicCode?: string;
+    line: {publicCode?: string};
+  };
+  toServiceJourney?: {
+    id: string;
+    publicCode?: string;
+    line: {publicCode?: string};
+  };
+};

--- a/src/api/types/generated/fragments/legs.ts
+++ b/src/api/types/generated/fragments/legs.ts
@@ -1,6 +1,7 @@
 import * as Types from '@atb/api/types/generated/journey_planner_v3_types';
 import type {AuthorityFragment} from '@atb/api/types/generated/fragments/authority';
 import type {BookingArrangementFragment} from '@atb/api/types/generated/fragments/booking-arrangements';
+import type {InterchangeFragment} from '@atb/api/types/generated/fragments/interchanges';
 import type {LineFragment} from '@atb/api/types/generated/fragments/lines';
 import type {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import type {SituationFragment} from '@atb/api/types/generated/fragments/situations';
@@ -76,12 +77,8 @@ export type LegFragment = {
     notices: Array<NoticeFragment>;
     journeyPattern?: {notices: Array<NoticeFragment>};
   };
-  interchangeTo?: {
-    guaranteed?: boolean;
-    maximumWaitTime?: number;
-    staySeated?: boolean;
-    toServiceJourney?: {id: string};
-  };
+  interchangeTo?: InterchangeFragment;
+  interchangeFrom?: InterchangeFragment;
   pointsOnLink?: {points?: string; length?: number};
   intermediateEstimatedCalls: Array<{
     date: any;

--- a/src/screen-components/travel-details-screens/components/InterchangeSection.tsx
+++ b/src/screen-components/travel-details-screens/components/InterchangeSection.tsx
@@ -1,0 +1,105 @@
+import {type Leg} from '@atb/api/types/trips';
+import {InterchangeFragment} from '@atb/api/types/generated/fragments/interchanges';
+import {
+  Language,
+  type TranslateFunction,
+  TripDetailsTexts,
+  useTranslation,
+} from '@atb/translations';
+import {secondsToDuration} from '@atb/utils/date';
+import {useTransportColor} from '@atb/utils/use-transport-color';
+import {StyleSheet} from '@atb/theme';
+import {View} from 'react-native';
+import {TripLegDecoration} from './TripLegDecoration';
+import {NEW_TRIP_DIMENSIONS, TripRow} from './TripRow';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Connection, StaySeated} from '@atb/assets/svg/mono-icons/miscellaneous';
+import {ThemeText} from '@atb/components/text';
+
+export const InterchangeSection = ({leg}: {leg: Leg}) => {
+  const {t, language} = useTranslation();
+  const style = useStyles();
+  const legColor = useTransportColor().secondary;
+
+  const interchange = leg.interchangeFrom;
+
+  if (!interchange?.guaranteed) return null;
+
+  const interchangeTexts = getInterchangeTexts(interchange, t, language);
+
+  return (
+    <View style={style.container}>
+      <TripLegDecoration
+        dimensionOverrides={NEW_TRIP_DIMENSIONS}
+        color={legColor.background}
+        hasStart={false}
+        hasEnd={false}
+      />
+      <TripRow
+        dimensionOverrides={NEW_TRIP_DIMENSIONS}
+        accessibilityLabel={`${interchangeTexts.title}. ${interchangeTexts.body}`}
+        accessible={true}
+      >
+        <View style={style.interchangeInfo}>
+          <ThemeIcon
+            size="normal"
+            svg={interchange.staySeated ? StaySeated : Connection}
+          />
+          <View style={style.interchangeText}>
+            <ThemeText typography="body__m">{interchangeTexts.title}</ThemeText>
+            <ThemeText typography="body__s" type="secondary">
+              {interchangeTexts.body}
+            </ThemeText>
+          </View>
+        </View>
+      </TripRow>
+    </View>
+  );
+};
+
+const getInterchangeTexts = (
+  interchange: InterchangeFragment,
+  t: TranslateFunction,
+  language: Language,
+): {title: string; body: string} => {
+  const maxWaitTime =
+    interchange.maximumWaitTime && interchange.maximumWaitTime > 0
+      ? secondsToDuration(interchange.maximumWaitTime, language)
+      : undefined;
+
+  const fromPublicCode = getPublicCode(interchange.fromServiceJourney);
+  const toPublicCode = getPublicCode(interchange.toServiceJourney);
+
+  if (interchange.staySeated) {
+    return {
+      title: t(TripDetailsTexts.messages.staySeatedMainText),
+      body: t(
+        TripDetailsTexts.messages.staySeatedSubText(
+          fromPublicCode,
+          toPublicCode,
+        ),
+      ),
+    };
+  }
+
+  return {
+    title: t(TripDetailsTexts.messages.interchangeMainText),
+    body: t(TripDetailsTexts.messages.interchangeSubText(maxWaitTime)),
+  };
+};
+
+const getPublicCode = (
+  serviceJourney: InterchangeFragment['fromServiceJourney'],
+) => serviceJourney?.publicCode ?? serviceJourney?.line.publicCode;
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  container: {
+    marginBottom: theme.spacing.large, // Note: Should rather gap on parent
+  },
+  interchangeInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.small,
+  },
+  interchangeText: {flex: 1},
+}));

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -7,7 +7,7 @@ import {
 } from '@atb/utils/date';
 import React, {useCallback, useRef} from 'react';
 import {View} from 'react-native';
-import {getPlaceName, InterchangeDetails, TripSection} from './TripSection';
+import {TripSection} from './TripSection';
 import {WaitDetails} from './WaitSection';
 import {ServiceJourneyDeparture} from '../types';
 import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
@@ -195,10 +195,6 @@ export const Trip: React.FC<TripProps> = ({
                 wait={legWaitDetails(index, filteredLegs)}
                 isLast={index == filteredLegs.length - 1}
                 step={index + 1}
-                interchangeDetails={getInterchangeDetails(
-                  filteredLegs,
-                  leg.interchangeTo?.toServiceJourney?.id,
-                )}
                 leg={leg}
                 testID={'leg' + index}
                 onPressShowLive={
@@ -271,24 +267,6 @@ const useStyle = StyleSheet.createThemeHook((theme) => ({
     marginTop: theme.spacing.medium,
   },
 }));
-
-function getInterchangeDetails(
-  legs: Leg[],
-  id: string | undefined,
-): InterchangeDetails | undefined {
-  if (!id) return undefined;
-  const interchangeLeg = legs.find(
-    (leg) => leg.line && leg.serviceJourney?.id === id,
-  );
-
-  if (interchangeLeg?.line?.publicCode) {
-    return {
-      publicCode: interchangeLeg.line.publicCode,
-      fromPlace: getPlaceName(interchangeLeg.fromPlace),
-    };
-  }
-  return undefined;
-}
 
 function isNetworkError(error: ErrorResponse): boolean {
   return error.kind === 'AXIOS_NETWORK_ERROR' || error.kind === 'AXIOS_TIMEOUT';

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -68,13 +68,13 @@ import {AuthorityFragment} from '@atb/api/types/generated/fragments/authority';
 import {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {CancelledDepartureMessage} from './CancelledDepartureMessage';
 import {WalkFill} from '@atb/assets/svg/mono-icons/transportation';
+import {InterchangeSection} from './InterchangeSection';
 
 type TripSectionProps = {
   isLast?: boolean;
   wait?: WaitDetails;
   isFirst?: boolean;
   step?: number;
-  interchangeDetails?: InterchangeDetails;
   leg: Leg;
   testID?: string;
   onPressShowLive?(serviceJourneyPolylines: ServiceJourneyPolylines): void;
@@ -82,17 +82,11 @@ type TripSectionProps = {
   onPressQuay: TripProps['onPressQuay'];
 };
 
-export type InterchangeDetails = {
-  publicCode: string;
-  fromPlace: string;
-};
-
 export const TripSection: React.FC<TripSectionProps> = ({
   isLast,
   isFirst,
   wait,
   step,
-  interchangeDetails,
   leg,
   testID,
   onPressShowLive,
@@ -150,9 +144,6 @@ export const TripSection: React.FC<TripSectionProps> = ({
   }
 
   const translatedModeName = getTranslatedModeName(leg.mode);
-
-  const showInterchangeSection =
-    leg.interchangeTo?.guaranteed && interchangeDetails && leg.line;
 
   const showQuayDescription =
     !!leg.fromPlace.quay?.description && !isWalkSection && !isBikeSection;
@@ -224,6 +215,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
 
   const sectionOutput = (
     <>
+      <InterchangeSection leg={leg} />
       <View style={style.tripSection} testID={testID}>
         {!!step && leg.mode && (
           <AccessibleText
@@ -534,14 +526,6 @@ export const TripSection: React.FC<TripSectionProps> = ({
           </TripRow>
         )}
       </View>
-      {showInterchangeSection && (
-        <InterchangeSection
-          publicCode={publicCode}
-          interchangeDetails={interchangeDetails}
-          maximumWaitTime={leg.interchangeTo?.maximumWaitTime}
-          staySeated={leg.interchangeTo?.staySeated}
-        />
-      )}
       <FlexibleTransportBookingDetailsSheet
         leg={leg}
         bottomSheetModalRef={bottomSheetModalRef}
@@ -911,76 +895,6 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   );
 };
 
-type InterchangeSectionProps = {
-  publicCode: string;
-  interchangeDetails: InterchangeDetails;
-  maximumWaitTime?: number;
-  staySeated?: boolean;
-};
-
-function InterchangeSection({
-  publicCode,
-  interchangeDetails,
-  maximumWaitTime,
-  staySeated,
-}: InterchangeSectionProps) {
-  const {t, language} = useTranslation();
-  const style = useSectionStyles();
-  const legColor = useTransportColor().secondary;
-
-  let text = '';
-  if (publicCode && staySeated) {
-    text = t(
-      TripDetailsTexts.messages.lineChangeStaySeated(
-        publicCode,
-        interchangeDetails.publicCode,
-      ),
-    );
-  } else if (publicCode) {
-    text = t(
-      TripDetailsTexts.messages.interchange(
-        publicCode,
-        interchangeDetails.publicCode,
-        interchangeDetails.fromPlace,
-      ),
-    );
-  } else {
-    text = t(
-      TripDetailsTexts.messages.interchangeWithUnknownFromPublicCode(
-        interchangeDetails.publicCode,
-        interchangeDetails.fromPlace,
-      ),
-    );
-  }
-
-  // If maximum wait time is defined or over 0, append it to the message.
-  // In some cases with missing data the maximum wait time can be -1.
-  if (maximumWaitTime && maximumWaitTime > 0 && !staySeated) {
-    text =
-      text +
-      ' ' +
-      t(
-        TripDetailsTexts.messages.interchangeMaxWait(
-          secondsToDuration(maximumWaitTime, language),
-        ),
-      );
-  }
-
-  return (
-    <View style={style.interchangeSection}>
-      <TripLegDecoration
-        dimensionOverrides={NEW_TRIP_DIMENSIONS}
-        color={legColor.background}
-        hasStart={false}
-        hasEnd={false}
-      />
-      <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-        <MessageInfoBox type="info" message={text} />
-      </TripRow>
-    </View>
-  );
-}
-
 export function getPlaceName(place: Place): string {
   const fallback = place.name ?? '';
   return place.quay ? (getQuayName(place.quay) ?? fallback) : fallback;
@@ -1042,9 +956,6 @@ const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   },
   authoritySection: {
     rowGap: theme.spacing.medium,
-  },
-  interchangeSection: {
-    marginBottom: theme.spacing.large,
   },
   intermediateStop: {
     flex: 1,

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -438,6 +438,26 @@ const TripDetailsTexts = {
       'Rail replacement bus',
       'Buss for tog',
     ),
+    interchangeMainText: _(
+      'Korrespondanse',
+      'Correspondence',
+      'Korrespondanse',
+    ),
+    interchangeSubText: (maxWaitTime?: string) =>
+      _(
+        `Ved forsinkelser vil avgangen vente${maxWaitTime ? ` inntil ${maxWaitTime}` : ''}`,
+        `In case of delays, the departure will wait${maxWaitTime ? ` up to ${maxWaitTime}` : ''}`,
+        `Ved forseinkingar vil avgangen vente${maxWaitTime ? ` i opp til ${maxWaitTime}` : ''}`,
+      ),
+    staySeatedMainText: _(`Bli sittende`, `Stay seated`, `Bli sittande`),
+    staySeatedSubText: (fromPublicCode?: string, toPublicCode?: string) => {
+      const hasCodes = !!fromPublicCode && !!toPublicCode;
+      return _(
+        `Linjenummeret endres${hasCodes ? ` fra ${fromPublicCode} til ${toPublicCode}` : ''} på dette stoppet.`,
+        `The line number is changing${hasCodes ? ` from ${fromPublicCode} to ${toPublicCode}` : ''} at this stop.`,
+        `Linjenummeret endrar seg${hasCodes ? ` frå ${fromPublicCode} til ${toPublicCode}` : ''} på dette stoppet.`,
+      );
+    },
     interchange: (
       fromPublicCode: string,
       toPublicCode: string,


### PR DESCRIPTION
Replace the MessageInfoBox-based interchange notice with a dedicated
component using an icon and structured title/body text. Use the new
`interchangeFrom` field on legs so the section renders at the start
of the next leg rather than at the end of the previous one.

**Before/After**
<div>
<img width="350" src="https://github.com/user-attachments/assets/d5e62ea0-2f09-41f0-b2d9-90c120630140" />
<img width="350" src="https://github.com/user-attachments/assets/6d8cbde0-15d9-4342-8081-db1f133b20d6" />

