### PR TITLE
fix: screen reader announcement when new fare contract becomes valid

### DIFF
--- a/src/modules/fare-contracts/index.ts
+++ b/src/modules/fare-contracts/index.ts
@@ -17,6 +17,7 @@ export type {
   SupplementProductWithCount,
 } from './types';
 export {FareContractOrReservation} from './FareContractOrReservation';
+export {useAnnounceNewValidFareContract} from './use-announce-new-valid-fare-contract';
 export {
   sortFcOrReservationByCreation,
   getSortedFareContractsAndReservations,

--- a/src/modules/fare-contracts/use-announce-new-valid-fare-contract.ts
+++ b/src/modules/fare-contracts/use-announce-new-valid-fare-contract.ts
@@ -1,0 +1,67 @@
+import {useCallback, useEffect, useRef} from 'react';
+import {AccessibilityInfo} from 'react-native';
+import {FareContractType, getAvailabilityStatus} from '@atb-as/utils';
+import {
+  findReferenceDataById,
+  getReferenceDataName,
+} from '@atb/modules/configuration';
+import {useGetFareProductsQuery} from '@atb/modules/ticketing';
+import {TicketingTexts, useTranslation} from '@atb/translations';
+
+type Args = {
+  fareContracts: FareContractType[];
+  now: number;
+  isFocused: boolean;
+};
+
+/**
+ * Fires an accessibility announcement when a fare contract in the given list
+ * transitions to `valid`, either freshly purchased or newly activated. The
+ * first render is skipped, and the announcement is only spoken when the screen
+ * is focused.
+ */
+export const useAnnounceNewValidFareContract = ({
+  fareContracts,
+  now,
+  isFocused,
+}: Args) => {
+  const getMessage = useNewValidTicketMessage();
+  const seenValidIdsRef = useRef<Set<string> | undefined>(undefined);
+
+  useEffect(() => {
+    const previous = seenValidIdsRef.current;
+    const validFcs = fareContracts.filter(
+      (fc) => getAvailabilityStatus(fc, now).status === 'valid',
+    );
+    seenValidIdsRef.current = new Set(validFcs.map((fc) => fc.id));
+    if (previous === undefined) return;
+    if (!isFocused) return;
+
+    const newValid = validFcs.find((fc) => !previous.has(fc.id));
+    if (newValid) {
+      AccessibilityInfo.announceForAccessibility(getMessage(newValid));
+    }
+  }, [fareContracts, now, isFocused, getMessage]);
+};
+
+const useNewValidTicketMessage = () => {
+  const {data: preassignedFareProducts} = useGetFareProductsQuery();
+  const {t, language} = useTranslation();
+  return useCallback(
+    (fc: FareContractType) => {
+      const product = findReferenceDataById(
+        preassignedFareProducts,
+        fc.travelRights[0]?.fareProductRef,
+      );
+      const productName = product
+        ? getReferenceDataName(product, language)
+        : '';
+      return t(
+        TicketingTexts.availableFareProductsAndReservationsTab.newValidTicketAnnouncement(
+          productName,
+        ),
+      );
+    },
+    [preassignedFareProducts, language, t],
+  );
+};

--- a/src/modules/fare-contracts/use-announce-new-valid-fare-contract.ts
+++ b/src/modules/fare-contracts/use-announce-new-valid-fare-contract.ts
@@ -39,7 +39,11 @@ export const useAnnounceNewValidFareContract = ({
 
     const newValid = validFcs.find((fc) => !previous.has(fc.id));
     if (newValid) {
-      AccessibilityInfo.announceForAccessibility(getMessage(newValid));
+      const message = getMessage(newValid);
+      // Wait 1s before queuing the announcement, so it isn't overridden by focus change events
+      setTimeout(() => {
+        AccessibilityInfo.announceForAccessibility(message);
+      }, 1000);
     }
   }, [fareContracts, now, isFocused, getMessage]);
 };

--- a/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_FareContractDetailsScreen.tsx
@@ -1,5 +1,8 @@
 import {useTicketInfo} from '@atb/components/screen-header';
-import {DetailsContent} from '@atb/modules/fare-contracts';
+import {
+  DetailsContent,
+  useAnnounceNewValidFareContract,
+} from '@atb/modules/fare-contracts';
 import {StyleSheet, useThemeContext} from '@atb/theme';
 import {
   FareContractTexts,
@@ -43,6 +46,12 @@ export function Root_FareContractDetailsScreen({navigation, route}: Props) {
   const {fareContract, preassignedFareProduct} = useTicketInfo(
     route.params.fareContractId,
   );
+
+  useAnnounceNewValidFareContract({
+    fareContracts: fareContract ? [fareContract] : [],
+    now: serverNow,
+    isFocused,
+  });
 
   const isSentFareContract =
     fareContract?.customerAccountId !== fareContract?.purchasedBy &&

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_TicketTabNavStack/TicketTabNav_AvailableFareContractsTabScreen.tsx
@@ -6,7 +6,10 @@ import {
 } from '@atb/modules/ticketing';
 import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
-import {FareContractAndReservationsList} from '@atb/modules/fare-contracts';
+import {
+  FareContractAndReservationsList,
+  useAnnounceNewValidFareContract,
+} from '@atb/modules/fare-contracts';
 import {useTranslation, TicketingTexts, dictionary} from '@atb/translations';
 import {useAnalyticsContext} from '@atb/modules/analytics';
 import {useTimeContext} from '@atb/modules/time';
@@ -53,6 +56,12 @@ export const TicketTabNav_AvailableFareContractsTabScreen = ({
   const styles = useStyles();
   const {t} = useTranslation();
   const {scrollHandler} = useTabScrollHandler(1);
+
+  useAnnounceNewValidFareContract({
+    fareContracts: availableFareContracts,
+    now: serverNow,
+    isFocused: isFocused,
+  });
 
   const onPressChangeButton = () =>
     navigation.navigate('Root_SelectTravelTokenScreen');

--- a/src/translations/screens/Ticketing.ts
+++ b/src/translations/screens/Ticketing.ts
@@ -121,6 +121,12 @@ const TicketingTexts = {
       'When you buy a ticket, it will show up here. ',
       'Når du kjøper ein billett, vil han visast her. ',
     ),
+    newValidTicketAnnouncement: (productName: string) =>
+      _(
+        `${productName} er nå gyldig`,
+        `${productName} is now valid`,
+        `${productName} er no gyldig`,
+      ),
   },
   purchaseHistory: {
     title: _('Kjøpshistorikk', 'Purchase history', 'Kjøpshistorikk'),


### PR DESCRIPTION
Moving screen reader focus (e.g. to the Billetter header) after activating or
consuming a fare contract does not work reliably on the "My tickets" list. When
a fare contract transitions to valid the list re-renders, which drops screen
reader focus no matter where it is on the page.

Instead, watch the available fare contracts for a new valid entry and post an
accessibility announcement with the product name. The same is done on the
details screen.
