### PR TITLE
fix: do not round an arrival up past the next departure

### DIFF
--- a/src/screen-components/travel-details-screens/__tests__/next-displayed-departure.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/next-displayed-departure.test.ts
@@ -1,4 +1,5 @@
 import {Leg} from '@atb/api/types/trips';
+import {arrivalRoundingMethod} from '@atb/utils/date';
 import {nextDisplayedDeparture} from '../utils';
 
 describe('nextDisplayedDeparture', () => {
@@ -47,5 +48,65 @@ describe('nextDisplayedDeparture', () => {
 
   it('handles an empty trip', () => {
     expect(nextDisplayedDeparture([], 0)).toBeUndefined();
+  });
+});
+
+describe('arrival rounding over whole trips', () => {
+  const at = (time: string) => `2024-01-01T${time}.000Z`;
+  const withTimes = (mode: string, start: string, end: string) =>
+    ({mode, expectedStartTime: at(start), expectedEndTime: at(end)}) as Leg;
+  const transit = (start: string, end: string) => withTimes('bus', start, end);
+  const walking = (start: string, end: string) => withTimes('foot', start, end);
+
+  const roundingFor = (legs: Leg[], index: number) =>
+    arrivalRoundingMethod(
+      legs[index].expectedEndTime,
+      nextDisplayedDeparture(legs, index),
+    );
+
+  it('floors a same-minute transfer between transit legs', () => {
+    const legs = [
+      transit('10:00:00', '10:17:11'),
+      transit('10:17:34', '10:30:00'),
+    ];
+    expect(roundingFor(legs, 0)).toBe('floor');
+  });
+
+  it('floors across an intermediate walk when the connection is tight', () => {
+    // The walk shows no departure row, so the tight transit departure behind
+    // it is what the arrival has to agree with.
+    const legs = [
+      transit('10:00:00', '10:17:11'),
+      walking('10:17:11', '10:17:20'),
+      transit('10:17:34', '10:30:00'),
+    ];
+    expect(roundingFor(legs, 0)).toBe('floor');
+  });
+
+  it('does not floor when a walk absorbs the transfer', () => {
+    // The walk starts exactly at the arrival, so treating it as the next
+    // departure would compare the arrival against itself and floor wrongly.
+    const legs = [
+      transit('10:00:00', '10:17:11'),
+      walking('10:17:11', '10:19:00'),
+      transit('10:22:40', '10:40:00'),
+    ];
+    expect(roundingFor(legs, 0)).toBe('ceil');
+  });
+
+  it('does not floor before a trailing walk', () => {
+    const legs = [
+      transit('10:00:00', '10:17:11'),
+      walking('10:17:11', '10:25:00'),
+    ];
+    expect(roundingFor(legs, 0)).toBe('ceil');
+  });
+
+  it('does not floor the final arrival', () => {
+    const legs = [
+      transit('10:00:00', '10:17:11'),
+      transit('10:17:34', '10:30:00'),
+    ];
+    expect(roundingFor(legs, 1)).toBe('ceil');
   });
 });

--- a/src/screen-components/travel-details-screens/__tests__/next-displayed-departure.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/next-displayed-departure.test.ts
@@ -1,0 +1,51 @@
+import {Leg} from '@atb/api/types/trips';
+import {nextDisplayedDeparture} from '../utils';
+
+describe('nextDisplayedDeparture', () => {
+  const leg = (mode: string, expectedStartTime: string) =>
+    ({mode, expectedStartTime}) as Leg;
+
+  const bus1 = leg('bus', '2024-01-01T10:00:00.000Z');
+  const walk = leg('foot', '2024-01-01T10:10:00.000Z');
+  const bus2 = leg('bus', '2024-01-01T10:15:00.000Z');
+
+  it('returns the next transit departure', () => {
+    expect(nextDisplayedDeparture([bus1, bus2], 0)).toBe(
+      '2024-01-01T10:15:00.000Z',
+    );
+  });
+
+  it('skips a walk leg, which shows no departure row', () => {
+    expect(nextDisplayedDeparture([bus1, walk, bus2], 0)).toBe(
+      '2024-01-01T10:15:00.000Z',
+    );
+  });
+
+  it('skips several walk legs in a row', () => {
+    expect(nextDisplayedDeparture([bus1, walk, walk, bus2], 0)).toBe(
+      '2024-01-01T10:15:00.000Z',
+    );
+  });
+
+  it('is undefined on the last leg', () => {
+    expect(nextDisplayedDeparture([bus1, bus2], 1)).toBeUndefined();
+  });
+
+  it('is undefined when only walks follow', () => {
+    expect(nextDisplayedDeparture([bus1, walk], 0)).toBeUndefined();
+  });
+
+  it('is undefined for an index past the end', () => {
+    expect(nextDisplayedDeparture([bus1], 5)).toBeUndefined();
+  });
+
+  it('ignores legs before the index', () => {
+    expect(nextDisplayedDeparture([bus1, walk, bus2], 1)).toBe(
+      '2024-01-01T10:15:00.000Z',
+    );
+  });
+
+  it('handles an empty trip', () => {
+    expect(nextDisplayedDeparture([], 0)).toBeUndefined();
+  });
+});

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -16,6 +16,7 @@ import {
   getShouldShowLiveVehicle,
   hasShortWaitTime,
   hasShortWaitTimeAndNotGuaranteedCorrespondence,
+  nextDisplayedDeparture,
   withinZoneIds,
 } from '../utils';
 import {
@@ -194,6 +195,7 @@ export const Trip: React.FC<TripProps> = ({
                 isLast={index == filteredLegs.length - 1}
                 step={index + 1}
                 leg={leg}
+                nextLegStartTime={nextDisplayedDeparture(filteredLegs, index)}
                 testID={'leg' + index}
                 onPressShowLive={
                   !isScreenReaderEnabled && legVehiclePosition

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -179,6 +179,11 @@ export const TripSection: React.FC<TripSectionProps> = ({
   const bikeA11yLabel = useBikeA11yLabel(leg, walkBikeRounding);
   const isWalkOrBike = isWalkSection || isBikeSection;
 
+  const arrivalRounding = arrivalRoundingMethod(
+    leg.expectedEndTime,
+    nextLegStartTime,
+  );
+
   const warningCount =
     leg.situations.length +
     (leg.transportSubmode === TransportSubmode.RailReplacementBus ? 1 : 0);
@@ -215,7 +220,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
       t(
         TripDetailsTexts.trip.leg.transport.a11yLabel.arrival(
           getPlaceName(leg.toPlace),
-          formatToClock(leg.expectedEndTime, language, 'ceil'),
+          formatToClock(leg.expectedEndTime, language, arrivalRounding),
         ),
       ),
     );
@@ -561,7 +566,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
                   formatToClock(
                     endTimes.expectedTime ?? endTimes.aimedTime,
                     language,
-                    'ceil',
+                    arrivalRounding,
                   ),
                 ),
               )}
@@ -577,10 +582,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
               rowLabel={
                 <Time
                   timeValues={endTimes}
-                  roundingMethod={arrivalRoundingMethod(
-                    leg.expectedEndTime,
-                    nextLegStartTime,
-                  )}
+                  roundingMethod={arrivalRounding}
                   timeIsApproximation={timesAreApproximations}
                 />
               }

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -18,6 +18,7 @@ import {
   useTranslation,
 } from '@atb/translations';
 import {
+  arrivalRoundingMethod,
   formatToClock,
   secondsToDuration,
   secondsToDurationShort,
@@ -85,6 +86,11 @@ type TripSectionProps = {
   isFirst?: boolean;
   step?: number;
   leg: Leg;
+  /**
+   * Next *displayed* departure, for `arrivalRoundingMethod`. A walk leg shows
+   * no departure row, so it is not it.
+   */
+  nextLegStartTime?: string;
   testID?: string;
   onPressShowLive?(serviceJourneyPolylines: ServiceJourneyPolylines): void;
   onPressDeparture: TripProps['onPressDeparture'];
@@ -97,6 +103,7 @@ export const TripSection: React.FC<TripSectionProps> = ({
   wait,
   step,
   leg,
+  nextLegStartTime,
   testID,
   onPressShowLive,
   onPressDeparture,
@@ -570,7 +577,10 @@ export const TripSection: React.FC<TripSectionProps> = ({
               rowLabel={
                 <Time
                   timeValues={endTimes}
-                  roundingMethod="ceil"
+                  roundingMethod={arrivalRoundingMethod(
+                    leg.expectedEndTime,
+                    nextLegStartTime,
+                  )}
                   timeIsApproximation={timesAreApproximations}
                 />
               }

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -209,6 +209,19 @@ export function hasShortWaitTimeAndNotGuaranteedCorrespondence(
   ).conclusion;
 }
 
+/**
+ * The next departure time actually shown after leg `index` arrives. A walk leg
+ * shows a departure only when it is first, so walks after `index` never are.
+ * Undefined when nothing following it shows one.
+ */
+export function nextDisplayedDeparture(
+  legs: Pick<Leg, 'mode' | 'expectedStartTime'>[],
+  index: number,
+): string | undefined {
+  return legs.slice(index + 1).find((leg) => leg.mode !== 'foot')
+    ?.expectedStartTime;
+}
+
 function parseDateIfString(date: any): Date {
   if (typeof date === 'string') {
     return parseISO(date);

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -4,6 +4,7 @@
 import {Language} from '@atb/translations';
 import timeMocker from 'timezone-mock';
 import {
+  arrivalRoundingMethod,
   convertIsoStringFieldsToDate,
   dateWithReplacedTime,
   formatLocaleTime,
@@ -571,5 +572,44 @@ describe('isValidDateString', () => {
     expect(isValidDateTimeString('2024-09-01')).toBe(false);
     expect(isValidDateTimeString('12:00')).toBe(false);
     expect(isValidDateTimeString('41ABCD5E')).toBe(false);
+  });
+});
+
+describe('arrivalRoundingMethod', () => {
+  const at = (time: string) => `2024-01-01T${time}.000Z`;
+
+  it('rounds up when there is no next departure', () => {
+    expect(arrivalRoundingMethod(at('10:10:30'), undefined)).toBe('ceil');
+  });
+
+  it('rounds down when rounding up would invert the order', () => {
+    // 10:10:11 -> 10:11 and 10:10:34 -> 10:10 reads as leaving before arriving.
+    expect(arrivalRoundingMethod(at('10:10:11'), at('10:10:34'))).toBe('floor');
+  });
+
+  it('rounds down across a whole-minute departure in the same minute', () => {
+    expect(arrivalRoundingMethod(at('10:10:10'), at('10:10:55'))).toBe('floor');
+  });
+
+  it('rounds up when both already read as the same minute', () => {
+    expect(arrivalRoundingMethod(at('10:10:10'), at('10:11:40'))).toBe('ceil');
+  });
+
+  it('rounds up when there is plenty of time', () => {
+    expect(arrivalRoundingMethod(at('10:10:10'), at('10:13:10'))).toBe('ceil');
+  });
+
+  it('rounds up on a genuinely missed connection, so it still looks missed', () => {
+    expect(arrivalRoundingMethod(at('10:11:40'), at('10:10:30'))).toBe('ceil');
+  });
+
+  it('rounds up when the arrival is already on a whole minute', () => {
+    expect(arrivalRoundingMethod(at('10:10:00'), at('10:10:30'))).toBe('ceil');
+  });
+
+  it('accepts Date as well as string', () => {
+    expect(
+      arrivalRoundingMethod(new Date(at('10:10:11')), new Date(at('10:10:34'))),
+    ).toBe('floor');
   });
 });

--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -587,7 +587,7 @@ describe('arrivalRoundingMethod', () => {
     expect(arrivalRoundingMethod(at('10:10:11'), at('10:10:34'))).toBe('floor');
   });
 
-  it('rounds down across a whole-minute departure in the same minute', () => {
+  it('rounds down for a long wait inside one minute', () => {
     expect(arrivalRoundingMethod(at('10:10:10'), at('10:10:55'))).toBe('floor');
   });
 
@@ -601,6 +601,12 @@ describe('arrivalRoundingMethod', () => {
 
   it('rounds up on a genuinely missed connection, so it still looks missed', () => {
     expect(arrivalRoundingMethod(at('10:11:40'), at('10:10:30'))).toBe('ceil');
+  });
+
+  it('rounds up on a negative gap inside one minute', () => {
+    // Rounding alone would floor this to a matching 10:10/10:10 and hide a
+    // connection that really does leave first.
+    expect(arrivalRoundingMethod(at('10:10:40'), at('10:10:10'))).toBe('ceil');
   });
 
   it('rounds up when the arrival is already on a whole minute', () => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -192,6 +192,34 @@ export function minutesBetween(
   return differenceInMinutes(parsedEnd, parsedStart);
 }
 
+/**
+ * Arrivals round up and departures round down, so a transfer of a few seconds
+ * within the same minute reads as the connection leaving before the arrival.
+ * Round the arrival down in that case, and both then show the same minute.
+ *
+ * Only when rounding is the whole problem. A genuinely missed connection keeps
+ * rounding up, so it still looks missed.
+ */
+export function arrivalRoundingMethod(
+  arrival: string | Date,
+  nextDeparture: string | Date | undefined,
+): RoundingMethod {
+  if (!nextDeparture) return 'ceil';
+
+  const arrivalTime = parseIfNeeded(arrival);
+  const departureTime = parseIfNeeded(nextDeparture);
+  if (arrivalTime > departureTime) return 'ceil';
+
+  // Rounded the way `formatToClock` will, so the decision matches the display.
+  const roundedArrival = roundToNearestMinutes(arrivalTime, {
+    roundingMethod: 'ceil',
+  });
+  const roundedDeparture = roundToNearestMinutes(departureTime, {
+    roundingMethod: 'floor',
+  });
+  return roundedArrival > roundedDeparture ? 'floor' : 'ceil';
+}
+
 export function formatToClock(
   isoDate: string | Date,
   language: Language,


### PR DESCRIPTION
## Issue Reference
ref: https://mittatb.slack.com/archives/C09CJU3JUH5/p1788525063105659

## Description
Our current convention regarding trip times, are:
- For arrival time, round up (ceil) the timing to the next minute.
- For departure time, round down (floor) the timing to the current minute.

This is because we don't want to be overly optimistic when there are transfers involved in the trip. We want the user to think that the time is _shorter_ so they can be prepared for situations where they may not catch the next bus/transit.

The implication? see below.

<img width="300" alt="weird timing" src="https://github.com/user-attachments/assets/bed1708a-56fb-4ccc-84e1-29131c45b035" />
<img width="300" alt="show seconds" src="https://github.com/user-attachments/assets/77256078-d875-4d15-86c1-9720a7165629" />

Because the arrival time is rounded up to 14:20 and 14:27 respectively, and departure time is rounded down to 14:19 and 14:26, we get this awkward situation where the displayed time no longer matches the actual situation (Image 1). If we go to debug menu and turn on the seconds display on trips, it shows clearly what the actual timing is (Image 2). On the second image, we can clearly see that this situation "short transfer time" is correct, because the difference between previous bus and next bus is 7 and 5 seconds respectively. But when we round that up, the user sees a 1 minute difference, which is weird.

## Solution
Already implemented in Planner-Web https://github.com/AtB-AS/planner-web/pull/784, which the logic is copied over to the app.

- Round the arrival **down** when rounding it up would push it past the minute the next departure displays. Both then read as the same minute.
- "Next departure" means the next one actually shown, so walk legs are skipped: a tight connection behind a walk still rounds down, a comfortable one does not.
- If nothing after this leg shows a departure — the last leg, or only walking follows — round up as usual.
- If the connection genuinely does leave before the arrival, round up as usual, so a missed transfer still looks missed

The arrival time is also spoken by two accessibility labels, which had the old rounding hardcoded. Both now share the value used by the row, so a screen reader cannot announce a different minute than the one on screen.

<img width="300" alt="solution" src="https://github.com/user-attachments/assets/fade8f2f-2804-4ead-859b-9bea115972e6" />


## Acceptance Criteria
- [x] No more valid trips that shows weird timing (the previous leg arrival is later than the next leg departure)
- [x] Uncertain transfers should show correct timing