### PR TITLE
feat: add transfer risk messages to trip detail screen

### DIFF
--- a/src/modules/trip-patterns/__tests__/interchange-risk.test.ts
+++ b/src/modules/trip-patterns/__tests__/interchange-risk.test.ts
@@ -1,0 +1,19 @@
+import {getInterchangeRisk} from '../utils';
+
+describe('Interchange risk evaluator', () => {
+  it('passes when there is time to spare', () => {
+    expect(getInterchangeRisk(1)).toBeUndefined();
+    expect(getInterchangeRisk(600)).toBeUndefined();
+  });
+  it('catches an uncertain interchange', () => {
+    expect(getInterchangeRisk(0)).toBe('uncertain');
+    expect(getInterchangeRisk(-60)).toBe('uncertain');
+  });
+  it('treats -120 seconds as the last uncertain second', () => {
+    expect(getInterchangeRisk(-120)).toBe('uncertain');
+  });
+  it('catches an impossible interchange from -121 seconds', () => {
+    expect(getInterchangeRisk(-121)).toBe('impossible');
+    expect(getInterchangeRisk(-600)).toBe('impossible');
+  });
+});

--- a/src/modules/trip-patterns/__tests__/is-short-wait-time.test.ts
+++ b/src/modules/trip-patterns/__tests__/is-short-wait-time.test.ts
@@ -15,24 +15,28 @@ describe('significantWaitTime', () => {
 });
 
 describe('isShortWaitTime', () => {
-  it('should be false for 0 seconds (not significant)', () => {
+  it('should be false for 0 seconds (an interchange risk, not a short wait)', () => {
     expect(isShortWaitTime(0)).toBe(false);
   });
 
-  it('should be false for 30 seconds (boundary, not significant)', () => {
-    expect(isShortWaitTime(30)).toBe(false);
+  it('should be true for 1 second', () => {
+    expect(isShortWaitTime(1)).toBe(true);
   });
 
-  it('should be true for 31 seconds (significant and short)', () => {
+  it('should be true for 30 seconds (too short to display as a duration)', () => {
+    expect(isShortWaitTime(30)).toBe(true);
+  });
+
+  it('should be true for 31 seconds', () => {
     expect(isShortWaitTime(31)).toBe(true);
   });
 
-  it('should be true for 180 seconds (significant and at the 3-min boundary)', () => {
-    expect(isShortWaitTime(180)).toBe(true);
+  it('should be true for 119 seconds (just under the 2-min boundary)', () => {
+    expect(isShortWaitTime(119)).toBe(true);
   });
 
-  it('should be false for 181 seconds (significant but not short)', () => {
-    expect(isShortWaitTime(181)).toBe(false);
+  it('should be false for 120 seconds (stated as an exact duration)', () => {
+    expect(isShortWaitTime(120)).toBe(false);
   });
 
   it('should be false for negative values', () => {

--- a/src/modules/trip-patterns/index.ts
+++ b/src/modules/trip-patterns/index.ts
@@ -1,2 +1,3 @@
 export {useRefreshTripQuery} from './use-refresh-trip-query';
 export {significantWaitTime, isShortWaitTime, getTripPatternKey} from './utils';
+export type {InterchangeRisk} from './utils';

--- a/src/modules/trip-patterns/utils.ts
+++ b/src/modules/trip-patterns/utils.ts
@@ -20,16 +20,7 @@ export function significantWaitTime(seconds: number): boolean {
 const SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS = 120;
 /**
  * Whether a wait time is short enough to warn the user about a tight
- * transfer — between 1 and 119 seconds (> 0 s and < 2 min). Two minutes and
- * above is stated as an exact duration instead.
- *
- * Deliberately not gated on significantWaitTime: a wait too short to be worth
- * displaying as a duration is still worth warning about, and gating on it
- * left waits of 30 seconds or less without any indicator at all.
- *
- * This is the single definition of a short transfer — the trip details wait
- * row, the trip details banner and the travel card all key off it, so they
- * cannot disagree about where the boundary falls.
+ * transfer — between 1 and 119 seconds (> 0 s and < 2 min). 
  */
 export function isShortWaitTime(seconds: number): boolean {
   return seconds > 0 && seconds < SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS;
@@ -41,8 +32,7 @@ const IMPOSSIBLE_INTERCHANGE_LIMIT_IN_SECONDS = -120;
 
 /**
  * How risky an interchange is when the next leg departs at or before the
- * current leg arrives, which real time updates can cause on an already
- * started trip.
+ * current leg arrives
  *
  * 0 to -120 seconds is 'uncertain', -121 seconds and below is 'impossible'.
  * Returns undefined when there is time to spare.

--- a/src/modules/trip-patterns/utils.ts
+++ b/src/modules/trip-patterns/utils.ts
@@ -20,7 +20,7 @@ export function significantWaitTime(seconds: number): boolean {
 const SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS = 120;
 /**
  * Whether a wait time is short enough to warn the user about a tight
- * transfer — between 1 and 119 seconds (> 0 s and < 2 min). 
+ * transfer — between 1 and 119 seconds (> 0 s and < 2 min).
  */
 export function isShortWaitTime(seconds: number): boolean {
   return seconds > 0 && seconds < SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS;

--- a/src/modules/trip-patterns/utils.ts
+++ b/src/modules/trip-patterns/utils.ts
@@ -17,15 +17,41 @@ export function significantWaitTime(seconds: number): boolean {
   return seconds > MIN_SIGNIFICANT_WAIT_IN_SECONDS;
 }
 
-const SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS = 180;
+const SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS = 120;
 /**
- * Whether a wait time is significant but dangerously short — between 31 and
- * 180 seconds (> 30 s and ≤ 3 min). Used to warn the user about tight
- * transfers.
+ * Whether a wait time is short enough to warn the user about a tight
+ * transfer — between 1 and 119 seconds (> 0 s and < 2 min). Two minutes and
+ * above is stated as an exact duration instead.
+ *
+ * Deliberately not gated on significantWaitTime: a wait too short to be worth
+ * displaying as a duration is still worth warning about, and gating on it
+ * left waits of 30 seconds or less without any indicator at all.
+ *
+ * This is the single definition of a short transfer — the trip details wait
+ * row, the trip details banner and the travel card all key off it, so they
+ * cannot disagree about where the boundary falls.
  */
 export function isShortWaitTime(seconds: number): boolean {
-  return (
-    significantWaitTime(seconds) &&
-    seconds <= SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS
-  );
+  return seconds > 0 && seconds < SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS;
+}
+
+export type InterchangeRisk = 'uncertain' | 'impossible';
+
+const IMPOSSIBLE_INTERCHANGE_LIMIT_IN_SECONDS = -120;
+
+/**
+ * How risky an interchange is when the next leg departs at or before the
+ * current leg arrives, which real time updates can cause on an already
+ * started trip.
+ *
+ * 0 to -120 seconds is 'uncertain', -121 seconds and below is 'impossible'.
+ * Returns undefined when there is time to spare.
+ */
+export function getInterchangeRisk(
+  seconds: number,
+): InterchangeRisk | undefined {
+  if (seconds > 0) return undefined;
+  return seconds < IMPOSSIBLE_INTERCHANGE_LIMIT_IN_SECONDS
+    ? 'impossible'
+    : 'uncertain';
 }

--- a/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
+++ b/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
@@ -110,23 +110,27 @@ describe('getMsgTypeForTravelCardLeg', () => {
 
   describe('short transfer time', () => {
     it('returns info for a short wait time from the previous leg', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(120), 1)).toBe('info');
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(60), 1)).toBe('info');
     });
 
-    it('returns undefined for an insignificant wait time (30s or less)', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(30), 1)).toBeUndefined();
+    it('returns info for a wait time too short to display as a duration', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(30), 1)).toBe('info');
     });
 
-    it('returns info just above the insignificant wait time limit', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(31), 1)).toBe('info');
+    it('returns info for the shortest possible wait time', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(1), 1)).toBe('info');
     });
 
-    it('returns info at the short transfer time limit (180s)', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(180), 1)).toBe('info');
+    it('returns info just under the short transfer time limit (119s)', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(119), 1)).toBe('info');
     });
 
-    it('returns undefined just above the short transfer time limit', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(181), 1)).toBeUndefined();
+    it('returns undefined at the short transfer time limit (120s)', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(120), 1)).toBeUndefined();
+    });
+
+    it('returns undefined for a zero wait time', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(0), 1)).toBeUndefined();
     });
 
     it('returns undefined for a negative wait time', () => {
@@ -134,7 +138,7 @@ describe('getMsgTypeForTravelCardLeg', () => {
     });
 
     it('returns undefined for the first leg regardless of times', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(120), 0)).toBeUndefined();
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(60), 0)).toBeUndefined();
     });
   });
 

