### PR TITLE
fix: add logEvent to all bonus checkboxes (also disabled ones)

### DIFF
--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -68,7 +68,7 @@ export const PayWithBonusPointsCheckbox = ({
     hasSufficientBalance: boolean,
     newState?: boolean,
   ) => {
-logEvent('Bonus', 'bonus points checkbox toggled', {
+    logEvent('Bonus', 'bonus points checkbox toggled', {
       bonusProductId: bonusProduct.id,
       hasSufficientBalance,
       ...(newState !== undefined && {newState}),
@@ -111,7 +111,13 @@ logEvent('Bonus', 'bonus points checkbox toggled', {
               <Pressable
                 onPress={() => logCheckboxEvent(false)}
                 accessible={false}
-                style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0}}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                }}
               />
             </View>
           </GenericSectionItem>

--- a/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
+++ b/src/modules/bonus/components/PayWithBonusPointsCheckbox.tsx
@@ -14,12 +14,13 @@ import {
   getTextForLanguage,
   useTranslation,
 } from '@atb/translations';
-import {View} from 'react-native';
+import {Pressable, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {isDefined} from '@atb/utils/presence';
 import {BonusStarFill} from './BonusStarFill';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {MessageInfoText} from '@atb/components/message-info-text';
+import {useAnalyticsContext} from '@atb/modules/analytics';
 
 type Props = SectionProps & {
   bonusProduct: BonusProductType;
@@ -37,6 +38,7 @@ export const PayWithBonusPointsCheckbox = ({
 }: Props) => {
   const styles = useStyles();
   const {t, language} = useTranslation();
+  const {logEvent} = useAnalyticsContext();
 
   const {data: userBonusBalance, status: userBonusBalanceStatus} =
     useBonusBalanceQuery();
@@ -61,6 +63,17 @@ export const PayWithBonusPointsCheckbox = ({
           : null,
       ),
     );
+
+  const logCheckboxEvent = (
+    hasSufficientBalance: boolean,
+    newState?: boolean,
+  ) => {
+logEvent('Bonus', 'bonus points checkbox toggled', {
+      bonusProductId: bonusProduct.id,
+      hasSufficientBalance,
+      ...(newState !== undefined && {newState}),
+    });
+  };
 
   const content = (
     <View style={styles.container}>
@@ -92,13 +105,23 @@ export const PayWithBonusPointsCheckbox = ({
     <>
       <Section {...props}>
         {hasInsufficientBalance ? (
-          <GenericSectionItem accessibility={{accessibilityLabel: a11yLabel}}>
-            {content}
+          <GenericSectionItem>
+            <View style={{flex: 1}}>
+              {content}
+              <Pressable
+                onPress={() => logCheckboxEvent(false)}
+                accessible={false}
+                style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0}}
+              />
+            </View>
           </GenericSectionItem>
         ) : (
           <GenericClickableSectionItem
             active={isChecked}
-            onPress={onPress}
+            onPress={() => {
+              logCheckboxEvent(true, !isChecked);
+              onPress();
+            }}
             disabled={isError}
             accessibilityRole="checkbox"
             accessibilityState={{checked: isChecked}}

--- a/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
+++ b/src/modules/mobility/components/BicycleSheetNotIntegratedView.tsx
@@ -4,7 +4,6 @@ import {Parking} from '@atb/assets/svg/mono-icons/places';
 import {BicycleFill} from '@atb/assets/svg/mono-icons/transportation';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
-import {useAnalyticsContext} from '@atb/modules/analytics';
 import {
   PayWithBonusPointsCheckbox,
   useRelevantVoucherBonusProduct,
@@ -52,8 +51,6 @@ export const BikeStationNotIntegratedView = ({
   const {operatorBenefit} = useOperatorBenefit(operatorId);
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const bonusProduct = useRelevantVoucherBonusProduct(operatorId);
-  const {logEvent} = useAnalyticsContext();
-
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
 
   return (
@@ -113,16 +110,7 @@ export const BikeStationNotIntegratedView = ({
             bonusProduct={bonusProduct}
             operatorName={operatorName}
             isChecked={payWithBonusPoints}
-            onPress={() =>
-              setPayWithBonusPoints((payWithBonusPoints) => {
-                const newState = !payWithBonusPoints;
-                logEvent('Bonus', 'bonus points checkbox toggled', {
-                  bonusProductId: bonusProduct.id,
-                  newState: newState,
-                });
-                return newState;
-              })
-            }
+            onPress={() => setPayWithBonusPoints((prev) => !prev)}
             style={styles.payWithBonusPointsSection}
           />
         )}

--- a/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
+++ b/src/modules/mobility/components/CarSharingStationBottomSheet.tsx
@@ -30,7 +30,6 @@ import {
   BottomSheetHeaderType,
   MapBottomSheet,
 } from '@atb/components/bottom-sheet';
-import {useAnalyticsContext} from '@atb/modules/analytics';
 import {Loading} from '@atb/components/loading';
 
 type Props = {
@@ -68,8 +67,6 @@ export const CarSharingStationBottomSheet = ({
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const bonusProduct = useRelevantVoucherBonusProduct(operatorId);
-
-  const {logEvent} = useAnalyticsContext();
 
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
   useDoOnceOnItemReceived(onStationReceived, station);
@@ -144,16 +141,7 @@ export const CarSharingStationBottomSheet = ({
                   bonusProduct={bonusProduct}
                   operatorName={operatorName}
                   isChecked={payWithBonusPoints}
-                  onPress={() =>
-                    setPayWithBonusPoints((payWithBonusPoints) => {
-                      const newState = !payWithBonusPoints;
-                      logEvent('Bonus', 'bonus points checkbox toggled', {
-                        bonusProductId: bonusProduct.id,
-                        newState: newState,
-                      });
-                      return newState;
-                    })
-                  }
+                  onPress={() => setPayWithBonusPoints((prev) => !prev)}
                   style={styles.payWithBonusPointsSection}
                 />
               )}

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -46,7 +46,6 @@ import {
   useIsBonusActiveForUser,
   useRelevantSharedMobilityBonusProduct,
 } from '@atb/modules/bonus';
-import {useAnalyticsContext} from '@atb/modules/analytics';
 import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
 
 type Props = {
@@ -128,7 +127,6 @@ export const VehicleSheet = ({
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
   const bonusProduct = useRelevantSharedMobilityBonusProduct(vehicleTypeId);
-  const {logEvent} = useAnalyticsContext();
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
 
   const isDeepIntegrationEnabled =
@@ -224,16 +222,7 @@ export const VehicleSheet = ({
                   bonusProduct={bonusProduct}
                   operatorName={operatorName}
                   isChecked={payWithBonusPoints}
-                  onPress={() =>
-                    setPayWithBonusPoints((prev) => {
-                      const newState = !prev;
-                      logEvent('Bonus', 'bonus points checkbox toggled', {
-                        bonusProductId: bonusProduct.id,
-                        newState,
-                      });
-                      return newState;
-                    })
-                  }
+                  onPress={() => setPayWithBonusPoints((prev) => !prev)}
                 />
               )}
               <ShmoActionButton


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/team-platform/issues/1088

## Description
Adds common log event for all bonus checkbox presses
- Also adds for disabled checkboxes, as this was wanted from design



## 📋 Acceptance criteria

- [x] All presses on bonus checkboxes are logged

## 💣 Test input

- [ ] 200% Zoom
- [ ] Screen reader
- [ ] Light and dark mode
- [ ] Language
- [x] Presses on enabled bonus checkboxes are logged with correct hasSufficientBalance value and  newState value 
- [x] Presses on disabled bonus checkboxes are logged with correct hasSufficientBalance and no newState value