### PR TITLE
feat: renamed texts to be more generic for all vehicles

### DIFF
--- a/src/modules/map/hooks/use-shmo-warnings.tsx
+++ b/src/modules/map/hooks/use-shmo-warnings.tsx
@@ -43,12 +43,12 @@ export const useShmoWarnings = (
     };
 
     if (vehicle?.isDisabled) {
-      return t(ShmoWarnings.scooterDisabled);
+      return t(ShmoWarnings.vehicleDisabled);
     }
 
     if (!isOpen && openingTime && closingTime) {
       return t(
-        ShmoWarnings.scooterClosed(
+        ShmoWarnings.vehicleClosed(
           openingTime?.toLocaleTimeString([], timeFormatOptions),
           closingTime?.toLocaleTimeString([], timeFormatOptions),
         ),

--- a/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
@@ -1,10 +1,7 @@
 import React, {RefObject, useCallback, useEffect} from 'react';
 import {useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {
-  MobilityTexts,
-  ScooterTexts,
-} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {Alert, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
@@ -274,7 +271,7 @@ export const ActiveShmoSheet = ({
             <View style={styles.footer}>
               <MessageInfoBox
                 type="error"
-                message={t(ScooterTexts.loadingFailed)}
+                message={t(MobilityTexts.loadingFailed)}
               />
             </View>
           )}

--- a/src/modules/mobility/components/sheets/FinishedShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/FinishedShmoSheet.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {FareContractTexts, useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {
-  MobilityTexts,
-  ScooterTexts,
-} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
@@ -148,7 +145,7 @@ export const FinishedShmoSheet = ({
             <View style={styles.footer}>
               <MessageInfoBox
                 type="error"
-                message={t(ScooterTexts.loadingFailed)}
+                message={t(MobilityTexts.loadingFailed)}
               />
             </View>
           )}

--- a/src/modules/mobility/components/sheets/FinishingScooterSheet.tsx
+++ b/src/modules/mobility/components/sheets/FinishingScooterSheet.tsx
@@ -1,10 +1,7 @@
 import React, {useCallback, useEffect} from 'react';
 import {useTranslation} from '@atb/translations';
 import {StyleSheet} from '@atb/theme';
-import {
-  MobilityTexts,
-  ScooterTexts,
-} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
@@ -109,7 +106,7 @@ export const FinishingScooterSheet = ({
         <View style={styles.container}>
           <MessageInfoBox
             type="error"
-            message={t(ScooterTexts.loadingFailed)}
+            message={t(MobilityTexts.loadingFailed)}
           />
         </View>
       )}

--- a/src/modules/mobility/components/sheets/VehicleSheet.tsx
+++ b/src/modules/mobility/components/sheets/VehicleSheet.tsx
@@ -1,10 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import {getTextForLanguage, useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {
-  MobilityTexts,
-  ScooterTexts,
-} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {useMapVehicle} from '../../use-map-vehicle';
 import {Linking, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
@@ -242,7 +239,7 @@ export const VehicleSheet = ({
         <View style={styles.messageInfo}>
           <MessageInfoBox
             type="error"
-            message={t(ScooterTexts.loadingFailed)}
+            message={t(MobilityTexts.loadingFailed)}
           />
         </View>
       )}

--- a/src/translations/GeoLocation.ts
+++ b/src/translations/GeoLocation.ts
@@ -17,14 +17,14 @@ const GeoLocationTexts = {
     message: (isPrecise: boolean) =>
       isPrecise
         ? _(
-            'Vi bruker presis posisjon til å vise din posisjon i kart og reisesøk, til å finne holdeplasser og steder i nærheten, og til å bekrefte din posisjon når du bruker sparkesykler. For å bruke presis posisjon må du endre innstillingene for appen.',
-            'We use precise location to show your location on the map and in travel search, to find stops and places nearby, and to confirm your location when using scooters. To use precise location, you must change the app settings.',
-            'Vi brukar presis posisjon for å vise posisjonen din i kart og reisesøk, til å finne haldeplassar og stader i nærleiken, og til å bekrefte posisjonen din når du brukar sparkesyklar. For å bruke presis posisjon må du endre innstillingane for appen.',
+            'Vi bruker presis posisjon til å vise din posisjon i kart og reisesøk, til å finne holdeplasser og steder i nærheten, og til å bekrefte din posisjon når du bruker delte kjøretøy. For å bruke presis posisjon må du endre innstillingene for appen.',
+            'We use precise location to show your location on the map and in travel search, to find stops and places nearby, and to confirm your location when using shared vehicles. To use precise location, you must change the app settings.',
+            'Vi brukar presis posisjon for å vise posisjonen din i kart og reisesøk, til å finne haldeplassar og stader i nærleiken, og til å bekrefte posisjonen din når du brukar delte køyretøy. For å bruke presis posisjon må du endre innstillingane for appen.',
           )
         : _(
-            'Vi bruker posisjon til å vise din posisjon i kart og reisesøk, til å finne holdeplasser og steder i nærheten, og til å bekrefte din posisjon når du bruker sparkesykler.',
-            'We use location to show your location on the map and in travel search, to find stops and places nearby, and to confirm your location when using scooters.',
-            'Vi brukar posisjon for å vise posisjonen din i kart og reisesøk, til å finne holdeplassar og stader i nærleiken, og til å bekrefte posisjonen din når du brukar sparkesyklar.',
+            'Vi bruker posisjon til å vise din posisjon i kart og reisesøk, til å finne holdeplasser og steder i nærheten, og til å bekrefte din posisjon når du bruker delte kjøretøy.',
+            'We use location to show your location on the map and in travel search, to find stops and places nearby, and to confirm your location when using shared vehicles.',
+            'Vi brukar posisjon for å vise posisjonen din i kart og reisesøk, til å finne holdeplassar og stader i nærleiken, og til å bekrefte posisjonen din når du brukar delte køyretøy.',
           ),
     goToSettings: _(
       'Gå til innstillinger',

--- a/src/translations/screens/ContactScooterOperator.ts
+++ b/src/translations/screens/ContactScooterOperator.ts
@@ -45,9 +45,9 @@ export const ContactShmoOperatorTexts = {
     },
     noEndInfo: (operatorName: string) => {
       return _(
-        `Alle turer avsluttes etter én time. Sett sparkesykkelen på et trygt sted og send inn dette skjemaet slik at ${operatorName} kan rette opp feilen.`,
-        `All trips end after one hour. Park the scooter in a safe spot and submit this form so that ${operatorName} can correct the error.`,
-        `Alle turar blir avslutta etter éin time. Sett sparkesykkelen på ein trygg stad og send inn dette skjemaet slik at ${operatorName} kan retta opp feilen.`,
+        `Alle turer avsluttes etter én time. Sett kjøretøyet på et trygt sted og send inn dette skjemaet slik at ${operatorName} kan rette opp feilen.`,
+        `All trips end after one hour. Park the vehicle in a safe spot and submit this form so that ${operatorName} can correct the error.`,
+        `Alle turar blir avslutta etter éin time. Sett køyretøyet på ein trygg stad og send inn dette skjemaet slik at ${operatorName} kan retta opp feilen.`,
       );
     },
   },

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -148,6 +148,11 @@ export const MobilityTexts = {
       ),
     },
   },
+  loadingFailed: _(
+    'Vi fant ikke dette kjøretøyet',
+    "We couldn't find this vehicle",
+    'Vi fann ikkje dette køyretøyet',
+  ),
   loadingBookingFailed: _(
     'Ops! Vi kunne ikke hente informasjon om turen',
     "Ops! We couldn't fetch the trip information",
@@ -161,9 +166,9 @@ export const MobilityTexts = {
       'Ta eit bilde før du avsluttar',
     ),
     p1: _(
-      'Du kan få bot hvis sparkesykkelen meldes som feilparkert.',
-      'You may get a fine if the scooter is reported as incorrectly parked.',
-      'Du kan få bot viss sparkesykkelen vert meldt som feilparkert.',
+      'Du kan få bot hvis kjøretøyet meldes som feilparkert.',
+      'You may get a fine if the vehicle is reported as incorrectly parked.',
+      'Du kan få bot viss køyretøyet vert meldt som feilparkert.',
     ),
     p2: _(
       'Bilde kan brukes som bevis på at du har parkert riktig.',
@@ -219,9 +224,9 @@ export const MobilityTexts = {
     ),
     underAgeWarning: (legalAge: number) =>
       _(
-        `Du må være ${legalAge} år eller eldre for å bruke denne el-sparkesykkelen`,
-        `You must be ${legalAge} years or older to use this e-scooter`,
-        `Du må vere ${legalAge} år eller eldre for å bruke denne el-sparkesykkelen`,
+        `Du må være ${legalAge} år eller eldre for å bruke dette kjøretøyet`,
+        `You must be ${legalAge} years or older to use this vehicle`,
+        `Du må vere ${legalAge} år eller eldre for å bruke dette køyretøyet`,
       ),
     shmoBlockers: _('Fullfør steg', 'Complete steps', 'Fullfør steg'),
     shmoBlockersInfoMessage: (numberOfBlockers: number) =>
@@ -237,9 +242,9 @@ export const MobilityTexts = {
         'Vi treng posisjonen din',
       ),
       description: _(
-        'Du må gi tilgang til posisjonen din for å bruke en el-sparkesykkel',
-        'You need to give access to your location to use an electric scooter',
-        'Du må gi tilgang til posisjonen din for å bruke ein el-sparkesykkel',
+        'Du må gi tilgang til posisjonen din for å bruke et kjøretøy',
+        'You need to give access to your location to use a vehicle',
+        'Du må gi tilgang til posisjonen din for å bruke eit køyretøy',
       ),
       button: _('Del posisjon', 'Share location', 'Del posisjon'),
     },
@@ -250,9 +255,9 @@ export const MobilityTexts = {
         'Vi må sjekke alderen din',
       ),
       description: _(
-        'El-sparkesykler har en aldersgrense. Bekreft alderen din med Vipps.',
-        'E-scooters have an age limit. Verify your age with Vipps.',
-        'El-sparkesyklar har ein aldersgrense. Verifiser alderen din med Vipps.',
+        'Noen kjøretøy har en aldersgrense. Bekreft alderen din med Vipps.',
+        'Some vehicles have an age limit. Verify your age with Vipps.',
+        'Nokre køyretøy har ei aldersgrense. Verifiser alderen din med Vipps.',
       ),
       button: _(
         'Fortsett med Vipps',
@@ -267,9 +272,9 @@ export const MobilityTexts = {
         'Vi treng eit betalingskort',
       ),
       description: _(
-        'Du må legge til et betalingskort for å bruke en el-sparkesykkel',
-        'You need to add a payment card to use an electric scooter',
-        'Du må legge til et betalingskort for å bruke ein el-sparkesykkel',
+        'Du må legge til et betalingskort for å bruke et kjøretøy',
+        'You need to add a payment card to use a vehicle',
+        'Du må legge til eit betalingskort for å bruke eit køyretøy',
       ),
       button: _(
         'Legg til betalingskort',
@@ -465,11 +470,6 @@ export const ScooterTexts = {
           )
         : _('Gratis oppstart', 'Free to unlock', 'Gratis oppstart'),
   },
-  loadingFailed: _(
-    'Vi fant ikke denne sparkesykkelen',
-    "We couldn't find this scooter",
-    'Vi fann ikkje denne sparkesykkelen',
-  ),
   range: _('rekkevidde', 'range', 'rekkjevidde'),
   unlock: _('opplåsning', 'unlock', 'opplåsing'),
   freeMinutesDescription: (minutes: number) =>
@@ -622,11 +622,7 @@ export const ParkAndRideTexts = {
 export const GeofencingZoneExplanations: GeofencingZoneExplanationsType = {
   allowed: {
     title: _('Tillatt sone', 'Allowed Area', 'Tillatt sone'),
-    description: _(
-      'Her kan du kjøre el-sparkesykkelen',
-      'You can ride the e-scooter here',
-      'Her kan du køyre el-sparkesykkelen',
-    ),
+    description: _('Du kan kjøre her', 'You can ride here', 'Du kan køyre her'),
   },
   slow: {
     title: _('Saktesone', 'Slow Zone', 'Saktesone'),
@@ -694,27 +690,27 @@ export const GeofencingZoneExtraExplanations = {
 };
 
 export const ShmoWarnings = {
-  scooterDisabled: _(
-    'Denne el-sparkesykkelen er ikke tilgjengelig akkurat nå ',
-    'This e-scooter is not available right now',
-    'Denne el-sparkesykkelen er ikkje tilgjengeleg akkurat no',
+  vehicleDisabled: _(
+    'Dette kjøretøyet er ikke tilgjengelig akkurat nå',
+    'This vehicle is not available right now',
+    'Dette køyretøyet er ikkje tilgjengeleg akkurat no',
   ),
-  scooterClosed: (start: string | undefined, end: string | undefined) =>
+  vehicleClosed: (start: string | undefined, end: string | undefined) =>
     start && end
       ? _(
-          `Elsparkesykkelen er kun tilgjengelig mellom ${start} og ${end}`,
-          `The E-scooter is only available between ${start} and ${end}`,
-          `Elsparkesykkelen er berre tilgjengeleg mellom ${start} og ${end}`,
+          `Kjøretøyet er kun tilgjengelig mellom ${start} og ${end}`,
+          `The vehicle is only available between ${start} and ${end}`,
+          `Køyretøyet er berre tilgjengeleg mellom ${start} og ${end}`,
         )
       : _(
-          'Elsparkesykkelen er utenfor åpningstiden',
-          'The E-scooter is outside opening hours',
-          'Elsparkesykkelen er utanfor opningstiden',
+          'Kjøretøyet er utenfor åpningstiden',
+          'The vehicle is outside opening hours',
+          'Køyretøyet er utanfor opningstida',
         ),
-  scooterNotNear: _(
-    'Du må være i nærheten av elsparkesykkelen for å starte en tur',
-    'You need to be near the e-scooter to start a ride.',
-    'Du må vere i nærleiken av elsparkesykkelen for å starte ein tur',
+  vehicleNotNear: _(
+    'Du må være i nærheten av kjøretøyet for å starte en tur',
+    'You need to be near the vehicle to start a ride.',
+    'Du må vere i nærleiken av køyretøyet for å starte ein tur',
   ),
   positionUnavailable: _(
     'Posisjon utilgjengelig. Det kan oppstå problemer med å avslutte turen.',


### PR DESCRIPTION
Renamed scooter specific texts in the app to be more generic since its reused for both scooters, citybikes and cars