### PR TITLE
feat: prevent QR code screenshots on iOS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -216,6 +216,7 @@ module.exports = {
         'types/*',
         'src/translations/**',
         'src/modules/storybook/stories/**',
+        'src/modules/native/*NativeComponent.ts',
       ],
       rules: {
         'no-restricted-exports': [

--- a/ios/TurboModules/RCTSecureView.h
+++ b/ios/TurboModules/RCTSecureView.h
@@ -2,12 +2,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Fabric host view backing the JS `SecureView` component. React children are
- * mounted inside a `secureTextEntry` UITextField's canvas, whose layer iOS
- * excludes from screenshots and screen recordings while still rendering it on
- * screen.
- */
 @interface RCTSecureView : RCTViewComponentView
 
 @end

--- a/ios/TurboModules/RCTSecureView.h
+++ b/ios/TurboModules/RCTSecureView.h
@@ -1,0 +1,15 @@
+#import <React/RCTViewComponentView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Fabric host view backing the JS `SecureView` component. React children are
+ * mounted inside a `secureTextEntry` UITextField's canvas, whose layer iOS
+ * excludes from screenshots and screen recordings while still rendering it on
+ * screen.
+ */
+@interface RCTSecureView : RCTViewComponentView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/TurboModules/RCTSecureView.mm
+++ b/ios/TurboModules/RCTSecureView.mm
@@ -1,0 +1,74 @@
+#import "RCTSecureView.h"
+
+#import <react/renderer/components/AtBTurboModuleSpec/ComponentDescriptors.h>
+#import <react/renderer/components/AtBTurboModuleSpec/Props.h>
+#import <react/renderer/components/AtBTurboModuleSpec/RCTComponentViewHelpers.h>
+
+#import "SecureViewImplObjC.h"
+
+using namespace facebook::react;
+
+@interface RCTSecureView () <RCTSecureViewViewProtocol>
+@end
+
+@implementation RCTSecureView {
+  SecureViewImpl *_impl;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<SecureViewComponentDescriptor>();
+}
+
+// UIKit constructor
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const SecureViewProps>();
+    _props = defaultProps;
+    _impl = [SecureViewImpl new];
+    [_impl attachToHostView:self];
+  }
+  return self;
+}
+
+// UIKit calls this when the view is added or removed from a window
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  [_impl applySecureIfPossible];
+}
+
+// UIKit calls this when bounds change
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [_impl layoutWithBounds:self.bounds];
+}
+
+// RCTComponentViewProtocol / React mount
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView
+                          index:(NSInteger)index
+{
+  [_impl mountChild:childComponentView atIndex:index];
+}
+
+// RCTComponentViewProtocol / React unmount
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView
+                            index:(NSInteger)index
+{
+  [_impl unmountChild:childComponentView];
+}
+
++ (BOOL)shouldBeRecycled
+{
+  // Re-using the view causes crashes when it is re-mounted, so we opt out
+  return NO;
+}
+
+@end
+
+Class<RCTComponentViewProtocol> RCTSecureViewCls(void)
+{
+  return RCTSecureView.class;
+}

--- a/ios/TurboModules/SecureViewImpl.swift
+++ b/ios/TurboModules/SecureViewImpl.swift
@@ -1,12 +1,11 @@
 import Foundation
 import UIKit
 
-/// UIKit implementation backing the `RCTSecureView` Fabric component.
+/// UIKit implementation of the RCTSecureView component.
 ///