--- a/src/screen-components/travel-details-screens/__tests__/has-short-wait-time-and-not-guaranteed-correspondance.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/has-short-wait-time-and-not-guaranteed-correspondance.test.ts
@@ -52,11 +52,11 @@ describe('hasShortWaitTimeAndNotGuaranteedCorrespondence', () => {
         interchangeTo: {guaranteed: true},
       },
       {
-        expectedStartTime: '2024-10-31T15:02:00Z',
+        expectedStartTime: '2024-10-31T15:01:00Z',
         expectedEndTime: '2024-10-31T15:10:00Z',
       },
       {
-        expectedStartTime: '2024-10-31T15:12:00Z',
+        expectedStartTime: '2024-10-31T15:11:00Z',
         expectedEndTime: '2024-10-31T15:20:00Z',
       },
     ] as Leg[];

--- a/src/screen-components/travel-details-screens/__tests__/leg-interchange-risk.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/leg-interchange-risk.test.ts
@@ -1,0 +1,79 @@
+import {Leg} from '@atb/api/types/trips';
+import {legInterchangeRisk} from '../utils';
+
+describe('Leg interchange risk evaluator', () => {
+  const place = (stopPlaceId: string) =>
+    ({quay: {stopPlace: {id: stopPlaceId}}}) as Leg['fromPlace'];
+
+  const busLeg = (
+    fromStopPlaceId: string,
+    toStopPlaceId: string,
+    interchangeTo?: Leg['interchangeTo'],
+  ) =>
+    ({
+      mode: 'bus',
+      fromPlace: place(fromStopPlaceId),
+      toPlace: place(toStopPlaceId),
+      interchangeTo,
+    }) as Leg;
+
+  const footLeg = (fromStopPlaceId: string, toStopPlaceId: string) =>
+    ({
+      mode: 'foot',
+      fromPlace: place(fromStopPlaceId),
+      toPlace: place(toStopPlaceId),
+    }) as Leg;
+
+  it('catches a missed interchange at the same stop place', () => {
+    const legs = [busLeg('A', 'B'), busLeg('B', 'C')];
+    expect(legInterchangeRisk(0, legs, -60)).toBe('uncertain');
+    expect(legInterchangeRisk(0, legs, -300)).toBe('impossible');
+  });
+
+  it('passes when there is time to spare', () => {
+    const legs = [busLeg('A', 'B'), busLeg('B', 'C')];
+    expect(legInterchangeRisk(0, legs, 120)).toBeUndefined();
+  });
+
+  it('catches a missed interchange when walking to another stop place', () => {
+    const legs = [busLeg('A', 'B'), footLeg('B', 'C'), busLeg('C', 'D')];
+    expect(legInterchangeRisk(1, legs, -60)).toBe('uncertain');
+  });
+
+  it('catches a missed interchange when walking within the same stop place', () => {
+    const legs = [busLeg('A', 'B'), footLeg('B', 'B'), busLeg('B', 'C')];
+    expect(legInterchangeRisk(1, legs, -60)).toBe('uncertain');
+  });
+
+  it('passes on the leg leading into a walk, so it is only reported once', () => {
+    const legs = [busLeg('A', 'B'), footLeg('B', 'B'), busLeg('B', 'C')];
+    expect(legInterchangeRisk(0, legs, -60)).toBeUndefined();
+  });
+
+  it('passes on a guaranteed interchange', () => {
+    const legs = [busLeg('A', 'B', {guaranteed: true}), busLeg('B', 'C')];
+    expect(legInterchangeRisk(0, legs, -300)).toBeUndefined();
+  });
+
+  it('passes on a guaranteed interchange with a walk in between', () => {
+    const legs = [
+      busLeg('A', 'B', {guaranteed: true}),
+      footLeg('B', 'B'),
+      busLeg('B', 'C'),
+    ];
+    expect(legInterchangeRisk(1, legs, -300)).toBeUndefined();
+  });
+
+  it('catches a missed interchange when the stop place is unknown', () => {
+    const legs = [
+      {mode: 'bus', fromPlace: {}, toPlace: {}} as Leg,
+      busLeg('B', 'C'),
+    ];
+    expect(legInterchangeRisk(0, legs, -60)).toBe('uncertain');
+  });
+
+  it('passes on the last leg', () => {
+    const legs = [busLeg('A', 'B')];
+    expect(legInterchangeRisk(0, legs, -60)).toBeUndefined();
+  });
+});

