### PR TITLE
fix: wrap price information rows on large font scale

### DIFF
--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -126,8 +126,8 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
           {rows.map(({label, value}, index) => (
             <GenericSectionItem key={index}>
               <View style={styles.row}>
-                <ThemeText>{label}</ThemeText>
-                <ThemeText>{value}</ThemeText>
+                <ThemeText style={styles.label}>{label}</ThemeText>
+                <ThemeText style={styles.value}>{value}</ThemeText>
               </View>
             </GenericSectionItem>
           ))}
@@ -150,6 +150,14 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    gap: theme.spacing.small,
+  },
+  label: {
+    flexShrink: 1,
+  },
+  value: {
+    flexShrink: 1,
+    textAlign: 'right',
   },
   sectionLabel: {
     marginLeft: theme.spacing.small,


### PR DESCRIPTION
## Issue Reference

https://github.com/AtB-AS/kundevendt/issues/23813

## Description

The rows in the SHMO price information screen were a flex row with two non-shrinkable `ThemeText`s. Since `Text` defaults to `flexShrink: 0`, the label kept its full single-line width at increased phone zoom/font scale, overflowed the card, and pushed the value outside the clipped bounds so it looked like it disappeared.

- Label and value can now shrink, so the text wraps instead of overflowing.
- Value stays right-aligned when it breaks onto two lines.
- Added a small gap between label and value.