### PR TITLE
chore: screenshot warning text update

### DIFF
--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -208,9 +208,9 @@ const FareContractTexts = {
         'Skjermbilete er ikkje gyldig som billett',
       ),
       description: _(
-        'Skjermbilder kan ikke skannes i kontroll. Billetten din er lagret og fungerer også uten internett. Vis alltid billetten direkte fra appen.',
-        'Screenshots cannot be scanned in inspection. Your ticket is stored and also works without an internet connection. Always show the ticket directly from the app.',
-        'Skjermbilete kan ikkje skannast i kontroll. Billetten din er lagra og fungerer også utan internett. Vis alltid billetten direkte frå appen.',
+        'Billetten din er lagret og fungerer også uten internett. Vis alltid billetten direkte fra appen. Om du skal gi billett til andre må du benytte "send billetten til andre" i appen.',
+        'Your ticket is stored and also works without an internet connection. Always show the ticket directly from the app. If you want to send the ticket, use "send the ticket to someone else" in the app.',
+        'Billetten din er lagra og fungerer også utan internett. Vis alltid billetten direkte frå appen. Om du skal gi billett til andre må du bruke «send billetten til andre» i appen.',
       ),
     },
   },


### PR DESCRIPTION
### Background
<img width="1249" height="417" alt="Screenshot 2026-08-11 at 10 13 57" src="https://github.com/user-attachments/assets/5699d5e9-910f-4c93-8ab4-213531ad7fbc" />

### Acceptance criteria
- [ ] Texts in app are the same as the screenshot