### PR TITLE
fix: show only favorites on first widget open of a stop place

### DIFF
--- a/src/screen-components/place-screen/components/QuayView.tsx
+++ b/src/screen-components/place-screen/components/QuayView.tsx
@@ -91,10 +91,12 @@ export function QuayView({
   );
 
   // If all favorites are removed while setShowOnlyFavorites is true, reset the
-  // value to false
+  // value to false. Skip while quays are still loading so we don't clobber a
+  // deep-linked showOnlyFavoritesByDefault before favorites can be evaluated.
   useEffect(() => {
+    if (stopPlace.quays === undefined) return;
     if (!placeHasFavorites) setShowOnlyFavorites(false);
-  }, [placeHasFavorites, setShowOnlyFavorites]);
+  }, [stopPlace.quays, placeHasFavorites, setShowOnlyFavorites]);
 
   const refreshControlProps = useManualRefreshControlProps({
     onRefresh: refetchDepartures,

--- a/src/screen-components/place-screen/components/StopPlacesView.tsx
+++ b/src/screen-components/place-screen/components/StopPlacesView.tsx
@@ -123,11 +123,15 @@ export const StopPlacesView = (props: Props) => {
     refetchDepartures,
   } = useDepartures(departuresProps);
 
+  const allQuaysLoaded = stopPlaces.every((sp) => sp.quays !== undefined);
+
   // If all favorites are removed while setShowOnlyFavorites is true, reset the
-  // value to false
+  // value to false. Skip while quays are still loading so we don't clobber a
+  // deep-linked showOnlyFavoritesByDefault before favorites can be evaluated.
   useEffect(() => {
+    if (!allQuaysLoaded) return;
     if (!placeHasFavorites) setShowOnlyFavorites(false);
-  }, [placeHasFavorites, setShowOnlyFavorites]);
+  }, [allQuaysLoaded, placeHasFavorites, setShowOnlyFavorites]);
 
   const refreshControlProps = useManualRefreshControlProps({
     onRefresh: refetchDepartures,


### PR DESCRIPTION
Opening a stop place from the favourites widget did not apply the
favourites filter unless that stop place had already been visited in
the current session. On first open `stopPlace.quays` is still loading,
so `placeHasFavorites` is false and the reset-when-no-favorites effect
clobbered the deep-linked `showOnlyFavoritesByDefault=true` before
favourites could be evaluated. Skip the effect until quays are defined.

### Acceptance criteria
- [x] Opening the stop place screen from the widget always has "show only favorite departures" toggled on
- [x] Existing "show only favorite departures" toggle logic works like before
