### PR TITLE
fix: hide shared car stations during active city bike trip

### DIFF
--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -134,13 +134,7 @@ export const Map = (props: MapProps) => {
   const startingCoordinates = getCurrentCoordinatesGlobal() || FOCUS_ORIGIN;
 
   const showVehicles = mapFilter?.mobility.SCOOTER?.showAll ?? false;
-  const showStations =
-    (mapFilter?.mobility.BICYCLE?.showAll ||
-      mapFilter?.mobility.CAR?.showAll) ??
-    false;
   const showTariffZones = mapFilter?.showTariffZones ?? true;
-  const shouldShowVehiclesAndStations =
-    isFocused && (showVehicles || showStations); // don't send tile requests while in the background, and always get fresh data upon enter
 
   const selectedFeature = mapState.feature;
 
@@ -161,6 +155,15 @@ export const Map = (props: MapProps) => {
 
   const isActiveTrip = isActiveTripBooking(activeShmoBooking);
   const isActiveBikeTrip = isActiveBikeTripBooking(activeShmoBooking);
+
+  const showCityBikeStations = mapFilter?.mobility.BICYCLE?.showAll ?? false;
+  // Shared car stations are just noise during an active city bike trip. They are
+  // not relevant for the trip, and are not interactive while a trip is in use.
+  const showSharedCarStations =
+    (mapFilter?.mobility.CAR?.showAll ?? false) && !isActiveBikeTrip;
+  const showStations = showCityBikeStations || showSharedCarStations;
+  const shouldShowVehiclesAndStations =
+    isFocused && (showVehicles || showStations); // don't send tile requests while in the background, and always get fresh data upon enter
 
   const showGeofencingZones =
     isGeofencingZonesEnabled &&
@@ -560,7 +563,8 @@ export const Map = (props: MapProps) => {
               selectedFeatureId={activeFeatureId}
               onPress={onMapItemClick}
               showVehicles={showVehicles}
-              showStations={showStations}
+              showCityBikeStations={showCityBikeStations}
+              showSharedCarStations={showSharedCarStations}
               showBikeStationParkingInfo={isActiveBikeTrip}
             />
           )}
@@ -614,6 +618,8 @@ export const Map = (props: MapProps) => {
             <StationsWithClusters
               selectedFeatureId={undefined}
               showNonVirtualStations={true}
+              showCityBikeStations={showCityBikeStations}
+              showSharedCarStations={showSharedCarStations}
               hideSymbols={true}
             />
           )}

--- a/src/modules/map/components/mobility/VehiclesAndStations.tsx
+++ b/src/modules/map/components/mobility/VehiclesAndStations.tsx
@@ -1,10 +1,6 @@
 import React, {useMemo} from 'react';
 import MapboxGL from '@rnmapbox/maps';
-import {
-  hitboxCoveringIconOnly,
-  useMapContext,
-  useMapSymbolStyles,
-} from '@atb/modules/map';
+import {hitboxCoveringIconOnly, useMapSymbolStyles} from '@atb/modules/map';
 import {SelectedFeatureIdProp} from '../../types';
 import {OnPressEvent} from 'node_modules/@rnmapbox/maps/src/types/OnPressEvent';
 
@@ -74,10 +70,14 @@ export const VehiclesWithClusters = ({
 export const StationsWithClusters = ({
   selectedFeatureId,
   showNonVirtualStations,
+  showCityBikeStations,
+  showSharedCarStations,
   hideSymbols = false,
   showBikeStationParkingInfo = false,
 }: SelectedFeatureIdProp & {
   showNonVirtualStations: boolean;
+  showCityBikeStations: boolean;
+  showSharedCarStations: boolean;
   hideSymbols?: boolean;
   showBikeStationParkingInfo?: boolean;
 }) => {
@@ -94,10 +94,6 @@ export const StationsWithClusters = ({
     reachFullScaleAtZoomLevel: minZoomLevel + scaleTransitionZoomRange + 0.2,
     showBikeStationParkingInfo,
   });
-
-  const {mapFilter} = useMapContext();
-  const showCityBikes = mapFilter?.mobility.BICYCLE?.showAll ?? false;
-  const showSharedCars = mapFilter?.mobility.CAR?.showAll ?? false;
 
   const filter: {filter: FilterExpression} | undefined = useMemo(() => {
     const isVirtualStation: Expression = ['get', 'is_virtual_station'];
@@ -121,12 +117,12 @@ export const StationsWithClusters = ({
               [
                 'all',
                 ['==', vehicle_type_form_factor, 'BICYCLE'],
-                ['!', !showCityBikes],
+                ['!', !showCityBikeStations],
               ],
               [
                 'all',
                 ['==', vehicle_type_form_factor, 'CAR'],
-                ['!', !showSharedCars],
+                ['!', !showSharedCarStations],
               ],
             ],
             hideItemsInTheDistanceFilter,
@@ -136,8 +132,8 @@ export const StationsWithClusters = ({
     isSelected,
     showVirtualStations,
     showNonVirtualStations,
-    showCityBikes,
-    showSharedCars,
+    showCityBikeStations,
+    showSharedCarStations,
     hideSymbols,
   ]);
 
@@ -170,14 +166,17 @@ export const VehiclesAndStations = ({
   selectedFeatureId,
   onPress,
   showVehicles,
-  showStations,
+  showCityBikeStations,
+  showSharedCarStations,
   showBikeStationParkingInfo = false,
 }: SelectedFeatureIdProp & {
   onPress?: (e: OnPressEvent) => void;
   showVehicles: boolean;
-  showStations: boolean;
+  showCityBikeStations: boolean;
+  showSharedCarStations: boolean;
   showBikeStationParkingInfo?: boolean;
 }) => {
+  const showStations = showCityBikeStations || showSharedCarStations;
   if (!showVehicles && !showStations) return null;
 
   return (
@@ -195,6 +194,8 @@ export const VehiclesAndStations = ({
           <StationsWithClusters
             selectedFeatureId={selectedFeatureId}
             showNonVirtualStations={true}
+            showCityBikeStations={showCityBikeStations}
+            showSharedCarStations={showSharedCarStations}
             showBikeStationParkingInfo={showBikeStationParkingInfo}
           />
         )}


### PR DESCRIPTION
## Issue Reference

https://github.com/AtB-AS/kundevendt/issues/23712#issuecomment-5291466306 (note 1)

## Description

Shared car stations (Hyre) were shown in the map during an active city bike trip. They are not relevant during a bike trip, and they are not even interactive while a trip is in use (`Map.tsx` returns early on tap for everything but bike stations), so they only add noise.

Station visibility was previously derived from the map filter alone, in two places: `showStations` in `Map.tsx` and the form factor filter expression inside `StationsWithClusters` (which read `mapFilter` from context on its own). This PR moves that decision to a single place in `Map.tsx` and passes `showCityBikeStations` / `showSharedCarStations` down as props, with shared car stations turned off while a city bike trip is active.

City bike stations, scooters and everything else are unaffected, and nothing changes when there is no active bike trip.