### PR TITLE
fix: vehicle bottom sheet now show system name (like station sheets)

### DIFF
--- a/src/modules/mobility/use-system.tsx
+++ b/src/modules/mobility/use-system.tsx
@@ -4,12 +4,11 @@ import {Platform} from 'react-native';
 import {useThemeContext} from '@atb/theme';
 import {useGetOperatorsQuery} from './queries/use-get-operators-query';
 import {getOperatorNameById} from '@atb/api/utils';
-import {LocalizedString, System} from '@atb/api/types/mobility';
+import {System} from '@atb/api/types/mobility';
 import {SystemFragment} from '@atb/api/types/generated/fragments/mobility-shared';
 
 export const useSystem = <T extends {system: SystemFragment | System}>(
   entity: T | undefined | null,
-  operator: LocalizedString | undefined = entity?.system.name,
 ) => {
   const {t, language} = useTranslation();
   const {themeName} = useThemeContext();
@@ -32,7 +31,7 @@ export const useSystem = <T extends {system: SystemFragment | System}>(
       : entity?.system.brandAssets?.brandImageUrl;
 
   const operatorNameFallback =
-    getTextForLanguage(operator?.translation, language) ??
+    getTextForLanguage(entity?.system.name?.translation, language) ??
     t(MobilityTexts.unknownOperator) ??
     '';
 

--- a/src/modules/mobility/use-vehicle.tsx
+++ b/src/modules/mobility/use-vehicle.tsx
@@ -12,10 +12,7 @@ export const useVehicle = (
     isLoading,
     isError,
   } = useVehicleQuery(vehicleId, vehicleTypeId, stationId);
-  const {appStoreUri, brandLogoUrl, operatorId, operatorName} = useSystem(
-    vehicle,
-    vehicle?.system.operator.name,
-  );
+  const {appStoreUri, brandLogoUrl, operatorId, operatorName} = useSystem(vehicle);
 
   return {
     vehicle,

--- a/src/modules/mobility/use-vehicle.tsx
+++ b/src/modules/mobility/use-vehicle.tsx
@@ -12,7 +12,8 @@ export const useVehicle = (
     isLoading,
     isError,
   } = useVehicleQuery(vehicleId, vehicleTypeId, stationId);
-  const {appStoreUri, brandLogoUrl, operatorId, operatorName} = useSystem(vehicle);
+  const {appStoreUri, brandLogoUrl, operatorId, operatorName} =
+    useSystem(vehicle);
 
   return {
     vehicle,


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23697
Note 6 from @hanne-at-atb 

## Description
previously: **station** bottom sheets showed `system.operator.name` while **vehicle** bottom sheets showed `system.name` value at the top of the bottom sheets.

Now: both bottom sheets show the same value, which is system.name. This is possible because Ryde has updated their value for this field, so all operators have a displayable name.


Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3cd21c8d-487d-44fc-9d2b-17f3e9bda77f" />

After:
<img width="200"  alt="image" src="https://github.com/user-attachments/assets/dcd55a9a-193f-48a0-98be-274375622039" />
