### PR TITLE
fix: show trip receipt when a booking ends while the app is backgrounded

### DIFF
--- a/src/modules/map/MapBottomSheets.tsx
+++ b/src/modules/map/MapBottomSheets.tsx
@@ -37,6 +37,7 @@ import {useWindowDimensions} from 'react-native';
 import {useBottomNavigationStyles} from '@atb/utils/navigation';
 import {useBottomSheetContext} from '@atb/components/bottom-sheet';
 import {MapBottomSheetType, useMapContext} from './MapContext';
+import {useFinishedBookingDetection} from './hooks/use-finished-booking-detection';
 import {useIsFocusedAndActive} from '@atb/utils/use-is-focused-and-active';
 import {ShmoHelpParams} from '@atb/stacks-hierarchy';
 
@@ -84,6 +85,8 @@ export const MapBottomSheets = ({
   const isFocusedAndActive = useIsFocusedAndActive();
   const {data: activeBooking} = useActiveShmoBookingQuery(isFocusedAndActive);
   const {bottomSheetMapRef} = useBottomSheetContext();
+
+  useFinishedBookingDetection(isFocusedAndActive, dispatchMapState);
 
   const {height: screenHeight} = useWindowDimensions();
   const {minHeight: tabBarMinHeight} = useBottomNavigationStyles();

--- a/src/modules/map/MapContext.tsx
+++ b/src/modules/map/MapContext.tsx
@@ -8,7 +8,6 @@ import React, {
 import {MapFilterType} from '@atb/modules/map';
 import {useUserMapFilters} from './hooks/use-map-filter';
 import {
-  MapStateActionType,
   mapStateReducer,
   ReducerMapState,
   ReducerMapStateAction,
@@ -18,12 +17,6 @@ import {storage, StorageModelKeysEnum} from '@atb/modules/storage';
 import {Feature, GeoJsonProperties, Point} from 'geojson';
 import MapboxGL from '@rnmapbox/maps';
 import {useRemoteConfigContext} from '../remote-config';
-import {EventKind} from '../event-stream/types';
-import {ShmoBooking, ShmoBookingState} from '@atb/api/types/mobility';
-import {useQueryClient} from '@tanstack/react-query';
-import {getShmoBookingQueryKey} from '../mobility/queries/use-shmo-booking-query';
-import {languageGlobal} from '../locale';
-import {useEventStreamContext} from '../event-stream';
 
 type MapContextState = {
   mapFilter?: MapFilterType;
@@ -68,8 +61,6 @@ type Props = {
 
 export const MapContextProvider = ({children}: Props) => {
   const {mapbox_api_token} = useRemoteConfigContext();
-  const {useStreamEventListener} = useEventStreamContext();
-  const queryClient = useQueryClient();
   useEffect(() => {
     MapboxGL.setAccessToken(mapbox_api_token);
   }, [mapbox_api_token]);
@@ -101,21 +92,6 @@ export const MapContextProvider = ({children}: Props) => {
   });
 
   const [paddingBottomMap, setPaddingBottomMap] = useState(0);
-
-  useStreamEventListener(EventKind.ShmoBookingUpdated, (streamEvent) => {
-    const existingBooking: ShmoBooking | undefined = queryClient.getQueryData(
-      getShmoBookingQueryKey(streamEvent.bookingId, languageGlobal),
-    );
-    if (
-      existingBooking?.state !== ShmoBookingState.FINISHED &&
-      streamEvent.state === ShmoBookingState.FINISHED
-    ) {
-      dispatchMapState({
-        type: MapStateActionType.FinishedBooking,
-        bookingId: streamEvent.bookingId,
-      });
-    }
-  });
 
   return (
     <MapContext.Provider

--- a/src/modules/map/__tests__/use-finished-booking-detection.test.ts
+++ b/src/modules/map/__tests__/use-finished-booking-detection.test.ts
@@ -1,0 +1,144 @@
+import {renderHook, waitFor} from '@testing-library/react-native';
+import {useFinishedBookingDetection} from '../hooks/use-finished-booking-detection';
+import {MapStateActionType} from '../mapStateReducer';
+import {
+  clearPendingFinishedBooking,
+  getPendingFinishedBooking,
+  setPendingFinishedBooking,
+} from '../pending-finished-booking';
+
+const USER_ID_A = 'user-a';
+const USER_ID_B = 'user-b';
+const BOOKING_ID = 'booking-1';
+
+jest.mock('../mapStateReducer', () => ({
+  MapStateActionType: {FinishedBooking: 'FINISHED_BOOKING'},
+}));
+
+jest.mock('../pending-finished-booking', () => ({
+  getPendingFinishedBooking: jest.fn(),
+  setPendingFinishedBooking: jest.fn(),
+  clearPendingFinishedBooking: jest.fn(),
+}));
+
+let mockUserId: string | undefined;
+jest.mock('@atb/modules/auth', () => ({
+  useAuthContext: () => ({userId: mockUserId}),
+}));
+
+let mockActiveBookingQuery: {data: any; isSuccess: boolean};
+jest.mock('@atb/modules/mobility', () => ({
+  useActiveShmoBookingQuery: () => mockActiveBookingQuery,
+}));
+
+const mockedGetPending = getPendingFinishedBooking as jest.Mock;
+
+const renderDetection = () => {
+  const dispatchMapState = jest.fn();
+  const hook = renderHook(() =>
+    useFinishedBookingDetection(true, dispatchMapState),
+  );
+  return {...hook, dispatchMapState};
+};
+
+describe('useFinishedBookingDetection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserId = USER_ID_A;
+    mockedGetPending.mockResolvedValue(undefined);
+    mockActiveBookingQuery = {data: null, isSuccess: true};
+  });
+
+  it('stores the booking id while a booking is active', async () => {
+    mockActiveBookingQuery = {
+      data: {bookingId: BOOKING_ID},
+      isSuccess: true,
+    };
+    const {dispatchMapState} = renderDetection();
+
+    expect(setPendingFinishedBooking).toHaveBeenCalledWith({
+      bookingId: BOOKING_ID,
+      userId: USER_ID_A,
+    });
+    expect(dispatchMapState).not.toHaveBeenCalled();
+  });
+
+  it('opens the receipt when the active booking disappears', async () => {
+    mockedGetPending.mockResolvedValue({
+      bookingId: BOOKING_ID,
+      userId: USER_ID_A,
+    });
+    const {dispatchMapState} = renderDetection();
+
+    await waitFor(() =>
+      expect(dispatchMapState).toHaveBeenCalledWith({
+        type: MapStateActionType.FinishedBooking,
+        bookingId: BOOKING_ID,
+      }),
+    );
+    expect(clearPendingFinishedBooking).toHaveBeenCalled();
+  });
+
+  it('opens the receipt when a booking goes from active to gone', async () => {
+    mockedGetPending.mockResolvedValue({
+      bookingId: BOOKING_ID,
+      userId: USER_ID_A,
+    });
+    mockActiveBookingQuery = {
+      data: {bookingId: BOOKING_ID},
+      isSuccess: true,
+    };
+    const {dispatchMapState, rerender} = renderDetection();
+    expect(dispatchMapState).not.toHaveBeenCalled();
+
+    mockActiveBookingQuery = {data: null, isSuccess: true};
+    rerender({});
+
+    await waitFor(() =>
+      expect(dispatchMapState).toHaveBeenCalledWith({
+        type: MapStateActionType.FinishedBooking,
+        bookingId: BOOKING_ID,
+      }),
+    );
+  });
+
+  it('does not open the receipt when the booking could not be fetched', async () => {
+    mockedGetPending.mockResolvedValue({
+      bookingId: BOOKING_ID,
+      userId: USER_ID_A,
+    });
+    mockActiveBookingQuery = {data: undefined, isSuccess: false};
+    const {dispatchMapState} = renderDetection();
+
+    await waitFor(() => expect(mockedGetPending).not.toHaveBeenCalled());
+    expect(dispatchMapState).not.toHaveBeenCalled();
+    expect(clearPendingFinishedBooking).not.toHaveBeenCalled();
+  });
+
+  it('discards a booking belonging to another user', async () => {
+    mockedGetPending.mockResolvedValue({
+      bookingId: BOOKING_ID,
+      userId: USER_ID_B,
+    });
+    const {dispatchMapState} = renderDetection();
+
+    await waitFor(() => expect(clearPendingFinishedBooking).toHaveBeenCalled());
+    expect(dispatchMapState).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no stored booking', async () => {
+    const {dispatchMapState} = renderDetection();
+
+    await waitFor(() => expect(mockedGetPending).toHaveBeenCalled());
+    expect(dispatchMapState).not.toHaveBeenCalled();
+    expect(clearPendingFinishedBooking).not.toHaveBeenCalled();
+  });
+
+  it('does nothing before the user is known', async () => {
+    mockUserId = undefined;
+    const {dispatchMapState} = renderDetection();
+
+    await waitFor(() => expect(mockedGetPending).not.toHaveBeenCalled());
+    expect(dispatchMapState).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/map/hooks/use-finished-booking-detection.ts
+++ b/src/modules/map/hooks/use-finished-booking-detection.ts
@@ -1,0 +1,56 @@
+import React, {useEffect} from 'react';
+import {useAuthContext} from '@atb/modules/auth';
+import {useActiveShmoBookingQuery} from '@atb/modules/mobility';
+import {MapStateActionType, ReducerMapStateAction} from '../mapStateReducer';
+import {
+  clearPendingFinishedBooking,
+  getPendingFinishedBooking,
+  setPendingFinishedBooking,
+} from '../pending-finished-booking';
+
+/**
+ * Opens the receipt for a booking which has ended while we weren't looking.
+ *
+ * The active booking only exists while the booking is in a non-terminal state,
+ * so when it disappears the booking has been finished or cancelled. We can't
+ * rely on the booking event for this, as the event stream is only connected
+ * while the app is in the foreground, and delivers no events for the time it
+ * was disconnected.
+ */
+export const useFinishedBookingDetection = (
+  isFocusedAndActive: boolean,
+  dispatchMapState: React.Dispatch<ReducerMapStateAction>,
+) => {
+  const {userId} = useAuthContext();
+  const {data: activeBooking, isSuccess} =
+    useActiveShmoBookingQuery(isFocusedAndActive);
+  const activeBookingId = activeBooking?.bookingId;
+
+  useEffect(() => {
+    // Only a successful fetch tells us whether there is an active booking. A
+    // failed one also leaves us without booking data, and must not be mistaken
+    // for the booking having ended.
+    if (!isSuccess || !userId) return;
+
+    if (activeBookingId) {
+      setPendingFinishedBooking({bookingId: activeBookingId, userId});
+      return;
+    }
+
+    let isCancelled = false;
+    getPendingFinishedBooking().then((pendingFinishedBooking) => {
+      if (isCancelled || !pendingFinishedBooking) return;
+      clearPendingFinishedBooking();
+      // Belongs to a previous user, after a logout or an account switch.
+      if (pendingFinishedBooking.userId !== userId) return;
+      console.log('dispatching end booking');
+      dispatchMapState({
+        type: MapStateActionType.FinishedBooking,
+        bookingId: pendingFinishedBooking.bookingId,
+      });
+    });
+    return () => {
+      isCancelled = true;
+    };
+  }, [activeBookingId, isSuccess, userId, dispatchMapState]);
+};

--- a/src/modules/map/index.ts
+++ b/src/modules/map/index.ts
@@ -64,6 +64,7 @@ export {
   CUSTOM_SCAN_ZOOM_LEVEL,
 } from './utils';
 export {MapStateActionType} from './mapStateReducer.ts';
+export {clearPendingFinishedBooking} from './pending-finished-booking';
 export {useMapSelectionAnalytics} from './hooks/use-map-selection-analytics.tsx';
 export {MapButtons} from './components/MapButtons.tsx';
 export {TariffZoneLinesAndLabels} from './components/TariffZoneLinesAndLabels';

--- a/src/modules/map/pending-finished-booking.ts
+++ b/src/modules/map/pending-finished-booking.ts
@@ -1,0 +1,40 @@
+import {z} from 'zod';
+import {storage, StorageModelKeysEnum} from '@atb/modules/storage';
+import {jsonStringToObject} from '@atb/utils/object';
+
+/**
+ * The booking we have seen as active, but not yet shown a receipt for.
+ *
+ * The event stream only delivers events while the app is in the foreground, so
+ * a booking which is finished or cancelled while the phone is locked never
+ * reaches us. Keeping the id in storage lets us detect it afterwards, by seeing
+ * that the active booking has disappeared. The user id is stored alongside it
+ * so a booking is never shown to another user after a logout or account switch.
+ */
+const PendingFinishedBookingSchema = z.object({
+  bookingId: z.string(),
+  userId: z.string(),
+});
+
+type PendingFinishedBooking = z.infer<typeof PendingFinishedBookingSchema>;
+
+export const setPendingFinishedBooking = (
+  pendingFinishedBooking: PendingFinishedBooking,
+) =>
+  storage.set(
+    StorageModelKeysEnum.PendingFinishedBooking,
+    JSON.stringify(pendingFinishedBooking),
+  );
+
+export const getPendingFinishedBooking = async (): Promise<
+  PendingFinishedBooking | undefined
+> => {
+  const stored = await storage.get(StorageModelKeysEnum.PendingFinishedBooking);
+  const parsed = PendingFinishedBookingSchema.safeParse(
+    jsonStringToObject(stored),
+  );
+  return parsed.success ? parsed.data : undefined;
+};
+
+export const clearPendingFinishedBooking = () =>
+  storage.remove(StorageModelKeysEnum.PendingFinishedBooking);

--- a/src/modules/mobility/components/sheets/FinishedShmoSheet.tsx
+++ b/src/modules/mobility/components/sheets/FinishedShmoSheet.tsx
@@ -6,6 +6,7 @@ import {View} from 'react-native';
 import {MessageInfoBox} from '@atb/components/message-info-box';
 import {Button} from '@atb/components/button';
 import {FormFactor} from '@atb/api/types/generated/mobility-types_v2';
+import {ShmoBookingState} from '@atb/api/types/mobility';
 import {useFeatureTogglesContext} from '@atb/modules/feature-toggles';
 import {ShmoTripDetailsSectionItem} from '../ShmoTripDetailsSectionItem';
 import {GenericSectionItem, Section} from '@atb/components/sections';
@@ -103,7 +104,11 @@ export const FinishedShmoSheet = ({
                   <Section>
                     <GenericSectionItem>
                       <ThemeText typography="heading__m">
-                        {t(FareContractTexts.shmoDetails.tripEnded())}
+                        {t(
+                          shmoBooking.state === ShmoBookingState.CANCELLED
+                            ? FareContractTexts.shmoDetails.tripCancelled
+                            : FareContractTexts.shmoDetails.tripEnded(),
+                        )}
                       </ThemeText>
                     </GenericSectionItem>
 

--- a/src/modules/storage/StorageModel.tsx
+++ b/src/modules/storage/StorageModel.tsx
@@ -5,6 +5,7 @@ export enum StorageModelKeysEnum {
   PreviousPaymentMethods = '@ATB_previous_payment_methods',
   ScooterConsent = '@ATB_scooter_consent',
   BicycleConsent = '@ATB_bicycle_consent',
+  PendingFinishedBooking = '@ATB_pending_finished_booking',
 }
 
 type StorageModelKeysTypes = keyof typeof StorageModelKeysEnum;

--- a/src/stacks-hierarchy/Root_ParkingPhotoScreen.tsx
+++ b/src/stacks-hierarchy/Root_ParkingPhotoScreen.tsx
@@ -10,7 +10,11 @@ import {PhotoCapture} from '@atb/components/PhotoCapture';
 import {PhotoFile} from '@atb/components/camera';
 import {View} from 'react-native';
 import {StyleSheet} from '@atb/theme';
-import {MapStateActionType, useMapContext} from '@atb/modules/map';
+import {
+  clearPendingFinishedBooking,
+  MapStateActionType,
+  useMapContext,
+} from '@atb/modules/map';
 import {compressImageToBase64} from '@atb/utils/image';
 import {useCallback} from 'react';
 import {useFocusOnLoad} from '@atb/utils/use-focus-on-load';
@@ -76,6 +80,9 @@ export const Root_ParkingPhotoScreen = ({
       await onEndTrip(route.params.bookingId, base64data);
     }
 
+    // The receipt is shown right away here, so the booking disappearing from
+    // the active booking query shouldn't open it a second time.
+    clearPendingFinishedBooking();
     dispatchMapState({
       type: MapStateActionType.FinishedBooking,
       bookingId: route.params.bookingId,

--- a/src/translations/screens/FareContract.ts
+++ b/src/translations/screens/FareContract.ts
@@ -62,6 +62,7 @@ const FareContractTexts = {
         `Trip ended ${dateTime ?? ''}`,
         `Tur avsluttet ${dateTime ?? ''}`,
       ),
+    tripCancelled: _('Tur kansellert', 'Trip cancelled', 'Tur kansellert'),
   },
   details: {
     header: {


### PR DESCRIPTION
## Issue Reference

Closes https://github.com/AtB-AS/kundevendt/issues/24493

## Description

When a trip ended while the phone was locked in the user's pocket, the receipt sheet never appeared.

The receipt was triggered by a `SHMO_BOOKING_UPDATED` event from the event stream. That stream is a WebSocket with no replay — when the OS suspends the app the socket dies, and on reconnect the server only sends events from that point on. Any booking finished while backgrounded produced an event that was simply never delivered, so the listener never ran.

This replaces the event trigger with a reconciliation against server state. The active booking only exists while a booking is in a non-terminal state, so its disappearance *is* the signal that the trip ended. The id of the booking we've seen as active is kept in AsyncStorage, which lets us recognise it after the fact — including across an app restart.

On unlock, `refetchOnWindowFocus` refetches the active booking, it comes back `null`, and the stored id tells us which receipt to open.

### Notable details

- **Only a successful fetch counts.** A failed refetch also leaves us without booking data, and must not be mistaken for the booking having ended — otherwise going offline mid-trip would pop a receipt for a trip still running.
- **The stored id carries a `userId`**, so a booking is never shown to another user after a logout or account switch. Comparing on read avoids clearing the id on every cold start, which watching `userId` for changes would have done.
- **The listener in `MapContext` is removed** rather than kept as a fast path. `useGlobalEventStreamListeners` already invalidates the active booking query on the same event, so the foreground case now flows through the same single path at the same latency.
- **Cancelled bookings show the receipt too**, so it's clear no money was charged. The sheet already degrades to `00:00` / `0 kr`; only the heading needed a new string.
- `Root_ParkingPhotoScreen` shows the receipt immediately after the photo upload, so it clears the stored id to avoid the sheet reopening once the query catches up.

### Testing

7 unit tests for the detection hook. Manually verified on device.

Note: `tsc` and 4 test suites fail on `master` already (`@react-native-firebase` typings, missing `@atb-as/utils` exports). Unrelated to this change and unaffected by it.
