### PR TITLE
fix: hide vehicle sheet header while vehicle is loading

### DIFF
--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -202,11 +202,15 @@ export const VehicleSheet = ({
       closeOnBackdropPress={false}
       allowBackgroundTouch={true}
       enableDynamicSizing={true}
-      heading={t(MobilityTexts.vehicleName(formFactor, false, propulsionType))}
-      subText={operatorName}
+      heading={
+        vehicle
+          ? t(MobilityTexts.vehicleName(formFactor, false, propulsionType))
+          : undefined
+      }
+      subText={vehicle ? operatorName : undefined}
       bottomSheetHeaderType={BottomSheetHeaderType.Close}
       logoIcon={
-        operatorLogo ? (
+        !vehicle ? null : operatorLogo ? (
           <BrandingImage logoUrl={operatorLogo} logoSize={28} rounded={true} />
         ) : (
           <TransportationIconBox mode={mode} subMode={subMode} rounded={true} />


### PR DESCRIPTION
## Issue Reference
Follow-up to #6218 ([comment](https://github.com/AtB-AS/mittatb-app/pull/6218#issuecomment-4913434193)).

## Description
The vehicle bottom sheet header (title, operator name, logo) was rendered
unconditionally from the vehicle query. While the query is loading — e.g.
switching selected vehicles on the map, or opening a station-based vehicle
(now fetched async since #6218) — `vehicle` is `undefined`, so the header
fell back to the "unknown" transport icon (UFO) and "Unknown operator",
flashing for a split second before the real data arrived.

Gate the header content (`heading`, `subText`, `logoIcon`) on `vehicle`
presence so it renders empty during loading instead of the misleading
fallbacks. The body already shows a loading spinner, so no data is missing —
only the transient wrong-looking header is removed.

No query/prop changes, so start-trip actions remain gated on loaded data
(no risk of binding to a stale vehicle).
