### PR TITLE
fix: allow deep links to take effect on cold start

### DIFF
--- a/src/modules/onboarding/use-onboarding-flow.ts
+++ b/src/modules/onboarding/use-onboarding-flow.ts
@@ -53,24 +53,23 @@ export const useOnboardingFlow = (assumeUserCreationOnboarded = false) => {
   /**
    * add defaultInitialRouteName as root when userCreationOnboarded
    * this allows goBack from an onboarding screen when used as initial screen
-   * @returns navigation state object
+   * @returns navigation state object, or undefined when there is no onboarding
+   * to show so that deep links can take effect on cold start
    */
   const getInitialNavigationContainerState = useCallback(() => {
     const defaultInitialRouteName = 'Root_TabNavigatorStack';
     const nextOnboardingSection = getNextOnboardingSection(); // dont rely on effects as it will be too late for initialState
     const initialOnboardingScreen = nextOnboardingSection?.initialScreen;
+    if (!initialOnboardingScreen?.name) return undefined;
     const initialOnboardingRoute = {
-      name: initialOnboardingScreen?.name ?? defaultInitialRouteName,
-      params: initialOnboardingScreen?.params,
+      name: initialOnboardingScreen.name,
+      params: initialOnboardingScreen.params,
     };
 
     const routes: PartialRoute<
       Route<keyof RootStackParamList, object | undefined>
     >[] = [initialOnboardingRoute];
-    if (
-      !nextOnboardingSection?.shouldShowBeforeUserCreated &&
-      initialOnboardingScreen?.name
-    ) {
+    if (!nextOnboardingSection?.shouldShowBeforeUserCreated) {
       routes.unshift({name: defaultInitialRouteName});
     }
     return {routes};


### PR DESCRIPTION
getInitialNavigationContainerState now returns undefined when there is
no onboarding to show, instead of an explicit
{routes: [{name: 'Root_TabNavigatorStack'}]}. An explicit initialState
on NavigationContainer overrides the linking config, which was
clobbering deep-link resolution on cold start.

Normal cold start behavior is preserved: Root_TabNavigatorStack is the
first Stack.Screen declared in the root navigator, so with no deep link
and no onboarding, React Navigation still lands on the tab navigator —
same destination as before.

When onboarding is required, the returned route shape is identical to
before, so the onboarding path is unchanged.

### Acceptance criteria
- [x] Deep links work even on app cold start, when no onboarding
- [x] Other start screens (configured by the user) than dashboard/reise works as before
- [x] Onboarding works as before
