### PR TITLE
refactor: use SituationFragment instead of SituationType

### DIFF
--- a/src/modules/situations/SituationBottomSheet.tsx
+++ b/src/modules/situations/SituationBottomSheet.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import {View} from 'react-native';
 import {InfoLinkFragment} from '@atb/api/types/generated/fragments/shared';
 import {StyleSheet} from '@atb/theme';
-import {SituationType} from './types';
+import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {SituationOrNoticeIcon} from './SituationOrNoticeIcon';
 import {daysBetween, formatToLongDateTime} from '@atb/utils/date';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -27,7 +27,7 @@ import {
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 
 type Props = {
-  situation: SituationType;
+  situation: SituationFragment;
   bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   onCloseFocusRef: React.RefObject<View | null>;
 };
@@ -112,7 +112,9 @@ const filterInfoLinks = (
     (il: Partial<InfoLinkFragment>): il is InfoLinkFragment => !!il.uri,
   ) || [];
 
-const useValidityPeriodText = (period?: SituationType['validityPeriod']) => {
+const useValidityPeriodText = (
+  period?: SituationFragment['validityPeriod'],
+) => {
   const {t, language} = useTranslation();
 
   const endTime = validateEndTime(period?.endTime);

--- a/src/modules/situations/SituationMessageBox.tsx
+++ b/src/modules/situations/SituationMessageBox.tsx
@@ -5,13 +5,13 @@ import {
 import React from 'react';
 import {getMessageTypeForSituation, getSituationSummary} from './utils';
 import {dictionary, useTranslation} from '@atb/translations';
-import {SituationType} from './types';
+import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import type {A11yLiveRegion} from '@atb/components/screen-reader-announcement';
 import {SituationBottomSheet} from './SituationBottomSheet';
 import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 
 export type Props = {
-  situation: SituationType;
+  situation: SituationFragment;
   noStatusIcon?: MessageInfoBoxProps['noStatusIcon'];
   style?: MessageInfoBoxProps['style'];
   a11yLiveRegion?: A11yLiveRegion;

--- a/src/modules/situations/SituationOrNoticeIcon.tsx
+++ b/src/modules/situations/SituationOrNoticeIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {getSvgForMostCriticalSituationOrNotice} from './utils';
-import {SituationType} from './types';
+import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
 import {StyleProp, ViewStyle} from 'react-native';
@@ -11,7 +11,7 @@ type Props = {
   accessibilityLabel?: string;
   notices?: NoticeFragment[];
   cancellation?: boolean;
-} & ({situations: SituationType[]} | {situation: SituationType});
+} & ({situations: SituationFragment[]} | {situation: SituationFragment});
 
 export const SituationOrNoticeIcon = ({
   style,

--- a/src/modules/situations/SituationSectionItem.tsx
+++ b/src/modules/situations/SituationSectionItem.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {dictionary, useTranslation} from '@atb/translations';
 import {MessageSectionItem, SectionItemProps} from '@atb/components/sections';
 import {getMessageTypeForSituation, getSituationSummary} from './utils';
-import {SituationType} from './types';
+import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {SituationBottomSheet} from './SituationBottomSheet';
 import {View} from 'react-native';
 import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 
 type Props = SectionItemProps<{
-  situation: SituationType;
+  situation: SituationFragment;
 }>;
 
 export const SituationSectionItem = ({situation, ...sectionProps}: Props) => {

--- a/src/modules/situations/types.ts
+++ b/src/modules/situations/types.ts
@@ -1,4 +1,0 @@
-import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
-import {PtSituationElement} from '@atb/api/types/generated/journey_planner_v3_types';
-
-export type SituationType = PtSituationElement | SituationFragment;

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -1,4 +1,3 @@
-import {SituationType} from './types';
 import {
   getTextForLanguage,
   Language,
@@ -79,7 +78,7 @@ export function findAllSituations(
  * Get the situation summary, with a fallback to the description.
  */
 export const getSituationSummary = (
-  situation: SituationType,
+  situation: SituationFragment,
   language: Language,
 ): string | undefined => {
   let text = getTextForLanguage(situation.summary, language);
@@ -90,12 +89,12 @@ export const getSituationSummary = (
 };
 
 export const getMessageTypeForSituation = (
-  situation: SituationType,
+  situation: SituationFragment,
 ): Extract<Statuses, 'warning' | 'info'> =>
   situation.reportType === 'incident' ? 'warning' : 'info';
 
 export const getMsgTypeForMostCriticalSituationOrNotice = (
-  situations: SituationType[],
+  situations: SituationFragment[],
   notices?: NoticeFragment[],
   cancellation: boolean = false,
 ): Exclude<Statuses, 'valid'> | undefined => {
@@ -126,7 +125,7 @@ export const toMostCriticalStatus = <T extends Statuses | undefined>(
 };
 
 export const getSvgForMostCriticalSituationOrNotice = (
-  situations: SituationType[],
+  situations: SituationFragment[],
   themeName: Mode,
   notices?: NoticeFragment[],
   cancellation: boolean = false,
@@ -178,7 +177,7 @@ export const getA11yLabelForLeg = (
 };
 
 export const getSituationOrNoticeA11yLabel = (
-  situations: SituationType[],
+  situations: SituationFragment[],
   notices: NoticeFragment[],
   cancellation: boolean = false,
   t: TranslateFunction,
@@ -206,7 +205,7 @@ export const getSituationOrNoticeA11yLabel = (
  */
 export const isSituationValidAtDate =
   (date: string | Date = new Date()) =>
-  (situation: SituationType) => {
+  (situation: SituationFragment) => {
     const {startTime, endTime} = situation.validityPeriod || {};
     if (startTime && endTime) {
       return isBetween(date, startTime, endTime);


### PR DESCRIPTION
The SituationType union of PtSituationElement | SituationFragment is no
longer needed, all call sites in the situations module now work with
SituationFragment directly.

### Acceptance criteria

Technical issue, no testing necessary
