### PR TITLE
fix: bonus product operator list include no duplicates

### DIFF
--- a/src/modules/bonus/components/BonusProductList.tsx
+++ b/src/modules/bonus/components/BonusProductList.tsx
@@ -64,13 +64,17 @@ export const BonusProductList = ({
         const formFactors = getFormFactorsFromTransportMode(
           group.transportMode,
         );
-        const operatorNames = memberProducts
-          .map(
-            (bp) =>
-              mobilityOperators?.find((op) => op.id === bp.operatorId)?.name,
-          )
-          .filter(Boolean)
-          .join(', ');
+        const operatorNames = [
+          ...new Set(
+            memberProducts
+              .map(
+                (bp) =>
+                  mobilityOperators?.find((op) => op.id === bp.operatorId)
+                    ?.name,
+              )
+              .filter((name): name is string => !!name),
+          ),
+        ].join(', ');
         const showMapButton = !!onNavigateToMap && formFactors.length > 0;
 
         return (


### PR DESCRIPTION

## Description
Bonus product operator list can no longer include duplicates

Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5ae11335-a54d-4e28-8637-759e0960b2d0" />

After: 
<img width="200" lt="image" src="https://github.com/user-attachments/assets/24643a88-4c6d-403d-a57a-d3904b2133fd" />
