### PR TITLE
revert: incomplete vehicle 404 fix from #6222

### DIFF
--- a/src/modules/mobility/use-map-vehicle.tsx
+++ b/src/modules/mobility/use-map-vehicle.tsx
@@ -1,22 +1,12 @@
 import {useMapContext} from '../map';
 import {useVehicle} from './use-vehicle';
 import {isVehicle} from './utils';
-import {useActiveShmoBookingQuery} from './queries/use-active-shmo-booking-query';
-import {ShmoBookingState} from '@atb/api/types/mobility';
 
 export const useMapVehicle = () => {
   const {mapState} = useMapContext();
-  const {data: activeShmoBooking} = useActiveShmoBookingQuery(true);
-
-  // During an active trip the rented vehicle is removed from the vehicles feed,
-  // so fetching it by id (or via the station mock endpoint) would 404. Vehicle
-  // data comes from the active booking instead.
-  const hasActiveBooking =
-    activeShmoBooking?.state === ShmoBookingState.IN_USE ||
-    activeShmoBooking?.state === ShmoBookingState.FINISHING;
 
   let vehicleId = '';
-  if (!mapState.isStationBasedBooking && !hasActiveBooking) {
+  if (!mapState.isStationBasedBooking) {
     if (isVehicle(mapState.feature)) {
       vehicleId = mapState.feature?.properties?.id;
     } else {
@@ -24,8 +14,5 @@ export const useMapVehicle = () => {
     }
   }
 
-  const vehicleTypeId = hasActiveBooking ? undefined : mapState.vehicleTypeId;
-  const stationId = hasActiveBooking ? undefined : mapState.stationId;
-
-  return useVehicle(vehicleId, vehicleTypeId, stationId);
+  return useVehicle(vehicleId, mapState.vehicleTypeId, mapState.stationId);
 };


### PR DESCRIPTION
Reverts #6222.

The `useMapVehicle` guard added in #6222 only covered the `Map.tsx` fetch path. The active-trip 404 on `/mobility/v1/vehicles/:id` also originates from `ActiveShmoSheet` → `useShmoWarnings` → `useVehicle`, which #6222 did not touch — so testers still hit repeated 404s during an active booking (confirmed for bicycle rides).

Reverting here so the fix can be replaced with a single centralized guard in `useVehicleQuery` (separate PR).