### PR TITLE
fix: handle time interval in shared mobility pricing

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -89,25 +89,25 @@ const ShmoPricingSegmentSchema = z.object({
     .number()
     .int()
     .describe(
-      'The minute at which this segment rate starts being charged (inclusive)',
+      'The minute or km at which this segment rate starts being charged (inclusive)',
     ),
   end: z
     .number()
     .int()
     .nullish()
     .describe(
-      'The minute at which the rate will no longer apply (exclusive). If not provided, the rate applies until the trip ends.',
+      'The minute or km at which the rate will no longer apply (exclusive). If not provided, the rate applies until the trip ends.',
     ),
   interval: z
     .number()
     .int()
     .describe(
-      'Interval in minutes at which the rate of this segment is reapplied. An interval of 0 indicates the rate is only charged once.',
+      'Interval in minutes or kms at which the rate of this segment is reapplied. An interval of 0 indicates the rate is only charged once.',
     ),
   rate: z
     .number()
     .describe(
-      'Rate that is charged for each minute interval after the start. Can be a negative number, indicating a discount.',
+      'Rate that is charged for each minute or km interval after the start. Can be a negative number, indicating a discount.',
     ),
 });
 

--- a/src/modules/mobility/__tests__/utils.test.ts
+++ b/src/modules/mobility/__tests__/utils.test.ts
@@ -1,0 +1,245 @@
+// `utils.ts` transitively pulls in native-module-dependent code (RN image
+// libs via `@atb/api/types/mobility`, and theme/native-bridges via
+// `@atb/theme/ThemedAssets` and `@atb/modules/map`) that Jest can't run.
+// The functions tested here don't touch any of that, so stub it out.
+jest.mock('@atb/utils/image', () => {
+  const {z} = require('zod');
+  return {Base64ImageSchema: z.string()};
+});
+jest.mock('@atb/modules/map', () => ({
+  getVisibleRange: jest.fn(),
+  toFeaturePoint: jest.fn(),
+}));
+jest.mock('@atb/theme/ThemedAssets', () => ({
+  ThemedElectricCityBike: {},
+  ThemedScooter: {},
+}));
+
+import {Language, TranslateFunction} from '@atb/translations';
+import type {PriceAdjustmentType} from '@atb/api/types/benefit';
+import type {
+  ShmoPricingPlan,
+  ShmoPricingSegment,
+} from '@atb/api/types/mobility';
+import {
+  computeFreeMinuteCount,
+  formatMinuteBoundaryWithUnit,
+  formatMinuteRange,
+  formatRatePerUnit,
+  hasMultiplePricingPlans,
+} from '../utils';
+
+const t: TranslateFunction = (arg) => arg[Language.Norwegian];
+
+const segment = (
+  overrides: Partial<ShmoPricingSegment>,
+): ShmoPricingSegment => ({
+  start: 0,
+  end: null,
+  interval: 1,
+  rate: 0,
+  ...overrides,
+});
+
+const freeMinutesAdjustment = (amount: number): PriceAdjustmentType => ({
+  amount,
+  type: 'FREE_MINUTES',
+  description: '',
+});
+
+describe('formatRatePerUnit', () => {
+  it('formats a per-minute rate from the first perMinPricing segment', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 8,
+      perMinPricing: [
+        segment({interval: 1, rate: 1}),
+        segment({start: 20, interval: 1, rate: 2}),
+      ],
+    };
+    expect(formatRatePerUnit(plan, Language.Norwegian)).toEqual({
+      rate: 1,
+      formattedRate: '1 kr',
+      perUnit: 'min',
+      interval: 1,
+    });
+  });
+
+  it('falls back to perKmPricing when there is no perMinPricing', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 0,
+      perKmPricing: [segment({interval: 1, rate: 3})],
+    };
+    expect(formatRatePerUnit(plan, Language.Norwegian)).toEqual({
+      rate: 3,
+      formattedRate: '3 kr',
+      perUnit: 'km',
+      interval: 1,
+    });
+  });
+
+  it('prefers perMinPricing over perKmPricing when both are present', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 0,
+      perMinPricing: [segment({interval: 1, rate: 1})],
+      perKmPricing: [segment({interval: 1, rate: 3})],
+    };
+    expect(formatRatePerUnit(plan, Language.Norwegian)?.perUnit).toBe('min');
+  });
+
+  it('returns undefined when neither pricing array is present', () => {
+    const plan: ShmoPricingPlan = {currency: 'NOK', price: 8};
+    expect(formatRatePerUnit(plan, Language.Norwegian)).toBeUndefined();
+  });
+
+  it('formats a decimal rate with the currency symbol and language locale', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'GBP',
+      price: 0,
+      perKmPricing: [segment({interval: 1, rate: 2.5})],
+    };
+    expect(formatRatePerUnit(plan, Language.Norwegian)?.formattedRate).toBe(
+      '2,50 £',
+    );
+    expect(formatRatePerUnit(plan, Language.English)?.formattedRate).toBe(
+      '2.50 £',
+    );
+  });
+});
+
+describe('hasMultiplePricingPlans', () => {
+  it('is falsy for a single perMinPricing segment and no perKmPricing', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 0,
+      perMinPricing: [segment({})],
+    };
+    expect(hasMultiplePricingPlans(plan)).toBeFalsy();
+  });
+
+  it('is truthy when both perMinPricing and perKmPricing are present', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 0,
+      perMinPricing: [segment({})],
+      perKmPricing: [segment({})],
+    };
+    expect(hasMultiplePricingPlans(plan)).toBeTruthy();
+  });
+
+  it('is truthy when perMinPricing has more than one segment', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 0,
+      perMinPricing: [segment({end: 10}), segment({start: 10})],
+    };
+    expect(hasMultiplePricingPlans(plan)).toBeTruthy();
+  });
+
+  it('is truthy when perKmPricing has more than one segment', () => {
+    const plan: ShmoPricingPlan = {
+      currency: 'NOK',
+      price: 0,
+      perKmPricing: [segment({end: 5}), segment({start: 5})],
+    };
+    expect(hasMultiplePricingPlans(plan)).toBeTruthy();
+  });
+});
+
+describe('formatMinuteBoundaryWithUnit', () => {
+  it('adds the unit for minutes under an hour', () => {
+    expect(formatMinuteBoundaryWithUnit(12, t)).toBe('12 min');
+  });
+
+  it('formats exactly one hour without a minutes remainder', () => {
+    expect(formatMinuteBoundaryWithUnit(60, t)).toBe('1 time');
+  });
+
+  it('formats an hour-and-minutes boundary', () => {
+    expect(formatMinuteBoundaryWithUnit(90, t)).toBe('1 time 30 min');
+  });
+
+  it('formats multiple hours with a minutes remainder', () => {
+    expect(formatMinuteBoundaryWithUnit(125, t)).toBe('2 timer 5 min');
+  });
+});
+
+describe('formatMinuteRange', () => {
+  it('shows the unit once when both boundaries are under an hour', () => {
+    expect(formatMinuteRange(0, 45, t)).toBe('0-45 min');
+  });
+
+  it('shows the unit once when both boundaries are whole hours', () => {
+    expect(formatMinuteRange(60, 300, t)).toBe('1-5 timer');
+  });
+
+  it('spells out both boundaries when they cross the hour threshold', () => {
+    expect(formatMinuteRange(30, 60, t)).toBe('30 min-1 time');
+  });
+
+  it('spells out both boundaries when the end has a minutes remainder', () => {
+    expect(formatMinuteRange(45, 95, t)).toBe('45 min-1 time 35 min');
+  });
+
+  it('spells out both boundaries when neither is a whole hour', () => {
+    expect(formatMinuteRange(90, 150, t)).toBe('1 time 30 min-2 timer 30 min');
+  });
+});
+
+describe('computeFreeMinuteCount', () => {
+  it('converts a budget into minutes for a plain per-minute segment', () => {
+    const perMinPricing = [segment({interval: 1, rate: 1})];
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-50), perMinPricing),
+    ).toBe(50);
+  });
+
+  it('rounds down to whole intervals for a non-1-minute interval', () => {
+    // budget 12, rate 5 per 30-min interval -> only 2 intervals (10 kr) fit
+    const perMinPricing = [segment({interval: 30, rate: 5})];
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-12), perMinPricing),
+    ).toBe(60);
+  });
+
+  it('treats interval 0 as a one-time fee covering the whole segment', () => {
+    const perMinPricing = [segment({end: 10, interval: 0, rate: 8})];
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-10), perMinPricing),
+    ).toBe(10);
+  });
+
+  it('skips a one-time-fee segment entirely when the budget is too small', () => {
+    const perMinPricing = [segment({end: 10, interval: 0, rate: 8})];
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-5), perMinPricing),
+    ).toBe(0);
+  });
+
+  it('treats a zero-or-negative rate segment as fully free', () => {
+    const perMinPricing = [segment({end: 20, interval: 1, rate: 0})];
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-1), perMinPricing),
+    ).toBe(20);
+  });
+
+  it('spends the remaining budget on a later segment once the first is exhausted', () => {
+    const perMinPricing = [
+      segment({end: 10, interval: 1, rate: 2}),
+      segment({start: 10, interval: 1, rate: 5}),
+    ];
+    // First 10 min cost 20, leaving 5 -> 1 more minute at 5/min = 11 total.
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-25), perMinPricing),
+    ).toBe(11);
+  });
+
+  it('caps the result at 180 minutes', () => {
+    const perMinPricing = [segment({interval: 1, rate: 1})];
+    expect(
+      computeFreeMinuteCount(freeMinutesAdjustment(-300), perMinPricing),
+    ).toBe(180);
+  });
+});

