### PR TITLE
fix: keep snackbar icon visible during exit animation

### DIFF
--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -117,7 +117,7 @@ const SnackbarInstance = ({
         onLayout={animatedViewOnLayout}
       >
         <View style={styles.snackbar}>
-          {content?.iconNode ?? null}
+          {activeContent?.iconNode ?? null}
           <View style={styles.snackbarTexts} ref={focusRef} accessible={true}>
             {activeContent?.title && (
               <ThemeText


### PR DESCRIPTION
## Issue Reference

Fixes https://github.com/AtB-AS/kundevendt/issues/24112

## Description

The snackbar icon disappeared as soon as the slide-out animation started, while the title and description stayed visible for the full 300ms.

Cause: the icon read from the live `content` prop, while the texts read from `activeContent` — which falls back to `stablePreviousContent` during the exit animation. As soon as the parent cleared its snackbar state (`hideSnackbar()`, or the `onHideSnackbar` callback firing on auto-hide), `content` became `undefined` and the icon unmounted immediately.

Fix is to read the icon from `activeContent` like the texts do. `stablePreviousContent` already holds the full content object including `iconNode`.

Introduced in #5545, which added the icon line but wired it to `content` instead of the then-new `activeContent`.