### PR TITLE
fix: getFeatureFromScan

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -545,6 +545,10 @@ export const VehicleFeaturePropertiesSchema = z.object({
   num_vehicles_available: z.never().optional(), // to differenciate from station features, which have this field
 });
 
+export type VehicleFeatureProperties = z.infer<
+  typeof VehicleFeaturePropertiesSchema
+>;
+
 export const VehicleFeatureSchema =
   GeoJsonFeatureWithPointGeometrySchema.extend({
     properties: VehicleFeaturePropertiesSchema,

--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -193,7 +193,6 @@ export const MapBottomSheets = ({
               if (mapState.assetIsScanned) {
                 const feature: Feature<Point, GeoJsonProperties> =
                   getFeatureFromScan({
-                    mapBottomSheetType: mapState.bottomSheetType,
                     vehicle,
                   });
                 dispatchMapState({
@@ -275,7 +274,6 @@ export const MapBottomSheets = ({
             if (mapState.assetIsScanned) {
               const feature: Feature<Point, GeoJsonProperties> =
                 getFeatureFromScan({
-                  mapBottomSheetType: mapState.bottomSheetType,
                   station,
                 });
 
@@ -309,7 +307,6 @@ export const MapBottomSheets = ({
             if (mapState.assetIsScanned) {
               const feature: Feature<Point, GeoJsonProperties> =
                 getFeatureFromScan({
-                  mapBottomSheetType: mapState.bottomSheetType,
                   station,
                 });
 

--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -189,14 +189,13 @@ export const MapBottomSheets = ({
         !openPaymentType &&
         !activeBooking?.bookingId && (
           <VehicleSheet
-            onVehicleReceived={(item) => {
+            onVehicleReceived={(vehicle) => {
               if (mapState.assetIsScanned) {
                 const feature: Feature<Point, GeoJsonProperties> =
-                  getFeatureFromScan(
-                    item,
-                    mapState.bottomSheetType,
-                    item.vehicleType.formFactor,
-                  );
+                  getFeatureFromScan({
+                    mapBottomSheetType: mapState.bottomSheetType,
+                    vehicle,
+                  });
                 dispatchMapState({
                   type: MapStateActionType.Vehicle,
                   feature: feature,
@@ -272,10 +271,13 @@ export const MapBottomSheets = ({
           stationId={mapState.feature?.properties?.id ?? mapState.assetId ?? ''}
           distance={undefined}
           onClose={handleCloseSheet}
-          onStationReceived={(item) => {
+          onStationReceived={(station) => {
             if (mapState.assetIsScanned) {
               const feature: Feature<Point, GeoJsonProperties> =
-                getFeatureFromScan(item, mapState.bottomSheetType);
+                getFeatureFromScan({
+                  mapBottomSheetType: mapState.bottomSheetType,
+                  station,
+                });
 
               dispatchMapState({
                 type: MapStateActionType.BikeStation,
@@ -303,10 +305,13 @@ export const MapBottomSheets = ({
           stationId={mapState.feature?.properties?.id ?? mapState.assetId ?? ''}
           distance={undefined}
           onClose={handleCloseSheet}
-          onStationReceived={(item) => {
+          onStationReceived={(station) => {
             if (mapState.assetIsScanned) {
               const feature: Feature<Point, GeoJsonProperties> =
-                getFeatureFromScan(item, mapState.bottomSheetType);
+                getFeatureFromScan({
+                  mapBottomSheetType: mapState.bottomSheetType,
+                  station,
+                });
 
               dispatchMapState({
                 type: MapStateActionType.CarStation,

--- a/src/modules/map/types.ts
+++ b/src/modules/map/types.ts
@@ -25,7 +25,7 @@ import {TranslatedString} from '@atb/translations';
 import {GeofencingZoneCode, GeofencingZoneStyle} from '@atb-as/theme';
 import {ContrastColor} from '@atb/theme/colors';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
-import {ShmoPricingPlan, Station, Vehicle} from '@atb/api/types/mobility';
+import {ShmoPricingPlan} from '@atb/api/types/mobility';
 import type {MobilityPriceAdjustmentBenefitType} from '@atb/api/types/benefit';
 
 export type SelectionLocationCallback = (
@@ -171,8 +171,6 @@ export type SelectedMapItemProperties = GeoJsonProperties & {
 export type SelectedFeatureIdProp = {
   selectedFeatureId: SelectedMapItemProperties['id'];
 };
-
-export type AutoSelectableMapItem = Vehicle | Station;
 
 export type MapPropertiesType = {
   center: GeoJSON.Position;

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -36,7 +36,6 @@ import {
   isVehicleCluster,
   isStationCluster,
 } from '@atb/modules/mobility';
-import {MapBottomSheetType} from './MapContext';
 import {
   FormFactor,
   PropulsionType,
@@ -136,25 +135,10 @@ export const getFeaturesAtPoint = async (
   return featuresAtPoint?.features;
 };
 
-function mapMapBottomSheetTypeToFormFactor(
-  mapBottomSheetType?: MapBottomSheetType,
-): FormFactor | undefined {
-  switch (mapBottomSheetType) {
-    case MapBottomSheetType.BikeStation:
-      return FormFactor.Bicycle;
-    case MapBottomSheetType.CarStation:
-      return FormFactor.Car;
-    default:
-      return undefined;
-  }
-}
-
 export const getFeatureFromScan = ({
-  mapBottomSheetType,
   vehicle,
   station,
 }: {
-  mapBottomSheetType: MapBottomSheetType;
   vehicle?: Vehicle;
   station?: Station;
 }): Feature<Point, GeoJsonProperties> => {
@@ -166,22 +150,17 @@ export const getFeatureFromScan = ({
       id: vehicle.id,
       system_id: vehicle.system.id,
       count: 1,
-      vehicle_type_form_factor:
-        vehicle.vehicleType.formFactor ??
-        mapMapBottomSheetTypeToFormFactor(mapBottomSheetType),
+      vehicle_type_form_factor: vehicle.vehicleType.formFactor,
       vehicle_type_propulsion_type: vehicle.vehicleType.propulsionType,
     } satisfies VehicleFeatureProperties;
   } else if (station) {
-    const vehicleType = station.vehicleTypesAvailable?.[0]?.vehicleType;
+    const vehicleType = station.vehicleTypesAvailable?.[0]?.vehicleType; // currently only supporting 1 formFactor per feature
     coordinates = [station.lon, station.lat];
     properties = {
       id: station.id,
       system_id: station.system.id,
       count: 1,
-      vehicle_type_form_factor:
-        vehicleType?.formFactor ??
-        mapMapBottomSheetTypeToFormFactor(mapBottomSheetType) ??
-        FormFactor.Other,
+      vehicle_type_form_factor: vehicleType?.formFactor ?? FormFactor.Other,
       vehicle_type_propulsion_type:
         vehicleType?.propulsionType ?? PropulsionType.Human,
       is_virtual_station: false, // lacking this info atm, assume false for now

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -135,6 +135,13 @@ export const getFeaturesAtPoint = async (
   return featuresAtPoint?.features;
 };
 
+/**
+ * Builds a GeoJSON Point feature from a scanned vehicle or station, with
+ * properties matching those received from the map's onPressEvent.
+ * @param vehicle - The scanned vehicle, if a vehicle was scanned
+ * @param station - The scanned station, if a station was scanned
+ * @returns A GeoJSON Point feature representing the scanned entity
+ */
 export const getFeatureFromScan = ({
   vehicle,
   station,

--- a/src/modules/map/utils.ts
+++ b/src/modules/map/utils.ts
@@ -15,12 +15,12 @@ import {
   Polygon,
   Position,
 } from 'geojson';
+import {ParkingType, GeofencingZoneCustomProps} from './types';
 import {
-  ParkingType,
-  AutoSelectableMapItem,
-  GeofencingZoneCustomProps,
-} from './types';
-import {
+  Station,
+  StationFeatureProperties,
+  Vehicle,
+  VehicleFeatureProperties,
   VehiclesClusteredProperties,
   VehiclesClusteredPropertiesSchema,
 } from '@atb/api/types/mobility';
@@ -37,7 +37,10 @@ import {
   isStationCluster,
 } from '@atb/modules/mobility';
 import {MapBottomSheetType} from './MapContext';
-import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {
+  FormFactor,
+  PropulsionType,
+} from '@atb/api/types/generated/mobility-types_v2';
 import z from 'zod';
 import {GeofencingZoneCode} from '@atb-as/theme';
 
@@ -146,25 +149,56 @@ function mapMapBottomSheetTypeToFormFactor(
   }
 }
 
-export const getFeatureFromScan = (
-  mapItem: AutoSelectableMapItem,
-  mapBottomSheetType: MapBottomSheetType,
-  formFactor?: FormFactor,
-): Feature<Point, GeoJsonProperties> => {
+export const getFeatureFromScan = ({
+  mapBottomSheetType,
+  vehicle,
+  station,
+}: {
+  mapBottomSheetType: MapBottomSheetType;
+  vehicle?: Vehicle;
+  station?: Station;
+}): Feature<Point, GeoJsonProperties> => {
+  let coordinates: Position = [];
+  let properties: GeoJsonProperties = {}; // properties should match the one received from the map onPressEvent
+  if (vehicle) {
+    coordinates = [vehicle.lon, vehicle.lat];
+    properties = {
+      id: vehicle.id,
+      system_id: vehicle.system.id,
+      count: 1,
+      vehicle_type_form_factor:
+        vehicle.vehicleType.formFactor ??
+        mapMapBottomSheetTypeToFormFactor(mapBottomSheetType),
+      vehicle_type_propulsion_type: vehicle.vehicleType.propulsionType,
+    } satisfies VehicleFeatureProperties;
+  } else if (station) {
+    const vehicleType = station.vehicleTypesAvailable?.[0]?.vehicleType;
+    coordinates = [station.lon, station.lat];
+    properties = {
+      id: station.id,
+      system_id: station.system.id,
+      count: 1,
+      vehicle_type_form_factor:
+        vehicleType?.formFactor ??
+        mapMapBottomSheetTypeToFormFactor(mapBottomSheetType) ??
+        FormFactor.Other,
+      vehicle_type_propulsion_type:
+        vehicleType?.propulsionType ?? PropulsionType.Human,
+      is_virtual_station: false, // lacking this info atm, assume false for now
+      num_vehicles_available: Math.max(
+        station.capacity - (station?.numDocksAvailable ?? 0),
+        0,
+      ), // should get this without calculation too
+      capacity: station.capacity,
+    } satisfies StationFeatureProperties;
+  }
   const feature: Feature<Point, GeoJsonProperties> = {
     type: 'Feature',
     geometry: {
       type: 'Point',
-      coordinates: [mapItem?.lon, mapItem?.lat],
+      coordinates,
     },
-    // properties should match the one received from the map onPressEvent
-    properties: {
-      id: mapItem.id,
-      system_id: mapItem?.system.id,
-      count: 1,
-      vehicle_type_form_factor:
-        formFactor ?? mapMapBottomSheetTypeToFormFactor(mapBottomSheetType),
-    },
+    properties,
   };
 
   return feature;


### PR DESCRIPTION
Bugfix: select the correct map item after a qr scan. This fixes the map item icon of a vehicle/station after scanning with a qr code.

| Before | After |
|--------|-------|
| <img width="200" src="https://github.com/user-attachments/assets/2dfca3e7-a6ba-4c2d-91ff-ba236f428416" /> | <img width="200" src="https://github.com/user-attachments/assets/5d7d6e37-29ff-4bf0-84f1-5edbb040eb1d" /> |


Acceptance Criteria:
- [x] Scanning a vehicle works
   - [ ] Correct item in bottom sheet
   - [ ] Correct icon/item in map
- [x] Scanning a station or vehicle that returns a station works (when only `stationId` is set in the qr response)
   - [ ] Correct item in bottom sheet
   - [ ] Correct icon/item in map