### PR TITLE
feat: better tripsearch-to-ticket for booking

### DIFF
--- a/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/TripDetailsScreenComponent.tsx
@@ -20,6 +20,7 @@ import {ServiceJourneyDeparture} from './types';
 import {
   canSellCollabTicket,
   getNonFreeLegs,
+  getTicketInfoForExpressBoatBookingTrip,
   getTripPatternAnalytics,
   type TripAnalytics,
 } from './utils';
@@ -244,6 +245,23 @@ function usePurchaseSelectionFromTrip(
   if (!isFromTravelSearchToTicketBoatEnabled) {
     // Boat ticket is disabled, avoid returning any ticket info
     return;
+  }
+
+  const ticketInfoForExpressBoatBookingTrip =
+    getTicketInfoForExpressBoatBookingTrip(
+      nonFreeLegs,
+      fareProductTypeConfigs,
+      harbors,
+      ticketStartTime,
+    );
+  if (ticketInfoForExpressBoatBookingTrip) {
+    return purchaseSelectionBuilder
+      .forType(ticketInfoForExpressBoatBookingTrip.fareProductTypeConfig.type)
+      .fromStopPlace(ticketInfoForExpressBoatBookingTrip.fromPlace)
+      .toStopPlace(ticketInfoForExpressBoatBookingTrip.toPlace)
+      .legs(ticketInfoForExpressBoatBookingTrip.legs)
+      .date(ticketInfoForExpressBoatBookingTrip.ticketStartTime)
+      .build().selection;
   }
 
   const ticketInfoForBoat = getTicketInfoForBoat(

--- a/src/screen-components/travel-details-screens/__tests__/get-ticket-info-for-express-boat-booking-trip.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/get-ticket-info-for-express-boat-booking-trip.test.ts
@@ -1,0 +1,101 @@
+import {Leg} from '@atb/api/types/trips';
+import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
+import {TransportSubmode} from '@atb/api/types/generated/journey_planner_v3_types';
+import {FareProductTypeConfig} from '@atb/modules/configuration';
+import {getTicketInfoForExpressBoatBookingTrip} from '../utils';
+
+const makeLeg = (opts?: {
+  submode?: TransportSubmode;
+  hasDatedServiceJourney?: boolean;
+  fromStopPlaceId?: string;
+  toStopPlaceId?: string;
+}): Leg =>
+  ({
+    transportSubmode:
+      opts?.submode ?? TransportSubmode.HighSpeedPassengerService,
+    datedServiceJourney:
+      (opts?.hasDatedServiceJourney ?? true) ? {id: 'dsj-1'} : undefined,
+    fromPlace: {
+      quay: {stopPlace: {id: opts?.fromStopPlaceId ?? 'harbor-from'}},
+    },
+    toPlace: {quay: {stopPlace: {id: opts?.toStopPlaceId ?? 'harbor-to'}}},
+  }) as unknown as Leg;
+
+const harbors = [
+  {id: 'harbor-from'},
+  {id: 'harbor-to'},
+] as unknown as StopPlaceFragment[];
+
+const boatSingleConfigs = [
+  {type: 'boat-single'},
+] as unknown as FareProductTypeConfig[];
+
+describe('getTicketInfoForExpressBoatBookingTrip', () => {
+  it('returns ticket info for a boat-only trip with dated service journeys', () => {
+    const legs = [
+      makeLeg({toStopPlaceId: 'harbor-mid'}),
+      makeLeg({fromStopPlaceId: 'harbor-mid'}),
+    ];
+
+    const result = getTicketInfoForExpressBoatBookingTrip(
+      legs,
+      boatSingleConfigs,
+      harbors,
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.fromPlace.id).toBe('harbor-from');
+    expect(result?.toPlace.id).toBe('harbor-to');
+    expect(result?.legs).toHaveLength(2);
+    expect(result?.fareProductTypeConfig.type).toBe('boat-single');
+  });
+
+  it('passes through ticketStartTime', () => {
+    const result = getTicketInfoForExpressBoatBookingTrip(
+      [makeLeg()],
+      boatSingleConfigs,
+      harbors,
+      '2024-01-01T07:00:00Z',
+    );
+
+    expect(result?.ticketStartTime).toBe('2024-01-01T07:00:00Z');
+  });
+
+  it('returns undefined when the trip combines express boat with other modes', () => {
+    const legs = [makeLeg(), makeLeg({submode: TransportSubmode.LocalBus})];
+
+    expect(
+      getTicketInfoForExpressBoatBookingTrip(legs, boatSingleConfigs, harbors),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when an express boat leg lacks a dated service journey', () => {
+    const legs = [makeLeg(), makeLeg({hasDatedServiceJourney: false})];
+
+    expect(
+      getTicketInfoForExpressBoatBookingTrip(legs, boatSingleConfigs, harbors),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when there are no express boat legs', () => {
+    const legs = [makeLeg({submode: TransportSubmode.LocalBus})];
+
+    expect(
+      getTicketInfoForExpressBoatBookingTrip(legs, boatSingleConfigs, harbors),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the from or to harbor is unknown', () => {
+    const legs = [makeLeg({fromStopPlaceId: 'unknown-harbor'})];
+
+    expect(
+      getTicketInfoForExpressBoatBookingTrip(legs, boatSingleConfigs, harbors),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the boat-single config is missing', () => {
+    expect(
+      getTicketInfoForExpressBoatBookingTrip([makeLeg()], [], harbors),
+    ).toBeUndefined();
+  });
+});

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -17,8 +17,12 @@ import {
   onlyUniquesBasedOnField,
   onlyUniquesBasedOnPredicate,
 } from '@atb/utils/only-uniques';
-import {FareZone as ConfigFareZone} from '@atb/modules/configuration';
+import {
+  FareProductTypeConfig,
+  FareZone as ConfigFareZone,
+} from '@atb/modules/configuration';
 import {NoticeFragment} from '@atb/api/types/generated/fragments/notices';
+import {StopPlaceFragment} from '@atb/api/types/generated/fragments/stop-places';
 import {ServiceJourneyWithEstCallsFragment} from '@atb/api/types/generated/fragments/service-journeys';
 import {EstimatedCall} from '@atb/api/types/departures';
 import {iterateWithNext} from '@atb/utils/array';
@@ -592,5 +596,66 @@ export function getTripPatternAnalytics(
       new Date(now),
       tripPattern.expectedStartTime,
     ),
+  };
+}
+
+type TicketInfoForExpressBoatBookingTrip = {
+  fromPlace: StopPlaceFragment;
+  toPlace: StopPlaceFragment;
+  legs: Leg[];
+  ticketStartTime: string | undefined;
+  fareProductTypeConfig: FareProductTypeConfig;
+};
+
+function isExpressBoatLeg(leg: Leg): boolean {
+  return (
+    leg.transportSubmode === TransportSubmode.HighSpeedPassengerService ||
+    leg.transportSubmode === TransportSubmode.HighSpeedVehicleService
+  );
+}
+
+/**
+ * A booking trip is identified by a trip whose non-free legs are all express
+ * boat legs carrying a datedServiceJourney. Trips that combine express boat
+ * with other transport modes are not sold. When matched we sell a boat-single
+ * ("Enkeltbillett hurtigbåt") ticket spanning the first from-harbor to the
+ * last to-harbor.
+ */
+export function getTicketInfoForExpressBoatBookingTrip(
+  nonFreeLegs: Leg[],
+  fareProductTypeConfigs: FareProductTypeConfig[],
+  harbors: StopPlaceFragment[],
+  ticketStartTime?: string,
+): TicketInfoForExpressBoatBookingTrip | undefined {
+  const expressBoatLegs = nonFreeLegs.filter(isExpressBoatLeg);
+  if (!expressBoatLegs.length) return;
+  if (expressBoatLegs.length !== nonFreeLegs.length) return;
+
+  const isBookingTrip = expressBoatLegs.every(
+    (leg) => !!leg.datedServiceJourney,
+  );
+  if (!isBookingTrip) return;
+
+  const fromHarbor = harbors.find(
+    (harbor) => harbor.id === expressBoatLegs[0].fromPlace.quay?.stopPlace?.id,
+  );
+  const toHarbor = harbors.find(
+    (harbor) =>
+      harbor.id ===
+      expressBoatLegs[expressBoatLegs.length - 1].toPlace.quay?.stopPlace?.id,
+  );
+  if (!fromHarbor || !toHarbor) return;
+
+  const fareProductTypeConfig = fareProductTypeConfigs.find(
+    (config) => config.type === 'boat-single',
+  );
+  if (!fareProductTypeConfig) return;
+
+  return {
+    fromPlace: fromHarbor,
+    toPlace: toHarbor,
+    legs: expressBoatLegs,
+    ticketStartTime,
+    fareProductTypeConfig,
   };
 }

--- a/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseHarborSearchScreen/Root_PurchaseHarborSearchScreen.tsx
@@ -37,6 +37,7 @@ export const Root_PurchaseHarborSearchScreen = ({
     const builder = selectionBuilder.fromSelection(selection);
     if (!selection.stopPlaces?.from) builder.fromStopPlace(selectedStopPlace);
     if (selection.stopPlaces?.from) builder.toStopPlace(selectedStopPlace);
+    builder.legs([]);
     const {selection: newSelection} = builder.build();
     navigation.popTo(
       'Root_PurchaseOverviewScreen',

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -128,6 +128,11 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     selection,
   });
 
+  // When the trip's legs are already known (e.g. an express boat booking trip
+  // coming from travel search), the departure is already chosen, so skip the
+  // Root_TripSelectionScreen step and go straight to payment.
+  const hasPreselectedLegs = selection.legs.length > 0;
+
   const canProceed = (() => {
     const hasOffer =
       (selection.userProfilesWithCount.some((u) => u.count) &&
@@ -145,7 +150,12 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
     if (!isBookingRequired) {
       return offerError;
     }
-    if (offerError && isBookingRequired && !isBookingError) {
+    if (
+      offerError &&
+      isBookingRequired &&
+      !isBookingError &&
+      !hasPreselectedLegs
+    ) {
       return undefined; // Do not display the error from the offer if we have trips that require booking
     }
     if (isBookingError) return {type: 'booking-error'};
@@ -153,7 +163,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   })();
 
   const onPressBuy = () => {
-    if (isBookingRequired) {
+    if (isBookingRequired && !hasPreselectedLegs) {
       navigation.push('Root_TripSelectionScreen', {
         ...rootPurchaseConfirmationScreenParams,
       });
@@ -197,7 +207,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
   };
 
   const summaryButtonText = () => {
-    if (isBookingRequired) {
+    if (isBookingRequired && !hasPreselectedLegs) {
       return t(PurchaseOverviewTexts.summary.button.selectDeparture);
     }
     if (selection.isOnBehalfOf) {
@@ -354,11 +364,19 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
             )}
 
             <Summary
-              isLoading={isBookingRequired ? false : isSearchingOffer}
+              isLoading={
+                isBookingRequired && !hasPreselectedLegs
+                  ? false
+                  : isSearchingOffer
+              }
               isFree={isFree}
               isDisabled={!!error || !canProceed}
               originalPrice={originalPrice}
-              price={isBookingRequired ? undefined : totalPrice}
+              price={
+                isBookingRequired && !hasPreselectedLegs
+                  ? undefined
+                  : totalPrice
+              }
               summaryButtonText={summaryButtonText()}
               onPressBuy={() => {
                 analytics.logEvent('Ticketing', 'Purchase summary clicked', {

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/Root_PurchaseOverviewScreen.tsx
@@ -316,6 +316,7 @@ export const Root_PurchaseOverviewScreen: React.FC<Props> = ({
                   .fromSelection(selection)
                   .fromStopPlace(selection.stopPlaces?.to)
                   .toStopPlace(selection.stopPlaces?.from)
+                  .legs([])
                   .build();
                 setSelection(newSelection);
               }}


### PR DESCRIPTION
With the current implementation, when a user in troms or nordland makes a trip search for express boat and press "Buy ticket", they have to re-select the departure, even if they had implicitly selected it through the trip search. 

This solves that in the purchase flow, by preselecting the legs and skipping the trip-selection step, taking the user
through the normal PurchaseOverview --> PurchaseConfirmation flow. 
