### PR TITLE
fix: add checkbox for bonus in Bicycle VehicleBottomSheet

### DIFF
--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -182,7 +182,7 @@ export const VehicleSheet = ({
   const showParkingViolation =
     !isBicycle && isParkingViolationsReportingEnabled;
   const showBonusCheckbox =
-    !isBicycle && isBonusActiveForUser && hasBonusOffer && !!clientBonusProduct;
+    isBonusActiveForUser && hasBonusOffer && !!clientBonusProduct;
 
   // Drive the CTA from the server `actionButton` when present, otherwise fall
   // back to the existing deep-integration / operator branching.


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23935

## Description
Removes the `!bicycle` check for `showBonusCheckbox` so that bicycle related bonus products show on bicycle bottom sheets.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/22e875c9-cf28-4c1a-bd4c-5aaecfff7b72" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/a42be722-7b39-44e2-848e-ab35dca26eb1" />
