### PR TITLE
test: add missing e2e dep

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@perf-profiler/reporter": "0.9.0",
     "@perf-profiler/types": "0.8.0",
+    "@types/node": ">=18",
     "@wdio/appium-service": "9.27.0",
     "@wdio/cli": "9.27.0",
     "@wdio/globals": "9.27.0",
@@ -26,6 +27,7 @@
     "appium": "3.3.0",
     "appium-inspector-plugin": "2026.2.1",
     "appium-uiautomator2-driver": "7.1.2",
+    "expect-webdriverio": "^5.6.5",
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
     "jest-junit": "^16.0.0",

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@perf-profiler/types':
         specifier: 0.8.0
         version: 0.8.0
+      '@types/node':
+        specifier: '>=18'
+        version: 20.19.39
       '@wdio/appium-service':
         specifier: 9.27.0
         version: 9.27.0
@@ -47,6 +50,9 @@ importers:
       appium-uiautomator2-driver:
         specifier: 7.1.2
         version: 7.1.2(appium@3.3.0)
+      expect-webdriverio:
+        specifier: ^5.6.5
+        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.3.3))


### PR DESCRIPTION
Fix tsc error when running `tsc` from the `e2e`folder (GH [run](https://github.com/AtB-AS/mittatb-app/actions/runs/27736805455/job/82055256273))
```
error TS2688: Cannot find type definition file for 'expect-webdriverio'.
  The file is in the program because:
    Entry point of type library 'expect-webdriverio' specified in compilerOptions
error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
```
