### PR TITLE
feat: Enforce unique Feide-connections

### DIFF
--- a/src/modules/feide/queries/use-connect-feide-mutation.tsx
+++ b/src/modules/feide/queries/use-connect-feide-mutation.tsx
@@ -1,10 +1,15 @@
-import {connectFeide, ConnectFeideParams} from '@atb/api/identity';
+import {
+  connectFeide,
+  ConnectFeideParams,
+  FeideConnectResponse,
+} from '@atb/api/identity';
+import {RequestError} from '@atb/api/utils';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {feideConnectionQueryKey} from './use-get-feide-connection-query';
 
 export const useConnectFeideMutation = () => {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<FeideConnectResponse, RequestError, ConnectFeideParams>({
     mutationFn: (params: ConnectFeideParams) => connectFeide(params),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [feideConnectionQueryKey]});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_FeideConnectionScreen.tsx
@@ -43,6 +43,7 @@ export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
   const {data: connection} = useGetFeideConnectionQuery();
   const isConnected = !!connection?.connected;
 
+  const isAlreadyConnectedError = connectError?.http?.code === 409;
   const hasError = localError || !!connectError;
 
   useEffect(() => {
@@ -101,16 +102,28 @@ export const Profile_FeideConnectionScreen = ({navigation}: Props) => {
           />
         )}
 
-        {hasError && (
-          <MessageInfoBox
-            type="error"
-            message={
-              connectError
-                ? t(dictionary.genericErrorMsg)
-                : t(FeideConnectionTexts.error)
-            }
-          />
-        )}
+        {hasError &&
+          (isAlreadyConnectedError ? (
+            <MessageInfoBox
+              type="error"
+              title={t(FeideConnectionTexts.alreadyConnectedError.title)}
+              message={t(FeideConnectionTexts.alreadyConnectedError.message)}
+              onPressConfig={{
+                action: () =>
+                  navigation.navigate('Profile_HelpAndContactScreen'),
+                text: t(FeideConnectionTexts.alreadyConnectedError.contactLink),
+              }}
+            />
+          ) : (
+            <MessageInfoBox
+              type="error"
+              message={
+                connectError
+                  ? t(dictionary.genericErrorMsg)
+                  : t(FeideConnectionTexts.error)
+              }
+            />
+          ))}
 
         <Button
           onPress={() => {

--- a/src/translations/screens/subscreens/FeideConnectionTexts.ts
+++ b/src/translations/screens/subscreens/FeideConnectionTexts.ts
@@ -41,6 +41,23 @@ const FeideConnectionTexts = {
     'We could not connect with Feide. Please try again.',
     'Vi klarte ikkje å koble til Feide. Prøv igjen.',
   ),
+  alreadyConnectedError: {
+    title: _(
+      'Feide er allerede i bruk',
+      'Feide already in use',
+      'Feide er allereie i bruk',
+    ),
+    message: _(
+      'En annen konto er allerede koblet til denne Feide-brukeren. Ta kontakt med kundeservice for hjelp med Feide-tilkobling og skoleskyssbilletter.',
+      'Another account is already connected to this Feide user. Contact customer support for help with Feide connection and school transport tickets.',
+      'Ein annan konto er allereie kopla til denne Feide-brukaren. Ta kontakt med kundeservice for hjelp med Feide-tilkopling og skuleskyssbillettar.',
+    ),
+    contactLink: _(
+      'Kontakt kundeservice',
+      'Contact customer support',
+      'Kontakt kundeservice',
+    ),
+  },
 };
 
 export default FeideConnectionTexts;


### PR DESCRIPTION
Allow only a single connection to Feide at a time, so multiple app-users cannot be connected to the same Feide-user.

Will route users to customer support if there is a conflict, since this most likely requires manual clean up if they have a new phone number.

Fixes: https://github.com/AtB-AS/identity/pull/78#issuecomment-4751887689

Dependent on: https://github.com/AtB-AS/identity/pull/81

<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/fd8fccd6-e237-4046-9d33-f7845dfd6577" />
