### PR TITLE
feat(mobility): consume shmo vehicle contract v2 (benefit, bonus offer, action button)

### DIFF
--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -2,6 +2,7 @@ import {client} from '@atb/api/index';
 import {stringifyUrl} from '@atb/api/utils';
 import qs from 'query-string';
 import {AxiosRequestConfig} from 'axios';
+import {z} from 'zod';
 import {
   AssetSchema,
   AssetFromQrCodeQuery,
@@ -28,6 +29,10 @@ import {
   ViolationsReportQueryResult,
   ViolationsReportQueryResultSchema,
 } from './types/mobility';
+
+const AppSwitchUrlSchema = z.object({url: z.string()});
+
+export type AppSwitchUrl = z.infer<typeof AppSwitchUrlSchema>;
 
 export const getActiveShmoBooking = (
   acceptLanguage: string,
@@ -175,6 +180,38 @@ export const getStation = (
     .catch((error) => {
       console.error('Error in StationSchema parsing: ', error);
       return null;
+    });
+};
+
+export const getAppSwitchUrl = (
+  vehicleTypeId: string,
+  bonusProductId?: string,
+): Promise<AppSwitchUrl> => {
+  const url = `/mobility/v1/app-switch/vehicle-type/${vehicleTypeId}`;
+  const query = qs.stringify({bonusProductId});
+  return client
+    .post<AppSwitchUrl>(stringifyUrl(url, query), undefined, {
+      authWithIdToken: true,
+    })
+    .then((response) => AppSwitchUrlSchema.parse(response.data));
+};
+
+export const getMockVehicle = (
+  stationId: string,
+  vehicleTypeId: string,
+  opts?: VehicleRequestOpts,
+): Promise<Vehicle> => {
+  return client
+    .get(`/mobility/v1/stations/${stationId}/mock-vehicles/${vehicleTypeId}`, {
+      ...opts,
+    })
+    .then((response) => {
+      const result = VehicleSchema.safeParse(response.data);
+      if (!result.success) {
+        console.error(result.error.format());
+        throw result.error;
+      }
+      return result.data;
     });
 };
 

--- a/src/api/types/__tests__/mobility.test.ts
+++ b/src/api/types/__tests__/mobility.test.ts
@@ -1,0 +1,149 @@
+// `mobility.ts` pulls in `@atb/utils/image`, which transitively imports native
+// modules that Jest can't transform. We only exercise schema parsing here, so
+// stub the image schema to keep this test free of native dependencies.
+jest.mock('@atb/utils/image', () => {
+  const {z} = require('zod');
+  return {Base64ImageSchema: z.string()};
+});
+
+import {ActionButtonType, BonusOfferSchema, VehicleSchema} from '../mobility';
+
+const baseVehicle = {
+  id: 'vehicle-1',
+  lat: 63.43,
+  lon: 10.39,
+  currentRangeMeters: 12000,
+  isReserved: false,
+  isDisabled: false,
+  pricingPlan: {currency: 'NOK', price: 10},
+  system: {
+    id: 'system-1',
+    operator: {id: 'operator-1', name: {}},
+    name: {},
+  },
+  vehicleType: {
+    id: 'vehicle-type-1',
+    formFactor: 'SCOOTER',
+    propulsionType: 'ELECTRIC',
+    name: {},
+  },
+};
+
+describe('VehicleSchema (shmo vehicle contract v2)', () => {
+  it('parses a vehicle that omits the new v2 fields (backward compatible)', () => {
+    const result = VehicleSchema.safeParse(baseVehicle);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.benefit).toBeUndefined();
+      expect(result.data.bonusOffer).toBeUndefined();
+      expect(result.data.actionButton).toBeUndefined();
+    }
+  });
+
+  it('parses a benefit, defaults title/description, and ignores server-only fields', () => {
+    const result = VehicleSchema.safeParse({
+      ...baseVehicle,
+      benefit: {
+        // kind / eligibility / vehicleTypeIds / systemIds are resolved server-side
+        // and stripped by the slim app schema.
+        kind: 'PRICE_ADJUSTMENT',
+        eligibility: 'bundling',
+        title: [{language: 'en', value: 'Free unlock'}],
+        illustrationName: 'TicketValid',
+        vehicleTypeIds: ['vehicle-type-1'],
+        systemIds: ['system-1'],
+        priceAdjustments: [
+          {amount: 0, adjustmentType: 'FREE_UNLOCK', description: ''},
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.benefit?.title).toEqual([
+        {language: 'en', value: 'Free unlock'},
+      ]);
+      // description is optional on the wire and defaults to an empty array
+      expect(result.data.benefit?.description).toEqual([]);
+      expect(result.data.benefit?.illustrationName).toBe('TicketValid');
+      expect(result.data.benefit?.priceAdjustments[0]).toEqual({
+        amount: 0,
+        type: 'FREE_UNLOCK',
+        description: '',
+      });
+      expect(result.data.benefit).not.toHaveProperty('eligibility');
+    }
+  });
+
+  it('parses a bonusOffer on the vehicle', () => {
+    const result = VehicleSchema.safeParse({
+      ...baseVehicle,
+      bonusOffer: {
+        bonusProductId: 'bonus-product-1',
+        bonusProductPrice: {amount: 50, currencyCode: 'NOK'},
+        priceAdjustments: [
+          {
+            amount: 0,
+            adjustmentType: 'FREE_UNLOCK',
+            description: '',
+            systemIds: ['system-1'],
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.bonusOffer?.bonusProductId).toBe('bonus-product-1');
+      expect(result.data.bonusOffer?.bonusProductPrice.currencyCode).toBe(
+        'NOK',
+      );
+    }
+  });
+
+  it('parses a START_TRIP action button', () => {
+    const result = VehicleSchema.safeParse({
+      ...baseVehicle,
+      actionButton: {type: 'START_TRIP'},
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.actionButton?.type).toBe(ActionButtonType.START_TRIP);
+    }
+  });
+
+  it('parses an APP_SWITCH action button with url and label', () => {
+    const result = VehicleSchema.safeParse({
+      ...baseVehicle,
+      actionButton: {
+        type: 'APP_SWITCH',
+        url: 'operator://deeplink',
+        label: [{language: 'en', value: 'Open in operator app'}],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success && result.data.actionButton?.type === 'APP_SWITCH') {
+      expect(result.data.actionButton.url).toBe('operator://deeplink');
+      expect(result.data.actionButton.label).toEqual([
+        {language: 'en', value: 'Open in operator app'},
+      ]);
+    }
+  });
+
+  it('rejects an APP_SWITCH action button missing its url', () => {
+    const result = VehicleSchema.safeParse({
+      ...baseVehicle,
+      actionButton: {type: 'APP_SWITCH'},
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('BonusOfferSchema', () => {
+  it('parses a standalone bonus offer', () => {
+    const result = BonusOfferSchema.safeParse({
+      bonusProductId: 'bonus-product-1',
+      bonusProductPrice: {amount: 50, currencyCode: 'NOK'},
+      priceAdjustments: [],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/api/types/benefit.ts
+++ b/src/api/types/benefit.ts
@@ -1,7 +1,8 @@
 import {z} from 'zod';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
+import {LanguageAndTextTypeArray} from '@atb-as/config-specs/lib/common';
 
-export const MobilityPriceAdjustmentSchema = z
+export const PriceAdjustmentSchema = z
   .object({
     amount: z.number(),
     adjustmentType: PriceAdjustmentEnum,
@@ -13,16 +14,15 @@ export const MobilityPriceAdjustmentSchema = z
     description: x.description,
   }));
 
-export const MobilityPriceAdjustmentBenefitSchema = z.object({
-  kind: z.literal('MOBILITY_PRICE_ADJUSTMENT'),
-  vehicleTypeIds: z.array(z.string()).default([]),
-  systemIds: z.array(z.string()).default([]),
-  priceAdjustments: z.array(MobilityPriceAdjustmentSchema),
+// The backend resolves a single benefit for the vehicle (kind, eligibility,
+// vehicle/system filtering all happen server-side), so the app only models the
+// display payload.
+export const BenefitSchema = z.object({
+  title: LanguageAndTextTypeArray.default([]),
+  description: LanguageAndTextTypeArray.default([]),
+  illustrationName: z.string().optional(),
+  priceAdjustments: z.array(PriceAdjustmentSchema),
 });
 
-export type MobilityPriceAdjustmentType = z.infer<
-  typeof MobilityPriceAdjustmentSchema
->;
-export type MobilityPriceAdjustmentBenefitType = z.infer<
-  typeof MobilityPriceAdjustmentBenefitSchema
->;
+export type PriceAdjustmentType = z.infer<typeof PriceAdjustmentSchema>;
+export type BenefitType = z.infer<typeof BenefitSchema>;

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -7,7 +7,8 @@ import {isValidPhoneNumber} from 'libphonenumber-js';
 import {isValidEmail} from '@atb/utils/validation';
 import {Feature, MultiPolygon, Point, Polygon} from 'geojson';
 import {Base64ImageSchema} from '@atb/utils/image';
-import {MobilityPriceAdjustmentBenefitSchema} from '@atb/api/types/benefit';
+import {BenefitSchema, PriceAdjustmentSchema} from '@atb/api/types/benefit';
+import {LanguageAndTextTypeArray} from '@atb-as/config-specs/lib/common';
 
 export const ViolationsReportingInitQuerySchema = z.object({
   lng: z.string(),
@@ -236,6 +237,33 @@ const RentalUrisSchema = z
 
 export type RentalUris = z.infer<typeof RentalUrisSchema>;
 
+export const BonusOfferSchema = z.object({
+  bonusProductId: z.string(),
+  bonusProductPrice: z.object({
+    amount: z.number(),
+    currencyCode: z.string(),
+  }),
+  priceAdjustments: z.array(PriceAdjustmentSchema),
+});
+
+export type BonusOffer = z.infer<typeof BonusOfferSchema>;
+
+export enum ActionButtonType {
+  START_TRIP = 'START_TRIP',
+  APP_SWITCH = 'APP_SWITCH',
+}
+
+export const ActionButtonSchema = z.discriminatedUnion('type', [
+  z.object({type: z.literal(ActionButtonType.START_TRIP)}),
+  z.object({
+    type: z.literal(ActionButtonType.APP_SWITCH),
+    url: z.string(),
+    label: LanguageAndTextTypeArray.default([]),
+  }),
+]);
+
+export type ActionButton = z.infer<typeof ActionButtonSchema>;
+
 export const VehicleSchema = z.object({
   id: z.string(),
   lat: z.number(),
@@ -250,7 +278,11 @@ export const VehicleSchema = z.object({
   station: z.object({id: z.string()}).nullable().optional(),
   rentalUris: RentalUrisSchema.nullable().optional(),
   vehicleType: VehicleTypeSchema,
-  benefit: MobilityPriceAdjustmentBenefitSchema.nullable().optional(),
+  // Tolerant: a malformed/unknown benefit shape degrades to undefined rather
+  // than failing the whole vehicle parse.
+  benefit: BenefitSchema.nullable().optional().catch(undefined),
+  bonusOffer: BonusOfferSchema.nullable().optional(),
+  actionButton: ActionButtonSchema.nullable().optional(),
 });
 
 export type Vehicle = z.infer<typeof VehicleSchema>;

--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -24,7 +24,7 @@ import {
 } from './utils';
 import MapboxGL from '@rnmapbox/maps';
 import {ShmoBookingState, ShmoPricingPlan} from '@atb/api/types/mobility';
-import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
+import type {BenefitType} from '@atb/api/types/benefit';
 import {MapFilterType, MapProps} from './types';
 import {ExternalRealtimeMapSheet} from './components/external-realtime-map/ExternalRealtimeMapSheet';
 import {DeparturesDialogSheet} from './components/DeparturesDialogSheet';
@@ -55,7 +55,7 @@ type MapBottomSheetsProps = {
   navigateToPaymentMethods: () => void;
   navigateToPricingDetails: (
     pricingPlan: ShmoPricingPlan,
-    benefit: MobilityPriceAdjustmentBenefitType | undefined,
+    benefit: BenefitType | undefined,
   ) => void;
 };
 

--- a/src/modules/map/types.ts
+++ b/src/modules/map/types.ts
@@ -26,7 +26,7 @@ import {GeofencingZoneCode, GeofencingZoneStyle} from '@atb-as/theme';
 import {ContrastColor} from '@atb/theme/colors';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
 import {ShmoPricingPlan} from '@atb/api/types/mobility';
-import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
+import type {BenefitType} from '@atb/api/types/benefit';
 
 export type SelectionLocationCallback = (
   selectedLocation?: GeoLocation | SearchLocation,
@@ -76,7 +76,7 @@ export type MapProps = {
   navigateToBonusScreen?: () => void;
   navigateToPricingDetails: (
     pricingPlan: ShmoPricingPlan,
-    benefit: MobilityPriceAdjustmentBenefitType | undefined,
+    benefit: BenefitType | undefined,
   ) => void;
 };
 

--- a/src/modules/mobility/__tests__/use-is-eligible-for-benefit.test.ts
+++ b/src/modules/mobility/__tests__/use-is-eligible-for-benefit.test.ts
@@ -10,10 +10,14 @@ const periodicTicketBenefits: VoucherBenefitType[] = [
   {
     operatorId: 'YTR:Operator:trondheimbysykkel',
     benefitTypes: ['free-unlock'],
+    title: [],
+    description: [],
   },
   {
     operatorId: 'HYR:Operator:Hyre',
     benefitTypes: ['single-unlock'],
+    title: [],
+    description: [],
   },
 ];
 
@@ -21,6 +25,8 @@ const freeUseBenefits: VoucherBenefitType[] = [
   {
     operatorId: 'YTR:Operator:trondheimbysykkel',
     benefitTypes: ['free-use'],
+    title: [],
+    description: [],
   },
 ];
 

--- a/src/modules/mobility/api/api.ts
+++ b/src/modules/mobility/api/api.ts
@@ -1,5 +1,6 @@
 import {client} from '@atb/api';
 import {OperatorBenefitId} from '@atb-as/config-specs/lib/mobility';
+import {LanguageAndTextTypeArray} from '@atb-as/config-specs/lib/common';
 import {z} from 'zod';
 import type {PreassignedFareProduct} from '@atb/modules/ticketing';
 import {RequestError, isErrorResponse} from '@atb/api/utils';
@@ -7,6 +8,9 @@ import {RequestError, isErrorResponse} from '@atb/api/utils';
 const VoucherBenefit = z.object({
   operatorId: z.string(),
   benefitTypes: OperatorBenefitId.array(),
+  title: LanguageAndTextTypeArray.default([]),
+  description: LanguageAndTextTypeArray.default([]),
+  illustrationName: z.string().optional(),
 });
 export type VoucherBenefitType = z.infer<typeof VoucherBenefit>;
 

--- a/src/modules/mobility/components/BenefitIllustration.tsx
+++ b/src/modules/mobility/components/BenefitIllustration.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {View, ViewStyle} from 'react-native';
+import {SvgProps} from 'react-native-svg';
+// eslint-disable-next-line no-restricted-syntax -- resolve a themed asset dynamically by its server-driven name
+import * as ThemedAssets from '@atb/theme/ThemedAssets';
+
+type ThemedAsset = (props: SvgProps) => React.JSX.Element;
+
+const themedAssets = ThemedAssets as unknown as Record<
+  string,
+  ThemedAsset | undefined
+>;
+
+/**
+ * Resolves the server-driven `illustration` string to a themed asset by name,
+ * e.g. "BonusStar" -> ThemedBonusStar. Any existing themed asset can be used
+ * without maintaining a registry; unknown values render nothing.
+ */
+const resolveIllustration = (
+  illustration: string | undefined,
+): ThemedAsset | undefined => {
+  if (!illustration) return undefined;
+  const asset = themedAssets[`Themed${illustration}`];
+  return typeof asset === 'function' ? asset : undefined;
+};
+
+type BenefitIllustrationProps = {
+  illustrationName: string | undefined;
+  style?: ViewStyle;
+};
+
+export const BenefitIllustration = ({
+  illustrationName,
+  style,
+}: BenefitIllustrationProps): React.JSX.Element | null => {
+  const Asset = resolveIllustration(illustrationName);
+  if (!Asset) return null;
+  return (
+    <View style={style}>
+      <Asset height={54} width={54} />
+    </View>
+  );
+};

--- a/src/modules/mobility/components/MobilityBenefitsInfoSectionItem.tsx
+++ b/src/modules/mobility/components/MobilityBenefitsInfoSectionItem.tsx
@@ -1,18 +1,16 @@
 import {View} from 'react-native';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {BorderedInfoBox} from '@atb/components/bordered-info-box';
-import {OperatorBenefitType} from '@atb-as/config-specs/lib/mobility';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
-import {BenefitImageAsset} from './BenefitImage';
+import {BenefitIllustration} from './BenefitIllustration';
 import React from 'react';
 import {SectionItemProps, useSectionItem} from '@atb/components/sections';
-import {toFormFactorEnum} from '../utils';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
-import {useFontScale} from '@atb/utils/use-font-scale';
+import type {FareProductBenefitType} from '../use-operator-benefits-for-fare-product';
 
 type Props = SectionItemProps<{
-  benefits: OperatorBenefitType[];
+  benefits: FareProductBenefitType[];
 }>;
 
 export const MobilityBenefitsInfoSectionItem = ({
@@ -28,13 +26,13 @@ export const MobilityBenefitsInfoSectionItem = ({
     t(MobilityTexts.includedWithTheTicket) +
     screenReaderPause +
     benefits
-      .map(
-        (b) =>
-          b.formFactors.map((ff) =>
-            t(MobilityTexts.vehicleName(toFormFactorEnum(ff))),
-          ) +
-          screenReaderPause +
-          getTextForLanguage(b.ticketDescription, language),
+      .map((b) =>
+        [
+          getTextForLanguage(b.title, language),
+          getTextForLanguage(b.description, language),
+        ]
+          .filter(Boolean)
+          .join(screenReaderPause),
       )
       .join(screenReaderPause);
 
@@ -54,7 +52,7 @@ export const MobilityBenefitsInfoSectionItem = ({
       >
         <View style={styles.borderedInfoBoxContent}>
           {benefits.map((b) => (
-            <BenefitInfo benefit={b} key={b.id + b.callToAction.url} />
+            <BenefitInfo benefit={b} key={b.operatorId} />
           ))}
         </View>
       </BorderedInfoBox>
@@ -63,29 +61,25 @@ export const MobilityBenefitsInfoSectionItem = ({
 };
 
 const BenefitInfo = ({
-  benefit: {formFactors, ticketDescription},
+  benefit: {illustrationName, title, description},
 }: {
-  benefit: OperatorBenefitType;
+  benefit: FareProductBenefitType;
 }) => {
   const {language} = useTranslation();
   const styles = useStyles();
-  const fontScale = useFontScale();
+  const titleText = getTextForLanguage(title, language);
+  const descriptionText = getTextForLanguage(description, language);
   return (
     <View style={styles.benefitInfo}>
-      {!!formFactors.length && (
-        <View style={{height: 18 * fontScale, width: 28 * fontScale}}>
-          {formFactors.map((ff) => (
-            <BenefitImageAsset
-              formFactor={toFormFactorEnum(ff)}
-              svgProps={{height: '100%', width: '100%'}}
-              key={ff}
-            />
-          ))}
-        </View>
-      )}
-      <ThemeText typography="body__xs" style={styles.benefitText}>
-        {getTextForLanguage(ticketDescription, language)}
-      </ThemeText>
+      <BenefitIllustration illustrationName={illustrationName} />
+      <View style={styles.benefitText}>
+        {!!titleText && (
+          <ThemeText typography="body__s__strong">{titleText}</ThemeText>
+        )}
+        {!!descriptionText && (
+          <ThemeText typography="body__xs">{descriptionText}</ThemeText>
+        )}
+      </View>
     </View>
   );
 };
@@ -94,7 +88,12 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
   return {
     borderedInfoBox: {marginTop: theme.spacing.small},
     borderedInfoBoxContent: {gap: theme.spacing.small},
-    benefitInfo: {flexDirection: 'row', flex: 1, gap: theme.spacing.small},
-    benefitText: {flex: 1},
+    benefitInfo: {
+      flexDirection: 'row',
+      flex: 1,
+      gap: theme.spacing.small,
+      alignItems: 'center',
+    },
+    benefitText: {flex: 1, gap: theme.spacing.xSmall},
   };
 });

--- a/src/modules/mobility/components/OperatorActionButton.tsx
+++ b/src/modules/mobility/components/OperatorActionButton.tsx
@@ -25,7 +25,22 @@ type OperatorActionButtonProps = {
   isBonusPayment?: boolean;
   setIsBonusPayment?: (isBonusPayment: boolean) => void;
   bonusProductId?: string;
+  /**
+   * When provided, the button is driven by the server `actionButton` of type
+   * `APP_SWITCH`: it shows `label` and mints/claims a voucher via the app-switch
+   * endpoint before opening the returned deep link. This bypasses the legacy
+   * operator-benefit value-code flow below.
+   */
+  appSwitchAction?: AppSwitchAction;
 };
+
+type AppSwitchAction = {
+  label: string;
+  onPress: () => void;
+  isLoading: boolean;
+  hasError: boolean;
+};
+
 export const OperatorActionButton = ({
   operatorId,
   operatorName,
@@ -34,6 +49,7 @@ export const OperatorActionButton = ({
   isBonusPayment,
   setIsBonusPayment,
   bonusProductId,
+  appSwitchAction,
 }: OperatorActionButtonProps) => {
   const {logEvent} = useAnalyticsContext();
   const {t, language} = useTranslation();
@@ -156,6 +172,35 @@ export const OperatorActionButton = ({
     extendedRentalAppUri,
     setIsBonusPayment,
   ]);
+
+  if (appSwitchAction) {
+    if (appSwitchAction.isLoading) {
+      return <Loading />;
+    }
+    if (appSwitchAction.hasError) {
+      return (
+        <MessageInfoBox
+          type="error"
+          message={t(MobilityTexts.errorLoadingValueCode.message)}
+          onPressConfig={{
+            action: appSwitchAction.onPress,
+            text: t(MobilityTexts.errorLoadingValueCode.retry),
+          }}
+        />
+      );
+    }
+    return (
+      <Button
+        expanded={true}
+        text={appSwitchAction.label}
+        onPress={appSwitchAction.onPress}
+        mode="primary"
+        interactiveColor={theme.color.interactive[0]}
+        rightIcon={{svg: ExternalLink}}
+        accessibilityRole="link"
+      />
+    );
+  }
 
   if (isLoading) {
     return <Loading />;

--- a/src/modules/mobility/components/PriceDetailsCard.tsx
+++ b/src/modules/mobility/components/PriceDetailsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useTranslation} from '@atb/translations';
+import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {StyleSheet} from '@atb/theme';
 import {
   GenericSectionItem,
@@ -9,6 +9,8 @@ import {
 import {View} from 'react-native';
 import {Unlock, PricePerTime} from '@atb/assets/svg/mono-icons/mobility';
 import {VehicleCardStat} from './VehicleCardStat';
+import {ThemeText} from '@atb/components/text';
+import {BenefitIllustration} from './BenefitIllustration';
 import {
   MobilityTexts,
   ScooterTexts,
@@ -23,29 +25,27 @@ import {formatNumberToString} from '@atb-as/utils';
 import {getCurrencySymbol} from '@atb/translations/currency';
 import {ShmoPricingPlan} from '@atb/api/types/mobility';
 import SvgChevronRight from '@atb/assets/svg/mono-icons/navigation/ChevronRight';
-import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
+import type {BenefitType} from '@atb/api/types/benefit';
 
 type Props = {
   pricingPlan: ShmoPricingPlan;
-  benefit?: MobilityPriceAdjustmentBenefitType;
-  systemId: string;
+  benefit?: BenefitType;
   onNavigatePricingDetails?: (
     pricingPlan: ShmoPricingPlan,
-    benefit: MobilityPriceAdjustmentBenefitType | undefined,
+    benefit: BenefitType | undefined,
   ) => void;
 };
 
 export const PriceDetailsCard = ({
   pricingPlan,
   benefit,
-  systemId,
   onNavigatePricingDetails,
 }: Props) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const ratePrUnit = formatRatePerUnit(pricingPlan, language);
-  const freeUnlock = getFreeUnlock(benefit, systemId);
-  const freeMinutes = getFreeMinutes(benefit, systemId);
+  const freeUnlock = getFreeUnlock(benefit);
+  const freeMinutes = getFreeMinutes(benefit);
 
   const unlockStat = freeUnlock
     ? t(ScooterTexts.free)
@@ -69,8 +69,34 @@ export const PriceDetailsCard = ({
       )
     : t(ScooterTexts.per.unit(ratePrUnit?.perUnit ?? ''));
 
+  const benefitTitle = getTextForLanguage(benefit?.title, language);
+  const benefitDescription = getTextForLanguage(benefit?.description, language);
+  const hasBenefitInfo = !!benefitTitle || !!benefitDescription;
+
   return (
     <Section>
+      {hasBenefitInfo && (
+        <GenericSectionItem>
+          <View style={styles.benefitContainer}>
+            <BenefitIllustration
+              illustrationName={benefit?.illustrationName}
+              style={styles.benefitIllustration}
+            />
+            <View style={styles.benefitContent}>
+              {benefitTitle && (
+                <ThemeText typography="body__m__strong">
+                  {benefitTitle}
+                </ThemeText>
+              )}
+              {benefitDescription && (
+                <ThemeText typography="body__s" type="secondary">
+                  {benefitDescription}
+                </ThemeText>
+              )}
+            </View>
+          </View>
+        </GenericSectionItem>
+      )}
       <GenericSectionItem style={styles.sectionWrapper}>
         <View style={styles.content}>
           <VehicleCardStat
@@ -111,6 +137,16 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
     sectionWrapper: {
       padding: theme.spacing.small,
+    },
+    benefitContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    benefitIllustration: {
+      marginEnd: theme.spacing.medium,
+    },
+    benefitContent: {
+      flex: 1,
     },
   };
 });

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -1,13 +1,13 @@
 import {VehicleId} from '@atb/api/types/generated/fragments/vehicles';
-import React, {useState} from 'react';
-import {useTranslation} from '@atb/translations';
+import React, {useCallback, useState} from 'react';
+import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
   MobilityTexts,
   ScooterTexts,
 } from '@atb/translations/screens/subscreens/MobilityTexts';
 import {useVehicle} from '../../use-vehicle';
-import {View} from 'react-native';
+import {Linking, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
 import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
@@ -34,7 +34,12 @@ import {
   MapBottomSheet,
 } from '@atb/components/bottom-sheet';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
-import {ShmoPricingPlan, Vehicle} from '@atb/api/types/mobility';
+import {
+  ActionButtonType,
+  BonusOffer,
+  ShmoPricingPlan,
+  Vehicle,
+} from '@atb/api/types/mobility';
 import {PriceDetailsCard} from '../PriceDetailsCard';
 import {Loading} from '@atb/components/loading';
 import {SupportButton} from '../SupportButton';
@@ -42,11 +47,15 @@ import {TransportationIconBox} from '@atb/components/icon-box';
 import {BrandingImage} from '../BrandingImage';
 import {getTransportModeAndSubMode} from '../../utils';
 import {
+  BonusProductType,
   PayWithBonusPointsCheckbox,
   useIsBonusActiveForUser,
   useRelevantSharedMobilityBonusProduct,
 } from '@atb/modules/bonus';
-import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
+import {useAnalyticsContext} from '@atb/modules/analytics';
+import type {BenefitType} from '@atb/api/types/benefit';
+import {useAppSwitchMutation} from '../../queries/use-app-switch-mutation';
+import {showAppMissingAlert} from '../../show-app-missing-alert';
 
 type Props = {
   selectPaymentMethod: () => void;
@@ -61,7 +70,7 @@ type Props = {
   navigateToScanQrCode: () => void;
   navigateToPricingDetails: (
     pricingPlan: ShmoPricingPlan,
-    benefit: MobilityPriceAdjustmentBenefitType | undefined,
+    benefit: BenefitType | undefined,
   ) => void;
 };
 
@@ -78,7 +87,7 @@ export const VehicleSheet = ({
   navigateToScanQrCode,
   navigateToPricingDetails,
 }: Props) => {
-  const {t} = useTranslation();
+  const {t, language} = useTranslation();
   const {theme} = useThemeContext();
   const styles = useStyles();
   const {
@@ -126,8 +135,48 @@ export const VehicleSheet = ({
   } = useFeatureTogglesContext();
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
-  const bonusProduct = useRelevantSharedMobilityBonusProduct(vehicleTypeId);
+  // Prefer the server-provided bonus offer; fall back to the client-side
+  // lookup only when the vehicle response omits it.
+  const clientBonusProduct =
+    useRelevantSharedMobilityBonusProduct(vehicleTypeId);
+  const serverBonusOffer = vehicle?.bonusOffer ?? undefined;
+  const hasBonusOffer = !!serverBonusOffer || !!clientBonusProduct;
+  const selectedBonusProductId =
+    serverBonusOffer?.bonusProductId ?? clientBonusProduct?.id;
+  const {logEvent} = useAnalyticsContext();
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
+
+  const {
+    mutateAsync: getAppSwitchUrl,
+    isPending: isAppSwitchPending,
+    isError: isAppSwitchError,
+  } = useAppSwitchMutation();
+
+  const actionButton = vehicle?.actionButton ?? undefined;
+
+  const onAppSwitchPress = useCallback(async () => {
+    if (!vehicleTypeId) return;
+    const {url} = await getAppSwitchUrl({
+      vehicleTypeId,
+      bonusProductId: payWithBonusPoints ? selectedBonusProductId : undefined,
+    });
+    logEvent('Mobility', 'Open operator app', {
+      operatorId,
+      paidWithBonusPoints: payWithBonusPoints,
+    });
+    await Linking.openURL(url).catch(() =>
+      showAppMissingAlert(operatorName, appStoreUri ?? undefined),
+    );
+  }, [
+    vehicleTypeId,
+    getAppSwitchUrl,
+    payWithBonusPoints,
+    selectedBonusProductId,
+    logEvent,
+    operatorId,
+    operatorName,
+    appStoreUri,
+  ]);
 
   const isDeepIntegrationEnabled =
     isShmoDeepIntegrationEnabled &&
@@ -136,7 +185,17 @@ export const VehicleSheet = ({
   const showParkingViolation =
     !isBicycle && isParkingViolationsReportingEnabled;
   const showBonusCheckbox =
-    !isBicycle && isBonusActiveForUser && !!bonusProduct;
+    !isBicycle && isBonusActiveForUser && hasBonusOffer && !!clientBonusProduct;
+
+  // Drive the CTA from the server `actionButton` when present, otherwise fall
+  // back to the existing deep-integration / operator branching.
+  const showStartTrip = actionButton
+    ? actionButton.type === ActionButtonType.START_TRIP
+    : isDeepIntegrationEnabled &&
+      !!operatorId &&
+      !!operatorIsIntegrationEnabled;
+  const showAppSwitchAction =
+    actionButton?.type === ActionButtonType.APP_SWITCH;
 
   return (
     <MapBottomSheet
@@ -196,30 +255,21 @@ export const VehicleSheet = ({
 
             <PriceDetailsCard
               pricingPlan={vehicle.pricingPlan}
-              benefit={
-                payWithBonusPoints && bonusProduct?.priceAdjustments
-                  ? ({
-                      kind: 'MOBILITY_PRICE_ADJUSTMENT' as const,
-                      vehicleTypeIds: vehicleTypeId ? [vehicleTypeId] : [],
-                      systemIds: [vehicle.system.id],
-                      priceAdjustments: bonusProduct.priceAdjustments.filter(
-                        (pa) => pa.systemIds.includes(vehicle.system.id),
-                      ),
-                    } satisfies MobilityPriceAdjustmentBenefitType)
-                  : (vehicle.benefit ?? undefined)
-              }
-              systemId={vehicle.system.id}
+              benefit={getDisplayedBenefit({
+                payWithBonusPoints,
+                vehicle,
+                serverBonusOffer,
+                clientBonusProduct,
+              })}
               onNavigatePricingDetails={navigateToPricingDetails}
             />
           </View>
 
-          {isDeepIntegrationEnabled &&
-          operatorId &&
-          operatorIsIntegrationEnabled ? (
+          {showStartTrip && operatorId ? (
             <>
-              {showBonusCheckbox && (
+              {showBonusCheckbox && clientBonusProduct && (
                 <PayWithBonusPointsCheckbox
-                  bonusProduct={bonusProduct}
+                  bonusProduct={clientBonusProduct}
                   operatorName={operatorName}
                   isChecked={payWithBonusPoints}
                   onPress={() => setPayWithBonusPoints((prev) => !prev)}
@@ -232,7 +282,7 @@ export const VehicleSheet = ({
                 operatorId={operatorId}
                 paymentMethod={selectedPaymentMethod}
                 bonusProductId={
-                  payWithBonusPoints ? bonusProduct?.id : undefined
+                  payWithBonusPoints ? selectedBonusProductId : undefined
                 }
                 formFactor={formFactor}
               />
@@ -253,6 +303,25 @@ export const VehicleSheet = ({
                 />
               </View>
             </>
+          ) : showAppSwitchAction && rentalAppUri ? (
+            <OperatorActionButton
+              operatorId={operatorId}
+              operatorName={operatorName}
+              appStoreUri={appStoreUri ?? ''}
+              rentalAppUri={rentalAppUri}
+              appSwitchAction={{
+                label:
+                  getTextForLanguage(
+                    actionButton?.type === ActionButtonType.APP_SWITCH
+                      ? actionButton.label
+                      : undefined,
+                    language,
+                  ) ?? t(MobilityTexts.operatorAppSwitchButton(operatorName)),
+                onPress: onAppSwitchPress,
+                isLoading: isAppSwitchPending,
+                hasError: isAppSwitchError,
+              }}
+            />
           ) : (
             <>
               {rentalAppUri && (
@@ -279,6 +348,44 @@ export const VehicleSheet = ({
       )}
     </MapBottomSheet>
   );
+};
+
+/**
+ * Resolves which benefit drives the price display. Benefit and bonus offer never
+ * stack: the server benefit applies by default, and choosing to pay with bonus
+ * points overrides it with the bonus offer's price adjustments. The server bonus
+ * offer wins over the client-side product when both are present.
+ */
+const getDisplayedBenefit = ({
+  payWithBonusPoints,
+  vehicle,
+  serverBonusOffer,
+  clientBonusProduct,
+}: {
+  payWithBonusPoints: boolean;
+  vehicle: Vehicle;
+  serverBonusOffer: BonusOffer | undefined;
+  clientBonusProduct: BonusProductType | undefined;
+}): BenefitType | undefined => {
+  if (!payWithBonusPoints) return vehicle.benefit ?? undefined;
+
+  // The server-driven offer is already scoped to the vehicle's system. The
+  // client-side product is the legacy fallback and still filters by system.
+  const bonusPriceAdjustments = serverBonusOffer
+    ? serverBonusOffer.priceAdjustments
+    : (clientBonusProduct?.priceAdjustments
+        ?.filter((pa) => pa.systemIds.includes(vehicle.system.id))
+        .map((pa) => ({
+          amount: pa.amount,
+          type: pa.type,
+          description: pa.description,
+        })) ?? []);
+
+  return {
+    title: [],
+    description: [],
+    priceAdjustments: bonusPriceAdjustments,
+  };
 };
 
 const useStyles = StyleSheet.createThemeHook((theme) => {

--- a/src/modules/mobility/queries/use-app-switch-mutation.tsx
+++ b/src/modules/mobility/queries/use-app-switch-mutation.tsx
@@ -1,0 +1,18 @@
+import {useMutation} from '@tanstack/react-query';
+import {getAppSwitchUrl} from '@atb/api/mobility';
+import {useAuthContext} from '@atb/modules/auth';
+import {ErrorResponse} from '@atb-as/utils';
+
+type AppSwitchVariables = {
+  vehicleTypeId: string;
+  bonusProductId?: string;
+};
+
+export const useAppSwitchMutation = () => {
+  const {userId} = useAuthContext();
+  return useMutation<{url: string}, ErrorResponse, AppSwitchVariables>({
+    mutationKey: ['appSwitchUrl', userId],
+    mutationFn: ({vehicleTypeId, bonusProductId}: AppSwitchVariables) =>
+      getAppSwitchUrl(vehicleTypeId, bonusProductId),
+  });
+};

--- a/src/modules/mobility/use-operator-benefits-for-fare-product.tsx
+++ b/src/modules/mobility/use-operator-benefits-for-fare-product.tsx
@@ -6,14 +6,21 @@ import {LanguageAndTextType} from '@atb-as/config-specs';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
 import {UseQueryResult} from '@tanstack/react-query';
 import {isDefined} from '@atb/utils/presence';
+import type {VoucherBenefitType} from './api/api';
 
 export type FormFactorTicketDescriptionPair = {
   formFactor: FormFactor;
   ticketDescription: LanguageAndTextType[] | undefined;
 };
 
+// Operator config supplies the form-factor image and the detail-screen fields
+// (callToAction, descriptionWhenActive, ...). The fare-contract card text
+// (title/description) now comes from the benefit service instead of config.
 export type FareProductBenefitType = {
   operatorId: string;
+  title: VoucherBenefitType['title'];
+  description: VoucherBenefitType['description'];
+  illustrationName: VoucherBenefitType['illustrationName'];
 } & OperatorBenefitType;
 
 export const useOperatorBenefitsForFareProduct = (
@@ -32,13 +39,16 @@ export const useOperatorBenefitsForFareProduct = (
         (mobilityOperator) =>
           mobilityOperator.id === fareProductBenefit.operatorId,
       );
-      const operatorBenefits = operator?.benefits.find((mobilityBenefit) =>
+      const operatorBenefit = operator?.benefits.find((mobilityBenefit) =>
         fareProductBenefit.benefitTypes.includes(mobilityBenefit.id),
       );
-      if (!operatorBenefits) return;
+      if (!operatorBenefit) return;
       return {
-        ...operatorBenefits,
+        ...operatorBenefit,
         operatorId: fareProductBenefit.operatorId,
+        title: fareProductBenefit.title,
+        description: fareProductBenefit.description,
+        illustrationName: fareProductBenefit.illustrationName,
       };
     })
     .filter(isDefined);

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -20,10 +20,7 @@ import {enumFromString} from '@atb/utils/enum-from-string';
 import {MobilityOperatorType} from '@atb-as/config-specs/lib/mobility';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import {TransportModeType} from '@atb-as/config-specs/lib/common';
-import type {
-  MobilityPriceAdjustmentBenefitType,
-  MobilityPriceAdjustmentType,
-} from '@atb/api/types/benefit';
+import type {BenefitType, PriceAdjustmentType} from '@atb/api/types/benefit';
 import {
   BatteryEmpty,
   BatteryFull,
@@ -259,31 +256,24 @@ export const isShowAll = (
 export const toFormFactorEnum = (str: string): FormFactor =>
   enumFromString(FormFactor, str) || FormFactor.Other;
 
-// A mobility benefit carries its `systemIds` at the benefit level. The real
-// mobility path is already system-filtered server-side; the bonus-product path
-// sets the benefit-level `systemIds` when building its synthetic benefit.
+// The benefit is already resolved and system-filtered server-side, so the app
+// just reads the relevant price adjustment off it.
 export const getFreeUnlock = (
-  benefit: MobilityPriceAdjustmentBenefitType | undefined,
-  systemId: string,
-): MobilityPriceAdjustmentType | undefined =>
-  benefit?.systemIds.includes(systemId)
-    ? benefit.priceAdjustments.find(
-        (e) => e.type === PriceAdjustmentEnum.enum.FREE_UNLOCK,
-      )
-    : undefined;
+  benefit: BenefitType | undefined,
+): PriceAdjustmentType | undefined =>
+  benefit?.priceAdjustments.find(
+    (e) => e.type === PriceAdjustmentEnum.enum.FREE_UNLOCK,
+  );
 
 export const getFreeMinutes = (
-  benefit: MobilityPriceAdjustmentBenefitType | undefined,
-  systemId: string,
-): MobilityPriceAdjustmentType | undefined =>
-  benefit?.systemIds.includes(systemId)
-    ? benefit.priceAdjustments.find(
-        (e) => e.type === PriceAdjustmentEnum.enum.FREE_MINUTES,
-      )
-    : undefined;
+  benefit: BenefitType | undefined,
+): PriceAdjustmentType | undefined =>
+  benefit?.priceAdjustments.find(
+    (e) => e.type === PriceAdjustmentEnum.enum.FREE_MINUTES,
+  );
 
 export const computeFreeMinuteCount = (
-  freeMinutes: MobilityPriceAdjustmentType,
+  freeMinutes: PriceAdjustmentType,
   perMinPricing: ShmoPricingSegment[],
 ): number => {
   let budget = Math.abs(freeMinutes.amount);

--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -13,7 +13,7 @@ import {formatNumberToString} from '@atb-as/utils';
 import {getCurrencySymbol} from '@atb/translations/currency';
 import {ShmoPricingSegment} from '@atb/api/types/mobility';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
-import type {MobilityPriceAdjustmentType} from '@atb/api/types/benefit';
+import type {PriceAdjustmentType} from '@atb/api/types/benefit';
 import {computeFreeMinuteCount} from '@atb/modules/mobility';
 
 type Props = RootStackScreenProps<'Root_ShmoPricingDetailsScreen'>;
@@ -32,11 +32,11 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
     (pricingPlan.perMinPricing?.length ?? 0) > 1;
 
   const freeUnlockPriceAdjustment = benefit?.priceAdjustments.find(
-    (adj: MobilityPriceAdjustmentType) =>
+    (adj: PriceAdjustmentType) =>
       adj.type === PriceAdjustmentEnum.enum.FREE_UNLOCK,
   );
   const freeMinutesPriceAdjustment = benefit?.priceAdjustments.find(
-    (adj: MobilityPriceAdjustmentType) =>
+    (adj: PriceAdjustmentType) =>
       adj.type === PriceAdjustmentEnum.enum.FREE_MINUTES,
   );
   const hasCampaign = !!(

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/Map_RootScreen.tsx
@@ -7,7 +7,7 @@ import {
 import {MapScreenProps} from './navigation-types';
 import {Quay, StopPlace} from '@atb/api/types/departures';
 import {ShmoPricingPlan} from '@atb/api/types/mobility';
-import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
+import type {BenefitType} from '@atb/api/types/benefit';
 import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
 import {MapDisabledForScreenReader} from './components/MapDisabledForScreenReader';
 import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
@@ -156,10 +156,7 @@ export const Map_RootScreen = ({
   }, [navigation, bonusScreenParams]);
 
   const navigateToPricingDetails = useCallback(
-    (
-      pricingPlan: ShmoPricingPlan,
-      benefit: MobilityPriceAdjustmentBenefitType | undefined,
-    ) => {
+    (pricingPlan: ShmoPricingPlan, benefit: BenefitType | undefined) => {
       navigation.navigate('Root_ShmoPricingDetailsScreen', {
         pricingPlan,
         benefit,

--- a/src/stacks-hierarchy/navigation-types.ts
+++ b/src/stacks-hierarchy/navigation-types.ts
@@ -15,7 +15,7 @@ import {
   ShmoBooking,
   ShmoPricingPlan,
 } from '@atb/api/types/mobility';
-import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
+import type {BenefitType} from '@atb/api/types/benefit';
 import {Root_ChooseTicketRecipientScreenParams} from '@atb/stacks-hierarchy/Root_ChooseTicketRecipientScreen/navigation-types';
 import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import type {TripAnalytics} from '@atb/screen-components/travel-details-screens';
@@ -159,7 +159,7 @@ export type RootStackParamList = StackParams<{
   Root_ShmoOnboardingScreen: {formFactor?: FormFactor};
   Root_ShmoPricingDetailsScreen: {
     pricingPlan: ShmoPricingPlan;
-    benefit?: MobilityPriceAdjustmentBenefitType;
+    benefit?: BenefitType;
   };
   Root_ContactShmoOperatorScreen: Root_ContactShmoOperatorScreenParams;
   Root_ContactShmoOperatorConfirmationScreen: Root_ContactShmoOperatorConfirmationScreenParams;


### PR DESCRIPTION
## What

Consume the shared-mobility **vehicle contract v2** in the app: a single benefit and an
optional bonus offer resolved server-side by mobility-service, plus an action button that
drives the CTA. History cleaned up into 4 reviewable commits and rebased on `master`.

## Commits

1. **adopt shmo vehicle contract v2 types** — slim `BenefitSchema` to the display payload
   (`title`, `description`, `illustrationName`, `priceAdjustments`); `kind`, `eligibility`
   and vehicle/system filtering all live server-side now. `Vehicle` gains optional nullable
   `bonusOffer` and `actionButton` (discriminated union `START_TRIP | APP_SWITCH{url,label}`).
   `BonusOffer` and `Benefit` share one `PriceAdjustmentSchema`. Adds `getAppSwitchUrl` /
   `getMockVehicle` client calls + schema-parse tests (with/without the new fields).
2. **consume vehicle benefit, price details and app switch** — `PriceDetailsCard` renders the
   server benefit text + price adjustments; `VehicleSheet` prefers `vehicle.bonusOffer`
   (client lookup only as fallback), never stacks benefit + bonus, and drives the app switch
   via `useAppSwitchMutation`.
3. **resolve benefit illustration by name** — `BenefitIllustration` maps `illustrationName`
   to a themed asset with a safe fallback for unknown values.
4. **wire pricing-details screen and map bottom sheets** — the shmo pricing-details route +
   threading the selected benefit through the map bottom sheets and navigation types.

## Notes

- No DB changes.
- `preReqs` on the action button is intentionally **not** consumed (deferred per the contract).
- `getMockVehicle` is added for completeness; the station-based-vehicle rename is tracked
   separately (see #6191).
- App-side deep-integration stays gated by the `isShmoDeepIntegration*` remote-config toggles
   with an app-switch fallback, so the server's `actionButton` is safe across app versions.
- Ships in sync with mobility#113, benefit#16, bonus#41.

## Verification

- `pnpm tsc` — no new errors from this change. (Pre-existing `ThemedAssets.tsx` /
   `icon-box/utils.ts` asset-codegen errors exist on `master` too — `TicketValid` /
   `ParkingThick` assets — unrelated to this PR.)
- `pnpm lint`, `pnpm prettier` — clean on all changed files.
- `pnpm test` (mobility/benefit) — 11 passing, incl. the schema tests.

Resolves AtB-AS/kundevendt#24093

---
📋 **Change overview & deploy runbook:** https://claude.ai/code/artifact/59f5bed8-d0bd-43d3-810d-e6cf899b09c5
