### PR TITLE
fix: place Mapbox information button next to the logo

### DIFF
--- a/patches/@rnmapbox__maps@10.3.0.patch
+++ b/patches/@rnmapbox__maps@10.3.0.patch
@@ -1,5 +1,5 @@
 diff --git a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
-index bfbeff4..a270d5b 100644
+index bfbeff47ff0f3e6470f05b8f63bbb9502c48b9fd..a270d5b3ef59abb20a6dc3607acb7a0bb76f5208 100644
 --- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
 +++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
 @@ -66,6 +66,11 @@ class RNMBXBackgroundLayerManager : ViewGroupManager<RNMBXBackgroundLayer>(),
@@ -15,7 +15,7 @@ index bfbeff4..a270d5b 100644
          const val REACT_CLASS = "RNMBXBackgroundLayer"
      }
 diff --git a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
-index 8f1a3ee..8ab230a 100644
+index 8f1a3ee4a00cf3bacd212ac0785101068bc76249..8ab230a11d0b666a0bd1f080a7cc0130334051a9 100644
 --- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
 +++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
 @@ -71,6 +71,11 @@ class RNMBXFillExtrusionLayerManager : ViewGroupManager<RNMBXFillExtrusionLayer>
@@ -31,7 +31,7 @@ index 8f1a3ee..8ab230a 100644
          const val REACT_CLASS = "RNMBXFillExtrusionLayer"
      }
 diff --git a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
-index 838851d..af2b24c 100644
+index 838851d55c73b659d674c294a56c557c6c83321d..af2b24cddb9f728f394bef719a88f48b6f737187 100644
 --- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
 +++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
 @@ -66,6 +66,11 @@ class RNMBXSkyLayerManager : ViewGroupManager<RNMBXSkyLayer>(),
@@ -47,7 +47,7 @@ index 838851d..af2b24c 100644
          const val REACT_CLASS = "RNMBXSkyLayer"
      }
 diff --git a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt
-index 66280ed..4e23817 100644
+index 66280ed35cca372a12c6633f180fc7a372269347..4e238178fd826e2c963e7706a4dde699fe7ea8b6 100644
 --- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt
 +++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSource.kt
 @@ -18,6 +18,9 @@ import com.rnmapbox.rnmbx.v11compat.feature.*
