### PR TITLE
fix: remove unused bonus texts

### DIFF
--- a/src/modules/configuration/FirestoreConfigurationContext.tsx
+++ b/src/modules/configuration/FirestoreConfigurationContext.tsx
@@ -27,7 +27,6 @@ import {
   OperatorBenefitIdType,
   FirestoreConfigStatus,
   NotificationConfigType,
-  BonusTextsType,
   ConsentLineType,
   CompiledKnownQrCodeUrl,
   RefundReasonType,
@@ -40,7 +39,6 @@ import {
   mapToHarborConnectionOverride,
   mapToMobilityOperators,
   mapToShmoFaqs,
-  mapToBonusTexts,
   mapToBenefitIdsRequiringValueCode,
   mapToNotificationConfig,
   mapToTransportModeFilterOptions,
@@ -85,7 +83,6 @@ type ConfigurationContextState = {
   bicycleFaqs: ShmoFaqType[] | undefined;
   scooterConsentLines: ConsentLineType[] | undefined;
   bicycleConsentLines: ConsentLineType[] | undefined;
-  bonusTexts: BonusTextsType | undefined;
   benefitIdsRequiringValueCode: OperatorBenefitIdType[] | undefined;
   harborConnectionOverrides: HarborConnectionOverrideType[] | undefined;
   firestoreConfigStatus: FirestoreConfigStatus;
@@ -139,7 +136,6 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
   const [bicycleConsentLines, setBicycleConsentLines] = useState<
     ConsentLineType[]
   >([]);
-  const [bonusTexts, setBonusTexts] = useState<BonusTextsType>();
   const [benefitIdsRequiringValueCode, setBenefitIdsRequiringValueCode] =
     useState<OperatorBenefitIdType[]>([]);
   const [harborConnectionOverrides, setHarborConnectionOverrides] = useState<
@@ -257,11 +253,6 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
             setBicycleConsentLines(bicycleConsentLines);
           }
 
-          const bonusTexts = getBonusTextsFromSnapshot(snapshot);
-          if (bonusTexts) {
-            setBonusTexts(bonusTexts);
-          }
-
           const benefitIdsRequiringValueCode =
             getBenefitIdsRequiringValueCodeFromSnapshot(snapshot);
           if (benefitIdsRequiringValueCode) {
@@ -353,7 +344,6 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
       bicycleFaqs,
       scooterConsentLines,
       bicycleConsentLines,
-      bonusTexts,
       benefitIdsRequiringValueCode,
       harborConnectionOverrides,
       notificationConfig,
@@ -381,7 +371,6 @@ export const FirestoreConfigurationContextProvider = ({children}: Props) => {
     bicycleFaqs,
     scooterConsentLines,
     bicycleConsentLines,
-    bonusTexts,
     benefitIdsRequiringValueCode,
     harborConnectionOverrides,
     notificationConfig,
@@ -715,13 +704,6 @@ function getBicycleConsentLinesFromSnapshot(
 ): ConsentLineType[] | undefined {
   const consentLines = snapshot.docs.find((doc) => doc.id == 'mobility');
   return mapToConsentLines(consentLines?.get('bicycleConsentLines'));
-}
-
-function getBonusTextsFromSnapshot(
-  snapshot: FirebaseFirestoreTypes.QuerySnapshot,
-): BonusTextsType | undefined {
-  const texts = snapshot.docs.find((doc) => doc.id == 'mobility');
-  return mapToBonusTexts(texts?.get('bonusTexts'));
 }
 
 function getBenefitIdsRequiringValueCodeFromSnapshot(

--- a/src/modules/configuration/converters.ts
+++ b/src/modules/configuration/converters.ts
@@ -9,7 +9,6 @@ import {
   FareProductGroupType,
   OperatorBenefitId,
   ShmoFaq,
-  BonusTexts,
   ConsentLine,
 } from './types';
 import {LanguageAndTextType} from '@atb/translations/types';
@@ -211,16 +210,6 @@ export function mapToConsentLines(consentLines?: any) {
       return parseResult.data;
     })
     .filter(isDefined);
-}
-
-export function mapToBonusTexts(bonusTexts?: any) {
-  if (!bonusTexts) return;
-  const parseResult = BonusTexts.safeParse(bonusTexts);
-  if (!parseResult.success) {
-    console.warn(`mapToBonusTexts failed safeParsing:\n`, parseResult.error);
-    return;
-  }
-  return parseResult.data;
 }
 
 export function mapToBenefitIdsRequiringValueCode(


### PR DESCRIPTION
Resolves https://github.com/AtB-AS/kundevendt/issues/24057

Remove the unused (setup for) texts for Bonus from Firestore.

config-specs: https://github.com/AtB-AS/config-specs/pull/201
firestore-configuration: https://github.com/AtB-AS/firestore-configuration/pull/1117

Co-authored-by: Jorunn Leithe <jorunn@selbu.org>