### PR TITLE
fix: tighten notice spacing on trip details

### DIFF
--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -296,11 +296,12 @@ export const TripSection: React.FC<TripSectionProps> = ({
               )}
             </TripRow>
           )}
-          {fromEstimatedCallNotices.map((notice) => (
+          {fromEstimatedCallNotices.map((notice, index) => (
             <TripRow
               dimensionOverrides={NEW_TRIP_DIMENSIONS}
               key={notice.id}
               accessible={false}
+              style={[style.notice, index === 0 && style.noticeFirst]}
             >
               <MessageInfoText type="info" message={notice.text} />
             </TripRow>
@@ -416,6 +417,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
               dimensionOverrides={NEW_TRIP_DIMENSIONS}
               key={notice.id}
               accessible={false}
+              style={style.notice}
             >
               <MessageInfoText type="info" message={notice.text} />
             </TripRow>
@@ -556,11 +558,12 @@ export const TripSection: React.FC<TripSectionProps> = ({
             </TripRow>
           )}
         </View>
-        {toEstimatedCallNotices.map((notice) => (
+        {toEstimatedCallNotices.map((notice, index) => (
           <TripRow
             dimensionOverrides={NEW_TRIP_DIMENSIONS}
             key={notice.id}
             accessible={false}
+            style={[style.notice, index === 0 && style.noticeFirst]}
           >
             <MessageInfoText type="info" message={notice.text} />
           </TripRow>
@@ -1002,5 +1005,11 @@ const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   },
   intermediateStop: {
     flex: 1,
+  },
+  notice: {
+    paddingTop: 0,
+  },
+  noticeFirst: {
+    marginTop: -theme.spacing.xSmall,
   },
 }));


### PR DESCRIPTION
Use 8px between consecutive notices and reduce the gap between
from/to estimated call notices and the quay row above to 4px.

Done as a quick fix (negative margin) now as a larger refactor of
trip details are incoming.

**Before/After**
<div>
<img width="350" src="https://github.com/user-attachments/assets/45e767d5-36b6-4c6c-a56e-8b7191b21b4d" />
<img width="350" src="https://github.com/user-attachments/assets/c9ceba6f-01b0-4c4c-b67f-05597c9b0dcd" />