--- a/src/screen-components/travel-details-screens/__tests__/short-wait-time.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/short-wait-time.test.ts
@@ -10,7 +10,7 @@ describe('Short wait time evaluator', () => {
   } as Leg;
 
   const Leg2: Leg = {
-    expectedStartTime: addMinutes(nowDate, 7),
+    expectedStartTime: addMinutes(nowDate, 6),
     expectedEndTime: addMinutes(nowDate, 10),
   } as Leg;
 

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -16,6 +16,7 @@ import {
   getShouldShowLiveVehicle,
   hasShortWaitTime,
   hasShortWaitTimeAndNotGuaranteedCorrespondence,
+  legInterchangeRisk,
   withinZoneIds,
 } from '../utils';
 import {
@@ -250,7 +251,11 @@ function legWaitDetails(index: number, legs: Leg[]): WaitDetails | undefined {
     );
 
     const mustWaitForNextLeg = waitTimeInSeconds > 0;
-    return {mustWaitForNextLeg, waitTimeInSeconds};
+    return {
+      mustWaitForNextLeg,
+      waitTimeInSeconds,
+      interchangeRisk: legInterchangeRisk(index, legs, waitTimeInSeconds),
+    };
   }
 }
 

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -44,13 +44,12 @@ import {
   getBookingStatus,
   significantWalkTime,
 } from '../utils';
