### PR TITLE
feat: added fix for big text in startTripOverlay

### DIFF
--- a/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
+++ b/src/modules/mobility/components/CityBikeStartTripOverlay.tsx
@@ -73,11 +73,12 @@ export const CityBikeStartTripOverlay = ({
   );
 };
 
-const useStyles = StyleSheet.createThemeHook((theme) => ({
+const useStyles = StyleSheet.createThemeHook((theme, {top: safeTopInset}) => ({
   overlay: {
     ...StyleSheet.absoluteFill,
     backgroundColor: theme.color.background.neutral[1].background,
     paddingHorizontal: theme.spacing.xLarge,
+    paddingTop: safeTopInset,
     paddingBottom: theme.spacing.xLarge,
     zIndex: 100,
   },


### PR DESCRIPTION
Fixes this comment https://github.com/AtB-AS/kundevendt/issues/22834#issuecomment-4924739759

 With big text size the stationSlotName was pushed up behind the camera. This makes it stop before it goes out of frame
 
 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/877a6f05-8f80-4502-96eb-800dbaaafb46" />
