### PR TITLE
fix: sort departure list by expected departure time

### DIFF
--- a/src/departure-list/utils.test.ts
+++ b/src/departure-list/utils.test.ts
@@ -65,6 +65,14 @@ describe('sortEstimatedCallsByExpectedTime', () => {
       '2024-01-01T07:03:00Z',
     ]);
   });
+  it('keeps relative order when expectedDepartureTime is equal', () => {
+    const result = sortEstimatedCallsByExpectedTime([
+      call('a', '2024-01-01T07:05:00Z'),
+      call('b', '2024-01-01T07:05:00Z'),
+    ]);
+
+    expect(result.map((c) => c.serviceJourney.id)).toEqual(['sj-a', 'sj-b']);
+  });
 });
 
 describe('getDeparturesAugmentedWithRealtimeData', () => {

--- a/src/departure-list/utils.test.ts
+++ b/src/departure-list/utils.test.ts
@@ -1,0 +1,103 @@
+import {EstimatedCall} from '@atb/api/types/departures';
+import {DeparturesRealtimeData} from '@atb/api/bff/departures';
+import {
+  getDeparturesAugmentedWithRealtimeData,
+  sortEstimatedCallsByExpectedTime,
+} from './utils';
+
+const call = (
+  id: string,
+  expectedDepartureTime: string,
+  serviceJourneyId = `sj-${id}`,
+  quayId = 'quay-1',
+): EstimatedCall =>
+  ({
+    expectedDepartureTime,
+    aimedDepartureTime: expectedDepartureTime,
+    serviceJourney: {id: serviceJourneyId},
+    quay: {id: quayId},
+  }) as unknown as EstimatedCall;
+
+const realtime = (
+  serviceJourneyId: string,
+  expectedDepartureTime: string,
+  quayId = 'quay-1',
+): DeparturesRealtimeData => ({
+  [quayId]: {
+    quayId,
+    departures: {
+      [serviceJourneyId]: {
+        serviceJourneyId,
+        timeData: {
+          realtime: true,
+          expectedDepartureTime,
+          aimedDepartureTime: expectedDepartureTime,
+        },
+      },
+    },
+  },
+});
+
+describe('sortEstimatedCallsByExpectedTime', () => {
+  it('sorts ascending by expectedDepartureTime', () => {
+    const result = sortEstimatedCallsByExpectedTime([
+      call('a', '2024-01-01T07:05:00Z'),
+      call('b', '2024-01-01T07:03:00Z'),
+      call('c', '2024-01-01T07:08:00Z'),
+    ]);
+
+    expect(result.map((c) => c.expectedDepartureTime)).toEqual([
+      '2024-01-01T07:03:00Z',
+      '2024-01-01T07:05:00Z',
+      '2024-01-01T07:08:00Z',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      call('a', '2024-01-01T07:05:00Z'),
+      call('b', '2024-01-01T07:03:00Z'),
+    ];
+    sortEstimatedCallsByExpectedTime(input);
+
+    expect(input.map((c) => c.expectedDepartureTime)).toEqual([
+      '2024-01-01T07:05:00Z',
+      '2024-01-01T07:03:00Z',
+    ]);
+  });
+});
+
+describe('getDeparturesAugmentedWithRealtimeData', () => {
+  it('returns [] when estimatedCalls is undefined', () => {
+    expect(getDeparturesAugmentedWithRealtimeData(undefined, {})).toEqual([]);
+  });
+
+  it('returns estimatedCalls unchanged when no realtime data', () => {
+    const calls = [call('a', '2024-01-01T07:05:00Z')];
+    expect(getDeparturesAugmentedWithRealtimeData(calls, undefined)).toBe(
+      calls,
+    );
+  });
+
+  it('updates expectedDepartureTime from realtime data', () => {
+    const result = getDeparturesAugmentedWithRealtimeData(
+      [call('a', '2024-01-01T07:05:00Z', 'sj-a')],
+      realtime('sj-a', '2024-01-01T07:01:00Z'),
+    );
+
+    expect(result[0].expectedDepartureTime).toBe('2024-01-01T07:01:00Z');
+    expect(result[0].realtime).toBe(true);
+  });
+
+  it('re-sorts when a realtime update makes one departure overtake another', () => {
+    const result = getDeparturesAugmentedWithRealtimeData(
+      [
+        call('a', '2024-01-01T07:02:00Z', 'sj-a'),
+        call('b', '2024-01-01T07:04:00Z', 'sj-b'),
+      ],
+      realtime('sj-a', '2024-01-01T07:06:00Z'),
+    );
+
+    expect(result.map((c) => c.serviceJourney.id)).toEqual(['sj-b', 'sj-a']);
+  });
+});

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -116,30 +116,36 @@ export function getDeparturesAugmentedWithRealtimeData(
   if (!estimatedCalls) return [];
   if (!realtimeDeparturesData) return estimatedCalls;
 
-  return estimatedCalls
-    .map((departure) => {
-      const serviceJourneyId = departure.serviceJourney?.id;
-      const quayId = departure.quay?.id;
-      if (!serviceJourneyId || !quayId) return departure;
+  const augmentedCalls = estimatedCalls.map((departure) => {
+    const serviceJourneyId = departure.serviceJourney?.id;
+    const quayId = departure.quay?.id;
+    if (!serviceJourneyId || !quayId) return departure;
 
-      const quayRealtime = realtimeDeparturesData[quayId];
-      if (!quayRealtime) return departure;
+    const quayRealtime = realtimeDeparturesData[quayId];
+    if (!quayRealtime) return departure;
 
-      const departureRealtime = quayRealtime.departures[serviceJourneyId];
-      if (!departureRealtime) return departure;
+    const departureRealtime = quayRealtime.departures[serviceJourneyId];
+    if (!departureRealtime) return departure;
 
-      return {
-        ...departure,
-        expectedDepartureTime: departureRealtime.timeData.expectedDepartureTime,
-        actualDepartureTime: departureRealtime.timeData.actualDepartureTime,
-        realtime: departureRealtime.timeData.realtime,
-      };
-    })
-    .sort((a, b) => {
-      // Sort departures based on expectedDepartureTime, for cases where a
-      // realtime update shows that a departure has passed another.
-      return a.expectedDepartureTime < b.expectedDepartureTime ? -1 : 1;
-    });
+    return {
+      ...departure,
+      expectedDepartureTime: departureRealtime.timeData.expectedDepartureTime,
+      actualDepartureTime: departureRealtime.timeData.actualDepartureTime,
+      realtime: departureRealtime.timeData.realtime,
+    };
+  });
+
+  return sortEstimatedCallsByExpectedTime(augmentedCalls);
+}
+
+// Sort departures based on expectedDepartureTime, for cases where a
+// realtime update shows that a departure has passed another.
+export function sortEstimatedCallsByExpectedTime(
+  estimatedCalls: EstimatedCall[],
+): EstimatedCall[] {
+  return [...estimatedCalls].sort((a, b) =>
+    a.expectedDepartureTime < b.expectedDepartureTime ? -1 : 1,
+  );
 }
 
 export function hasNoGroupsWithDepartures(

--- a/src/departure-list/utils.ts
+++ b/src/departure-list/utils.ts
@@ -144,7 +144,7 @@ export function sortEstimatedCallsByExpectedTime(
   estimatedCalls: EstimatedCall[],
 ): EstimatedCall[] {
   return [...estimatedCalls].sort((a, b) =>
-    a.expectedDepartureTime < b.expectedDepartureTime ? -1 : 1,
+    a.expectedDepartureTime.localeCompare(b.expectedDepartureTime),
   );
 }
 

--- a/src/screen-components/place-screen/hooks/use-departures-query.ts
+++ b/src/screen-components/place-screen/hooks/use-departures-query.ts
@@ -14,7 +14,10 @@ import {
   UserFavoriteDepartures,
 } from '@atb/modules/favorites';
 import {flatMap} from '@atb/utils/array';
-import {getDeparturesAugmentedWithRealtimeData} from '@atb/departure-list/utils';
+import {
+  getDeparturesAugmentedWithRealtimeData,
+  sortEstimatedCallsByExpectedTime,
+} from '@atb/departure-list/utils';
 import {EstimatedCall} from '@atb/api/types/departures';
 import {minutesBetween} from '@atb/utils/date';
 import {getDepartureRefetchInterval} from '@atb/utils/get-departure-refetch-interval';
@@ -90,7 +93,10 @@ export const useDeparturesQuery = ({
           ? flatMap(departuresRaw.quays, (q) => q.estimatedCalls)
           : [];
         potentiallyMigrateFavoriteDepartures(departures);
-        return {departures, startTime};
+        return {
+          departures: sortEstimatedCallsByExpectedTime(departures),
+          startTime,
+        };
       } else {
         const departuresRealtimeQuery: DepartureRealtimeQuery = {
           quayIds: query.ids,


### PR DESCRIPTION
## Issue Reference
Slack (with video and description): https://mittatb.slack.com/archives/C0116FMPX4Y/p1780299944608929

## Description
The departure list ("avganger") could show departures out of order relative to their displayed times — e.g. "5 min" listed above "3 min". 

The full-fetch path returned departures in BFF order and was never re-sorted client-side, and that is a problem since the BFF / Entur seems to return in `aimedDepartureTime` order, while we display `expectedDepartureTime`. The refresh-fetch path already sorted by `expectedDepartureTime`, so this does that for full-fetch also. 