@@ -84,7 +84,7 @@ index 66280ed..4e23817 100644
  
      fun querySourceFeatures(
 diff --git a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
-index 68d619f..edc49a8 100644
+index 68d619fa7290603716f5d19ccc0943fd74caa60d..edc49a8c8782f929a5e78ad59a4bd621f452c7bd 100644
 --- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
 +++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
 @@ -44,6 +44,11 @@ class RNMBXVectorSourceManager(reactApplicationContext: ReactApplicationContext)
@@ -100,7 +100,7 @@ index 68d619f..edc49a8 100644
          return eventMapOf(
              EventKeys.VECTOR_SOURCE_LAYER_CLICK to "onMapboxVectorSourcePress",
 diff --git a/ios/RNMBX/RNMBXFabricHelpers.h b/ios/RNMBX/RNMBXFabricHelpers.h
-index 974ee24..67bbc6a 100644
+index 974ee2429521568149d1e1c76919c711d3878f0f..67bbc6a6a14072d21e76fde409558a4cf1790824 100644
 --- a/ios/RNMBX/RNMBXFabricHelpers.h
 +++ b/ios/RNMBX/RNMBXFabricHelpers.h
 @@ -105,6 +105,10 @@ void RNMBXSetCommonLayerPropsWithoutSourceID(const T& newProps, RNMBXLayer *_vie
@@ -114,11 +114,28 @@ index 974ee24..67bbc6a 100644
  }
  
  template <typename T>
+diff --git a/ios/RNMBX/RNMBXMapView.swift b/ios/RNMBX/RNMBXMapView.swift
+index 62861b53c4cffe38d4baf286f43fb2b5655a7c87..94248c24b4fb02f9560078115ce33eb1b4f1b296 100644
+--- a/ios/RNMBX/RNMBXMapView.swift
++++ b/ios/RNMBX/RNMBXMapView.swift
+@@ -1004,7 +1004,11 @@ open class RNMBXMapView: UIView, RCTInvalidating {
+     } else if let bottom = bottom, let right = right {
+       return (OrnamentPosition.bottomTrailing, CGPoint(x: Int(truncating: right), y: Int(truncating: bottom)))
+     } else if let bottom = bottom, let left = left {
+-      return (OrnamentPosition.bottomLeading, CGPoint(x: Int(truncating: left), y: Int(truncating: bottom)))
++      // `bottomLeft` instead of `bottomLeading`: MapboxMaps stacks ornaments that
++      // share a position, ignoring the margins of all but the first one. The logo
++      // occupies `bottomLeading` by default, so an ornament placed next to it must
++      // use a different position to keep its own margins.
++      return (OrnamentPosition.bottomLeft, CGPoint(x: Int(truncating: left), y: Int(truncating: bottom)))
+     }
+ 
+     return nil
 diff --git a/ios/RNMBX/RNMBXMapViewComponentView.mm b/ios/RNMBX/RNMBXMapViewComponentView.mm
-index 6ee6808..ca7efa2 100644
+index 6ee6808cdd4cb9d9dcc6983b40c9b9e785007b10..ca7efa2be043a3072a87f928133a8acfe0706525 100644
 --- a/ios/RNMBX/RNMBXMapViewComponentView.mm
 +++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
-@@ -193,6 +193,11 @@ - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &
+@@ -193,6 +193,11 @@ using namespace facebook::react;
  
      RNMBX_REMAP_OPTIONAL_PROP_BOOL(pitchEnabled, reactPitchEnabled)
    
@@ -131,13 +148,13 @@ index 6ee6808..ca7efa2 100644
  
      id preferredFramesPerSecond = RNMBXConvertFollyDynamicToId(newViewProps.preferredFramesPerSecond);
 diff --git a/ios/RNMBX/RNMBXSource.swift b/ios/RNMBX/RNMBXSource.swift
-index d13af2a..317238d 100644
+index d13af2a5832c33cb3733b5f2a258cc22b1c0eddb..9e6141d793e8cf89d709b31cbecfebd88ea03e2d 100644
 --- a/ios/RNMBX/RNMBXSource.swift
 +++ b/ios/RNMBX/RNMBXSource.swift
 @@ -29,6 +29,10 @@ public class RNMBXSource : RNMBXInteractiveElement {
      fatalError("Subclasses should override makeSource")
    }
- 
+   
 +  func doAddSource(style: Style, source: Source) throws {
 +    try style.addSource(source)
 +  }
@@ -155,7 +172,7 @@ index d13af2a..317238d 100644
      }
  
 diff --git a/ios/RNMBX/RNMBXVectorSource.swift b/ios/RNMBX/RNMBXVectorSource.swift
-index ad07b5b..8a5a134 100644
+index ad07b5bec4f121e6783d10adc55a0f1125d6952f..8a5a13415a6bd6a09e9fa4fec4ad89af9c8488f2 100644
 --- a/ios/RNMBX/RNMBXVectorSource.swift
 +++ b/ios/RNMBX/RNMBXVectorSource.swift
 @@ -8,6 +8,7 @@ public class RNMBXVectorSource : RNMBXTileSource {
@@ -194,10 +211,10 @@ index ad07b5b..8a5a134 100644
    /*
    - (nullable MGLSource*)makeSource
 diff --git a/ios/RNMBX/RNMBXVectorSourceComponentView.mm b/ios/RNMBX/RNMBXVectorSourceComponentView.mm
-index a8bf74c..1a406df 100644
+index a8bf74c3892a3fb6fead8c5e3842db0be5c90af3..1a406df2f4322a02c84f4a2efee560c7f1b1ab45 100644
 --- a/ios/RNMBX/RNMBXVectorSourceComponentView.mm
 +++ b/ios/RNMBX/RNMBXVectorSourceComponentView.mm
-@@ -117,6 +117,10 @@ - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &
+@@ -117,6 +117,10 @@ using namespace facebook::react;
      if (tms != nil) {
          _view.tms = tms;
      }
@@ -209,7 +226,7 @@ index a8bf74c..1a406df 100644
      if (attribution != nil) {
          _view.attribution = attribution;
 diff --git a/lib/module/components/VectorSource.js b/lib/module/components/VectorSource.js
-index 72a72a9..e9523a9 100644
+index 72a72a9f3aeba41ac272a0d66bb95a1a049c764d..e9523a9f2010394394174e758e8c8352777ca6ec 100644
 --- a/lib/module/components/VectorSource.js
 +++ b/lib/module/components/VectorSource.js
 @@ -69,6 +69,7 @@ class VectorSource extends AbstractSource {
@@ -221,7 +238,7 @@ index 72a72a9..e9523a9 100644
        hitbox: this.props.hitbox,
        hasPressListener: isFunction(this.props.onPress),
 diff --git a/lib/module/specs/RNMBXVectorSourceNativeComponent.ts b/lib/module/specs/RNMBXVectorSourceNativeComponent.ts
-index f7aa0ee..cce51af 100644
+index f7aa0eed4d1932a0e5a5eabad54a5f5f6d7de795..cce51af80d8f4783b7d4893e932f65921cdbf162 100644
 --- a/lib/module/specs/RNMBXVectorSourceNativeComponent.ts
 +++ b/lib/module/specs/RNMBXVectorSourceNativeComponent.ts
 @@ -19,6 +19,7 @@ export interface NativeProps extends ViewProps {
@@ -233,7 +250,7 @@ index f7aa0ee..cce51af 100644
    hitbox: UnsafeMixed<any>;
    onMapboxVectorSourcePress: DirectEventHandler<OnMapboxVectorSourcePressEventType>;
 diff --git a/src/components/VectorSource.tsx b/src/components/VectorSource.tsx
-index 51afb11..9dcb4b7 100644
+index 51afb118613cc3f6c8896fbfbd1b473de405880d..9dcb4b73b9804df8cc26f1f3d9b82aa63a94060c 100644
 --- a/src/components/VectorSource.tsx
 +++ b/src/components/VectorSource.tsx
 @@ -53,6 +53,12 @@ interface Props {
@@ -258,7 +275,7 @@ index 51afb11..9dcb4b7 100644
        hitbox: this.props.hitbox,
        hasPressListener: isFunction(this.props.onPress),
 diff --git a/src/specs/RNMBXBackgroundLayerNativeComponent.ts b/src/specs/RNMBXBackgroundLayerNativeComponent.ts
-index fb1bcc8..59cd3ea 100644
+index fb1bcc8c05d5eba3edeca5a14dfb584dbff11d55..59cd3ea57ceeb51fa0c3880680bc3afeb6f6ae04 100644
 --- a/src/specs/RNMBXBackgroundLayerNativeComponent.ts
 +++ b/src/specs/RNMBXBackgroundLayerNativeComponent.ts
 @@ -21,6 +21,7 @@ export interface NativeProps extends ViewProps {
@@ -270,7 +287,7 @@ index fb1bcc8..59cd3ea 100644
  
  // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
 diff --git a/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts b/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts
-index 9cced9e..5909e2b 100644
+index 9cced9ed5cf8a5c21846be9d8d9787847ef03700..5909e2b2d87371bcf1a4def519cb87ecb7c93d13 100644
 --- a/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts
 +++ b/src/specs/RNMBXFillExtrusionLayerNativeComponent.ts
 @@ -22,6 +22,7 @@ export interface NativeProps extends ViewProps {
@@ -282,7 +299,7 @@ index 9cced9e..5909e2b 100644
  
  // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
 diff --git a/src/specs/RNMBXSkyLayerNativeComponent.ts b/src/specs/RNMBXSkyLayerNativeComponent.ts
-index 27f7e2f..6e28347 100644
+index 27f7e2fb9d85073c14bfd20df3f4b1a2fa3faa71..6e28347d1fd210b7753c238eb923167bc1ca27ce 100644
 --- a/src/specs/RNMBXSkyLayerNativeComponent.ts
 +++ b/src/specs/RNMBXSkyLayerNativeComponent.ts
 @@ -21,6 +21,7 @@ export interface NativeProps extends ViewProps {
@@ -294,7 +311,7 @@ index 27f7e2f..6e28347 100644
  
  // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
 diff --git a/src/specs/RNMBXVectorSourceNativeComponent.ts b/src/specs/RNMBXVectorSourceNativeComponent.ts
-index f7aa0ee..cce51af 100644
+index f7aa0eed4d1932a0e5a5eabad54a5f5f6d7de795..cce51af80d8f4783b7d4893e932f65921cdbf162 100644
 --- a/src/specs/RNMBXVectorSourceNativeComponent.ts
 +++ b/src/specs/RNMBXVectorSourceNativeComponent.ts
 @@ -19,6 +19,7 @@ export interface NativeProps extends ViewProps {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@react-native-async-storage/async-storage@2.2.0': 978d0cd98900573029698cd20e58864c336768147bc65f9b0d4197e1ff8412c7
-  '@rnmapbox/maps@10.3.0': eda638edc08c2778bd0e8fa80b866381883bcf39d759d0b4beaed864f748fa7b
+  '@rnmapbox/maps@10.3.0': e80c219c5aaa8635d63177ce97e35d0c7ecdfa694c5eb6dd9e8b41c5c5bab2be
   app-icon@0.13.2: d3e7d0e029be173ad1d91a689e45ebfa9a7211c4e405dc895cd05417f6ff7ed4
   react-native-date-picker@5.0.13: 46389d5801d03db0d425e3719fd23fac2f8d0e55766bb0125e8667fb43b0377a
   react-native@0.83.5: f8449f25d7efeea520cb9dc1f0db78412a7dc90223f939f164f0fcde702c8df1
@@ -110,7 +110,7 @@ importers:
         version: 7.6.14(23b0ccba59d827c125bdb3724b20085c)
       '@rnmapbox/maps':
         specifier: 10.3.0
-        version: 10.3.0(patch_hash=eda638edc08c2778bd0e8fa80b866381883bcf39d759d0b4beaed864f748fa7b)(react-dom@19.1.1(react@19.2.0))(react-native@0.83.5(patch_hash=f8449f25d7efeea520cb9dc1f0db78412a7dc90223f939f164f0fcde702c8df1)(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
+        version: 10.3.0(patch_hash=e80c219c5aaa8635d63177ce97e35d0c7ecdfa694c5eb6dd9e8b41c5c5bab2be)(react-dom@19.1.1(react@19.2.0))(react-native@0.83.5(patch_hash=f8449f25d7efeea520cb9dc1f0db78412a7dc90223f939f164f0fcde702c8df1)(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)
       '@sayem314/react-native-keep-awake':
         specifier: ^1.4.0
         version: 1.4.0
@@ -9714,7 +9714,7 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@rnmapbox/maps@10.3.0(patch_hash=eda638edc08c2778bd0e8fa80b866381883bcf39d759d0b4beaed864f748fa7b)(react-dom@19.1.1(react@19.2.0))(react-native@0.83.5(patch_hash=f8449f25d7efeea520cb9dc1f0db78412a7dc90223f939f164f0fcde702c8df1)(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)':
+  '@rnmapbox/maps@10.3.0(patch_hash=e80c219c5aaa8635d63177ce97e35d0c7ecdfa694c5eb6dd9e8b41c5c5bab2be)(react-dom@19.1.1(react@19.2.0))(react-native@0.83.5(patch_hash=f8449f25d7efeea520cb9dc1f0db78412a7dc90223f939f164f0fcde702c8df1)(@babel/core@7.29.0)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@react-native/metro-config@0.83.5(@babel/core@7.29.0))(@types/react@19.2.7)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@turf/along': 6.5.0
       '@turf/distance': 6.5.0

--- a/src/modules/map/hooks/use-map-view-config.ts
+++ b/src/modules/map/hooks/use-map-view-config.ts
@@ -11,8 +11,8 @@ const mapViewStaticConfig = {
   compassEnabled: true,
   scaleBarEnabled: false,
   attributionPosition: Platform.select({
-    default: {bottom: 8, left: 95},
-    android: {bottom: 5, left: 120},
+    default: {bottom: 8, left: 85},
+    android: {bottom: 4, left: 92},
   }),
 };
 


### PR DESCRIPTION
## Issue Reference

Closes https://github.com/AtB-AS/kundevendt/issues/24327

## Screenshots 

<details><summary>↓</summary>
<p>
iOS:

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/1388e11c-1a24-4050-839e-9a2044f1840b" />


Android:

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/3f05ea20-1e30-4def-b269-f8d3b0e8702a" />



</p>
</details> 

## Description

The Mapbox attribution ("i") button was positioned too far right of the logo on both platforms, and on iOS it also sat above the logo instead of beside it.

**iOS.** `attributionPosition: {bottom, left}` is mapped to the `bottomLeading` ornament position by rnmapbox, which is where MapboxMaps places the Mapbox logo by default. MapboxMaps stacks ornaments that share a position vertically and only honours the margins of the first one, so the button was pinned above the logo and its `bottom` value was discarded. This PR patches rnmapbox to map `{bottom, left}` to `bottomLeft` instead, so the button gets its own position and keeps its margins, and adjusts the margins to line it up with the logo. Note that the patched position does not flip in RTL layouts, unlike `bottomLeading`.

**Android.** The logo and the attribution button are separate plugins with independent margins, so it was only a matter of replacing the hardcoded margins with values matching the logo (which happen to be the Mapbox defaults).

Verified in the iOS and Android simulators.