### PR TITLE
fix: count unique transport modes for overflow counter

### DIFF
--- a/src/components/icon-box/TransportationIconBoxList.tsx
+++ b/src/components/icon-box/TransportationIconBoxList.tsx
@@ -17,7 +17,6 @@ export type TransportModePair = {
 
 type Props = {
   modes: TransportModePair[];
-  maxNumberOfBoxes?: number;
   iconSize?: keyof Theme['icon']['size'];
 } & AccessibilityProps;
 
@@ -28,14 +27,12 @@ export const TransportationIconBoxList = ({
 }: Props) => {
   const styles = useStyles({iconSize})();
   const {t} = useTranslation();
-  const numberOfModes: number = modes.length;
-  const hasOverflow = numberOfModes > TRANSPORTATION_ICON_BOX_LIST_MAX_ITEMS;
-  const numberOfModesToDisplay = hasOverflow
-    ? TRANSPORTATION_ICON_BOX_LIST_MAX_ITEMS - 1
-    : numberOfModes;
-  const modesToDisplay = modes
-    .filter(removeDuplicatesByIconNameFilter)
-    .slice(0, numberOfModesToDisplay);
+  const deduplicatedModes = modes.filter(removeDuplicatesByIconNameFilter);
+  const modesToDisplay =
+    deduplicatedModes.length > TRANSPORTATION_ICON_BOX_LIST_MAX_ITEMS
+      ? deduplicatedModes.slice(0, TRANSPORTATION_ICON_BOX_LIST_MAX_ITEMS - 1)
+      : deduplicatedModes;
+  const overflowCount = deduplicatedModes.length - modesToDisplay.length;
 
   return (
     <View
@@ -52,9 +49,9 @@ export const TransportationIconBoxList = ({
           iconSize={iconSize}
         />
       ))}
-      {hasOverflow && (
+      {overflowCount > 0 && (
         <CounterIconBox
-          count={numberOfModes - numberOfModesToDisplay}
+          count={overflowCount}
           size={iconSize}
           textType={iconSize === 'xSmall' ? 'heading__xs' : 'body__s'}
         />


### PR DESCRIPTION
Use the list of unique transport modes when deciding whether to show
the overflow counter and what number to display.

**Before/After**
Example with 4 different boat submodes in Firestore-configuration, but they all resolve to same icon.

<div>
<img width="350" src="https://github.com/user-attachments/assets/ae47bd67-0b70-4d43-8243-bd18d2a06075" />
<img width="350" src="https://github.com/user-attachments/assets/90982027-802f-4a6f-b625-b8b702e8d43f" />
</div>

### Acceptance criteria
- [x] Only unique mode icons count toward the overflow counter