### PR TITLE
fix: pick real vs. mock-vehicle app-switch endpoint by booking type, not fetched id

### DIFF
--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -100,7 +100,7 @@ export const VehicleSheet = ({
     appStoreUri,
   } = useMapVehicle();
 
-  const vehicleId = vehicle?.id;
+  const vehicleId = mapState.isStationBasedBooking ? undefined : vehicle?.id;
 
   const formFactor = vehicle?.vehicleType.formFactor ?? FormFactor.Other;
   const propulsionType = vehicle?.vehicleType.propulsionType;


### PR DESCRIPTION
Follow-up to #6259.

## Description

`vehicle?.id` is truthy for a station-based (mock) vehicle too — it's the server's synthetic `"mock:..."` id, not a real vehicle id — so `getVehicleAppSwitch`'s `!!vehicleId` check in `getVehiclePath` always picked the real-vehicle endpoint (`/vehicles/:vehicleId/app-switch`), even for docked vehicles that have no real vehicle id at all.

This broke the app-switch/voucher flow for docked, non-deep-integrated vehicle types (e.g. Trondheim Bysykkel): the request would carry a fake vehicle id to the real-vehicle endpoint, which now (mobility PR [#116](https://github.com/AtB-AS/mobility/pull/116)) only resolves real Entur vehicle ids and 404s on anything else.

## Fix

Gate `vehicleId` on `mapState.isStationBasedBooking` before deriving it from the fetched vehicle, matching how `useMapVehicle` already decides this before fetching the vehicle in the first place:

```diff
- const vehicleId = vehicle?.id;
+ const vehicleId = mapState.isStationBasedBooking ? undefined : vehicle?.id;
```

With `vehicleId` correctly `undefined` for a mock vehicle, `getVehiclePath` falls through to the dedicated `/stations/:stationId/mock-vehicles/:vehicleTypeId/app-switch` route.

## Tests

`tsc --noEmit`, `eslint`, `prettier -c src`, and the full Jest suite (62 suites / 806 tests) all pass.