### PR TITLE
feat: new icon to stationSheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@atb-as/config-specs": "^11.0.0",
-    "@atb-as/generate-assets": "^18.15.0",
+    "@atb-as/generate-assets": "^18.16.0",
     "@atb-as/theme": "^15.2.0",
     "@atb-as/utils": "^6.1.0",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0(zod@4.1.11)
       '@atb-as/generate-assets':
-        specifier: ^18.15.0
-        version: 18.15.0
+        specifier: ^18.16.0
+        version: 18.16.0
       '@atb-as/theme':
         specifier: ^15.2.0
         version: 15.2.0
@@ -502,8 +502,8 @@ packages:
     peerDependencies:
       zod: ^4.1.11
 
-  '@atb-as/generate-assets@18.15.0':
-    resolution: {integrity: sha512-yPPeW1oSeT7THIN3e2ZpvWif154GHM+5x0iNr1huuQxO1G6lg1Od5XaoWgEozY4aN1vFdqDc0oqBP/tSQlqfqA==}
+  '@atb-as/generate-assets@18.16.0':
+    resolution: {integrity: sha512-0+IqmDI2Ya8PYHyV2fl04BhkjQ4Bq5dUY0g6xLDnVx9rpubeYqO8Rl1Ebfl0+btgyQIujmc2GbDEJ/0lHzovmA==}
     hasBin: true
 
   '@atb-as/theme@14.0.1':
@@ -7399,7 +7399,7 @@ snapshots:
       yargs: 17.7.2
       zod: 4.1.11
 
-  '@atb-as/generate-assets@18.15.0':
+  '@atb-as/generate-assets@18.16.0':
     dependencies:
       '@atb-as/theme': 14.0.1
       commander: 9.5.0
@@ -9587,7 +9587,7 @@ snapshots:
       chrome-launcher: 0.15.2
       chromium-edge-launcher: 0.2.0
       connect: 3.7.0
-      debug: 4.4.1
+      debug: 4.4.3
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2

--- a/src/modules/mobility/components/BikeStationIntegrationView.tsx
+++ b/src/modules/mobility/components/BikeStationIntegrationView.tsx
@@ -30,8 +30,7 @@ import {
   MOCK_VEHICLE_ID,
 } from '../queries/use-vehicle-query';
 import {SupportButton} from './SupportButton';
-import {ThemedCityBikeStation} from '@atb/theme/ThemedAssets';
-import Parking from '@atb/assets/svg/color/icons/vehicles/light/Parking';
+import {ThemedCityBikeStation, ThemedParkingIcon} from '@atb/theme/ThemedAssets';
 
 type Props = {
   station: Station;
@@ -155,7 +154,7 @@ export const BikeStationIntegrationView = ({
         </Section>
         <Section>
           <GenericSectionItem style={styles.freeParkingSection}>
-            <ThemeIcon svg={Parking} size="large" />
+            <ThemeIcon svg={ThemedParkingIcon} size="large" />
             <ThemeText>
               {t(
                 MobilityTexts.freeBikeParkingSpaces(

--- a/src/modules/mobility/components/BikeStationIntegrationView.tsx
+++ b/src/modules/mobility/components/BikeStationIntegrationView.tsx
@@ -17,7 +17,6 @@ import {
   FormFactor,
   PropulsionType,
 } from '@atb/api/types/generated/mobility-types_v2';
-import SvgParking from '@atb/assets/svg/mono-icons/places/Parking';
 import {ThemeText} from '@atb/components/text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
@@ -32,6 +31,7 @@ import {
 } from '../queries/use-vehicle-query';
 import {SupportButton} from './SupportButton';
 import {ThemedCityBikeStation} from '@atb/theme/ThemedAssets';
+import Parking from '@atb/assets/svg/color/icons/vehicles/light/Parking';
 
 type Props = {
   station: Station;
@@ -155,7 +155,7 @@ export const BikeStationIntegrationView = ({
         </Section>
         <Section>
           <GenericSectionItem style={styles.freeParkingSection}>
-            <ThemeIcon svg={SvgParking} size="large" />
+            <ThemeIcon svg={Parking} size="large" />
             <ThemeText>
               {t(
                 MobilityTexts.freeBikeParkingSpaces(

--- a/src/modules/mobility/components/BikeStationIntegrationView.tsx
+++ b/src/modules/mobility/components/BikeStationIntegrationView.tsx
@@ -30,7 +30,10 @@ import {
   MOCK_VEHICLE_ID,
 } from '../queries/use-vehicle-query';
 import {SupportButton} from './SupportButton';
-import {ThemedCityBikeStation, ThemedParkingIcon} from '@atb/theme/ThemedAssets';
+import {
+  ThemedCityBikeStation,
+  ThemedParkingIcon,
+} from '@atb/theme/ThemedAssets';
 
 type Props = {
   station: Station;

--- a/src/theme/ThemedAssets.tsx
+++ b/src/theme/ThemedAssets.tsx
@@ -103,6 +103,8 @@ import {
   CarRegister as CarRegisterDark,
   CarValidTicket as CarValidTicketDark,
 } from '@atb/assets/svg/color/images/smart-park-and-ride/dark';
+import {Parking as ParkingLight} from '@atb/assets/svg/color/icons/vehicles/light';
+import {Parking as ParkingDark} from '@atb/assets/svg/color/icons/vehicles/dark';
 import {useThemeContext} from '@atb/theme/ThemeContext';
 import {SvgProps} from 'react-native-svg';
 
@@ -251,3 +253,4 @@ export const ThemedCarValidTicket = getThemedAsset(
   CarValidTicketLight,
   CarValidTicketDark,
 );
+export const ThemedParkingIcon = getThemedAsset(ParkingLight, ParkingDark);


### PR DESCRIPTION
Added a new blue parking icon (P) to the station bottomsheet, replacing the old mono parking icon

<img width="250" alt="image" src="https://github.com/user-attachments/assets/c0139822-2a27-4899-9c0f-7d0c8fa6221e" />

From [figma](https://www.figma.com/design/YfLcr1BKOuaXk9HIUilXJK/City-bike-integration-V1?node-id=1119-93908&t=dNfx9Q544enciAeP-0)

<img width="250" alt="image" src="https://github.com/user-attachments/assets/7efaf73c-6062-46a2-8ddd-c534068459c9" />

