### PR TITLE
refactor: improve encapsulation of bottom sheet modal

### DIFF
--- a/src/components/bottom-sheet/BottomSheetHeader.tsx
+++ b/src/components/bottom-sheet/BottomSheetHeader.tsx
@@ -3,7 +3,6 @@ import {NativeBorderlessButton} from '../native-button';
 import {ThemeText} from '../text';
 import {ThemeIcon} from '../theme-icon';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import BottomSheet, {BottomSheetModal} from '@gorhom/bottom-sheet';
 import {BrandingImage} from '@atb/modules/mobility';
 import {Ref} from 'react';
 import {
@@ -17,7 +16,7 @@ type BottomSheetHeaderProps = {
   subText?: string;
   logoUrl?: string;
   logoIcon?: React.JSX.Element | null;
-  bottomSheetRef: React.RefObject<BottomSheetModal | BottomSheet | null>;
+  onClose: () => void;
   headerNode?: React.ReactNode;
   focusRef?: Ref<any>;
   testID?: string;
@@ -29,7 +28,7 @@ export const BottomSheetHeader = ({
   subText,
   logoUrl,
   logoIcon,
-  bottomSheetRef,
+  onClose,
   headerNode,
   focusRef,
   testID,
@@ -68,7 +67,7 @@ export const BottomSheetHeader = ({
                 style={styles.dismissButton}
                 testID="closeBottomSheet"
                 accessibilityRole="button"
-                onPress={() => bottomSheetRef.current?.close()}
+                onPress={onClose}
                 hitSlop={insets.all(theme.spacing.small)}
               >
                 {headerData?.text && (

--- a/src/components/bottom-sheet/bottom-sheet-map/MapBottomSheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet-map/MapBottomSheet.tsx
@@ -151,7 +151,7 @@ export const MapBottomSheet = ({
           subText={subText}
           logoUrl={logoUrl}
           logoIcon={logoIcon}
-          bottomSheetRef={bottomSheetMapRef}
+          onClose={() => bottomSheetMapRef.current?.close()}
           headerNode={headerNode}
           bottomSheetHeaderType={bottomSheetHeaderType}
         />

--- a/src/components/bottom-sheet/bottom-sheet-modal/BottomSheetModal.tsx
+++ b/src/components/bottom-sheet/bottom-sheet-modal/BottomSheetModal.tsx
@@ -147,8 +147,6 @@ export const BottomSheetModal = ({
 
   const {internalRef} = useInternalBottomSheetModalRef(
     bottomSheetModalRef,
-    onClose,
-    onOpen,
     overrideClose,
   );
 
@@ -245,23 +243,19 @@ const useBottomSheetContent = (
 
 const useInternalBottomSheetModalRef = (
   externalBottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>,
-  onClose: () => void,
-  onOpen: () => void,
   overrideClose: () => boolean,
 ) => {
   const internalRef = useRef<GorhomBottomSheetModalMethods>(null);
 
   useImperativeHandle(externalBottomSheetModalRef, (): BottomSheetModalMethods => {
     return {
-      present: () => internalRef.current?.present() && onOpen(),
+      present: () => internalRef.current?.present(),
       dismiss: () => {
-        if (overrideClose()) {
-          return;
-        }
-        return internalRef.current?.dismiss() && onClose();
+        if (overrideClose()) return;
+        internalRef.current?.dismiss();
       },
     };
-  }, [internalRef, onClose, onOpen, overrideClose]);
+  }, [internalRef, overrideClose]);
 
   return {internalRef};
 };

--- a/src/components/bottom-sheet/bottom-sheet-modal/BottomSheetModal.tsx
+++ b/src/components/bottom-sheet/bottom-sheet-modal/BottomSheetModal.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import {
   BottomSheetModal as GorhomBottomSheetModal,
-  BottomSheetModalProps as GorhomBottomSheetModalProps,
   BottomSheetBackdrop,
   BottomSheetScrollView,
   BottomSheetFooter as GorhomBottomSheetFooter,
@@ -24,17 +23,15 @@ import {useBottomSheetContext} from '../BottomSheetContext';
 import {useIsScreenReaderEnabled} from '@atb/utils/use-is-screen-reader-enabled';
 import {giveFocus} from '@atb/utils/use-focus-on-load';
 import {BottomSheetHeaderType} from '../use-bottom-sheet-header-type';
-import {
-  BottomSheetModalMethods,
-  SpringConfig,
-  TimingConfig,
-} from '@gorhom/bottom-sheet/lib/typescript/types';
+import {BottomSheetModalMethods as GorhomBottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 
-type BottomSheetModalChildren<T extends any> =
-  GorhomBottomSheetModalProps<T>['children'];
+export type BottomSheetModalMethods = {
+  dismiss: () => void;
+  present: () => void;
+};
 
-type BottomSheetModalProps<T extends any> = {
-  children: BottomSheetModalChildren<T>;
+type BottomSheetModalProps = {
+  children: React.ReactNode;
   bottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>;
   enablePanDownToClose?: boolean;
   heading?: string;
@@ -54,7 +51,7 @@ type BottomSheetModalProps<T extends any> = {
   bottomSheetHeaderType: BottomSheetHeaderType;
 };
 
-export const BottomSheetModal = <T extends any>({
+export const BottomSheetModal = ({
   children,
   bottomSheetModalRef,
   heading,
@@ -73,7 +70,7 @@ export const BottomSheetModal = <T extends any>({
   closeOnBackdropPress = true,
   overrideClose = () => false,
   bottomSheetHeaderType,
-}: BottomSheetModalProps<T>) => {
+}: BottomSheetModalProps) => {
   const styles = useBottomSheetStyles();
   const {height: screenHeight} = useWindowDimensions();
   const {top: safeAreaTop} = useSafeAreaInsets();
@@ -131,30 +128,6 @@ export const BottomSheetModal = <T extends any>({
     [Footer, theme.color.background.neutral, theme.spacing.large],
   );
 
-  const renderHandle = useCallback(
-    () => (
-      <BottomSheetHeader
-        focusRef={focusRef}
-        heading={heading}
-        subText={subText}
-        logoUrl={logoUrl}
-        bottomSheetRef={bottomSheetModalRef}
-        headerNode={headerNode}
-        testID={testID}
-        bottomSheetHeaderType={bottomSheetHeaderType}
-      />
-    ),
-    [
-      bottomSheetHeaderType,
-      bottomSheetModalRef,
-      headerNode,
-      heading,
-      logoUrl,
-      subText,
-      testID,
-    ],
-  );
-
   const canRunCallbacksRef = useRef<boolean>(isOpen);
 
   const onClose = useCallback(() => {
@@ -179,10 +152,34 @@ export const BottomSheetModal = <T extends any>({
     overrideClose,
   );
 
+  const renderHandle = useCallback(
+    () => (
+      <BottomSheetHeader
+        focusRef={focusRef}
+        heading={heading}
+        subText={subText}
+        logoUrl={logoUrl}
+        onClose={() => bottomSheetModalRef.current?.dismiss()}
+        headerNode={headerNode}
+        testID={testID}
+        bottomSheetHeaderType={bottomSheetHeaderType}
+      />
+    ),
+    [
+      bottomSheetHeaderType,
+      bottomSheetModalRef,
+      headerNode,
+      heading,
+      logoUrl,
+      subText,
+      testID,
+    ],
+  );
+
   const content = useBottomSheetContent(children, footerHeight);
 
   return (
-    <GorhomBottomSheetModal<T>
+    <GorhomBottomSheetModal
       ref={internalRef}
       accessibilityViewIsModal
       importantForAccessibility="yes"
@@ -215,8 +212,8 @@ export const BottomSheetModal = <T extends any>({
   );
 };
 
-const useBottomSheetContent = <T extends any>(
-  children: BottomSheetModalChildren<T>,
+const useBottomSheetContent = (
+  children: React.ReactNode,
   footerHeight: number,
 ) => {
   const {theme} = useThemeContext();
@@ -232,22 +229,8 @@ const useBottomSheetContent = <T extends any>(
     [safeAreaBottom, theme, footerHeight],
   );
 
-  return useMemo(() => {
-    if (typeof children === 'function') {
-      const ChildrenComponent = children;
-
-      return ({data}: {data?: T | undefined}) => (
-        <BottomSheetScrollView
-          keyboardShouldPersistTaps="handled"
-          alwaysBounceVertical={false}
-          contentContainerStyle={contentContainerStyle}
-        >
-          <ChildrenComponent data={data} />
-        </BottomSheetScrollView>
-      );
-    }
-
-    return (
+  return useMemo(
+    () => (
       <BottomSheetScrollView
         keyboardShouldPersistTaps="handled"
         alwaysBounceVertical={false}
@@ -255,52 +238,27 @@ const useBottomSheetContent = <T extends any>(
       >
         {children}
       </BottomSheetScrollView>
-    );
-  }, [children, contentContainerStyle]);
+    ),
+    [children, contentContainerStyle],
+  );
 };
 
-const useInternalBottomSheetModalRef = <T extends any>(
-  externalBottomSheetModalRef: React.RefObject<BottomSheetModalMethods<T> | null>,
+const useInternalBottomSheetModalRef = (
+  externalBottomSheetModalRef: React.RefObject<BottomSheetModalMethods | null>,
   onClose: () => void,
   onOpen: () => void,
   overrideClose: () => boolean,
 ) => {
-  const internalRef = useRef<BottomSheetModalMethods<T>>(null);
+  const internalRef = useRef<GorhomBottomSheetModalMethods>(null);
 
-  useImperativeHandle(externalBottomSheetModalRef, (): BottomSheetModalMethods<T> => {
+  useImperativeHandle(externalBottomSheetModalRef, (): BottomSheetModalMethods => {
     return {
-      present: (data?: T) => internalRef.current?.present(data) && onOpen(),
-      dismiss: (animationConfigs?: SpringConfig | TimingConfig | undefined) => {
+      present: () => internalRef.current?.present() && onOpen(),
+      dismiss: () => {
         if (overrideClose()) {
           return;
         }
-        return internalRef.current?.dismiss(animationConfigs) && onClose();
-      },
-      snapToIndex: (
-        index: number,
-        animationConfigs?: SpringConfig | TimingConfig | undefined,
-      ) => internalRef.current?.snapToIndex(index, animationConfigs),
-      snapToPosition: (
-        position: string | number,
-        animationConfigs?: SpringConfig | TimingConfig | undefined,
-      ) => internalRef.current?.snapToPosition(position, animationConfigs),
-      expand: (animationConfigs?: SpringConfig | TimingConfig | undefined) =>
-        internalRef.current?.expand(animationConfigs),
-      collapse: (animationConfigs?: SpringConfig | TimingConfig | undefined) =>
-        internalRef.current?.collapse(animationConfigs),
-      close: (animationConfigs?: SpringConfig | TimingConfig | undefined) => {
-        if (overrideClose()) {
-          return;
-        }
-        return internalRef.current?.close(animationConfigs) && onClose();
-      },
-      forceClose: (
-        animationConfigs?: SpringConfig | TimingConfig | undefined,
-      ) => {
-        if (overrideClose()) {
-          return;
-        }
-        return internalRef.current?.forceClose(animationConfigs) && onClose();
+        return internalRef.current?.dismiss() && onClose();
       },
     };
   }, [internalRef, onClose, onOpen, overrideClose]);

--- a/src/components/bottom-sheet/index.ts
+++ b/src/components/bottom-sheet/index.ts
@@ -1,8 +1,7 @@
-export {BottomSheetModal} from './bottom-sheet-modal/BottomSheetModal';
+export {
+  BottomSheetModal,
+  type BottomSheetModalMethods,
+} from './bottom-sheet-modal/BottomSheetModal';
 export {MapBottomSheet} from './bottom-sheet-map/MapBottomSheet';
 export {useBottomSheetContext} from './BottomSheetContext';
 export {BottomSheetHeaderType} from './use-bottom-sheet-header-type';
-// The type of the ref methods (present/dismiss/etc.) for a bottom sheet modal.
-// Re-exported here so consumers don't reach into @gorhom internals, and because
-// @gorhom no longer exports it from its package root.
-export type {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/Profile_DesignSystemScreen.tsx
@@ -47,7 +47,7 @@ import {
   BottomSheetHeaderType,
   BottomSheetModal,
 } from '@atb/components/bottom-sheet';
-import {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
+import {BottomSheetModalMethods} from '@atb/components/bottom-sheet';
 import {Settings} from '@atb/assets/svg/mono-icons/profile';
 import {statusTypeToIcon} from '@atb/utils/status-type-to-icon';
 


### PR DESCRIPTION
Expose just the currently used present() and dismiss() methods, and
drop the unused generic data typing, method parameters, and function
form children. The BottomSheetModalMethods type is now defined
locally instead of re-exported from gorhom.

BottomSheetHeader now takes an onClose callback instead of a ref,
so the header close button routes through our dismiss and respects
overrideClose.
