### PR TITLE
fix: add bottom safe area inset to refund reason screen

### DIFF
--- a/src/stacks-hierarchy/Root_RefundConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_RefundConfirmationScreen.tsx
@@ -138,9 +138,10 @@ export function Root_RefundConfirmationScreen({navigation, route}: Props) {
   );
 }
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => ({
   content: {
     padding: theme.spacing.medium,
+    paddingBottom: bottom + theme.spacing.medium,
     gap: theme.spacing.medium,
   },
   descriptionRow: {


### PR DESCRIPTION
## Issue Reference

https://mittatb.slack.com/archives/C0116FMPX4Y/p1782818808543369

## Description

Same solution as e.g. Root_PurchaseConfirmationScreen