### PR TITLE
feat: add departures deep links

### DIFF
--- a/ios/departureWidget/WidgetViewModel.swift
+++ b/ios/departureWidget/WidgetViewModel.swift
@@ -58,7 +58,6 @@ struct WidgetViewModel {
 
         var queryItems = [
             URLQueryItem(name: "stopId", value: stopPlace.id),
-            URLQueryItem(name: "stopName", value: stopPlace.name),
             URLQueryItem(name: "quayId", value: quay.id),
             URLQueryItem(name: "latitude", value: String(stopPlace.latitude)),
             URLQueryItem(name: "longitude", value: String(stopPlace.longitude)),

--- a/src/modules/deep-links/__tests__/use-deep-link-options.test.ts
+++ b/src/modules/deep-links/__tests__/use-deep-link-options.test.ts
@@ -182,7 +182,7 @@ describe('map', () => {
 describe('widget', () => {
   // Links as built by `WidgetViewModel.deepLink` in ios/departureWidget
   const stopParams =
-    'stopId=NSR:StopPlace:41613&stopName=Prinsens%20gate&quayId=NSR:Quay:71184&latitude=63.4326&longitude=10.3951';
+    'stopId=NSR:StopPlace:41613&quayId=NSR:Quay:71184&latitude=63.4326&longitude=10.3951';
 
   it('opens nearby stop places in favourite mode when there are no favourite departures', () => {
     const state = getStateFrom('widget/addFavoriteDeparture');
@@ -198,10 +198,7 @@ describe('widget', () => {
       name: 'Departures_PlaceScreen',
       index: 1,
       params: {
-        place: {
-          id: 'NSR:StopPlace:41613',
-          name: 'Prinsens gate',
-        },
+        place: {id: 'NSR:StopPlace:41613'},
         selectedQuayId: 'NSR:Quay:71184',
         showOnlyFavoritesByDefault: true,
         mode: 'Departure',

--- a/src/modules/deep-links/use-deep-links.ts
+++ b/src/modules/deep-links/use-deep-links.ts
@@ -75,9 +75,10 @@ export function useDeepLinks() {
             customerProfile,
             purchaseSelectionBuilder,
           );
+        case 'departures':
         case 'widget':
         case 'widgetdetails':
-          return routeForWidgetDepartures(path, params);
+          return routeForDepartures(path, params);
         case 'widget/addFavoriteDeparture':
           return routeForWidgetAddFavoriteDeparture();
         default:
@@ -241,10 +242,11 @@ function routeForWidgetAddFavoriteDeparture(): ResultState | undefined {
 }
 
 /**
- * `atb://widget?stopId=...&stopName=...&quayId=...`
+ * `atb://departures?stopId=...&quayId=...`
+ * `atb://widget?stopId=...&quayId=...`
  * `atb://widgetdetails?...&serviceJourneyId=...&serviceDate=...`
  */
-function routeForWidgetDepartures(
+function routeForDepartures(
   path: string,
   params: DeepLink['params'],
 ): ResultState | undefined {
@@ -259,12 +261,9 @@ function routeForWidgetDepartures(
       name: 'Departures_PlaceScreen',
       index: 1,
       params: {
-        place: {
-          name: params.stopName,
-          id: params.stopId,
-        },
+        place: {id: params.stopId},
         selectedQuayId: params.quayId,
-        showOnlyFavoritesByDefault: true,
+        showOnlyFavoritesByDefault: path !== 'departures',
         mode: 'Departure',
       },
     },

--- a/src/screen-components/place-screen/PlaceScreenComponent.tsx
+++ b/src/screen-components/place-screen/PlaceScreenComponent.tsx
@@ -13,12 +13,20 @@ import type {DepartureSearchTime} from 'src/components/date-selection';
 import {useStopsDetailsDataQuery} from './hooks/use-stops-details-data-query';
 import {useScrollBorder} from '@atb/utils/use-scroll-border';
 import {FullScreenView} from '@atb/components/screen-view';
+import {Loading} from '@atb/components/loading';
 
 export type PlaceScreenParams = {
-  place: StopPlace;
+  /**
+   * Stop place with quay data, or let them be fetched by stop id.
+   */
+  place: StopPlace | {id: string};
   selectedQuayId?: string;
   showOnlyFavoritesByDefault?: boolean;
 };
+
+const hasLoadedQuays = (
+  place: PlaceScreenParams['place'],
+): place is StopPlace => 'quays' in place && place.quays !== undefined;
 
 type Props = PlaceScreenParams & {
   onPressQuay?: (quayId: string | undefined) => void;
@@ -31,7 +39,7 @@ type Props = PlaceScreenParams & {
 const getThemeColor = (theme: Theme) => theme.color.background.neutral[1];
 
 export const PlaceScreenComponent = ({
-  place,
+  place: placeParam,
   selectedQuayId,
   showOnlyFavoritesByDefault,
   onPressQuay,
@@ -50,23 +58,33 @@ export const PlaceScreenComponent = ({
   );
 
   const {data: stopsDetailsData, isError: isStopsDetailsError} =
-    useStopsDetailsDataQuery(place.quays === undefined ? [place.id] : []);
+    useStopsDetailsDataQuery(hasLoadedQuays(placeParam) ? [] : [placeParam.id]);
 
-  if (stopsDetailsData && place.quays === undefined) {
-    place = stopsDetailsData.stopPlaces[0];
-  }
+  const place = hasLoadedQuays(placeParam)
+    ? placeParam
+    : stopsDetailsData?.stopPlaces[0];
 
-  if (isStopsDetailsError) {
+  if (isStopsDetailsError || (stopsDetailsData && !place)) {
     return (
       <FullScreenView
         focusRef={undefined}
-        headerProps={{title: place.name, leftButton: {type: 'back'}}}
+        headerProps={{title: place?.name, leftButton: {type: 'back'}}}
       >
         <MessageInfoBox
           style={styles.messageBox}
           type="error"
           message={t(DeparturesTexts.message.resultNotFound)}
         />
+      </FullScreenView>
+    );
+  }
+  if (!place) {
+    return (
+      <FullScreenView
+        focusRef={undefined}
+        headerProps={{leftButton: {type: 'back'}}}
+      >
+        <Loading style={styles.loading} />
       </FullScreenView>
     );
   }
@@ -175,5 +193,9 @@ const useStyles = StyleSheet.createThemeHook((theme) => ({
   quayData: {flex: 1},
   messageBox: {
     margin: theme.spacing.medium,
+  },
+  loading: {
+    alignSelf: 'center',
+    margin: theme.spacing.xLarge,
   },
 }));


### PR DESCRIPTION
## Issue Reference

closes https://github.com/AtB-AS/kundevendt/issues/2936

part of https://github.com/AtB-AS/kundevendt/issues/24379

## Description

Adds the `atb://departures` deep link, that works similarly to the widget routes, but without `showOnlyFavoritesByDefault` enabled.

Also removes the `stopName` query param from the widget, since this is fetched by the app anyway, and we don't want to rely on the url to have the correct name.