### PR TITLE
feat: notify on forced selection changes when switching product

### DIFF
--- a/src/modules/fare-contracts/use-supplement-product-purchase-selection.ts
+++ b/src/modules/fare-contracts/use-supplement-product-purchase-selection.ts
@@ -90,7 +90,7 @@ export function useSupplementProductPurchaseSelection({
         .userProfiles(userProfile ? [{...userProfile, count: 1}] : [])
         .fromStopPlace(fromHarbor)
         .toStopPlace(toHarbor)
-        .build()
+        .build().selection
     );
 
     // We disable the exhaustive-deps rule here because we know builder is not

--- a/src/modules/fare-zones-selector/FareZonesSelectorMap.tsx
+++ b/src/modules/fare-zones-selector/FareZonesSelectorMap.tsx
@@ -85,7 +85,7 @@ const FareZonesSelectorMap = ({
     if (selectNext === 'from') builder.fromZone(zone);
     if (selectNext === 'to' || isApplicableOnSingleZoneOnly)
       builder.toZone(zone);
-    const newSelection = builder.build();
+    const {selection: newSelection} = builder.build();
     onSelect(newSelection);
   };
 

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-bonus-product-id.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-bonus-product-id.test.ts
@@ -3,7 +3,9 @@ import {TEST_INPUT} from './test-utils';
 
 describe('purchaseSelectionBuilder - bonusProductId', () => {
   it('Should be undefined by default', () => {
-    const selection = createEmptyBuilder(TEST_INPUT).forType('single').build();
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .build().selection;
     expect(selection.bonusProductId).toBeUndefined();
   });
 
@@ -11,7 +13,7 @@ describe('purchaseSelectionBuilder - bonusProductId', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .forType('single')
       .bonusProductId('some-bonus-id')
-      .build();
+      .build().selection;
     expect(selection.bonusProductId).toBe('some-bonus-id');
   });
 
@@ -19,12 +21,12 @@ describe('purchaseSelectionBuilder - bonusProductId', () => {
     const selection1 = createEmptyBuilder(TEST_INPUT)
       .forType('single')
       .bonusProductId('some-bonus-id')
-      .build();
+      .build().selection;
 
     const selection2 = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selection1)
       .bonusProductId(undefined)
-      .build();
+      .build().selection;
 
     expect(selection2.bonusProductId).toBeUndefined();
   });
@@ -33,11 +35,11 @@ describe('purchaseSelectionBuilder - bonusProductId', () => {
     const selection1 = createEmptyBuilder(TEST_INPUT)
       .forType('single')
       .bonusProductId('some-bonus-id')
-      .build();
+      .build().selection;
 
     const selection2 = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selection1)
-      .build();
+      .build().selection;
 
     expect(selection2.bonusProductId).toBe('some-bonus-id');
   });

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-existing-ticket.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-existing-ticket.test.ts
@@ -23,7 +23,7 @@ describe('PurchaseSelectionBuilder originFareContract', () => {
     const selection = builder
       .forType('single')
       .originFareContract(originFareContract)
-      .build();
+      .build().selection;
 
     expect(selection.originFareContract).toBe(originFareContract);
   });
@@ -40,7 +40,9 @@ describe('PurchaseSelectionBuilder originFareContract', () => {
       originFareContract: originFareContract,
     };
 
-    const newSelection = builder.fromSelection(initialSelection).build();
+    const newSelection = builder
+      .fromSelection(initialSelection)
+      .build().selection;
 
     expect(newSelection.originFareContract).toBe(originFareContract);
   });
@@ -59,7 +61,7 @@ describe('PurchaseSelectionBuilder originFareContract', () => {
     const selection = builder
       .fromSelection(selectionWithOriginFareContract)
       .originFareContract(undefined)
-      .build();
+      .build().selection;
 
     expect(selection.originFareContract).toBeUndefined();
   });
@@ -82,7 +84,7 @@ describe('PurchaseSelectionBuilder originFareContract', () => {
       .forType('single')
       .originFareContract(oneOriginFareContract)
       .originFareContract(anotherOriginFareContract)
-      .build();
+      .build().selection;
 
     expect(selection.originFareContract).toBe(anotherOriginFareContract);
   });
@@ -97,7 +99,7 @@ describe('PurchaseSelectionBuilder originFareContract', () => {
     const selection = builder
       .forType('single')
       .originFareContract(originFareContract)
-      .build();
+      .build().selection;
 
     expect(selection.fareProductTypeConfig.type).toBe('single');
     expect(selection.preassignedFareProduct.id).toBe('P1');

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-for-type.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-for-type.test.ts
@@ -12,7 +12,7 @@ import type {ZoneSelectionMode} from '@atb-as/config-specs';
 describe('purchaseSelectionBuilder - forType', () => {
   it("Throw error if config type doesn't exist", () => {
     const fn = () =>
-      createEmptyBuilder(TEST_INPUT).forType('not-existing').build();
+      createEmptyBuilder(TEST_INPUT).forType('not-existing').build().selection;
 
     expect(fn).toThrow();
   });
@@ -27,7 +27,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('A');
   });
@@ -42,7 +44,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('B');
   });
@@ -57,7 +61,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('C');
   });
@@ -81,7 +87,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       appVersion: '1.20',
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('C');
   });
@@ -96,7 +104,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       customerProfile: {debug: true},
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('A');
   });
@@ -110,7 +120,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('B');
   });
@@ -125,7 +137,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T1');
     expect(selection.zones?.to.id).toBe('T1');
@@ -142,7 +156,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       currentCoordinates: {latitude: 50, longitude: 50},
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T2');
     expect(selection.zones?.to.id).toBe('T2');
@@ -166,7 +182,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       currentCoordinates: {latitude: 50, longitude: 50},
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T3');
     expect(selection.zones?.to.id).toBe('T3');
@@ -184,7 +202,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       previousZoneIds: {from: 'T2', to: 'T3'},
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T2');
     expect(selection.zones?.to.id).toBe('T3');
@@ -211,7 +231,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       previousZoneIds: {from: 'T1', to: 'T1'},
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T3');
     expect(selection.zones?.to.id).toBe('T3');
@@ -239,7 +261,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       previousZoneIds: {from: 'T3', to: 'T3'},
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T2');
     expect(selection.zones?.to.id).toBe('T2');
@@ -266,7 +290,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T2');
     expect(selection.zones?.to.id).toBe('T2');
@@ -290,30 +316,32 @@ describe('purchaseSelectionBuilder - forType', () => {
 
     let selection = createEmptyBuilder(input('single'))
       .forType('single')
-      .build();
+      .build().selection;
     expect(selection.stopPlaces).toBe(undefined);
 
     selection = createEmptyBuilder(input('single-zone'))
       .forType('single')
-      .build();
+      .build().selection;
     expect(selection.stopPlaces).toBe(undefined);
 
     selection = createEmptyBuilder(input('single-stop'))
       .forType('single')
-      .build();
+      .build().selection;
     expect(selection.stopPlaces).toBe(undefined);
 
-    selection = createEmptyBuilder(input('multiple')).forType('single').build();
+    selection = createEmptyBuilder(input('multiple'))
+      .forType('single')
+      .build().selection;
     expect(selection.stopPlaces).toBe(undefined);
 
     selection = createEmptyBuilder(input('multiple-zone'))
       .forType('single')
-      .build();
+      .build().selection;
     expect(selection.stopPlaces).toBe(undefined);
 
     selection = createEmptyBuilder(input('multiple-stop'))
       .forType('single')
-      .build();
+      .build().selection;
     expect(selection.stopPlaces).toBe(undefined);
   });
 
@@ -333,7 +361,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T3');
     expect(selection.zones?.to.id).toBe('T3');
@@ -354,7 +384,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.stopPlaces?.from?.id).toBe(undefined);
     expect(selection.stopPlaces?.to?.id).toBe(undefined);
@@ -375,7 +407,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.stopPlaces).toBe(undefined);
     expect(selection.zones).toBe(undefined);
@@ -391,7 +425,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ],
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(1);
     expect(selection.userProfilesWithCount[0].id).toBe('UP1');
@@ -409,7 +445,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       defaultUserTypeString: 'CHILD',
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(1);
     expect(selection.userProfilesWithCount[0].id).toBe('UP2');
@@ -435,7 +473,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       defaultUserTypeString: 'CHILD',
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(1);
     expect(selection.userProfilesWithCount[0].id).toBe('UP3');
@@ -443,7 +483,9 @@ describe('purchaseSelectionBuilder - forType', () => {
   });
 
   it('Travel date should be undefined', () => {
-    const selection = createEmptyBuilder(TEST_INPUT).forType('single').build();
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .build().selection;
 
     expect(selection.travelDate).toBeUndefined();
   });
@@ -453,7 +495,9 @@ describe('purchaseSelectionBuilder - forType', () => {
       ...TEST_INPUT,
     };
 
-    const selection = createEmptyBuilder(input).forType('single').build();
+    const selection = createEmptyBuilder(input)
+      .forType('single')
+      .build().selection;
 
     expect(selection.isOnBehalfOf).toBe(false);
   });

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-from-selection.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-from-selection.test.ts
@@ -14,7 +14,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
   it('Should return same selection unaltered', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
-      .build();
+      .build().selection;
 
     expect(selection).toStrictEqual(TEST_SELECTION);
   });
@@ -30,7 +30,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
 
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(originalSelection)
-      .build();
+      .build().selection;
 
     expect(selection).toStrictEqual(originalSelection);
   });
