### PR TITLE
fix: overflowing trip details row labels

### DIFF
--- a/src/screen-components/travel-details-screens/components/Time.tsx
+++ b/src/screen-components/travel-details-screens/components/Time.tsx
@@ -45,6 +45,7 @@ export const Time: React.FC<{
               typography="body__m__strong"
               prefix={t(dictionary.travel.time.expectedPrefix)}
               testID="expTime"
+              style={styles.timeText}
             >
               {expected}
             </AccessibleText>
@@ -63,7 +64,11 @@ export const Time: React.FC<{
     }
     default: {
       return (
-        <ThemeText typography="body__m__strong" testID="schTime">
+        <ThemeText
+          typography="body__m__strong"
+          testID="schTime"
+          style={styles.timeText}
+        >
           {expected || scheduled}
         </ThemeText>
       );
@@ -84,5 +89,8 @@ const useStyles = StyleSheet.createThemeHook(() => ({
     textDecorationLine: 'line-through',
     position: 'absolute',
     top: '100%',
+  },
+  timeText: {
+    textAlign: 'right',
   },
 }));

--- a/src/screen-components/travel-details-screens/components/TripLegDecoration.tsx
+++ b/src/screen-components/travel-details-screens/components/TripLegDecoration.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
-import {StyleSheet} from '@atb/theme';
+import {StyleSheet, useThemeContext} from '@atb/theme';
 import {DimensionOverrides} from './TripRow';
 
 type TripLegDecorationProps = {
@@ -18,6 +18,7 @@ export const TripLegDecoration: React.FC<TripLegDecorationProps> = ({
   dimensionOverrides,
 }) => {
   const style = useStyles();
+  const {theme} = useThemeContext();
   const colorStyle = {backgroundColor: color};
 
   const leftOverride =
@@ -26,7 +27,8 @@ export const TripLegDecoration: React.FC<TripLegDecorationProps> = ({
       ? {
           left:
             dimensionOverrides.labelWidth +
-            dimensionOverrides.decorationContainerWidth / 2,
+            dimensionOverrides.decorationContainerWidth / 2 -
+            theme.tripLegDetail.decorationLineWidth / 2,
         }
       : undefined;
 

--- a/src/screen-components/travel-details-screens/components/TripRow.tsx
+++ b/src/screen-components/travel-details-screens/components/TripRow.tsx
@@ -11,9 +11,9 @@ export type DimensionOverrides = {
 
 // TODO: Remove / rename once old trip details are removed
 export const NEW_TRIP_DIMENSIONS: DimensionOverrides = {
-  labelWidth: 42,
-  decorationContainerWidth: 42,
-  labelAlignment: 'flex-start',
+  labelWidth: 72,
+  decorationContainerWidth: 28,
+  labelAlignment: 'flex-end',
 };
 
 type TripRowProps = {
@@ -41,6 +41,7 @@ export const TripRow: React.FC<TripRowProps> = ({
         style={[
           styles.leftColumn,
           dimensionOverrides?.labelWidth != null && {
+            width: dimensionOverrides.labelWidth,
             minWidth: dimensionOverrides.labelWidth,
           },
           dimensionOverrides?.labelAlignment != null && {


### PR DESCRIPTION
Needed to go back to right aligned row label to make room for the
"ca." prefix. Also fixed wrapping when the row label content is
too big.

**Background**
https://mittatb.slack.com/archives/C0116FMPX4Y/p1784496657121129

**Before**
<div>
<img width="350" src="https://github.com/user-attachments/assets/69a3dacb-386f-4f80-b730-07d227c21194" />
<img width="350" src="https://github.com/user-attachments/assets/6cbc37cf-31da-443c-af16-51cfb2de599e" />
</div>

**After**
<div>
<img width="350" src="https://github.com/user-attachments/assets/873b5eb7-bf15-4caa-a8ea-1ffc27619fea" />
<img width="350" src="https://github.com/user-attachments/assets/3cc729aa-546e-45fd-bde8-26d86ad6a727" />
</div>

### Acceptance criteria
- [x] There is room for the "ca." prefix on same line when standard font size on normal sized phones
- [x] The text wraps if not enough room for "ca." prefix on same line