### PR TITLE
fix: forward messageKey to Snackbar content prop

### DIFF
--- a/src/components/snackbar/use-snackbar.tsx
+++ b/src/components/snackbar/use-snackbar.tsx
@@ -23,8 +23,8 @@ export const useSnackbar = () => {
     [messageKey, snackbarProps?.content],
   );
 
-  const snackbarPropsWithContent = useMemo(
-    () => ({...snackbarProps, snackbarContent: snackbarContent}),
+  const snackbarPropsWithContent = useMemo<SnackbarProps>(
+    () => ({...snackbarProps, content: snackbarContent}),
     [snackbarProps, snackbarContent],
   );
   return {


### PR DESCRIPTION
The wrapper spread `snackbarContent` under the wrong key, so the
incrementing messageKey never reached <Snackbar/> and re-showing the
same message did not reliably work.

### Acceptance criteria
- [x] Snackbar is shown multiple times when re-selecting the same geofencing zone multiple times
