### PR TITLE
feat: update DebugServerOverrides bottom sheet

### DIFF
--- a/src/modules/debug/DebugServerOverrides.tsx
+++ b/src/modules/debug/DebugServerOverrides.tsx
@@ -8,6 +8,8 @@ import {
   BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {
+  GenericSectionItem,
+  Section,
   SectionSeparator,
   SelectionInlineSectionItem,
   TextInputSectionItem,
@@ -26,6 +28,8 @@ import Animated, {SharedValue, useAnimatedStyle} from 'react-native-reanimated';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import type {DebugServerOverride, HeaderOverride} from './types';
 import {BottomSheetTextInput} from '@gorhom/bottom-sheet';
+import {ContentHeading} from '@atb/components/heading';
+import {MessageInfoBox} from '@atb/components/message-info-box';
 
 type OftenUsedOverride = DebugServerOverride & {label: string};
 
@@ -277,29 +281,26 @@ function DebugServerInput(props: {
 
   return (
     <View style={styles.overrideInput}>
-      <ThemeText typography="body__m">
-        Any request matching the regex will get its baseURL replaced by the New
-        baseURL.
-      </ThemeText>
-      <View style={styles.oftenUsedContainer}>
-        <ThemeText typography="body__s">Often used</ThemeText>
-        <View style={styles.oftenUsedOptions}>
-          {oftenUsedOverrides.map((o) => (
-            <Button
-              key={o.label}
-              type="small"
-              expanded={false}
-              onPress={() => {
-                addExistingOverride(o);
-              }}
-              text={o.label}
-            />
-          ))}
-        </View>
+      <MessageInfoBox
+        type="info"
+        message="Any request matching the regex will get its baseURL replaced by the New baseURL."
+      />
+      <ContentHeading text="Often used" />
+      <View style={styles.oftenUsedOptions}>
+        {oftenUsedOverrides.map((o) => (
+          <Button
+            key={o.label}
+            type="small"
+            expanded={false}
+            onPress={() => {
+              addExistingOverride(o);
+            }}
+            text={o.label}
+          />
+        ))}
       </View>
-      <SectionSeparator />
-      <View>
-        <ThemeText typography="body__s">New override</ThemeText>
+      <ContentHeading text="New override" />
+      <Section>
         <TextInputSectionItem
           InputComponent={BottomSheetTextInput}
           label="Regex"
@@ -316,45 +317,43 @@ function DebugServerInput(props: {
           value={newValue}
           autoCapitalize="none"
         />
-      </View>
-      <View style={{gap: 12}}>
-        <ThemeText typography="body__s">Headers (optional)</ThemeText>
-        {headers.map((header, index) => (
-          <HeaderOverrideComponent
-            key={index}
-            headerKey={header.key}
-            headerValue={header.value}
-            onKeyChange={(newKey) => {
-              setHeaders((prev) =>
-                prev.map((h, i) =>
-                  i === index ? {key: newKey, value: h.value} : h,
-                ),
-              );
-            }}
-            onValueChange={(newValue) => {
-              setHeaders((prev) =>
-                prev.map((h, i) =>
-                  i === index ? {key: h.key, value: newValue} : h,
-                ),
-              );
-            }}
-            onDelete={() => {
-              setHeaders((prev) => prev.filter((_, i) => i !== index));
-            }}
-          />
-        ))}
-        <Button
-          onPress={() => {
-            setHeaders((prev) => {
-              return [...prev, {key: '', value: ''}];
-            });
+      </Section>
+      <ContentHeading text="Headers (optional)" />
+      {headers.map((header, index) => (
+        <HeaderOverrideComponent
+          key={index}
+          headerKey={header.key}
+          headerValue={header.value}
+          onKeyChange={(newKey) => {
+            setHeaders((prev) =>
+              prev.map((h, i) =>
+                i === index ? {key: newKey, value: h.value} : h,
+              ),
+            );
           }}
-          expanded={false}
-          type="small"
-          text="Add header"
-          disabled={headers.some((h) => h.key === '')}
+          onValueChange={(newValue) => {
+            setHeaders((prev) =>
+              prev.map((h, i) =>
+                i === index ? {key: h.key, value: newValue} : h,
+              ),
+            );
+          }}
+          onDelete={() => {
+            setHeaders((prev) => prev.filter((_, i) => i !== index));
+          }}
         />
-      </View>
+      ))}
+      <Button
+        onPress={() => {
+          setHeaders((prev) => {
+            return [...prev, {key: '', value: ''}];
+          });
+        }}
+        expanded={false}
+        type="small"
+        text="Add header"
+        disabled={headers.some((h) => h.key === '')}
+      />
       <Button
         text="Save Override"
         expanded={true}
@@ -383,11 +382,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     gap: theme.spacing.medium,
   },
   overrideInput: {
-    paddingVertical: theme.spacing.large,
     paddingHorizontal: theme.spacing.medium,
-    gap: theme.spacing.medium,
-  },
-  oftenUsedContainer: {
     gap: theme.spacing.small,
   },
   oftenUsedOptions: {

--- a/src/modules/debug/DebugServerOverrides.tsx
+++ b/src/modules/debug/DebugServerOverrides.tsx
@@ -8,9 +8,7 @@ import {
   BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {
-  GenericSectionItem,
   Section,
-  SectionSeparator,
   SelectionInlineSectionItem,
   TextInputSectionItem,
 } from '@atb/components/sections';

--- a/src/modules/debug/HeaderOverride.tsx
+++ b/src/modules/debug/HeaderOverride.tsx
@@ -1,8 +1,9 @@
-import {TextInputSectionItem} from '@atb/components/sections';
+import {Section, TextInputSectionItem} from '@atb/components/sections';
 import React from 'react';
 import {View} from 'react-native';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {Button} from '@atb/components/button';
+import {BottomSheetTextInput} from '@gorhom/bottom-sheet';
 
 type Props = {
   headerKey: string;
@@ -24,8 +25,9 @@ export function HeaderOverride({
 
   return (
     <View style={style.container}>
-      <View style={style.inputs}>
+      <Section>
         <TextInputSectionItem
+          InputComponent={BottomSheetTextInput}
           label="Key"
           placeholder="Authorization"
           onChangeText={onKeyChange}
@@ -33,33 +35,28 @@ export function HeaderOverride({
           autoCapitalize="none"
         />
         <TextInputSectionItem
+          InputComponent={BottomSheetTextInput}
           label="Value"
           placeholder="Bearer ..."
           onChangeText={onValueChange}
           value={headerValue}
           autoCapitalize="none"
         />
-      </View>
-      <View style={style.button}>
-        <Button
-          onPress={onDelete}
-          expanded={false}
-          type="small"
-          text="Remove"
-          mode="secondary"
-          backgroundColor={theme.color.background.neutral[1]}
-        />
-      </View>
+      </Section>
+      <Button
+        onPress={onDelete}
+        expanded={false}
+        type="small"
+        text="Remove"
+        mode="secondary"
+        backgroundColor={theme.color.background.neutral[1]}
+      />
     </View>
   );
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
-    gap: theme.spacing.medium,
-  },
-  inputs: {
     gap: theme.spacing.small,
   },
-  button: {},
 }));


### PR DESCRIPTION
Simplifies some styling by using standard components and best practices. Also adds keyboard avoiding view for the header inputs.

## Before/after

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-25 at 10 01 54" src="https://github.com/user-attachments/assets/4e7f1424-bc7e-44a4-990a-ee33554715ed" />
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-25 at 10 01 25" src="https://github.com/user-attachments/assets/3ea49b9a-d009-433f-8b06-8acb84de6c2c" />