-/// React children are mounted into `contentView`, whose layer is re-parented
-/// under a `isSecureTextEntry` UITextField's canvas layer. iOS omits that layer
-/// subtree from screenshots and screen recordings, while the view hierarchy is
-/// left intact so hit-testing/touch keep working.
+/// React children are placed under a UITextField canvas layer with
+/// `isSecureTextEntry` enabled. iOS omits that layer subtree from screenshots
+/// and screen recordings.
 @objc(SecureViewImpl)
 final class SecureViewImpl: NSObject {
   private let contentView = UIView()
@@ -17,7 +16,7 @@ final class SecureViewImpl: NSObject {
   override init() {
     super.init()
     secureTextField.isSecureTextEntry = true
-    // The field must not intercept touches meant for the content.
+    // Don't intercept touches meant for the content.
     secureTextField.isUserInteractionEnabled = false
   }
 
@@ -45,20 +44,38 @@ final class SecureViewImpl: NSObject {
     applySecureIfPossible()
   }
 
-  /// The secure canvas is the last sublayer of a `secureTextEntry` UITextField
-  /// (backing its private `_UITextLayoutCanvasView`). It is created lazily by
-  /// UIKit, so this bails and is retried on the next layout pass if it isn't
-  /// available yet. Lifting the field's layer to the content view's superlayer
-  /// and re-homing the content layer under the canvas redirects only the
-  /// rendering — the view hierarchy stays intact.
+  /// Moves the content view's rendering (layers) under the text field's secure
+  /// canvas.
+  ///
+  /// Layer tree before (created in `attachToHostView`):
+  /// ```
+  /// hostView
+  /// ├── contentView                  ← React children mounted here (in `mountChild`)
+  /// └── secureTextField              ← UITextField with isSecureTextEntry
+  ///     ├── [UITextField layers...]
+  ///     └── secureCanvas             ← last sublayer, which iOS excludes from captures
+  /// ```
+  ///
+  /// Layer tree after:
+  /// ```
+  /// hostView
+  /// └── secureTextField
+  ///     ├── [UITextField layers...]
+  ///     └── secureCanvas
+  ///         └── contentView          ← React children render here, omitted from captures
+  /// ```
+  ///
+  /// This rewires the *layer* tree only; the *view* tree is untouched
+  /// (`contentView` stays a subview of `hostView`), which is why hit-testing
+  /// and touches keep working.
   @objc func applySecureIfPossible() {
     guard !isSecured,
       contentView.window != nil,
-      let superlayer = contentView.layer.superlayer,
+      let hostViewLayer = contentView.layer.superlayer, // Resolves to hostView.layer when mounted
       let secureCanvas = secureTextField.layer.sublayers?.last
     else { return }
 
-    superlayer.addSublayer(secureTextField.layer)
+    hostViewLayer.addSublayer(secureTextField.layer)
     secureCanvas.addSublayer(contentView.layer)
     isSecured = true
   }

--- a/ios/TurboModules/SecureViewImpl.swift
+++ b/ios/TurboModules/SecureViewImpl.swift
@@ -1,0 +1,65 @@
+import Foundation
+import UIKit
+
+/// UIKit implementation backing the `RCTSecureView` Fabric component.
+///
+/// React children are mounted into `contentView`, whose layer is re-parented
+/// under a `isSecureTextEntry` UITextField's canvas layer. iOS omits that layer
+/// subtree from screenshots and screen recordings, while the view hierarchy is
+/// left intact so hit-testing/touch keep working.
+@objc(SecureViewImpl)
+final class SecureViewImpl: NSObject {
+  private let contentView = UIView()
+  private let secureTextField = UITextField()
+  private weak var hostView: UIView?
+  private var isSecured = false
+
+  override init() {
+    super.init()
+    secureTextField.isSecureTextEntry = true
+    // The field must not intercept touches meant for the content.
+    secureTextField.isUserInteractionEnabled = false
+  }
+
+  @objc(attachToHostView:)
+  func attach(toHostView host: UIView) {
+    hostView = host
+    host.addSubview(contentView)
+    host.addSubview(secureTextField)
+  }
+
+  @objc(mountChild:atIndex:)
+  func mountChild(_ child: UIView, atIndex index: Int) {
+    contentView.insertSubview(child, at: index)
+  }
+
+  @objc(unmountChild:)
+  func unmountChild(_ child: UIView) {
+    child.removeFromSuperview()
+  }
+
+  @objc(layoutWithBounds:)
+  func layout(withBounds bounds: CGRect) {
+    contentView.frame = bounds
+    secureTextField.frame = bounds
+    applySecureIfPossible()
+  }
+
+  /// The secure canvas is the last sublayer of a `secureTextEntry` UITextField
+  /// (backing its private `_UITextLayoutCanvasView`). It is created lazily by
+  /// UIKit, so this bails and is retried on the next layout pass if it isn't
+  /// available yet. Lifting the field's layer to the content view's superlayer
+  /// and re-homing the content layer under the canvas redirects only the
+  /// rendering — the view hierarchy stays intact.
+  @objc func applySecureIfPossible() {
+    guard !isSecured,
+      contentView.window != nil,
+      let superlayer = contentView.layer.superlayer,
+      let secureCanvas = secureTextField.layer.sublayers?.last
+    else { return }
+
+    superlayer.addSublayer(secureTextField.layer)
+    secureCanvas.addSublayer(contentView.layer)
+    isSecured = true
+  }
+}

--- a/ios/TurboModules/SecureViewImplObjC.h
+++ b/ios/TurboModules/SecureViewImplObjC.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SecureViewImpl : NSObject
+
+- (void)attachToHostView:(UIView *)hostView;
+- (void)mountChild:(UIView *)child atIndex:(NSInteger)index;
+- (void)unmountChild:(UIView *)child;
+- (void)layoutWithBounds:(CGRect)bounds;
+- (void)applySecureIfPossible;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
   },
   "codegenConfig": {
     "name": "AtBTurboModuleSpec",
-    "type": "modules",
+    "type": "all",
     "jsSrcsDir": "src/modules/native",
     "android": {
       "javaPackageName": "no.mittatb"
@@ -213,6 +213,9 @@
       "modulesProvider": {
         "ExperimentalFeature": "RCTExperimentalFeature",
         "ApplePayHandler": "RCTApplePayHandler"
+      },
+      "componentProvider": {
+        "SecureView": "RCTSecureView"
       }
     }
   }

--- a/src/modules/fare-contracts/details/Barcode.tsx
+++ b/src/modules/fare-contracts/details/Barcode.tsx
@@ -2,6 +2,7 @@ import DeviceBrightness from '@adrianso/react-native-device-brightness';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {ValidityStatus} from '../utils';
 import {useMobileTokenContext} from '@atb/modules/mobile-token';
+import {SecureView} from '@atb/modules/native';
 import {StyleSheet} from '@atb/theme';
 import {FareContractType} from '@atb-as/utils';
 import {FareContractTexts, useTranslation} from '@atb/translations';
@@ -133,7 +134,9 @@ const BarcodeInspectionView = () => {
   return (
     <View style={styles.barcodeInspectionContainer}>
       <View style={styles.barcodeInspection} testID="mobileTokenBarcode">
-        <RNBarcodeInspectionView sizeInCm={3.5} />
+        <SecureView>
+          <RNBarcodeInspectionView sizeInCm={3.5} />
+        </SecureView>
       </View>
     </View>
   );
@@ -174,7 +177,9 @@ const MobileTokenAztec = ({fc}: {fc: FareContractType}) => {
       accessibilityLabel={t(FareContractTexts.details.barcodeA11yLabel)}
       testID="mobileTokenBarcode"
     >
-      <SvgXml xml={aztecXml} width="100%" height="100%" />
+      <SecureView style={styles.secureViewFill}>
+        <SvgXml xml={aztecXml} width="100%" height="100%" />
+      </SecureView>
     </View>
   );
 };
@@ -262,7 +267,9 @@ const StaticAztec = ({fc}: {fc: FareContractType}) => {
           testID="staticBarcode"
           ref={onCloseFocusRef}
         >
-          <SvgXml xml={aztecXml} width="100%" height="100%" />
+          <SecureView style={styles.secureViewFill}>
+            <SvgXml xml={aztecXml} width="100%" height="100%" />
+          </SecureView>
         </NativeBlockButton>
       </View>
       <StaticBarcodeBottomSheet
@@ -307,7 +314,9 @@ const StaticQrCode = ({fc}: {fc: FareContractType}) => {
           testID="staticQRCode"
           ref={onCloseFocusRef}
         >
-          <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
+          <SecureView style={styles.secureViewFill}>
+            <SvgXml xml={qrCodeSvg} width="100%" height="100%" />
+          </SecureView>
         </NativeBlockButton>
       </View>
       <StaticBarcodeBottomSheet
@@ -330,6 +339,10 @@ const useStyles = StyleSheet.createThemeHook(() => ({
   barcodeInspection: {
     backgroundColor: 'white',
     padding: 20,
+  },
+  secureViewFill: {
+    width: '100%',
+    height: '100%',
   },
   barcodeInspectionContainer: {
     flex: 1,
@@ -381,7 +394,9 @@ const StaticBarcodeBottomSheet = ({
             )}
             testID="staticBigQRCode"
           >
-            <SvgXml xml={qrCodeSvg ?? ''} width="100%" height="100%" />
+            <SecureView style={styles.secureViewFill}>
+              <SvgXml xml={qrCodeSvg ?? ''} width="100%" height="100%" />
+            </SecureView>
           </NativeBlockButton>
         </View>
       </View>

--- a/src/modules/native/SecureView.tsx
+++ b/src/modules/native/SecureView.tsx
@@ -1,0 +1,20 @@
+import {PropsWithChildren} from 'react';
+import {Platform, View, ViewProps} from 'react-native';
+import SecureViewNativeComponent from './SecureViewNativeComponent';
+
+/**
+ * Hides its children from iOS screenshots and screen recordings while keeping
+ * them visible on screen. On iOS the children are mounted inside a native
+ * `secureTextEntry` canvas; on all other platforms this is a passthrough
+ * `View`, so the content is rendered normally with no capture protection.
+ */
+export function SecureView({children, ...props}: PropsWithChildren<ViewProps>) {
+  if (Platform.OS === 'ios') {
+    return (
+      <SecureViewNativeComponent {...props}>
+        {children}
+      </SecureViewNativeComponent>
+    );
+  }
+  return <View {...props}>{children}</View>;
+}

--- a/src/modules/native/SecureView.tsx
+++ b/src/modules/native/SecureView.tsx
@@ -3,10 +3,9 @@ import {Platform, View, ViewProps} from 'react-native';
 import SecureViewNativeComponent from './SecureViewNativeComponent';
 
 /**
- * Hides its children from iOS screenshots and screen recordings while keeping
- * them visible on screen. On iOS the children are mounted inside a native
- * `secureTextEntry` canvas; on all other platforms this is a passthrough
- * `View`, so the content is rendered normally with no capture protection.
+ * View that wraps its children in a "secure text entry" canvas on iOS,
+ * preventing them from being captured in screenshots or screen recordings. On
+ * Android, it behaves as a regular `View`.
  */
 export function SecureView({children, ...props}: PropsWithChildren<ViewProps>) {
   if (Platform.OS === 'ios') {

--- a/src/modules/native/SecureViewNativeComponent.ts
+++ b/src/modules/native/SecureViewNativeComponent.ts
@@ -1,0 +1,15 @@
+import {
+  codegenNativeComponent,
+  type HostComponent,
+  type ViewProps,
+} from 'react-native';
+
+export interface NativeProps extends ViewProps {}
+
+/**
+ * iOS native view whose children are rendered inside a `secureTextEntry`
+ * UITextField canvas, which iOS excludes from screenshots.
+ */
+export default codegenNativeComponent<NativeProps>('SecureView', {
+  excludedPlatforms: ['android'],
+}) as HostComponent<NativeProps>;

--- a/src/modules/native/SecureViewNativeComponent.ts
+++ b/src/modules/native/SecureViewNativeComponent.ts
@@ -6,10 +6,6 @@ import {
 
 export interface NativeProps extends ViewProps {}
 
-/**
- * iOS native view whose children are rendered inside a `secureTextEntry`
- * UITextField canvas, which iOS excludes from screenshots.
- */
 export default codegenNativeComponent<NativeProps>('SecureView', {
   excludedPlatforms: ['android'],
 }) as HostComponent<NativeProps>;

--- a/src/modules/native/index.ts
+++ b/src/modules/native/index.ts
@@ -1,2 +1,3 @@
 export {ExperimentalFeature} from './NativeExperimentalFeature';
 export {NativeApplePayHandler} from './NativeApplePayHandler';
+export {SecureView} from './SecureView';


### PR DESCRIPTION
## Issue Reference

First part of https://github.com/AtB-AS/kundevendt/issues/23927

## Description

Adds a TurboModule component `<SecureView>` that hides its children from screenshots and recordings on iOS. It's a bit of a hack to make this work, since iOS doesn't provide an official API for this. Instead we put react content inside a special canvas layer that iOS creates as part of a UITextField with `isSecureTextEntry=true`. See the comment in SecureViewImpl.swift for a proper explanation.

Android should be unaffected for now, and work like before.

The resulting screenshots look like this:

<img width="300" alt="IMG_4943" src="https://github.com/user-attachments/assets/550aacc5-1e44-4ac9-b461-357fc8eb5468" />