@@ -42,7 +42,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
         preassignedFareProduct: {...TEST_PRODUCT, id: 'P5', type: 'other'},
         travelDate: new Date().toISOString(),
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
     expect(selection.travelDate).toBeUndefined();
@@ -63,7 +63,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
         },
         travelDate: new Date().toISOString(),
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
     expect(selection.zones?.from.id).toBe(TEST_ZONE.id);
@@ -85,7 +85,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
         },
         travelDate: new Date().toISOString(),
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
     expect(selection.zones?.to.id).toBe(TEST_ZONE.id);
@@ -107,7 +107,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
         userProfilesWithCount: [{...TEST_USER_PROFILE, id: 'U_X', count: 1}],
         travelDate: new Date().toISOString(),
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
     expect(selection.userProfilesWithCount[0].id).toBe(TEST_USER_PROFILE.id);
@@ -121,7 +121,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
         preassignedFareProduct: {...TEST_PRODUCT, id: 'P5'},
         travelDate: 'whatever',
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(TEST_PRODUCT.id);
     expect(selection.travelDate).toBeUndefined();
@@ -133,7 +133,7 @@ describe('purchaseSelectionBuilder - fromSelection', () => {
         ...TEST_SELECTION,
         isOnBehalfOf: true,
       })
-      .build();
+      .build().selection;
 
     expect(selection.isOnBehalfOf).toBe(true);
   });
@@ -150,7 +150,7 @@ it('Should create builder with baggage products', () => {
 
   const selection = createEmptyBuilder(TEST_INPUT)
     .fromSelection(selectionWithSupplements)
-    .build();
+    .build().selection;
 
   expect(selection.supplementProductsWithCount).toHaveLength(2);
   expect(selection.supplementProductsWithCount[0].id).toBe('SP1');
@@ -195,7 +195,7 @@ it('Should build the default selection when some supplement products are not all
 
   const selection = createEmptyBuilder(TEST_INPUT)
     .fromSelection(TEST_SELECTION_WITH_PRODUCT_WITH_LIMITATIONS)
-    .build();
+    .build().selection;
 
   expect(selection.supplementProductsWithCount).toEqual([]);
   expect(selection.preassignedFareProduct.id).toBe('P1');

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-legs.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-legs.test.ts
@@ -106,7 +106,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selectionWithTravelDate)
       .legs(validLegs)
-      .build();
+      .build().selection;
 
     expect(selection.legs).toHaveLength(2);
     expect(selection.legs?.[0].fromPlace.quay?.stopPlace?.id).toBe('SP1');
@@ -170,7 +170,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selectionWithTravelDate)
       .legs(invalidLegs)
-      .build();
+      .build().selection;
 
     expect(selection.legs).toHaveLength(0);
   });
@@ -227,7 +227,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection({...TEST_SELECTION, travelDate: undefined}) // No travel date set
       .legs(validLegs)
-      .build();
+      .build().selection;
 
     expect(selection.legs).toHaveLength(1);
   });
@@ -236,7 +236,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .legs([])
-      .build();
+      .build().selection;
 
     expect(selection.legs).toHaveLength(0);
   });
@@ -245,7 +245,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .legs(TEST_SELECTION.legs)
-      .build();
+      .build().selection;
 
     expect(selection.legs).toEqual(TEST_SELECTION.legs);
   });
@@ -352,7 +352,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selectionWithTravelDate)
       .legs(mixedLegs)
-      .build();
+      .build().selection;
 
     expect(selection.legs).toHaveLength(2);
     expect(selection.legs?.[0].fromPlace.quay?.stopPlace?.id).toBe('SP1');
@@ -362,7 +362,7 @@ describe('purchaseSelectionBuilder - legs', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .legs([])
-      .build();
+      .build().selection;
 
     expect(selection.legs).toEqual(TEST_SELECTION.legs);
   });

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-on-behalf-of.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-on-behalf-of.test.ts
@@ -3,26 +3,30 @@ import {TEST_INPUT} from './test-utils';
 
 describe('purchaseSelectionBuilder - isOnBehalfOf', () => {
   it('Should be false by default', () => {
-    const selection = createEmptyBuilder(TEST_INPUT).forType('single').build();
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .build().selection;
     expect(selection.isOnBehalfOf).toBe(false);
   });
 
   it('Should correctly set and unset isOnBehalfOf using the builder function', () => {
-    const selection1 = createEmptyBuilder(TEST_INPUT).forType('single').build();
+    const selection1 = createEmptyBuilder(TEST_INPUT)
+      .forType('single')
+      .build().selection;
 
     expect(selection1.isOnBehalfOf).toBe(false);
 
     const selection2 = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selection1)
       .isOnBehalfOf(true)
-      .build();
+      .build().selection;
 
     expect(selection2.isOnBehalfOf).toBe(true);
 
     const selection3 = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selection2)
       .isOnBehalfOf(true)
-      .build();
+      .build().selection;
 
     expect(selection3.isOnBehalfOf).toBe(true);
   });

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
@@ -282,3 +282,190 @@ describe('purchaseSelectionBuilder - product', () => {
     expect(selection.preassignedFareProduct.id).toBe('P2');
   });
 });
+
+describe('purchaseSelectionBuilder - product forced changes', () => {
+  it('Should report no forced changes for a fully compatible product change', () => {
+    const {forcedChanges} = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(TEST_SELECTION)
+      .product({...TEST_SELECTION.preassignedFareProduct, id: 'P2'})
+      .buildWithForcedChanges();
+
+    expect(forcedChanges).toEqual([]);
+  });
+
+  it('Should report no forced changes when the product is rejected', () => {
+    const {forcedChanges} = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(TEST_SELECTION)
+      .product({
+        ...TEST_SELECTION.preassignedFareProduct,
+        id: 'P2',
+        type: 'other-type',
+      })
+      .buildWithForcedChanges();
+
+    expect(forcedChanges).toEqual([]);
+  });
+
+  it('Should report userProfile when the user profile is swapped to default', () => {
+    const input = {
+      ...TEST_INPUT,
+      userProfiles: [
+        {...TEST_USER_PROFILE, id: 'UP1', userTypeString: 'ADULT'},
+        {...TEST_USER_PROFILE, id: 'UP2', userTypeString: 'CHILD'},
+        {...TEST_USER_PROFILE, id: 'UP3', userTypeString: 'SENIOR'},
+      ],
+      defaultUserTypeString: 'SENIOR',
+    };
+
+    const {selection, forcedChanges} = createEmptyBuilder(input)
+      .fromSelection(TEST_SELECTION)
+      .product({
+        ...TEST_PRODUCT,
+        limitations: {
+          ...TEST_PRODUCT.limitations,
+          userProfiles: [{userProfileRef: 'UP2'}, {userProfileRef: 'UP3'}],
+        },
+        id: 'P2',
+      })
+      .buildWithForcedChanges();
+
+    expect(selection.userProfilesWithCount[0].id).toBe('UP3');
+    expect(forcedChanges).toEqual(['userProfile']);
+  });
+
+  it('Should report userProfile when invalid profiles are filtered out', () => {
+    const input = {
+      ...TEST_INPUT,
+      userProfiles: [
+        {...TEST_USER_PROFILE, id: 'UP1', userTypeString: 'ADULT'},
+        {...TEST_USER_PROFILE, id: 'UP2', userTypeString: 'CHILD'},
+        {...TEST_USER_PROFILE, id: 'UP3', userTypeString: 'SENIOR'},
+      ],
+      defaultUserTypeString: 'SENIOR',
+    };
+
+    const {forcedChanges} = createEmptyBuilder(input)
+      .fromSelection({
+        ...TEST_SELECTION,
+        userProfilesWithCount: [
+          {...TEST_USER_PROFILE, id: 'UP1', count: 2},
+          {...TEST_USER_PROFILE, id: 'UP2', count: 3},
+        ],
+      })
+      .product({
+        ...TEST_SELECTION.preassignedFareProduct,
+        limitations: {
+          ...TEST_SELECTION.preassignedFareProduct.limitations,
+          userProfiles: [{userProfileRef: 'UP2'}, {userProfileRef: 'UP3'}],
+        },
+        id: 'P2',
+      })
+      .buildWithForcedChanges();
+
+    expect(forcedChanges).toEqual(['userProfile']);
+  });
+
+  it('Should report zone when zones are auto-corrected', () => {
+    const input = {
+      ...TEST_INPUT,
+      fareZones: [
+        {...TEST_ZONE, id: 'T1'},
+        {...TEST_ZONE, id: 'T2', isDefault: true},
+        {...TEST_ZONE, id: 'T3'},
+      ],
+    };
+
+    const {forcedChanges} = createEmptyBuilder(input)
+      .fromSelection({
+        ...TEST_SELECTION,
+        zones: {
+          from: {...TEST_ZONE, id: 'T3', resultType: 'zone'},
+          to: {...TEST_ZONE, id: 'T1', resultType: 'zone'},
+        },
+      })
+      .product({
+        ...TEST_PRODUCT,
+        id: 'P2',
+        limitations: {
+          ...TEST_PRODUCT.limitations,
+          fareZoneRefs: ['T2', 'T3'],
+        },
+      })
+      .buildWithForcedChanges();
+
+    expect(forcedChanges).toEqual(['zone']);
+  });
+
+  it('Should report both userProfile and zone when both are auto-corrected', () => {
+    const input = {
+      ...TEST_INPUT,
+      userProfiles: [
+        {...TEST_USER_PROFILE, id: 'UP1', userTypeString: 'ADULT'},
+        {...TEST_USER_PROFILE, id: 'UP2', userTypeString: 'CHILD'},
+        {...TEST_USER_PROFILE, id: 'UP3', userTypeString: 'SENIOR'},
+      ],
+      defaultUserTypeString: 'SENIOR',
+      fareZones: [
+        {...TEST_ZONE, id: 'T1'},
+        {...TEST_ZONE, id: 'T2', isDefault: true},
+        {...TEST_ZONE, id: 'T3'},
+      ],
+    };
+
+    const {forcedChanges} = createEmptyBuilder(input)
+      .fromSelection({
+        ...TEST_SELECTION,
+        zones: {
+          from: {...TEST_ZONE, id: 'T1', resultType: 'zone'},
+          to: {...TEST_ZONE, id: 'T1', resultType: 'zone'},
+        },
+      })
+      .product({
+        ...TEST_PRODUCT,
+        id: 'P2',
+        limitations: {
+          ...TEST_PRODUCT.limitations,
+          userProfiles: [{userProfileRef: 'UP2'}, {userProfileRef: 'UP3'}],
+          fareZoneRefs: ['T2', 'T3'],
+        },
+      })
+      .buildWithForcedChanges();
+
+    expect(forcedChanges).toEqual(['userProfile', 'zone']);
+  });
+
+  it('Should replace, not accumulate, forced changes across multiple product calls', () => {
+    const input = {
+      ...TEST_INPUT,
+      userProfiles: [
+        {...TEST_USER_PROFILE, id: 'UP1', userTypeString: 'ADULT'},
+        {...TEST_USER_PROFILE, id: 'UP2', userTypeString: 'CHILD'},
+        {...TEST_USER_PROFILE, id: 'UP3', userTypeString: 'SENIOR'},
+      ],
+      defaultUserTypeString: 'SENIOR',
+    };
+
+    const productWithLimitations = {
+      ...TEST_PRODUCT,
+      id: 'P2',
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        userProfiles: [{userProfileRef: 'UP2'}, {userProfileRef: 'UP3'}],
+      },
+    };
+
+    const productWithoutLimitations = {
+      ...TEST_PRODUCT,
+      id: 'P3',
+    };
+
+    const {selection, forcedChanges} = createEmptyBuilder(input)
+      .fromSelection(TEST_SELECTION)
+      .product(productWithLimitations) // forces userProfile change
+      .product(productWithoutLimitations) // no forced change
+      .buildWithForcedChanges();
+
+    expect(forcedChanges).toEqual([]);
+    expect(selection.userProfilesWithCount[0].id).toBe('UP1');
+  });
+});

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
@@ -13,7 +13,7 @@ describe('purchaseSelectionBuilder - product', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .product({...TEST_SELECTION.preassignedFareProduct, id: 'P2'})
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('P2');
   });
