### PR TITLE
fix: correct memoization checks in EstimatedCallItem

### DIFF
--- a/src/screen-components/place-screen/components/EstimatedCallItem.tsx
+++ b/src/screen-components/place-screen/components/EstimatedCallItem.tsx
@@ -77,8 +77,12 @@ export const EstimatedCallItem = memo(
     );
   },
   (prev, next) => {
-    const prevMinutesUntilDeparture = prev.secondsUntilDeparture % 60;
-    const nextMinutesUntilDeparture = next.secondsUntilDeparture % 60;
+    const prevMinutesUntilDeparture = Math.floor(
+      prev.secondsUntilDeparture / 60,
+    );
+    const nextMinutesUntilDeparture = Math.floor(
+      next.secondsUntilDeparture / 60,
+    );
     if (
       nextMinutesUntilDeparture < 10 &&
       prevMinutesUntilDeparture !== nextMinutesUntilDeparture
@@ -97,7 +101,7 @@ export const EstimatedCallItem = memo(
     )
       return false;
     if (
-      destinationDisplaysAreEqual(
+      !destinationDisplaysAreEqual(
         prev.departure.destinationDisplay,
         next.departure.destinationDisplay,
       )


### PR DESCRIPTION
Two bugs in the React.memo comparator:

1. Minute change detection used `secondsUntilDeparture % 60`, which
   gives the seconds-part of the value, not the minute count. Replace
   with `Math.floor(secondsUntilDeparture / 60)` so the check actually
   triggers on minute transitions as the comment describes.

2. The `destinationDisplaysAreEqual` guard was inverted: it returned
   false (rerender) when displays were equal instead of when they
   differed. Flip to `!destinationDisplaysAreEqual(...)` to match the
   pattern of every other check in the comparator.
