### PR TITLE
fix: fixed bottomsheet height when big text

### DIFF
--- a/src/components/bottom-sheet/bottom-sheet-map/MapBottomSheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet-map/MapBottomSheet.tsx
@@ -215,7 +215,7 @@ export const MapBottomSheet = ({
         }}
         onClose={onClose}
         accessible={false}
-        maxDynamicContentSize={screenHeight - safeAreaTop - headerHeight}
+        maxDynamicContentSize={screenHeight - safeAreaTop - tabBarMinHeight}
         index={canMinimize ? 1 : 0}
         overrideReduceMotion={ReduceMotion.Never}
       >


### PR DESCRIPTION
fixes issue described in Note 10: https://github.com/AtB-AS/kundevendt/issues/23697#issuecomment-5250927392

Using the safeArea and then height of the tabbar to determin the height of the bottomsheet, seems more correct and covers more of the screen 

<img width="250" alt="image" src="https://github.com/user-attachments/assets/3679012a-8816-4c23-aafd-0e301c4553d5" />

should doublecheck other bottomsheets that they work fine aswell 
