### PR TITLE
fix: priceInfo interval display

### DIFF
--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -87,15 +87,19 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
     });
   }
 
-  pricingPlan.perMinPricing?.forEach((seg) => {
-    rows.push({
-      label: getMinuteSegmentLabel(
-        seg,
-        hasCampaign ? Math.max(freeMinCount, seg.start) : seg.start,
-      ),
-      value: `${formatNumberToString(seg.rate, language)} ${currency}/min`,
+  pricingPlan.perMinPricing
+    // Segments entirely inside the free window are paid for by the campaign, so
+    // showing them would render an inverted range like "30-20 min".
+    ?.filter((seg) => !hasCampaign || seg.end == null || seg.end > freeMinCount)
+    .forEach((seg) => {
+      rows.push({
+        label: getMinuteSegmentLabel(
+          seg,
+          hasCampaign ? Math.max(freeMinCount, seg.start) : seg.start,
+        ),
+        value: `${formatNumberToString(seg.rate, language)} ${currency}/min`,
+      });
     });
-  });
 
   return (
     <FullScreenView


### PR DESCRIPTION
Fixed bug where interval showing wierd timeranges, like from this images:

<img width="250" alt="image" src="https://github.com/user-attachments/assets/2ae33200-5bba-45b1-a81c-29c83d31fb12" />


After update:

<img width="250" alt="image" src="https://github.com/user-attachments/assets/b2b5750d-f930-40c3-b4ad-32c0f92b32b0" />

