### PR TITLE
feat: show error message on fare contract loading errors

### DIFF
--- a/src/modules/event-stream/handle-stream-event.ts
+++ b/src/modules/event-stream/handle-stream-event.ts
@@ -1,6 +1,6 @@
 import {QueryClient} from '@tanstack/react-query';
 import {EventKind, StreamEvent} from './types';
-import {fareContractsQueryKey} from '../ticketing/use-fare-contracts';
+import {invalidateFareContractsQuery} from '../ticketing/use-fare-contracts';
 import {getBonusAmountEarnedQueryKey} from '../bonus';
 import {getActiveShmoBookingQueryKey} from '../mobility/queries/use-active-shmo-booking-query';
 import {getShmoBookingQueryKey} from '../mobility/queries/use-shmo-booking-query';
@@ -20,9 +20,7 @@ export const handleStreamEvent = (
   switch (streamEvent.event) {
     case EventKind.FareContract:
       if (featureToggles.isEventStreamFareContractsEnabled) {
-        queryClient.invalidateQueries({
-          queryKey: [fareContractsQueryKey],
-        });
+        invalidateFareContractsQuery(queryClient);
       }
       break;
     case EventKind.ShmoBookingUpdated:

--- a/src/modules/ticketing/index.ts
+++ b/src/modules/ticketing/index.ts
@@ -3,7 +3,7 @@ export {
   useTicketingContext,
 } from './TicketingContext';
 export {useGetHasReservationOrAvailableFareContract} from './use-get-has-reservation-or-available-fare-contract';
-export {useFareContracts} from './use-fare-contracts';
+export {useFareContracts, useNeedsRefreshStore} from './use-fare-contracts';
 export {useListRecurringPaymentsQuery} from './use-list-recurring-payments-query';
 export {useRefundFareContractMutation} from './use-refund-mutation';
 export {useActivateFareContractNowMutation} from './use-activate-fare-contract-now-mutation';

--- a/src/modules/ticketing/use-accept-ticket-transfer-mutation.ts
+++ b/src/modules/ticketing/use-accept-ticket-transfer-mutation.ts
@@ -1,13 +1,12 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {acceptTicketTransfer} from './api';
-import {fareContractsQueryKey} from './use-fare-contracts';
+import {invalidateFareContractsQuery} from './use-fare-contracts';
 
 export const useAcceptTicketTransferMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (transferId: string) => acceptTicketTransfer(transferId),
-    onSuccess: () =>
-      queryClient.invalidateQueries({queryKey: [fareContractsQueryKey]}),
+    onSuccess: () => invalidateFareContractsQuery(queryClient),
   });
 };

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -8,6 +8,8 @@ import {getAvailabilityStatus, AvailabilityStatus} from '@atb-as/utils';
 import {isDefined} from '@atb/utils/presence';
 import {ONE_WEEK_MS} from '@atb/utils/durations';
 import {getServerNowGlobal} from '../time';