@@ -30,7 +30,7 @@ describe('purchaseSelectionBuilder - product', () => {
           appVersionMax: '1.46',
         },
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('P2');
   });
@@ -43,7 +43,7 @@ describe('purchaseSelectionBuilder - product', () => {
         id: 'P2',
         type: 'other-type',
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(
       TEST_SELECTION.preassignedFareProduct.id,
@@ -62,7 +62,7 @@ describe('purchaseSelectionBuilder - product', () => {
           appVersionMin: '1.46',
         },
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(
       TEST_SELECTION.preassignedFareProduct.id,
@@ -81,7 +81,7 @@ describe('purchaseSelectionBuilder - product', () => {
           appVersionMax: '1.44',
         },
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(
       TEST_SELECTION.preassignedFareProduct.id,
@@ -97,7 +97,7 @@ describe('purchaseSelectionBuilder - product', () => {
         id: 'P2',
         distributionChannel: ['web'],
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe(
       TEST_SELECTION.preassignedFareProduct.id,
@@ -126,7 +126,7 @@ describe('purchaseSelectionBuilder - product', () => {
         },
         id: 'P2',
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('P2');
     expect(selection.userProfilesWithCount.length).toBe(1);
@@ -160,7 +160,7 @@ describe('purchaseSelectionBuilder - product', () => {
         },
         id: 'P2',
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('P2');
     expect(selection.userProfilesWithCount.length).toBe(1);
@@ -194,7 +194,7 @@ describe('purchaseSelectionBuilder - product', () => {
           fareZoneRefs: ['T2', 'T3'],
         },
       })
-      .build();
+      .build().selection;
 
     expect(selection.preassignedFareProduct.id).toBe('P2');
     expect(selection.zones?.from.id).toBe('T2');
@@ -216,7 +216,7 @@ describe('purchaseSelectionBuilder - product', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(selectionWithSupplement)
       .product({...TEST_SELECTION.preassignedFareProduct, id: 'P2'})
-      .build();
+      .build().selection;
 
     expect(selection.supplementProductsWithCount).toEqual(
       testSupplementProductWithCount,
@@ -246,7 +246,7 @@ describe('purchaseSelectionBuilder - product', () => {
       .fromSelection(TEST_SELECTION)
       .product(productWithLimitations)
       .supplementProducts(testBaggageProductWithCount)
-      .build();
+      .build().selection;
 
     expect(selection.supplementProductsWithCount).toEqual([]);
     expect(selection.preassignedFareProduct.id).toBe('P2');
@@ -274,7 +274,7 @@ describe('purchaseSelectionBuilder - product', () => {
       .fromSelection(TEST_SELECTION)
       .product(productWithLimitations)
       .supplementProducts(testBaggageProductWithCount)
-      .build();
+      .build().selection;
 
     expect(selection.supplementProductsWithCount).toEqual(
       testBaggageProductWithCount,
@@ -288,7 +288,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
     const {forcedChanges} = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .product({...TEST_SELECTION.preassignedFareProduct, id: 'P2'})
-      .buildWithForcedChanges();
+      .build();
 
     expect(forcedChanges).toEqual([]);
   });
@@ -301,7 +301,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
         id: 'P2',
         type: 'other-type',
       })
-      .buildWithForcedChanges();
+      .build();
 
     expect(forcedChanges).toEqual([]);
   });
@@ -327,7 +327,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
         },
         id: 'P2',
       })
-      .buildWithForcedChanges();
+      .build();
 
     expect(selection.userProfilesWithCount[0].id).toBe('UP3');
     expect(forcedChanges).toEqual(['userProfile']);
@@ -360,7 +360,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
         },
         id: 'P2',
       })
-      .buildWithForcedChanges();
+      .build();
 
     expect(forcedChanges).toEqual(['userProfile']);
   });
@@ -391,7 +391,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
           fareZoneRefs: ['T2', 'T3'],
         },
       })
-      .buildWithForcedChanges();
+      .build();
 
     expect(forcedChanges).toEqual(['zone']);
   });
@@ -429,7 +429,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
           fareZoneRefs: ['T2', 'T3'],
         },
       })
-      .buildWithForcedChanges();
+      .build();
 
     expect(forcedChanges).toEqual(['userProfile', 'zone']);
   });
@@ -463,7 +463,7 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
       .fromSelection(TEST_SELECTION)
       .product(productWithLimitations) // forces userProfile change
       .product(productWithoutLimitations) // no forced change
-      .buildWithForcedChanges();
+      .build();
 
     expect(forcedChanges).toEqual([]);
     expect(selection.userProfilesWithCount[0].id).toBe('UP1');

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-stop-places.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-stop-places.test.ts
@@ -10,7 +10,7 @@ describe('purchaseSelectionBuilder - stop places', () => {
         stopPlaces: {from: undefined, to: undefined},
       })
       .fromStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
-      .build();
+      .build().selection;
 
     expect(selection.stopPlaces?.from?.id).toBe('a-stop-id');
     expect(selection.stopPlaces?.to?.id).toBe(undefined);
@@ -24,7 +24,7 @@ describe('purchaseSelectionBuilder - stop places', () => {
         stopPlaces: {from: undefined, to: undefined},
       })
       .toStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
-      .build();
+      .build().selection;
 
     expect(selection.stopPlaces?.from?.id).toBe(undefined);
     expect(selection.stopPlaces?.to?.id).toBe('a-stop-id');
@@ -34,7 +34,7 @@ describe('purchaseSelectionBuilder - stop places', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .fromStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
-      .build();
+      .build().selection;
 
     expect(selection.stopPlaces?.from?.id).toBe(undefined);
     expect(selection.stopPlaces?.to?.id).toBe(undefined);
@@ -44,7 +44,7 @@ describe('purchaseSelectionBuilder - stop places', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .toStopPlace({id: 'a-stop-id', name: 'Trondheim Kai'})
-      .build();
+      .build().selection;
 
     expect(selection.stopPlaces?.from?.id).toBe(undefined);
     expect(selection.stopPlaces?.to?.id).toBe(undefined);

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-travel-date.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-travel-date.test.ts
@@ -7,7 +7,7 @@ describe('purchaseSelectionBuilder - travelDate', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .date(dateString)
-      .build();
+      .build().selection;
 
     expect(selection.travelDate).toEqual(dateString);
   });
@@ -17,7 +17,7 @@ describe('purchaseSelectionBuilder - travelDate', () => {
     const selection = builder
       .fromSelection({...TEST_SELECTION, travelDate: new Date().toISOString()})
       .date(undefined)
-      .build();
+      .build().selection;
 
     expect(selection.travelDate).toBeUndefined();
   });
@@ -27,7 +27,7 @@ describe('purchaseSelectionBuilder - travelDate', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .date(dateString)
-      .build();
+      .build().selection;
 
     expect(selection.travelDate).toBeUndefined();
   });

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-user-profiles.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-user-profiles.test.ts
@@ -22,7 +22,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
         {...TEST_USER_PROFILE, id: 'UP2', count: 2},
         {...TEST_USER_PROFILE, id: 'UP3', count: 1},
       ])
