### PR TITLE
fix: improved android keyboard avoiding full screen views

### DIFF
--- a/src/components/screen-footer/FullScreenFooter.tsx
+++ b/src/components/screen-footer/FullScreenFooter.tsx
@@ -1,6 +1,6 @@
 import {StyleSheet, Theme} from '@atb/theme';
 import React from 'react';
-import {KeyboardAvoidingView, View} from 'react-native';
+import {KeyboardAvoidingView, Platform, View} from 'react-native';
 
 type ScreenFooterProps = {
   children: React.ReactNode;
@@ -17,7 +17,10 @@ export function FullScreenFooter({
   const containerStyle = {...styles.container, backgroundColor: footerColor};
 
   return avoidKeyboard ? (
-    <KeyboardAvoidingView behavior="padding" style={containerStyle}>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'android' ? undefined : 'padding'}
+      style={containerStyle}
+    >
       {children}
     </KeyboardAvoidingView>
   ) : (

--- a/src/components/screen-view/FullScreenView.tsx
+++ b/src/components/screen-view/FullScreenView.tsx
@@ -5,6 +5,7 @@ import {
   KeyboardAvoidingView,
   RefreshControl,
   RefreshControlProps,
+  Platform,
 } from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 // eslint-disable-next-line rulesdir/navigation-only-in-screens
@@ -116,7 +117,10 @@ export function FullScreenView(props: Props) {
       </View>
 
       {props.avoidKeyboard ? (
-        <KeyboardAvoidingView behavior="padding" style={{flex: 1}}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'android' ? undefined : 'padding'}
+          style={{flex: 1}}
+        >
           {contentComponent}
         </KeyboardAvoidingView>
       ) : (

--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -179,7 +179,7 @@ export const DetailsContent: React.FC<Props> = ({
   const {data: schoolCarnetInfo} = useSchoolCarnetInfoQuery(fc, validityStatus);
 
   return (
-    <Section style={styles.section}>
+    <Section>
       {hasShmoBookingId(fc) ? (
         <FareContractShmoHeaderSectionItem fareContract={fc} now={now} />
       ) : (
@@ -326,18 +326,10 @@ export const DetailsContent: React.FC<Props> = ({
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme, {bottom}) => {
+const useStyles = StyleSheet.createThemeHook((theme) => {
   return {
     globalMessages: {
       flex: 1,
-      rowGap: theme.spacing.medium,
-    },
-    section: {
-      marginBottom: bottom,
-    },
-    fareContractDetails: {
-      flex: 1,
-      paddingBottom: theme.spacing.large,
       rowGap: theme.spacing.medium,
     },
     enlargedWhiteBarcodePaddingView: {

--- a/src/modules/payment/SelectPaymentMethodSheet.tsx
+++ b/src/modules/payment/SelectPaymentMethodSheet.tsx
@@ -89,7 +89,6 @@ export const SelectPaymentMethodSheet: React.FC<Props> = ({
     <FullScreenFooter>
       <Button
         expanded={true}
-        style={styles.confirmButton}
         interactiveColor={theme.color.interactive[0]}
         text={t(SelectPaymentMethodTexts.confirm_button.text)}
         accessibilityHint={t(SelectPaymentMethodTexts.confirm_button.a11yhint)}
@@ -198,8 +197,5 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     padding: theme.spacing.medium,
     borderRadius: theme.border.radius.regular,
-  },
-  confirmButton: {
-    marginTop: theme.spacing.small,
   },
 }));

--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -1,4 +1,4 @@
-import {FullScreenHeader, useTicketInfo} from '@atb/components/screen-header';
+import {useTicketInfo} from '@atb/components/screen-header';
 import {DetailsContent} from '@atb/modules/fare-contracts';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
@@ -7,7 +7,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import React, {useCallback} from 'react';
-import {ScrollView, View} from 'react-native';
+import {View} from 'react-native';
 import {
   RootStackScreenProps,
   ShmoHelpParams,
@@ -25,6 +25,7 @@ import type {PurchaseSelectionType} from '@atb/modules/purchase-selection';
 import {useApplePassPresentationSuppression} from '@atb/modules/native-bridges';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {ONE_MINUTE_MS, ONE_SECOND_MS} from '@atb/utils/durations';
+import {FullScreenView} from '@atb/components/screen-view';
 
 type Props = RootStackScreenProps<'Root_FareContractDetailsScreen'>;
 
@@ -108,11 +109,10 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
   );
 
   return (
-    <View style={styles.container}>
-      <FullScreenHeader
-        showBorder={false}
-        leftButton={{type: 'back'}}
-        rightButton={
+    <FullScreenView
+      headerProps={{
+        leftButton: {type: 'back'},
+        rightButton:
           enable_ticket_information && !hasShmoBookingId(fareContract)
             ? {
                 type: 'custom',
@@ -124,11 +124,13 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
                   FareContractTexts.details.header.infoButtonA11yHint,
                 ),
               }
-            : undefined
-        }
-        title={t(FareContractTexts.details.header.title)}
-      />
-      <ScrollView contentContainerStyle={styles.content}>
+            : undefined,
+
+        title: t(FareContractTexts.details.header.title),
+      }}
+      focusRef={undefined}
+    >
+      <View style={styles.container}>
         {fareContract && (
           <ErrorBoundary
             message={t(
@@ -151,17 +153,14 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
             />
           </ErrorBoundary>
         )}
-      </ScrollView>
-    </View>
+      </View>
+    </FullScreenView>
   );
 }
 
 const useStyles = StyleSheet.createThemeHook((theme) => ({
   container: {
     flex: 1,
-  },
-  content: {
-    padding: theme.spacing.medium,
-    paddingBottom: theme.spacing.xLarge,
+    margin: theme.spacing.medium,
   },
 }));

--- a/src/stacks-hierarchy/Root_ShmoHelp/Root_ContactShmoOperatorScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoHelp/Root_ContactShmoOperatorScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {KeyboardAvoidingView, ScrollView, View} from 'react-native';
+import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
 import {ThemeText} from '@atb/components/text';
 import {useTranslation} from '@atb/translations';
@@ -26,11 +26,10 @@ import {MessageInfoBox} from '@atb/components/message-info-box';
 import {useSendSupportRequestMutation} from '@atb/modules/mobility';
 import {getCurrentCoordinatesGlobal} from '@atb/modules/geolocation';
 import {useProfileQuery} from '@atb/queries';
-import {FullScreenHeader} from '@atb/components/screen-header';
-import {useScrollBorder} from '@atb/utils/use-scroll-border';
 import {CustomerProfile} from '@atb/api/types/profile';
 import {useNavigation} from '@react-navigation/native';
 import {useOperators} from '@atb/modules/mobility';
+import {FullScreenView} from '@atb/components/screen-view';
 
 export type Root_ContactShmoOperatorScreenProps =
   RootStackScreenProps<'Root_ContactShmoOperatorScreen'>;
@@ -50,7 +49,6 @@ export const Root_ContactShmoOperatorScreen = ({
   const styles = useStyles();
   const {t} = useTranslation();
   const navigation = useNavigation<RootNavigationProps>();
-  const {onScroll, isScrolled} = useScrollBorder();
 
   const onSuccess = () => {
     navigation.navigate('Root_ContactShmoOperatorConfirmationScreen', {
@@ -79,176 +77,161 @@ export const Root_ContactShmoOperatorScreen = ({
   );
 
   return (
-    <View style={styles.container}>
-      <FullScreenHeader
-        leftButton={{type: 'back'}}
-        title={t(ContactShmoOperatorTexts.title(operatorName ?? ''))}
-        showBorder={isScrolled}
-      />
-      <KeyboardAvoidingView behavior="padding" style={styles.mainView}>
-        <ScrollView
-          keyboardShouldPersistTaps="handled"
-          centerContent={true}
-          onScroll={onScroll}
-          scrollEventThrottle={16}
-        >
-          <View style={styles.contentContainer}>
-            <ContentHeading
-              text={t(ContactShmoOperatorTexts.supportType.header)}
-            />
-            <RadioGroupSection<SupportType>
-              keyExtractor={(supportType) => supportType}
-              selected={requestBody.supportType}
-              items={Object.values(SupportType) as SupportType[]}
-              onSelect={(supportType) =>
-                setRequestBody((prev) => ({...prev, supportType}))
-              }
-              itemToText={(supportType) =>
-                t(
-                  ContactShmoOperatorTexts.supportType.supportTypeDescription(
-                    supportType,
-                  ),
-                )
-              }
-            />
-            {requestBody.supportType === SupportType.UNABLE_TO_CLOSE && (
-              <MessageInfoBox
-                message={t(
-                  ContactShmoOperatorTexts.supportType.noEndInfo(
-                    operatorName ?? '',
-                  ),
-                )}
-                type="info"
-              />
+    <FullScreenView
+      headerProps={{
+        leftButton: {type: 'back'},
+        title: t(ContactShmoOperatorTexts.title(operatorName ?? '')),
+      }}
+      avoidKeyboard={true}
+      focusRef={undefined}
+    >
+      <View style={styles.contentContainer}>
+        <ContentHeading text={t(ContactShmoOperatorTexts.supportType.header)} />
+        <RadioGroupSection<SupportType>
+          keyExtractor={(supportType) => supportType}
+          selected={requestBody.supportType}
+          items={Object.values(SupportType) as SupportType[]}
+          onSelect={(supportType) =>
+            setRequestBody((prev) => ({...prev, supportType}))
+          }
+          itemToText={(supportType) =>
+            t(
+              ContactShmoOperatorTexts.supportType.supportTypeDescription(
+                supportType,
+              ),
+            )
+          }
+        />
+        {requestBody.supportType === SupportType.UNABLE_TO_CLOSE && (
+          <MessageInfoBox
+            message={t(
+              ContactShmoOperatorTexts.supportType.noEndInfo(
+                operatorName ?? '',
+              ),
             )}
-            <ContentHeading text={t(ContactShmoOperatorTexts.comment.header)} />
-            <Section>
-              <TextInputSectionItem
-                value={requestBody.comment ?? ''}
-                onChangeText={(comment) =>
-                  setRequestBody((prev) => ({...prev, comment}))
-                }
-                label={t(ContactShmoOperatorTexts.comment.label)}
-                placeholder={t(ContactShmoOperatorTexts.comment.placeholder)}
-                inlineLabel={false}
-                multiline={true}
-                maxLength={MAX_SUPPORT_COMMENT_LENGTH}
-                scrollEnabled={false}
-                autoCapitalize="sentences"
-                errorText={
-                  !isCommentValid && showError
-                    ? t(
-                        ContactShmoOperatorTexts.comment.errorMessage(
-                          MAX_SUPPORT_COMMENT_LENGTH,
-                        ),
-                      )
-                    : undefined
-                }
-              />
-            </Section>
-            <ContentHeading
-              text={t(ContactShmoOperatorTexts.contactInfo.header)}
-            />
-            <Section>
-              <TextInputSectionItem
-                value={requestBody.contactInformationEndUser.email ?? ''}
-                onChangeText={(email) =>
-                  setRequestBody((prev) => ({
-                    ...prev,
-                    contactInformationEndUser: {
-                      ...prev.contactInformationEndUser,
-                      email,
-                    },
-                  }))
-                }
-                label={t(ContactShmoOperatorTexts.contactInfo.email.label)}
-                placeholder={t(
-                  ContactShmoOperatorTexts.contactInfo.email.placeholder,
-                )}
-                showClear
-                inlineLabel={false}
-                keyboardType="email-address"
-                autoComplete="email"
-                autoCapitalize="none"
-                errorText={
-                  !isEmailValid && showError
-                    ? t(ContactShmoOperatorTexts.contactInfo.email.errorMessage)
-                    : !isContactInfoPresent && showError
-                      ? t(ContactShmoOperatorTexts.contactInfo.errorMessage)
-                      : undefined
-                }
-              />
-            </Section>
-            <Section>
-              <PhoneInputSectionItem
-                prefix={requestBody.contactInformationEndUser.phonePrefix ?? ''}
-                onChangePrefix={(phonePrefix) =>
-                  setRequestBody((prev) => ({
-                    ...prev,
-                    contactInformationEndUser: {
-                      ...prev.contactInformationEndUser,
-                      phonePrefix,
-                    },
-                  }))
-                }
-                onChangeText={(phoneNumber) =>
-                  setRequestBody((prev) => ({
-                    ...prev,
-                    contactInformationEndUser: {
-                      ...prev.contactInformationEndUser,
-                      phoneNumber,
-                    },
-                  }))
-                }
-                value={requestBody.contactInformationEndUser.phoneNumber ?? ''}
-                label={t(ContactShmoOperatorTexts.contactInfo.phone.label)}
-                placeholder={t(
-                  ContactShmoOperatorTexts.contactInfo.phone.placeholder,
-                )}
-                showClear
-                textContentType="telephoneNumber"
-                errorText={
-                  !isPhoneNumberValid && showError
-                    ? t(ContactShmoOperatorTexts.contactInfo.phone.errorMessage)
-                    : !isContactInfoPresent && showError
-                      ? t(ContactShmoOperatorTexts.contactInfo.errorMessage)
-                      : undefined
-                }
-              />
-            </Section>
-            <View style={styles.description}>
-              <ThemeText typography="body__s">
-                {t(ContactShmoOperatorTexts.location.header)}
-              </ThemeText>
-              <ThemeText typography="body__xs">
-                {t(
-                  ContactShmoOperatorTexts.location.description(
-                    operatorName ?? '',
-                  ),
-                )}
-              </ThemeText>
-            </View>
-            {supportRequestStatus === 'error' &&
-              isAllInputValid &&
-              showError && (
-                <MessageInfoBox
-                  message={t(
-                    ContactShmoOperatorTexts.submitError(operatorName ?? ''),
-                  )}
-                  type="error"
-                />
-              )}
-            <Button
-              loading={supportRequestStatus === 'pending'}
-              expanded={true}
-              mode="primary"
-              text={t(ContactShmoOperatorTexts.submitButton)}
-              onPress={onSubmit}
-            />
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
-    </View>
+            type="info"
+          />
+        )}
+        <ContentHeading text={t(ContactShmoOperatorTexts.comment.header)} />
+        <Section>
+          <TextInputSectionItem
+            value={requestBody.comment ?? ''}
+            onChangeText={(comment) =>
+              setRequestBody((prev) => ({...prev, comment}))
+            }
+            label={t(ContactShmoOperatorTexts.comment.label)}
+            placeholder={t(ContactShmoOperatorTexts.comment.placeholder)}
+            inlineLabel={false}
+            multiline={true}
+            maxLength={MAX_SUPPORT_COMMENT_LENGTH}
+            scrollEnabled={false}
+            autoCapitalize="sentences"
+            errorText={
+              !isCommentValid && showError
+                ? t(
+                    ContactShmoOperatorTexts.comment.errorMessage(
+                      MAX_SUPPORT_COMMENT_LENGTH,
+                    ),
+                  )
+                : undefined
+            }
+          />
+        </Section>
+        <ContentHeading text={t(ContactShmoOperatorTexts.contactInfo.header)} />
+        <Section>
+          <TextInputSectionItem
+            value={requestBody.contactInformationEndUser.email ?? ''}
+            onChangeText={(email) =>
+              setRequestBody((prev) => ({
+                ...prev,
+                contactInformationEndUser: {
+                  ...prev.contactInformationEndUser,
+                  email,
+                },
+              }))
+            }
+            label={t(ContactShmoOperatorTexts.contactInfo.email.label)}
+            placeholder={t(
+              ContactShmoOperatorTexts.contactInfo.email.placeholder,
+            )}
+            showClear
+            inlineLabel={false}
+            keyboardType="email-address"
+            autoComplete="email"
+            autoCapitalize="none"
+            errorText={
+              !isEmailValid && showError
+                ? t(ContactShmoOperatorTexts.contactInfo.email.errorMessage)
+                : !isContactInfoPresent && showError
+                  ? t(ContactShmoOperatorTexts.contactInfo.errorMessage)
+                  : undefined
+            }
+          />
+        </Section>
+        <Section>
+          <PhoneInputSectionItem
+            prefix={requestBody.contactInformationEndUser.phonePrefix ?? ''}
+            onChangePrefix={(phonePrefix) =>
+              setRequestBody((prev) => ({
+                ...prev,
+                contactInformationEndUser: {
+                  ...prev.contactInformationEndUser,
+                  phonePrefix,
+                },
+              }))
+            }
+            onChangeText={(phoneNumber) =>
+              setRequestBody((prev) => ({
+                ...prev,
+                contactInformationEndUser: {
+                  ...prev.contactInformationEndUser,
+                  phoneNumber,
+                },
+              }))
+            }
+            value={requestBody.contactInformationEndUser.phoneNumber ?? ''}
+            label={t(ContactShmoOperatorTexts.contactInfo.phone.label)}
+            placeholder={t(
+              ContactShmoOperatorTexts.contactInfo.phone.placeholder,
+            )}
+            showClear
+            textContentType="telephoneNumber"
+            errorText={
+              !isPhoneNumberValid && showError
+                ? t(ContactShmoOperatorTexts.contactInfo.phone.errorMessage)
+                : !isContactInfoPresent && showError
+                  ? t(ContactShmoOperatorTexts.contactInfo.errorMessage)
+                  : undefined
+            }
+          />
+        </Section>
+        <View style={styles.description}>
+          <ThemeText typography="body__s">
+            {t(ContactShmoOperatorTexts.location.header)}
+          </ThemeText>
+          <ThemeText typography="body__xs">
+            {t(
+              ContactShmoOperatorTexts.location.description(operatorName ?? ''),
+            )}
+          </ThemeText>
+        </View>
+        {supportRequestStatus === 'error' && isAllInputValid && showError && (
+          <MessageInfoBox
+            message={t(
+              ContactShmoOperatorTexts.submitError(operatorName ?? ''),
+            )}
+            type="error"
+          />
+        )}
+        <Button
+          loading={supportRequestStatus === 'pending'}
+          expanded={true}
+          mode="primary"
+          text={t(ContactShmoOperatorTexts.submitButton)}
+          onPress={onSubmit}
+        />
+      </View>
+    </FullScreenView>
   );
 };
 
@@ -262,7 +245,6 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   contentContainer: {
     rowGap: theme.spacing.small,
     margin: theme.spacing.medium,
-    paddingBottom: theme.spacing.xLarge,
   },
   description: {
     padding: theme.spacing.medium,

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EnrollmentScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_EnrollmentScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {KeyboardAvoidingView, View} from 'react-native';
+import {View} from 'react-native';
 import {Button} from '@atb/components/button';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
@@ -58,63 +58,62 @@ export const Profile_EnrollmentScreen = ({navigation}: Props) => {
   );
 
   return (
-    <KeyboardAvoidingView style={{flex: 1}} behavior="padding">
-      <FullScreenView
-        focusRef={focusRef}
-        headerProps={{
-          title: t(EnrollmentTexts.header),
-          leftButton: {type: 'back'},
-        }}
-        headerContent={(focusRef) => (
-          <ScreenHeading ref={focusRef} text={t(EnrollmentTexts.header)} />
-        )}
-      >
-        <View style={styles.contentContainer}>
-          <Section>
-            <GenericSectionItem>
-              <View style={styles.horizontalContainer}>
-                <ThemedBeacons
-                  height={61 * fontScale}
-                  width={61 * fontScale}
-                  style={{
-                    alignSelf: 'flex-start',
-                  }}
-                />
-                <View style={styles.headerTextContainer}>
-                  <ThemeText typography="body__s" type="secondary">
-                    {t(EnrollmentTexts.info)}
-                  </ThemeText>
-                </View>
+    <FullScreenView
+      focusRef={focusRef}
+      headerProps={{
+        title: t(EnrollmentTexts.header),
+        leftButton: {type: 'back'},
+      }}
+      headerContent={(focusRef) => (
+        <ScreenHeading ref={focusRef} text={t(EnrollmentTexts.header)} />
+      )}
+      avoidKeyboard={true}
+    >
+      <View style={styles.contentContainer}>
+        <Section>
+          <GenericSectionItem>
+            <View style={styles.horizontalContainer}>
+              <ThemedBeacons
+                height={61 * fontScale}
+                width={61 * fontScale}
+                style={{
+                  alignSelf: 'flex-start',
+                }}
+              />
+              <View style={styles.headerTextContainer}>
+                <ThemeText typography="body__s" type="secondary">
+                  {t(EnrollmentTexts.info)}
+                </ThemeText>
               </View>
-            </GenericSectionItem>
-          </Section>
+            </View>
+          </GenericSectionItem>
+        </Section>
 
-          <TextInputSectionItem
-            radius="top-bottom"
-            inlineLabel={false}
-            label={t(EnrollmentTexts.label)}
-            placeholder={t(EnrollmentTexts.placeholder)}
-            value={inviteCode}
-            onChangeText={setInviteCode}
-            autoCapitalize="none"
-            errorText={hasError ? t(EnrollmentTexts.warning) : undefined}
+        <TextInputSectionItem
+          radius="top-bottom"
+          inlineLabel={false}
+          label={t(EnrollmentTexts.label)}
+          placeholder={t(EnrollmentTexts.placeholder)}
+          value={inviteCode}
+          onChangeText={setInviteCode}
+          autoCapitalize="none"
+          errorText={hasError ? t(EnrollmentTexts.warning) : undefined}
+        />
+        {isEnrolled && (
+          <MessageInfoBox
+            type="valid"
+            message={t(EnrollmentTexts.success(programTitle ?? ''))}
           />
-          {isEnrolled && (
-            <MessageInfoBox
-              type="valid"
-              message={t(EnrollmentTexts.success(programTitle ?? ''))}
-            />
-          )}
-          <Button
-            expanded={true}
-            onPress={() => onEnroll(inviteCode, () => setInviteCode(''))}
-            text={t(EnrollmentTexts.button)}
-            interactiveColor={interactiveColor}
-            loading={isLoading}
-          />
-        </View>
-      </FullScreenView>
-    </KeyboardAvoidingView>
+        )}
+        <Button
+          expanded={true}
+          onPress={() => onEnroll(inviteCode, () => setInviteCode(''))}
+          text={t(EnrollmentTexts.button)}
+          interactiveColor={interactiveColor}
+          loading={isLoading}
+        />
+      </View>
+    </FullScreenView>
   );
 };
 


### PR DESCRIPTION
## Issue Reference

Fixes feedback from @hanne-at-atb on https://github.com/AtB-AS/mittatb-app/pull/6213#issuecomment-4891826117

## Description

- Sets keyboard avoiding behavior for FullScreenFooter to be `undefined` on Android, while keeping `'padding'` on iOS. I've found this works the best on on both platforms.
- Removed a bit of padding at the bottom of the payment method bottom sheet
- Updated some screens to use FullScreenView: 
	- FareContractDetailsScreen
	- ContactShmoOperatorScreen
	- EnrollmentScreen