### PR TITLE
refactor: simplify TripSearchScreen render body

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -169,6 +169,11 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const [flexibleTransportInfoDismissed, setFlexibleTransportInfoDismissed] =
     useState(false);
   const isFlexibleTransportEnabled = isFlexibleTransportEnabledInRemoteConfig;
+  const shouldShowCityZoneMessage =
+    isFlexibleTransportEnabled &&
+    !flexibleTransportInfoDismissed &&
+    (tripPatterns.length > 0 || tripsSearchState === 'search-empty-result') &&
+    !tripsIsError;
 
   const [searchStateMessage, setSearchStateMessage] = useState<
     string | undefined
@@ -418,23 +423,19 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
                 .filter(onlyUniques),
             }}
           />
-          {isFlexibleTransportEnabled &&
-            !flexibleTransportInfoDismissed &&
-            (tripPatterns.length > 0 ||
-              tripsSearchState === 'search-empty-result') &&
-            !tripsIsError && (
-              <CityZoneMessage
-                from={from}
-                to={to}
-                onDismiss={() => {
-                  setFlexibleTransportInfoDismissed(true);
-                  analytics.logEvent(
-                    'Flexible transport',
-                    'Message box dismissed',
-                  );
-                }}
-              />
-            )}
+          {shouldShowCityZoneMessage && (
+            <CityZoneMessage
+              from={from}
+              to={to}
+              onDismiss={() => {
+                setFlexibleTransportInfoDismissed(true);
+                analytics.logEvent(
+                  'Flexible transport',
+                  'Message box dismissed',
+                );
+              }}
+            />
+          )}
           {tripSearchEnabled && (
             <NonTransitResults
               tripsProps={tripsProps}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -48,14 +48,17 @@ import {TripPattern} from '@atb/api/types/trips';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
 import {NativeBlockButton} from '@atb/components/native-button';
-import {getSearchTime, getSearchTimeLabel, sanitizeSearchTime} from './utils';
+import {
+  getSearchTime,
+  getSearchTimeLabel,
+  sanitizeSearchTime,
+  uniqueLegValues,
+} from './utils';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {
   GlobalMessage,
   GlobalMessageContextEnum,
 } from '@atb/modules/global-messages';
-import {isDefined} from '@atb/utils/presence';
-import {onlyUniques} from '@atb/utils/only-uniques';
 import {DatePickerSheet} from '@atb/components/date-selection';
 import SharedTexts from '@atb/translations/shared';
 import {TravelSearchFiltersBottomSheet} from './components/TravelSearchFiltersBottomSheet';
@@ -401,26 +404,19 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
             style={styles.globalMessage}
             globalMessageContext={GlobalMessageContextEnum.appTripResults}
             ruleVariables={{
-              transportModes: tripPatterns
-                .flatMap((tp) => tp.legs)
-                .map((leg) => leg.mode)
-                .filter(isDefined)
-                .filter(onlyUniques),
-              transportSubmodes: tripPatterns
-                .flatMap((tp) => tp.legs)
-                .map((leg) => leg.transportSubmode)
-                .filter(isDefined)
-                .filter(onlyUniques),
-              authorities: tripPatterns
-                .flatMap((tp) => tp.legs)
-                .map((leg) => leg.authority?.id)
-                .filter(isDefined)
-                .filter(onlyUniques),
-              publicCodes: tripPatterns
-                .flatMap((tp) => tp.legs)
-                .map((leg) => leg.line?.publicCode)
-                .filter(isDefined)
-                .filter(onlyUniques),
+              transportModes: uniqueLegValues(tripPatterns, (leg) => leg.mode),
+              transportSubmodes: uniqueLegValues(
+                tripPatterns,
+                (leg) => leg.transportSubmode,
+              ),
+              authorities: uniqueLegValues(
+                tripPatterns,
+                (leg) => leg.authority?.id,
+              ),
+              publicCodes: uniqueLegValues(
+                tripPatterns,
+                (leg) => leg.line?.publicCode,
+              ),
             }}
           />
           {shouldShowCityZoneMessage && (

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -90,7 +90,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const focusRef = useFocusOnLoad(navigation);
 
   const {language, t} = useTranslation();
-  const [updatingLocation] = useState<boolean>(false);
   const analytics = useAnalyticsContext();
   const filterButtonWrapperRef = useRef(null);
   const filterButtonRef = useRef(null);
@@ -167,7 +166,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
   const showEmptyScreen = !tripPatterns && !isSearching && !tripsIsError;
   const isEmptyResult = !isSearching && !tripPatterns?.length;
   const noResultReasons = computeNoResultReasons(t, searchTime, from, to);
-  const isValidLocations = isValidTripLocations(from, to);
   const [flexibleTransportInfoDismissed, setFlexibleTransportInfoDismissed] =
     useState(false);
   const isFlexibleTransportEnabled = isFlexibleTransportEnabledInRemoteConfig;
@@ -302,7 +300,6 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
               svgIcon={Swap}
               onPress={swap}
               overlayPosition="right"
-              isLoading={updatingLocation && !to}
               accessibilityLabel={
                 t(TripSearchTexts.location.swapButton.a11yLabel) +
                 screenReaderPause
@@ -460,7 +457,7 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
             />
           )}
           {!tripPatterns.length && <View style={styles.emptyResultsSpacer} />}
-          {!tripsIsError && isValidLocations && (
+          {!tripsIsError && tripSearchEnabled && (
             <NativeBlockButton
               onPress={loadMoreTrips}
               disabled={tripsSearchState === 'searching'}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/Dashboard_TripSearchScreen.tsx
@@ -1,9 +1,7 @@
 import {Filter, Swap} from '@atb/assets/svg/mono-icons/actions';
-import {ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
 import {screenReaderPause, ThemeText} from '@atb/components/text';
 import {ScreenReaderAnnouncement} from '@atb/components/screen-reader-announcement';
 import {LocationInputSectionItem, Section} from '@atb/components/sections';
-import {ThemeIcon} from '@atb/components/theme-icon';
 import {
   GeoLocation,
   Location,
@@ -44,10 +42,10 @@ import {useTravelSearchFiltersState} from '@atb/stacks-hierarchy/Root_TabNavigat
 
 import {FullScreenView} from '@atb/components/screen-view';
 import {CityZoneMessage} from './components/CityZoneMessage';
+import {LoadMoreButton} from './components/LoadMoreButton';
 import {TripPattern} from '@atb/api/types/trips';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {NonTransitResults} from '@atb/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/NonTransitResults';
-import {NativeBlockButton} from '@atb/components/native-button';
 import {
   getSearchTime,
   getSearchTimeLabel,
@@ -65,7 +63,6 @@ import {TravelSearchFiltersBottomSheet} from './components/TravelSearchFiltersBo
 import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {WithOverlayButton} from '@atb/components/overlay-button';
-import {Loading} from '@atb/components/loading';
 import {useManualRefreshControlProps} from '@atb/utils/use-manual-refresh-props';
 import type {TravelSearchFiltersSelectionType} from '@atb/modules/travel-search-filters';
 
@@ -454,51 +451,13 @@ export const Dashboard_TripSearchScreen: React.FC<RootProps> = ({
             />
           )}
           {!tripPatterns.length && <View style={styles.emptyResultsSpacer} />}
-          {!tripsIsError && tripSearchEnabled && (
-            <NativeBlockButton
-              onPress={loadMoreTrips}
-              disabled={tripsSearchState === 'searching'}
-              style={[styles.loadMoreButton, {opacity: 1}]}
-              testID="loadMoreButton"
-            >
-              {tripsSearchState === 'searching' ? (
-                <View style={styles.loadingIndicator}>
-                  {tripPatterns.length ? (
-                    <>
-                      <Loading
-                        style={{
-                          marginRight: theme.spacing.medium,
-                        }}
-                      />
-                      <ThemeText type="secondary" testID="searchingForResults">
-                        {t(TripSearchTexts.results.fetchingMore)}
-                      </ThemeText>
-                    </>
-                  ) : (
-                    <ThemeText type="secondary" testID="searchingForResults">
-                      {t(TripSearchTexts.searchState.searching)}
-                    </ThemeText>
-                  )}
-                </View>
-              ) : (
-                <>
-                  {loadMoreTrips ? (
-                    <>
-                      <ThemeIcon
-                        color="secondary"
-                        svg={ExpandMore}
-                        size="normal"
-                      />
-                      <ThemeText type="secondary" testID="resultsLoaded">
-                        {' '}
-                        {t(TripSearchTexts.results.fetchMore)}
-                      </ThemeText>
-                    </>
-                  ) : null}
-                </>
-              )}
-            </NativeBlockButton>
-          )}
+          <LoadMoreButton
+            loadMoreTrips={loadMoreTrips}
+            isSearching={isSearching}
+            hasResults={tripPatterns.length > 0}
+            tripsIsError={tripsIsError}
+            tripSearchEnabled={tripSearchEnabled}
+          />
         </View>
       </FullScreenView>
       {filtersState.filtersSelection && (
@@ -689,20 +648,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     marginTop: theme.spacing.medium,
     backgroundColor: getHeaderBackgroundColor(theme).background,
   },
-  loadingIndicator: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
   missingLocationText: {
     padding: theme.spacing.xLarge,
     textAlign: 'center',
-  },
-  loadMoreButton: {
-    paddingVertical: theme.spacing.medium,
-    marginBottom: theme.spacing.xLarge,
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'center',
   },
   emptyResultsSpacer: {
     marginTop: theme.spacing.xLarge * 3,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/__tests__/unique-leg-values.test.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/__tests__/unique-leg-values.test.ts
@@ -1,0 +1,60 @@
+import {Leg} from '@atb/api/types/trips';
+import {Mode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {uniqueLegValues} from '../utils';
+
+const leg = (partial: Partial<Leg>): Leg => partial as Leg;
+const tripPattern = (...legs: Leg[]) => ({legs});
+
+describe('uniqueLegValues', () => {
+  it('returns an empty array when there are no trip patterns', () => {
+    expect(uniqueLegValues([], (l) => l.mode)).toEqual([]);
+  });
+
+  it('returns an empty array when the trip patterns have no legs', () => {
+    expect(
+      uniqueLegValues([tripPattern(), tripPattern()], (l) => l.mode),
+    ).toEqual([]);
+  });
+
+  it('flattens legs across all trip patterns and collects the selected value', () => {
+    const result = uniqueLegValues(
+      [tripPattern(leg({mode: Mode.Bus})), tripPattern(leg({mode: Mode.Rail}))],
+      (l) => l.mode,
+    );
+    expect(result).toEqual([Mode.Bus, Mode.Rail]);
+  });
+
+  it('de-duplicates values across legs and trip patterns, keeping first-seen order', () => {
+    const result = uniqueLegValues(
+      [
+        tripPattern(leg({mode: Mode.Bus}), leg({mode: Mode.Rail})),
+        tripPattern(leg({mode: Mode.Bus}), leg({mode: Mode.Tram})),
+      ],
+      (l) => l.mode,
+    );
+    expect(result).toEqual([Mode.Bus, Mode.Rail, Mode.Tram]);
+  });
+
+  it('drops null and undefined values returned by the selector', () => {
+    const result = uniqueLegValues(
+      [tripPattern(leg({mode: Mode.Bus}), leg({}), leg({mode: Mode.Rail}))],
+      (l) => l.mode,
+    );
+    expect(result).toEqual([Mode.Bus, Mode.Rail]);
+  });
+
+  it('drops values that are absent via optional chaining (e.g. line?.publicCode)', () => {
+    const result = uniqueLegValues(
+      [
+        tripPattern(
+          leg({line: {publicCode: '1'} as Leg['line']}),
+          leg({}), // no line -> publicCode is undefined
+          leg({line: {publicCode: '1'} as Leg['line']}), // duplicate
+          leg({line: {publicCode: '2'} as Leg['line']}),
+        ),
+      ],
+      (l) => l.line?.publicCode,
+    );
+    expect(result).toEqual(['1', '2']);
+  });
+});

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/LoadMoreButton.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/LoadMoreButton.tsx
@@ -28,49 +28,44 @@ export const LoadMoreButton = ({
 
   if (tripsIsError || !tripSearchEnabled) return null;
 
-  const renderContent = () => {
-    if (isSearching && hasResults) {
-      return (
+  if (isSearching && hasResults) {
+    return (
+      <View style={styles.loadMoreButton}>
         <View style={styles.loadingIndicator}>
           <Loading style={styles.loadingSpinner} />
           <ThemeText type="secondary" testID="searchingForResults">
             {t(TripSearchTexts.results.fetchingMore)}
           </ThemeText>
         </View>
-      );
-    }
+      </View>
+    );
+  }
 
-    if (isSearching) {
-      return (
+  if (isSearching) {
+    return (
+      <View style={styles.loadMoreButton}>
         <View style={styles.loadingIndicator}>
           <ThemeText type="secondary" testID="searchingForResults">
             {t(TripSearchTexts.searchState.searching)}
           </ThemeText>
         </View>
-      );
-    }
-
-    if (!loadMoreTrips) return null;
-
-    return (
-      <>
-        <ThemeIcon color="secondary" svg={ExpandMore} size="normal" />
-        <ThemeText type="secondary" testID="resultsLoaded">
-          {' '}
-          {t(TripSearchTexts.results.fetchMore)}
-        </ThemeText>
-      </>
+      </View>
     );
-  };
+  }
+
+  if (!loadMoreTrips) return null;
 
   return (
     <NativeBlockButton
       onPress={loadMoreTrips}
-      disabled={isSearching}
-      style={[styles.loadMoreButton, {opacity: 1}]}
+      style={styles.loadMoreButton}
       testID="loadMoreButton"
     >
-      {renderContent()}
+      <ThemeIcon color="secondary" svg={ExpandMore} size="normal" />
+      <ThemeText type="secondary" testID="resultsLoaded">
+        {' '}
+        {t(TripSearchTexts.results.fetchMore)}
+      </ThemeText>
     </NativeBlockButton>
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/LoadMoreButton.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/LoadMoreButton.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {View} from 'react-native';
+import {ExpandMore} from '@atb/assets/svg/mono-icons/navigation';
+import {NativeBlockButton} from '@atb/components/native-button';
+import {ThemeText} from '@atb/components/text';
+import {ThemeIcon} from '@atb/components/theme-icon';
+import {Loading} from '@atb/components/loading';
+import {TripSearchTexts, useTranslation} from '@atb/translations';
+import {StyleSheet} from '@atb/theme';
+
+type Props = {
+  loadMoreTrips?: () => void;
+  isSearching: boolean;
+  hasResults: boolean;
+  tripsIsError: boolean;
+  tripSearchEnabled: boolean;
+};
+
+export const LoadMoreButton = ({
+  loadMoreTrips,
+  isSearching,
+  hasResults,
+  tripsIsError,
+  tripSearchEnabled,
+}: Props) => {
+  const {t} = useTranslation();
+  const styles = useStyles();
+
+  if (tripsIsError || !tripSearchEnabled) return null;
+
+  const renderContent = () => {
+    if (isSearching && hasResults) {
+      return (
+        <View style={styles.loadingIndicator}>
+          <Loading style={styles.loadingSpinner} />
+          <ThemeText type="secondary" testID="searchingForResults">
+            {t(TripSearchTexts.results.fetchingMore)}
+          </ThemeText>
+        </View>
+      );
+    }
+
+    if (isSearching) {
+      return (
+        <View style={styles.loadingIndicator}>
+          <ThemeText type="secondary" testID="searchingForResults">
+            {t(TripSearchTexts.searchState.searching)}
+          </ThemeText>
+        </View>
+      );
+    }
+
+    if (!loadMoreTrips) return null;
+
+    return (
+      <>
+        <ThemeIcon color="secondary" svg={ExpandMore} size="normal" />
+        <ThemeText type="secondary" testID="resultsLoaded">
+          {' '}
+          {t(TripSearchTexts.results.fetchMore)}
+        </ThemeText>
+      </>
+    );
+  };
+
+  return (
+    <NativeBlockButton
+      onPress={loadMoreTrips}
+      disabled={isSearching}
+      style={[styles.loadMoreButton, {opacity: 1}]}
+      testID="loadMoreButton"
+    >
+      {renderContent()}
+    </NativeBlockButton>
+  );
+};
+
+const useStyles = StyleSheet.createThemeHook((theme) => ({
+  loadMoreButton: {
+    paddingVertical: theme.spacing.medium,
+    marginBottom: theme.spacing.xLarge,
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  loadingIndicator: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  loadingSpinner: {
+    marginRight: theme.spacing.medium,
+  },
+}));

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/utils.ts
@@ -21,6 +21,7 @@ import {getRealtimeState} from '@atb/utils/realtime';
 import {TravelSearchTransportModesType} from '@atb-as/config-specs';
 import {enumFromString} from '@atb/utils/enum-from-string';
 import {isDefined} from '@atb/utils/presence';
+import {onlyUniques} from '@atb/utils/only-uniques';
 import {ONE_SECOND_MS} from '@atb/utils/durations';
 
 export type TimeSearch = {
@@ -144,3 +145,18 @@ export function isSignificantDifference(leg: Leg) {
     }) === 'significant-difference'
   );
 }
+
+/**
+ * Collects a single value from every leg across all trip patterns, dropping
+ * nullish values and de-duplicating the result. Used to derive rule-engine
+ * inputs (transport modes, authorities, etc.) from a set of trip patterns.
+ */
+export const uniqueLegValues = <T>(
+  tripPatterns: {legs: Leg[]}[],
+  selector: (leg: Leg) => T | undefined | null,
+): NonNullable<T>[] =>
+  tripPatterns
+    .flatMap((tp) => tp.legs)
+    .map(selector)
+    .filter(isDefined)
+    .filter(onlyUniques);


### PR DESCRIPTION
## Description
I think `Dashboard_TripSearchScreen` has become large and hard to read, and it gets worse with the new Skeleton loader. I try to preempt that a little by making a small refactor. 

- Remove dead `updatingLocation` state and duplicate valid-locations check
- Name the `CityZoneMessage` visibility condition
- Extract `uniqueLegValues` helper for the global-message rule variables
- Extract `LoadMoreButton` (if-statements / early returns instead of nested ternaries)


## Test input
Has been tested by me and seems to be functionally equivalent. Has touched code in the TravelSearch results, and mainly the LoadMore button.