### PR TITLE
feat: get station based vehicles from new endpoint

### DIFF
--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -166,7 +166,6 @@ export const getVehicle = (
         : `/mobility/v1/stations/${stationId}/mock-vehicles/${vehicleTypeId}`,
       {
         ...opts,
-        ...{baseURL: 'http://localhost:8080'},
       },
     )
     .then((response) => {

--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -152,14 +152,23 @@ export const getVehicles = (
 };
 
 export const getVehicle = (
-  id?: string,
+  vehicleId?: string,
+  vehicleTypeId?: string,
+  stationId?: string,
   opts?: VehicleRequestOpts,
 ): Promise<Vehicle | null> => {
-  if (!id || id === '') return Promise.resolve(null);
+  if (!vehicleId && (!vehicleTypeId || !stationId))
+    return Promise.resolve(null);
   return client
-    .get(`/mobility/v1/vehicles/${id}`, {
-      ...opts,
-    })
+    .get(
+      !!vehicleId
+        ? `/mobility/v1/vehicles/${vehicleId}`
+        : `/mobility/v1/stations/${stationId}/mock-vehicles/${vehicleTypeId}`,
+      {
+        ...opts,
+        ...{baseURL: 'http://localhost:8080'},
+      },
+    )
     .then((response) => {
       const result = VehicleSchema.safeParse(response.data);
       if (!result.success) {

--- a/src/api/types/generated/fragments/vehicles.ts
+++ b/src/api/types/generated/fragments/vehicles.ts
@@ -24,5 +24,3 @@ export type VehicleExtendedFragment = {
   rentalUris?: RentalUrisFragment;
   vehicleType: VehicleTypeFragment;
 } & VehicleBasicFragment;
-
-export type VehicleId = string;

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -43,7 +43,7 @@ import {
 
 import {
   isScooter,
-  useVehicleQuery,
+  useMapVehicle,
   isStation,
   isCarStation,
   isBikeStation,
@@ -155,12 +155,10 @@ export const Map = (props: MapProps) => {
         activeShmoBooking.state === ShmoBookingState.IN_USE));
 
   const {
-    data: vehicle,
+    vehicle,
     isLoading: vehicleIsLoading,
     isError: vehicleError,
-  } = useVehicleQuery(
-    selectedFeatureIsAVehicle ? selectedFeature?.properties?.id : undefined,
-  );
+  } = useMapVehicle();
 
   const activeFeatureId =
     activeShmoBooking?.asset.id ?? selectedFeature?.properties?.id;

--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -203,9 +203,6 @@ export const MapBottomSheets = ({
               }
             }}
             selectPaymentMethod={selectPaymentMethod}
-            vehicleId={
-              mapState.feature?.properties?.id ?? mapState.assetId ?? ''
-            }
             onClose={handleCloseSheet}
             onReportParkingViolation={onReportParkingViolation}
             startOnboardingCallback={navigateToShmoOnboarding}
@@ -287,14 +284,19 @@ export const MapBottomSheets = ({
           locationArrowOnPress={locationArrowOnPress}
           navigateToScanQrCode={navigateToScanQrCode}
           navigateSupportCallback={navigateToShmoSupport}
-          onVehicleTypeSelected={(vehicleId, isStationBasedBooking) => {
-            if (vehicleId) {
-              dispatchMapState({
-                type: MapStateActionType.VehicleScanned,
-                assetId: vehicleId,
-                isStationBasedBooking: isStationBasedBooking,
-              });
-            }
+          onVehicleTypeSelected={(
+            isStationBasedBooking,
+            vehicleId,
+            vehicleTypeId,
+            stationId,
+          ) => {
+            dispatchMapState({
+              type: MapStateActionType.VehicleScanned,
+              assetId: vehicleId,
+              isStationBasedBooking,
+              vehicleTypeId,
+              stationId,
+            });
           }}
         />
       )}

--- a/src/modules/map/hooks/use-shmo-warnings.tsx
+++ b/src/modules/map/hooks/use-shmo-warnings.tsx
@@ -21,7 +21,7 @@ import {GeofencingZoneCode} from '@atb-as/theme';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 
 export const useShmoWarnings = (
-  vehicleId: string,
+  vehicleId?: string,
   mapViewRef?: RefObject<MapView | null>,
 ) => {
   const {isGeofencingZonesAsTilesEnabled} = useFeatureTogglesContext();

--- a/src/modules/map/mapStateReducer.ts
+++ b/src/modules/map/mapStateReducer.ts
@@ -28,6 +28,8 @@ export type ReducerMapState = {
   bookingId?: string;
   customZoomLevel?: number;
   isStationBasedBooking?: boolean;
+  vehicleTypeId?: string;
+  stationId?: string;
 };
 
 export type ReducerMapStateAction =
@@ -35,11 +37,15 @@ export type ReducerMapStateAction =
       type: MapStateActionType.Vehicle;
       feature: Feature<Point>;
       customZoomLevel?: number;
+      vehicleTypeId?: string;
+      stationId?: string;
     }
   | {
       type: MapStateActionType.VehicleScanned;
-      assetId: string;
+      assetId?: string;
       isStationBasedBooking?: boolean;
+      vehicleTypeId?: string;
+      stationId?: string;
     }
   | {
       type: MapStateActionType.BikeStation;
@@ -99,6 +105,8 @@ export const mapStateReducer = (
         feature: action.feature,
         customZoomLevel: action?.customZoomLevel,
         isStationBasedBooking: mapState.isStationBasedBooking,
+        vehicleTypeId: mapState.vehicleTypeId,
+        stationId: mapState.stationId,
       };
     case MapStateActionType.VehicleScanned:
       return {
@@ -106,6 +114,8 @@ export const mapStateReducer = (
         assetId: action.assetId,
         assetIsScanned: true,
         isStationBasedBooking: action.isStationBasedBooking,
+        vehicleTypeId: action.vehicleTypeId,
+        stationId: action.stationId,
       };
     case MapStateActionType.BikeStation:
       return {

--- a/src/modules/mobility/components/BikeStationIntegrationView.tsx
+++ b/src/modules/mobility/components/BikeStationIntegrationView.tsx
@@ -24,11 +24,7 @@ import {useVehiclesByVehicleTypeIdsQueries} from '../queries/use-vehicles-by-veh
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Loading} from '@atb/components/loading';
 import {useQueryClient} from '@tanstack/react-query';
-import {Vehicle} from '@atb/api/types/mobility';
-import {
-  getVehicleQueryKey,
-  MOCK_VEHICLE_ID,
-} from '../queries/use-vehicle-query';
+import {getVehicleQueryKey} from '../queries/use-vehicle-query';
 import {SupportButton} from './SupportButton';
 import {
   ThemedCityBikeStation,
@@ -39,8 +35,10 @@ type Props = {
   station: Station;
   navigateSupportCallback: (params: ShmoHelpParams) => void;
   onPressVehicleType: (
-    vehicleId: string,
     isStationBasedBooking: boolean,
+    vehicleId?: string,
+    vehicleTypeId?: string,
+    stationId?: string,
   ) => void;
 };
 
@@ -127,29 +125,14 @@ export const BikeStationIntegrationView = ({
                       getVehicleQueryKey(vehicle.id),
                       vehicle,
                     );
-                    onPressVehicleType(vehicle.id, false);
+                    onPressVehicleType(false, vehicle.id);
                   } else {
-                    const mockVehicle: Vehicle = {
-                      id: MOCK_VEHICLE_ID,
-                      lat: station.lat,
-                      lon: station.lon,
-                      currentRangeMeters: 1000,
-                      isReserved: false,
-                      isDisabled: false,
-                      pricingPlan: e.vehicleType.pricingPlans?.[0] ?? {
-                        price: 0,
-                        currency: 'NOK',
-                      },
-                      system: station.system,
-                      station: {id: station.id},
-                      vehicleType: {...e.vehicleType, name: {}},
-                    };
-
-                    queryClient.setQueryData(
-                      getVehicleQueryKey(mockVehicle.id),
-                      mockVehicle,
+                    onPressVehicleType(
+                      true,
+                      undefined,
+                      e.vehicleType.id,
+                      station.id,
                     );
-                    onPressVehicleType(mockVehicle.id, true);
                   }
                 }}
               />

--- a/src/modules/mobility/components/ShmoActionButton.tsx
+++ b/src/modules/mobility/components/ShmoActionButton.tsx
@@ -18,7 +18,7 @@ import {useMapContext, useShmoWarnings} from '@atb/modules/map';
 import {MessageInfoText} from '@atb/components/message-info-text';
 import {AgeVerificationEnum} from '../queries/use-get-age-verification-query';
 import {useAnalyticsContext} from '@atb/modules/analytics';
-import {useVehicle} from '../use-vehicle.tsx';
+import {useMapVehicle} from '../use-map-vehicle.tsx';
 
 type ShmoActionButtonProps = {
   onStartOnboarding: () => void;
@@ -46,10 +46,13 @@ export const ShmoActionButton = ({
   const {theme} = useThemeContext();
   const styles = useStyles();
   const coordinates = getCurrentCoordinatesGlobal();
-  const {warningMessage} = useShmoWarnings(vehicleId);
   const {logEvent} = useAnalyticsContext();
-  const {vehicle} = useVehicle(vehicleId);
   const {mapState} = useMapContext();
+  const {vehicle} = useMapVehicle();
+  const {warningMessage} = useShmoWarnings(
+    // Shmo warnings not yet supported for station based vehicles.
+    mapState.isStationBasedBooking ? undefined : vehicleId,
+  );
 
   const {
     mutateAsync: initShmoOneStopBooking,

--- a/src/modules/mobility/components/sheets/BikeStationBottomSheet.tsx
+++ b/src/modules/mobility/components/sheets/BikeStationBottomSheet.tsx
@@ -28,8 +28,10 @@ type Props = {
   navigateToScanQrCode: () => void;
   navigateSupportCallback: (params: ShmoHelpParams) => void;
   onVehicleTypeSelected: (
-    vehicleId: string,
     isStationBasedBooking: boolean,
+    vehicleId?: string,
+    vehicleTypeId?: string,
+    stationId?: string,
   ) => void;
 };
 

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -1,4 +1,3 @@
-import {VehicleId} from '@atb/api/types/generated/fragments/vehicles';
 import React, {useCallback, useState} from 'react';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -6,7 +5,7 @@ import {
   MobilityTexts,
   ScooterTexts,
 } from '@atb/translations/screens/subscreens/MobilityTexts';
-import {useVehicle} from '../../use-vehicle';
+import {useMapVehicle} from '../../use-map-vehicle';
 import {Linking, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
@@ -59,7 +58,6 @@ import {showAppMissingAlert} from '../../show-app-missing-alert';
 
 type Props = {
   selectPaymentMethod: () => void;
-  vehicleId: VehicleId;
   onClose: () => void;
   onReportParkingViolation: () => void;
   onVehicleReceived?: (vehicle: Vehicle) => void;
@@ -76,7 +74,6 @@ type Props = {
 
 export const VehicleSheet = ({
   selectPaymentMethod,
-  vehicleId: id,
   onClose,
   onReportParkingViolation,
   onVehicleReceived,
@@ -98,7 +95,7 @@ export const VehicleSheet = ({
     operatorName,
     rentalAppUri,
     appStoreUri,
-  } = useVehicle(id);
+  } = useMapVehicle();
 
   const formFactor = vehicle?.vehicleType.formFactor ?? FormFactor.Other;
   const propulsionType = vehicle?.vehicleType.propulsionType;
@@ -278,7 +275,7 @@ export const VehicleSheet = ({
               <ShmoActionButton
                 onStartOnboarding={() => startOnboardingCallback(formFactor)}
                 loginCallback={navigateToLogin}
-                vehicleId={id}
+                vehicleId={vehicle.id}
                 operatorId={operatorId}
                 paymentMethod={selectedPaymentMethod}
                 bonusProductId={
@@ -298,7 +295,11 @@ export const VehicleSheet = ({
 
                 <SupportButton
                   navigateToSupport={() => {
-                    navigateToSupport({vehicleId: id, operatorId, formFactor});
+                    navigateToSupport({
+                      vehicleId: vehicle.id,
+                      operatorId,
+                      formFactor,
+                    });
                   }}
                 />
               </View>

--- a/src/modules/mobility/index.ts
+++ b/src/modules/mobility/index.ts
@@ -36,6 +36,7 @@ export {useOperatorBenefitsForFareProduct} from './use-operator-benefits-for-far
 export {useOperators} from './use-operators';
 export {useShmoRequirements} from './use-shmo-requirements';
 export {useVehicle} from './use-vehicle';
+export {useMapVehicle} from './use-map-vehicle';
 export {useDeleteAgeVerificationMutation} from './queries/use-remove-age-verification-mutation';
 export {
   computeFreeMinuteCount,

--- a/src/modules/mobility/queries/use-vehicle-query.tsx
+++ b/src/modules/mobility/queries/use-vehicle-query.tsx
@@ -1,20 +1,24 @@
 import {useQuery} from '@tanstack/react-query';
 import {ONE_MINUTE_MS} from '@atb/utils/durations';
 import {getVehicle} from '@atb/api/mobility';
-import {useMapContext} from '@atb/modules/map';
 
-export const MOCK_VEHICLE_ID = 'mock-vehicle-id';
+export const getVehicleQueryKey = (
+  vehicleId?: string,
+  vehicleTypeId?: string,
+  stationId?: string,
+) => ['GET_VEHICLE', [vehicleId, vehicleTypeId, stationId]];
 
-export const getVehicleQueryKey = (id?: string) => ['GET_VEHICLE', id];
-
-export const useVehicleQuery = (id?: string) => {
-  const {mapState} = useMapContext();
+export const useVehicleQuery = (
+  vehicleId?: string,
+  vehicleTypeId?: string,
+  stationId?: string,
+) => {
   return useQuery({
-    queryKey: getVehicleQueryKey(id),
-    queryFn: ({signal}) => getVehicle(id, {signal}),
+    queryKey: getVehicleQueryKey(vehicleId, vehicleTypeId, stationId),
+    queryFn: ({signal}) =>
+      getVehicle(vehicleId, vehicleTypeId, stationId, {signal}),
     gcTime: ONE_MINUTE_MS,
-    refetchOnMount: mapState.isStationBasedBooking ? false : 'always',
-    enabled: !mapState.isStationBasedBooking,
+    refetchOnMount: 'always',
     retry: 5,
   });
 };

--- a/src/modules/mobility/use-map-vehicle.tsx
+++ b/src/modules/mobility/use-map-vehicle.tsx
@@ -1,0 +1,18 @@
+import {useMapContext} from '../map';
+import {useVehicle} from './use-vehicle';
+import {isVehicle} from './utils';
+
+export const useMapVehicle = () => {
+  const {mapState} = useMapContext();
+
+  let vehicleId = '';
+  if (!mapState.isStationBasedBooking) {
+    if (isVehicle(mapState.feature)) {
+      vehicleId = mapState.feature?.properties?.id;
+    } else {
+      vehicleId = mapState.assetId ?? '';
+    }
+  }
+
+  return useVehicle(vehicleId, mapState.vehicleTypeId, mapState.stationId);
+};

--- a/src/modules/mobility/use-vehicle.tsx
+++ b/src/modules/mobility/use-vehicle.tsx
@@ -2,8 +2,16 @@ import {useSystem} from './use-system';
 import {getRentalAppUri} from './utils';
 import {useVehicleQuery} from './queries/use-vehicle-query';
 
-export const useVehicle = (id?: string) => {
-  const {data: vehicle, isLoading, isError} = useVehicleQuery(id);
+export const useVehicle = (
+  vehicleId?: string,
+  vehicleTypeId?: string,
+  stationId?: string,
+) => {
+  const {
+    data: vehicle,
+    isLoading,
+    isError,
+  } = useVehicleQuery(vehicleId, vehicleTypeId, stationId);
   const {appStoreUri, brandLogoUrl, operatorId, operatorName} = useSystem(
     vehicle,
     vehicle?.system.operator.name,


### PR DESCRIPTION
## Issue Reference
<!-- Which issue is fixed in this PR? Include link to reference if possible -->
Part of https://github.com/AtB-AS/kundevendt/issues/24096
Depends on https://github.com/AtB-AS/mobility/pull/113

## Description
<!-- What does this PR do? -->
Rather than create a station based vehicle in the app, it is now fetched from the mobility svc based on vehicleTypeId and stationId. With the new API for deep integration and benefits from mobility svc, this means we can align station based vehicles with normal vehicles. Otherwise we'd have to add new props to vehicleTypesAvailable on `station` as well. However that would not play well with potential refresh mechanisms, while a separate endpoint does.

This also fixes a bug for getting the correct state after opening a station based vehicle, and then logging in or out:

| Before | After |
|--------|-------|
| <img width="150" src="https://github.com/user-attachments/assets/af74966e-38be-4ee7-809a-d83f4abe6d52" /> | <img width="150" src="https://github.com/user-attachments/assets/0d34bcad-9669-4b14-af66-7d2f4a293902" /> |

**Acceptance Criteria:**
- [x] Correct station based vehicle data received (matching the station and vehicleType selected just before)
- [x] Existing vehicles not affected
- [x] No unnecessary api calls / guaranteed errors