### PR TITLE
feat: handle nullable benefit title and description

### DIFF
--- a/src/api/types/__tests__/mobility.test.ts
+++ b/src/api/types/__tests__/mobility.test.ts
@@ -40,7 +40,7 @@ describe('VehicleSchema (shmo vehicle contract v2)', () => {
     }
   });
 
-  it('parses a benefit, defaults title/description, and ignores server-only fields', () => {
+  it('parses a benefit, handles undefined description, and ignores server-only fields', () => {
     const result = VehicleSchema.safeParse({
       ...baseVehicle,
       benefit: {
@@ -62,8 +62,8 @@ describe('VehicleSchema (shmo vehicle contract v2)', () => {
       expect(result.data.benefit?.title).toEqual([
         {language: 'en', value: 'Free unlock'},
       ]);
-      // description is optional on the wire and defaults to an empty array
-      expect(result.data.benefit?.description).toEqual([]);
+      // an undefined description on the wire is normalized to undefined
+      expect(result.data.benefit?.description).toBeUndefined();
       expect(result.data.benefit?.illustrationName).toBe('TicketValid');
       expect(result.data.benefit?.priceAdjustments[0]).toEqual({
         amount: 0,

--- a/src/api/types/benefit.ts
+++ b/src/api/types/benefit.ts
@@ -18,8 +18,10 @@ export const PriceAdjustmentSchema = z
 // vehicle/system filtering all happen server-side), so the app only models the
 // display payload.
 export const BenefitSchema = z.object({
-  title: LanguageAndTextTypeArray.default([]),
-  description: LanguageAndTextTypeArray.default([]),
+  title: LanguageAndTextTypeArray.nullable().transform((v) => v ?? undefined),
+  description: LanguageAndTextTypeArray.nullable().transform(
+    (v) => v ?? undefined,
+  ),
   illustrationName: z.string().optional(),
   priceAdjustments: z.array(PriceAdjustmentSchema),
 });

--- a/src/api/types/benefit.ts
+++ b/src/api/types/benefit.ts
@@ -18,8 +18,8 @@ export const PriceAdjustmentSchema = z
 // vehicle/system filtering all happen server-side), so the app only models the
 // display payload.
 export const BenefitSchema = z.object({
-  title: LanguageAndTextTypeArray.nullable().transform((v) => v ?? undefined),
-  description: LanguageAndTextTypeArray.nullable().transform(
+  title: LanguageAndTextTypeArray.nullish().transform((v) => v ?? undefined),
+  description: LanguageAndTextTypeArray.nullish().transform(
     (v) => v ?? undefined,
   ),
   illustrationName: z.string().optional(),

--- a/src/modules/mobility/api/api.ts
+++ b/src/modules/mobility/api/api.ts
@@ -8,8 +8,8 @@ import {RequestError, isErrorResponse} from '@atb/api/utils';
 const VoucherBenefit = z.object({
   operatorId: z.string(),
   benefitTypes: OperatorBenefitId.array(),
-  title: LanguageAndTextTypeArray.nullable().transform((v) => v ?? undefined),
-  description: LanguageAndTextTypeArray.nullable().transform(
+  title: LanguageAndTextTypeArray.nullish().transform((v) => v ?? undefined),
+  description: LanguageAndTextTypeArray.nullish().transform(
     (v) => v ?? undefined,
   ),
   illustrationName: z.string().optional(),

--- a/src/modules/mobility/api/api.ts
+++ b/src/modules/mobility/api/api.ts
@@ -8,8 +8,10 @@ import {RequestError, isErrorResponse} from '@atb/api/utils';
 const VoucherBenefit = z.object({
   operatorId: z.string(),
   benefitTypes: OperatorBenefitId.array(),
-  title: LanguageAndTextTypeArray.default([]),
-  description: LanguageAndTextTypeArray.default([]),
+  title: LanguageAndTextTypeArray.nullable().transform((v) => v ?? undefined),
+  description: LanguageAndTextTypeArray.nullable().transform(
+    (v) => v ?? undefined,
+  ),
   illustrationName: z.string().optional(),
 });
 export type VoucherBenefitType = z.infer<typeof VoucherBenefit>;


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/24392

## Description
App can now handle nullable title and description from benefit in the APIs from benefit and mobility.
These values were set to nullable in the db here: https://github.com/AtB-AS/benefit/pull/20
To actually return null values from backend will be done in the future, in this issue: https://github.com/AtB-AS/team-platform/issues/1154