### PR TITLE
fix: filter supplement products against new product on product change

### DIFF
--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-product.test.ts
@@ -281,6 +281,61 @@ describe('purchaseSelectionBuilder - product', () => {
     );
     expect(selection.preassignedFareProduct.id).toBe('P2');
   });
+
+  it('Should filter supplement products against the new product limitations, not the previous product', () => {
+    // Previous product (TEST_PRODUCT) allows SP1; new product does NOT.
+    // If the filter is applied against the previous product, SP1 would be kept.
+    const newProduct = {
+      ...TEST_PRODUCT,
+      id: 'P2',
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        supplementProductRefs: ['SP2'],
+      },
+    };
+    const selectionWithSupplement = {
+      ...TEST_SELECTION,
+      supplementProductsWithCount: [
+        {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 2},
+      ],
+    };
+
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(selectionWithSupplement)
+      .product(newProduct)
+      .build().selection;
+
+    expect(selection.preassignedFareProduct.id).toBe('P2');
+    expect(selection.supplementProductsWithCount).toEqual([]);
+  });
+
+  it('Should drop only supplement products not allowed by the new product limitations', () => {
+    const newProduct = {
+      ...TEST_PRODUCT,
+      id: 'P2',
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        supplementProductRefs: ['SP1'],
+      },
+    };
+    const selectionWithSupplements = {
+      ...TEST_SELECTION,
+      supplementProductsWithCount: [
+        {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 2},
+        {...TEST_SUPPLEMENT_PRODUCT, id: 'SP2', count: 1},
+      ],
+    };
+
+    const selection = createEmptyBuilder(TEST_INPUT)
+      .fromSelection(selectionWithSupplements)
+      .product(newProduct)
+      .build().selection;
+
+    expect(selection.preassignedFareProduct.id).toBe('P2');
+    expect(selection.supplementProductsWithCount).toHaveLength(1);
+    expect(selection.supplementProductsWithCount[0].id).toBe('SP1');
+    expect(selection.supplementProductsWithCount[0].count).toBe(2);
+  });
 });
 
 describe('purchaseSelectionBuilder - product forced changes', () => {
@@ -432,6 +487,52 @@ describe('purchaseSelectionBuilder - product forced changes', () => {
       .build();
 
     expect(forcedChanges).toEqual(['userProfile', 'zone']);
+  });
+
+  it('Should report supplementProduct when a supplement product is dropped', () => {
+    const newProduct = {
+      ...TEST_PRODUCT,
+      id: 'P2',
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        supplementProductRefs: ['SP2'],
+      },
+    };
+
+    const {forcedChanges} = createEmptyBuilder(TEST_INPUT)
+      .fromSelection({
+        ...TEST_SELECTION,
+        supplementProductsWithCount: [
+          {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 2},
+        ],
+      })
+      .product(newProduct)
+      .build();
+
+    expect(forcedChanges).toEqual(['supplementProduct']);
+  });
+
+  it('Should not report supplementProduct when all supplement products remain valid', () => {
+    const newProduct = {
+      ...TEST_PRODUCT,
+      id: 'P2',
+      limitations: {
+        ...TEST_PRODUCT.limitations,
+        supplementProductRefs: ['SP1'],
+      },
+    };
+
+    const {forcedChanges} = createEmptyBuilder(TEST_INPUT)
+      .fromSelection({
+        ...TEST_SELECTION,
+        supplementProductsWithCount: [
+          {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1', count: 2},
+        ],
+      })
+      .product(newProduct)
+      .build();
+
+    expect(forcedChanges).toEqual([]);
   });
 
   it('Should replace, not accumulate, forced changes across multiple product calls', () => {

--- a/src/modules/purchase-selection/__tests__/purchase-selection-builder-user-profiles.test.ts
+++ b/src/modules/purchase-selection/__tests__/purchase-selection-builder-user-profiles.test.ts
@@ -187,9 +187,12 @@ describe('isSelectableSupplementProduct', () => {
       },
     };
     const supplementProduct = {...TEST_SUPPLEMENT_PRODUCT, id: 'SP1'};
-    expect(isSelectableSupplementProduct(selection, supplementProduct)).toBe(
-      true,
-    );
+    expect(
+      isSelectableSupplementProduct(
+        selection.preassignedFareProduct,
+        supplementProduct,
+      ),
+    ).toBe(true);
   });
 
   it('returns false if supplement product is not allowed by limitations', () => {
@@ -204,9 +207,12 @@ describe('isSelectableSupplementProduct', () => {
       },
     };
     const supplementProduct = {...TEST_SUPPLEMENT_PRODUCT, id: 'SP3'};
-    expect(isSelectableSupplementProduct(selection, supplementProduct)).toBe(
-      false,
-    );
+    expect(
+      isSelectableSupplementProduct(
+        selection.preassignedFareProduct,
+        supplementProduct,
+      ),
+    ).toBe(false);
   });
 
   it('returns true if supplementProductRefs is empty (no limitations)', () => {
@@ -221,9 +227,12 @@ describe('isSelectableSupplementProduct', () => {
       },
     };
     const supplementProduct = {...TEST_SUPPLEMENT_PRODUCT, id: 'SP3'};
-    expect(isSelectableSupplementProduct(selection, supplementProduct)).toBe(
-      true,
-    );
+    expect(
+      isSelectableSupplementProduct(
+        selection.preassignedFareProduct,
+        supplementProduct,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -444,9 +453,12 @@ describe('isSelectableSupplementProduct - undefined limitations', () => {
       },
     };
     const supplementProduct = {...TEST_SUPPLEMENT_PRODUCT, id: 'SP99'};
-    expect(isSelectableSupplementProduct(selection, supplementProduct)).toBe(
-      true,
-    );
+    expect(
+      isSelectableSupplementProduct(
+        selection.preassignedFareProduct,
+        supplementProduct,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/modules/purchase-selection/index.ts
+++ b/src/modules/purchase-selection/index.ts
@@ -7,5 +7,5 @@ export type {
 export {usePurchaseSelectionBuilder} from './use-purchase-selection-builder';
 export {useSelectableUserProfiles} from './use-selectable-user-profiles';
 export {useSelectableFareZones} from './use-selectable-fare-zones';
-export {useSelectableBaggageProducts} from './use-selectable-baggage-products';
+export {useSelectableSupplementProducts} from './use-selectable-supplement-products';
 export {usePreviousZonesStore} from './use-previous-zones-store';

--- a/src/modules/purchase-selection/purchase-selection-builder.ts
+++ b/src/modules/purchase-selection/purchase-selection-builder.ts
@@ -184,7 +184,10 @@ const createBuilder = (
       );
       const areSupplementProductsValid =
         onlySupplementProductsWithActualCount.every((sp) =>
-          isSelectableSupplementProduct(currentSelection, sp),
+          isSelectableSupplementProduct(
+            currentSelection.preassignedFareProduct,
+            sp,
+          ),
         );
 
       if (

--- a/src/modules/purchase-selection/types.ts
+++ b/src/modules/purchase-selection/types.ts
@@ -25,7 +25,10 @@ export type FareContractStub = {
  * (currently only via `.product()`) when the current selection is not
  * applicable for a newly applied product.
  */
-export type ForcedSelectionChange = 'userProfile' | 'zone';
+export type ForcedSelectionChange =
+  | 'userProfile'
+  | 'zone'
+  | 'supplementProduct';
 
 /**
  * Result of `PurchaseSelectionBuilder.build()`. Carries the built selection

--- a/src/modules/purchase-selection/use-selectable-supplement-products.ts
+++ b/src/modules/purchase-selection/use-selectable-supplement-products.ts
@@ -3,7 +3,7 @@ import {useGetSupplementProductsQuery} from '../ticketing';
 import {BaggageProduct} from '@atb/modules/configuration';
 import {isSelectableSupplementProduct} from './utils';
 
-export function useSelectableBaggageProducts(
+export function useSelectableSupplementProducts(
   selection: PurchaseSelectionType,
 ): BaggageProduct[] {
   const {data: allSupplementProducts} = useGetSupplementProductsQuery();
@@ -11,5 +11,7 @@ export function useSelectableBaggageProducts(
     .map((sp) => BaggageProduct.safeParse(sp))
     .filter((sp) => sp.success)
     .map((sp) => sp.data)
-    .filter((sp) => isSelectableSupplementProduct(selection, sp));
+    .filter((sp) =>
+      isSelectableSupplementProduct(selection.preassignedFareProduct, sp),
+    );
 }

--- a/src/modules/purchase-selection/utils.ts
+++ b/src/modules/purchase-selection/utils.ts
@@ -153,11 +153,11 @@ export const isSelectableProfile = (
   );
 
 export const isSelectableSupplementProduct = (
-  currentSelection: PurchaseSelectionType,
+  product: PreassignedFareProduct,
   supplementProduct: SupplementProduct,
 ) => {
   const supplementProductLimitations =
-    currentSelection.preassignedFareProduct.limitations.supplementProductRefs;
+    product.limitations.supplementProductRefs;
   if (
     !supplementProductLimitations ||
     supplementProductLimitations.length === 0
@@ -201,7 +201,7 @@ export const isValidSelection = (
 
   const areSupplementProductsValid =
     selection.supplementProductsWithCount.every((sp) =>
-      isSelectableSupplementProduct(selection, sp),
+      isSelectableSupplementProduct(selection.preassignedFareProduct, sp),
     );
   if (!areSupplementProductsValid) return false;
 
@@ -263,9 +263,9 @@ export const applyProductChange = (
   const selectableProfiles = currentSelection.userProfilesWithCount.filter(
     (up) => isSelectableProfile(product, up),
   );
-  const supplementProductCount =
+  const selectableSupplements =
     currentSelection.supplementProductsWithCount.filter((sp) =>
-      isSelectableSupplementProduct(currentSelection, sp),
+      isSelectableSupplementProduct(product, sp),
     );
 
   const isFromZoneValid =
@@ -282,7 +282,7 @@ export const applyProductChange = (
     : getDefaultZones(input, currentSelection.fareProductTypeConfig, product);
 
   const userProfiles =
-    !selectableProfiles.length && !supplementProductCount.length
+    !selectableProfiles.length && !selectableSupplements.length
       ? getDefaultUserProfiles(input, product)
       : selectableProfiles;
 
@@ -298,12 +298,19 @@ export const applyProductChange = (
   if (!bothZonesValid) {
     forcedChanges.push('zone');
   }
+  if (
+    selectableSupplements.length !==
+    currentSelection.supplementProductsWithCount.length
+  ) {
+    forcedChanges.push('supplementProduct');
+  }
 
   return {
     selection: {
       ...currentSelection,
       preassignedFareProduct: product,
       userProfilesWithCount: userProfiles,
+      supplementProductsWithCount: selectableSupplements,
       zones: newZones ?? currentSelection.zones,
     },
     forcedChanges,

--- a/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-baggage-count-state.ts
+++ b/src/stacks-hierarchy/Root_PurchaseOverviewScreen/components/Travellers/use-baggage-count-state.ts
@@ -1,6 +1,6 @@
 import {
   type PurchaseSelectionType,
-  useSelectableBaggageProducts,
+  useSelectableSupplementProducts,
 } from '@atb/modules/purchase-selection';
 import {BaggageProduct} from '@atb/modules/configuration';
 import {useUniqueCountState} from '@atb/utils/unique-with-count';
@@ -9,7 +9,7 @@ const findBaggageProduct = (a: BaggageProduct, b: BaggageProduct) =>
   a.id === b.id;
 
 export function useBaggageCountState(selection: PurchaseSelectionType) {
-  const selectableBaggageProducts = useSelectableBaggageProducts(selection);
+  const selectableBaggageProducts = useSelectableSupplementProducts(selection);
   const initialState = selectableBaggageProducts.map((b) => {
     return {
       ...b,

--- a/src/translations/screens/subscreens/PurchaseOverview.ts
+++ b/src/translations/screens/subscreens/PurchaseOverview.ts
@@ -163,6 +163,11 @@ const PurchaseOverviewTexts = {
       items: {
         userProfile: _('reisekategori', 'traveller category', 'reisekategori'),
         zone: _('soner', 'zones', 'soner'),
+        supplementProduct: _(
+          'tilleggsprodukt',
+          'supplement product',
+          'tilleggsprodukt',
+        ),
       },
     },
   },


### PR DESCRIPTION
When switching preassigned fare product, supplement products (e.g.
baggage) were filtered against the old product's limitations, and the
filtered result was never written back to the selection. Pass the target
product to isSelectableSupplementProduct and assign the filtered list on
the returned selection.

Also report dropped supplement products as a forced change so the user
is notified via the existing snackbar.

### Acceptance criteria 
There are no noticeable changes for users. The bug would have been there if for example 30 days period ticket allowed supplement products, but 180 days did not. But I don't think it is necessary to do the necessary setup for testing this like that.

- [x] Supplement products works as before.