### PR TITLE
fix: correct focus order screen reader trip details on Android

### DIFF
--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -249,6 +249,15 @@ export const TripSection: React.FC<TripSectionProps> = ({
             )}
           />
         )}
+        {/*
+          Android flattens layout-only views and re-parents their children.
+          Positions stay correct, but a11y traversal follows native child index,
+          so re-parented rows can end up in the wrong reading order.
+          Without collapsableChildren the decoration and TripRow wrappers are
+          dropped and their content is appended straight onto this container;
+          without collapsable the container itself is dropped and everything
+          lands in the section above. Both scramble the focus order.
+        */}
         <View
           style={style.legPath}
           collapsable={false}

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -249,7 +249,11 @@ export const TripSection: React.FC<TripSectionProps> = ({
             )}
           />
         )}
-        <View style={style.legPath}>
+        <View
+          style={style.legPath}
+          collapsable={false}
+          collapsableChildren={false}
+        >
           <TripLegDecoration
             dimensionOverrides={NEW_TRIP_DIMENSIONS}
             color={legColor}


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/24374

## Description
Fixes the referenced issue, which is Android-only.

Cause and fix by Claude:
```
  Cause

  React Native flattens Android views whose props are purely layout-related: the view is not
  created natively and its children are re-parented to the nearest surviving ancestor with an
  absolute frame. legPath, the TripRow wrappers and their inner columns were all eligible
  (accessible={false} does not prevent collapsing).

  Flattening keeps pixel positions correct, because each view carries its own absolute frame.
  It does not keep accessibility order correct, because Android derives the traversal order
  from the native child index alone. The two are independent, which is why the screen looked
  right while reading wrong.

  The rows that ended up misplaced are the ones whose data arrives with the refetch —
  leg.situations and leg.intermediateEstimatedCalls. Trip details renders data ?? tripPattern
  and refetches every 20s, so those rows mount after their siblings, and a re-parented child
  mounting into an already-mounted flattened parent is appended at the end instead of
  inserted at its index.

  Because it depends on mount timing, the resulting order was not stable between runs.

  Fix

  collapsableChildren={false} on the leg container keeps every TripRow wrapper and the leg
  decoration as real native views, so no child is hoisted into the container and
  late-mounting rows insert their own wrapper at the correct index. collapsable={false}
  covers the complementary case: were the container itself collapsed, its children would be
  re-parented into the section above it and the ordering problem could return.

  Flattening is Android-only, so there is no iOS impact. Layout and bounds are unchanged.
  Cost is a handful of extra native views per leg.
```