### PR TITLE
refactor: resolve shmo bonus product by id

### DIFF
--- a/src/modules/bonus/index.ts
+++ b/src/modules/bonus/index.ts
@@ -6,11 +6,9 @@ export {
   UserBonusBalance,
   UserBonusBalanceContent,
 } from './components';
-export {
-  useRelevantSharedMobilityBonusProduct,
-  useRelevantVoucherBonusProduct,
-} from './use-relevant-bonus-product';
+export {useRelevantVoucherBonusProduct} from './use-relevant-bonus-product';
 export {useRelevantTicketBonusProduct} from './use-relevant-ticket-bonus-product';
+export {useBonusProductById} from './use-bonus-product-by-id';
 export type {ProductPointsItem} from './api/api';
 export {
   useBonusBalanceQuery,

--- a/src/modules/bonus/use-bonus-product-by-id.ts
+++ b/src/modules/bonus/use-bonus-product-by-id.ts
@@ -1,0 +1,10 @@
+import {useActiveBonusProductsQuery} from './queries';
+import type {BonusProductType} from './types';
+
+export const useBonusProductById = (
+  id: string | undefined,
+): BonusProductType | undefined => {
+  const {data: activeBonusProducts} = useActiveBonusProductsQuery(Boolean(id));
+  if (!id) return undefined;
+  return activeBonusProducts?.find((bonusProduct) => bonusProduct.id === id);
+};

--- a/src/modules/bonus/use-relevant-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-bonus-product.ts
@@ -1,20 +1,6 @@
 import {useActiveBonusProductsQuery} from './queries';
 import {BonusProductTypeEnum} from './types';
 
-export const useRelevantSharedMobilityBonusProduct = (
-  vehicleTypeId: string | undefined,
-) => {
-  const {data: activeBonusProducts} = useActiveBonusProductsQuery(
-    Boolean(vehicleTypeId),
-  );
-  if (!vehicleTypeId) return undefined;
-  return activeBonusProducts?.find(
-    (bonusProduct) =>
-      bonusProduct.productType === BonusProductTypeEnum.SHARED_MOBILITY &&
-      bonusProduct.vehicleTypeIds.includes(vehicleTypeId),
-  );
-};
-
 export const useRelevantVoucherBonusProduct = (
   operatorId: string | undefined,
 ) => {

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -46,10 +46,9 @@ import {TransportationIconBox} from '@atb/components/icon-box';
 import {BrandingImage} from '../BrandingImage';
 import {getTransportModeAndSubMode} from '../../utils';
 import {
-  BonusProductType,
   PayWithBonusPointsCheckbox,
+  useBonusProductById,
   useIsBonusActiveForUser,
-  useRelevantSharedMobilityBonusProduct,
 } from '@atb/modules/bonus';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import type {BenefitType} from '@atb/api/types/benefit';
@@ -132,14 +131,11 @@ export const VehicleSheet = ({
   } = useFeatureTogglesContext();
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
-  // Prefer the server-provided bonus offer; fall back to the client-side
-  // lookup only when the vehicle response omits it.
-  const clientBonusProduct =
-    useRelevantSharedMobilityBonusProduct(vehicleTypeId);
   const serverBonusOffer = vehicle?.bonusOffer ?? undefined;
-  const hasBonusOffer = !!serverBonusOffer || !!clientBonusProduct;
-  const selectedBonusProductId =
-    serverBonusOffer?.bonusProductId ?? clientBonusProduct?.id;
+  const selectedBonusProductId = serverBonusOffer?.bonusProductId;
+  // The checkbox needs the full product (paymentDescription/productType), which
+  // the server offer doesn't carry, so resolve it by id from active products.
+  const bonusProduct = useBonusProductById(selectedBonusProductId);
   const {logEvent} = useAnalyticsContext();
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
 
@@ -181,8 +177,7 @@ export const VehicleSheet = ({
   const showVehicleCard = !isBicycle || isElectric;
   const showParkingViolation =
     !isBicycle && isParkingViolationsReportingEnabled;
-  const showBonusCheckbox =
-    isBonusActiveForUser && hasBonusOffer && !!clientBonusProduct;
+  const showBonusCheckbox = isBonusActiveForUser && !!bonusProduct;
 
   // Drive the CTA from the server `actionButton` when present, otherwise fall
   // back to the existing deep-integration / operator branching.
@@ -256,7 +251,6 @@ export const VehicleSheet = ({
                 payWithBonusPoints,
                 vehicle,
                 serverBonusOffer,
-                clientBonusProduct,
               })}
               onNavigatePricingDetails={navigateToPricingDetails}
             />
@@ -264,9 +258,9 @@ export const VehicleSheet = ({
 
           {showStartTrip && operatorId ? (
             <>
-              {showBonusCheckbox && clientBonusProduct && (
+              {showBonusCheckbox && bonusProduct && (
                 <PayWithBonusPointsCheckbox
-                  bonusProduct={clientBonusProduct}
+                  bonusProduct={bonusProduct}
                   operatorName={operatorName}
                   isChecked={payWithBonusPoints}
                   onPress={() => setPayWithBonusPoints((prev) => !prev)}
@@ -354,38 +348,23 @@ export const VehicleSheet = ({
 /**
  * Resolves which benefit drives the price display. Benefit and bonus offer never
  * stack: the server benefit applies by default, and choosing to pay with bonus
- * points overrides it with the bonus offer's price adjustments. The server bonus
- * offer wins over the client-side product when both are present.
+ * points overrides it with the bonus offer's price adjustments.
  */
 const getDisplayedBenefit = ({
   payWithBonusPoints,
   vehicle,
   serverBonusOffer,
-  clientBonusProduct,
 }: {
   payWithBonusPoints: boolean;
   vehicle: Vehicle;
   serverBonusOffer: BonusOffer | undefined;
-  clientBonusProduct: BonusProductType | undefined;
 }): BenefitType | undefined => {
   if (!payWithBonusPoints) return vehicle.benefit ?? undefined;
-
-  // The server-driven offer is already scoped to the vehicle's system. The
-  // client-side product is the legacy fallback and still filters by system.
-  const bonusPriceAdjustments = serverBonusOffer
-    ? serverBonusOffer.priceAdjustments
-    : (clientBonusProduct?.priceAdjustments
-        ?.filter((pa) => pa.systemIds.includes(vehicle.system.id))
-        .map((pa) => ({
-          amount: pa.amount,
-          type: pa.type,
-          description: pa.description,
-        })) ?? []);
 
   return {
     title: [],
     description: [],
-    priceAdjustments: bonusPriceAdjustments,
+    priceAdjustments: serverBonusOffer?.priceAdjustments ?? [],
   };
 };
 


### PR DESCRIPTION
resolves https://github.com/AtB-AS/kundevendt/issues/24106

## What

Item 1 of #24106 (shmo vehicle v2 app cleanup follow-ups).

`VehicleSheet` resolved the bonus product via the legacy client-side `useRelevantSharedMobilityBonusProduct(vehicleTypeId)` lookup, and `getDisplayedBenefit` had a legacy branch that filtered the client product's price adjustments by system id. The server now sends `bonusOffer`, so:

- Add `useBonusProductById(id)` — resolves the full bonus product from active products by id (mirrors the existing relevant-product hooks, enabled-gated on `Boolean(id)`).
- Resolve the checkbox's `BonusProductType` from `bonusOffer.bonusProductId` (the offer alone lacks `paymentDescription`/`productType`, so the full product is still needed).
- Drop `useRelevantSharedMobilityBonusProduct` (VehicleSheet was its only consumer).
- Simplify `getDisplayedBenefit`: server offer `priceAdjustments` only; legacy `systemIds` branch removed.

## Behavior

No user-facing change. The checkbox is hidden when there's no offer or the product isn't in the active list (query loading / inactive product) — same semantics as before; only the match key changed (offer id vs vehicle type).

## Notes

- `BonusPriceAdjustmentSchema.systemIds` (`src/modules/bonus/types.ts`) is now parsed-but-unread. Left out of scope (orthogonal one-line removal).
- Items 2 (showStartTrip fallback) and 3 (benefit illustration) tracked separately.

## Checks

`tsc`, `eslint`, `prettier` clean on changed files.