### PR TITLE
feat: restructure trip details notices by source level

### DIFF
--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -5,6 +5,7 @@ import {
   ThemeText,
 } from '@atb/components/text';
 import {MessageInfoBox} from '@atb/components/message-info-box';
+import {MessageInfoText} from '@atb/components/message-info-text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {TransportationIconBox} from '@atb/components/icon-box';
 import {ServiceJourneyDeparture} from '../types';
@@ -28,7 +29,9 @@ import {useHumanizeDistance} from '@atb/utils/location';
 import {
   getLineDestinationName,
   getLineName,
-  getNoticesForLeg,
+  getNoticesForFromEstimatedCall,
+  getNoticesForRoute,
+  getNoticesForToEstimatedCall,
   getPublicCodeFromLeg,
   isLineFlexibleTransport,
   getBookingStatus,
@@ -122,7 +125,9 @@ export const TripSection: React.FC<TripSectionProps> = ({
 
   const {startTimes, endTimes} = mapLegToTimeValues(leg);
 
-  const notices = getNoticesForLeg(leg);
+  const fromEstimatedCallNotices = getNoticesForFromEstimatedCall(leg);
+  const routeNotices = getNoticesForRoute(leg);
+  const toEstimatedCallNotices = getNoticesForToEstimatedCall(leg);
 
   const realtimeText = useRealtimeText(leg.serviceJourneyEstimatedCalls);
 
@@ -169,7 +174,10 @@ export const TripSection: React.FC<TripSectionProps> = ({
     leg.situations.length +
     (leg.transportSubmode === TransportSubmode.RailReplacementBus ? 1 : 0);
   const errorCount = leg.fromEstimatedCall?.cancellation ? 1 : 0;
-  const noticeCount = notices.length;
+  const noticeCount =
+    fromEstimatedCallNotices.length +
+    routeNotices.length +
+    toEstimatedCallNotices.length;
 
   const transportA11yLabel = (() => {
     const parts: string[] = [
@@ -238,303 +246,333 @@ export const TripSection: React.FC<TripSectionProps> = ({
             )}
           />
         )}
-        <TripLegDecoration
-          dimensionOverrides={NEW_TRIP_DIMENSIONS}
-          color={legColor}
-          hasStart={showFrom}
-          hasEnd={showTo}
-        />
-        {showFrom && (
-          <TripRow
+        <View style={style.legPath}>
+          <TripLegDecoration
             dimensionOverrides={NEW_TRIP_DIMENSIONS}
-            alignChildren="flex-start"
-            accessibilityLabel={
-              fromRowAbsorbsLegA11y
-                ? isWalkSection
-                  ? walkA11yLabel
-                  : bikeA11yLabel
-                : transportA11yLabel
-            }
-            accessibilityHint={
-              isWalkOrBike
-                ? undefined
-                : t(
-                    TripDetailsTexts.trip.leg.transport.a11yLabel.hint(
-                      getPlaceName(leg.fromPlace),
-                    ),
-                  )
-            }
-            rowLabel={
-              <Time
-                timeValues={startTimes}
-                roundingMethod="floor"
-                timeIsApproximation={timesAreApproximations}
-              />
-            }
-            onPress={
-              leg.fromPlace.quay
-                ? () => handleQuayPress(leg.fromPlace.quay)
-                : undefined
-            }
-            testID={`${testID}FromPlace`}
-          >
-            <ThemeText
-              typography="body__m__strong"
-              testID={`${testID}FromPlaceName`}
+            color={legColor}
+            hasStart={showFrom}
+            hasEnd={showTo}
+          />
+          {showFrom && (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              alignChildren="flex-start"
+              accessibilityLabel={
+                fromRowAbsorbsLegA11y
+                  ? isWalkSection
+                    ? walkA11yLabel
+                    : bikeA11yLabel
+                  : transportA11yLabel
+              }
+              accessibilityHint={
+                isWalkOrBike
+                  ? undefined
+                  : t(
+                      TripDetailsTexts.trip.leg.transport.a11yLabel.hint(
+                        getPlaceName(leg.fromPlace),
+                      ),
+                    )
+              }
+              rowLabel={
+                <Time
+                  timeValues={startTimes}
+                  roundingMethod="floor"
+                  timeIsApproximation={timesAreApproximations}
+                />
+              }
+              onPress={
+                leg.fromPlace.quay
+                  ? () => handleQuayPress(leg.fromPlace.quay)
+                  : undefined
+              }
+              testID={`${testID}FromPlace`}
             >
-              {getPlaceName(leg.fromPlace)}
-            </ThemeText>
-            {showQuayDescription && (
               <ThemeText
-                testID={`${testID}FromPlaceQuayDescription`}
-                typography="body__s"
-                type="secondary"
+                typography="body__m__strong"
+                testID={`${testID}FromPlaceName`}
               >
-                {leg.fromPlace.quay?.description}
+                {getPlaceName(leg.fromPlace)}
               </ThemeText>
-            )}
-          </TripRow>
-        )}
-        {isWalkSection ? (
-          <View
-            accessibilityElementsHidden={fromRowAbsorbsLegA11y}
-            importantForAccessibility={
-              fromRowAbsorbsLegA11y ? 'no-hide-descendants' : 'auto'
-            }
-          >
-            <WalkSection
-              leg={leg}
-              wait={wait}
-              timeRounding={walkBikeRounding}
-            />
-          </View>
-        ) : isBikeSection ? (
-          <View
-            accessibilityElementsHidden={fromRowAbsorbsLegA11y}
-            importantForAccessibility={
-              fromRowAbsorbsLegA11y ? 'no-hide-descendants' : 'auto'
-            }
-          >
-            <BikeSection
-              leg={leg}
-              wait={wait}
-              timeRounding={walkBikeRounding}
-            />
-          </View>
-        ) : (
-          <TripRow
-            dimensionOverrides={NEW_TRIP_DIMENSIONS}
-            testID={`${testID}Mode`}
-            accessibilityLabel={
-              t(
-                TripDetailsTexts.trip.leg.transport.lineA11yLabel(
-                  t(
-                    getTranslatedModeName(leg.mode, leg.line?.transportSubmode),
-                  ),
-                  getLineName(t, leg),
-                ),
-              ) +
-              (isFlexible
-                ? screenReaderPause +
-                  t(TripDetailsTexts.flexibleTransport.onDemandTransportLabel)
-                : '') +
-              (realtimeText ? screenReaderPause + realtimeText : '')
-            }
-            accessibilityHint={
-              hasIntermediateStops
-                ? t(TripDetailsTexts.trip.leg.transport.a11yHint)
-                : undefined
-            }
-            onPress={
-              hasIntermediateStops ? () => handleDeparturePress(leg) : undefined
-            }
-          >
-            {leg.transportSubmode === TransportSubmode.NightBus && (
-              <ThemeText
-                type="secondary"
-                typography="body__s"
-                style={style.secondaryTransportLabel}
-              >
-                {t(getTranslatedModeName(leg.mode, leg.line?.transportSubmode))}
-              </ThemeText>
-            )}
-            <View style={style.transportLine}>
-              <TransportationIconBox
-                mode={leg.mode}
-                subMode={leg.line?.transportSubmode}
-                isFlexible={isFlexible}
-                lineNumber={publicCode}
-                spacious
-                rounded
+              {showQuayDescription && (
+                <ThemeText
+                  testID={`${testID}FromPlaceQuayDescription`}
+                  typography="body__s"
+                  type="secondary"
+                >
+                  {leg.fromPlace.quay?.description}
+                </ThemeText>
+              )}
+            </TripRow>
+          )}
+          {fromEstimatedCallNotices.map((notice) => (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              key={notice.id}
+              accessible={false}
+            >
+              <MessageInfoText type="info" message={notice.text} />
+            </TripRow>
+          ))}
+          {isWalkSection ? (
+            <View
+              accessibilityElementsHidden={fromRowAbsorbsLegA11y}
+              importantForAccessibility={
+                fromRowAbsorbsLegA11y ? 'no-hide-descendants' : 'auto'
+              }
+            >
+              <WalkSection
+                leg={leg}
+                wait={wait}
+                timeRounding={walkBikeRounding}
               />
-              <ThemeText>{getLineDestinationName(t, leg)}</ThemeText>
             </View>
-            {isFlexible && (
-              <ThemeText
-                type="secondary"
-                typography="body__s"
-                style={style.onDemandTransportLabel}
+          ) : isBikeSection ? (
+            <View
+              accessibilityElementsHidden={fromRowAbsorbsLegA11y}
+              importantForAccessibility={
+                fromRowAbsorbsLegA11y ? 'no-hide-descendants' : 'auto'
+              }
+            >
+              <BikeSection
+                leg={leg}
+                wait={wait}
+                timeRounding={walkBikeRounding}
+              />
+            </View>
+          ) : (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              testID={`${testID}Mode`}
+              accessibilityLabel={
+                t(
+                  TripDetailsTexts.trip.leg.transport.lineA11yLabel(
+                    t(
+                      getTranslatedModeName(
+                        leg.mode,
+                        leg.line?.transportSubmode,
+                      ),
+                    ),
+                    getLineName(t, leg),
+                  ),
+                ) +
+                (isFlexible
+                  ? screenReaderPause +
+                    t(TripDetailsTexts.flexibleTransport.onDemandTransportLabel)
+                  : '') +
+                (realtimeText ? screenReaderPause + realtimeText : '')
+              }
+              accessibilityHint={
+                hasIntermediateStops
+                  ? t(TripDetailsTexts.trip.leg.transport.a11yHint)
+                  : undefined
+              }
+              onPress={
+                hasIntermediateStops
+                  ? () => handleDeparturePress(leg)
+                  : undefined
+              }
+            >
+              {leg.transportSubmode === TransportSubmode.NightBus && (
+                <ThemeText
+                  type="secondary"
+                  typography="body__s"
+                  style={style.secondaryTransportLabel}
+                >
+                  {t(
+                    getTranslatedModeName(leg.mode, leg.line?.transportSubmode),
+                  )}
+                </ThemeText>
+              )}
+              <View style={style.transportLine}>
+                <TransportationIconBox
+                  mode={leg.mode}
+                  subMode={leg.line?.transportSubmode}
+                  isFlexible={isFlexible}
+                  lineNumber={publicCode}
+                  spacious
+                  rounded
+                />
+                <ThemeText>{getLineDestinationName(t, leg)}</ThemeText>
+              </View>
+              {isFlexible && (
+                <ThemeText
+                  type="secondary"
+                  typography="body__s"
+                  style={style.onDemandTransportLabel}
+                >
+                  {t(TripDetailsTexts.flexibleTransport.onDemandTransportLabel)}
+                </ThemeText>
+              )}
+            </TripRow>
+          )}
+          {leg.fromEstimatedCall?.cancellation && (
+            <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
+              <CancelledDepartureMessage />
+            </TripRow>
+          )}
+          {leg.situations.map((situation) => (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              key={situation.id}
+              accessible={false}
+            >
+              <SituationMessageBox situation={situation} />
+            </TripRow>
+          ))}
+          {routeNotices.map((notice) => (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              key={notice.id}
+              accessible={false}
+            >
+              <MessageInfoText type="info" message={notice.text} />
+            </TripRow>
+          ))}
+          {bookingStatus !== 'none' && (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              accessible={false}
+            >
+              <BookingInfoBox
+                bookingArrangements={leg.bookingArrangements}
+                aimedStartTime={leg.aimedStartTime}
+                now={now}
+                focusRef={onCloseFocusRef}
+                onPressConfig={
+                  shouldShowButtonForOpeningFlexBottomSheet
+                    ? {
+                        text: t(
+                          TripDetailsTexts.flexibleTransport.needsBookingWhatIsThis(
+                            publicCode,
+                          ),
+                        ),
+                        action: openBookingDetails,
+                      }
+                    : undefined
+                }
+              />
+            </TripRow>
+          )}
+          {bookingStatus === 'bookable' && (
+            <View style={style.flexBookingOptions}>
+              <TripRow
+                dimensionOverrides={NEW_TRIP_DIMENSIONS}
+                accessible={false}
               >
-                {t(TripDetailsTexts.flexibleTransport.onDemandTransportLabel)}
+                <BookingOptions bookingArrangements={leg.bookingArrangements} />
+              </TripRow>
+            </View>
+          )}
+
+          {leg.transportSubmode === TransportSubmode.RailReplacementBus && (
+            <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
+              <MessageInfoBox
+                type="warning"
+                message={t(
+                  TripDetailsTexts.messages.departureIsRailReplacementBus,
+                )}
+              />
+            </TripRow>
+          )}
+          {leg.authority && <AuthorityRow {...leg.authority} />}
+          {realtimeText && (
+            <View
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+            >
+              <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
+                <View style={style.realtime}>
+                  <ThemeIcon
+                    svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
+                    size="xSmall"
+                    style={style.realtimeIcon}
+                  />
+                  <ThemeText
+                    style={style.realtimeText}
+                    typography="body__s"
+                    type="secondary"
+                  >
+                    {realtimeText}
+                  </ThemeText>
+                </View>
+              </TripRow>
+            </View>
+          )}
+          {onPressShowLive && serviceJourneyPolyline ? (
+            <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
+              <Button
+                type="small"
+                expanded={false}
+                mode="secondary"
+                leftIcon={{svg: Map}}
+                text={t(TripDetailsTexts.trip.leg.live(t(translatedModeName)))}
+                backgroundColor={theme.color.background.neutral[1]}
+                onPress={() => onPressShowLive(serviceJourneyPolyline)}
+              />
+            </TripRow>
+          ) : null}
+          {hasIntermediateStops && (
+            <IntermediateInfo
+              leg={leg}
+              testID={testID}
+              onPressQuay={onPressQuay}
+            />
+          )}
+          {showTo && (
+            <TripRow
+              dimensionOverrides={NEW_TRIP_DIMENSIONS}
+              alignChildren="flex-end"
+              accessibilityLabel={t(
+                TripDetailsTexts.trip.leg.end.a11yLabel(
+                  getPlaceName(leg.toPlace),
+                  formatToClock(
+                    endTimes.expectedTime ?? endTimes.aimedTime,
+                    language,
+                    'ceil',
+                  ),
+                ),
+              )}
+              accessibilityHint={
+                isWalkOrBike
+                  ? undefined
+                  : t(
+                      TripDetailsTexts.trip.leg.transport.a11yLabel.hint(
+                        getPlaceName(leg.toPlace),
+                      ),
+                    )
+              }
+              rowLabel={
+                <Time
+                  timeValues={endTimes}
+                  roundingMethod="ceil"
+                  timeIsApproximation={timesAreApproximations}
+                />
+              }
+              onPress={
+                leg.toPlace.quay
+                  ? () => handleQuayPress(leg.toPlace.quay)
+                  : undefined
+              }
+              testID={`${testID}ToPlace`}
+            >
+              <ThemeText
+                typography="body__m__strong"
+                testID={`${testID}ToPlaceName`}
+              >
+                {getPlaceName(leg.toPlace)}
               </ThemeText>
-            )}
-          </TripRow>
-        )}
-        {leg.fromEstimatedCall?.cancellation && (
-          <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-            <CancelledDepartureMessage />
-          </TripRow>
-        )}
-        {leg.situations.map((situation) => (
-          <TripRow
-            dimensionOverrides={NEW_TRIP_DIMENSIONS}
-            key={situation.id}
-            accessible={false}
-          >
-            <SituationMessageBox situation={situation} />
-          </TripRow>
-        ))}
-        {notices.map((notice) => (
+            </TripRow>
+          )}
+        </View>
+        {toEstimatedCallNotices.map((notice) => (
           <TripRow
             dimensionOverrides={NEW_TRIP_DIMENSIONS}
             key={notice.id}
             accessible={false}
           >
-            <MessageInfoBox type="info" message={notice.text} />
+            <MessageInfoText type="info" message={notice.text} />
           </TripRow>
         ))}
-        {bookingStatus !== 'none' && (
-          <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS} accessible={false}>
-            <BookingInfoBox
-              bookingArrangements={leg.bookingArrangements}
-              aimedStartTime={leg.aimedStartTime}
-              now={now}
-              focusRef={onCloseFocusRef}
-              onPressConfig={
-                shouldShowButtonForOpeningFlexBottomSheet
-                  ? {
-                      text: t(
-                        TripDetailsTexts.flexibleTransport.needsBookingWhatIsThis(
-                          publicCode,
-                        ),
-                      ),
-                      action: openBookingDetails,
-                    }
-                  : undefined
-              }
-            />
-          </TripRow>
-        )}
-        {bookingStatus === 'bookable' && (
-          <View style={style.flexBookingOptions}>
-            <TripRow
-              dimensionOverrides={NEW_TRIP_DIMENSIONS}
-              accessible={false}
-            >
-              <BookingOptions bookingArrangements={leg.bookingArrangements} />
-            </TripRow>
-          </View>
-        )}
-
-        {leg.transportSubmode === TransportSubmode.RailReplacementBus && (
-          <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-            <MessageInfoBox
-              type="warning"
-              message={t(
-                TripDetailsTexts.messages.departureIsRailReplacementBus,
-              )}
-            />
-          </TripRow>
-        )}
-        {leg.authority && <AuthorityRow {...leg.authority} />}
-        {realtimeText && (
-          <View
-            accessibilityElementsHidden
-            importantForAccessibility="no-hide-descendants"
-          >
-            <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-              <View style={style.realtime}>
-                <ThemeIcon
-                  svg={themeName == 'dark' ? RealtimeDark : RealtimeLight}
-                  size="xSmall"
-                  style={style.realtimeIcon}
-                />
-                <ThemeText
-                  style={style.realtimeText}
-                  typography="body__s"
-                  type="secondary"
-                >
-                  {realtimeText}
-                </ThemeText>
-              </View>
-            </TripRow>
-          </View>
-        )}
-        {onPressShowLive && serviceJourneyPolyline ? (
-          <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-            <Button
-              type="small"
-              expanded={false}
-              mode="secondary"
-              leftIcon={{svg: Map}}
-              text={t(TripDetailsTexts.trip.leg.live(t(translatedModeName)))}
-              backgroundColor={theme.color.background.neutral[1]}
-              onPress={() => onPressShowLive(serviceJourneyPolyline)}
-            />
-          </TripRow>
-        ) : null}
-        {hasIntermediateStops && (
-          <IntermediateInfo
-            leg={leg}
-            testID={testID}
-            onPressQuay={onPressQuay}
-          />
-        )}
-        {showTo && (
-          <TripRow
-            dimensionOverrides={NEW_TRIP_DIMENSIONS}
-            alignChildren="flex-end"
-            accessibilityLabel={t(
-              TripDetailsTexts.trip.leg.end.a11yLabel(
-                getPlaceName(leg.toPlace),
-                formatToClock(
-                  endTimes.expectedTime ?? endTimes.aimedTime,
-                  language,
-                  'ceil',
-                ),
-              ),
-            )}
-            accessibilityHint={
-              isWalkOrBike
-                ? undefined
-                : t(
-                    TripDetailsTexts.trip.leg.transport.a11yLabel.hint(
-                      getPlaceName(leg.toPlace),
-                    ),
-                  )
-            }
-            rowLabel={
-              <Time
-                timeValues={endTimes}
-                roundingMethod="ceil"
-                timeIsApproximation={timesAreApproximations}
-              />
-            }
-            onPress={
-              leg.toPlace.quay
-                ? () => handleQuayPress(leg.toPlace.quay)
-                : undefined
-            }
-            testID={`${testID}ToPlace`}
-          >
-            <ThemeText
-              typography="body__m__strong"
-              testID={`${testID}ToPlaceName`}
-            >
-              {getPlaceName(leg.toPlace)}
-            </ThemeText>
-          </TripRow>
-        )}
       </View>
       {showInterchangeSection && (
         <InterchangeSection
@@ -1007,6 +1045,9 @@ const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   tripSection: {
     flex: 1,
     marginBottom: theme.spacing.large,
+  },
+  legPath: {
+    flex: 1,
   },
   a11yHelper: {
     position: 'absolute',

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -47,6 +47,20 @@ export const getNoticesForLeg = (leg: Leg) =>
     ...(leg.toEstimatedCall?.notices || []),
   ]);
 
+/** Get notices on "route" level: ServiceJourney, JourneyPatter, Line */
+export const getNoticesForRoute = (leg: Leg) =>
+  filterNotices([
+    ...(leg.line?.notices || []),
+    ...(leg.serviceJourney?.notices || []),
+    ...(leg.serviceJourney?.journeyPattern?.notices || []),
+  ]);
+
+export const getNoticesForFromEstimatedCall = (leg: Leg) =>
+  filterNotices(leg.fromEstimatedCall?.notices || []);
+
+export const getNoticesForToEstimatedCall = (leg: Leg) =>
+  filterNotices(leg.toEstimatedCall?.notices || []);
+
 export const getNoticesForServiceJourney = (
   serviceJourney: ServiceJourneyWithEstCallsFragment,
   fromStopPosition: number,


### PR DESCRIPTION
Render notices for the fromEstimatedCall above the line info, route
level notices (line, serviceJourney, journeyPattern) below the line
info, and toEstimatedCall notices below the toQuay row. Display
notices as MessageInfoText instead of MessageInfoBox.

Note: The notice on toEstimatedCall should be closer to the quay name, to better visualise that they are connected. Will however do it in its own PR, since quite a bit of code changes was necessary to fix it.

**Before/After**
<div>
<img width="350" src="https://github.com/user-attachments/assets/30f62b9f-7536-422a-8dfc-58baafc6f62b" />
<img width="350" src="https://github.com/user-attachments/assets/d8f1addd-7ab7-422f-b6df-4b57ab4f4521" />

