### PR TITLE
fix: hide refund action when refund window has passed

### DIFF
--- a/src/modules/fare-contracts/details/DetailsContent.tsx
+++ b/src/modules/fare-contracts/details/DetailsContent.tsx
@@ -315,13 +315,15 @@ export const DetailsContent: React.FC<Props> = ({
           rightIcon={{svg: Mail}}
         />
       )}
-      {refundOptions?.isRefundable && (
-        <LinkSectionItem
-          text={t(FareContractTexts.refund.refund)}
-          onPress={onRefundNavigate}
-          rightIcon={{svg: TicketInvalid}}
-        />
-      )}
+      {refundOptions?.isRefundable &&
+        (!refundOptions.lastRefundTime ||
+          now < refundOptions.lastRefundTime.getTime()) && (
+          <LinkSectionItem
+            text={t(FareContractTexts.refund.refund)}
+            onPress={onRefundNavigate}
+            rightIcon={{svg: TicketInvalid}}
+          />
+        )}
     </Section>
   );
 };

--- a/src/modules/ticketing/api.ts
+++ b/src/modules/ticketing/api.ts
@@ -293,12 +293,14 @@ export async function getFareContracts(
   return validFareContracts;
 }
 
-export async function getRefundOptions(orderId: string) {
+export async function getRefundOptions(
+  orderId: string,
+): Promise<RefundOptions> {
   const url = `sales/v1/refund/options/${orderId}`;
   const response = await client.get<RefundOptions>(url, {
     authWithIdToken: true,
   });
-  return response.data;
+  return convertIsoStringFieldsToDate(response.data);
 }
 
 export async function refundFareContract(orderId: string, reasonId?: string) {

--- a/src/modules/ticketing/types.ts
+++ b/src/modules/ticketing/types.ts
@@ -194,9 +194,9 @@ export type AddPaymentMethodResponse = {
  * Defined by RefundOptionsResponse in
  * https://github.com/AtB-AS/sales/blob/main/sales-service/src/handlers/sales/refund.rs
  */
-export type RefundOptions = {
-  isRefundable: boolean;
-};
+export type RefundOptions =
+  | {isRefundable: false}
+  | {isRefundable: true; lastRefundTime?: Date};
 
 /**
  * Defined by ConsumableSchoolCarnetResponse in

--- a/src/stacks-hierarchy/Root_RefundConfirmationScreen.tsx
+++ b/src/stacks-hierarchy/Root_RefundConfirmationScreen.tsx
@@ -29,6 +29,8 @@ import {RootStackScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {CUSTOMER_SERVICE_URL} from '@env';
 import {ThemedBeacons} from '@atb/theme/ThemedAssets';
+import {useTimeContext} from '@atb/modules/time';
+import {ONE_SECOND_MS} from '@atb/utils/durations';
 
 type Props = RootStackScreenProps<'Root_RefundConfirmationScreen'>;
 
@@ -41,7 +43,12 @@ export function Root_RefundConfirmationScreen({navigation, route}: Props) {
   const focusRef = useFocusOnLoad(navigation);
   const [missingReason, setMissingReason] = useState(false);
 
-  const {status: refundOptionsStatus} = useRefundOptionsQuery(orderId, state);
+  const optionsQuery = useRefundOptionsQuery(orderId, state);
+  const {serverNow} = useTimeContext(ONE_SECOND_MS * 5);
+  const noLongerRefundable =
+    optionsQuery.isSuccess &&
+    (!optionsQuery.data.isRefundable ||
+      serverNow >= (optionsQuery.data.lastRefundTime?.getTime() ?? Infinity));
 
   const {mutate: refund, status: refundStatus} =
     useRefundFareContractMutation();
@@ -124,13 +131,18 @@ export function Root_RefundConfirmationScreen({navigation, route}: Props) {
             }}
           />
         )}
+        {noLongerRefundable && (
+          <MessageInfoBox
+            message={t(FareContractTexts.refund.noLongerRefundable)}
+            type="warning"
+          />
+        )}
         <Button
           expanded={true}
           onPress={onRefund}
           text={t(FareContractTexts.refund.confirm)}
-          loading={
-            refundStatus === 'pending' || refundOptionsStatus === 'pending'
-          }
+          loading={refundStatus === 'pending' || optionsQuery.isPending}
+          disabled={noLongerRefundable}
           interactiveColor={theme.color.interactive.destructive}
         />
       </View>

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -261,6 +261,11 @@ const FareContractTexts = {
       'Contact customer support',
       'Kontakt kundeservice',
     ),
+    noLongerRefundable: _(
+      'Angrefristen for denne billetten har utløpt.',
+      'The refund period for this ticket has ended.',
+      'Angrefristen for denne billetten har gått ut.',
+    ),
   },
   carnet: {
     numberOfUsedAccessesRemaining: (count: number) =>


### PR DESCRIPTION
Uses the new lastRefundTime field from the sales API to hide the
refund link on ticket details when the refund window has passed,
and to disable the confirm button on the refund confirmation screen
with an accompanying message when the window closes while the sheet
is open.

Fixes AtB-AS/kundevendt#23751
