### PR TITLE
chore: update header borders

### DIFF
--- a/src/components/screen-header/ScreenHeader.tsx
+++ b/src/components/screen-header/ScreenHeader.tsx
@@ -1,9 +1,4 @@
-import {
-  LayoutChangeEvent,
-  LayoutRectangle,
-  View,
-  ViewStyle,
-} from 'react-native';
+import {LayoutChangeEvent, LayoutRectangle, View} from 'react-native';
 import React, {Ref, useMemo, useState} from 'react';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {HeaderButton, HeaderButtonProps} from './HeaderButton';
@@ -44,7 +39,6 @@ export type ScreenHeaderProps = {
    * header. If no context is specified then no alerts are shown.
    */
   globalMessageContext?: GlobalMessageContextEnum;
-  style?: ViewStyle;
   color?: ContrastColor;
   textOpacity?: number;
   focusRef?: Ref<any>;
@@ -53,7 +47,6 @@ export type ScreenHeaderProps = {
 
 export const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   color,
-  style,
   title,
   titleA11yLabel,
   globalMessageContext,
@@ -87,9 +80,7 @@ export const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   );
 
   return (
-    <View
-      style={[styles.container, style, {backgroundColor, borderBottomColor}]}
-    >
+    <View style={[styles.container, {backgroundColor, borderBottomColor}]}>
       <View
         accessibilityLabel={titleA11yLabel}
         accessible={!!title && !!textOpacity}

--- a/src/components/screen-view/FullScreenView.tsx
+++ b/src/components/screen-view/FullScreenView.tsx
@@ -18,7 +18,7 @@ import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled'
 import {useLayout} from '@atb/utils/use-layout';
 
 type Props = {
-  headerProps: ScreenHeaderProps;
+  headerProps: Omit<ScreenHeaderProps, 'showBorder' | 'textOpacity'>;
   /**
    * JSX content that will be displayed between header and children, and will
    * disappear when scrolling.
@@ -78,7 +78,7 @@ export function FullScreenView(props: Props) {
   const hasTabBar = useContext(BottomTabBarHeightContext) !== undefined;
   const bottomInset = props.footer || hasTabBar ? 0 : bottom;
 
-  const showBorder = props.headerProps.showBorder ?? isScrolled;
+  const showBorder = isScrolled;
 
   const contentComponent = hasHeaderContent(props) ? (
     <ChildrenWithHeaderContent

--- a/src/stacks-hierarchy/Root_LocationSearchByMapScreen.tsx
+++ b/src/stacks-hierarchy/Root_LocationSearchByMapScreen.tsx
@@ -33,6 +33,7 @@ export const Root_LocationSearchByMapScreen: React.FC<Props> = ({
       <FullScreenHeader
         title={t(LocationSearchTexts.mapSelection.header.title)}
         leftButton={{type: 'back'}}
+        showBorder={false}
       />
       <ExploreLocationMap
         onLocationSelect={onLocationSelect}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_RootScreen.tsx
@@ -27,7 +27,7 @@ export const Ticketing_RootScreen = ({navigation}: Props) => {
   return (
     <View style={styles.container}>
       <FullScreenHeader
-        textOpacity={0}
+        showBorder={false}
         globalMessageContext={GlobalMessageContextEnum.appTicketing}
       />
       <View style={styles.headingContainer}>


### PR DESCRIPTION
Two very small details with header borders:

- On ticketing root screen `textOpacity={0}` was used instead of `showBorder={false}` (No functional difference)
- Removed a border on the location search by map screen that I don't think should be there 👇

<img width="300" alt="IMG_F931AC0DBACF-1" src="https://github.com/user-attachments/assets/11f730f9-6f22-4597-a8af-75b68cd185a5" />
