### PR TITLE
refactor: remove dead shmo action-button fallback

### DIFF
--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -106,7 +106,6 @@ export const VehicleSheet = ({
     propulsionType === PropulsionType.ElectricAssist;
 
   const operator = useOperators().byId(operatorId);
-  const operatorIsIntegrationEnabled = operator?.isDeepIntegrationEnabled;
   const vehicleTypeId = vehicle?.vehicleType.id;
   const operatorLogo = operator?.brandAssets?.brandImageUrl;
 
@@ -125,11 +124,7 @@ export const VehicleSheet = ({
 
   useDoOnceOnItemReceived(onVehicleReceived, vehicle);
 
-  const {
-    isParkingViolationsReportingEnabled,
-    isShmoDeepIntegrationEnabled,
-    isShmoDeepIntegrationCitybikeEnabled,
-  } = useFeatureTogglesContext();
+  const {isParkingViolationsReportingEnabled} = useFeatureTogglesContext();
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
   // Prefer the server-provided bonus offer; fall back to the client-side
@@ -175,22 +170,13 @@ export const VehicleSheet = ({
     appStoreUri,
   ]);
 
-  const isDeepIntegrationEnabled =
-    isShmoDeepIntegrationEnabled &&
-    (!isBicycle || isShmoDeepIntegrationCitybikeEnabled);
   const showVehicleCard = !isBicycle || isElectric;
   const showParkingViolation =
     !isBicycle && isParkingViolationsReportingEnabled;
   const showBonusCheckbox =
     isBonusActiveForUser && hasBonusOffer && !!clientBonusProduct;
 
-  // Drive the CTA from the server `actionButton` when present, otherwise fall
-  // back to the existing deep-integration / operator branching.
-  const showStartTrip = actionButton
-    ? actionButton.type === ActionButtonType.START_TRIP
-    : isDeepIntegrationEnabled &&
-      !!operatorId &&
-      !!operatorIsIntegrationEnabled;
+  const showStartTrip = actionButton?.type === ActionButtonType.START_TRIP;
   const showAppSwitchAction =
     actionButton?.type === ActionButtonType.APP_SWITCH;
 


### PR DESCRIPTION
resolves https://github.com/AtB-AS/kundevendt/issues/24106

## What

Item 2 of #24106 (shmo vehicle v2 app cleanup follow-ups).

The server now always sends `actionButton`, so `showStartTrip`'s deep-integration fallback is dead:

- Reduce `showStartTrip` to `actionButton?.type === START_TRIP`.
- Drop the now-unused locals `operatorIsIntegrationEnabled` and `isDeepIntegrationEnabled`.
- Drop `isShmoDeepIntegrationEnabled` / `isShmoDeepIntegrationCitybikeEnabled` from the `useFeatureTogglesContext()` destructure (kept `isParkingViolationsReportingEnabled`).

## Scope guards

- Both feature toggles stay defined — still used by MapButtons, use-shmo-requirements, the shmo query hooks, ActiveShmoSheet, FinishedShmoSheet, BikeStationBottomSheet.
- `BikeStationBottomSheet` has its own independent `operatorIsIntegrationEnabled` — untouched.
- The legacy render branch (plain `OperatorActionButton` + parking-violation button) is **kept** as a defensive fallback for a missing `actionButton` (schema is `.nullable().optional()`); it's the only host of the parking-violation button.

## Behavior

No runtime change under the v2 contract. For a residual null-`actionButton` vehicle, `showStartTrip` is now `false` (was possibly `true` via the fallback) → degrades to the operator-app / parking-violation branch, the intended "no server action" path.

## Checks

`tsc`, `eslint`, `prettier` clean on the changed file.