### PR TITLE
fix: avoid vehicle 404 during active shmo trip

### DIFF
--- a/src/modules/mobility/use-map-vehicle.tsx
+++ b/src/modules/mobility/use-map-vehicle.tsx
@@ -1,12 +1,22 @@
 import {useMapContext} from '../map';
 import {useVehicle} from './use-vehicle';
 import {isVehicle} from './utils';
+import {useActiveShmoBookingQuery} from './queries/use-active-shmo-booking-query';
+import {ShmoBookingState} from '@atb/api/types/mobility';
 
 export const useMapVehicle = () => {
   const {mapState} = useMapContext();
+  const {data: activeShmoBooking} = useActiveShmoBookingQuery(true);
+
+  // During an active trip the rented vehicle is removed from the vehicles feed,
+  // so fetching it by id (or via the station mock endpoint) would 404. Vehicle
+  // data comes from the active booking instead.
+  const hasActiveBooking =
+    activeShmoBooking?.state === ShmoBookingState.IN_USE ||
+    activeShmoBooking?.state === ShmoBookingState.FINISHING;
 
   let vehicleId = '';
-  if (!mapState.isStationBasedBooking) {
+  if (!mapState.isStationBasedBooking && !hasActiveBooking) {
     if (isVehicle(mapState.feature)) {
       vehicleId = mapState.feature?.properties?.id;
     } else {
@@ -14,5 +24,8 @@ export const useMapVehicle = () => {
     }
   }
 
-  return useVehicle(vehicleId, mapState.vehicleTypeId, mapState.stationId);
+  const vehicleTypeId = hasActiveBooking ? undefined : mapState.vehicleTypeId;
+  const stationId = hasActiveBooking ? undefined : mapState.stationId;
+
+  return useVehicle(vehicleId, vehicleTypeId, stationId);
 };


### PR DESCRIPTION
## Problem

After #6218 (station based vehicles from new endpoint), `/mobility/v1/vehicles/:id` returns **404** repeatedly during an active shmo trip on an ebike.

## Cause

`useMapVehicle` resolves the vehicle id from the persisted scanned `mapState.assetId` (or station mock params) with no active-booking guard. Previously the map-level query was gated on `selectedFeatureIsAVehicle`, so it fired only when a vehicle feature was selected on the map — never during an active trip.

A rented vehicle is removed from the vehicles feed, so the backend `get_vehicle` handler returns `NotFound` → 404, retried 5x (`retry: 5`, `refetchOnMount: 'always'`) for the duration of the trip.

## Fix

Gate `useMapVehicle` on the active booking: when the booking is `IN_USE` or `FINISHING`, skip fetching by id / station mock params. During a trip, vehicle data already comes from `activeShmoBooking.asset`. Pre-trip behavior (scan/select to show the sheet and start the trip) is unchanged.

## Testing

- `pnpm check-all` green (tsc, lint, 803 tests, prettier)
- Manual: start an ebike trip, confirm no repeated `/vehicles/:id` 404s