### PR TITLE
feat: improve departures empty state message

### DIFF
--- a/src/screen-components/place-screen/PlaceScreenComponent.tsx
+++ b/src/screen-components/place-screen/PlaceScreenComponent.tsx
@@ -12,6 +12,7 @@ import {StopPlacesView} from './components/StopPlacesView';
 import type {DepartureSearchTime} from 'src/components/date-selection';
 import {useStopsDetailsDataQuery} from './hooks/use-stops-details-data-query';
 import {useScrollBorder} from '@atb/utils/use-scroll-border';
+import {FullScreenView} from '@atb/components/screen-view';
 
 export type PlaceScreenParams = {
   place: StopPlace;

--- a/src/screen-components/place-screen/PlaceScreenComponent.tsx
+++ b/src/screen-components/place-screen/PlaceScreenComponent.tsx
@@ -52,26 +52,36 @@ export const PlaceScreenComponent = ({
   const {data: stopsDetailsData, isError: isStopsDetailsError} =
     useStopsDetailsDataQuery(place.quays === undefined ? [place.id] : []);
 
-  let missingStopData = false;
-
   if (stopsDetailsData && place.quays === undefined) {
-    if (stopsDetailsData.stopPlaces[0].quays?.length) {
-      place = stopsDetailsData.stopPlaces[0];
-    } else {
-      missingStopData = true;
-    }
+    place = stopsDetailsData.stopPlaces[0];
   }
 
-  if (isStopsDetailsError || missingStopData) {
+  if (isStopsDetailsError) {
     return (
-      <View style={styles.container}>
-        <FullScreenHeader title={place.name} leftButton={{type: 'back'}} />
+      <FullScreenView
+        focusRef={undefined}
+        headerProps={{title: place.name, leftButton: {type: 'back'}}}
+      >
         <MessageInfoBox
           style={styles.messageBox}
           type="error"
           message={t(DeparturesTexts.message.resultNotFound)}
         />
-      </View>
+      </FullScreenView>
+    );
+  }
+  if (place.quays?.length === 0) {
+    return (
+      <FullScreenView
+        focusRef={undefined}
+        headerProps={{title: place.name, leftButton: {type: 'back'}}}
+      >
+        <MessageInfoBox
+          style={styles.messageBox}
+          type="info"
+          message={t(DeparturesTexts.message.emptyResult)}
+        />
+      </FullScreenView>
     );
   }
 

--- a/src/translations/screens/Departures.ts
+++ b/src/translations/screens/Departures.ts
@@ -133,9 +133,9 @@ const DeparturesTexts = {
       'Du har ingen favorittavgangar.',
     ),
     emptyResult: _(
-      'Fant ingen avganger på valgt sted.',
-      'No departures found at the specified location',
-      'Fann ingen avgangar på valt stad.',
+      'Ingen avganger fra denne holdeplassen.',
+      'No departures from this stop place.',
+      'Ingen avgangar frå denne haldeplassen.',
     ),
     resultFailed: _(
       'Kunne ikke laste avganger.',


### PR DESCRIPTION
This improves error handling for stops that have no quays, like St. Olavs gate, and uses the same wording as in https://github.com/AtB-AS/planner-web/pull/771

## Before/after

<img width="300" alt="IMG_4965" src="https://github.com/user-attachments/assets/2f6a3604-47bd-4e1d-86f1-e66224ecc1c7" />
<img width="300" alt="IMG_AA1DEA386F81-1" src="https://github.com/user-attachments/assets/58b6ffd0-34e3-4aa4-865c-aa98a154e9c0" />

## Acceptance criteria

- [x] Info message shows up instead of error on stops like St. Olavs gate
