### PR TITLE
fix: refresh geolocation when app returns from background

### DIFF
--- a/src/modules/geolocation/GeolocationContext.tsx
+++ b/src/modules/geolocation/GeolocationContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useReducer,
+  useRef,
   useState,
 } from 'react';
 import {Alert, Linking, Platform} from 'react-native';
@@ -29,12 +30,16 @@ import {Coordinates} from '@atb/utils/coordinates';
 import {tGlobal} from '@atb/modules/locale';
 import {coordinatesDistanceInMetres} from '@atb/utils/location';
 
+const LOCATION_MAX_AGE_MS = 60000;
+
 const config: GeolocationOptions = {
   enableHighAccuracy: true,
   distanceFilter: 20,
+  maximumAge: LOCATION_MAX_AGE_MS,
 };
 
 let currentCoordinatesGlobal: Coordinates | undefined = undefined;
+let currentCoordinatesUpdatedAt: number | undefined = undefined;
 export const getCurrentCoordinatesGlobal = () =>
   currentCoordinatesGlobal && {
     ...currentCoordinatesGlobal,
@@ -89,6 +94,7 @@ const geolocationReducer: GeolocationReducer = (prevState, action) => {
         action.locationName,
       );
       currentCoordinatesGlobal = location?.coordinates;
+      currentCoordinatesUpdatedAt = Date.now();
       return {
         ...prevState,
         location,
@@ -230,6 +236,21 @@ export const GeolocationContextProvider = ({children}: Props) => {
     }
   }, [currentLocationError, appStatus, geoLocationName]);
 
+  const previousAppStatusRef = useRef(appStatus);
+
+  useEffect(() => {
+    const cameToForeground =
+      previousAppStatusRef.current !== 'active' && appStatus === 'active';
+    previousAppStatusRef.current = appStatus;
+    if (cameToForeground && locationIsAvailable) {
+      Geolocation.getCurrentPosition(
+        (position) => updateLocation(position, geoLocationName),
+        handleLocationError,
+        {...config, timeout: 15000},
+      );
+    }
+  }, [appStatus, locationIsAvailable, geoLocationName]);
+
   useEffect(() => {
     async function checkPermission() {
       if (appStatus === 'active') {
@@ -262,7 +283,10 @@ export const GeolocationContextProvider = ({children}: Props) => {
       askForPermissionIfBlocked: boolean | undefined = false,
     ): Promise<Coordinates | undefined> => {
       return new Promise(async (resolve) => {
-        if (currentCoordinatesGlobal) {
+        const coordinatesAreFresh =
+          currentCoordinatesUpdatedAt !== undefined &&
+          Date.now() - currentCoordinatesUpdatedAt < LOCATION_MAX_AGE_MS;
+        if (currentCoordinatesGlobal && coordinatesAreFresh) {
           resolve(currentCoordinatesGlobal);
         } else {
           if (state.status === 'blocked' && !askForPermissionIfBlocked) {

--- a/src/modules/geolocation/GeolocationContext.tsx
+++ b/src/modules/geolocation/GeolocationContext.tsx
@@ -4,7 +4,6 @@ import React, {
   useContext,
   useEffect,
   useReducer,
-  useRef,
   useState,
 } from 'react';
 import {Alert, Linking, Platform} from 'react-native';
@@ -235,21 +234,6 @@ export const GeolocationContextProvider = ({children}: Props) => {
       );
     }
   }, [currentLocationError, appStatus, geoLocationName]);
-
-  const previousAppStatusRef = useRef(appStatus);
-
-  useEffect(() => {
-    const cameToForeground =
-      previousAppStatusRef.current !== 'active' && appStatus === 'active';
-    previousAppStatusRef.current = appStatus;
-    if (cameToForeground && locationIsAvailable) {
-      Geolocation.getCurrentPosition(
-        (position) => updateLocation(position, geoLocationName),
-        handleLocationError,
-        {...config, timeout: 15000},
-      );
-    }
-  }, [appStatus, locationIsAvailable, geoLocationName]);
 
   useEffect(() => {
     async function checkPermission() {


### PR DESCRIPTION
## Issue Reference
Fixes AtB-AS/kundevendt#23978

## Description
Location stayed stale after returning from background. Adds `maximumAge: 60s` (library default: infinite), a one-shot fresh fix on background→active, and a staleness guard on the `getCurrentCoordinates` cache.