### PR TITLE
fix: follow mode citybike

### DIFF
--- a/src/modules/map/Map.tsx
+++ b/src/modules/map/Map.tsx
@@ -209,11 +209,13 @@ export const Map = (props: MapProps) => {
   const stablePreviousActiveShmoBooking =
     useStablePreviousValue(activeShmoBooking);
   const stableActiveShmoBooking = useStableValue(activeShmoBooking);
+
   useEffect(() => {
+    const wasInUse =
+      stablePreviousActiveShmoBooking?.state === ShmoBookingState.IN_USE;
     if (
-      !stablePreviousActiveShmoBooking &&
-      stableActiveShmoBooking &&
-      stableActiveShmoBooking.state === ShmoBookingState.IN_USE
+      !wasInUse &&
+      stableActiveShmoBooking?.state === ShmoBookingState.IN_USE
     ) {
       setFollowUserLocation(true);
     }


### PR DESCRIPTION
Fixed that the citybike now autofollows the user on starting a trip. 
What was wrong: From scooters we went from no booking to IN_USE, making the useffect work for first time startup. But for citybike we go from Preparing -> IN_USE, so it did not register. So we alter to see if it went from any state to IN_USE.

Acceptance criteria:

The map autofollows the user on starting a trip