-import {significantWaitTime} from '@atb/modules/trip-patterns';
 import {Time} from './Time';
 import {TripLegDecoration} from './TripLegDecoration';
 import {NEW_TRIP_DIMENSIONS, TripRow} from './TripRow';
 import {BookingInfoBox} from './BookingInfoBox';
 
-import {WaitDetails, WaitSection} from './WaitSection';
+import {shouldShowWaitSection, WaitDetails, WaitSection} from './WaitSection';
 import {Realtime as RealtimeDark} from '@atb/assets/svg/color/icons/status/dark';
 import {Realtime as RealtimeLight} from '@atb/assets/svg/color/icons/status/light';
 import {TripProps} from './Trip';
@@ -164,8 +163,8 @@ export const TripSection: React.FC<TripSectionProps> = ({
 
   const hasIntermediateStops = leg.intermediateEstimatedCalls.length > 0;
   const walkBikeRounding = isFirst ? 'floor' : 'ceil';
-  const walkA11yLabel = useWalkA11yLabel(leg, wait, walkBikeRounding);
-  const bikeA11yLabel = useBikeA11yLabel(leg, wait, walkBikeRounding);
+  const walkA11yLabel = useWalkA11yLabel(leg, walkBikeRounding);
+  const bikeA11yLabel = useBikeA11yLabel(leg, walkBikeRounding);
   const isWalkOrBike = isWalkSection || isBikeSection;
 
   const warningCount =
@@ -320,11 +319,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
                 fromRowAbsorbsLegA11y ? 'no-hide-descendants' : 'auto'
               }
             >
-              <WalkSection
-                leg={leg}
-                wait={wait}
-                timeRounding={walkBikeRounding}
-              />
+              <WalkSection leg={leg} timeRounding={walkBikeRounding} />
             </View>
           ) : isBikeSection ? (
             <View
@@ -333,11 +328,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
                 fromRowAbsorbsLegA11y ? 'no-hide-descendants' : 'auto'
               }
             >
-              <BikeSection
-                leg={leg}
-                wait={wait}
-                timeRounding={walkBikeRounding}
-              />
+              <BikeSection leg={leg} timeRounding={walkBikeRounding} />
             </View>
           ) : (
             <TripRow
@@ -586,10 +577,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
   return (
     <>
       {sectionOutput}
-      {wait?.mustWaitForNextLeg &&
-        significantWaitTime(wait.waitTimeInSeconds) && (
-          <WaitSection {...wait} />
-        )}
+      {wait && shouldShowWaitSection(wait) && <WaitSection {...wait} />}
     </>
   );
 
@@ -763,7 +751,6 @@ const getIntermediateInfoTexts = (
 
 function useWalkA11yLabel(
   leg: Leg,
-  wait?: WaitDetails,
   roundingMethod: 'floor' | 'ceil' = 'floor',
 ): string {
   const {t, language} = useTranslation();
@@ -805,22 +792,11 @@ function useWalkA11yLabel(
     );
   }
 
-  if (wait?.mustWaitForNextLeg && significantWaitTime(wait.waitTimeInSeconds)) {
-    parts.push(
-      t(
-        TripDetailsTexts.trip.leg.walk.a11yLabel.waitTime(
-          secondsToDuration(wait.waitTimeInSeconds, language),
-        ),
-      ),
-    );
-  }
-
   return parts.join('. ') + '.';
 }
 
 function useBikeA11yLabel(
   leg: Leg,
-  wait?: WaitDetails,
   roundingMethod: 'floor' | 'ceil' = 'floor',
 ): string {
   const {t, language} = useTranslation();
@@ -849,32 +825,21 @@ function useBikeA11yLabel(
     );
   }
 
-  if (wait?.mustWaitForNextLeg && significantWaitTime(wait.waitTimeInSeconds)) {
-    parts.push(
-      t(
-        TripDetailsTexts.trip.leg.bicycle.a11yLabel.waitTime(
-          secondsToDuration(wait.waitTimeInSeconds, language),
-        ),
-      ),
-    );
-  }
-
   return parts.join('. ') + '.';
 }
 
 type WalkSectionProps = {
   leg: Leg;
-  wait?: WaitDetails;
   timeRounding?: 'floor' | 'ceil';
 };
 
