### PR TITLE
refactor: remove save_trip_swipe_threshold remote config

### DIFF
--- a/src/modules/experimental-store-trip-patterns/SwipeableResultRow.tsx
+++ b/src/modules/experimental-store-trip-patterns/SwipeableResultRow.tsx
@@ -8,9 +8,10 @@ import Animated, {SharedValue, useAnimatedStyle} from 'react-native-reanimated';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Delete, Save} from '@atb/assets/svg/mono-icons/actions';
 import {SvgProps} from 'react-native-svg';
-import {useRemoteConfigContext} from '@atb/modules/remote-config';
 
 export type RightActionKind = 'delete' | 'save';
+
+const RIGHT_SWIPE_THRESHOLD = 40;
 
 export const SwipeableResultRow: React.FC<
   React.PropsWithChildren<{
@@ -22,7 +23,6 @@ export const SwipeableResultRow: React.FC<
   }>
 > = ({children, onRightAction, rightActionKind}) => {
   const swipeableRef = useRef<SwipeableMethods | null>(null);
-  const {save_trip_swipe_threshold} = useRemoteConfigContext();
 
   const closeSwipeable = useCallback(() => {
     swipeableRef.current?.close();
@@ -50,7 +50,7 @@ export const SwipeableResultRow: React.FC<
       friction={2}
       overshootFriction={8}
       enableTrackpadTwoFingerGesture
-      rightThreshold={save_trip_swipe_threshold}
+      rightThreshold={RIGHT_SWIPE_THRESHOLD}
       renderRightActions={RightAction}
       onSwipeableOpen={handleSwipe}
     >

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -85,7 +85,6 @@ export type RemoteConfig = {
   mapbox_user_name: string;
   minimum_app_version: string;
   service_disruption_url: string;
-  save_trip_swipe_threshold: number;
   token_timeout_in_seconds: number;
   use_geocoder_v3: boolean;
   use_product_api_v2: boolean;
@@ -171,7 +170,6 @@ export const defaultRemoteConfig: RemoteConfig = {
   mapbox_user_name: MAPBOX_USER_NAME,
   minimum_app_version: '',
   service_disruption_url: '',
-  save_trip_swipe_threshold: 40,
   token_timeout_in_seconds: 10,
   use_geocoder_v3: false,
   use_product_api_v2: false,
@@ -393,9 +391,6 @@ export function getConfig(): RemoteConfig {
   const service_disruption_url =
     values['service_disruption_url']?.asString() ??
     defaultRemoteConfig.service_disruption_url;
-  const save_trip_swipe_threshold =
-    values['save_trip_swipe_threshold']?.asNumber() ??
-    defaultRemoteConfig.save_trip_swipe_threshold;
   const token_timeout_in_seconds =
     values['token_timeout_in_seconds']?.asNumber() ??
     defaultRemoteConfig.token_timeout_in_seconds;
@@ -482,7 +477,6 @@ export function getConfig(): RemoteConfig {
     mapbox_user_name,
     minimum_app_version,
     service_disruption_url,
-    save_trip_swipe_threshold,
     token_timeout_in_seconds,
     use_geocoder_v3,
     use_product_api_v2,


### PR DESCRIPTION
## Description

The `save_trip_swipe_threshold` remote config value has never been changed from its default of `40`, so there's no need to keep it configurable.

Removed the remote config entry (type, default, parsing, and return in `remote-config.ts`) and hardcoded the value as `RIGHT_SWIPE_THRESHOLD = 40` directly in `SwipeableResultRow`.