### PR TITLE
fix: disable vehicle query during active shmo booking

### DIFF
--- a/src/modules/mobility/queries/use-vehicle-query.tsx
+++ b/src/modules/mobility/queries/use-vehicle-query.tsx
@@ -1,6 +1,8 @@
 import {useQuery} from '@tanstack/react-query';
 import {ONE_MINUTE_MS} from '@atb/utils/durations';
 import {getVehicle} from '@atb/api/mobility';
+import {useActiveShmoBookingQuery} from './use-active-shmo-booking-query';
+import {ShmoBookingState} from '@atb/api/types/mobility';
 
 export const getVehicleQueryKey = (
   vehicleId?: string,
@@ -13,6 +15,16 @@ export const useVehicleQuery = (
   vehicleTypeId?: string,
   stationId?: string,
 ) => {
+  const {data: activeShmoBooking} = useActiveShmoBookingQuery(true);
+
+  // A rented vehicle is removed from the vehicles feed for the duration of the
+  // trip, so fetching it by id (or via the station endpoint) returns 404.
+  // Disable the query while a booking is active; consumers fall back to the
+  // active booking's asset for vehicle details.
+  const hasActiveBooking =
+    activeShmoBooking?.state === ShmoBookingState.IN_USE ||
+    activeShmoBooking?.state === ShmoBookingState.FINISHING;
+
   return useQuery({
     queryKey: getVehicleQueryKey(vehicleId, vehicleTypeId, stationId),
     queryFn: ({signal}) =>
@@ -20,5 +32,6 @@ export const useVehicleQuery = (
     gcTime: ONE_MINUTE_MS,
     refetchOnMount: 'always',
     retry: 5,
+    enabled: !hasActiveBooking,
   });
 };


### PR DESCRIPTION
## Problem

During an active shmo trip, the app repeatedly hits `GET /mobility/v1/vehicles/:id` with a **404** (confirmed for bicycle rides). A rented vehicle is removed from the vehicles feed for the duration of the trip, so the backend `get_vehicle` handler returns `NotFound`. With `retry: 5` and `refetchOnMount: 'always'`, this produces persistent 404 noise throughout the trip.

## Why the previous fix (#6222) was incomplete

#6222 gated only the `Map.tsx` → `useMapVehicle` path. But the vehicle-by-id query fires from more than one place during an active trip — notably `ActiveShmoSheet` → `useShmoWarnings` → `useVehicle`. That path was untouched, so testers still saw the 404s. #6222 is reverted in #6224.

## Fix

Centralize the guard in `useVehicleQuery`: disable the query while a booking is `IN_USE` or `FINISHING`. This covers every call site (Map, VehicleSheet, ShmoActionButton, ActiveShmoSheet, ShmoTesting) and both the real (`/vehicles/:id`) and station (`/stations/:id/mock-vehicles/:typeId`) endpoints.

- Consumers already fall back to `activeShmoBooking.asset` for vehicle details during a trip.
- `useShmoWarnings` keeps being called during the trip — its geofencing-zone warnings are computed from map features + location and are independent of the vehicle fetch, so they continue to work. Only the vehicle-derived `warningMessage` (disabled/opening-hours), which was already `null` due to the 404, is affected.

## Testing

- `pnpm check-all` green (tsc, lint, 803 tests, prettier)
- Manual: needs device verification on an active bicycle ride (and scooter) to confirm no `/vehicles/:id` 404s.

Depends on / follows #6224 (revert of #6222).