### PR TITLE
feat: handling for electric citybike for the start trip overlay

### DIFF
--- a/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
+++ b/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
@@ -6,11 +6,17 @@ import {useTranslation} from '@atb/translations';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {Parking} from '@atb/assets/svg/mono-icons/places';
 import {StyleSheet} from '@atb/theme';
-import {ThemedStartCityBike} from '@atb/theme/ThemedAssets';
+import {
+  ThemedStartCityBike,
+  ThemedElectricCityBikeStationPerson,
+} from '@atb/theme/ThemedAssets';
 import {LinkSectionItem} from '@atb/components/sections';
 import {ShmoBooking} from '@atb/api/types/mobility';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
-import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {
+  FormFactor,
+  PropulsionType,
+} from '@atb/api/types/generated/mobility-types_v2';
 
 type Props = {
   activeBooking: ShmoBooking;
@@ -23,6 +29,8 @@ export const CityBikeStartTripOverlay = ({
 }: Props) => {
   const styles = useStyles();
   const {t} = useTranslation();
+
+  const isManual = activeBooking.asset?.propulsionType === PropulsionType.Human;
 
   return (
     <View style={styles.overlay}>
@@ -43,13 +51,21 @@ export const CityBikeStartTripOverlay = ({
             </ThemeText>
           )}
         </View>
-        <ThemedStartCityBike />
+        {isManual ? (
+          <ThemedStartCityBike />
+        ) : (
+          <ThemedElectricCityBikeStationPerson />
+        )}
         <View style={styles.content}>
-          <ThemeText typography="heading__xl" style={styles.contentText}>
-            {t(MobilityTexts.cityBike.startTripView.title)}
-          </ThemeText>
+          {isManual && (
+            <ThemeText typography="heading__xl" style={styles.contentText}>
+              {t(MobilityTexts.cityBike.startTripView.title)}
+            </ThemeText>
+          )}
           <ThemeText style={styles.contentText}>
-            {t(MobilityTexts.cityBike.startTripView.description)}
+            {isManual
+              ? t(MobilityTexts.cityBike.startTripView.description)
+              : t(MobilityTexts.cityBike.startTripView.electricDescription)}
           </ThemeText>
           <ThemeText style={styles.contentText}>
             {t(MobilityTexts.cityBike.startTripView.safeTrip)}

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -123,9 +123,14 @@ export const MobilityTexts = {
         'Trykk på knappen på styret',
       ),
       description: _(
-        'Når knappen lyser grønt og sykkelen lager lyd kan du ta den ut av stativet og sykle av sted.',
-        'When the button lights up green and the bike makes a sound, you can take it out of the dock and start riding.',
-        'Når knappen lyser grønt og sykkelen lagar lyd kan du ta den ut av stativet og sykle av stad.',
+        'Deretter kan du ta sykkelen ut av stativet og sykle av sted.',
+        'Then you can take the bike out of the dock and start riding.',
+        'Deretter kan du ta sykkelen ut av stativet og sykle av stad.',
+      ),
+      electricDescription: _(
+        'Nå kan du ta sykkelen ut av stativet og sykle av sted.',
+        'Now you can take the bike out of the dock and start riding.',
+        'No kan du ta sykkelen ut av stativet og sykle av stad.',
       ),
       safeTrip: _('God tur!', 'Have a nice trip!', 'God tur!'),
       header: _('Start tur', 'Start trip', 'Start tur'),


### PR DESCRIPTION
Fixes [Note 1](https://github.com/AtB-AS/kundevendt/issues/23697#issuecomment-4890934152)

Note that we should have a overlay there for electric aswell, since we need to communicate to the user where the bike is parked, but we altered the text and icon to match electric behavior.

Closes https://github.com/AtB-AS/kundevendt/issues/23697