### PR TITLE
feat: show affected stop places in situation bottom sheet

### DIFF
--- a/src/api/types/generated/fragments/situations.ts
+++ b/src/api/types/generated/fragments/situations.ts
@@ -5,6 +5,40 @@ import type {
   ValidityPeriodFragment,
 } from '@atb/api/types/generated/fragments/shared';
 
+export type Affects_AffectedLine_Fragment = {__typename: 'AffectedLine'};
+
+export type Affects_AffectedServiceJourney_Fragment = {
+  __typename: 'AffectedServiceJourney';
+};
+
+export type Affects_AffectedStopPlace_Fragment = {
+  __typename: 'AffectedStopPlace';
+  stopPlace?: {name: string};
+  quay?: {name: string};
+};
+
+export type Affects_AffectedStopPlaceOnLine_Fragment = {
+  __typename: 'AffectedStopPlaceOnLine';
+  stopPlace?: {name: string};
+  quay?: {name: string};
+};
+
+export type Affects_AffectedStopPlaceOnServiceJourney_Fragment = {
+  __typename: 'AffectedStopPlaceOnServiceJourney';
+  stopPlace?: {name: string};
+  quay?: {name: string};
+};
+
+export type Affects_AffectedUnknown_Fragment = {__typename: 'AffectedUnknown'};
+
+export type AffectsFragment =
+  | Affects_AffectedLine_Fragment
+  | Affects_AffectedServiceJourney_Fragment
+  | Affects_AffectedStopPlace_Fragment
+  | Affects_AffectedStopPlaceOnLine_Fragment
+  | Affects_AffectedStopPlaceOnServiceJourney_Fragment
+  | Affects_AffectedUnknown_Fragment;
+
 export type SituationFragment = {
   id: string;
   situationNumber?: string;
@@ -14,4 +48,5 @@ export type SituationFragment = {
   advice: Array<MultilingualStringFragment>;
   infoLinks?: Array<InfoLinkFragment>;
   validityPeriod?: ValidityPeriodFragment;
+  affects: Array<AffectsFragment>;
 };

--- a/src/modules/situations/SituationBottomSheet.tsx
+++ b/src/modules/situations/SituationBottomSheet.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import {View} from 'react-native';
 import {InfoLinkFragment} from '@atb/api/types/generated/fragments/shared';
 import {StyleSheet} from '@atb/theme';
-import {SituationFragment} from '@atb/api/types/generated/fragments/situations';
+import type {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import {SituationOrNoticeIcon} from './SituationOrNoticeIcon';
 import {daysBetween, formatToLongDateTime} from '@atb/utils/date';
 import {ThemeIcon} from '@atb/components/theme-icon';
@@ -17,7 +17,10 @@ import {Time} from '@atb/assets/svg/mono-icons/time';
 import {screenReaderPause} from '@atb/components/text';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {NativeBlockButton} from '@atb/components/native-button';
-import {getMsgTypeForMostCriticalSituationOrNotice} from './utils';
+import {
+  getAffectedStopNames,
+  getMsgTypeForMostCriticalSituationOrNotice,
+} from './utils';
 import {openInAppBrowser} from '../in-app-browser';
 import {
   BottomSheetHeaderType,
@@ -25,6 +28,7 @@ import {
   BottomSheetModalMethods,
 } from '@atb/components/bottom-sheet';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
+import {isDefined} from '@atb/utils/presence';
 
 type Props = {
   situation: SituationFragment;
@@ -44,6 +48,7 @@ export const SituationBottomSheet = ({
   const description = getTextForLanguage(situation.description, language);
   const advice = getTextForLanguage(situation.advice, language);
   const infoLinks = filterInfoLinks(situation.infoLinks);
+  const affectedStopsText = useAffectedStopNamesText(situation.affects);
   const validityPeriodText = useValidityPeriodText(situation.validityPeriod);
   const msgType = getMsgTypeForMostCriticalSituationOrNotice([situation]);
 
@@ -57,9 +62,14 @@ export const SituationBottomSheet = ({
       <Section style={styles.section}>
         <GenericSectionItem type="spacious">
           <View
-            accessibilityLabel={[summary, description, advice].join(
-              screenReaderPause,
-            )}
+            accessibilityLabel={[
+              summary,
+              description,
+              advice,
+              affectedStopsText,
+            ]
+              .filter(isDefined)
+              .join(screenReaderPause)}
             accessible={true}
             style={styles.textContainer}
           >
@@ -76,6 +86,11 @@ export const SituationBottomSheet = ({
               <ThemeText style={styles.description}>{description}</ThemeText>
             )}
             {advice && <ThemeText style={styles.advice}>{advice}</ThemeText>}
+            {affectedStopsText && (
+              <ThemeText style={styles.affectedStops}>
+                {affectedStopsText}
+              </ThemeText>
+            )}
           </View>
           {infoLinks?.length ? (
             <View style={styles.infoLinksContainer}>
@@ -111,6 +126,38 @@ const filterInfoLinks = (
   infoLinks?.filter(
     (il: Partial<InfoLinkFragment>): il is InfoLinkFragment => !!il.uri,
   ) || [];
+
+/**
+ * Build the text for listing affected stop places. Up to 10 names are
+ * shown in full; beyond that the list is truncated to 8 names followed by an
+ * "N other stops" tail. Returns undefined if no stop places are affected.
+ */
+const useAffectedStopNamesText = (
+  affects: SituationFragment['affects'],
+): string | undefined => {
+  const {t} = useTranslation();
+  const names = getAffectedStopNames(affects);
+  if (names.length === 0) return undefined;
+
+  const displayItems =
+    names.length > 10
+      ? [
+          ...names.slice(0, 8),
+          t(
+            SituationsTexts.bottomSheet.affectedStopPlaces.otherStops(
+              names.length - 8,
+            ),
+          ),
+        ]
+      : names;
+
+  const list =
+    displayItems.length > 1
+      ? `${displayItems.slice(0, -1).join(', ')} ${t(dictionary.listConcatWord)} ${displayItems[displayItems.length - 1]}`
+      : displayItems[0];
+
+  return `${t(SituationsTexts.bottomSheet.affectedStopPlaces.header)}: ${list}`;
+};
 
 const useValidityPeriodText = (
   period?: SituationFragment['validityPeriod'],
@@ -179,6 +226,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   advice: {marginTop: theme.spacing.medium},
   infoLinksContainer: {marginTop: theme.spacing.medium, flexDirection: 'row'},
   infoLink: {marginRight: theme.spacing.medium},
+  affectedStops: {marginTop: theme.spacing.medium},
   validityContainer: {flexDirection: 'row', marginTop: theme.spacing.medium},
   validityIcon: {marginRight: theme.spacing.small},
   validityText: {flex: 1},

--- a/src/modules/situations/__tests__/utils.test.ts
+++ b/src/modules/situations/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import {
   findAllNotices,
   findAllSituationsFromLeg,
   findAllSituations,
+  getAffectedStopNames,
   getSituationSummary,
   getMessageTypeForSituation,
   getMsgTypeForMostCriticalSituationOrNotice,
@@ -36,6 +37,7 @@ const makeSituation = (
   validityPeriod: overrides.validityPeriod,
   situationNumber: overrides.situationNumber,
   infoLinks: overrides.infoLinks,
+  affects: overrides.affects ?? [],
 });
 
 const makeMinimalLeg = (overrides: Partial<Leg> = {}): Leg =>
@@ -441,5 +443,56 @@ describe('getSituationOrNoticeA11yLabel', () => {
       t,
     );
     expect(result).toBeDefined();
+  });
+});
+
+describe('getAffectedStopNames', () => {
+  type Affects = SituationFragment['affects'];
+
+  it('returns empty array when affects is empty', () => {
+    expect(getAffectedStopNames([])).toEqual([]);
+  });
+
+  it('extracts names from all stop-place variants, preferring stopPlace over quay', () => {
+    const affects: Affects = [
+      {
+        __typename: 'AffectedStopPlace',
+        stopPlace: {name: 'Stop'},
+        quay: {name: 'Quay'},
+      },
+      {
+        __typename: 'AffectedStopPlaceOnLine',
+        quay: {name: 'On line quay'},
+      },
+      {
+        __typename: 'AffectedStopPlaceOnServiceJourney',
+        stopPlace: {name: 'On journey stop'},
+      },
+    ];
+    expect(getAffectedStopNames(affects)).toEqual([
+      'Stop',
+      'On line quay',
+      'On journey stop',
+    ]);
+  });
+
+  it('skips non stop-place variants and entries without stopPlace or quay', () => {
+    const affects: Affects = [
+      {__typename: 'AffectedLine'},
+      {__typename: 'AffectedServiceJourney'},
+      {__typename: 'AffectedUnknown'},
+      {__typename: 'AffectedStopPlace'},
+      {__typename: 'AffectedStopPlace', stopPlace: {name: 'Kept'}},
+    ];
+    expect(getAffectedStopNames(affects)).toEqual(['Kept']);
+  });
+
+  it('deduplicates names', () => {
+    const affects: Affects = [
+      {__typename: 'AffectedStopPlace', stopPlace: {name: 'A'}},
+      {__typename: 'AffectedStopPlace', stopPlace: {name: 'B'}},
+      {__typename: 'AffectedStopPlaceOnLine', stopPlace: {name: 'A'}},
+    ];
+    expect(getAffectedStopNames(affects)).toEqual(['A', 'B']);
   });
 });

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -12,7 +12,8 @@ import {statusComparator} from '@atb/utils/status-comparator';
 import {Statuses} from '@atb/theme';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
 import {Mode} from '@atb-as/theme';
-import {onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import {onlyUniques, onlyUniquesBasedOnField} from '@atb/utils/only-uniques';
+import {isDefined} from '@atb/utils/presence';
 import type {SituationFragment} from '@atb/api/types/generated/fragments/situations';
 import type {TripPatternFragment} from '@atb/api/types/generated/fragments/trips';
 import type {Leg} from '@atb/api/types/trips';
@@ -194,6 +195,26 @@ export const getSituationOrNoticeA11yLabel = (
     );
   return t(SituationsTexts.a11yLabel[messageType]);
 };
+
+/**
+ * Extract unique stop place / quay names from a situation's affects list.
+ */
+export const getAffectedStopNames = (
+  affects: SituationFragment['affects'],
+): string[] =>
+  affects
+    .map((affect) => {
+      switch (affect.__typename) {
+        case 'AffectedStopPlace':
+        case 'AffectedStopPlaceOnServiceJourney':
+        case 'AffectedStopPlaceOnLine':
+          return affect.stopPlace?.name ?? affect.quay?.name;
+        default:
+          return undefined;
+      }
+    })
+    .filter(isDefined)
+    .filter(onlyUniques);
 
 /**
  * Check if a situation is valid at a specific date by comparing it to the

--- a/src/modules/storybook/stories/TravelCard.stories.tsx
+++ b/src/modules/storybook/stories/TravelCard.stories.tsx
@@ -151,6 +151,7 @@ const TRIP_SCENARIOS = {
             summary: [{value: 'Forsinkelse'}],
             description: [{value: 'Det er forsinkelser grunnet trafikk'}],
             advice: [],
+            affects: [],
           },
         ],
       }),

--- a/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
+++ b/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
@@ -28,6 +28,7 @@ const makeSituation = (
   validityPeriod: overrides.validityPeriod,
   situationNumber: overrides.situationNumber,
   infoLinks: overrides.infoLinks,
+  affects: overrides.affects ?? [],
 });
 
 const makeLeg = (overrides: Partial<Leg> = {}): Leg =>

--- a/src/translations/components/SituationsTexts.ts
+++ b/src/translations/components/SituationsTexts.ts
@@ -40,6 +40,15 @@ const SituationsTexts = {
       warning: _('Advarsel', 'Warning', 'Advarsel'),
       error: _('Feil', 'Error', 'Feil'),
     },
+    affectedStopPlaces: {
+      header: _('Påvirker', 'Affects', 'Påverkar'),
+      otherStops: (count: number) =>
+        _(
+          `${count} andre stopp`,
+          `${count} other stops`,
+          `${count} andre stopp`,
+        ),
+    },
     validity: {
       from: (fromDate: string) =>
         _(


### PR DESCRIPTION
Adds an "Affects" line to the situation bottom sheet that lists the
stop places (or quays) impacted by a situation. Up to 10 names are
shown in full; beyond that the list is truncated to "first 8 + N other
stops".

<img width="400" src="https://github.com/user-attachments/assets/8f3bbeb1-02dc-4322-80c6-8866ebf5281e" />