-      .build();
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(2);
     expect(
@@ -42,7 +42,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
         {...TEST_USER_PROFILE, id: 'UP4', count: 1},
         {...TEST_USER_PROFILE, id: 'UP5', count: 0},
       ])
-      .build();
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(2);
     expect(
@@ -62,7 +62,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
         {...TEST_USER_PROFILE, id: 'UP4', count: 0},
         {...TEST_USER_PROFILE, id: 'UP5', count: 0},
       ])
-      .build();
+      .build().selection;
 
     expect(selection).toBe(TEST_SELECTION);
   });
@@ -85,7 +85,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
         {...TEST_USER_PROFILE, id: 'UP2', count: 2},
         {...TEST_USER_PROFILE, id: 'UP3', count: 1},
       ])
-      .build();
+      .build().selection;
 
     expect(selection).toBe(originalSelection);
   });
@@ -111,7 +111,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
         {...TEST_USER_PROFILE, id: 'UP2', count: 2},
         {...TEST_USER_PROFILE, id: 'UP3', count: 1},
       ])
-      .build();
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(2);
     expect(
@@ -141,7 +141,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
         {...TEST_USER_PROFILE, id: 'UP2', count: 1},
         {...TEST_USER_PROFILE, id: 'UP3', count: 1},
       ])
-      .build();
+      .build().selection;
 
     expect(selection).toBe(originalSelection);
   });
@@ -168,7 +168,7 @@ describe('purchaseSelectionBuilder - userProfiles', () => {
           count: 2,
         },
       ])
-      .build();
+      .build().selection;
 
     expect(selection).toBe(originalSelection);
   });
@@ -235,7 +235,7 @@ it('Should not apply supplement products with zero count', () => {
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP2', count: 3},
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP3', count: 0},
     ])
-    .build();
+    .build().selection;
 
   expect(selection.supplementProductsWithCount).toHaveLength(1);
   expect(selection.supplementProductsWithCount[0].id).toBe('SP2');
@@ -253,7 +253,7 @@ it('Should not apply any user profiles or supplement products if all have zero c
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 0},
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP2', count: 0},
     ])
-    .build();
+    .build().selection;
 
   expect(selection.userProfilesWithCount).toHaveLength(1);
   expect(selection.supplementProductsWithCount).toHaveLength(0);
@@ -271,7 +271,7 @@ it('Should apply both user profiles and supplement products with positive count'
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 2},
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP2', count: 1},
     ])
-    .build();
+    .build().selection;
 
   expect(selection.userProfilesWithCount).toHaveLength(2);
   expect(selection.supplementProductsWithCount).toHaveLength(2);
@@ -282,7 +282,7 @@ it('Should apply zero count user profile with existing supplement product', () =
     .fromSelection(TEST_SELECTION)
     .supplementProducts([{...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 2}])
     .userProfiles([{...TEST_USER_PROFILE, id: 'UP2', count: 0}])
-    .build();
+    .build().selection;
 
   expect(selection.userProfilesWithCount).toHaveLength(0);
   expect(selection.supplementProductsWithCount).toHaveLength(1);
@@ -298,7 +298,7 @@ it('Should apply zero count user profile with multiple supplement products', () 
       {...TEST_SUPPLEMENT_PRODUCT, id: 'SP2', count: 1},
     ])
     .userProfiles([{...TEST_USER_PROFILE, id: 'UP2', count: 0}])
-    .build();
+    .build().selection;
 
   expect(selection.userProfilesWithCount).toHaveLength(0);
   expect(selection.supplementProductsWithCount).toHaveLength(2);
@@ -425,7 +425,7 @@ describe('isSelectableProfile with userProfileRefs', () => {
         {...TEST_USER_PROFILE, id: 'UP2', count: 2},
         {...TEST_USER_PROFILE, id: 'UP3', count: 1},
       ])
-      .build();
+      .build().selection;
 
     expect(selection).toBe(originalSelection);
   });
@@ -532,7 +532,7 @@ describe('purchaseSelectionBuilder - maxCountPerOrder', () => {
         {...TEST_USER_PROFILE, id: 'UP1', count: 2},
         {...TEST_USER_PROFILE, id: 'UP2', count: 2},
       ])
-      .build();
+      .build().selection;
 
     expect(selection).toBe(originalSelection);
   });
@@ -555,7 +555,7 @@ describe('purchaseSelectionBuilder - maxCountPerOrder', () => {
         {...TEST_USER_PROFILE, id: 'UP1', count: 2},
         {...TEST_USER_PROFILE, id: 'UP2', count: 3},
       ])
