### PR TITLE
fix: fixed issue with filter showing in active trip

### DIFF
--- a/src/modules/map/components/MapButtons.tsx
+++ b/src/modules/map/components/MapButtons.tsx
@@ -50,6 +50,8 @@ export const MapButtons = ({
     !mapFilterIsOpen;
 
   const showMapFilterButton =
+    !activeShmoBooking &&
+    !activeShmoBookingIsLoading &&
     mapState.bottomSheetType === MapBottomSheetType.None;
 
   return (


### PR DESCRIPTION
There was possible to toggle the filter in the map when in an active trip if the app was reloaded while in an active trip, the filter then appeared again