### PR TITLE
feat: show "kort byttetid" on a zero-second transfer

### DIFF
--- a/src/modules/trip-patterns/__tests__/is-short-wait-time.test.ts
+++ b/src/modules/trip-patterns/__tests__/is-short-wait-time.test.ts
@@ -1,4 +1,5 @@
-import {isShortWaitTime, significantWaitTime} from '../utils';
+import {type TransferLeg} from '@atb-as/utils';
+import {isShortWaitTime, isTransferInto, significantWaitTime} from '../utils';
 
 describe('significantWaitTime', () => {
   it('should be false for 0 seconds', () => {
@@ -15,8 +16,8 @@ describe('significantWaitTime', () => {
 });
 
 describe('isShortWaitTime', () => {
-  it('should be false for 0 seconds (an interchange risk, not a short wait)', () => {
-    expect(isShortWaitTime(0)).toBe(false);
+  it('should be true for 0 seconds (a flush transfer the planner vouched for)', () => {
+    expect(isShortWaitTime(0)).toBe(true);
   });
 
   it('should be true for 1 second', () => {
@@ -41,5 +42,51 @@ describe('isShortWaitTime', () => {
 
   it('should be false for negative values', () => {
     expect(isShortWaitTime(-10)).toBe(false);
+  });
+});
+
+describe('isTransferInto', () => {
+  const at = (minutes: number) =>
+    new Date(Date.UTC(2026, 5, 3, 12, minutes)).toISOString();
+
+  const transit = (id = 'ATB:ServiceJourney:1'): TransferLeg => ({
+    aimedStartTime: at(0),
+    expectedStartTime: at(0),
+    expectedEndTime: at(10),
+    serviceJourney: {id},
+  });
+
+  const walk = (): TransferLeg => ({
+    aimedStartTime: at(0),
+    expectedStartTime: at(0),
+    expectedEndTime: at(5),
+  });
+
+  it('is true boarding a service straight after another service', () => {
+    expect(isTransferInto([transit('a'), transit('b')], 1)).toBe(true);
+  });
+
+  it('is true boarding a service after a walk between stops', () => {
+    expect(isTransferInto([transit('a'), walk(), transit('b')], 2)).toBe(true);
+  });
+
+  it('is false for the first service, reached by walking from the origin', () => {
+    expect(isTransferInto([walk(), transit()], 1)).toBe(false);
+  });
+
+  it('is false for a service that starts the trip', () => {
+    expect(isTransferInto([transit(), walk()], 0)).toBe(false);
+  });
+
+  it('is false for the walk to the destination', () => {
+    expect(isTransferInto([transit(), walk()], 1)).toBe(false);
+  });
+
+  it('is false for a trip with no service at all', () => {
+    expect(isTransferInto([walk(), walk()], 1)).toBe(false);
+  });
+
+  it('is false for an index past the end', () => {
+    expect(isTransferInto([transit(), transit()], 5)).toBe(false);
   });
 });

--- a/src/modules/trip-patterns/index.ts
+++ b/src/modules/trip-patterns/index.ts
@@ -1,2 +1,7 @@
 export {useRefreshTripQuery} from './use-refresh-trip-query';
-export {significantWaitTime, isShortWaitTime, getTripPatternKey} from './utils';
+export {
+  significantWaitTime,
+  isShortWaitTime,
+  isTransferInto,
+  getTripPatternKey,
+} from './utils';

--- a/src/modules/trip-patterns/utils.ts
+++ b/src/modules/trip-patterns/utils.ts
@@ -1,3 +1,4 @@
+import {isTransitLeg, type TransferLeg} from '@atb-as/utils';
 import {TripPattern} from '@atb/api/types/trips';
 
 export function getTripPatternKey(tripPattern: TripPattern): string {
@@ -20,8 +21,39 @@ export function significantWaitTime(seconds: number): boolean {
 const SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS = 120;
 /**
  * Whether a wait time is short enough to warn the user about a tight
- * transfer — between 1 and 119 seconds (> 0 s and < 2 min).
+ * transfer — between 0 and 119 seconds (< 2 min).
+ *
+ * Zero counts. The planner only returns itineraries it considers feasible, so a
+ * connection leaving the instant you arrive is a tight transfer rather than an
+ * impossible one, and `getTransferRisk` deliberately leaves it unflagged.
+ *
+ * This is a threshold only. Callers must first establish that the gap is a real
+ * transfer, with `isTransferInto` — otherwise the zero-second gap Entur reports
+ * on a leading or trailing walk reads as a tight transfer.
  */
 export function isShortWaitTime(seconds: number): boolean {
-  return seconds > 0 && seconds < SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS;
+  return seconds >= 0 && seconds < SHORT_TRANSFER_TIME_LIMIT_IN_SECONDS;
+}
+
+/**
+ * Whether the gap before `boardingIndex` is a transfer between services, rather
+ * than walking to the first stop or away from the last one.
+ *
+ * Only a real transfer can legitimately be flush. Entur reports a zero-second
+ * gap between a walk and the leg beside it as a matter of adjacency, not
+ * urgency, so counting those would warn on nearly every trip.
+ *
+ * `boardingIndex` is the leg you board, which is where a transfer warning
+ * belongs — the same leg the BFF stamps `transferRisk` on.
+ */
+export function isTransferInto(
+  legs: TransferLeg[],
+  boardingIndex: number,
+): boolean {
+  const boarding = legs[boardingIndex];
+  return (
+    !!boarding &&
+    isTransitLeg(boarding) &&
+    legs.slice(0, boardingIndex).some(isTransitLeg)
+  );
 }

--- a/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
+++ b/src/screen-components/travel-card/__tests__/get-msg-type-for-travel-card-leg.test.ts
@@ -34,6 +34,7 @@ const makeSituation = (
 const makeLeg = (overrides: Partial<Leg> = {}): Leg =>
   ({
     mode: 'bus',
+    serviceJourney: {id: 'ATB:ServiceJourney:1'},
     expectedStartTime: atSeconds(0),
     expectedEndTime: atSeconds(600),
     fromPlace: {quay: null},
@@ -146,8 +147,8 @@ describe('getMsgTypeForTravelCardLeg', () => {
       expect(getMsgTypeForTravelCardLeg(makeLegPair(120), 1)).toBeUndefined();
     });
 
-    it('returns undefined for a zero wait time', () => {
-      expect(getMsgTypeForTravelCardLeg(makeLegPair(0), 1)).toBeUndefined();
+    it('returns info for a transfer that leaves the instant you arrive', () => {
+      expect(getMsgTypeForTravelCardLeg(makeLegPair(0), 1)).toBe('info');
     });
 
     it('returns undefined for a negative wait time', () => {
@@ -160,17 +161,50 @@ describe('getMsgTypeForTravelCardLeg', () => {
   });
 
   describe('foot legs', () => {
+    const footLeg = {
+      mode: 'foot',
+      serviceJourney: null,
+    } as unknown as Partial<Leg>;
+
     it('returns undefined for a foot leg even with short wait from the previous leg', () => {
-      const legs = makeLegPair(120, {mode: 'foot'} as Partial<Leg>);
+      const legs = makeLegPair(120, footLeg);
       expect(getMsgTypeForTravelCardLeg(legs, 1)).toBeUndefined();
     });
 
     it('returns the leg-specific notification for a foot leg', () => {
       const legs = makeLegPair(120, {
-        mode: 'foot',
+        ...footLeg,
         situations: [makeSituation({reportType: ReportType.Incident})],
-      } as Partial<Leg>);
+      });
       expect(getMsgTypeForTravelCardLeg(legs, 1)).toBe('warning');
+    });
+
+    it('returns undefined for the first service, reached by walking from the origin', () => {
+      const legs = [
+        makeLeg({
+          ...footLeg,
+          expectedStartTime: atSeconds(-300),
+          expectedEndTime: atSeconds(0),
+        }),
+        makeLeg({expectedStartTime: atSeconds(0)}),
+      ];
+      expect(getMsgTypeForTravelCardLeg(legs, 1)).toBeUndefined();
+    });
+
+    it('returns info boarding a service after a walk between two stops', () => {
+      const legs = [
+        makeLeg({
+          expectedStartTime: atSeconds(0),
+          expectedEndTime: atSeconds(600),
+        }),
+        makeLeg({
+          ...footLeg,
+          expectedStartTime: atSeconds(600),
+          expectedEndTime: atSeconds(660),
+        }),
+        makeLeg({expectedStartTime: atSeconds(660)}),
+      ];
+      expect(getMsgTypeForTravelCardLeg(legs, 2)).toBe('info');
     });
   });
 

--- a/src/screen-components/travel-card/utils.ts
+++ b/src/screen-components/travel-card/utils.ts
@@ -10,7 +10,10 @@ import {
   toMostCriticalStatus,
 } from '@atb/modules/situations/utils';
 // eslint-disable-next-line no-restricted-imports
-import {isShortWaitTime} from '@atb/modules/trip-patterns/utils';
+import {
+  isShortWaitTime,
+  isTransferInto,
+} from '@atb/modules/trip-patterns/utils';
 import {Statuses} from '@atb/theme';
 import {TransferRisk} from '@atb-as/utils';
 import type {StatusTextConfig, TripPatternStatus} from './types';
@@ -46,8 +49,8 @@ export function getTripPatternStatus(
 /**
  * Get the most critical message type for a leg in the travel card, considering
  * both leg-specific notifications (situations, notices, etc.) and short
- * transfer time from the previous leg. Transfer time is only considered for
- * transit legs.
+ * transfer time from the previous leg. Transfer time is only considered where
+ * the gap is a real transfer, so walking to the first stop never counts.
  */
 export function getMsgTypeForTravelCardLeg(
   legs: Leg[],
@@ -55,11 +58,13 @@ export function getMsgTypeForTravelCardLeg(
 ): Exclude<Statuses, 'valid'> | undefined {
   const leg = legs[index];
   const legMsgType = getMsgTypeForLeg(leg);
-  if (leg.mode === 'foot') return legMsgType;
-  const previousLeg = legs[index - 1];
-  const waitTimeInSeconds = previousLeg
-    ? secondsBetween(previousLeg.expectedEndTime, leg.expectedStartTime)
-    : 0;
+  if (!isTransferInto(legs, index)) return legMsgType;
+
+  // A transfer has a leg before it by definition, so there is a gap to measure.
+  const waitTimeInSeconds = secondsBetween(
+    legs[index - 1].expectedEndTime,
+    leg.expectedStartTime,
+  );
   const shortTransferMsgType: Exclude<Statuses, 'valid'> | undefined =
     isShortWaitTime(waitTimeInSeconds) ? 'info' : undefined;
   return toMostCriticalStatus(legMsgType, shortTransferMsgType);

--- a/src/screen-components/travel-details-screens/__tests__/short-wait-time.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/short-wait-time.test.ts
@@ -4,30 +4,53 @@ import {hasShortWaitTime} from '../utils';
 
 describe('Short wait time evaluator', () => {
   const nowDate = Date.now();
+  const serviceJourney = {id: 'ATB:ServiceJourney:1'};
+
   const Leg1: Leg = {
     expectedStartTime: nowDate,
     expectedEndTime: addMinutes(nowDate, 5),
+    serviceJourney,
   } as Leg;
 
   const Leg2: Leg = {
     expectedStartTime: addMinutes(nowDate, 6),
     expectedEndTime: addMinutes(nowDate, 10),
+    serviceJourney,
   } as Leg;
 
   const Leg3: Leg = {
     expectedStartTime: addMinutes(nowDate, 9),
     expectedEndTime: addMinutes(nowDate, 10),
+    serviceJourney,
   } as Leg;
 
   const Leg4: Leg = {
     expectedStartTime: addMinutes(nowDate, 15),
     expectedEndTime: addMinutes(nowDate, 20),
+    serviceJourney,
   } as Leg;
 
   const weirdLeg: Leg = {
     expectedStartTime: 'non parsable string',
     expectedEndTime: {weird: true},
+    serviceJourney,
   } as Leg;
+
+  /** A walk that ends the instant the following leg departs, as Entur reports it. */
+  const walkEndingAt = (minutes: number): Leg =>
+    ({
+      mode: 'foot',
+      expectedStartTime: addMinutes(nowDate, minutes - 4),
+      expectedEndTime: addMinutes(nowDate, minutes),
+    }) as Leg;
+
+  /** A service departing the instant the previous leg arrives. */
+  const flushTransitAt = (minutes: number): Leg =>
+    ({
+      expectedStartTime: addMinutes(nowDate, minutes),
+      expectedEndTime: addMinutes(nowDate, minutes + 5),
+      serviceJourney,
+    }) as Leg;
 
   it('catches a short wait', () => {
     const isShortWait = hasShortWaitTime([Leg1, Leg2]);
@@ -52,5 +75,25 @@ describe('Short wait time evaluator', () => {
   it('passes on weird data', () => {
     const isShortWait = hasShortWaitTime([weirdLeg, weirdLeg]);
     expect(isShortWait).toBe(false);
+  });
+
+  it('catches a transfer that leaves the instant you arrive', () => {
+    const isShortWait = hasShortWaitTime([Leg1, flushTransitAt(5)]);
+    expect(isShortWait).toBe(true);
+  });
+
+  it('passes on walking to the first stop, which Entur reports as flush', () => {
+    const isShortWait = hasShortWaitTime([walkEndingAt(0), Leg1]);
+    expect(isShortWait).toBe(false);
+  });
+
+  it('passes on walking to the destination', () => {
+    const isShortWait = hasShortWaitTime([Leg1, walkEndingAt(9)]);
+    expect(isShortWait).toBe(false);
+  });
+
+  it('catches a short wait after a walk between two stops', () => {
+    const legs = [Leg1, walkEndingAt(6), flushTransitAt(6)];
+    expect(hasShortWaitTime(legs)).toBe(true);
   });
 });

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -18,6 +18,7 @@ import {
   hasShortWaitTimeAndNotGuaranteedCorrespondence,
   withinZoneIds,
 } from '../utils';
+import {isTransferInto} from '@atb/modules/trip-patterns';
 import {
   CompactTravelDetailsMap,
   TravelDetailsMapScreenParams,
@@ -249,7 +250,9 @@ function legWaitDetails(index: number, legs: Leg[]): WaitDetails | undefined {
       next.expectedStartTime,
     );
 
-    const mustWaitForNextLeg = waitTimeInSeconds > 0;
+    const mustWaitForNextLeg = isTransferInto(legs, index + 1)
+      ? waitTimeInSeconds >= 0
+      : waitTimeInSeconds > 0;
     return {
       mustWaitForNextLeg,
       waitTimeInSeconds,

--- a/src/screen-components/travel-details-screens/components/WaitSection.tsx
+++ b/src/screen-components/travel-details-screens/components/WaitSection.tsx
@@ -54,7 +54,11 @@ function getWaitMessage(
     };
   }
 
-  const wholeMinutes = Math.ceil(waitTimeInSeconds / ONE_MINUTE_IN_SECONDS);
+  const wholeMinutes = Math.max(
+    1,
+    Math.ceil(waitTimeInSeconds / ONE_MINUTE_IN_SECONDS),
+  );
+  
   return {
     icon: Warning,
     emphasis: 'info',

--- a/src/screen-components/travel-details-screens/components/WaitSection.tsx
+++ b/src/screen-components/travel-details-screens/components/WaitSection.tsx
@@ -58,7 +58,7 @@ function getWaitMessage(
     1,
     Math.ceil(waitTimeInSeconds / ONE_MINUTE_IN_SECONDS),
   );
-  
+
   return {
     icon: Warning,
     emphasis: 'info',

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -9,6 +9,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import {
   isShortWaitTime,
+  isTransferInto,
   significantWaitTime,
 } from '@atb/modules/trip-patterns/utils';
 import {Leg, Line, TripPattern} from '@atb/api/types/trips';
@@ -162,14 +163,16 @@ export function getLineA11yLabel(
 }
 
 export function hasShortWaitTime(legs: Leg[]) {
-  return iterateWithNext(legs)
-    .map((pair) => {
-      return differenceInSeconds(
-        parseDateIfString(pair.next.expectedStartTime),
-        parseDateIfString(pair.current.expectedEndTime),
-      );
-    })
-    .some((waitTime) => isShortWaitTime(waitTime));
+  return iterateWithNext(legs).some((pair, index) => {
+    // `index` is the pair's first leg, so the leg being boarded is the next one.
+    if (!isTransferInto(legs, index + 1)) return false;
+
+    const waitTime = differenceInSeconds(
+      parseDateIfString(pair.next.expectedStartTime),
+      parseDateIfString(pair.current.expectedEndTime),
+    );
+    return isShortWaitTime(waitTime);
+  });
 }
 
 export function hasShortWaitTimeAndNotGuaranteedCorrespondence(


### PR DESCRIPTION
## Issue Reference
https://github.com/AtB-AS/kundevendt/issues/24416

## Description

Same implementation with https://github.com/AtB-AS/planner-web/pull/785

`isShortWaitTime` now accepts zero (`>= 0 && < 120`), and a new `isTransferInto(legs, boardingIndex)` establishes that the gap is a real transfer between transit, before the threshold is applied.

Three places should now show something where they previously showed nothing (or "usikker overgang" on the transfer):

1. Trip search results: an info badge on the leg you board.
2. Trip details, top of screen: "Vær oppmerksom på kort byttetid."
3. Trip details, the wait row between the legs: "Kort byttetid" and "Under 1 minutt ventetid".

### Screenshots

#### Before (current prod) vs after this PR, trip result list

<img width="300" src="https://github.com/user-attachments/assets/c10049ad-f47c-4362-89b8-cf05434b149b" /><img width="307" src="https://github.com/user-attachments/assets/994c2abb-f07a-4863-841a-3fc27b8fb308" />


#### Before vs after, trip details

<img width="300" src="https://github.com/user-attachments/assets/9762892d-4f22-4a39-a152-ea9e70efeb30" />
<img width="300" src="https://github.com/user-attachments/assets/a12e9a33-046f-4ea4-a604-ce1d8d5e208d" />

#### Before vs after, saved trip

<img width="405" height="160" alt="image" src="https://github.com/user-attachments/assets/82430557-6764-4e8f-b608-f06ad51647e4" />
<img width="416" height="166" alt="image" src="https://github.com/user-attachments/assets/cdbfc9fc-87b8-411d-b4d9-3c1a37d46bfe" />

