### PR TITLE
fix: update screen reader map blocker look

### DIFF
--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/components/MapDisabledForScreenReader.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_MapStack/components/MapDisabledForScreenReader.tsx
@@ -1,7 +1,6 @@
 import {screenReaderPause} from '@atb/components/text';
 import {ThemeText} from '@atb/components/text';
 import {StyleSheet} from '@atb/theme';
-import {ThemedMapImage} from '@atb/theme/ThemedAssets';
 import {MapTexts, useTranslation} from '@atb/translations';
 import {Ref} from 'react';
 import {View} from 'react-native';
@@ -16,7 +15,6 @@ export const MapDisabledForScreenReader = ({focusRef}: Props) => {
   const {t} = useTranslation();
   return (
     <SafeAreaView style={styles.container}>
-      <ThemedMapImage width={150} height={150} />
       <View
         ref={focusRef}
         accessible={true}
@@ -26,7 +24,7 @@ export const MapDisabledForScreenReader = ({focusRef}: Props) => {
           t(MapTexts.disabledForScreenReader.description)
         }
       >
-        <ThemeText typography="body__m__strong" style={styles.header}>
+        <ThemeText typography="heading__2xl" style={styles.header}>
           {t(MapTexts.disabledForScreenReader.title)}
         </ThemeText>
         <ThemeText style={styles.description}>


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/21643

## Description
Removes ThemedMapImage and increases text size for screen reader map blocker screen

<img width="200" alt="image" src="https://github.com/user-attachments/assets/17f13cdc-f6ff-431d-a952-aa7e3e65bfe7" />
