### PR TITLE
refactor: Fix OverflowContainer rendering race condition

### DIFF
--- a/src/components/overflow-container/OverflowContainer.tsx
+++ b/src/components/overflow-container/OverflowContainer.tsx
@@ -1,6 +1,7 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useState} from 'react';
 import {LayoutChangeEvent, StyleSheet, View} from 'react-native';
 import Animated, {Easing, FadeIn} from 'react-native-reanimated';
+import {computeFit, FitResult} from './compute-fit';
 
 type Props = {
   children: React.ReactNode[];
@@ -10,11 +11,6 @@ type Props = {
   revealDuration?: number;
 };
 
-type FitResult = {
-  visibleCount: number;
-  needsOverflow: boolean;
-};
-
 export const OverflowContainer: React.FC<Props> = ({
   children,
   overflow,
@@ -22,111 +18,72 @@ export const OverflowContainer: React.FC<Props> = ({
   gap = 0,
   revealDuration = 200,
 }) => {
-  const widthsRef = useRef<(number | null)[]>(
-    Array(children.length).fill(null),
+  const [widthByKey, setWidthByKey] = useState<Record<string, number>>({});
+  const [overflowWidth, setOverflowWidth] = useState<number>();
+
+  const items = React.Children.toArray(children);
+  const orderedKeys = items.map((child, i) =>
+    React.isValidElement(child) && child.key != null ? child.key : `__idx_${i}`,
   );
-  const overflowWidthRef = useRef<number | null>(null);
-  const measuredCountRef = useRef(0);
 
-  const [fitResult, setFitResult] = useState<FitResult | null>(null);
-
-  useEffect(() => {
-    if (maxWidth === 0) return;
-    widthsRef.current = Array(children.length).fill(null);
-    overflowWidthRef.current = null;
-    measuredCountRef.current = 0;
-    setFitResult(null);
-  }, [maxWidth, children.length]);
-
-  const tryCompute = () => {
-    if (maxWidth === 0) return;
-
-    if (
-      measuredCountRef.current < children.length ||
-      overflowWidthRef.current === null
-    ) {
-      return;
-    }
-
-    const overflowWidth = overflowWidthRef.current;
-    const widths = widthsRef.current as number[];
-    let currentWidth = 0;
-    let visibleCount = 0;
-
-    for (let i = 0; i < widths.length; i++) {
-      const isLast = i === widths.length - 1;
-      const gapBefore = i > 0 ? gap : 0;
-      const overflowReserve = isLast ? 0 : overflowWidth + gap;
-
-      if (currentWidth + gapBefore + widths[i] + overflowReserve <= maxWidth) {
-        currentWidth += gapBefore + widths[i];
-        visibleCount++;
-      } else {
-        break;
-      }
-    }
-
-    setFitResult({visibleCount, needsOverflow: visibleCount < children.length});
-  };
-
-  const handleChildLayout = (index: number, width: number) => {
-    if (widthsRef.current[index] !== null) return;
-    widthsRef.current[index] = width;
-    measuredCountRef.current++;
-    tryCompute();
-  };
-
-  const handleOverflowLayout = (width: number) => {
-    if (overflowWidthRef.current !== null) return;
-    overflowWidthRef.current = width;
-    tryCompute();
-  };
+  // Derived during render; null until maxWidth and all child widths are in.
+  const widths = orderedKeys
+    .map((k) => widthByKey[k])
+    .filter((w): w is number => w != null);
+  const fitResult: FitResult | null =
+    maxWidth > 0 &&
+    overflowWidth != null &&
+    widths.length === orderedKeys.length
+      ? computeFit({widths, overflowWidth, maxWidth, gap})
+      : null;
 
   const entering = FadeIn.duration(revealDuration).easing(
     Easing.out(Easing.ease),
   );
 
-  const hiddenCount = children.length - (fitResult?.visibleCount ?? 0);
+  const hiddenCount = items.length - (fitResult?.visibleCount ?? 0);
 
   return (
     <View style={[styles.row, {gap}]}>
-      {!fitResult && (
-        // Key includes the child count so a count change remounts this pass and
-        // every child re-fires onLayout — reused views don't re-measure, which
-        // would otherwise leave the row blank.
-        <View
-          key={`${maxWidth}-${children.length}`}
-          style={[styles.measureWrapper, {width: maxWidth}]}
-          pointerEvents="none"
-        >
-          <View style={[styles.row, {gap}]}>
-            {children.map((child, i) => (
-              <View
-                key={i}
-                style={styles.measureChild}
-                onLayout={(e: LayoutChangeEvent) =>
-                  handleChildLayout(i, e.nativeEvent.layout.width)
-                }
-              >
-                {child}
-              </View>
-            ))}
+      {/* Hidden, out-of-flow measurer; onLayout keeps widthByKey fresh. */}
+      <View
+        style={[styles.measureWrapper, {width: maxWidth}]}
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <View style={[styles.row, {gap}]}>
+          {items.map((child, i) => (
             <View
+              key={orderedKeys[i]}
               style={styles.measureChild}
-              onLayout={(e: LayoutChangeEvent) =>
-                handleOverflowLayout(e.nativeEvent.layout.width)
-              }
+              onLayout={(e: LayoutChangeEvent) => {
+                const width = e.nativeEvent.layout.width;
+                const key = orderedKeys[i];
+                setWidthByKey((prev) =>
+                  prev[key] === width ? prev : {...prev, [key]: width},
+                );
+              }}
             >
-              {overflow(children.length)}
+              {child}
             </View>
+          ))}
+          <View
+            style={styles.measureChild}
+            onLayout={(e: LayoutChangeEvent) => {
+              const width = e.nativeEvent.layout.width;
+              setOverflowWidth((prev) => (prev === width ? prev : width));
+            }}
+          >
+            {overflow(items.length)}
           </View>
         </View>
-      )}
+      </View>
 
       {fitResult && (
         <Animated.View style={[styles.row, {gap}]} entering={entering}>
-          {children.slice(0, fitResult.visibleCount).map((child, i) => (
-            <View key={i}>{child}</View>
+          {items.slice(0, fitResult.visibleCount).map((child, i) => (
+            <View key={orderedKeys[i]}>{child}</View>
           ))}
           {fitResult.needsOverflow && overflow(hiddenCount)}
         </Animated.View>
@@ -140,6 +97,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   measureWrapper: {
+    position: 'absolute',
     overflow: 'hidden',
   },
   measureChild: {

--- a/src/components/overflow-container/__tests__/OverflowContainer.test.tsx
+++ b/src/components/overflow-container/__tests__/OverflowContainer.test.tsx
@@ -1,10 +1,11 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import {
   fireEvent,
   render,
   type RenderResult,
 } from '@testing-library/react-native';
+import type {ReactTestInstance} from 'react-test-renderer';
 import {OverflowContainer} from '../OverflowContainer';
 
 // Minimal mock for the reveal animation OverflowContainer imports from reanimated.
@@ -19,102 +20,72 @@ jest.mock('react-native-reanimated', () => {
   };
 });
 
-/**
- * What OverflowContainer does, and what these tests pin down.
- *
- * OverflowContainer shows as many children as fit in `maxWidth`, plus a "+N"
- * overflow badge when some don't. Deciding how many fit needs each child's pixel
- * width, which isn't known until it has been rendered and laid out — so it works
- * in two phases:
- *
- *  1. Measure pass: while `fitResult` is null it renders every child and the
- *     badge invisibly (opacity 0, clipped), purely so React Native fires
- *     `onLayout` for each and reports its width. Widths accumulate in refs; once
- *     every child and the badge have reported, it computes how many fit and sets
- *     `fitResult`.
- *  2. Reveal: with `fitResult` set it renders the real, visible row — the
- *     children that fit, plus the badge if needed.
- *
- * If `fitResult` is never set, only the invisible measure pass renders and the
- * row looks blank. Each shown child therefore mounts twice in the normal flow:
- * once to be measured, then again when the row is revealed.
- *
- * The subtlety these tests guard: React Native delivers `onLayout` when a view
- * mounts (or its layout changes), but not when a view is merely reconciled in
- * place. When the child set changes, OverflowContainer resets its measurement and
- * re-measures — which only completes if the measure pass remounts the children.
- * If the measure pass is reused instead, the surviving children never report
- * layout again, measurement can't finish, and the row stays blank.
- *
- * These tests rely on real React behaviour rather than re-simulating onLayout
- * timing: the "measuring" state is reproduced simply by not firing onLayout, and
- * a child re-running its mount effect is how we observe a remount.
- */
-
-let legMounts: Record<string, number> = {};
-
-// Records its own mounts through the real React lifecycle: a reconciled-in-place
-// instance does not re-run this effect, a remounted one does.
-function Leg({id}: {id: string}) {
-  useEffect(() => {
-    legMounts[id] = (legMounts[id] ?? 0) + 1;
-  }, [id]);
-  return <View testID={id} />;
-}
-
 const legs = (count: number) =>
-  Array.from({length: count}, (_, i) => <Leg key={i} id={`leg-${i}`} />);
-const overflowNode = () => <Leg id="overflow" />;
+  Array.from({length: count}, (_, i) => (
+    <View key={`leg-${i}`} testID={`leg-${i}`} />
+  ));
+const overflow = () => <View testID="overflow" />;
 
-// In the measure pass every child is wrapped in a View carrying onLayout; the
-// settled row carries none, so these nodes also report whether measurement is
-// still in progress.
-const measureChildren = (view: RenderResult) =>
+// Measure-pass children carry onLayout; firing it reports a width for each.
+const measureNodes = (view: RenderResult) =>
   view.UNSAFE_root.findAll((n) => typeof n.props?.onLayout === 'function');
 
+const reportWidths = (view: RenderResult, width = 30) =>
+  measureNodes(view).forEach((n) =>
+    fireEvent(n, 'layout', {
+      nativeEvent: {layout: {x: 0, y: 0, width, height: 20}},
+    }),
+  );
+
+const hasOnLayoutAncestor = (node: ReactTestInstance) => {
+  for (let p = node.parent; p; p = p.parent) {
+    if (typeof p.props?.onLayout === 'function') return true;
+  }
+  return false;
+};
+
+// Measurer children live under an onLayout wrapper; the visible row does not. A
+// leg counts as revealed once it renders outside the measurer — independent of
+// either implementation's measurer details (unmounted vs. always-mounted).
+const isRevealed = (view: RenderResult, id: string) =>
+  view.UNSAFE_root.findAll((n) => n.props?.testID === id).some(
+    (n) => !hasOnLayoutAncestor(n),
+  );
+
 describe('OverflowContainer', () => {
-  beforeEach(() => {
-    legMounts = {};
-  });
-
-  it('shows its children once a layout pass reports every width', () => {
+  it('reveals the children once their widths are reported', () => {
     const view = render(
-      <OverflowContainer maxWidth={200} overflow={overflowNode}>
+      <OverflowContainer maxWidth={200} overflow={overflow}>
         {legs(3)}
       </OverflowContainer>,
     );
 
-    // One layout pass: report a width for every measure child.
-    measureChildren(view).forEach((node) =>
-      fireEvent(node, 'layout', {
-        nativeEvent: {layout: {x: 0, y: 0, width: 30, height: 20}},
-      }),
-    );
-
-    expect(view.getByTestId('leg-0')).toBeTruthy();
-    expect(measureChildren(view)).toHaveLength(0);
-
-    // Each shown leg mounts twice in the normal flow: once in the hidden measure
-    // pass, then again when the measured row is revealed.
-    [0, 1, 2].forEach((i) => expect(legMounts[`leg-${i}`]).toBe(2));
+    expect(isRevealed(view, 'leg-0')).toBe(false);
+    reportWidths(view);
+    expect(isRevealed(view, 'leg-0')).toBe(true);
   });
 
-  // Expected behaviour: a change to the child set re-runs the measure pass,
-  // remounting the children so their new widths can be measured.
-  it('remounts the measure pass when the child count changes', () => {
+  // The bug behind "intermittent blank legs": widths are measured before the
+  // parent reports maxWidth (TravelCard starts it at 0). The component must reveal
+  // from those widths when the real maxWidth arrives — WITHOUT a second layout
+  // pass. The old code discarded the pre-maxWidth widths and got stuck whenever the
+  // re-measure didn't land, leaving the row blank.
+  it('reveals from widths measured before maxWidth is known, with no re-measure', () => {
     const view = render(
-      <OverflowContainer maxWidth={200} overflow={overflowNode}>
-        {legs(4)}
+      <OverflowContainer maxWidth={0} overflow={overflow}>
+        {legs(3)}
       </OverflowContainer>,
     );
-    const mountsBefore = legMounts['leg-0'];
+    reportWidths(view);
+    expect(isRevealed(view, 'leg-0')).toBe(false); // maxWidth is 0: still measuring
 
+    // Real width arrives; deliberately fire NO new layout events.
     view.rerender(
-      <OverflowContainer maxWidth={200} overflow={overflowNode}>
+      <OverflowContainer maxWidth={200} overflow={overflow}>
         {legs(3)}
       </OverflowContainer>,
     );
 
-    expect(legMounts['leg-0']).toBeGreaterThan(mountsBefore);
+    expect(isRevealed(view, 'leg-0')).toBe(true);
   });
 });

--- a/src/components/overflow-container/__tests__/compute-fit.test.ts
+++ b/src/components/overflow-container/__tests__/compute-fit.test.ts
@@ -1,0 +1,75 @@
+import {computeFit} from '../compute-fit';
+
+describe('computeFit', () => {
+  it('shows every child and no badge when they all fit', () => {
+    expect(
+      computeFit({
+        widths: [20, 20, 20],
+        overflowWidth: 30,
+        maxWidth: 100,
+        gap: 0,
+      }),
+    ).toEqual({visibleCount: 3, needsOverflow: false});
+  });
+
+  it('reserves space for the badge and overflows when space is tight', () => {
+    const result = computeFit({
+      widths: [20, 20, 20],
+      overflowWidth: 30,
+      maxWidth: 55,
+      gap: 0,
+    });
+    expect(result).toEqual({visibleCount: 1, needsOverflow: true});
+    // hidden count is derived by the caller as length - visibleCount
+    expect(3 - result.visibleCount).toBe(2);
+  });
+
+  it('does not reserve badge space for the last item', () => {
+    // The second (last) item only fits because no overflow space is reserved
+    // after it; with the reserve it would be pushed out.
+    expect(
+      computeFit({widths: [20, 20], overflowWidth: 30, maxWidth: 50, gap: 0}),
+    ).toEqual({visibleCount: 2, needsOverflow: false});
+  });
+
+  it('applies gap only before non-first items', () => {
+    const base = {widths: [20, 20], overflowWidth: 10, maxWidth: 45};
+    expect(computeFit({...base, gap: 0})).toEqual({
+      visibleCount: 2,
+      needsOverflow: false,
+    });
+    // The 10px gap before the second item now pushes it out.
+    expect(computeFit({...base, gap: 10})).toEqual({
+      visibleCount: 1,
+      needsOverflow: true,
+    });
+  });
+
+  it('shows nothing visible when the first item alone does not fit', () => {
+    expect(
+      computeFit({widths: [40, 20], overflowWidth: 10, maxWidth: 30, gap: 0}),
+    ).toEqual({visibleCount: 0, needsOverflow: true});
+  });
+
+  it('handles an empty child set', () => {
+    expect(
+      computeFit({widths: [], overflowWidth: 10, maxWidth: 100, gap: 0}),
+    ).toEqual({visibleCount: 0, needsOverflow: false});
+  });
+
+  it('recomputes for a same-length set with different widths (stale-content regression)', () => {
+    // The previous implementation reset measurement only on a child-count change,
+    // so a same-length swap (e.g. a leg gaining a notification badge, or a
+    // different trip at the same list index) kept the stale fit. A pure recompute
+    // must reflect the new widths.
+    const args = {overflowWidth: 30, maxWidth: 100, gap: 0};
+    expect(computeFit({...args, widths: [20, 20, 20]})).toEqual({
+      visibleCount: 3,
+      needsOverflow: false,
+    });
+    expect(computeFit({...args, widths: [20, 60, 20]})).toEqual({
+      visibleCount: 1,
+      needsOverflow: true,
+    });
+  });
+});

--- a/src/components/overflow-container/compute-fit.ts
+++ b/src/components/overflow-container/compute-fit.ts
@@ -1,0 +1,40 @@
+export type FitResult = {
+  visibleCount: number;
+  needsOverflow: boolean;
+};
+
+/**
+ * Greedily fit children left-to-right within `maxWidth`. Reserves space for the
+ * overflow badge (`overflowWidth + gap`) after every item except the last, so a
+ * set that fits exactly shows no badge. Pure (no React/RN), so the fit logic is
+ * unit-testable without rendering.
+ */
+export function computeFit({
+  widths,
+  overflowWidth,
+  maxWidth,
+  gap,
+}: {
+  widths: number[];
+  overflowWidth: number;
+  maxWidth: number;
+  gap: number;
+}): FitResult {
+  let currentWidth = 0;
+  let visibleCount = 0;
+
+  for (let i = 0; i < widths.length; i++) {
+    const isLast = i === widths.length - 1;
+    const gapBefore = i > 0 ? gap : 0;
+    const overflowReserve = isLast ? 0 : overflowWidth + gap;
+
+    if (currentWidth + gapBefore + widths[i] + overflowReserve <= maxWidth) {
+      currentWidth += gapBefore + widths[i];
+      visibleCount++;
+    } else {
+      break;
+    }
+  }
+
+  return {visibleCount, needsOverflow: visibleCount < widths.length};
+}


### PR DESCRIPTION
## Issue Reference
Closes https://github.com/AtB-AS/kundevendt/issues/24085

## Description
Refactors `OverflowContainer` to remove the fragile two-pass, `useEffect`-driven measurement that caused intermittent blank legs (getting stuck in the measure pass).

- The visible fit is now **derived during render** from cached child widths, instead of being set from a layout handler in a second pass. A child whose width is measured before `maxWidth` arrives no longer gets stuck, and no reset/remount is needed.
- The fit math is extracted into a pure `computeFit` helper with unit tests.

No behavior change for consumers. A follow-up PR adds travel-card skeleton loading on top of this (it relies on the reliable measurement this refactor provides).
