### PR TITLE
feat: set `FLAG_SECURE` in `<SecureView>` on Android

### DIFF
--- a/android/app/src/main/java/no/mittatb/MainApplication.kt
+++ b/android/app/src/main/java/no/mittatb/MainApplication.kt
@@ -22,6 +22,7 @@ class MainApplication : Application(), ReactApplication {
                 PackageList(this).packages.apply {
                     // Packages that cannot be autolinked yet can be added manually here, for example:
                     add(ExperimentalFeaturePackage())
+                    add(SecureFlagPackage())
                 }
         )
     }

--- a/android/app/src/main/java/no/mittatb/SecureFlagModule.kt
+++ b/android/app/src/main/java/no/mittatb/SecureFlagModule.kt
@@ -1,0 +1,49 @@
+package no.mittatb
+
+import android.view.WindowManager
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UiThreadUtil
+
+class SecureFlagModule(
+    private val reactContext: ReactApplicationContext
+) : NativeSecureFlagSpec(reactContext) {
+
+    // FLAG_SECURE applies to the entire window, but can be enabled and disabled
+    // from several sources. This keeps track of the number of times secure flag
+    // is enabled. We set FLAG_SECURE only when the first source enables it, and
+    // clears it only when the last source disables it.
+    private var secureFlagCount = 0
+
+    override fun getName() = NAME
+
+    override fun enableSecureFlag() {
+        UiThreadUtil.runOnUiThread {
+            secureFlagCount++
+            // Set FLAG_SECURE if this is the first source to enable it
+            if (secureFlagCount == 1) {
+                reactContext.currentActivity?.window?.setFlags(
+                    WindowManager.LayoutParams.FLAG_SECURE,
+                    WindowManager.LayoutParams.FLAG_SECURE
+                )
+            }
+        }
+    }
+
+    override fun disableSecureFlag() {
+        UiThreadUtil.runOnUiThread {
+            if (secureFlagCount > 0) {
+                secureFlagCount--
+            }
+            // Clear FLAG_SECURE if this is the last source to disable it
+            if (secureFlagCount == 0) {
+                reactContext.currentActivity?.window?.clearFlags(
+                    WindowManager.LayoutParams.FLAG_SECURE
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val NAME = "SecureFlag"
+    }
+}

--- a/android/app/src/main/java/no/mittatb/SecureFlagPackage.kt
+++ b/android/app/src/main/java/no/mittatb/SecureFlagPackage.kt
@@ -1,0 +1,30 @@
+package no.mittatb
+
+import com.facebook.react.BaseReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
+
+class SecureFlagPackage : BaseReactPackage() {
+
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? =
+        if (name == SecureFlagModule.NAME) {
+            SecureFlagModule(reactContext)
+        } else {
+            null
+        }
+
+    override fun getReactModuleInfoProvider() = ReactModuleInfoProvider {
+        mapOf(
+            SecureFlagModule.NAME to ReactModuleInfo(
+                name = SecureFlagModule.NAME,
+                className = SecureFlagModule.NAME,
+                canOverrideExistingModule = false,
+                needsEagerInit = false,
+                isCxxModule = false,
+                isTurboModule = true
+            )
+        )
+    }
+}

--- a/src/modules/native/NativeSecureFlag.ts
+++ b/src/modules/native/NativeSecureFlag.ts
@@ -1,0 +1,10 @@
+import {TurboModule, TurboModuleRegistry} from 'react-native';
+
+export interface Spec extends TurboModule {
+  enableSecureFlag(): void;
+  disableSecureFlag(): void;
+}
+
+export const NativeSecureFlag = TurboModuleRegistry.get<Spec>(
+  'SecureFlag',
+) as Spec;

--- a/src/modules/native/SecureView.tsx
+++ b/src/modules/native/SecureView.tsx
@@ -1,11 +1,15 @@
-import {PropsWithChildren} from 'react';
+import {PropsWithChildren, useEffect} from 'react';
 import {Platform, View, ViewProps} from 'react-native';
 import SecureViewNativeComponent from './SecureViewNativeComponent';
+import {NativeSecureFlag} from './NativeSecureFlag';
 
 /**
  * View that wraps its children in a "secure text entry" canvas on iOS,
  * preventing them from being captured in screenshots or screen recordings. On
- * Android, it behaves as a regular `View`.
+ * Android, it sets the window-level `FLAG_SECURE` while mounted, which blocks
+ * screenshots and screen recordings of the whole screen.
+ *
+ * https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE
  */
 export function SecureView({children, ...props}: PropsWithChildren<ViewProps>) {
   if (Platform.OS === 'ios') {
@@ -15,5 +19,16 @@ export function SecureView({children, ...props}: PropsWithChildren<ViewProps>) {
       </SecureViewNativeComponent>
     );
   }
+  return <AndroidSecureView {...props}>{children}</AndroidSecureView>;
+}
+
+function AndroidSecureView({children, ...props}: PropsWithChildren<ViewProps>) {
+  // This is reference counted natively, so if several AndroidSecureView's are
+  // mounted at once, the flag remains set until the last one unmounts.
+  useEffect(() => {
+    NativeSecureFlag.enableSecureFlag();
+    return () => NativeSecureFlag.disableSecureFlag();
+  }, []);
+
   return <View {...props}>{children}</View>;
 }


### PR DESCRIPTION
## Issue Reference

closes https://github.com/AtB-AS/kundevendt/issues/23927

## Description

Sets [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) on Android whenever `<SecureView>` is mounted, which makes the entire screen black:

<img width="300" alt="Screenshot_20260713-163345" src="https://github.com/user-attachments/assets/6417553f-c829-416c-8aa6-77f1511ccd8a" />
