### PR TITLE
fix: remove chevron and expose travel card skeleton to screen readers

### DIFF
--- a/src/screen-components/travel-card/skeleton/TravelCardSkeleton.tsx
+++ b/src/screen-components/travel-card/skeleton/TravelCardSkeleton.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {ThemeIcon} from '@atb/components/theme-icon';
-import {ChevronRight} from '@atb/assets/svg/mono-icons/navigation';
+import {TravelCardTexts, useTranslation} from '@atb/translations';
 import {LegsSkeleton} from './LegsSkeleton';
 import {SkeletonBlock} from './SkeletonBlock';
 
@@ -12,22 +11,18 @@ import {SkeletonBlock} from './SkeletonBlock';
  */
 export const TravelCardSkeleton = () => {
   const styles = useThemeStyles();
+  const {t} = useTranslation();
   return (
     <View
       style={styles.container}
-      accessibilityElementsHidden
-      importantForAccessibility="no-hide-descendants"
+      accessible={true}
+      accessibilityLabel={t(TravelCardTexts.skeleton.a11yLabel)}
     >
       <View style={styles.header}>
         <SkeletonBlock style={styles.timeBlock} />
         <SkeletonBlock style={styles.durationBlock} />
       </View>
-      <View style={styles.legsContainer}>
-        <View style={styles.legsArea}>
-          <LegsSkeleton />
-        </View>
-        <ThemeIcon svg={ChevronRight} color="secondary" />
-      </View>
+      <LegsSkeleton />
     </View>
   );
 };
@@ -54,13 +49,5 @@ const useThemeStyles = StyleSheet.createThemeHook((theme) => ({
     width: 48,
     height: 16,
     borderRadius: theme.border.radius.small,
-  },
-  legsContainer: {
-    gap: theme.spacing.medium,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  legsArea: {
-    flex: 1,
   },
 }));

--- a/src/translations/components/TravelCard.ts
+++ b/src/translations/components/TravelCard.ts
@@ -146,6 +146,13 @@ const TravelCardTexts = {
       a11yLabel: _('Korrespondanse', 'Correspondance', 'Korrespondanse'),
     },
   },
+  skeleton: {
+    a11yLabel: _(
+      'Laster reiseforslag',
+      'Loading trip suggestion',
+      'Lastar reiseforslag',
+    ),
+  },
 };
 
 export default TravelCardTexts;


### PR DESCRIPTION
## Issue Reference
Follow-up to post-merge feedback on #6204:
- [Chevron shown while loading](https://github.com/AtB-AS/mittatb-app/pull/6204#issuecomment-4956396473) 
- [Screen reader skips the loading state](https://github.com/AtB-AS/mittatb-app/pull/6204#issuecomment-4956600171)

## Description
Addresses the two issues raised after #6204 was merged:

- **Chevron implied clickability**: The skeleton showed a `ChevronRight` even though the card can't be pressed while loading. The chevron is removed from the skeleton.
- **Screen readers skipped the loading state**: The skeleton was hidden from accessibility, so loading placeholders were unreachable in the focus order. The skeleton is now a focusable accessibility element with the label «Laster reiseforslag».