+import {useFeatureTogglesContext} from '../feature-toggles';
+import {useRemoteConfigContext} from '../remote-config';
 
 type AvailabilityStatusInput = {
   availability: Exclude<AvailabilityStatus['availability'], 'invalid'>;
@@ -28,14 +30,24 @@ export const useFareContracts = (
 ): {
   fareContracts: FareContractType[];
   refetch: () => void;
-  isRefetching: boolean;
+  isFetching: boolean;
+  isError: boolean;
 } => {
   const {fareContracts: fareContractsFromFirestore} = useTicketingContext();
-  const {refetch: getFareContractsFromBackend, isRefetching} =
-    useGetFareContractsQuery({
-      enabled: false,
-      availability: availabilityStatus.availability,
-    });
+  const {enable_ticketing} = useRemoteConfigContext();
+  const {isEventStreamEnabled, isEventStreamFareContractsEnabled} =
+    useFeatureTogglesContext();
+  const {
+    refetch: getFareContractsFromBackend,
+    isFetching,
+    isError,
+  } = useGetFareContractsQuery({
+    enabled:
+      enable_ticketing &&
+      isEventStreamEnabled &&
+      isEventStreamFareContractsEnabled,
+    availability: availabilityStatus.availability,
+  });
 
   const [fareContracts, setFareContracts] = useState(
     fareContractsFromFirestore,
@@ -65,7 +77,12 @@ export const useFareContracts = (
     now,
   );
 
-  return {fareContracts: filteredFareContracts, refetch, isRefetching};
+  return {
+    fareContracts: filteredFareContracts,
+    refetch,
+    isFetching,
+    isError,
+  };
 };
 export const fareContractsQueryKey = 'FETCH_FARE_CONTRACTS';
 export const useGetFareContractsQuery = (props: {

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -43,6 +43,8 @@ export const useFareContracts = (
     isFetching,
     isError,
     status,
+    isFetchedAfterMount,
+    dataUpdatedAt,
   } = useGetFareContractsQuery({
     enabled:
       enable_ticketing &&
@@ -55,8 +57,12 @@ export const useFareContracts = (
     (state) => state.setNeedsRefresh,
   );
   useEffect(() => {
-    if (status === 'success') setNeedsRefresh(false);
-  }, [status, setNeedsRefresh]);
+    // Whenever data is updated (`dataUpdatedAt` changes), we should reset the
+    // needsRefresh flag if
+    // 1. the query was successful
+    // 2. the data is fresh and not from cache (`isFetchedAfterMount`)
+    if (status === 'success' && isFetchedAfterMount) setNeedsRefresh(false);
+  }, [status, isFetchedAfterMount, setNeedsRefresh, dataUpdatedAt]);
 
   const [fareContracts, setFareContracts] = useState(
     fareContractsFromFirestore,

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -10,6 +10,7 @@ import {ONE_WEEK_MS} from '@atb/utils/durations';
 import {getServerNowGlobal} from '../time';
 import {useFeatureTogglesContext} from '../feature-toggles';
 import {useRemoteConfigContext} from '../remote-config';
+import {create} from 'zustand';
 
 type AvailabilityStatusInput = {
   availability: Exclude<AvailabilityStatus['availability'], 'invalid'>;
@@ -41,6 +42,7 @@ export const useFareContracts = (
     refetch: getFareContractsFromBackend,
     isFetching,
     isError,
+    status,
   } = useGetFareContractsQuery({
     enabled:
       enable_ticketing &&
@@ -48,6 +50,13 @@ export const useFareContracts = (
       isEventStreamFareContractsEnabled,
     availability: availabilityStatus.availability,
   });
+
+  const setNeedsRefresh = useNeedsRefreshStore(
+    (state) => state.setNeedsRefresh,
+  );
+  useEffect(() => {
+    if (status === 'success') setNeedsRefresh(false);
+  }, [status, setNeedsRefresh]);
 
   const [fareContracts, setFareContracts] = useState(
     fareContractsFromFirestore,
@@ -84,7 +93,7 @@ export const useFareContracts = (
     isError,
   };
 };
-export const fareContractsQueryKey = 'FETCH_FARE_CONTRACTS';
+const fareContractsQueryKey = 'FETCH_FARE_CONTRACTS';
 export const useGetFareContractsQuery = (props: {
   enabled: boolean;
   availability: AvailabilityStatusInput['availability'] | undefined;
@@ -105,6 +114,13 @@ export const useGetFareContractsQuery = (props: {
   });
 };
 
+export const invalidateFareContractsQuery = (
+  queryClient: ReturnType<typeof useQueryClient>,
+) => {
+  queryClient.invalidateQueries({queryKey: [fareContractsQueryKey]});
+  useNeedsRefreshStore.getState().setNeedsRefresh(true);
+};
+
 export const getFilterdFareContracts = (
   fareContracts: FareContractType[],
   availabilityStatus: AvailabilityStatusInput,
@@ -120,3 +136,20 @@ export const getFilterdFareContracts = (
 
     return false;
   });
+
+type FareContractsNeedRefreshStore = {
+  needsRefresh: boolean;
+  setNeedsRefresh: (needsRefresh: boolean) => void;
+};
+/**
+ * Keeps track of whether fare contracts are in a known outdated state. E.g.
+ * after a ticket purchase. We use this to show a message to the user in cases
+ * where the fare contracts state is empty or outdated, but not when a single
+ * fetch failed, since that's likely not a problem.
+ */
+export const useNeedsRefreshStore = create<FareContractsNeedRefreshStore>(
+  (set) => ({
+    needsRefresh: true,
+    setNeedsRefresh: (needsRefresh) => set({needsRefresh}),
+  }),
+);

--- a/src/modules/ticketing/use-fare-contracts.ts
+++ b/src/modules/ticketing/use-fare-contracts.ts
@@ -75,7 +75,7 @@ export const useFareContracts = (
   const refetch = () => {
     // On refetch, also invalidate queries with availability !== 'available' to
     // ensure consistency throughout the app.
-    queryClient.invalidateQueries({queryKey: [fareContractsQueryKey]});
+    invalidateFareContractsQuery(queryClient);
     getFareContractsFromBackend().then(({data, isSuccess}) => {
       if (isSuccess) {
         const parsedFareContracts = data

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -25,6 +25,7 @@ import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {ONE_SECOND_MS} from '@atb/utils/durations';
 import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 import {MessageInfoBox} from '@atb/components/message-info-box';
+import {useNeedsRefreshStore} from '@atb/modules/ticketing';
 
 type Props =
   TicketTabNavScreenProps<'TicketTabNav_AvailableFareContractsTabScreen'>;
@@ -113,6 +114,7 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
     onRefresh,
     refreshing: isFetchingAvailableFareContracts,
   });
+  const needsRefresh = useNeedsRefreshStore((state) => state.needsRefresh);
 
   return (
     <View style={styles.container}>
@@ -135,18 +137,21 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           alwaysShowErrors={false}
           onPressChangeButton={onPressChangeButton}
         />
-        {isErrorAvailableFareContracts && !isFetchingAvailableFareContracts && (
-          <MessageInfoBox
-            message={t(
-              TicketingTexts.availableFareProductsAndReservationsTab.loadError,
-            )}
-            type="error"
-            onPressConfig={{
-              action: onRefresh,
-              text: t(dictionary.retry),
-            }}
-          />
-        )}
+        {isErrorAvailableFareContracts &&
+          needsRefresh &&
+          !isFetchingAvailableFareContracts && (
+            <MessageInfoBox
+              message={t(
+                TicketingTexts.availableFareProductsAndReservationsTab
+                  .loadError,
+              )}
+              type="error"
+              onPressConfig={{
+                action: onRefresh,
+                text: t(dictionary.retry),
+              }}
+            />
+          )}
         <FareContractAndReservationsList
           reservations={reservations}
           fareContracts={availableFareContracts}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -7,7 +7,7 @@ import {
 import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import {FareContractAndReservationsList} from '@atb/modules/fare-contracts';
-import {useTranslation, TicketingTexts} from '@atb/translations';
+import {useTranslation, TicketingTexts, dictionary} from '@atb/translations';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useTimeContext} from '@atb/modules/time';
 import {LinkSectionItem, Section} from '@atb/components/sections';
@@ -44,7 +44,8 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
   const {
     fareContracts: availableFareContracts,
     refetch: refetchAvailableFareContracts,
-    isRefetching: isRefetchingAvailableFareContracts,
+    isFetching: isFetchingAvailableFareContracts,
+    isError: isErrorAvailableFareContracts,
   } = useFareContracts({availability: 'available'}, serverNow);
   const {refetch: refetchPreassignedFareProducts} = useGetFareProductsQuery();
 
@@ -97,19 +98,20 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
     return () => clearTimeout(timeout);
   }, [showTransferCodeSuccess]);
 
+  const onRefresh = () => {
+    refetchAvailableFareContracts();
+    refetchPreassignedFareProducts();
+    queryClient.invalidateQueries({
+      queryKey: [SCHOOL_CARNET_QUERY_KEY],
+    });
+    analytics.logEvent('Ticketing', 'Pull to refresh tickets', {
+      reservationsCount: reservations.length,
+      availableFareContractsCount: availableFareContracts.length,
+    });
+  };
   const refreshControlProps = useManualRefreshControlProps({
-    onRefresh: () => {
-      refetchAvailableFareContracts();
-      refetchPreassignedFareProducts();
-      queryClient.invalidateQueries({
-        queryKey: [SCHOOL_CARNET_QUERY_KEY],
-      });
-      analytics.logEvent('Ticketing', 'Pull to refresh tickets', {
-        reservationsCount: reservations.length,
-        availableFareContractsCount: availableFareContracts.length,
-      });
-    },
-    refreshing: isRefetchingAvailableFareContracts,
+    onRefresh,
+    refreshing: isFetchingAvailableFareContracts,
   });
 
   return (
@@ -133,6 +135,18 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
           alwaysShowErrors={false}
           onPressChangeButton={onPressChangeButton}
         />
+        {isErrorAvailableFareContracts && !isFetchingAvailableFareContracts && (
+          <MessageInfoBox
+            message={t(
+              TicketingTexts.availableFareProductsAndReservationsTab.loadError,
+            )}
+            type="error"
+            onPressConfig={{
+              action: onRefresh,
+              text: t(dictionary.retry),
+            }}
+          />
+        )}
         <FareContractAndReservationsList
           reservations={reservations}
           fareContracts={availableFareContracts}

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -111,6 +111,11 @@ const TicketingTexts = {
       'No active tickets',
       'Ingen aktive billettar',
     ),
+    loadError: _(
+      'Vi klarte ikke å hente oppdatert informasjon om billettene dine.',
+      'We were unable to fetch updated information about your tickets.',
+      'Vi klarte ikkje å hente oppdatert informasjon om billettane dine.',
+    ),
     noActiveTicketsDetails: _(
       'Når du kjøper en billett, vil den vises her.',
       'When you buy a ticket, it will show up here. ',


### PR DESCRIPTION
## Background

This all started with reports from users that had just upgraded their app, that said their period tickets were missing. They then bought a new ticket, and ended up with two. This caused refund requests to customer service.

The likely technical explanation for this is that we discard the react query cache on app update (`buster: APP_VERSION`  in ReactQueryProvider), and if the app is then opened without a network connection, no tickets are shown from cache, and no information is given that things failed.

I wanted to add an error message for this, but not one that would appear on every failed request to `/ticket/v4/list`, since we have a 7 day cache that is fine to fall back to in most cases.

## Solution

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-25 at 13 00 21" src="https://github.com/user-attachments/assets/841ab5db-7a98-41f6-8c12-679c68806c57" />


This PR adds an error message that appears

1. When the app has just been opened, and the first request to `/ticket/v4/list` fails.
2. When we know the current data is outdated, e.g. after ticket purchase and the fare contract stream event is received.
3. On pull to refresh

I didn't find an very elegant solution to this (e.g. using the built-in  `stale` state) in react query, so I opted to create a zustand store with a `needsRefresh` field for this instead. `needsRefresh` is true on app start, and whenever the fare contracts query is invalidated.

## Note

I feel like this was a lot harder to work with than it should have been, mostly because fare contract state is still connected to firestore loading logic in TicketingContext in ways that is hard to wrap your head around. We should migrate away from this as soon as we're sure the stream service solution is working well enough to not need a feature toggle.

## Acceptance criteria

- [x] When the app is launched without a network connection, an error message is shown in the "My tickets" list.
- [x] If requests to `/ticket/v4/list` after ticket purchase, the message is shown.
- [x] On pull to refresh, the message is shown
- [x] When requests to `/ticket/v4/list` otherwise fails without user interaction (e.g. after app focus), the message is not shown.
- [x] Clicking "Try again" should reload the list
