### PR TITLE
feat: added numDocksAvailable

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -532,6 +532,8 @@ export const StationFeaturePropertiesSchema = z.object({
   vehicle_type_propulsion_type: MapItemPropulsionTypeSchema,
   num_vehicles_available: z.number(),
   capacity: z.number(),
+  num_docks_available: z.number().optional(),
+  name: z.string().optional(),
   count: z.literal(1),
   is_virtual_station: z.boolean(),
 });

--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -51,15 +51,10 @@ import {
   isVirtualStation,
   isActiveBikeTripBooking,
   isActiveTripBooking,
-  getStationQueryKey,
 } from '@atb/modules/mobility';
 
 import {Snackbar, useSnackbar, useStableValue} from '@atb/components/snackbar';
 import {useActiveShmoBookingQuery} from '@atb/modules/mobility';
-import {useQueryClient} from '@tanstack/react-query';
-import {getStation} from '@atb/api/mobility';
-import {ONE_MINUTE_MS} from '@atb/utils/durations';
-import {getTextForLanguage} from '@atb/translations/utils';
 import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {ThemedParkingIcon} from '@atb/theme/ThemedAssets';
@@ -149,7 +144,6 @@ export const Map = (props: MapProps) => {
 
   const {getGeofencingZoneContent} = useGeofencingZoneContent();
   const {snackbarProps, showSnackbar, hideSnackbar} = useSnackbar();
-  const queryClient = useQueryClient();
 
   const {data: activeShmoBooking} = useActiveShmoBookingQuery(isFocused);
 
@@ -241,23 +235,13 @@ export const Map = (props: MapProps) => {
   );
 
   const showBikeStationParkingSnackbar = useCallback(
-    async (stationId: string, parkingSpacesAvailable: number) => {
-      // The count comes from the map item, which the vector source keeps refreshed, so it
-      // is never stale and always matches the number rendered on the icon. Only the station
-      // name is fetched, since the tile has no name field - and names don't change, so
-      // serving it from the cache shared with useStationQuery is safe here.
-      const station = await queryClient.fetchQuery({
-        queryKey: getStationQueryKey(stationId),
-        queryFn: ({signal}) => getStation(stationId, {signal}),
-        staleTime: ONE_MINUTE_MS,
-      });
-
+    (stationName: string | undefined, parkingSpacesAvailable: number) => {
+      // Both come from the map item, which the vector source keeps refreshed, so they are
+      // never stale and the count always matches the number rendered on the icon.
       showSnackbar({
         content: {
           iconNode: <ThemeIcon svg={ThemedParkingIcon} size="large" />,
-          title: station
-            ? getTextForLanguage(station.name.translation, language)
-            : undefined,
+          title: stationName,
           description: t(
             MobilityTexts.freeBikeParkingSpaces(parkingSpacesAvailable),
           ),
@@ -265,7 +249,7 @@ export const Map = (props: MapProps) => {
         position: 'top',
       });
     },
-    [queryClient, showSnackbar, language, t],
+    [showSnackbar, t],
   );
 
   const locationArrowOnPress = useCallback(async () => {
@@ -403,12 +387,9 @@ export const Map = (props: MapProps) => {
           // During a trip, tapping a bike station shows its free parking spaces
           // instead of opening a bottom sheet. Other features stay non-interactive.
           if (isActiveBikeTrip && isBikeStation(featureToSelect)) {
-            const {id, capacity, num_vehicles_available} =
-              featureToSelect.properties;
-            showBikeStationParkingSnackbar(
-              id,
-              Math.max(0, capacity - num_vehicles_available),
-            );
+            const {name, num_docks_available} = featureToSelect.properties;
+            // Matches the fallback used for the icon in useMapSymbolStyles.
+            showBikeStationParkingSnackbar(name, num_docks_available ?? 0);
           }
           return;
         }

--- a/src/modules/map/hooks/use-map-symbol-styles.ts
+++ b/src/modules/map/hooks/use-map-symbol-styles.ts
@@ -56,11 +56,13 @@ export const useMapSymbolStyles = ({
   const countPropName = 'count';
   const count: Expression = ['get', countPropName];
   const numVehiclesAvailable: Expression = ['get', 'num_vehicles_available'];
-  const capacity: Expression = ['to-number', ['get', 'capacity'], 0];
+  // Cannot be derived from capacity - num_vehicles_available: docks that are out of
+  // service are neither occupied nor available. Absent when the operator doesn't report
+  // it, and 0 then errs on the safe side rather than promising space that may not exist.
   const parkingSpacesAvailable: Expression = [
-    'max',
+    'to-number',
+    ['get', 'num_docks_available'],
     0,
-    ['-', capacity, numVehiclesAvailable],
   ];
 
   const isCluster: Expression = [

--- a/src/modules/mobility/index.ts
+++ b/src/modules/mobility/index.ts
@@ -32,7 +32,6 @@ export {useShmoBookingQuery} from './queries/use-shmo-booking-query';
 export {useInitAgeVerificationMutation} from './queries/use-init-age-verification-mutation';
 export {useGetOperatorsQuery} from './queries/use-get-operators-query';
 export {useVehicleQuery} from './queries/use-vehicle-query';
-export {getStationQueryKey} from './queries/use-station-query';
 export {ShmoRequirementEnum} from './types';
 export {useOperatorBenefitsForFareProduct} from './use-operator-benefits-for-fare-product';
 export {useOperators} from './use-operators';

--- a/src/modules/mobility/queries/use-station-query.tsx
+++ b/src/modules/mobility/queries/use-station-query.tsx
@@ -2,11 +2,9 @@ import {useQuery} from '@tanstack/react-query';
 import {getStation} from '@atb/api/mobility';
 import {ONE_MINUTE_MS} from '@atb/utils/durations';
 
-export const getStationQueryKey = (id: string) => ['getStation', id];
-
 export const useStationQuery = (id: string) =>
   useQuery({
-    queryKey: getStationQueryKey(id),
+    queryKey: ['getStation', id],
     queryFn: ({signal}) => getStation(id, {signal}),
     staleTime: ONE_MINUTE_MS,
     gcTime: ONE_MINUTE_MS,


### PR DESCRIPTION
Closes https://github.com/AtB-AS/kundevendt/issues/24361

Added numDocksAvailable in map-service to get a more accurate number when showing parking spaces in active trip with citybike. Also added name to get rid of the extra servercall to fetch name in the app.

This in Map need to be merged first: https://github.com/AtB-AS/map/pull/26