### PR TITLE
fix(bonus): restore map button and transport mode rendering in product list

### DIFF
--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import {Pressable, View} from 'react-native';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
@@ -11,10 +11,14 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {StyleSheet} from '@atb/theme';
-import {getTransportModeAndSubMode} from '@atb/modules/mobility';
+import {getTranslatedModeName} from '@atb/utils/transportation-names';
+import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {getFormFactorsFromTransportMode} from '@atb/modules/mobility';
 import {TransportationIconBox} from '@atb/components/icon-box';
 import {ThemeIcon} from '@atb/components/theme-icon';
-import {MapFilterType} from '@atb/modules/map';
+import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
+import {MapPin} from '@atb/assets/svg/mono-icons/tab-bar';
+import {MapFilterType, useMapContext} from '@atb/modules/map';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 
 type Props = {
@@ -26,18 +30,39 @@ type Props = {
 export const BonusProductList = ({
   bonusProductGroups,
   bonusProducts,
-  onNavigateToMap: _onNavigateToMap,
+  onNavigateToMap,
 }: Props) => {
   const {t, language} = useTranslation();
   const styles = useStyles();
   const {mobilityOperators} = useFirestoreConfigurationContext();
+  const {mapFilter, setMapFilter} = useMapContext();
   const analytics = useAnalyticsContext();
+
+  const handleNavigateToMap = useCallback(
+    (formFactors: FormFactor[]) => {
+      if (!onNavigateToMap || !mapFilter?.mobility) return;
+      const updatedMobility = {...mapFilter.mobility};
+      formFactors.forEach((ff) => {
+        updatedMobility[ff] = {
+          operators: updatedMobility[ff]?.operators ?? [],
+          showAll: true,
+        };
+      });
+      const updatedFilter = {...mapFilter, mobility: updatedMobility};
+      setMapFilter(updatedFilter);
+      onNavigateToMap(updatedFilter);
+    },
+    [onNavigateToMap, mapFilter, setMapFilter],
+  );
 
   return (
     <View style={styles.container}>
       {bonusProductGroups.map((group) => {
         const memberProducts = bonusProducts.filter(
           (bp) => bp.bonusProductGroupId === group.id,
+        );
+        const formFactors = getFormFactorsFromTransportMode(
+          group.transportMode,
         );
         const operatorNames = memberProducts
           .map(
@@ -46,6 +71,7 @@ export const BonusProductList = ({
           )
           .filter(Boolean)
           .join(', ');
+        const showMapButton = !!onNavigateToMap && formFactors.length > 0;
 
         return (
           <Pressable
@@ -61,20 +87,19 @@ export const BonusProductList = ({
             <Section>
               <GenericSectionItem>
                 <View style={styles.horizontalContainer}>
-                  {(() => {
-                    const {mode, subMode} =
-                      getTransportModeAndSubMode(undefined);
-                    return (
-                      <TransportationIconBox
-                        mode={mode}
-                        subMode={subMode}
-                        rounded
-                      />
-                    );
-                  })()}
+                  <TransportationIconBox
+                    mode={group.transportMode}
+                    subMode={group.transportSubMode ?? undefined}
+                    rounded
+                  />
                   <View style={{flex: 1}} accessible={true}>
                     <ThemeText typography="body__s__strong">
-                      {operatorNames}
+                      {t(
+                        getTranslatedModeName(
+                          group.transportMode,
+                          group.transportSubMode ?? undefined,
+                        ),
+                      )}
                     </ThemeText>
                     {!!operatorNames && (
                       <ThemeText typography="body__s" type="secondary">
@@ -82,6 +107,31 @@ export const BonusProductList = ({
                       </ThemeText>
                     )}
                   </View>
+                  {!!showMapButton && (
+                    <Pressable
+                      onPress={() => {
+                        analytics.logEvent(
+                          'Bonus',
+                          'Map button on bonus product group clicked',
+                          {
+                            bonusProductGroupId: group.id,
+                          },
+                        );
+                        handleNavigateToMap(formFactors);
+                      }}
+                      style={styles.mapButton}
+                      accessibilityRole="button"
+                      accessibilityLabel={t(
+                        BonusProgramTexts.bonusProfile.mapButton.a11yLabel,
+                      )}
+                      accessibilityHint={t(
+                        BonusProgramTexts.bonusProfile.mapButton.a11yHint,
+                      )}
+                    >
+                      <ThemeIcon svg={MapPin} />
+                      <ThemeIcon svg={ChevronRight} />
+                    </Pressable>
+                  )}
                 </View>
               </GenericSectionItem>
               <GenericSectionItem>

--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -40,7 +40,7 @@ export const BonusProductList = ({
 
   const handleNavigateToMap = useCallback(
     (formFactors: FormFactor[]) => {
-      if (!onNavigateToMap || !mapFilter?.mobility) return;
+      if (!onNavigateToMap || !mapFilter) return;
       const updatedMobility = {...mapFilter.mobility};
       formFactors.forEach((ff) => {
         updatedMobility[ff] = {

--- a/src/modules/mobility/index.ts
+++ b/src/modules/mobility/index.ts
@@ -41,6 +41,7 @@ export {
   computeFreeMinuteCount,
   findOperatorBrandImageUrl,
   getAvailableVehicles,
+  getFormFactorsFromTransportMode,
   getFreeMinutes,
   getFreeUnlock,
   getTransportModeAndSubMode,

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -19,6 +19,7 @@ import {dictionary, Language} from '@atb/translations';
 import {enumFromString} from '@atb/utils/enum-from-string';
 import {MobilityOperatorType} from '@atb-as/config-specs/lib/mobility';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
+import {TransportModeType} from '@atb-as/config-specs/lib/common';
 import type {
   MobilityPriceAdjustmentBenefitType,
   MobilityPriceAdjustmentType,
@@ -374,6 +375,27 @@ export const getTransportModeAndSubMode = (
       return {mode: 'car', subMode: undefined};
     default:
       return {mode: 'unknown', subMode: undefined};
+  }
+};
+
+/**
+ * Maps a transport mode to the mobility form factors it represents. Inverse of
+ * the form-factor → mode mapping in `getTransportModeAndSubMode`. Used to drive
+ * the map filter (keyed by form factor) from a bonus product group's transport
+ * mode. Returns an empty array for modes with no mobility form factor.
+ */
+export const getFormFactorsFromTransportMode = (
+  transportMode: TransportModeType,
+): FormFactor[] => {
+  switch (transportMode) {
+    case 'bicycle':
+      return [FormFactor.Bicycle];
+    case 'scooter':
+      return [FormFactor.Scooter, FormFactor.ScooterStanding];
+    case 'car':
+      return [FormFactor.Car];
+    default:
+      return [];
   }
 };
 


### PR DESCRIPTION
## Why

PR #6120 was branched before #6125 and #6137. Merging it reverted `BonusProductList.tsx` to a stale version, dropping three behaviors — a regression:

- Map button on bonus product groups (#5999)
- Transport-mode icon + translated mode-name title (#6125)
- Conditional operator-name title (#6137)

## What

Restore the three behaviors.

#6120 also replaced `BonusProduct.formFactors` with `vehicleTypeIds` in the schema. Rather than depend on the now-removed `product.formFactors`, the map button derives its form factors from the group's `transportMode` via a new `getFormFactorsFromTransportMode` helper (inverse of `getTransportModeAndSubMode`). The `vehicleTypeId` refactor from #6120 is left fully intact.

## Files

- `mobility/utils.ts` — new `getFormFactorsFromTransportMode`
- `mobility/index.ts` — export it
- `bonus/components/BonusProductList.tsx` — restore map button + transport-mode rendering; derive form factors from `group.transportMode`

## Verification

`tsc --noEmit`, eslint, and prettier all clean.