-      .build();
+      .build().selection;
 
     expect(selection.userProfilesWithCount).toHaveLength(2);
   });

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-zones.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-zones.test.ts
@@ -12,7 +12,7 @@ describe('purchaseSelectionBuilder - zones', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .fromZone({...TEST_ZONE_WITH_MD, id: 'T2'})
-      .build();
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe('T2');
     expect(selection.zones?.to.id).toBe(TEST_SELECTION.zones?.to.id);
@@ -22,7 +22,7 @@ describe('purchaseSelectionBuilder - zones', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(TEST_SELECTION)
       .toZone({...TEST_ZONE_WITH_MD, id: 'T2'})
-      .build();
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe(TEST_SELECTION.zones?.from.id);
     expect(selection.zones?.to.id).toBe('T2');
@@ -32,7 +32,7 @@ describe('purchaseSelectionBuilder - zones', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection({...TEST_SELECTION, zones: undefined})
       .fromZone({...TEST_ZONE_WITH_MD, id: 'T2'})
-      .build();
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe(undefined);
     expect(selection.zones?.to.id).toBe(undefined);
@@ -42,7 +42,7 @@ describe('purchaseSelectionBuilder - zones', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection({...TEST_SELECTION, zones: undefined})
       .toZone({...TEST_ZONE_WITH_MD, id: 'T2'})
-      .build();
+      .build().selection;
 
     expect(selection.zones?.from.id).toBe(undefined);
     expect(selection.zones?.to.id).toBe(undefined);
@@ -63,7 +63,7 @@ describe('purchaseSelectionBuilder - zones', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(originalSelection)
       .fromZone({...TEST_ZONE_WITH_MD, id: 'T2'})
-      .build();
+      .build().selection;
 
     expect(selection).toStrictEqual(originalSelection);
   });
@@ -83,7 +83,7 @@ describe('purchaseSelectionBuilder - zones', () => {
     const selection = createEmptyBuilder(TEST_INPUT)
       .fromSelection(originalSelection)
       .toZone({...TEST_ZONE_WITH_MD, id: 'T2'})
-      .build();
+      .build().selection;
 
     expect(selection).toStrictEqual(originalSelection);
   });

--- a/src/modules/purchase-selection/index.ts
+++ b/src/modules/purchase-selection/index.ts
@@ -1,4 +1,9 @@
-export type {PurchaseSelectionType, FareContractStub} from './types';
+export type {
+  PurchaseSelectionType,
+  FareContractStub,
+  ForcedSelectionChange,
+  PurchaseSelectionBuildResult,
+} from './types';
 export {usePurchaseSelectionBuilder} from './use-purchase-selection-builder';
 export {useSelectableUserProfiles} from './use-selectable-user-profiles';
 export {useSelectableFareZones} from './use-selectable-fare-zones';

--- a/src/modules/purchase-selection/purchase-selection-builder.ts
+++ b/src/modules/purchase-selection/purchase-selection-builder.ts
@@ -3,6 +3,7 @@ import type {
   PurchaseSelectionBuilderInput,
   PurchaseSelectionEmptyBuilder,
   PurchaseSelectionType,
+  ForcedSelectionChange,
 } from './types';
 import {
   applyProductChange,
@@ -51,16 +52,19 @@ const createBuilder = (
     userProfilesWithCount: selection.userProfilesWithCount,
     supplementProductsWithCount: selection.supplementProductsWithCount,
   };
+  let forcedChanges: ForcedSelectionChange[] = [];
   const builder: PurchaseSelectionBuilder = {
     product: (preassignedFareProduct) => {
       if (
         isSelectableProduct(input, currentSelection, preassignedFareProduct)
       ) {
-        currentSelection = applyProductChange(
+        const {selection, forcedChanges: changes} = applyProductChange(
           input,
           currentSelection,
           preassignedFareProduct,
         );
+        currentSelection = selection;
+        forcedChanges = changes;
       }
 
       return builder;
@@ -199,6 +203,11 @@ const createBuilder = (
         supplementProductsWithCount: onlySupplementProductsWithActualCount,
       };
     },
+
+    buildWithForcedChanges: () => ({
+      selection: builder.build(),
+      forcedChanges: [...forcedChanges],
+    }),
   };
 
   return builder;

--- a/src/modules/purchase-selection/purchase-selection-builder.ts
+++ b/src/modules/purchase-selection/purchase-selection-builder.ts
@@ -194,20 +194,21 @@ const createBuilder = (
         !isWithinOrderMax ||
         !areSupplementProductsValid
       ) {
-        return currentSelection;
+        return {
+          selection: currentSelection,
+          forcedChanges,
+        };
       }
 
       return {
-        ...currentSelection,
-        userProfilesWithCount: onlyProfilesWithActualCount,
-        supplementProductsWithCount: onlySupplementProductsWithActualCount,
+        selection: {
+          ...currentSelection,
+          userProfilesWithCount: onlyProfilesWithActualCount,
+          supplementProductsWithCount: onlySupplementProductsWithActualCount,
+        },
+        forcedChanges,
       };
     },
-
-    buildWithForcedChanges: () => ({
-      selection: builder.build(),
-      forcedChanges: [...forcedChanges],
-    }),
   };
 
   return builder;

--- a/src/modules/purchase-selection/types.ts
+++ b/src/modules/purchase-selection/types.ts
@@ -22,8 +22,8 @@ export type FareContractStub = {
 
 /**
  * Categories of selection fields that the builder may forcibly change
- * (currently only via `.product()` / `applyProductChange`) when the current
- * selection is not applicable for a newly applied product.
+ * (currently only via `.product()`) when the current selection is not
+ * applicable for a newly applied product.
  */
 export type ForcedSelectionChange = 'userProfile' | 'zone';
 

--- a/src/modules/purchase-selection/types.ts
+++ b/src/modules/purchase-selection/types.ts
@@ -28,9 +28,10 @@ export type FareContractStub = {
 export type ForcedSelectionChange = 'userProfile' | 'zone';
 
 /**
- * Result of `PurchaseSelectionBuilder.buildWithForcedChanges()`. Carries the
- * built selection along with any forced changes the builder applied during the
- * chain.
+ * Result of `PurchaseSelectionBuilder.build()`. Carries the built selection
+ * along with any forced changes the builder applied during the chain (e.g.
+ * when a product change forced a swap of traveller or zone because the
+ * previous selection wasn't applicable for the new product).
  */
 export type PurchaseSelectionBuildResult = {
   selection: PurchaseSelectionType;
@@ -172,17 +173,11 @@ export type PurchaseSelectionBuilder = {
   bonusProductId: (id?: string) => PurchaseSelectionBuilder;
 
   /**
-   * Retrieve the built purchase selection. It is the purchase selection that
-   * should be passed around between components and screens, not the builder.
-   */
-  build: () => PurchaseSelectionType;
-
-  /**
    * Retrieve the built purchase selection along with the list of forced
-   * changes the builder applied during the chain (e.g. when a product change
-   * forced a swap of traveller or zone because the previous selection wasn't
-   * applicable for the new product). Use this in call sites that want to
-   * notify the user about the forced change.
+   * changes the builder applied during the chain. Only the `selection` field
+   * should be passed around between components and screens; the
+   * `forcedChanges` list is for the immediate call site that wants to notify
+   * the user about the forced change.
    */
-  buildWithForcedChanges: () => PurchaseSelectionBuildResult;
+  build: () => PurchaseSelectionBuildResult;
 };

--- a/src/modules/purchase-selection/types.ts
+++ b/src/modules/purchase-selection/types.ts
@@ -20,6 +20,23 @@ export type FareContractStub = {
   endDate: string;
 };
 
+/**
+ * Categories of selection fields that the builder may forcibly change
+ * (currently only via `.product()` / `applyProductChange`) when the current
+ * selection is not applicable for a newly applied product.
+ */
+export type ForcedSelectionChange = 'userProfile' | 'zone';
+
+/**
+ * Result of `PurchaseSelectionBuilder.buildWithForcedChanges()`. Carries the
+ * built selection along with any forced changes the builder applied during the
+ * chain.
+ */
+export type PurchaseSelectionBuildResult = {
+  selection: PurchaseSelectionType;
+  forcedChanges: ForcedSelectionChange[];
+};
+
 export type PurchaseSelectionType = {
   fareProductTypeConfig: FareProductTypeConfig;
   preassignedFareProduct: PreassignedFareProduct;
@@ -159,4 +176,13 @@ export type PurchaseSelectionBuilder = {
    * should be passed around between components and screens, not the builder.
    */
   build: () => PurchaseSelectionType;
+
+  /**
+   * Retrieve the built purchase selection along with the list of forced
+   * changes the builder applied during the chain (e.g. when a product change
+   * forced a swap of traveller or zone because the previous selection wasn't
+   * applicable for the new product). Use this in call sites that want to
+   * notify the user about the forced change.
+   */
+  buildWithForcedChanges: () => PurchaseSelectionBuildResult;
 };

--- a/src/modules/purchase-selection/utils.ts
+++ b/src/modules/purchase-selection/utils.ts
@@ -260,8 +260,8 @@ export const applyProductChange = (
   selection: PurchaseSelectionType;
   forcedChanges: ForcedSelectionChange[];
 } => {
-  const userCount = currentSelection.userProfilesWithCount.filter((up) =>
-    isSelectableProfile(product, up),
+  const selectableProfiles = currentSelection.userProfilesWithCount.filter(
+    (up) => isSelectableProfile(product, up),
   );
   const supplementProductCount =
     currentSelection.supplementProductsWithCount.filter((sp) =>
@@ -282,13 +282,13 @@ export const applyProductChange = (
     : getDefaultZones(input, currentSelection.fareProductTypeConfig, product);
 
   const userProfiles =
-    !userCount.length && !supplementProductCount.length
+    !selectableProfiles.length && !supplementProductCount.length
       ? getDefaultUserProfiles(input, product)
-      : userCount;
+      : selectableProfiles;
 
   const forcedChanges: ForcedSelectionChange[] = [];
   if (
-    !userProfilesWithCountEqual(
+    !isUserProfilesWithCountEqual(
       currentSelection.userProfilesWithCount,
       userProfiles,
     )
@@ -310,7 +310,7 @@ export const applyProductChange = (
   };
 };
 
-const userProfilesWithCountEqual = (
+const isUserProfilesWithCountEqual = (
   a: UserProfileWithCount[],
   b: UserProfileWithCount[],
 ): boolean => {

--- a/src/modules/purchase-selection/utils.ts
+++ b/src/modules/purchase-selection/utils.ts
@@ -2,6 +2,7 @@ import type {PreassignedFareProduct} from '@atb/modules/ticketing';
 import type {
   PurchaseSelectionBuilderInput,
   PurchaseSelectionType,
+  ForcedSelectionChange,
 } from './types';
 import {FareZoneWithMetadata} from '@atb/modules/fare-zones-selector';
 import turfBooleanPointInPolygon from '@turf/boolean-point-in-polygon';
@@ -245,12 +246,20 @@ export const getPlaceSelectionMode = (
  * the new product applied, and also the existing user profiles and zones
  * selection are validated in regard to limitations on the new product. If the
  * current profiles/zones are not applicable, then defaults are applied.
+ *
+ * Returns the resulting selection along with a list of forced changes applied
+ * (e.g. user profiles or zones that were swapped because they aren't available
+ * for the new product). Call sites can use the list to notify the user about
+ * the changes.
  */
 export const applyProductChange = (
   input: PurchaseSelectionBuilderInput,
   currentSelection: PurchaseSelectionType,
   product: PreassignedFareProduct,
-): PurchaseSelectionType => {
+): {
+  selection: PurchaseSelectionType;
+  forcedChanges: ForcedSelectionChange[];
+} => {
   const userCount = currentSelection.userProfilesWithCount.filter((up) =>
     isSelectableProfile(product, up),
   );
@@ -277,12 +286,37 @@ export const applyProductChange = (
       ? getDefaultUserProfiles(input, product)
       : userCount;
 
+  const forcedChanges: ForcedSelectionChange[] = [];
+  if (
+    !userProfilesWithCountEqual(
+      currentSelection.userProfilesWithCount,
+      userProfiles,
+    )
+  ) {
+    forcedChanges.push('userProfile');
+  }
+  if (!bothZonesValid) {
+    forcedChanges.push('zone');
+  }
+
   return {
-    ...currentSelection,
-    preassignedFareProduct: product,
-    userProfilesWithCount: userProfiles,
-    zones: newZones ?? currentSelection.zones,
+    selection: {
+      ...currentSelection,
+      preassignedFareProduct: product,
+      userProfilesWithCount: userProfiles,
+      zones: newZones ?? currentSelection.zones,
+    },
+    forcedChanges,
   };
+};
+
+const userProfilesWithCountEqual = (
+  a: UserProfileWithCount[],
+  b: UserProfileWithCount[],
+): boolean => {
+  if (a.length !== b.length) return false;
+  const aById = new Map(a.map((p) => [p.id, p.count]));
+  return b.every((p) => aById.get(p.id) === p.count);
 };
 
 export const isWithinUserProfileMaxCount = (

--- a/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -238,7 +238,7 @@ function usePurchaseSelectionFromTrip(
       .fromZone(ticketInfoForBus.fromPlace)
       .toZone(ticketInfoForBus.toPlace)
       .date(ticketInfoForBus.ticketStartTime)
-      .build();
+      .build().selection;
   }
 
   if (!isFromTravelSearchToTicketBoatEnabled) {
@@ -259,7 +259,7 @@ function usePurchaseSelectionFromTrip(
       .fromStopPlace(ticketInfoForBoat.fromPlace)
       .toStopPlace(ticketInfoForBoat.toPlace)
       .date(ticketInfoForBoat.ticketStartTime)
-      .build();
+      .build().selection;
   }
 }
 

--- a/src/screen-components/travel-details-screens/legacy/TripDetailsScreenContent.tsx
+++ b/src/screen-components/travel-details-screens/legacy/TripDetailsScreenContent.tsx
@@ -260,7 +260,7 @@ function usePurchaseSelectionFromTrip(
       .fromZone(ticketInfoForBus.fromPlace)
       .toZone(ticketInfoForBus.toPlace)
       .date(ticketInfoForBus.ticketStartTime)
-      .build();
+      .build().selection;
   }
 
   if (!isFromTravelSearchToTicketBoatEnabled) {
@@ -280,7 +280,7 @@ function usePurchaseSelectionFromTrip(
       .fromStopPlace(ticketInfoForBoat.fromPlace)
       .toStopPlace(ticketInfoForBoat.toPlace)
       .date(ticketInfoForBoat.ticketStartTime)
-      .build();
+      .build().selection;
   }
 }
 

--- a/src/stacks-hierarchy/RootStack.tsx
+++ b/src/stacks-hierarchy/RootStack.tsx
@@ -299,7 +299,7 @@ export const RootStack = () => {
                       isProductSellableInApp(product, customerProfile),
                   );
                   if (isSellable) {
-                    const selection = purchaseSelectionBuilder
+                    const {selection} = purchaseSelectionBuilder
                       .forType(type)
                       .build();
                     return {

--- a/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseConfirmationScreen/Root_PurchaseConfirmationScreen.tsx
@@ -385,7 +385,7 @@ export const Root_PurchaseConfirmationScreen: React.FC<Props> = ({
             onPress={() => {
               const isSelected =
                 selection.bonusProductId === relevantTicketBonusProduct.id;
-              const next = builder
+              const {selection: next} = builder
                 .fromSelection(selection)
                 .bonusProductId(
                   isSelected ? undefined : relevantTicketBonusProduct.id,

--- a/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/Root_PurchaseFareZonesSearchByTextScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseFareZonesSearchByTextScreen/Root_PurchaseFareZonesSearchByTextScreen.tsx
@@ -85,7 +85,7 @@ export const Root_PurchaseFareZonesSearchByTextScreen: React.FC<Props> = ({
     if (zone && (fromOrTo === 'to' || isApplicableOnSingleZoneOnly)) {
       builder.toZone(zone);
     }
-    const newSelection = builder.build();
+    const {selection: newSelection} = builder.build();
 
     navigation.popTo('Root_PurchaseFareZonesSearchByMapScreen', {
       selection: newSelection,

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -37,7 +37,7 @@ export const Root_PurchaseHarborSearchScreen = ({
     const builder = selectionBuilder.fromSelection(selection);
     if (!selection.stopPlaces?.from) builder.fromStopPlace(selectedStopPlace);
     if (selection.stopPlaces?.from) builder.toStopPlace(selectedStopPlace);
-    const newSelection = builder.build();
+    const {selection: newSelection} = builder.build();
     navigation.popTo(
       'Root_PurchaseOverviewScreen',
       {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -287,7 +287,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
               selection={selection}
               style={styles.selectionComponent}
               onSelect={(selection) => {
-                const newSelection = builder
+                const {selection: newSelection} = builder
                   .fromSelection(selection)
                   .fromStopPlace(selection.stopPlaces?.from)
                   .toStopPlace(selection.stopPlaces?.to)
@@ -302,7 +302,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                 );
               }}
               onSwap={() => {
-                const newSelection = builder
+                const {selection: newSelection} = builder
                   .fromSelection(selection)
                   .fromStopPlace(selection.stopPlaces?.to)
                   .toStopPlace(selection.stopPlaces?.from)

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -26,15 +26,21 @@ import {
 } from '@atb/modules/global-messages';
 import {useFocusRefs} from '@atb/utils/use-focus-refs';
 import {FullScreenView} from '@atb/components/screen-view';
+import {Snackbar, useSnackbar} from '@atb/components/snackbar';
+import {ThemeIcon} from '@atb/components/theme-icon';
 import {FareProductHeader} from '@atb/stacks-hierarchy/Root_PurchaseOverviewScreen/components/FareProductHeader';
 import {Root_PurchaseConfirmationScreenParams} from '@atb/stacks-hierarchy/Root_PurchaseConfirmationScreen';
 import {useProductAlternatives} from '@atb/modules/ticketing';
 import {useOtherDeviceIsInspectableWarning} from '@atb/modules/fare-contracts';
 import {useParamAsState} from '@atb/utils/use-param-as-state';
-import {usePurchaseSelectionBuilder} from '@atb/modules/purchase-selection';
+import {
+  type ForcedSelectionChange,
+  usePurchaseSelectionBuilder,
+} from '@atb/modules/purchase-selection';
 import {useBookingTrips} from '@atb/modules/booking';
 import {isValidSelection} from '@atb/modules/booking';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
+import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
 
 type PurchaseOverviewError = OfferError | {type: 'booking-error'};
 type Props = RootStackScreenProps<'Root_PurchaseOverviewScreen'>;
@@ -46,10 +52,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   const focusRef = useFocusOnLoad(navigation);
   const styles = useStyles();
   const {t, language} = useTranslation();
-  const {theme} = useThemeContext();
+  const {theme, themeName} = useThemeContext();
 
   const builder = usePurchaseSelectionBuilder();
   const [selection, setSelection] = useParamAsState(params.selection);
+  const {snackbarProps, showSnackbar, hideSnackbar} = useSnackbar();
 
   const isFree = params.selection.stopPlaces?.to?.isFree || false;
 
@@ -166,6 +173,29 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
       rootPurchaseConfirmationScreenParams,
     );
   };
+
+  const showForcedChangeSnackbar = (forcedChanges: ForcedSelectionChange[]) => {
+    const items = forcedChanges.map((c) =>
+      t(PurchaseOverviewTexts.productSelection.forcedChange.items[c]),
+    );
+    const conjunction = t(dictionary.listConcatWord);
+    const list =
+      items.length === 1
+        ? items[0]
+        : `${items.slice(0, -1).join(', ')} ${conjunction} ${items.at(-1)}`;
+    showSnackbar({
+      content: {
+        iconNode: <ThemeIcon svg={statusTypeToIcon('info', true, themeName)} />,
+        title: t(PurchaseOverviewTexts.productSelection.forcedChange.title),
+        description: t(
+          PurchaseOverviewTexts.productSelection.forcedChange.message(list),
+        ),
+      },
+      position: 'top',
+      isDismissable: true,
+    });
+  };
+
   const summaryButtonText = () => {
     if (isBookingRequired) {
       return t(PurchaseOverviewTexts.summary.button.selectDeparture);
@@ -177,188 +207,196 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   };
 
   return (
-    <FullScreenView
-      focusRef={focusRef}
-      headerProps={{
-        title: getTextForLanguage(
-          selection.fareProductTypeConfig.name,
-          language,
-        ),
-        leftButton: {
-          type: 'back',
-          onPress: closeModal,
-        },
-        globalMessageContext: GlobalMessageContextEnum.appTicketing,
-      }}
-      headerContent={(focusRef) => (
-        <FareProductHeader
-          ref={params.onFocusElement ? undefined : focusRef}
-          style={styles.header}
-          fareProductTypeConfig={selection.fareProductTypeConfig}
-          onTicketInfoButtonPress={handleTicketInfoButtonPress}
-        />
-      )}
-    >
-      <ScrollView testID="purchaseOverviewScrollView">
-        <View style={styles.contentContainer}>
-          {params.mode === 'TravelSearch' && (
-            <MessageInfoBox
-              type="valid"
-              message={t(PurchaseOverviewTexts.travelSearchInfo)}
-            />
-          )}
-          {!!error &&
-            (error?.type === 'not-available' ? (
+    <>
+      <FullScreenView
+        focusRef={focusRef}
+        headerProps={{
+          title: getTextForLanguage(
+            selection.fareProductTypeConfig.name,
+            language,
+          ),
+          leftButton: {
+            type: 'back',
+            onPress: closeModal,
+          },
+          globalMessageContext: GlobalMessageContextEnum.appTicketing,
+        }}
+        headerContent={(focusRef) => (
+          <FareProductHeader
+            ref={params.onFocusElement ? undefined : focusRef}
+            style={styles.header}
+            fareProductTypeConfig={selection.fareProductTypeConfig}
+            onTicketInfoButtonPress={handleTicketInfoButtonPress}
+          />
+        )}
+      >
+        <ScrollView testID="purchaseOverviewScrollView">
+          <View style={styles.contentContainer}>
+            {params.mode === 'TravelSearch' && (
               <MessageInfoBox
-                type="warning"
-                title={t(
-                  PurchaseOverviewTexts.errorMessageBox.productUnavailable.title(
-                    getReferenceDataName(preassignedFareProduct, language),
-                  ),
-                )}
-                message={t(
-                  PurchaseOverviewTexts.errorMessageBox.productUnavailable
-                    .message,
-                )}
+                type="valid"
+                message={t(PurchaseOverviewTexts.travelSearchInfo)}
               />
-            ) : (
-              <MessageInfoBox
-                type="error"
-                title={t(PurchaseOverviewTexts.errorMessageBox.title)}
-                message={t(PurchaseOverviewTexts.errorMessageBox.message)}
-                onPressConfig={{
-                  action: refreshOffer,
-                  text: t(dictionary.retry),
-                }}
-              />
-            ))}
-
-          <ProductSelection
-            selection={selection}
-            setSelection={setSelection}
-            style={styles.selectionComponent}
-          />
-
-          <TravellerSelection
-            selection={selection}
-            onSave={(selection) => {
-              setSelection(selection);
-            }}
-            style={styles.selectionComponent}
-          />
-
-          <FromToSelection
-            selection={selection}
-            style={styles.selectionComponent}
-            onSelect={(selection) => {
-              const newSelection = builder
-                .fromSelection(selection)
-                .fromStopPlace(selection.stopPlaces?.from)
-                .toStopPlace(selection.stopPlaces?.to)
-                .build();
-              setSelection(newSelection);
-              navigation.setParams({onFocusElement: undefined});
-              navigation.push(
-                zoneSelectionMode === 'multiple-stop-harbor'
-                  ? 'Root_PurchaseHarborSearchScreen'
-                  : 'Root_PurchaseFareZonesSearchByMapScreen',
-                {selection},
-              );
-            }}
-            onSwap={() => {
-              const newSelection = builder
-                .fromSelection(selection)
-                .fromStopPlace(selection.stopPlaces?.to)
-                .toStopPlace(selection.stopPlaces?.from)
-                .build();
-              setSelection(newSelection);
-            }}
-            ref={focusRefs}
-          />
-
-          {
-            // When booking is enabled, the next step is selecting the departure (implicitly the time)
-            !selection.preassignedFareProduct.isBookingEnabled && (
-              <StartTimeSelection
-                selection={selection}
-                setSelection={setSelection}
-                style={styles.selectionComponent}
-              />
-            )
-          }
-
-          {isFree ? (
-            <MessageInfoBox
-              type="valid"
-              message={t(PurchaseOverviewTexts.summary.free)}
-              style={styles.isFreeMessage}
-            />
-          ) : (
-            <View style={styles.messages}>
-              {inspectableTokenWarningText && (
+            )}
+            {!!error &&
+              (error?.type === 'not-available' ? (
                 <MessageInfoBox
                   type="warning"
-                  message={inspectableTokenWarningText}
-                  isMarkdown={true}
+                  title={t(
+                    PurchaseOverviewTexts.errorMessageBox.productUnavailable.title(
+                      getReferenceDataName(preassignedFareProduct, language),
+                    ),
+                  )}
+                  message={t(
+                    PurchaseOverviewTexts.errorMessageBox.productUnavailable
+                      .message,
+                  )}
                 />
-              )}
-              <GlobalMessage
-                globalMessageContext={
-                  GlobalMessageContextEnum.appPurchaseOverview
-                }
-                textColor={theme.color.background.neutral[0]}
-                ruleVariables={{
-                  preassignedFareProductType: preassignedFareProduct.type,
-                  fromFareZone: selection.zones?.from.id || 'none',
-                  toFareZone: selection.zones?.to.id || 'none',
-                  userTypes: userTypeStrings,
-                }}
-              />
-            </View>
-          )}
+              ) : (
+                <MessageInfoBox
+                  type="error"
+                  title={t(PurchaseOverviewTexts.errorMessageBox.title)}
+                  message={t(PurchaseOverviewTexts.errorMessageBox.message)}
+                  onPressConfig={{
+                    action: refreshOffer,
+                    text: t(dictionary.retry),
+                  }}
+                />
+              ))}
 
-          <Summary
-            isLoading={isBookingRequired ? false : isSearchingOffer}
-            isFree={isFree}
-            isDisabled={!!error || !canProceed}
-            originalPrice={originalPrice}
-            price={isBookingRequired ? undefined : totalPrice}
-            summaryButtonText={summaryButtonText()}
-            onPressBuy={() => {
-              analytics.logEvent('Ticketing', 'Purchase summary clicked', {
-                fareProduct: selection.fareProductTypeConfig.name,
-                fareZone: {
-                  from: selection.zones?.from.id,
-                  to: selection.zones?.to.id,
-                },
-                stopPlaces: {
-                  from: selection.stopPlaces?.from?.id,
-                  to: selection.stopPlaces?.to?.id,
-                },
-                userProfilesWithCount: selection.userProfilesWithCount.map(
-                  (t) => ({
-                    userType: t.userTypeString,
-                    count: t.count,
-                  }),
-                ),
-                baggageProductsWithCount:
-                  selection.supplementProductsWithCount.map((sp) => ({
-                    id: sp.id,
-                    count: sp.count,
-                  })),
-                preassignedFareProduct: {
-                  id: selection.preassignedFareProduct.id,
-                  name: selection.preassignedFareProduct.name.value,
-                },
-                travelDate: selection.travelDate,
-                mode: params.mode,
-              });
-              onPressBuy();
-            }}
-          />
-        </View>
-      </ScrollView>
-    </FullScreenView>
+            <ProductSelection
+              selection={selection}
+              onProductChange={({selection: newSelection, forcedChanges}) => {
+                setSelection(newSelection);
+                if (forcedChanges.length > 0) {
+                  showForcedChangeSnackbar(forcedChanges);
+                }
+              }}
+              style={styles.selectionComponent}
+            />
+
+            <TravellerSelection
+              selection={selection}
+              onSave={(selection) => {
+                setSelection(selection);
+              }}
+              style={styles.selectionComponent}
+            />
+
+            <FromToSelection
+              selection={selection}
+              style={styles.selectionComponent}
+              onSelect={(selection) => {
+                const newSelection = builder
+                  .fromSelection(selection)
+                  .fromStopPlace(selection.stopPlaces?.from)
+                  .toStopPlace(selection.stopPlaces?.to)
+                  .build();
+                setSelection(newSelection);
+                navigation.setParams({onFocusElement: undefined});
+                navigation.push(
+                  zoneSelectionMode === 'multiple-stop-harbor'
+                    ? 'Root_PurchaseHarborSearchScreen'
+                    : 'Root_PurchaseFareZonesSearchByMapScreen',
+                  {selection},
+                );
+              }}
+              onSwap={() => {
+                const newSelection = builder
+                  .fromSelection(selection)
+                  .fromStopPlace(selection.stopPlaces?.to)
+                  .toStopPlace(selection.stopPlaces?.from)
+                  .build();
+                setSelection(newSelection);
+              }}
+              ref={focusRefs}
+            />
+
+            {
+              // When booking is enabled, the next step is selecting the departure (implicitly the time)
+              !selection.preassignedFareProduct.isBookingEnabled && (
+                <StartTimeSelection
+                  selection={selection}
+                  setSelection={setSelection}
+                  style={styles.selectionComponent}
+                />
+              )
+            }
+
+            {isFree ? (
+              <MessageInfoBox
+                type="valid"
+                message={t(PurchaseOverviewTexts.summary.free)}
+                style={styles.isFreeMessage}
+              />
+            ) : (
+              <View style={styles.messages}>
+                {inspectableTokenWarningText && (
+                  <MessageInfoBox
+                    type="warning"
+                    message={inspectableTokenWarningText}
+                    isMarkdown={true}
+                  />
+                )}
+                <GlobalMessage
+                  globalMessageContext={
+                    GlobalMessageContextEnum.appPurchaseOverview
+                  }
+                  textColor={theme.color.background.neutral[0]}
+                  ruleVariables={{
+                    preassignedFareProductType: preassignedFareProduct.type,
+                    fromFareZone: selection.zones?.from.id || 'none',
+                    toFareZone: selection.zones?.to.id || 'none',
+                    userTypes: userTypeStrings,
+                  }}
+                />
+              </View>
+            )}
+
+            <Summary
+              isLoading={isBookingRequired ? false : isSearchingOffer}
+              isFree={isFree}
+              isDisabled={!!error || !canProceed}
+              originalPrice={originalPrice}
+              price={isBookingRequired ? undefined : totalPrice}
+              summaryButtonText={summaryButtonText()}
+              onPressBuy={() => {
+                analytics.logEvent('Ticketing', 'Purchase summary clicked', {
+                  fareProduct: selection.fareProductTypeConfig.name,
+                  fareZone: {
+                    from: selection.zones?.from.id,
+                    to: selection.zones?.to.id,
+                  },
+                  stopPlaces: {
+                    from: selection.stopPlaces?.from?.id,
+                    to: selection.stopPlaces?.to?.id,
+                  },
+                  userProfilesWithCount: selection.userProfilesWithCount.map(
+                    (t) => ({
+                      userType: t.userTypeString,
+                      count: t.count,
+                    }),
+                  ),
+                  baggageProductsWithCount:
+                    selection.supplementProductsWithCount.map((sp) => ({
+                      id: sp.id,
+                      count: sp.count,
+                    })),
+                  preassignedFareProduct: {
+                    id: selection.preassignedFareProduct.id,
+                    name: selection.preassignedFareProduct.name.value,
+                  },
+                  travelDate: selection.travelDate,
+                  mode: params.mode,
+                });
+                onPressBuy();
+              }}
+            />
+          </View>
+        </ScrollView>
+      </FullScreenView>
+      <Snackbar {...snackbarProps} onHideSnackbar={hideSnackbar} />
+    </>
   );
 };
 

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/HarborSelection.tsx
@@ -77,7 +77,7 @@ export const HarborSelection = forwardRef<
                     .fromStopPlace(undefined)
                     .toStopPlace(undefined)
                     .legs([])
-                    .build(),
+                    .build().selection,
                 )
               }
               ref={fromHarborRef}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelection.tsx
@@ -2,17 +2,20 @@ import {ProductSelectionByAlias} from './ProductSelectionByAlias';
 import {ProductSelectionByProducts} from './ProductSelectionByProducts';
 import {StyleProp, ViewStyle} from 'react-native';
 import {useThemeContext} from '@atb/theme';
-import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
+import type {
+  PurchaseSelectionBuildResult,
+  PurchaseSelectionType,
+} from '@atb/modules/purchase-selection';
 
 type ProductSelectionProps = {
   selection: PurchaseSelectionType;
-  setSelection: (s: PurchaseSelectionType) => void;
+  onProductChange: (result: PurchaseSelectionBuildResult) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ProductSelection({
   selection,
-  setSelection,
+  onProductChange,
   style,
 }: ProductSelectionProps) {
   const {theme} = useThemeContext();
@@ -22,7 +25,7 @@ export function ProductSelection({
       return (
         <ProductSelectionByProducts
           selection={selection}
-          setSelection={setSelection}
+          onProductChange={onProductChange}
           style={style}
         />
       );
@@ -32,7 +35,7 @@ export function ProductSelection({
         <ProductSelectionByAlias
           color={theme.color.interactive[2]}
           selection={selection}
-          setSelection={setSelection}
+          onProductChange={onProductChange}
           style={style}
         />
       );

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
@@ -16,6 +16,7 @@ import {
 import {ContentHeading} from '@atb/components/heading';
 import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
 import {
+  type PurchaseSelectionBuildResult,
   type PurchaseSelectionType,
   usePurchaseSelectionBuilder,
 } from '@atb/modules/purchase-selection';
@@ -24,14 +25,14 @@ import {isProductSellableInApp} from '@atb/utils/is-product-sellable-in-app';
 type Props = {
   color: InteractiveColor;
   selection: PurchaseSelectionType;
-  setSelection: (s: PurchaseSelectionType) => void;
+  onProductChange: (result: PurchaseSelectionBuildResult) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ProductSelectionByAlias({
   color,
   selection,
-  setSelection,
+  onProductChange,
   style,
 }: Props) {
   const {t, language} = useTranslation();
@@ -76,11 +77,11 @@ export function ProductSelectionByAlias({
                   : selection.preassignedFareProduct.id === fp.id
               }
               onPress={() => {
-                const newSelection = selectionBuilder
+                const result = selectionBuilder
                   .fromSelection(selection)
                   .product(fp)
-                  .build();
-                setSelection(newSelection);
+                  .buildWithForcedChanges();
+                onProductChange(result);
               }}
               key={i}
             />

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByAlias.tsx
@@ -80,7 +80,7 @@ export function ProductSelectionByAlias({
                 const result = selectionBuilder
                   .fromSelection(selection)
                   .product(fp)
-                  .buildWithForcedChanges();
+                  .build();
                 onProductChange(result);
               }}
               key={i}

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -90,7 +90,7 @@ export function ProductSelectionByProducts({
               const result = selectionBuilder
                 .fromSelection(selection)
                 .product(p)
-                .buildWithForcedChanges();
+                .build();
               onProductChange(result);
             }}
             accessibilityHint={t(

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/ProductSelectionByProducts.tsx
@@ -22,6 +22,7 @@ import {usePreferencesContext} from '@atb/modules/preferences';
 import {ContentHeading} from '@atb/components/heading';
 import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
 import {
+  type PurchaseSelectionBuildResult,
   type PurchaseSelectionType,
   usePurchaseSelectionBuilder,
 } from '@atb/modules/purchase-selection';
@@ -29,13 +30,13 @@ import {isProductSellableInApp} from '@atb/utils/is-product-sellable-in-app';
 
 type ProductSelectionByProductsProps = {
   selection: PurchaseSelectionType;
-  setSelection: (s: PurchaseSelectionType) => void;
+  onProductChange: (result: PurchaseSelectionBuildResult) => void;
   style?: StyleProp<ViewStyle>;
 };
 
 export function ProductSelectionByProducts({
   selection,
-  setSelection,
+  onProductChange,
   style,
 }: ProductSelectionByProductsProps) {
   const {t, language} = useTranslation();
@@ -86,11 +87,11 @@ export function ProductSelectionByProducts({
             }
             selected={selection.preassignedFareProduct}
             onSelect={(p) => {
-              const newSelection = selectionBuilder
+              const result = selectionBuilder
                 .fromSelection(selection)
                 .product(p)
-                .build();
-              setSelection(newSelection);
+                .buildWithForcedChanges();
+              onProductChange(result);
             }}
             accessibilityHint={t(
               PurchaseOverviewTexts.productSelection.a11yTitle,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/StartTimeSelection.tsx
@@ -75,7 +75,7 @@ export function StartTimeSelection({
           },
         ]}
         onSave={(selectedOption) => {
-          const newSelection = selectionBuilder
+          const {selection: newSelection} = selectionBuilder
             .fromSelection(selection)
             .date(
               selectedOption.option === 'now' ||

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelection.tsx
@@ -180,7 +180,7 @@ export function TravellerSelection({
           text={t(PurchaseOverviewTexts.onBehalfOf.sendToOthersText)}
           value={selection.isOnBehalfOf}
           onValueChange={(newValue) => {
-            const newSelection = builder
+            const {selection: newSelection} = builder
               .fromSelection(selection)
               .isOnBehalfOf(newValue)
               .build();

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/TravellerSelectionSheet.tsx
@@ -59,7 +59,7 @@ export const TravellerSelectionSheet = ({
     if (currentSelection?.baggageProducts)
       builder.supplementProducts(currentSelection.baggageProducts);
 
-    const newSelection = builder.build();
+    const {selection: newSelection} = builder.build();
     onSave(newSelection);
   };
 

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_PurchaseTabScreen/TicketTabNav_PurchaseTabScreen.tsx
@@ -78,7 +78,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
       type: fareProductTypeConfig.type,
     });
 
-    const selection = selectionBuilder
+    const {selection} = selectionBuilder
       .forType(fareProductTypeConfig.type)
       .build();
 
@@ -132,7 +132,7 @@ export const TicketTabNav_PurchaseTabScreen = ({navigation}: Props) => {
       .toStopPlace(mapPlace(rfc.pointToPointValidity?.toPlace));
     if (rfc.fromFareZone) builder.fromZone(mapZone(rfc.fromFareZone));
     if (rfc.toFareZone) builder.toZone(mapZone(rfc.toFareZone));
-    const selection = builder.build();
+    const {selection} = builder.build();
 
     /*
      *  If booking is enabled we need the user to select a departure, and

--- a/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
+++ b/src/stacks-hierarchy/Root_TripSelectionScreen/Root_TripSelectionScreen.tsx
@@ -64,11 +64,12 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
           searchTime={searchTime}
           setSearchTime={(searchTime) => {
             setSearchTime(searchTime);
-            setSelection((prevSelection) =>
-              builder
-                .fromSelection(prevSelection)
-                .date(searchTime.date)
-                .build(),
+            setSelection(
+              (prevSelection) =>
+                builder
+                  .fromSelection(prevSelection)
+                  .date(searchTime.date)
+                  .build().selection,
             );
           }}
         />
@@ -77,7 +78,7 @@ export const Root_TripSelectionScreen: React.FC<Props> = ({
         <BookingTripSelection
           selection={selection}
           onSelect={(legs) => {
-            const newSelection = builder
+            const {selection: newSelection} = builder
               .fromSelection(selection)
               .legs(legs)
               .build();

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -146,6 +146,23 @@ const PurchaseOverviewTexts = {
       'Activate to select ticket',
       'Aktivér for å velje billett',
     ),
+    forcedChange: {
+      title: _(
+        'Andre valg ble endret',
+        'Other selections were changed',
+        'Andre val vart endra',
+      ),
+      message: (changedItems: string) =>
+        _(
+          `Valgene for ${changedItems} ble endret fordi valgene ikke er tilgjengelige for den valgte billetten.`,
+          `The selections for ${changedItems} were changed because they are not available for the selected ticket.`,
+          `Vala for ${changedItems} vart endra fordi vala ikkje er tilgjengelege for den valde billetten.`,
+        ),
+      items: {
+        userProfile: _('reisende', 'travellers', 'reisande'),
+        zone: _('soner', 'zones', 'soner'),
+      },
+    },
   },
   travellerSelection: {
     titleSingle: _('Reisende', 'Traveller', 'Reisande'),

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -154,9 +154,9 @@ const PurchaseOverviewTexts = {
       ),
       message: (changedItems: string) =>
         _(
-          `Valgene for ${changedItems} ble endret fordi valgene ikke er tilgjengelige for den valgte billetten.`,
+          `Valgene for ${changedItems} ble endret fordi de ikke er tilgjengelige for den valgte billetten.`,
           `The selections for ${changedItems} were changed because they are not available for the selected ticket.`,
-          `Vala for ${changedItems} vart endra fordi vala ikkje er tilgjengelege for den valde billetten.`,
+          `Vala for ${changedItems} vart endra fordi dei ikkje er tilgjengelege for den valde billetten.`,
         ),
       items: {
         userProfile: _('reisende', 'travellers', 'reisande'),


### PR DESCRIPTION
When changing fare product forces a swap of traveller or zone, because
the previous selection isn't available for the new product, the
builder now reports the forced changes and the purchase overview shows
a snackbar so the user understands why their selection changed.

<img width="350" src="https://github.com/user-attachments/assets/899b6c8b-324f-4353-a472-0e566c0dca46" />
