### PR TITLE
chore: add missing dep for e2e

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,6 +13,7 @@
     "test:android:local:perfMeasure": "flashlight test --bundleId no.mittatb.debug --testCommand \"APP_ENV=debug pnpm test:android:local:dev --spec test/flashlight/performanceMeasures.e2e.ts\" --resultsTitle performanceMeasures --iterationCount 1 --maxRetries 1"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@perf-profiler/reporter": "0.9.0",
     "@perf-profiler/types": "0.8.0",
     "@types/node": ">=18",

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@perf-profiler/reporter':
         specifier: 0.9.0
         version: 0.9.0


### PR DESCRIPTION
Running `tsc` on the e2e folder in GitHub gives the error `test/utils/jestAssertions.ts(1,36): error TS2307: Cannot find module '@jest/globals' or its corresponding type declarations.`, which is not an issue locally since it's resolved through the parent workspace.