### PR TITLE
feat: add paused state with resume button + test pause button

### DIFF
--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -388,6 +388,7 @@ export type InitShmoOneStopBookingRequestBody = z.infer<
 >;
 
 export enum ShmoBookingEventType {
+  RESUME = 'RESUME',
   START_FINISHING = 'START_FINISHING',
   FINISH = 'FINISH',
 }
@@ -477,12 +478,13 @@ export type SendSupportRequestBody = z.infer<
   typeof SendSupportRequestBodySchema
 >;
 
+type ResumeEvent = {event: ShmoBookingEventType.RESUME};
 type StartFinishingEvent = {event: ShmoBookingEventType.START_FINISHING};
 type FinishEvent = {
   event: ShmoBookingEventType.FINISH;
 } & z.infer<typeof ShmoImageFileSchema>;
 
-export type ShmoBookingEvent = StartFinishingEvent | FinishEvent;
+export type ShmoBookingEvent = ResumeEvent | StartFinishingEvent | FinishEvent;
 
 export type AssetFromQrCodeResponse = z.infer<typeof AssetSchema>;
 

--- a/src/api/types/mobility.ts
+++ b/src/api/types/mobility.ts
@@ -388,6 +388,7 @@ export type InitShmoOneStopBookingRequestBody = z.infer<
 >;
 
 export enum ShmoBookingEventType {
+  PAUSE = 'PAUSE',
   RESUME = 'RESUME',
   START_FINISHING = 'START_FINISHING',
   FINISH = 'FINISH',
@@ -478,13 +479,18 @@ export type SendSupportRequestBody = z.infer<
   typeof SendSupportRequestBodySchema
 >;
 
+type PauseEvent = {event: ShmoBookingEventType.PAUSE};
 type ResumeEvent = {event: ShmoBookingEventType.RESUME};
 type StartFinishingEvent = {event: ShmoBookingEventType.START_FINISHING};
 type FinishEvent = {
   event: ShmoBookingEventType.FINISH;
 } & z.infer<typeof ShmoImageFileSchema>;
 
-export type ShmoBookingEvent = ResumeEvent | StartFinishingEvent | FinishEvent;
+export type ShmoBookingEvent =
+  | PauseEvent
+  | ResumeEvent
+  | StartFinishingEvent
+  | FinishEvent;
 
 export type AssetFromQrCodeResponse = z.infer<typeof AssetSchema>;
 

--- a/src/modules/feature-toggles/toggle-specifications.ts
+++ b/src/modules/feature-toggles/toggle-specifications.ts
@@ -142,6 +142,10 @@ export const toggleSpecifications = [
     remoteConfigKey: 'enable_shmo_deep_integration_citybike',
   },
   {
+    name: 'isShmoPauseButtonEnabled',
+    remoteConfigKey: 'enable_shmo_pause_button',
+  },
+  {
     name: 'isShowCancelledDeparturesEnabled',
     remoteConfigKey: 'enable_show_cancelled_departures',
   },

--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -228,7 +228,8 @@ export const MapBottomSheets = ({
         />
       )}
 
-      {activeBooking?.state === ShmoBookingState.IN_USE && (
+      {(activeBooking?.state === ShmoBookingState.IN_USE ||
+        activeBooking?.state === ShmoBookingState.PAUSED) && (
         <ActiveShmoSheet
           mapViewRef={mapViewRef}
           onForceClose={handleCloseSheet}

--- a/src/modules/mobility/components/ShmoTripCard.tsx
+++ b/src/modules/mobility/components/ShmoTripCard.tsx
@@ -45,7 +45,8 @@ export const ShmoTripCard = ({
       <ShmoTripDetailsSectionItem
         startDateTime={shmoBooking?.departureTime ?? new Date()}
         endDateTime={
-          shmoBooking?.state === ShmoBookingState.IN_USE
+          shmoBooking?.state === ShmoBookingState.IN_USE ||
+          shmoBooking?.state === ShmoBookingState.PAUSED
             ? new Date(serverNow)
             : new Date(shmoBooking?.arrivalTime ?? '')
         }

--- a/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
@@ -1,7 +1,10 @@
 import React, {RefObject, useCallback, useEffect} from 'react';
 import {useTranslation} from '@atb/translations';
 import {StyleSheet, useThemeContext} from '@atb/theme';
-import {MobilityTexts} from '@atb/translations/screens/subscreens/MobilityTexts';
+import {
+  MobilityTexts,
+  ShmoWarnings,
+} from '@atb/translations/screens/subscreens/MobilityTexts';
 import {Alert, View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
@@ -42,6 +45,7 @@ import {SupportButton} from '../SupportButton';
 import {BrandingImage} from '../BrandingImage';
 import {EndManualTripCard} from '../EndManualTripCard';
 import {ThemedCityBikeStation} from '@atb/theme/ThemedAssets';
+import {Unlock} from '@atb/assets/svg/mono-icons/mobility';
 
 type Props = {
   navigateSupportCallback: () => void;
@@ -87,6 +91,8 @@ export const ActiveShmoSheet = ({
 
   const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
 
+  const isPaused = activeBooking?.state === ShmoBookingState.PAUSED;
+
   useEffect(() => {
     if (activeBooking === null) {
       onForceClose();
@@ -128,6 +134,28 @@ export const ActiveShmoSheet = ({
     sendShmoBookingEvent,
   ]);
 
+  const resumeShmoBooking = useCallback(async () => {
+    if (activeBooking?.bookingId) {
+      const resumeEvent: ShmoBookingEvent = {
+        event: ShmoBookingEventType.RESUME,
+      };
+      await sendShmoBookingEvent({
+        bookingId: activeBooking.bookingId,
+        shmoBookingEvent: resumeEvent,
+      });
+
+      logEvent('Mobility', 'Shmo booking resume', {
+        operatorId: activeBooking.asset.operator.id,
+        bookingId: activeBooking.bookingId,
+      });
+    }
+  }, [
+    activeBooking?.asset.operator.id,
+    activeBooking?.bookingId,
+    logEvent,
+    sendShmoBookingEvent,
+  ]);
+
   const showEndAlert = async () => {
     Alert.alert(
       t(MobilityTexts.trip.button.end),
@@ -146,6 +174,33 @@ export const ActiveShmoSheet = ({
       ],
     );
   };
+
+  const endButtonProps = isPaused
+    ? {
+        mode: 'secondary' as const,
+        backgroundColor: theme.color.background.neutral[1],
+        text: t(MobilityTexts.trip.button.end),
+      }
+    : {
+        mode: 'primary' as const,
+        text: sendShmoBookingEventIsLoading
+          ? t(MobilityTexts.trip.button.endLoading)
+          : t(MobilityTexts.trip.button.end),
+      };
+
+  const endButton = (
+    <Button
+      {...endButtonProps}
+      active={false}
+      disabled={sendShmoBookingEventIsLoading}
+      interactiveColor={theme.color.interactive.destructive}
+      expanded={true}
+      type="large"
+      accessibilityRole="button"
+      onPress={showEndAlert}
+      loading={sendShmoBookingEventIsLoading}
+    />
+  );
 
   return (
     <MapBottomSheet
@@ -225,6 +280,16 @@ export const ActiveShmoSheet = ({
                       </View>
                     </View>
                   )}
+                  {isPaused && (
+                    <MessageInfoBox
+                      type="error"
+                      message={t(
+                        ShmoWarnings.bookingPaused(
+                          activeBooking.asset.formFactor ?? undefined,
+                        ),
+                      )}
+                    />
+                  )}
                   {warningMessage && (
                     <MessageInfoText type="warning" message={warningMessage} />
                   )}
@@ -237,6 +302,28 @@ export const ActiveShmoSheet = ({
                       )}
                     />
                   )}
+                  {isPaused && (
+                    <View style={styles.pausedButtonsRow}>
+                      <View style={styles.pausedButton}>
+                        <Button
+                          mode="primary"
+                          active={false}
+                          disabled={sendShmoBookingEventIsLoading}
+                          expanded={true}
+                          type="large"
+                          accessibilityRole="button"
+                          onPress={resumeShmoBooking}
+                          loading={sendShmoBookingEventIsLoading}
+                          rightIcon={{svg: Unlock}}
+                          text={t(MobilityTexts.trip.button.resume)}
+                        />
+                      </View>
+                      {activeBooking.asset.formFactor !==
+                        FormFactor.Bicycle && (
+                        <View style={styles.pausedButton}>{endButton}</View>
+                      )}
+                    </View>
+                  )}
                   {activeBooking.asset.formFactor === FormFactor.Bicycle ? (
                     <EndManualTripCard
                       title={t(MobilityTexts.cityBike.endManualTrip.title)}
@@ -244,22 +331,7 @@ export const ActiveShmoSheet = ({
                       image={<ThemedCityBikeStation height={54} width={90} />}
                     />
                   ) : (
-                    <Button
-                      mode="primary"
-                      active={false}
-                      disabled={sendShmoBookingEventIsLoading}
-                      interactiveColor={theme.color.interactive.destructive}
-                      expanded={true}
-                      type="large"
-                      accessibilityRole="button"
-                      onPress={showEndAlert}
-                      loading={sendShmoBookingEventIsLoading}
-                      text={
-                        sendShmoBookingEventIsLoading
-                          ? t(MobilityTexts.trip.button.endLoading)
-                          : t(MobilityTexts.trip.button.end)
-                      }
-                    />
+                    !isPaused && endButton
                   )}
 
                   <SupportButton navigateToSupport={navigateSupportCallback} />
@@ -306,6 +378,13 @@ const useStyles = StyleSheet.createThemeHook((theme) => {
       alignItems: 'center',
     },
     geofencingZoneWarningText: {
+      flex: 1,
+    },
+    pausedButtonsRow: {
+      flexDirection: 'row',
+      gap: theme.spacing.small,
+    },
+    pausedButton: {
       flex: 1,
     },
   };

--- a/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/ActiveShmoSheet.tsx
@@ -89,7 +89,8 @@ export const ActiveShmoSheet = ({
     mapViewRef,
   );
 
-  const {isShmoDeepIntegrationEnabled} = useFeatureTogglesContext();
+  const {isShmoDeepIntegrationEnabled, isShmoPauseButtonEnabled} =
+    useFeatureTogglesContext();
 
   const isPaused = activeBooking?.state === ShmoBookingState.PAUSED;
 
@@ -155,6 +156,18 @@ export const ActiveShmoSheet = ({
     logEvent,
     sendShmoBookingEvent,
   ]);
+
+  const pauseShmoBooking = useCallback(async () => {
+    if (activeBooking?.bookingId) {
+      const pauseEvent: ShmoBookingEvent = {
+        event: ShmoBookingEventType.PAUSE,
+      };
+      await sendShmoBookingEvent({
+        bookingId: activeBooking.bookingId,
+        shmoBookingEvent: pauseEvent,
+      });
+    }
+  }, [activeBooking?.bookingId, sendShmoBookingEvent]);
 
   const showEndAlert = async () => {
     Alert.alert(
@@ -332,6 +345,20 @@ export const ActiveShmoSheet = ({
                     />
                   ) : (
                     !isPaused && endButton
+                  )}
+
+                  {isShmoPauseButtonEnabled && !isPaused && (
+                    <Button
+                      mode="secondary"
+                      backgroundColor={theme.color.background.neutral[1]}
+                      active={false}
+                      disabled={sendShmoBookingEventIsLoading}
+                      expanded={true}
+                      type="large"
+                      accessibilityRole="button"
+                      onPress={pauseShmoBooking}
+                      text="Pause"
+                    />
                   )}
 
                   <SupportButton navigateToSupport={navigateSupportCallback} />

--- a/src/modules/mobility/queries/use-send-shmo-booking-event-mutation.tsx
+++ b/src/modules/mobility/queries/use-send-shmo-booking-event-mutation.tsx
@@ -25,6 +25,7 @@ export const useSendShmoBookingEventMutation = () => {
 
     onSuccess: (data: ShmoBooking, arg: BookingEventArgs) => {
       switch (arg.shmoBookingEvent.event) {
+        case ShmoBookingEventType.RESUME:
         case ShmoBookingEventType.START_FINISHING:
           queryClient.setQueryData(
             getActiveShmoBookingQueryKey(acceptLanguage),

--- a/src/modules/mobility/queries/use-send-shmo-booking-event-mutation.tsx
+++ b/src/modules/mobility/queries/use-send-shmo-booking-event-mutation.tsx
@@ -25,6 +25,7 @@ export const useSendShmoBookingEventMutation = () => {
 
     onSuccess: (data: ShmoBooking, arg: BookingEventArgs) => {
       switch (arg.shmoBookingEvent.event) {
+        case ShmoBookingEventType.PAUSE:
         case ShmoBookingEventType.RESUME:
         case ShmoBookingEventType.START_FINISHING:
           queryClient.setQueryData(

--- a/src/modules/mobility/utils.ts
+++ b/src/modules/mobility/utils.ts
@@ -135,6 +135,7 @@ export const isActiveTripBooking = (
   booking: ShmoBooking | null | undefined,
 ): boolean =>
   booking?.state === ShmoBookingState.IN_USE ||
+  booking?.state === ShmoBookingState.PAUSED ||
   booking?.state === ShmoBookingState.FINISHING;
 
 export const isActiveBikeTripBooking = (

--- a/src/modules/remote-config/remote-config.ts
+++ b/src/modules/remote-config/remote-config.ts
@@ -54,6 +54,7 @@ export type RemoteConfig = {
   enable_server_time: boolean;
   enable_shmo_deep_integration: boolean;
   enable_shmo_deep_integration_citybike: boolean;
+  enable_shmo_pause_button: boolean;
   enable_show_cancelled_departures: boolean;
   enable_show_valid_time_info: boolean;
   enable_surface_view_map: boolean;
@@ -137,6 +138,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   enable_server_time: true,
   enable_shmo_deep_integration: false,
   enable_shmo_deep_integration_citybike: false,
+  enable_shmo_pause_button: false,
   enable_show_cancelled_departures: false,
   enable_show_valid_time_info: true,
   enable_surface_view_map: true,
@@ -296,6 +298,9 @@ export function getConfig(): RemoteConfig {
   const enable_shmo_deep_integration_citybike =
     values['enable_shmo_deep_integration_citybike']?.asBoolean() ??
     defaultRemoteConfig.enable_shmo_deep_integration_citybike;
+  const enable_shmo_pause_button =
+    values['enable_shmo_pause_button']?.asBoolean() ??
+    defaultRemoteConfig.enable_shmo_pause_button;
   const enable_show_cancelled_departures =
     values['enable_show_cancelled_departures']?.asBoolean() ??
     defaultRemoteConfig.enable_show_cancelled_departures;
@@ -446,6 +451,7 @@ export function getConfig(): RemoteConfig {
     enable_server_time,
     enable_shmo_deep_integration,
     enable_shmo_deep_integration_citybike,
+    enable_shmo_pause_button,
     enable_show_cancelled_departures,
     enable_show_valid_time_info,
     enable_surface_view_map,

--- a/src/translations/screens/subscreens/MobilityTexts.ts
+++ b/src/translations/screens/subscreens/MobilityTexts.ts
@@ -393,6 +393,7 @@ export const MobilityTexts = {
       end: _('Avslutt tur', 'End trip', 'Avslutt tur'),
       endLoading: _('Avslutter tur', 'Ending trip', 'Avsluttar tur'),
       finishTrip: _('Lukk', 'Close', 'Lukk'),
+      resume: _('Lås opp', 'Unlock', 'Lås opp'),
     },
     endAlert: {
       header: _(
@@ -690,6 +691,29 @@ export const GeofencingZoneExtraExplanations = {
 };
 
 export const ShmoWarnings = {
+  bookingPaused: (formFactor?: FormFactor) => {
+    switch (formFactor) {
+      case FormFactor.Scooter:
+      case FormFactor.ScooterStanding:
+        return _(
+          'Elsparkesykkelen har låst seg',
+          'The scooter has locked itself',
+          'Elsparkesykkelen har låst seg',
+        );
+      case FormFactor.Bicycle:
+        return _(
+          'Sykkelen har låst seg',
+          'The bike has locked itself',
+          'Sykkelen har låst seg',
+        );
+      default:
+        return _(
+          'Kjøretøyet har låst seg',
+          'The vehicle has locked itself',
+          'Køyretøyet har låst seg',
+        );
+    }
+  },
   vehicleDisabled: _(
     'Dette kjøretøyet er ikke tilgjengelig akkurat nå',
     'This vehicle is not available right now',


### PR DESCRIPTION
## Issue Reference
closes https://github.com/AtB-AS/kundevendt/issues/24311

## Description

Adds handling of paused state in active booking bottom sheet. The bottom sheet now shows an error message (because the state should currently be unreachable) and a resume button.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/bf75e8be-09b1-434a-8541-89757258cba9" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/7eec6edd-d166-4720-9627-64a3422cad39" />

Also adds a pause button that is behind a feature toggle
<img width="200" alt="image" src="https://github.com/user-attachments/assets/6cb88c05-ab97-46a6-a9d3-1bce196b1270" />

