### PR TITLE
feat: added bundlingView in the app for deepintegration vehicles

### DIFF
--- a/src/modules/mobility/components/PriceDetailsCard.tsx
+++ b/src/modules/mobility/components/PriceDetailsCard.tsx
@@ -56,7 +56,9 @@ export const PriceDetailsCard = ({
 
   const hasFreeMinutes = !!(freeMinutes && pricingPlan.perMinPricing?.length);
 
-  const minutePriceStat = hasFreeMinutes ? zeroAmount : ratePrUnit?.formattedRate;
+  const minutePriceStat = hasFreeMinutes
+    ? zeroAmount
+    : ratePrUnit?.formattedRate;
 
   const minutePriceDescription = hasFreeMinutes
     ? t(

--- a/src/modules/mobility/components/PriceDetailsCard.tsx
+++ b/src/modules/mobility/components/PriceDetailsCard.tsx
@@ -47,24 +47,21 @@ export const PriceDetailsCard = ({
   const freeUnlock = getFreeUnlock(benefit);
   const freeMinutes = getFreeMinutes(benefit);
 
+  const currencySymbol = getCurrencySymbol(pricingPlan.currency);
+  const zeroAmount = `${formatNumberToString(0, language)} ${currencySymbol}`;
+
   const unlockStat = freeUnlock
-    ? t(ScooterTexts.free)
-    : `${formatNumberToString(pricingPlan.price, language)} ${getCurrencySymbol(pricingPlan.currency)}`;
+    ? zeroAmount
+    : `${formatNumberToString(pricingPlan.price, language)} ${currencySymbol}`;
 
-  const minutePriceStat =
-    freeMinutes && pricingPlan.perMinPricing?.length
-      ? `${formatNumberToString(
-          computeFreeMinuteCount(freeMinutes, pricingPlan.perMinPricing),
-          language,
-        )} min ${t(ScooterTexts.free).toLocaleLowerCase(language)}`
-      : ratePrUnit?.formattedRate;
+  const hasFreeMinutes = !!(freeMinutes && pricingPlan.perMinPricing?.length);
 
-  const minutePriceDescription = freeMinutes
+  const minutePriceStat = hasFreeMinutes ? zeroAmount : ratePrUnit?.formattedRate;
+
+  const minutePriceDescription = hasFreeMinutes
     ? t(
-        ScooterTexts.per.discount(
-          ratePrUnit?.perUnit ?? '',
-          ratePrUnit?.rate.toString() ?? '',
-          pricingPlan.currency,
+        ScooterTexts.freeMinutesDescription(
+          computeFreeMinuteCount(freeMinutes!, pricingPlan.perMinPricing!),
         ),
       )
     : t(ScooterTexts.per.unit(ratePrUnit?.perUnit ?? ''));
@@ -75,43 +72,44 @@ export const PriceDetailsCard = ({
 
   return (
     <Section>
-      {hasBenefitInfo && (
-        <GenericSectionItem>
-          <View style={styles.benefitContainer}>
-            <BenefitIllustration
-              illustrationName={benefit?.illustrationName}
-              style={styles.benefitIllustration}
-            />
-            <View style={styles.benefitContent}>
-              {benefitTitle && (
-                <ThemeText typography="body__m__strong">
-                  {benefitTitle}
-                </ThemeText>
-              )}
-              {benefitDescription && (
-                <ThemeText typography="body__s" type="secondary">
-                  {benefitDescription}
-                </ThemeText>
-              )}
-            </View>
-          </View>
-        </GenericSectionItem>
-      )}
       <GenericSectionItem style={styles.sectionWrapper}>
-        <View style={styles.content}>
-          <VehicleCardStat
-            icon={Unlock}
-            stat={unlockStat}
-            description={t(ScooterTexts.unlock)}
-            hasPriceAdjustment={!!freeUnlock}
-          />
-          {minutePriceStat && (
+        <View style={styles.sectionContent}>
+          <View style={styles.content}>
             <VehicleCardStat
-              icon={PricePerTime}
-              stat={minutePriceStat}
-              description={minutePriceDescription}
-              hasPriceAdjustment={!!freeMinutes}
+              icon={Unlock}
+              stat={unlockStat}
+              description={t(ScooterTexts.unlock)}
+              hasPriceAdjustment={!!freeUnlock}
             />
+            {minutePriceStat && (
+              <VehicleCardStat
+                icon={PricePerTime}
+                stat={minutePriceStat}
+                description={minutePriceDescription}
+                hasPriceAdjustment={!!freeMinutes}
+              />
+            )}
+          </View>
+
+          {hasBenefitInfo && (
+            <View style={styles.benefitContainer}>
+              <BenefitIllustration
+                illustrationName={benefit?.illustrationName}
+                style={styles.benefitIllustration}
+              />
+              <View style={styles.benefitContent}>
+                {benefitTitle && (
+                  <ThemeText typography="body__m__strong">
+                    {benefitTitle}
+                  </ThemeText>
+                )}
+                {benefitDescription && (
+                  <ThemeText typography="body__s" type="secondary">
+                    {benefitDescription}
+                  </ThemeText>
+                )}
+              </View>
+            </View>
           )}
         </View>
       </GenericSectionItem>
@@ -130,13 +128,16 @@ export const PriceDetailsCard = ({
 const useStyles = StyleSheet.createThemeHook((theme) => {
   return {
     content: {
-      flex: 1,
       flexDirection: 'row',
       alignItems: 'center',
       gap: theme.spacing.small,
     },
     sectionWrapper: {
       padding: theme.spacing.small,
+    },
+    sectionContent: {
+      flex: 1,
+      gap: theme.spacing.medium,
     },
     benefitContainer: {
       flexDirection: 'row',
@@ -147,6 +148,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
     },
     benefitContent: {
       flex: 1,
+      gap: theme.spacing.xSmall,
     },
   };
 });

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -222,7 +222,7 @@ export const VehicleSheet = ({
 
       {!isLoading && !shmoReqIsLoading && !isError && vehicle && (
         <View style={styles.container}>
-          {operatorBenefit && (
+          {operatorBenefit && showAppSwitchAction && (
             <OperatorBenefit
               benefit={operatorBenefit}
               formFactor={formFactor}

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -467,7 +467,8 @@ export const ScooterTexts = {
   ),
   range: _('rekkevidde', 'range', 'rekkjevidde'),
   unlock: _('opplåsning', 'unlock', 'opplåsing'),
-  free: _('Gratis', 'Free', 'Gratis'),
+  freeMinutesDescription: (minutes: number) =>
+    _(`i ${minutes} min`, `for ${minutes} min`, `i ${minutes} min`),
   per: {
     unit(unit: string) {
       switch (unit) {


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/22839

Added title, description and illustrationName if it exisits on a benefit, it should show under the price info as shown in the sketches.
It uses the newly added benefit attribute on a vehicle fetched from mobility. It does not need to be bundling. But for now we do have a title and description for bundling, so it will show. But we could add info on other benefits if we like aswell, and it will show in the same way

Seed data PR for the benefits needed in the database in order for it to show in the app https://github.com/AtB-AS/benefit/pull/17

<img width="250" alt="image" src="https://github.com/user-attachments/assets/6254d707-458b-4e5b-86ab-fad9daf4b9b4" />
