### PR TITLE
fix: bonus balance button moves down on large text

### DIFF
--- a/src/modules/bonus/components/BonusBalanceButton.tsx
+++ b/src/modules/bonus/components/BonusBalanceButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {StyleProp, ViewStyle} from 'react-native';
 import {Button} from '@atb/components/button';
 import {useThemeContext} from '@atb/theme';
 import {BonusProgramTexts, useTranslation} from '@atb/translations';
@@ -7,9 +8,13 @@ import {BonusStarFill} from './BonusStarFill';
 
 type BonusBalanceButtonProps = {
   onPress: () => void;
+  style?: StyleProp<ViewStyle>;
 };
 
-export const BonusBalanceButton = ({onPress}: BonusBalanceButtonProps) => {
+export const BonusBalanceButton = ({
+  onPress,
+  style,
+}: BonusBalanceButtonProps) => {
   const {t} = useTranslation();
   const {theme} = useThemeContext();
   const bonusInfo = useIsBonusBalanceButtonVisible();
@@ -27,6 +32,7 @@ export const BonusBalanceButton = ({onPress}: BonusBalanceButtonProps) => {
       accessibilityLabel={t(
         BonusProgramTexts.yourBonusBalanceA11yLabel(bonusInfo.bonusBalance),
       )}
+      style={style}
     />
   );
 };

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_RootScreen.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_TicketingStack/Ticketing_RootScreen.tsx
@@ -36,7 +36,10 @@ export const Ticketing_RootScreen = ({navigation}: Props) => {
           text={t(TicketingTexts.header.title)}
           isLarge={true}
         />
-        <BonusBalanceButton onPress={onNavigateToBonusScreen} />
+        <BonusBalanceButton
+          onPress={onNavigateToBonusScreen}
+          style={styles.bonusBalanceButton}
+        />
       </View>
       <Ticketing_TicketTabNavStack />
     </View>
@@ -49,9 +52,15 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   },
   headingContainer: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    rowGap: theme.spacing.small,
     paddingBottom: theme.spacing.medium,
     paddingHorizontal: theme.spacing.medium,
+  },
+  bonusBalanceButton: {
+    marginLeft: 'auto',
+    flexShrink: 1,
+    maxWidth: '100%',
   },
 }));


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/23851

## Description
BonusButton now has a styling prop, used to move it down on ticket screen for large text sizes. 
<img width="200"  alt="image" src="https://github.com/user-attachments/assets/8074da46-1011-446c-9e61-52b5e0d941d4" />
