### PR TITLE
feat: show request stop info on trip details and search results

### DIFF
--- a/src/api/types/generated/DeparturesQuery.ts
+++ b/src/api/types/generated/DeparturesQuery.ts
@@ -18,6 +18,7 @@ export type DeparturesQuery = {
       realtime: boolean;
       predictionInaccurate: boolean;
       cancellation: boolean;
+      requestStop: boolean;
       stopPositionInPattern: number;
       quay: {id: string};
       destinationDisplay?: {frontText?: string; via?: Array<string>};

--- a/src/api/types/generated/fragments/legs.ts
+++ b/src/api/types/generated/fragments/legs.ts
@@ -27,6 +27,7 @@ export type LegFragment = {
     expectedDepartureTime: any;
     stopPositionInPattern: number;
     cancellation: boolean;
+    requestStop: boolean;
     destinationDisplay?: {frontText?: string; via?: Array<string>};
     quay: {publicCode?: string; name: string};
     notices: Array<NoticeFragment>;
@@ -36,6 +37,7 @@ export type LegFragment = {
     actualArrivalTime?: any;
     stopPositionInPattern: number;
     cancellation: boolean;
+    requestStop: boolean;
     notices: Array<NoticeFragment>;
     situations: Array<SituationFragment>;
   };

--- a/src/modules/situations/utils.ts
+++ b/src/modules/situations/utils.ts
@@ -141,7 +141,8 @@ export const getSvgForMostCriticalSituationOrNotice = (
 
 /**
  * Get the most critical message type for a leg, considering situations, notices,
- * special transport submodes like RailReplacementBus, and booking requirements.
+ * special transport submodes like RailReplacementBus, booking requirements, and
+ * whether a stop request is necessary.
  */
 export const getMsgTypeForLeg = (
   leg: Leg,
@@ -158,10 +159,16 @@ export const getMsgTypeForLeg = (
       : undefined;
   const bookingMsgType: Exclude<Statuses, 'valid'> | undefined =
     leg.bookingArrangements ? 'warning' : undefined;
-  return [msgType, railReplacementBusMsgType, bookingMsgType].reduce(
-    toMostCriticalStatus,
-    undefined,
-  );
+  const requestStopMsgType: Exclude<Statuses, 'valid'> | undefined =
+    leg.fromEstimatedCall?.requestStop || leg.toEstimatedCall?.requestStop
+      ? 'info'
+      : undefined;
+  return [
+    msgType,
+    railReplacementBusMsgType,
+    bookingMsgType,
+    requestStopMsgType,
+  ].reduce(toMostCriticalStatus, undefined);
 };
 
 /**

--- a/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
+++ b/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
@@ -87,6 +87,7 @@ describe('getMsgTypeForTravelCardLeg', () => {
           expectedDepartureTime: atSeconds(0),
           stopPositionInPattern: 0,
           cancellation: false,
+          requestStop: false,
           quay: {name: 'A'},
           notices: [{id: 'notice-1', text: 'Some notice'}],
           situations: [],
@@ -105,6 +106,22 @@ describe('getMsgTypeForTravelCardLeg', () => {
     it('returns warning for a leg with booking arrangements', () => {
       const leg = makeLeg({bookingArrangements: {}} as Partial<Leg>);
       expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('warning');
+    });
+
+    it('returns info for a leg with a request stop', () => {
+      const leg = makeLeg({
+        fromEstimatedCall: {
+          aimedDepartureTime: atSeconds(0),
+          expectedDepartureTime: atSeconds(0),
+          stopPositionInPattern: 0,
+          cancellation: false,
+          requestStop: true,
+          quay: {name: 'A'},
+          notices: [],
+          situations: [],
+        },
+      });
+      expect(getMsgTypeForTravelCardLeg([leg], 0)).toBe('info');
     });
   });
 

--- a/src/screen-components/travel-card/__tests__/get-trip-pattern-status.test.ts
+++ b/src/screen-components/travel-card/__tests__/get-trip-pattern-status.test.ts
@@ -70,6 +70,7 @@ describe('getStatusTextConfig', () => {
           makeLeg({
             fromEstimatedCall: {
               cancellation: true,
+              requestStop: false,
               aimedDepartureTime: futureTime,
               expectedDepartureTime: futureTime,
               stopPositionInPattern: 0,
@@ -94,6 +95,7 @@ describe('getStatusTextConfig', () => {
           makeLeg({
             fromEstimatedCall: {
               cancellation: true,
+              requestStop: false,
               aimedDepartureTime: futureTime,
               expectedDepartureTime: futureTime,
               stopPositionInPattern: 0,
@@ -118,6 +120,7 @@ describe('getStatusTextConfig', () => {
           makeLeg({
             fromEstimatedCall: {
               cancellation: true,
+              requestStop: false,
               aimedDepartureTime: futureTime,
               expectedDepartureTime: futureTime,
               stopPositionInPattern: 0,

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -129,6 +129,11 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const routeNotices = getNoticesForRoute(leg);
   const toEstimatedCallNotices = getNoticesForToEstimatedCall(leg);
 
+  const hasFromEstimatedCallInfo =
+    !!leg.fromEstimatedCall?.requestStop || fromEstimatedCallNotices.length > 0;
+  const hasToEstimatedCallInfo =
+    !!leg.toEstimatedCall?.requestStop || toEstimatedCallNotices.length > 0;
+
   const realtimeText = useRealtimeText(leg.serviceJourneyEstimatedCalls);
 
   const {data: serviceJourneyPolyline} = useServiceJourneyPolylineQuery(
@@ -302,16 +307,32 @@ export const TripSection: React.FC<TripSectionProps> = ({
               )}
             </TripRow>
           )}
-          {fromEstimatedCallNotices.map((notice, index) => (
-            <TripRow
-              dimensionOverrides={NEW_TRIP_DIMENSIONS}
-              key={notice.id}
-              accessible={false}
-              style={[style.notice, index === 0 && style.noticeFirst]}
-            >
-              <MessageInfoText type="info" message={notice.text} />
-            </TripRow>
-          ))}
+          {hasFromEstimatedCallInfo && (
+            <View style={style.estimatedCallInfoContainer}>
+              {fromEstimatedCallNotices.map((notice) => (
+                <TripRow
+                  dimensionOverrides={NEW_TRIP_DIMENSIONS}
+                  key={notice.id}
+                  accessible={false}
+                  style={style.notice}
+                >
+                  <MessageInfoText type="info" message={notice.text} />
+                </TripRow>
+              ))}
+              {leg.fromEstimatedCall?.requestStop && (
+                <TripRow
+                  dimensionOverrides={NEW_TRIP_DIMENSIONS}
+                  accessible={false}
+                  style={style.notice}
+                >
+                  <MessageInfoText
+                    type="info"
+                    message={t(TripDetailsTexts.messages.requestStopBoarding)}
+                  />
+                </TripRow>
+              )}
+            </View>
+          )}
           {isWalkSection ? (
             <View
               accessibilityElementsHidden={fromRowAbsorbsLegA11y}
@@ -556,16 +577,32 @@ export const TripSection: React.FC<TripSectionProps> = ({
             </TripRow>
           )}
         </View>
-        {toEstimatedCallNotices.map((notice, index) => (
-          <TripRow
-            dimensionOverrides={NEW_TRIP_DIMENSIONS}
-            key={notice.id}
-            accessible={false}
-            style={[style.notice, index === 0 && style.noticeFirst]}
-          >
-            <MessageInfoText type="info" message={notice.text} />
-          </TripRow>
-        ))}
+        {hasToEstimatedCallInfo && (
+          <View style={style.estimatedCallInfoContainer}>
+            {toEstimatedCallNotices.map((notice) => (
+              <TripRow
+                dimensionOverrides={NEW_TRIP_DIMENSIONS}
+                key={notice.id}
+                accessible={false}
+                style={style.notice}
+              >
+                <MessageInfoText type="info" message={notice.text} />
+              </TripRow>
+            ))}
+            {leg.toEstimatedCall?.requestStop && (
+              <TripRow
+                dimensionOverrides={NEW_TRIP_DIMENSIONS}
+                accessible={false}
+                style={style.notice}
+              >
+                <MessageInfoText
+                  type="info"
+                  message={t(TripDetailsTexts.messages.requestStopAlighting)}
+                />
+              </TripRow>
+            )}
+          </View>
+        )}
       </View>
       <FlexibleTransportBookingDetailsSheet
         leg={leg}
@@ -1025,7 +1062,7 @@ const useSectionStyles = StyleSheet.createThemeHook((theme) => ({
   notice: {
     paddingTop: 0,
   },
-  noticeFirst: {
+  estimatedCallInfoContainer: {
     marginTop: -theme.spacing.xSmall,
   },
   intermediateNotices: {

--- a/src/screen-components/travel-details-screens/legacy/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/legacy/TripSection.tsx
@@ -5,6 +5,7 @@ import {
   ThemeText,
 } from '@atb/components/text';
 import {MessageInfoBox} from '@atb/components/message-info-box';
+import {MessageInfoText} from '@atb/components/message-info-text';
 import {ThemeIcon} from '@atb/components/theme-icon';
 import {TransportationIconBox} from '@atb/components/icon-box';
 import {ServiceJourneyDeparture} from '../types';
@@ -262,6 +263,14 @@ export const LegacyTripSection: React.FC<TripSectionProps> = ({
             )}
           </TripRow>
         )}
+        {leg.fromEstimatedCall?.requestStop && (
+          <TripRow>
+            <MessageInfoText
+              type="info"
+              message={t(TripDetailsTexts.messages.requestStopBoarding)}
+            />
+          </TripRow>
+        )}
         {leg.fromEstimatedCall?.cancellation && (
           <TripRow>
             <CancelledDepartureMessage />
@@ -379,6 +388,14 @@ export const LegacyTripSection: React.FC<TripSectionProps> = ({
             <ThemeText testID={`${testID}ToPlaceName`}>
               {getPlaceName(leg.toPlace)}
             </ThemeText>
+          </TripRow>
+        )}
+        {leg.toEstimatedCall?.requestStop && (
+          <TripRow>
+            <MessageInfoText
+              type="info"
+              message={t(TripDetailsTexts.messages.requestStopAlighting)}
+            />
           </TripRow>
         )}
       </View>

--- a/src/translations/screens/subscreens/TripDetails.ts
+++ b/src/translations/screens/subscreens/TripDetails.ts
@@ -454,6 +454,16 @@ const TripDetailsTexts = {
       'Rail replacement bus',
       'Buss for tog',
     ),
+    requestStopBoarding: _(
+      'Stopper kun ved behov. Stå synlig og rekk ut hånden så føreren ser deg.',
+      'Stops on request only. Stand visibly and raise your hand so the driver can see you.',
+      'Stoppar berre ved behov. Stå synleg og rekk ut handa så føraren ser deg.',
+    ),
+    requestStopAlighting: _(
+      'Stopper kun ved behov. Si ifra til føreren eller konduktøren på forhånd.',
+      'Stops on request only. Let the driver or conductor know in advance.',
+      'Stoppar berre ved behov. Sei ifrå til føraren eller konduktøren på førehand.',
+    ),
     interchangeMainText: _(
       'Korrespondanse',
       'Correspondence',


### PR DESCRIPTION
Display "Stopper kun ved behov..." message on boarding and alighting stops
in trip details when the estimated call has requestStop set, and surface
it as an info level status on trip search result cards.

Pictures in issue.