### PR TITLE
feat: send rentalAppUri to app-switch endpoint

### DIFF
--- a/src/api/mobility.ts
+++ b/src/api/mobility.ts
@@ -194,9 +194,10 @@ export const getStation = (
 export const getAppSwitchUrl = (
   vehicleTypeId: string,
   bonusProductId?: string,
+  rentalAppUri?: string,
 ): Promise<AppSwitchUrl> => {
   const url = `/mobility/v1/app-switch/vehicle-type/${vehicleTypeId}`;
-  const query = qs.stringify({bonusProductId});
+  const query = qs.stringify({bonusProductId, rentalAppUri});
   return client
     .post<AppSwitchUrl>(stringifyUrl(url, query), undefined, {
       authWithIdToken: true,

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -147,6 +147,7 @@ export const VehicleSheet = ({
     const {url} = await getAppSwitchUrl({
       vehicleTypeId,
       bonusProductId: payWithBonusPoints ? selectedBonusProductId : undefined,
+      rentalAppUri: rentalAppUri ?? undefined,
     });
     logEvent('Mobility', 'Open operator app', {
       operatorId,
@@ -160,6 +161,7 @@ export const VehicleSheet = ({
     getAppSwitchUrl,
     payWithBonusPoints,
     selectedBonusProductId,
+    rentalAppUri,
     logEvent,
     operatorId,
     operatorName,

--- a/src/modules/mobility/queries/use-app-switch-mutation.tsx
+++ b/src/modules/mobility/queries/use-app-switch-mutation.tsx
@@ -6,13 +6,18 @@ import {ErrorResponse} from '@atb-as/utils';
 type AppSwitchVariables = {
   vehicleTypeId: string;
   bonusProductId?: string;
+  rentalAppUri?: string;
 };
 
 export const useAppSwitchMutation = () => {
   const {userId} = useAuthContext();
   return useMutation<{url: string}, ErrorResponse, AppSwitchVariables>({
     mutationKey: ['appSwitchUrl', userId],
-    mutationFn: ({vehicleTypeId, bonusProductId}: AppSwitchVariables) =>
-      getAppSwitchUrl(vehicleTypeId, bonusProductId),
+    mutationFn: ({
+      vehicleTypeId,
+      bonusProductId,
+      rentalAppUri,
+    }: AppSwitchVariables) =>
+      getAppSwitchUrl(vehicleTypeId, bonusProductId, rentalAppUri),
   });
 };


### PR DESCRIPTION
## What
Send the opened vehicle's `rentalAppUri` to the server app-switch endpoint (`POST /mobility/v1/app-switch/vehicle-type/:id`).

## Why
Paired with AtB-AS/mobility#116, which moves operator deep-link URL building server-side. The server needs the per-vehicle rental URI to substitute into the operator `callToAction` `{APP_URL}` token. The app already resolved it for the opened vehicle, so passing it lets the service use it directly instead of re-deriving it via a nationwide vehicle scan.

## Ship order
Safe to deploy first — mobility ignores the extra query param until #116 lands.

## Changes
- `getAppSwitchUrl(…, rentalAppUri?)` → query param
- `useAppSwitchMutation` threads it through
- `VehicleSheet` passes the opened vehicle's `rentalAppUri`
