### PR TITLE
fix: app foregrounded 401 improved handling

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -85,7 +85,14 @@ function requestHandler(
 
 async function requestIdTokenHandler(config: InternalAxiosRequestConfig) {
   if (config.authWithIdToken) {
-    const idToken = getIdTokenGlobal();
+    let idToken = getIdTokenGlobal();
+    if (!idToken) {
+      // Token may be briefly missing/expired around app-resume while
+      // useRefreshIdTokenWhenNecessary triggers a refresh. Wait once
+      // so the in-flight refresh has a chance to land before we give up.
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      idToken = getIdTokenGlobal();
+    }
     if (idToken) {
       config.headers[Authorization] = 'Bearer ' + idToken;
       if (addDebugUserInfoHeader) {

--- a/src/modules/auth/use-refresh-id-token-when-necessary.ts
+++ b/src/modules/auth/use-refresh-id-token-when-necessary.ts
@@ -3,6 +3,7 @@ import {AuthReducerAction, AuthStatus} from './types';
 import {AuthReducerState} from './AuthContext';
 import {secondsToTokenExpiry} from './utils';
 import {useInterval} from '@atb/utils/use-interval';
+import {useAppStateStatus} from '@atb/utils/use-app-state-status';
 import {errorToMetadata, logToBugsnag} from '@atb/utils/bugsnag-utils';
 import {ONE_SECOND_MS} from '@atb/utils/durations';
 
@@ -10,7 +11,9 @@ export const useRefreshIdTokenWhenNecessary = (
   state: AuthReducerState,
   dispatch: Dispatch<AuthReducerAction>,
 ) => {
-  const disableInterval = !isIdTokenRefreshEnabled(state.authStatus);
+  const appStateStatus = useAppStateStatus();
+  const disableInterval =
+    !isIdTokenRefreshEnabled(state.authStatus) || appStateStatus !== 'active';
 
   useInterval(
     async () => {


### PR DESCRIPTION
On cold starts there is a loading boundary to ensure id token fetched
before requests are fired, but when app becomes active after being
backgrounded there is no such boundary.

We have seen issues where the ticket list requests get 401 on app
foreground, becuase the id token was expired.

This is a small fix to improve this, without making any big change.
It is not ment to be perfect, but reduce the amount of 401s we see
in our logs with a non-risky small fix.