-const WalkSection = ({leg, wait, timeRounding = 'floor'}: WalkSectionProps) => {
+const WalkSection = ({leg, timeRounding = 'floor'}: WalkSectionProps) => {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
   const isWalkTimeOfSignificance = significantWalkTime(leg.duration);
   const humanizedDistance = useHumanizeDistance(leg.distance);
   const durationText = secondsToDuration(leg.duration ?? 0, language);
-  const a11yLabel = useWalkA11yLabel(leg, wait, timeRounding);
+  const a11yLabel = useWalkA11yLabel(leg, timeRounding);
 
   return (
     <TripRow
@@ -907,16 +872,15 @@ const WalkSection = ({leg, wait, timeRounding = 'floor'}: WalkSectionProps) => {
 
 type BikeSectionProps = {
   leg: Leg;
-  wait?: WaitDetails;
   timeRounding?: 'floor' | 'ceil';
 };
 
-const BikeSection = ({leg, wait, timeRounding = 'floor'}: BikeSectionProps) => {
+const BikeSection = ({leg, timeRounding = 'floor'}: BikeSectionProps) => {
   const {t, language} = useTranslation();
   const style = useSectionStyles();
   const durationText = secondsToDuration(leg.duration ?? 0, language);
   const humanizedDistance = useHumanizeDistance(leg.distance);
-  const a11yLabel = useBikeA11yLabel(leg, wait, timeRounding);
+  const a11yLabel = useBikeA11yLabel(leg, timeRounding);
 
   return (
     <TripRow

--- a/src/screen-components/travel-details-screens/components/WaitSection.tsx
+++ b/src/screen-components/travel-details-screens/components/WaitSection.tsx
@@ -43,11 +43,6 @@ type WaitMessage = {
   emphasis?: 'info' | 'error';
 };
 
-/**
- * How the wait itself is described. Waits under two minutes are called a short
- * transfer and stated as "under x minutes", rounded up to whole minutes, since
- * a precise duration suggests more accuracy than the real time data has.
- */
 function getWaitMessage(
   waitTimeInSeconds: number,
   t: TranslateFunction,
@@ -103,11 +98,6 @@ const WaitMessageRow = ({icon, title, message, emphasis}: WaitMessage) => {
     ? theme.color.foreground.emphasis[emphasis]
     : undefined;
 
-  /**
-   * Anchors the text on the stop place names by shrinking the label column,
-   * leaving the icon one small gap to the left of the text. Keeping it a
-   * column rather than an offset lets the icon grow with the font scale.
-   */
   const dimensionOverrides: DimensionOverrides = {
     ...NEW_TRIP_DIMENSIONS,
     labelWidth: TRIP_CONTENT_OFFSET - theme.spacing.small,

--- a/src/screen-components/travel-details-screens/components/WaitSection.tsx
+++ b/src/screen-components/travel-details-screens/components/WaitSection.tsx
@@ -1,64 +1,184 @@
 import {Time} from '@atb/assets/svg/mono-icons/time';
+import {Unknown, Warning} from '@atb/assets/svg/mono-icons/status';
+import {Close} from '@atb/assets/svg/mono-icons/actions';
 import {ThemeText} from '@atb/components/text';
-import {MessageInfoBox} from '@atb/components/message-info-box';
-import {StyleSheet} from '@atb/theme';
-import {TripDetailsTexts, useTranslation} from '@atb/translations';
-import {isShortWaitTime} from '@atb/modules/trip-patterns';
+import {StyleSheet, useThemeContext} from '@atb/theme';
+import {
+  Language,
+  TranslateFunction,
+  TripDetailsTexts,
+  useTranslation,
+} from '@atb/translations';
+import {InterchangeRisk, isShortWaitTime} from '@atb/modules/trip-patterns';
 import {secondsToDuration} from '@atb/utils/date';
 import React from 'react';
 import {View} from 'react-native';
-import {TripLegDecoration} from './TripLegDecoration';
-import {NEW_TRIP_DIMENSIONS, TripRow} from './TripRow';
+import {DimensionOverrides, NEW_TRIP_DIMENSIONS, TripRow} from './TripRow';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {useTransportColor} from '@atb/utils/use-transport-color';
 
 export type WaitDetails = {
   mustWaitForNextLeg: boolean;
   waitTimeInSeconds: number;
+  interchangeRisk?: InterchangeRisk;
 };
+
+/** Whether the wait between two legs has anything worth showing. */
+export function shouldShowWaitSection(wait: WaitDetails): boolean {
+  return !!wait.interchangeRisk || wait.mustWaitForNextLeg;
+}
+
+/** Where a trip row's content starts, which is what stop place names align to. */
+const TRIP_CONTENT_OFFSET =
+  (NEW_TRIP_DIMENSIONS.labelWidth ?? 0) +
+  (NEW_TRIP_DIMENSIONS.decorationContainerWidth ?? 0);
+
+const ONE_MINUTE_IN_SECONDS = 60;
+
+type WaitMessage = {
+  icon: React.ComponentProps<typeof ThemeIcon>['svg'];
+  title?: string;
+  message: string;
+  /** Draws the icon and title in the named emphasis colour. */
+  emphasis?: 'info' | 'error';
+};
+
+/**
+ * How the wait itself is described. Waits under two minutes are called a short
+ * transfer and stated as "under x minutes", rounded up to whole minutes, since
+ * a precise duration suggests more accuracy than the real time data has.
+ */
+function getWaitMessage(
+  waitTimeInSeconds: number,
+  t: TranslateFunction,
+  language: Language,
+): WaitMessage {
+  if (!isShortWaitTime(waitTimeInSeconds)) {
+    return {
+      icon: Time,
+      message: t(
+        TripDetailsTexts.trip.leg.wait.label(
+          secondsToDuration(waitTimeInSeconds, language),
+        ),
+      ),
+    };
+  }
+
+  const wholeMinutes = Math.ceil(waitTimeInSeconds / ONE_MINUTE_IN_SECONDS);
+  return {
+    icon: Warning,
+    emphasis: 'info',
+    title: t(TripDetailsTexts.trip.leg.wait.messages.shortTime),
+    message: t(
+      TripDetailsTexts.trip.leg.wait.shortWait(
+        secondsToDuration(wholeMinutes * ONE_MINUTE_IN_SECONDS, language),
+      ),
+    ),
+  };
+}
 
 export const WaitSection: React.FC<WaitDetails> = (wait) => {
   const style = useSectionStyles();
   const {t, language} = useTranslation();
-  const waitTime = secondsToDuration(wait.waitTimeInSeconds, language);
-  const shortWait = isShortWaitTime(wait.waitTimeInSeconds);
-  const legColor = useTransportColor();
+  const interchange = getInterchangeMessage(wait.interchangeRisk, t);
 
   return (
     <View style={style.section}>
-      <TripLegDecoration
-        dimensionOverrides={NEW_TRIP_DIMENSIONS}
-        color={legColor.secondary.background}
-        hasStart={false}
-        hasEnd={false}
-      />
-      {shortWait && (
-        <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-          <MessageInfoBox
-            type="info"
-            message={t(TripDetailsTexts.trip.leg.wait.messages.shortTime)}
-          />
-        </TripRow>
+      {interchange && <WaitMessageRow {...interchange} />}
+      {wait.mustWaitForNextLeg && (
+        <WaitMessageRow
+          {...getWaitMessage(wait.waitTimeInSeconds, t, language)}
+        />
       )}
-      <TripRow dimensionOverrides={NEW_TRIP_DIMENSIONS}>
-        <View style={style.waitLine}>
-          <ThemeIcon svg={Time} color={legColor.secondary.background} />
-          <ThemeText typography="body__s" type="secondary">
-            {t(TripDetailsTexts.trip.leg.wait.label(waitTime))}
-          </ThemeText>
-        </View>
-      </TripRow>
     </View>
   );
 };
+
+const WaitMessageRow = ({icon, title, message, emphasis}: WaitMessage) => {
+  const style = useSectionStyles();
+  const {theme} = useThemeContext();
+  const legColor = useTransportColor();
+
+  const emphasisColor = emphasis
+    ? theme.color.foreground.emphasis[emphasis]
+    : undefined;
+
+  /**
+   * Anchors the text on the stop place names by shrinking the label column,
+   * leaving the icon one small gap to the left of the text. Keeping it a
+   * column rather than an offset lets the icon grow with the font scale.
+   */
+  const dimensionOverrides: DimensionOverrides = {
+    ...NEW_TRIP_DIMENSIONS,
+    labelWidth: TRIP_CONTENT_OFFSET - theme.spacing.small,
+    decorationContainerWidth: theme.spacing.small,
+  };
+
+  return (
+    <TripRow
+      dimensionOverrides={dimensionOverrides}
+      rowLabel={
+        <ThemeIcon
+          svg={icon}
+          size="large"
+          color={emphasisColor ?? legColor.secondary.background}
+        />
+      }
+    >
+      <View style={style.message}>
+        {title && (
+          <ThemeText
+            typography="body__s"
+            type="secondary"
+            color={emphasisColor}
+          >
+            {title}
+          </ThemeText>
+        )}
+        <ThemeText typography="body__s" type="secondary">
+          {message}
+        </ThemeText>
+      </View>
+    </TripRow>
+  );
+};
+
+function getInterchangeMessage(
+  interchangeRisk: InterchangeRisk | undefined,
+  t: TranslateFunction,
+): WaitMessage | undefined {
+  if (interchangeRisk === 'impossible') {
+    return {
+      icon: Close,
+      emphasis: 'error',
+      title: t(
+        TripDetailsTexts.trip.leg.wait.messages.interchange.impossible.label,
+      ),
+      message: t(
+        TripDetailsTexts.trip.leg.wait.messages.interchange.impossible.message,
+      ),
+    };
+  }
+  if (interchangeRisk === 'uncertain') {
+    return {
+      icon: Unknown,
+      emphasis: 'error',
+      title: t(
+        TripDetailsTexts.trip.leg.wait.messages.interchange.uncertain.label,
+      ),
+      message: t(
+        TripDetailsTexts.trip.leg.wait.messages.interchange.uncertain.message,
+      ),
+    };
+  }
+}
+
 const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   section: {
     flex: 1,
     marginBottom: theme.spacing.large,
   },
-  waitLine: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: theme.spacing.small,
+  message: {
+    rowGap: theme.spacing.xSmall,
   },
 }));

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -8,6 +8,8 @@ import {
 } from '@atb/utils/date';
 // eslint-disable-next-line no-restricted-imports
 import {
+  getInterchangeRisk,
+  InterchangeRisk,
   isShortWaitTime,
   significantWaitTime,
 } from '@atb/modules/trip-patterns/utils';
@@ -207,6 +209,43 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
     },
     {conclusion: false},
   ).conclusion;
+}
+
+/**
+ * The risk of missing the next vehicle, which real time updates can cause on
+ * an already started trip.
+ *
+ * Interchanges that involve walking are included, in which case the wait time
+ * is what is left after the walk. Guaranteed interchanges are left out, as the
+ * next vehicle waits for the previous one.
+ *
+ * Only evaluated on the leg immediately before the next vehicle, so a transfer
+ * is reported once even when a foot leg splits it in two.
+ */
+export function legInterchangeRisk(
+  index: number,
+  legs: Leg[],
+  waitTimeInSeconds: number,
+): InterchangeRisk | undefined {
+  const nextLeg = legs[index + 1];
+  if (!nextLeg || nextLeg.mode === 'foot') return undefined;
+
+  const previousVehicleLeg = previousNonFootLeg(index, legs);
+  if (!previousVehicleLeg) return undefined;
+  if (previousVehicleLeg.interchangeTo?.guaranteed) return undefined;
+
+  return getInterchangeRisk(waitTimeInSeconds);
+}
+
+/**
+ * The leg of the vehicle arriving at the interchange. Foot legs are skipped,
+ * since both the stop place and the interchange guarantee are described on
+ * the leg being transferred from.
+ */
+function previousNonFootLeg(index: number, legs: Leg[]): Leg | undefined {
+  for (let i = index; i >= 0; i--) {
+    if (legs[i].mode !== 'foot') return legs[i];
+  }
 }
 
 function parseDateIfString(date: any): Date {

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -211,17 +211,6 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
   ).conclusion;
 }
 
-/**
- * The risk of missing the next vehicle, which real time updates can cause on
- * an already started trip.
- *
- * Interchanges that involve walking are included, in which case the wait time
- * is what is left after the walk. Guaranteed interchanges are left out, as the
- * next vehicle waits for the previous one.
- *
- * Only evaluated on the leg immediately before the next vehicle, so a transfer
- * is reported once even when a foot leg splits it in two.
- */
 export function legInterchangeRisk(
   index: number,
   legs: Leg[],
@@ -237,11 +226,6 @@ export function legInterchangeRisk(
   return getInterchangeRisk(waitTimeInSeconds);
 }
 
-/**
- * The leg of the vehicle arriving at the interchange. Foot legs are skipped,
- * since both the stop place and the interchange guarantee are described on
- * the leg being transferred from.
- */
 function previousNonFootLeg(index: number, legs: Leg[]): Leg | undefined {
   for (let i = index; i >= 0; i--) {
     if (legs[i].mode !== 'foot') return legs[i];

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -319,12 +319,6 @@ const TripDetailsTexts = {
             ),
           distance: (distance: string) =>
             _(`${distance} gange`, `${distance} walking`, `${distance} gange`),
-          waitTime: (waitTime: string) =>
-            _(
-              `Vent i opptil ${waitTime}`,
-              `Wait for up to ${waitTime}`,
-              `Vent i opptil ${waitTime}`,
-            ),
         },
       },
       bicycle: {
@@ -358,12 +352,6 @@ const TripDetailsTexts = {
               `${distance} cycling`,
               `${distance} sykling`,
             ),
-          waitTime: (waitTime: string) =>
-            _(
-              `Vent i opptil ${waitTime}`,
-              `Wait for up to ${waitTime}`,
-              `Vent i opptil ${waitTime}`,
-            ),
         },
       },
       shortWalk: _(
@@ -374,12 +362,40 @@ const TripDetailsTexts = {
       wait: {
         label: (time: string) =>
           _(`Vent i ${time}`, `Wait for ${time}`, `Vent i ${time}`),
-        messages: {
-          shortTime: _(
-            'Kort byttetid',
-            'Short changeover time',
-            'Kort byttetid',
+        shortWait: (time: string) =>
+          _(
+            `Under ${time} ventetid`,
+            `Less than ${time} waiting time`,
+            `Under ${time} ventetid`,
           ),
+        messages: {
+          shortTime: _('Kort byttetid', 'Short transfer time', 'Kort byttetid'),
+          interchange: {
+            uncertain: {
+              label: _(
+                'Usikker overgang',
+                'Uncertain transfer',
+                'Usikker overgang',
+              ),
+              message: _(
+                'Det er ikke sikkert du rekker denne overgangen',
+                'You might not be able to catch the next vehicle',
+                'Det er ikkje sikkert du rekk denne overgangen',
+              ),
+            },
+            impossible: {
+              label: _(
+                'Overgang ikke lenger mulig',
+                'Transfer no longer possible',
+                'Overgang ikkje lenger mogleg',
+              ),
+              message: _(
+                'Du vil ikke rekke denne overgangen',
+                'You will not be able to catch the next vehicle',
+                'Du vil ikkje rekkje denne overgangen',
+              ),
+            },
+          },
         },
       },
       end: {
@@ -414,7 +430,7 @@ const TripDetailsTexts = {
   messages: {
     shortTime: _(
       'Vær oppmerksom på kort byttetid.',
-      'Please note short changeover time.',
+      'Please note short transfer time.',
       'Ver merksam på kort byttetid.',
     ),
     correspondenceNotGuaranteed: _('', '', ''),


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/24007

## Description

Adds two new states to the trip details screen for transfers between vehicle A and vehicle B, based on the gap between A's **expected arrival** and B's **expected departure**. Both are real-time values, so the state changes during an ongoing trip as delay data arrives (the screen already refreshes every 20 s).

| Gap | State | |
|---|---|---|
| ≥ +2:00 | **Vent i x minutter** | existing |
| +0:01 … +1:59 | **Kort byttetid** / Under x minutt(er) ventetid | updated |
| 0:00 … −2:00 | **Usikker overgang** | 🆕 |
| ≤ −2:01 | **Overgang ikke lenger mulig** | 🆕 |

A negative gap means B is expected to leave before A arrives. Note the boundaries are mirror images: 2 minutes late is still *uncertain*, and 2 minutes early is already *Vent i*.

The two new messages are deliberately **not** shown when:

- the interchange is **guaranteed** — B waits for A, so there is no risk
- the next leg is a **foot leg** — the message attaches to the last leg before a vehicle, so a transfer with a walk in the middle reports once rather than twice, measured on the time left *after* the walk

Transfers involving walking are otherwise included, not just same-stop transfers. Applies to all modes, not only bus.

## Screenshots
|||
|---|---|
| **Kort byttetid**<br><img width="300" alt="kort byttetid" src="https://github.com/user-attachments/assets/c2d723dc-e9d7-4b16-8128-43e9a0f9f761" /> | **Vent i x minutter**<br><img width="300" alt="vent i x minutter" src="https://github.com/user-attachments/assets/6e44e24c-90f9-4da8-9b84-d2d624e89347" /> |
| **Usikker overgang**<br><img width="300" alt="usikker overgang" src="https://github.com/user-attachments/assets/5253e2e9-3db3-4755-8a4b-2e18a209ce04" /> | **Overgang ikke lenger mulig**<br><img width="300" alt="overgang ikke lenger mulig" src="https://github.com/user-attachments/assets/e21121e2-ac89-46ea-984a-cdde285ff07e" /> |


## Also in this PR

**Short-transfer range changed from 31–180 s to 1–119 s.** `isShortWaitTime` is the single definition of a short transfer and is shared, so this changes four surfaces beyond the new messages:

- trip details top banner (`hasShortWaitTime`)
- correspondence banner (`hasShortWaitTimeAndNotGuaranteedCorrespondence`)
- travel card notification icon (`getMsgTypeForTravelCardLeg`)
- legacy trip details wait box

Net effect: **1–30 s gaps now warn** (previously silent), and **2–3 minute transfers no longer warn** (previously did). Consequently the new trip details screen now shows a wait row for gaps of 1–30 s, which previously rendered nothing at all.

Short waits are stated as "Under x minutt(er) ventetid" rounded up to whole minutes, so there will never be a "Under 0 minutter ventetid" showing.

### Why `significantWaitTime` is unchanged

The app now has two wait thresholds that look like they should agree:

- `significantWaitTime` (> 30 s) — decides which legs render at all (`getFilteredLegsByWalkOrWaitTime`)
- `isShortWaitTime` (> 0 s, < 120 s) — decides the wording of the wait row

Lowering `significantWaitTime` to `> 0` was considered, so that nothing falls between the two, but it is blocked: three surfaces pass the raw seconds straight to `secondsToDuration`, which renders anything under 30 s as **"0 minutter"**.

- `legacy/TripSection.tsx:404` — a visible row reading "Vent i 0 minutter"
- `TravelCardLegs.tsx:168` — screen reader: "vent 0 minutter"
- `ResultItem.tsx:445` — screen reader: "gå 1 min. vent 0 min"

The new trip details screen is immune because short waits are rounded up and phrased as "Under x minutt(er)" rather than stated exactly. Bringing the other three in line is a prerequisite for changing the threshold, and is left out of this PR.