### PR TITLE
fix: maintain starting/trailing walk on trip details

### DIFF
--- a/src/screen-components/travel-card/hooks.ts
+++ b/src/screen-components/travel-card/hooks.ts
@@ -18,16 +18,18 @@ export const useTripPatternInfo = (tripPattern: TripPattern) => {
   const {t} = useTranslation();
   const {theme} = useThemeContext();
 
-  let from = tripPattern.legs[0];
-  let fromName = from.fromPlace.name;
+  const firstLeg = tripPattern.legs[0];
   const to = tripPattern.legs[tripPattern.legs.length - 1];
   const toName = to.toPlace.name ?? '';
-  if (tripPattern.legs[0].mode === 'foot' && tripPattern.legs[1]) {
+  let from = firstLeg;
+  if (firstLeg.mode === 'foot' && tripPattern.legs[1]) {
     from = tripPattern.legs[1];
-    fromName = getQuayName(from.fromPlace.quay);
-  } else if (tripPattern.legs[0].mode !== 'foot') {
-    fromName = getQuayName(from.fromPlace.quay);
   }
+
+  let fromName =
+    firstLeg.mode === 'foot'
+      ? firstLeg.fromPlace.name
+      : getQuayName(firstLeg.fromPlace.quay);
 
   const startLegIsFlexibleTransport = isLineFlexibleTransport(from.line);
   const transportName = t(getTranslatedModeName(from.mode));

--- a/src/screen-components/travel-details-screens/__tests__/get-filtered-legs-by-walk-or-wait-time.test.ts
+++ b/src/screen-components/travel-details-screens/__tests__/get-filtered-legs-by-walk-or-wait-time.test.ts
@@ -1,0 +1,117 @@
+import {addSeconds} from 'date-fns';
+import {Leg, TripPattern} from '@atb/api/types/trips';
+import {getFilteredLegsByWalkOrWaitTime} from '../utils';
+
+describe('getFilteredLegsByWalkOrWaitTime', () => {
+  const nowDate = Date.now();
+  const at = (seconds: number) => addSeconds(nowDate, seconds);
+
+  /** A scheduled service. Never filtered, whatever its length. */
+  const bus = (startSeconds: number, endSeconds: number): Leg =>
+    ({
+      mode: 'bus',
+      duration: endSeconds - startSeconds,
+      expectedStartTime: at(startSeconds),
+      expectedEndTime: at(endSeconds),
+      serviceJourney: {id: 'ATB:ServiceJourney:1'},
+    }) as Leg;
+
+  const walk = (startSeconds: number, durationSeconds: number): Leg =>
+    ({
+      mode: 'foot',
+      duration: durationSeconds,
+      expectedStartTime: at(startSeconds),
+      expectedEndTime: at(startSeconds + durationSeconds),
+    }) as Leg;
+
+  const pattern = (legs: Leg[]) => ({legs}) as TripPattern;
+  const modes = (legs: Leg[]) => legs.map((l) => l.mode);
+
+  describe('by default', () => {
+    it('drops a short walk between two services', () => {
+      const legs = [bus(0, 600), walk(600, 20), bus(620, 1200)];
+      expect(modes(getFilteredLegsByWalkOrWaitTime(pattern(legs)))).toEqual([
+        'bus',
+        'bus',
+      ]);
+    });
+
+    it('drops a short walk to the destination', () => {
+      const legs = [bus(0, 600), walk(600, 24)];
+      expect(modes(getFilteredLegsByWalkOrWaitTime(pattern(legs)))).toEqual([
+        'bus',
+      ]);
+    });
+
+    it('keeps a walk longer than 30 seconds', () => {
+      const legs = [bus(0, 600), walk(600, 120)];
+      expect(modes(getFilteredLegsByWalkOrWaitTime(pattern(legs)))).toEqual([
+        'bus',
+        'foot',
+      ]);
+    });
+
+    it('keeps a short walk followed by a real wait', () => {
+      const legs = [bus(0, 600), walk(600, 20), bus(900, 1500)];
+      expect(modes(getFilteredLegsByWalkOrWaitTime(pattern(legs)))).toEqual([
+        'bus',
+        'foot',
+        'bus',
+      ]);
+    });
+
+    it('never filters a service, however short', () => {
+      const legs = [bus(0, 5), bus(5, 10)];
+      expect(getFilteredLegsByWalkOrWaitTime(pattern(legs))).toHaveLength(2);
+    });
+
+    it('returns an empty list for a pattern with no legs', () => {
+      expect(getFilteredLegsByWalkOrWaitTime(pattern([]))).toEqual([]);
+    });
+  });
+
+  describe('with keepEndpointWalks', () => {
+    const keep = {keepEndpointWalks: true};
+
+    it('keeps the short walk to the destination', () => {
+      const legs = [bus(0, 600), walk(600, 24)];
+      expect(
+        modes(getFilteredLegsByWalkOrWaitTime(pattern(legs), keep)),
+      ).toEqual(['bus', 'foot']);
+    });
+
+    it('keeps the short walk from the origin', () => {
+      const legs = [walk(0, 24), bus(24, 600)];
+      expect(
+        modes(getFilteredLegsByWalkOrWaitTime(pattern(legs), keep)),
+      ).toEqual(['foot', 'bus']);
+    });
+
+    it('still drops a short walk between two services', () => {
+      const legs = [bus(0, 600), walk(600, 20), bus(620, 1200)];
+      expect(
+        modes(getFilteredLegsByWalkOrWaitTime(pattern(legs), keep)),
+      ).toEqual(['bus', 'bus']);
+    });
+
+    it('keeps both ends while dropping the middle', () => {
+      const legs = [
+        walk(0, 24),
+        bus(24, 600),
+        walk(600, 20),
+        bus(620, 1200),
+        walk(1200, 24),
+      ];
+      expect(
+        modes(getFilteredLegsByWalkOrWaitTime(pattern(legs), keep)),
+      ).toEqual(['foot', 'bus', 'bus', 'foot']);
+    });
+
+    it('keeps a trip that is only a short walk', () => {
+      const legs = [walk(0, 24)];
+      expect(getFilteredLegsByWalkOrWaitTime(pattern(legs), keep)).toHaveLength(
+        1,
+      );
+    });
+  });
+});

--- a/src/screen-components/travel-details-screens/components/Trip.tsx
+++ b/src/screen-components/travel-details-screens/components/Trip.tsx
@@ -77,7 +77,9 @@ export const Trip: React.FC<TripProps> = ({
   const {modesWeSellTicketsFor} = useFirestoreConfigurationContext();
   const {requestReview} = useInAppReviewFlow();
 
-  const filteredLegs = getFilteredLegsByWalkOrWaitTime(tripPattern);
+  const filteredLegs = getFilteredLegsByWalkOrWaitTime(tripPattern, {
+    keepEndpointWalks: true,
+  });
 
   const isFocusedAndActive = useIsFocusedAndActive();
 

--- a/src/screen-components/travel-details-screens/utils.ts
+++ b/src/screen-components/travel-details-screens/utils.ts
@@ -246,14 +246,28 @@ function isSignificantFootLegWalkOrWaitTime(leg: Leg, nextLeg?: Leg) {
   return mustWait || mustWalk;
 }
 
-export function getFilteredLegsByWalkOrWaitTime(tripPattern: TripPattern) {
-  if (!!tripPattern?.legs?.length) {
-    return tripPattern.legs.filter((leg, i) =>
-      isSignificantFootLegWalkOrWaitTime(leg, tripPattern.legs[i + 1]),
-    );
-  } else {
-    return [];
-  }
+type LegFilterOptions = {
+  /**
+   * Keep the first and last leg however short they are. A walk at either end of
+   * the trip is what names where you actually start and end. Short walks
+   * *between* services stay filtered.
+   *
+   * false/turned off by default.
+   */
+  keepEndpointWalks?: boolean;
+};
+
+export function getFilteredLegsByWalkOrWaitTime(
+  tripPattern: TripPattern,
+  {keepEndpointWalks = false}: LegFilterOptions = {},
+) {
+  const legs = tripPattern?.legs;
+  if (!legs?.length) return [];
+
+  return legs.filter((leg, i) => {
+    if (keepEndpointWalks && (i === 0 || i === legs.length - 1)) return true;
+    return isSignificantFootLegWalkOrWaitTime(leg, legs[i + 1]);
+  });
 }
 
 export function canSellCollabTicket(tripPattern: TripPattern) {


### PR DESCRIPTION
## Issue reference
https://github.com/AtB-AS/kundevendt/issues/24494

## Description
The starting and trailing walk will now always be shown in the trip details if you search from place and not bus stop, since they are information that are relevant to the trip you searched. It will not be shown on the trip card because the walk is very short, and showing the transport you need to take is enough.

Trip header will now also correctly show the start-finish place name, instead of using the bus stop name as the start place name.

See video below for the fix (compare with the one in the issue):

https://github.com/user-attachments/assets/b2855bd3-8629-42e5-814d-2bee77672033
