### PR TITLE
fix: remove bonusProductPrice from BonusOfferSchema

### DIFF
--- a/src/api/types/__tests__/mobility.test.ts
+++ b/src/api/types/__tests__/mobility.test.ts
@@ -79,7 +79,6 @@ describe('VehicleSchema (shmo vehicle contract v2)', () => {
       ...baseVehicle,
       bonusOffer: {
         bonusProductId: 'bonus-product-1',
-        bonusProductPrice: {amount: 50, currencyCode: 'NOK'},
         priceAdjustments: [
           {
             amount: 0,
@@ -93,9 +92,6 @@ describe('VehicleSchema (shmo vehicle contract v2)', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.bonusOffer?.bonusProductId).toBe('bonus-product-1');
-      expect(result.data.bonusOffer?.bonusProductPrice.currencyCode).toBe(
-        'NOK',
-      );
     }
   });
 
@@ -141,7 +137,6 @@ describe('BonusOfferSchema', () => {
   it('parses a standalone bonus offer', () => {
     const result = BonusOfferSchema.safeParse({
       bonusProductId: 'bonus-product-1',
-      bonusProductPrice: {amount: 50, currencyCode: 'NOK'},
       priceAdjustments: [],
     });
     expect(result.success).toBe(true);

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -239,10 +239,6 @@ export type RentalUris = z.infer<typeof RentalUrisSchema>;
 
 export const BonusOfferSchema = z.object({
   bonusProductId: z.string(),
-  bonusProductPrice: z.object({
-    amount: z.number(),
-    currencyCode: z.string(),
-  }),
   priceAdjustments: z.array(PriceAdjustmentSchema),
 });
 


### PR DESCRIPTION
This removes `bonusProductPrice` from `BonusOfferSchema` since the price is always fetched via the `bonusProductId` instead.
Backend PR: https://github.com/AtB-AS/mobility/pull/118