--- a/src/modules/mobility/components/PriceDetailsCard.tsx
+++ b/src/modules/mobility/components/PriceDetailsCard.tsx
@@ -17,6 +17,7 @@ import {
 } from '@atb/translations/screens/subscreens/MobilityTexts';
 import {
   computeFreeMinuteCount,
+  formatMinuteBoundary,
   formatRatePerUnit,
   getFreeMinutes,
   getFreeUnlock,
@@ -56,6 +57,10 @@ export const PriceDetailsCard = ({
 
   const hasFreeMinutes = !!(freeMinutes && pricingPlan.perMinPricing?.length);
 
+  const freeMinuteCount = hasFreeMinutes
+    ? computeFreeMinuteCount(freeMinutes!, pricingPlan.perMinPricing!)
+    : 0;
+
   const minutePriceStat = hasFreeMinutes
     ? zeroAmount
     : ratePrUnit?.formattedRate;
@@ -63,10 +68,16 @@ export const PriceDetailsCard = ({
   const minutePriceDescription = hasFreeMinutes
     ? t(
         ScooterTexts.freeMinutesDescription(
-          computeFreeMinuteCount(freeMinutes!, pricingPlan.perMinPricing!),
+          `${formatMinuteBoundary(freeMinuteCount, t)}${freeMinuteCount < 60 ? ' min' : ''}`,
         ),
       )
-    : t(ScooterTexts.per.unit(ratePrUnit?.perUnit ?? ''));
+    : ratePrUnit
+      ? t(
+          ratePrUnit.perUnit === 'min'
+            ? ScooterTexts.per.intervalMin(ratePrUnit.interval)
+            : ScooterTexts.per.intervalKm(ratePrUnit.interval),
+        )
+      : '';
 
   const benefitTitle = getTextForLanguage(benefit?.title, language);
   const benefitDescription = getTextForLanguage(benefit?.description, language);

--- a/src/modules/mobility/components/PriceDetailsCard.tsx
+++ b/src/modules/mobility/components/PriceDetailsCard.tsx
@@ -11,10 +11,7 @@ import {Unlock, PricePerTime} from '@atb/assets/svg/mono-icons/mobility';
 import {VehicleCardStat} from './VehicleCardStat';
 import {ThemeText} from '@atb/components/text';
 import {BenefitIllustration} from './BenefitIllustration';
-import {
-  MobilityTexts,
-  ScooterTexts,
-} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {
   computeFreeMinuteCount,
   formatMinuteBoundary,
@@ -67,15 +64,15 @@ export const PriceDetailsCard = ({
 
   const minutePriceDescription = hasFreeMinutes
     ? t(
-        ScooterTexts.freeMinutesDescription(
+        MobilityTexts.pricingDetails.freeMinutesDescription(
           `${formatMinuteBoundary(freeMinuteCount, t)}${freeMinuteCount < 60 ? ' min' : ''}`,
         ),
       )
     : ratePrUnit
       ? t(
           ratePrUnit.perUnit === 'min'
-            ? ScooterTexts.per.intervalMin(ratePrUnit.interval)
-            : ScooterTexts.per.intervalKm(ratePrUnit.interval),
+            ? MobilityTexts.pricingDetails.intervalMin(ratePrUnit.interval)
+            : MobilityTexts.pricingDetails.intervalKm(ratePrUnit.interval),
         )
       : '';
 
@@ -91,7 +88,7 @@ export const PriceDetailsCard = ({
             <VehicleCardStat
               icon={Unlock}
               stat={unlockStat}
-              description={t(ScooterTexts.unlock)}
+              description={t(MobilityTexts.pricingDetails.unlockDescription)}
               hasPriceAdjustment={!!freeUnlock}
             />
             {minutePriceStat && (

--- a/src/modules/mobility/components/PriceDetailsCard.tsx
+++ b/src/modules/mobility/components/PriceDetailsCard.tsx
@@ -14,7 +14,7 @@ import {BenefitIllustration} from './BenefitIllustration';
 import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {
   computeFreeMinuteCount,
-  formatMinuteBoundary,
+  formatMinuteBoundaryWithUnit,
   formatRatePerUnit,
   getFreeMinutes,
   getFreeUnlock,
@@ -65,7 +65,7 @@ export const PriceDetailsCard = ({
   const minutePriceDescription = hasFreeMinutes
     ? t(
         MobilityTexts.pricingDetails.freeMinutesDescription(
-          `${formatMinuteBoundary(freeMinuteCount, t)}${freeMinuteCount < 60 ? ' min' : ''}`,
+          formatMinuteBoundaryWithUnit(freeMinuteCount, t),
         ),
       )
     : ratePrUnit

--- a/src/modules/mobility/components/VehicleCard.tsx
+++ b/src/modules/mobility/components/VehicleCard.tsx
@@ -5,7 +5,7 @@ import {GenericSectionItem, Section} from '@atb/components/sections';
 import {View} from 'react-native';
 import {BatteryHigh} from '@atb/assets/svg/mono-icons/miscellaneous';
 import {VehicleCardStat} from './VehicleCardStat';
-import {ScooterTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {
   formatRange,
   getBatteryLevelIcon,
@@ -41,7 +41,7 @@ export const VehicleCard = ({
                 : BatteryHigh
             }
             stat={formatRange(currentRangeMeters, language)}
-            description={t(ScooterTexts.range)}
+            description={t(MobilityTexts.rangeLabel)}
           />
           {!!ThemedIllustration && (
             <ThemedIllustration width={50} height={50} />

--- a/src/modules/mobility/index.ts
+++ b/src/modules/mobility/index.ts
@@ -42,6 +42,7 @@ export {useDeleteAgeVerificationMutation} from './queries/use-remove-age-verific
 export {
   computeFreeMinuteCount,
   findOperatorBrandImageUrl,
+  formatMinuteBoundary,
   getAvailableVehicles,
   getFormFactorsFromTransportMode,
   getFreeMinutes,

--- a/src/modules/mobility/index.ts
+++ b/src/modules/mobility/index.ts
@@ -42,7 +42,8 @@ export {useDeleteAgeVerificationMutation} from './queries/use-remove-age-verific
 export {
   computeFreeMinuteCount,
   findOperatorBrandImageUrl,
-  formatMinuteBoundary,
+  formatMinuteBoundaryWithUnit,
+  formatMinuteRange,
   getAvailableVehicles,
   getFormFactorsFromTransportMode,
   getFreeMinutes,

--- a/src/modules/mobility/types.ts
+++ b/src/modules/mobility/types.ts
@@ -14,7 +14,8 @@ export type ShmoRequirementType = {
 export type FormattedRatePerUnit = {
   formattedRate: string;
   rate: number;
-  perUnit: string;
+  perUnit: 'min' | 'km';
+  interval: number;
 };
 
 export type VehicleSortOptions = 'currentRangeMeters' | '-currentRangeMeters';

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -15,7 +15,8 @@ import {
   PropulsionType,
 } from '@atb/api/types/generated/mobility-types_v2';
 import {AnyMode, AnySubMode} from '@atb/components/icon-box';
-import {dictionary, Language} from '@atb/translations';
+import {dictionary, Language, TranslateFunction} from '@atb/translations';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {enumFromString} from '@atb/utils/enum-from-string';
 import {MobilityOperatorType} from '@atb-as/config-specs/lib/mobility';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
@@ -205,6 +206,19 @@ export const hasMultiplePricingPlans = (plan: ShmoPricingPlan) =>
   (plan.perKmPricing && plan.perKmPricing.length > 1) ||
   (plan.perMinPricing && plan.perMinPricing.length > 1);
 
+export const formatMinuteBoundary = (
+  minutes: number,
+  t: TranslateFunction,
+): string =>
+  minutes < 60
+    ? `${minutes}`
+    : t(
+        MobilityTexts.pricingDetails.minutesAsHoursAndMinutes(
+          Math.floor(minutes / 60),
+          minutes % 60,
+        ),
+      );
+
 export const formatRange = (rangeInMeters: number, language: Language) => {
   const rangeInKm =
     rangeInMeters > 5000
@@ -251,12 +265,14 @@ export const formatRatePerUnit = (
       rate: perMinPrice.rate,
       formattedRate: `${formatNumberToString(perMinPrice.rate, language)} ${getCurrencySymbol(pricingPlan.currency)}`,
       perUnit: 'min',
+      interval: perMinPrice.interval,
     };
   } else if (perKmPrice) {
     return {
       rate: perKmPrice.rate,
       formattedRate: `${formatNumberToString(perKmPrice.rate, language)} ${getCurrencySymbol(pricingPlan.currency)}`,
       perUnit: 'km',
+      interval: perKmPrice.interval,
     };
   }
   return undefined;
@@ -300,9 +316,24 @@ export const computeFreeMinuteCount = (
       total += segLengthMin;
       continue;
     }
-    const minutes = Math.min(Math.floor(budget / segment.rate), segLengthMin);
+    if (segment.interval === 0) {
+      // Rate is charged once for the whole segment, not per minute.
+      if (budget < segment.rate) continue;
+      total += segLengthMin;
+      budget -= segment.rate;
+      continue;
+    }
+    const maxIntervalsInSegment =
+      segLengthMin === Infinity
+        ? Infinity
+        : Math.ceil(segLengthMin / segment.interval);
+    const intervals = Math.min(
+      Math.floor(budget / segment.rate),
+      maxIntervalsInSegment,
+    );
+    const minutes = Math.min(intervals * segment.interval, segLengthMin);
     total += minutes;
-    budget -= minutes * segment.rate;
+    budget -= intervals * segment.rate;
   }
   return Math.min(total, 180);
 };

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -213,7 +213,7 @@ export const formatMinuteBoundary = (
   minutes < 60
     ? `${minutes}`
     : t(
-        MobilityTexts.pricingDetails.minutesAsHoursAndMinutes(
+        MobilityTexts.pricingDetails.hoursAndMinutes(
           Math.floor(minutes / 60),
           minutes % 60,
         ),

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -206,18 +206,38 @@ export const hasMultiplePricingPlans = (plan: ShmoPricingPlan) =>
   (plan.perKmPricing && plan.perKmPricing.length > 1) ||
   (plan.perMinPricing && plan.perMinPricing.length > 1);
 
-export const formatMinuteBoundary = (
+export const formatMinuteBoundaryWithUnit = (
   minutes: number,
   t: TranslateFunction,
 ): string =>
   minutes < 60
-    ? `${minutes}`
+    ? `${minutes} ${t(dictionary.date.units.short.minute)}`
     : t(
         MobilityTexts.pricingDetails.hoursAndMinutes(
           Math.floor(minutes / 60),
           minutes % 60,
         ),
       );
+
+/**
+ * Formats a minute range for display, collapsing the unit to a single
+ * trailing occurrence when both boundaries share it (e.g. "0-45 min",
+ * "1-5 timer"), and spelling out both boundaries when they don't
+ * (e.g. "30 min-1 time").
+ */
+export const formatMinuteRange = (
+  start: number,
+  end: number,
+  t: TranslateFunction,
+): string => {
+  if (end < 60) {
+    return `${start}-${end} ${t(dictionary.date.units.short.minute)}`;
+  }
+  if (start >= 60 && start % 60 === 0 && end % 60 === 0) {
+    return `${start / 60}-${formatMinuteBoundaryWithUnit(end, t)}`;
+  }
+  return `${formatMinuteBoundaryWithUnit(start, t)}-${formatMinuteBoundaryWithUnit(end, t)}`;
+};
 
 export const formatRange = (rangeInMeters: number, language: Language) => {
   const rangeInKm =

--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {ScrollView, View} from 'react-native';
 import {RootStackScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
-import {useTranslation} from '@atb/translations';
+import {dictionary, useTranslation} from '@atb/translations';
 import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
@@ -74,8 +74,8 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
       if (segment.end != null) {
         const rangeText =
           unit === 'min'
-            ? `${formatMinuteBoundary(effectiveStart, t)}-${formatMinuteBoundary(segment.end, t)}${segment.end < 60 ? ' min' : ''}`
-            : `${effectiveStart}-${segment.end} km`;
+            ? `${formatMinuteBoundary(effectiveStart, t)}-${formatMinuteBoundary(segment.end, t)}${segment.end < 60 ? ` ${t(dictionary.date.units.short.minute)}` : ''}`
+            : `${effectiveStart}-${segment.end} ${t(dictionary.distance.km)}`;
         return t(
           MobilityTexts.pricingDetails.pricePerIntervalRange(
             intervalPhrase,
@@ -85,8 +85,8 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
       } else {
         const fromText =
           unit === 'min'
-            ? `${formatMinuteBoundary(effectiveStart, t)}${effectiveStart < 60 ? ' min' : ''}`
-            : `${effectiveStart} km`;
+            ? `${formatMinuteBoundary(effectiveStart, t)}${effectiveStart < 60 ? ` ${t(dictionary.date.units.short.minute)}` : ''}`
+            : `${effectiveStart} ${t(dictionary.distance.km)}`;
         return t(
           MobilityTexts.pricingDetails.pricePerIntervalFrom(
             intervalPhrase,

--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -59,6 +59,9 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
         )
       : 0;
 
+  const formatPrice = (amount: number): string =>
+    `${formatNumberToString(amount, language)} ${currency}`;
+
   const getSegmentLabel = (
     segment: ShmoPricingSegment,
     effectiveStart: number,
@@ -102,8 +105,8 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
     label: t(MobilityTexts.pricingDetails.unlock),
     value:
       hasCampaign && freeUnlockPriceAdjustment
-        ? `0 ${currency}`
-        : `${formatNumberToString(pricingPlan.price, language)} ${currency}`,
+        ? formatPrice(0)
+        : formatPrice(pricingPlan.price),
   });
 
   if (hasCampaign && freeMinutesPriceAdjustment && freeMinCount > 0) {
@@ -114,7 +117,7 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
         'min',
         true,
       ),
-      value: `0 ${currency}`,
+      value: formatPrice(0),
     });
   }
 
@@ -130,7 +133,7 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
           'min',
           hasMultiplePerMinPricingPlans,
         ),
-        value: `${formatNumberToString(seg.rate, language)} ${currency}`,
+        value: formatPrice(seg.rate),
       });
     });
 
@@ -142,7 +145,7 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
         'km',
         hasMultiplePerKmPricingPlans,
       ),
-      value: `${formatNumberToString(seg.rate, language)} ${currency}`,
+      value: formatPrice(seg.rate),
     });
   });
 
@@ -205,7 +208,7 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
     flexShrink: 1,
   },
   value: {
-    flexShrink: 1,
+    flexShrink: 0,
     textAlign: 'right',
   },
   sectionLabel: {

--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -3,10 +3,7 @@ import {ScrollView, View} from 'react-native';
 import {RootStackScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {useTranslation} from '@atb/translations';
-import {
-  MobilityTexts,
-  ScooterTexts,
-} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -70,8 +67,8 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
   ): string => {
     const intervalPhrase = t(
       unit === 'min'
-        ? ScooterTexts.per.intervalMin(segment.interval)
-        : ScooterTexts.per.intervalKm(segment.interval),
+        ? MobilityTexts.pricingDetails.intervalMin(segment.interval)
+        : MobilityTexts.pricingDetails.intervalKm(segment.interval),
     );
     if (hasMultipleSegments || effectiveStart > 0) {
       if (segment.end != null) {

--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -3,7 +3,10 @@ import {ScrollView, View} from 'react-native';
 import {RootStackScreenProps} from './navigation-types';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
 import {useTranslation} from '@atb/translations';
-import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {
+  MobilityTexts,
+  ScooterTexts,
+} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {GenericSectionItem, Section} from '@atb/components/sections';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet, useThemeContext} from '@atb/theme';
@@ -14,7 +17,10 @@ import {getCurrencySymbol} from '@atb/translations/currency';
 import {ShmoPricingSegment} from '@atb/api/types/mobility';
 import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import type {PriceAdjustmentType} from '@atb/api/types/benefit';
-import {computeFreeMinuteCount} from '@atb/modules/mobility';
+import {
+  computeFreeMinuteCount,
+  formatMinuteBoundary,
+} from '@atb/modules/mobility';
 
 type Props = RootStackScreenProps<'Root_ShmoPricingDetailsScreen'>;
 type PricingRow = {label: string; value: string};
@@ -30,6 +36,8 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
   const rows: PricingRow[] = [];
   const hasMultiplePerMinPricingPlans =
     (pricingPlan.perMinPricing?.length ?? 0) > 1;
+  const hasMultiplePerKmPricingPlans =
+    (pricingPlan.perKmPricing?.length ?? 0) > 1;
 
   const freeUnlockPriceAdjustment = benefit?.priceAdjustments.find(
     (adj: PriceAdjustmentType) =>
@@ -51,25 +59,43 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
         )
       : 0;
 
-  const getMinuteSegmentLabel = (
-    perMinPricingSegment: ShmoPricingSegment,
-    effectiveStartMinute: number,
+  const getSegmentLabel = (
+    segment: ShmoPricingSegment,
+    effectiveStart: number,
+    unit: 'min' | 'km',
+    hasMultipleSegments: boolean,
   ): string => {
-    if (hasMultiplePerMinPricingPlans || effectiveStartMinute > 0) {
-      if (perMinPricingSegment.end != null) {
+    const intervalPhrase = t(
+      unit === 'min'
+        ? ScooterTexts.per.intervalMin(segment.interval)
+        : ScooterTexts.per.intervalKm(segment.interval),
+    );
+    if (hasMultipleSegments || effectiveStart > 0) {
+      if (segment.end != null) {
+        const rangeText =
+          unit === 'min'
+            ? `${formatMinuteBoundary(effectiveStart, t)}-${formatMinuteBoundary(segment.end, t)}${segment.end < 60 ? ' min' : ''}`
+            : `${effectiveStart}-${segment.end} km`;
         return t(
-          MobilityTexts.pricingDetails.minutePriceRange(
-            effectiveStartMinute,
-            perMinPricingSegment.end,
+          MobilityTexts.pricingDetails.pricePerIntervalRange(
+            intervalPhrase,
+            rangeText,
           ),
         );
       } else {
+        const fromText =
+          unit === 'min'
+            ? `${formatMinuteBoundary(effectiveStart, t)}${effectiveStart < 60 ? ' min' : ''}`
+            : `${effectiveStart} km`;
         return t(
-          MobilityTexts.pricingDetails.minutePriceFrom(effectiveStartMinute),
+          MobilityTexts.pricingDetails.pricePerIntervalFrom(
+            intervalPhrase,
+            fromText,
+          ),
         );
       }
     }
-    return t(MobilityTexts.pricingDetails.minutePrice);
+    return t(MobilityTexts.pricingDetails.pricePerInterval(intervalPhrase));
   };
 
   rows.push({
@@ -82,8 +108,13 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
 
   if (hasCampaign && freeMinutesPriceAdjustment && freeMinCount > 0) {
     rows.push({
-      label: t(MobilityTexts.pricingDetails.minutePriceRange(0, freeMinCount)),
-      value: `0 ${currency}/min`,
+      label: getSegmentLabel(
+        {start: 0, end: freeMinCount, interval: 1, rate: 0},
+        0,
+        'min',
+        true,
+      ),
+      value: `0 ${currency}`,
     });
   }
 
@@ -93,13 +124,27 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
     ?.filter((seg) => !hasCampaign || seg.end == null || seg.end > freeMinCount)
     .forEach((seg) => {
       rows.push({
-        label: getMinuteSegmentLabel(
+        label: getSegmentLabel(
           seg,
           hasCampaign ? Math.max(freeMinCount, seg.start) : seg.start,
+          'min',
+          hasMultiplePerMinPricingPlans,
         ),
-        value: `${formatNumberToString(seg.rate, language)} ${currency}/min`,
+        value: `${formatNumberToString(seg.rate, language)} ${currency}`,
       });
     });
+
+  pricingPlan.perKmPricing?.forEach((seg) => {
+    rows.push({
+      label: getSegmentLabel(
+        seg,
+        seg.start,
+        'km',
+        hasMultiplePerKmPricingPlans,
+      ),
+      value: `${formatNumberToString(seg.rate, language)} ${currency}`,
+    });
+  });
 
   return (
     <FullScreenView

--- a/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
+++ b/src/stacks-hierarchy/Root_ShmoPricingDetailsScreen.tsx
@@ -16,7 +16,8 @@ import {PriceAdjustmentEnum} from '@atb-as/config-specs/lib/mobility';
 import type {PriceAdjustmentType} from '@atb/api/types/benefit';
 import {
   computeFreeMinuteCount,
-  formatMinuteBoundary,
+  formatMinuteBoundaryWithUnit,
+  formatMinuteRange,
 } from '@atb/modules/mobility';
 
 type Props = RootStackScreenProps<'Root_ShmoPricingDetailsScreen'>;
@@ -74,7 +75,7 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
       if (segment.end != null) {
         const rangeText =
           unit === 'min'
-            ? `${formatMinuteBoundary(effectiveStart, t)}-${formatMinuteBoundary(segment.end, t)}${segment.end < 60 ? ` ${t(dictionary.date.units.short.minute)}` : ''}`
+            ? formatMinuteRange(effectiveStart, segment.end, t)
             : `${effectiveStart}-${segment.end} ${t(dictionary.distance.km)}`;
         return t(
           MobilityTexts.pricingDetails.pricePerIntervalRange(
@@ -85,7 +86,7 @@ export const Root_ShmoPricingDetailsScreen = ({navigation, route}: Props) => {
       } else {
         const fromText =
           unit === 'min'
-            ? `${formatMinuteBoundary(effectiveStart, t)}${effectiveStart < 60 ? ` ${t(dictionary.date.units.short.minute)}` : ''}`
+            ? formatMinuteBoundaryWithUnit(effectiveStart, t)
             : `${effectiveStart} ${t(dictionary.distance.km)}`;
         return t(
           MobilityTexts.pricingDetails.pricePerIntervalFrom(

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -1,4 +1,4 @@
-import {translation as _, Language} from '../../commons';
+import {translation as _} from '../../commons';
 import {Platform} from 'react-native';
 import {
   FormFactor,
@@ -8,8 +8,6 @@ import {
   GeofencingZoneExplanationsType,
   ParkingVehicleTypes,
 } from '@atb/modules/map';
-import {formatNumberToString} from '@atb-as/utils';
-import {getCurrencySymbol} from '@atb/translations/currency';
 
 export const MobilityTexts = {
   vehicleName: (
@@ -83,6 +81,9 @@ export const MobilityTexts = {
   pricingDetails: {
     priceInfo: _('Prisinformasjon', 'Price information', 'Prisinformasjon'),
     unlock: _('Opplåsing', 'Unlock', 'Opplåsing'),
+    unlockDescription: _('opplåsning', 'unlock', 'opplåsing'),
+    freeMinutesDescription: (durationText: string) =>
+      _(`i ${durationText}`, `for ${durationText}`, `i ${durationText}`),
     pricePerInterval: (intervalPhrase: string) =>
       _(
         `Pris ${intervalPhrase}`,
@@ -101,7 +102,7 @@ export const MobilityTexts = {
         `Price ${intervalPhrase} after ${fromText}`,
         `Pris ${intervalPhrase} etter ${fromText}`,
       ),
-    minutesAsHoursAndMinutes: (hours: number, minutes: number) => {
+    hoursAndMinutes: (hours: number, minutes: number) => {
       const nb = hours === 1 ? '1 time' : `${hours} timer`;
       const en = hours === 1 ? '1 hour' : `${hours} hours`;
       const nn = hours === 1 ? '1 time' : `${hours} timar`;
@@ -113,11 +114,50 @@ export const MobilityTexts = {
             `${nn} ${minutes} min`,
           );
     },
-    maxRentalTime: _(
-      'Makstid for leie',
-      'Max rental time',
-      'Makstid for leige',
-    ),
+    intervalMin(interval: number) {
+      if (interval === 0) {
+        return _('(engangsbeløp)', '(one-time fee)', '(eingongsbeløp)');
+      }
+      if (interval === 1) {
+        return _('per minutt', 'per minute', 'per minutt');
+      }
+      if (interval === 15) {
+        return _('per kvarter', 'per quarter hour', 'per kvarter');
+      }
+      if (interval === 30) {
+        return _('per halvtime', 'per half hour', 'per halvtime');
+      }
+      if (interval % 1440 === 0) {
+        const days = interval / 1440;
+        return days === 1
+          ? _('per døgn', 'per day', 'per døgn')
+          : _(`per ${days} døgn`, `per ${days} days`, `per ${days} døgn`);
+      }
+      if (interval % 60 === 0) {
+        const hours = interval / 60;
+        return hours === 1
+          ? _('per time', 'per hour', 'per time')
+          : _(`per ${hours} timer`, `per ${hours} hours`, `per ${hours} timar`);
+      }
+      return _(
+        `per ${interval} minutter`,
+        `per ${interval} min`,
+        `per ${interval} minuttar`,
+      );
+    },
+    intervalKm(interval: number) {
+      if (interval === 0) {
+        return _('(engangsbeløp)', '(one-time fee)', '(eingongsbeløp)');
+      }
+      if (interval === 1) {
+        return _('per kilometer', 'per kilometer', 'per kilometer');
+      }
+      return _(
+        `per ${interval} km`,
+        `per ${interval} km`,
+        `per ${interval} km`,
+      );
+    },
     campaignPrice: _('Kampanjepris', 'Campaign price', 'Kampanjepris'),
   },
   freeBikes: (amount: string) => {
@@ -382,6 +422,7 @@ export const MobilityTexts = {
       `approximately ${range} range`,
       `omlag ${range} rekkjevidde`,
     ),
+  rangeLabel: _('rekkevidde', 'range', 'rekkjevidde'),
   includedWithTheTicket: _(
     'Inkludert i billetten',
     'Included with the ticket',
@@ -467,97 +508,6 @@ export const MobilityTexts = {
           `Anna køyretøy frå ${operatorName}`,
         );
     }
-  },
-};
-
-export const ScooterTexts = {
-  seeAppForPrices: (operator: string) =>
-    _(
-      `Se ${operator}-appen for priser`,
-      `See ${operator} app for prices`,
-      `Sjå ${operator}-appen for prisar`,
-    ),
-  pricingPlan: {
-    price: (price: number, language: Language, currency?: string) =>
-      price > 0
-        ? _(
-            `+ ${formatNumberToString(price, language)} ${getCurrencySymbol(currency)} for oppstart`,
-            `+ ${formatNumberToString(price, language)} ${getCurrencySymbol(currency)} to unlock`,
-            `+ ${formatNumberToString(price, language)} ${getCurrencySymbol(currency)} for å låse opp`,
-          )
-        : _('Gratis oppstart', 'Free to unlock', 'Gratis oppstart'),
-  },
-  range: _('rekkevidde', 'range', 'rekkjevidde'),
-  unlock: _('opplåsning', 'unlock', 'opplåsing'),
-  freeMinutesDescription: (durationText: string) =>
-    _(`i ${durationText}`, `for ${durationText}`, `i ${durationText}`),
-  per: {
-    intervalMin(interval: number) {
-      if (interval === 0) {
-        return _('(engangsbeløp)', '(one-time fee)', '(eingongsbeløp)');
-      }
-      if (interval === 1) {
-        return _('per minutt', 'per minute', 'per minutt');
-      }
-      if (interval === 15) {
-        return _('per kvarter', 'per quarter hour', 'per kvarter');
-      }
-      if (interval === 30) {
-        return _('per halvtime', 'per half hour', 'per halvtime');
-      }
-      if (interval % 1440 === 0) {
-        const days = interval / 1440;
-        return days === 1
-          ? _('per døgn', 'per day', 'per døgn')
-          : _(`per ${days} døgn`, `per ${days} days`, `per ${days} døgn`);
-      }
-      if (interval % 60 === 0) {
-        const hours = interval / 60;
-        return hours === 1
-          ? _('per time', 'per hour', 'per time')
-          : _(`per ${hours} timer`, `per ${hours} hours`, `per ${hours} timar`);
-      }
-      return _(
-        `per ${interval} minutter`,
-        `per ${interval} min`,
-        `per ${interval} minuttar`,
-      );
-    },
-    intervalKm(interval: number) {
-      if (interval === 0) {
-        return _('(engangsbeløp)', '(one-time fee)', '(eingongsbeløp)');
-      }
-      if (interval === 1) {
-        return _('per kilometer', 'per kilometer', 'per kilometer');
-      }
-      return _(
-        `per ${interval} km`,
-        `per ${interval} km`,
-        `per ${interval} km`,
-      );
-    },
-    discount(unit: string, price: string, currency?: string) {
-      switch (unit) {
-        case 'min':
-          return _(
-            `så ${price}${getCurrencySymbol(currency)}/min`,
-            `then ${price}${getCurrencySymbol(currency)}/min`,
-            `så ${price}${getCurrencySymbol(currency)}/min`,
-          );
-        case 'km':
-          return _(
-            `så ${price}${getCurrencySymbol(currency)}/km`,
-            `then ${price}${getCurrencySymbol(currency)}/km`,
-            `så ${price}${getCurrencySymbol(currency)}/km`,
-          );
-        default:
-          return _(
-            `så ${price}${getCurrencySymbol(currency)}`,
-            `then ${price}${getCurrencySymbol(currency)}`,
-            `så ${price}${getCurrencySymbol(currency)}`,
-          );
-      }
-    },
   },
 };
 

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -83,19 +83,36 @@ export const MobilityTexts = {
   pricingDetails: {
     priceInfo: _('Prisinformasjon', 'Price information', 'Prisinformasjon'),
     unlock: _('Opplåsing', 'Unlock', 'Opplåsing'),
-    minutePrice: _('Minuttpris', 'Minute price', 'Minuttpris'),
-    minutePriceRange: (start: number, end: number) =>
+    pricePerInterval: (intervalPhrase: string) =>
       _(
-        `Minuttpris ${start}-${end} min`,
-        `Minute price ${start}-${end} min`,
-        `Minuttpris ${start}-${end} min`,
+        `Pris ${intervalPhrase}`,
+        `Price ${intervalPhrase}`,
+        `Pris ${intervalPhrase}`,
       ),
-    minutePriceFrom: (start: number) =>
+    pricePerIntervalRange: (intervalPhrase: string, rangeText: string) =>
       _(
-        `Minuttpris etter ${start} min`,
-        `Minute price after ${start} min`,
-        `Minuttpris etter ${start} min`,
+        `Pris ${intervalPhrase} fra ${rangeText}`,
+        `Price ${intervalPhrase} from ${rangeText}`,
+        `Pris ${intervalPhrase} frå ${rangeText}`,
       ),
+    pricePerIntervalFrom: (intervalPhrase: string, fromText: string) =>
+      _(
+        `Pris ${intervalPhrase} etter ${fromText}`,
+        `Price ${intervalPhrase} after ${fromText}`,
+        `Pris ${intervalPhrase} etter ${fromText}`,
+      ),
+    minutesAsHoursAndMinutes: (hours: number, minutes: number) => {
+      const nb = hours === 1 ? '1 time' : `${hours} timer`;
+      const en = hours === 1 ? '1 hour' : `${hours} hours`;
+      const nn = hours === 1 ? '1 time' : `${hours} timar`;
+      return minutes === 0
+        ? _(nb, en, nn)
+        : _(
+            `${nb} ${minutes} min`,
+            `${en} ${minutes} min`,
+            `${nn} ${minutes} min`,
+          );
+    },
     maxRentalTime: _(
       'Makstid for leie',
       'Max rental time',
@@ -472,18 +489,52 @@ export const ScooterTexts = {
   },
   range: _('rekkevidde', 'range', 'rekkjevidde'),
   unlock: _('opplåsning', 'unlock', 'opplåsing'),
-  freeMinutesDescription: (minutes: number) =>
-    _(`i ${minutes} min`, `for ${minutes} min`, `i ${minutes} min`),
+  freeMinutesDescription: (durationText: string) =>
+    _(`i ${durationText}`, `for ${durationText}`, `i ${durationText}`),
   per: {
-    unit(unit: string) {
-      switch (unit) {
-        case 'min':
-          return _('per minutt', 'per minute', 'per minutt');
-        case 'km':
-          return _('per kilometer', 'per kilometer', 'per kilometer');
-        default:
-          return _('per', 'per', 'per');
+    intervalMin(interval: number) {
+      if (interval === 0) {
+        return _('(engangsbeløp)', '(one-time fee)', '(eingongsbeløp)');
       }
+      if (interval === 1) {
+        return _('per minutt', 'per minute', 'per minutt');
+      }
+      if (interval === 15) {
+        return _('per kvarter', 'per quarter hour', 'per kvarter');
+      }
+      if (interval === 30) {
+        return _('per halvtime', 'per half hour', 'per halvtime');
+      }
+      if (interval % 1440 === 0) {
+        const days = interval / 1440;
+        return days === 1
+          ? _('per døgn', 'per day', 'per døgn')
+          : _(`per ${days} døgn`, `per ${days} days`, `per ${days} døgn`);
+      }
+      if (interval % 60 === 0) {
+        const hours = interval / 60;
+        return hours === 1
+          ? _('per time', 'per hour', 'per time')
+          : _(`per ${hours} timer`, `per ${hours} hours`, `per ${hours} timar`);
+      }
+      return _(
+        `per ${interval} minutter`,
+        `per ${interval} min`,
+        `per ${interval} minuttar`,
+      );
+    },
+    intervalKm(interval: number) {
+      if (interval === 0) {
+        return _('(engangsbeløp)', '(one-time fee)', '(eingongsbeløp)');
+      }
+      if (interval === 1) {
+        return _('per kilometer', 'per kilometer', 'per kilometer');
+      }
+      return _(
+        `per ${interval} km`,
+        `per ${interval} km`,
+        `per ${interval} km`,
+      );
     },
     discount(unit: string, price: string, currency?: string) {
       switch (unit) {

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -141,7 +141,7 @@ export const MobilityTexts = {
       }
       return _(
         `per ${interval} minutter`,
-        `per ${interval} min`,
+        `per ${interval} minutes`,
         `per ${interval} minuttar`,
       );
     },


### PR DESCRIPTION
closes https://github.com/AtB-AS/kundevendt/issues/24365

## Summary

<img width="200" alt="image" src="https://github.com/user-attachments/assets/69660a73-f59d-42a7-9aaa-47d82029164f" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/386dee3a-cc23-4fcf-bb3c-9d5d35ac6673" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/fc5bca0f-a81d-415d-bf26-47fc279891e5" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/7932201c-1478-46e9-89fb-f4adb41fd116" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/a03465c2-42ce-485d-a454-bb5fe6118b8f" />




- Price segments now account for `interval` when rendering `perMinPricing`/`perKmPricing` rates, so a segment with `interval: 30, rate: 5` shows as "5 kr per 30 min" instead of "5 kr/min"
- Segments with `interval: 0` (charged once, not per unit) now render as "(engangsbeløp)"/"(one-time fee)" instead of being mislabeled as per-minute/per-km
- Minute ranges/boundaries ≥ 60 min are now formatted as hours + minutes (e.g. "0-1 time 30 min"), capped at hours
- `computeFreeMinuteCount` now accounts for `interval` when converting a free-minutes campaign budget into minutes, instead of treating `rate` as a flat per-minute cost
- The campaign free-minutes row on the pricing details screen now goes through the same interval-aware label formatting as regular segments
