### PR TITLE
chore: remove redundant claude code write rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,12 +70,7 @@
       "Edit(**/.env.*)",
       "Edit(**/secrets/**)",
       "Edit(**/credentials/**)",
-      "Edit(**/.ssh/**)",
-      "Write(**/.env)",
-      "Write(**/.env.*)",
-      "Write(**/secrets/**)",
-      "Write(**/credentials/**)",
-      "Write(**/.ssh/**)"
+      "Edit(**/.ssh/**)"
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
These rules seems to be redundant, since the paths are already covered by edit rules above, and triggers warnings every time claude code is launched.

```
Permission deny rule (.claude/settings.json): Write(**/.env) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/.env) instead (Edit rules cover all file-editing tools).
Permission deny rule (.claude/settings.json): Write(**/.env.*) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/.env.*) instead (Edit rules cover all file-editing tools).
Permission deny rule (.claude/settings.json): Write(**/secrets/**) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/secrets/**) instead (Edit rules cover all file-editing tools).
Permission deny rule (.claude/settings.json): Write(**/credentials/**) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/credentials/**) instead (Edit rules cover all file-editing tools).
Permission deny rule (.claude/settings.json): Write(**/.ssh/**) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/.ssh/**) instead (Edit rules cover all file-editing tools).
```