### PR TITLE
fix: only use app switch endpoint if url missing on app switch action button

### DIFF
--- a/src/api/types/__tests__/mobility.test.ts
+++ b/src/api/types/__tests__/mobility.test.ts
@@ -124,12 +124,15 @@ describe('VehicleSchema (shmo vehicle contract v2)', () => {
     }
   });
 
-  it('rejects an APP_SWITCH action button missing its url', () => {
+  it('parses an APP_SWITCH action button missing its url', () => {
     const result = VehicleSchema.safeParse({
       ...baseVehicle,
       actionButton: {type: 'APP_SWITCH'},
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success && result.data.actionButton?.type === 'APP_SWITCH') {
+      expect(result.data.actionButton.url).toBeUndefined();
+    }
   });
 });
 

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -253,7 +253,7 @@ export const ActionButtonSchema = z.discriminatedUnion('type', [
   z.object({type: z.literal(ActionButtonType.START_TRIP)}),
   z.object({
     type: z.literal(ActionButtonType.APP_SWITCH),
-    url: z.string(),
+    url: z.string().optional(),
     label: LanguageAndTextTypeArray.default([]),
   }),
 ]);

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -151,14 +151,10 @@ export const VehicleSheet = ({
 
   const onAppSwitchPress = useCallback(async () => {
     let appSwitchUrl = '';
-    const logEventVariables = {
-      operatorId,
-      payWithBonusPoints,
-    };
-    if (!!actionButtonUrl) {
+    if (!!actionButtonUrl && !payWithBonusPoints) {
       appSwitchUrl = actionButtonUrl;
       logEvent('Mobility', 'Open operator app with direct url', {
-        ...logEventVariables,
+        operatorId,
         appSwitchUrl,
       });
     } else {
@@ -171,6 +167,11 @@ export const VehicleSheet = ({
       const vehicleAppSwitch = await getVehicleAppSwitch(
         vehicleAppSwitchVariables,
       );
+      const logEventVariables = {
+        operatorId,
+        payWithBonusPoints,
+        vehicleAppSwitchVariables,
+      };
       if (vehicleAppSwitch === null) {
         logEvent('Mobility', 'Failed to open operator app', logEventVariables);
         return;
@@ -179,10 +180,7 @@ export const VehicleSheet = ({
       logEvent(
         'Mobility',
         'Open operator app with url from app switch endpoint',
-        {
-          ...logEventVariables,
-          vehicleAppSwitchVariables,
-        },
+        logEventVariables,
       );
     }
     await Linking.openURL(appSwitchUrl).catch(() =>

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -144,39 +144,60 @@ export const VehicleSheet = ({
   } = useVehicleAppSwitchMutation();
 
   const actionButton = vehicle?.actionButton ?? undefined;
+  const actionButtonUrl =
+    actionButton?.type === ActionButtonType.APP_SWITCH
+      ? actionButton.url
+      : undefined;
 
   const onAppSwitchPress = useCallback(async () => {
-    const vehicleAppSwitchVariables: VehicleAppSwitchVariables = {
-      vehicleId,
-      vehicleTypeId: mapState.vehicleTypeId,
-      stationId: mapState.stationId,
-      bonusProductId: payWithBonusPoints ? selectedBonusProductId : undefined,
-    };
-    const vehicleAppSwitch = await getVehicleAppSwitch(
-      vehicleAppSwitchVariables,
-    );
+    let appSwitchUrl = '';
     const logEventVariables = {
       operatorId,
       payWithBonusPoints,
-      vehicleAppSwitchVariables,
     };
-    if (vehicleAppSwitch === null) {
-      logEvent('Mobility', 'Failed to open operator app', logEventVariables);
-      return;
+    if (!!actionButtonUrl) {
+      appSwitchUrl = actionButtonUrl;
+      logEvent('Mobility', 'Open operator app with direct url', {
+        ...logEventVariables,
+        appSwitchUrl,
+      });
+    } else {
+      const vehicleAppSwitchVariables: VehicleAppSwitchVariables = {
+        vehicleId,
+        vehicleTypeId: mapState.vehicleTypeId,
+        stationId: mapState.stationId,
+        bonusProductId: payWithBonusPoints ? selectedBonusProductId : undefined,
+      };
+      const vehicleAppSwitch = await getVehicleAppSwitch(
+        vehicleAppSwitchVariables,
+      );
+      if (vehicleAppSwitch === null) {
+        logEvent('Mobility', 'Failed to open operator app', logEventVariables);
+        return;
+      }
+      appSwitchUrl = vehicleAppSwitch.url;
+      logEvent(
+        'Mobility',
+        'Open operator app with url from app switch endpoint',
+        {
+          ...logEventVariables,
+          vehicleAppSwitchVariables,
+        },
+      );
     }
-    logEvent('Mobility', 'Open operator app', logEventVariables);
-    await Linking.openURL(vehicleAppSwitch.url).catch(() =>
+    await Linking.openURL(appSwitchUrl).catch(() =>
       showAppMissingAlert(operatorName, appStoreUri ?? undefined),
     );
   }, [
+    operatorId,
+    payWithBonusPoints,
+    actionButtonUrl,
+    logEvent,
     vehicleId,
     mapState.vehicleTypeId,
     mapState.stationId,
-    getVehicleAppSwitch,
-    payWithBonusPoints,
     selectedBonusProductId,
-    logEvent,
-    operatorId,
+    getVehicleAppSwitch,
     operatorName,
     appStoreUri,
   ]);


### PR DESCRIPTION
If url is present on an action button of type app switch, no request should be sent to get app switch url, since it has already been provided.