### PR TITLE
fix: remove shadow from bonus balance button

### DIFF
--- a/src/modules/bonus/components/BonusBalanceButton.tsx
+++ b/src/modules/bonus/components/BonusBalanceButton.tsx
@@ -24,7 +24,6 @@ export const BonusBalanceButton = ({onPress}: BonusBalanceButtonProps) => {
       expanded={false}
       interactiveColor={theme.color.interactive[2]}
       leftIcon={{svg: BonusStarFill}}
-      hasShadow={true}
       accessibilityLabel={t(
         BonusProgramTexts.yourBonusBalanceA11yLabel(bonusInfo.bonusBalance),
       )}


### PR DESCRIPTION
## Issue Reference
Closes https://github.com/AtB-AS/kundevendt/issues/24038

## Description
Removes the shadow from `BonusBalanceButton`. The component is shared, so this applies both to the map and the ticketing screen heading.