### PR TITLE
refactor: drop dead priceAdjustments from bonus product

### DIFF
--- a/src/modules/bonus/index.ts
+++ b/src/modules/bonus/index.ts
@@ -6,11 +6,9 @@ export {
   UserBonusBalance,
   UserBonusBalanceContent,
 } from './components';
-export {
-  useRelevantSharedMobilityBonusProduct,
-  useRelevantVoucherBonusProduct,
-} from './use-relevant-bonus-product';
+export {useRelevantVoucherBonusProduct} from './use-relevant-bonus-product';
 export {useRelevantTicketBonusProduct} from './use-relevant-ticket-bonus-product';
+export {useBonusProductById} from './use-bonus-product-by-id';
 export type {ProductPointsItem} from './api/api';
 export {
   useBonusBalanceQuery,

--- a/src/modules/bonus/types.ts
+++ b/src/modules/bonus/types.ts
@@ -1,5 +1,4 @@
 import {LanguageAndTextTypeArray} from '@atb/modules/configuration';
-import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import {
   TransportModeType,
   TransportSubmodeType,
@@ -17,18 +16,6 @@ const PriceSchema = z.object({
   amount: z.number(),
   currency: z.string(),
 });
-
-const BonusPriceAdjustmentSchema = z
-  .object({
-    amount: z.number(),
-    description: z.string(),
-    adjustmentType: PriceAdjustmentEnum,
-    systemIds: z.array(z.string()),
-  })
-  .transform(({adjustmentType, ...rest}) => ({
-    ...rest,
-    type: adjustmentType,
-  }));
 
 const TicketRuleSchema = z.object({
   preassignedFareProductIds: z.array(z.string()).nullish(),
@@ -48,7 +35,6 @@ export const BonusProductSchema = z.object({
   productType: z.enum(BonusProductTypeEnum),
   description: LanguageAndTextTypeArray,
   paymentDescription: LanguageAndTextTypeArray,
-  priceAdjustments: optionalNullish(z.array(BonusPriceAdjustmentSchema)),
   ticketRule: optionalNullish(TicketRuleSchema),
 });
 

--- a/src/modules/bonus/use-bonus-product-by-id.ts
+++ b/src/modules/bonus/use-bonus-product-by-id.ts
@@ -1,0 +1,10 @@
+import {useActiveBonusProductsQuery} from './queries';
+import type {BonusProductType} from './types';
+
+export const useBonusProductById = (
+  id: string | undefined,
+): BonusProductType | undefined => {
+  const {data: activeBonusProducts} = useActiveBonusProductsQuery(Boolean(id));
+  if (!id) return undefined;
+  return activeBonusProducts?.find((bonusProduct) => bonusProduct.id === id);
+};

--- a/src/modules/bonus/use-relevant-bonus-product.ts
+++ b/src/modules/bonus/use-relevant-bonus-product.ts
@@ -1,20 +1,6 @@
 import {useActiveBonusProductsQuery} from './queries';
 import {BonusProductTypeEnum} from './types';
 
-export const useRelevantSharedMobilityBonusProduct = (
-  vehicleTypeId: string | undefined,
-) => {
-  const {data: activeBonusProducts} = useActiveBonusProductsQuery(
-    Boolean(vehicleTypeId),
-  );
-  if (!vehicleTypeId) return undefined;
-  return activeBonusProducts?.find(
-    (bonusProduct) =>
-      bonusProduct.productType === BonusProductTypeEnum.SHARED_MOBILITY &&
-      bonusProduct.vehicleTypeIds.includes(vehicleTypeId),
-  );
-};
-
 export const useRelevantVoucherBonusProduct = (
   operatorId: string | undefined,
 ) => {

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -46,10 +46,9 @@ import {TransportationIconBox} from '@atb/components/icon-box';
 import {BrandingImage} from '../BrandingImage';
 import {getTransportModeAndSubMode} from '../../utils';
 import {
-  BonusProductType,
   PayWithBonusPointsCheckbox,
+  useBonusProductById,
   useIsBonusActiveForUser,
-  useRelevantSharedMobilityBonusProduct,
 } from '@atb/modules/bonus';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import type {BenefitType} from '@atb/api/types/benefit';
@@ -132,14 +131,11 @@ export const VehicleSheet = ({
   } = useFeatureTogglesContext();
 
   const isBonusActiveForUser = useIsBonusActiveForUser();
-  // Prefer the server-provided bonus offer; fall back to the client-side
-  // lookup only when the vehicle response omits it.
-  const clientBonusProduct =
-    useRelevantSharedMobilityBonusProduct(vehicleTypeId);
   const serverBonusOffer = vehicle?.bonusOffer ?? undefined;
-  const hasBonusOffer = !!serverBonusOffer || !!clientBonusProduct;
-  const selectedBonusProductId =
-    serverBonusOffer?.bonusProductId ?? clientBonusProduct?.id;
+  const selectedBonusProductId = serverBonusOffer?.bonusProductId;
+  // The checkbox needs the full product (paymentDescription/productType), which
+  // the server offer doesn't carry, so resolve it by id from active products.
+  const bonusProduct = useBonusProductById(selectedBonusProductId);
   const {logEvent} = useAnalyticsContext();
   const [payWithBonusPoints, setPayWithBonusPoints] = useState(false);
 
@@ -181,8 +177,7 @@ export const VehicleSheet = ({
   const showVehicleCard = !isBicycle || isElectric;
   const showParkingViolation =
     !isBicycle && isParkingViolationsReportingEnabled;
-  const showBonusCheckbox =
-    isBonusActiveForUser && hasBonusOffer && !!clientBonusProduct;
+  const showBonusCheckbox = isBonusActiveForUser && !!bonusProduct;
 
   // Drive the CTA from the server `actionButton` when present, otherwise fall
   // back to the existing deep-integration / operator branching.
@@ -256,7 +251,6 @@ export const VehicleSheet = ({
                 payWithBonusPoints,
                 vehicle,
                 serverBonusOffer,
-                clientBonusProduct,
               })}
               onNavigatePricingDetails={navigateToPricingDetails}
             />
@@ -264,9 +258,9 @@ export const VehicleSheet = ({
 
           {showStartTrip && operatorId ? (
             <>
-              {showBonusCheckbox && clientBonusProduct && (
+              {showBonusCheckbox && bonusProduct && (
                 <PayWithBonusPointsCheckbox
-                  bonusProduct={clientBonusProduct}
+                  bonusProduct={bonusProduct}
                   operatorName={operatorName}
                   isChecked={payWithBonusPoints}
                   onPress={() => setPayWithBonusPoints((prev) => !prev)}
@@ -354,38 +348,23 @@ export const VehicleSheet = ({
 /**
  * Resolves which benefit drives the price display. Benefit and bonus offer never
  * stack: the server benefit applies by default, and choosing to pay with bonus
- * points overrides it with the bonus offer's price adjustments. The server bonus
- * offer wins over the client-side product when both are present.
+ * points overrides it with the bonus offer's price adjustments.
  */
 const getDisplayedBenefit = ({
   payWithBonusPoints,
   vehicle,
   serverBonusOffer,
-  clientBonusProduct,
 }: {
   payWithBonusPoints: boolean;
   vehicle: Vehicle;
   serverBonusOffer: BonusOffer | undefined;
-  clientBonusProduct: BonusProductType | undefined;
 }): BenefitType | undefined => {
   if (!payWithBonusPoints) return vehicle.benefit ?? undefined;
-
-  // The server-driven offer is already scoped to the vehicle's system. The
-  // client-side product is the legacy fallback and still filters by system.
-  const bonusPriceAdjustments = serverBonusOffer
-    ? serverBonusOffer.priceAdjustments
-    : (clientBonusProduct?.priceAdjustments
-        ?.filter((pa) => pa.systemIds.includes(vehicle.system.id))
-        .map((pa) => ({
-          amount: pa.amount,
-          type: pa.type,
-          description: pa.description,
-        })) ?? []);
 
   return {
     title: [],
     description: [],
-    priceAdjustments: bonusPriceAdjustments,
+    priceAdjustments: serverBonusOffer?.priceAdjustments ?? [],
   };
 };
 


### PR DESCRIPTION
resolves https://github.com/AtB-AS/kundevendt/issues/24106

## What

Follow-on cleanup for #24106. System filtering of price adjustments happens server-side, and the app reads the live adjustments off the vehicle's `bonusOffer` / `benefit` — never off the bonus product itself. After #6236 removed the client-side lookup, the bonus product's `priceAdjustments` field (and its `systemIds`) has no reader.

- Remove `priceAdjustments` from `BonusProductSchema`.
- Delete `BonusPriceAdjustmentSchema`.
- Drop the now-unused `PriceAdjustmentEnum` import.

zod strips unknown keys, so the server may keep sending the field without effect.

## Base

Stacked on #6236 (which removes the last reader). **Merge #6236 first**, then this retargets to `master` automatically. Verified there are no other readers of `BonusProductType.priceAdjustments` across `src`.

## Checks

`tsc` / `eslint` / `prettier` / `jest` (803 tests) all clean.