### PR TITLE
refactor: remove usage of interactive sets 1 and 3

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -30,7 +30,7 @@ type ButtonModeAwareProps =
   | {mode?: 'primary'}
   | {
       mode: Exclude<ButtonMode, 'primary'>;
-      backgroundColor: ContrastColor;
+      backgroundColor?: ContrastColor;
     };
 
 export type ButtonProps = {
@@ -225,6 +225,11 @@ const getButtonColors = (
     ? props.interactiveColor
     : theme.color.interactive[0];
 
+  const transparentContrastColor: ContrastColor = {
+    background: 'transparent',
+    foreground: theme.color.foreground.dynamic,
+  };
+
   switch (props.mode) {
     case 'primary':
     case undefined:
@@ -236,20 +241,24 @@ const getButtonColors = (
           ? interactiveColor.outline.background
           : interactiveColor.default.background,
       };
-    case 'secondary':
+    case 'secondary': {
+      const backgroundColor = props.backgroundColor ?? transparentContrastColor;
       return {
         mainContrastColor: props.active
           ? interactiveColor.active
-          : props.backgroundColor,
+          : backgroundColor,
         borderColorValue: props.active
           ? interactiveColor.outline.background
-          : props.backgroundColor.foreground.primary,
+          : backgroundColor.foreground.primary,
       };
-    case 'tertiary':
+    }
+    case 'tertiary': {
+      const backgroundColor = props.backgroundColor ?? transparentContrastColor;
       return {
-        mainContrastColor: props.backgroundColor,
-        borderColorValue: props.backgroundColor.background,
+        mainContrastColor: backgroundColor,
+        borderColorValue: backgroundColor.background,
       };
+    }
   }
 };
 

--- a/src/components/empty-state/EmptyState.tsx
+++ b/src/components/empty-state/EmptyState.tsx
@@ -25,7 +25,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
 }) => {
   const styles = useStyles();
   const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[3];
+  const interactiveColor = theme.color.interactive[2];
 
   return (
     <View
@@ -53,7 +53,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
             expanded={false}
             interactiveColor={interactiveColor}
             text={buttonProps.text}
-            mode="primary"
+            mode="secondary"
             onPress={buttonProps.onPress}
             type="small"
           />

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -23,7 +23,7 @@ export function Toggle({
 }: Props) {
   const [checked, setChecked] = useState(value);
   const {theme} = useThemeContext();
-  const interactiveColorValue = interactiveColor ?? theme.color.interactive[1];
+  const interactiveColorValue = interactiveColor ?? theme.color.interactive[2];
   const backgroundColor = theme.color.background.neutral[3].background;
   const fontScale = useFontScale();
   const scale = Math.min(1.5, Math.max(fontScale, 1));

--- a/src/modules/storybook/stories/Toggle.stories.tsx
+++ b/src/modules/storybook/stories/Toggle.stories.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Toggle} from '@atb/components/toggle';
+import {
+  ThemedStoryDecorator,
+  ThemedStoryProps,
+  themedStoryControls,
+  themedStoryDefaultArgs,
+} from '../ThemedStoryDecorator';
+import {Meta} from '@storybook/react';
+import {themes} from '@atb/theme/colors';
+
+type ToggleProps = React.ComponentProps<typeof Toggle>;
+
+type ToggleMetaProps = ThemedStoryProps<
+  ToggleProps & {interactiveColorType: string}
+>;
+
+const ToggleMeta: Meta<ToggleMetaProps> = {
+  title: 'Toggle',
+  component: Toggle,
+  argTypes: {
+    interactiveColorType: {
+      options: [...Object.keys(themes['light'].color.interactive)],
+      control: {
+        type: 'select',
+      },
+    },
+    ...themedStoryControls,
+  },
+  args: {
+    interactiveColorType: '2',
+    ...themedStoryDefaultArgs,
+  },
+  decorators: [
+    (Story, {args}) => {
+      const interactiveColors = themes[args.theme].color.interactive;
+      const storyInteractiveColor =
+        interactiveColors[
+          args.interactiveColorType as keyof typeof interactiveColors
+        ];
+      return (
+        <View
+          style={{
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+            padding: 12,
+            flex: 1,
+            rowGap: 12,
+          }}
+        >
+          <Story
+            args={{
+              ...args,
+              value: true,
+              interactiveColor: storyInteractiveColor,
+            }}
+          />
+          <Story
+            args={{
+              ...args,
+              value: false,
+              interactiveColor: storyInteractiveColor,
+            }}
+          />
+          <Story
+            args={{
+              ...args,
+              value: true,
+              disabled: true,
+              interactiveColor: storyInteractiveColor,
+            }}
+          />
+          <Story
+            args={{
+              ...args,
+              value: false,
+              disabled: true,
+              interactiveColor: storyInteractiveColor,
+            }}
+          />
+        </View>
+      );
+    },
+    ThemedStoryDecorator,
+  ],
+};
+
+export default ToggleMeta;
+
+export const Basic = {};

--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -846,6 +846,7 @@ const FavoriteButton = ({
   return (
     <>
       <Button
+        mode="secondary"
         type="small"
         expanded={false}
         leftIcon={{svg: getFavoriteIcon(existingFavorite)}}

--- a/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
+++ b/src/screen-components/travel-details-screens/DepartureDetailsScreenComponent.tsx
@@ -113,7 +113,7 @@ export const DepartureDetailsScreenComponent = ({
 }: Props) => {
   const [activeItemIndexState, setActiveItem] = useState(activeItemIndex);
   const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[1];
+  const interactiveColor = theme.color.interactive[2];
   const ctaColor = theme.color.interactive[0];
   const backgroundColor = theme.color.background.neutral[1];
   const themeColor = theme.color.background.neutral[1];
@@ -337,6 +337,7 @@ export const DepartureDetailsScreenComponent = ({
                 {shouldShowMapButton && (
                   <View style={{flex: 1}}>
                     <Button
+                      mode="secondary"
                       type="small"
                       expanded={true}
                       leftIcon={{svg: Map}}
@@ -849,7 +850,7 @@ const FavoriteButton = ({
         expanded={false}
         leftIcon={{svg: getFavoriteIcon(existingFavorite)}}
         text={t(FavoriteDeparturesTexts.favoriteButton)}
-        interactiveColor={theme.color.interactive['1']}
+        interactiveColor={theme.color.interactive['0']}
         accessibilityLabel={
           existingFavorite &&
           (existingFavorite.destinationDisplay

--- a/src/screen-components/travel-details-screens/components/BookingOptions.tsx
+++ b/src/screen-components/travel-details-screens/components/BookingOptions.tsx
@@ -62,9 +62,10 @@ export const BookingOptions = ({bookingArrangements}: Props) => {
               TripDetailsTexts.flexibleTransport.bookByPhone(bookingPhone),
             )}
             onPress={() => openUrl(`tel:${bookingPhone}`)}
+            mode="secondary"
             type="small"
             expanded={false}
-            interactiveColor={theme.color.interactive[3]}
+            interactiveColor={theme.color.interactive[2]}
             leftIcon={{svg: Phone}}
           />
         </View>

--- a/src/screen-components/travel-details-screens/components/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/components/TripSection.tsx
@@ -976,7 +976,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   const style = useSectionStyles();
   const {t} = useTranslation();
   const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[3];
+  const interactiveColor = theme.color.interactive[2];
 
   if (id === AUTHORITY) return null;
   if (!url) {
@@ -1005,7 +1005,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
           )}
           leftIcon={{svg: ExternalLink}}
           onPress={() => url && openUrl(url)}
-          mode="primary"
+          mode="secondary"
           type="small"
           expanded={false}
           interactiveColor={interactiveColor}

--- a/src/screen-components/travel-details-screens/legacy/TripSection.tsx
+++ b/src/screen-components/travel-details-screens/legacy/TripSection.tsx
@@ -330,11 +330,12 @@ export const LegacyTripSection: React.FC<TripSectionProps> = ({
         {onPressShowLive && serviceJourneyPolyline ? (
           <TripRow>
             <Button
+              mode="secondary"
               type="small"
               expanded={false}
               leftIcon={{svg: Map}}
               text={t(TripDetailsTexts.trip.leg.live(t(translatedModeName)))}
-              interactiveColor={theme.color.interactive[3]}
+              interactiveColor={theme.color.interactive[2]}
               onPress={() => onPressShowLive(serviceJourneyPolyline)}
             />
           </TripRow>
@@ -539,7 +540,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
   const style = useSectionStyles();
   const {t} = useTranslation();
   const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[3];
+  const interactiveColor = theme.color.interactive[2];
 
   if (id === AUTHORITY) return null;
   if (!url) {
@@ -566,7 +567,7 @@ const AuthorityRow = ({id, name, url}: AuthorityFragment) => {
           )}
           leftIcon={{svg: ExternalLink}}
           onPress={() => url && openUrl(url)}
-          mode="primary"
+          mode="secondary"
           type="small"
           expanded={false}
           interactiveColor={interactiveColor}

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_DashboardStack/Dashboard_TripSearchScreen/components/CityZoneMessage.tsx
@@ -18,7 +18,6 @@ import {Close} from '@atb/assets/svg/mono-icons/actions';
 import {Section} from '@atb/components/sections';
 import CityBoxMessageTexts from '@atb/translations/components/CityBoxMessage';
 import {useFirestoreConfigurationContext} from '@atb/modules/configuration';
-import {InteractiveColor} from '@atb/theme/colors';
 import {Phone} from '@atb/assets/svg/mono-icons/devices';
 import {CityZone} from '@atb/modules/configuration';
 import {useAnalyticsContext} from '@atb/modules/analytics';
@@ -29,10 +28,10 @@ import {openInAppBrowser} from '@atb/modules/in-app-browser';
 type ActionButton = {
   id: string;
   text: string;
-  interactiveColor: InteractiveColor;
   icon?: (props: SvgProps) => React.JSX.Element;
   accessibilityHint?: string;
   onPress: () => void;
+  secondary?: boolean;
 };
 
 export type CityZoneMessageProps = {
@@ -102,8 +101,8 @@ const CityZoneBox = ({message, actionButtons, onDismiss}: CityZoneBoxProps) => {
               <Button
                 expanded={false}
                 key={actionButton.id}
+                mode={actionButton.secondary ? 'secondary' : 'primary'}
                 type="small"
-                interactiveColor={actionButton.interactiveColor}
                 text={actionButton.text}
                 onPress={actionButton.onPress}
                 accessibilityLabel={actionButton.text}
@@ -134,9 +133,6 @@ const CityZoneBox = ({message, actionButtons, onDismiss}: CityZoneBoxProps) => {
 
 const useActionButtons = (cityZone?: CityZone) => {
   const {t, language} = useTranslation();
-  const {theme} = useThemeContext();
-  const interactiveColor = theme.color.interactive[0];
-  const interactiveAccentColor = theme.color.interactive[3];
   const analytics = useAnalyticsContext();
 
   if (!cityZone) {
@@ -150,7 +146,6 @@ const useActionButtons = (cityZone?: CityZone) => {
       id: `book_online_action`,
       text: t(CityBoxMessageTexts.actionButtons.bookOnline),
       icon: ExternalLink,
-      interactiveColor: interactiveColor,
       accessibilityHint: t(dictionary.appNavigation.a11yHintForExternalContent),
       onPress: () => {
         analytics.logEvent('Flexible transport', 'Book online url opened', {
@@ -168,7 +163,6 @@ const useActionButtons = (cityZone?: CityZone) => {
       id: `book_by_phone_action`,
       icon: Phone,
       text: t(CityBoxMessageTexts.actionButtons.bookByPhone),
-      interactiveColor: interactiveColor,
       accessibilityHint: t(CityBoxMessageTexts.a11yHintForPhone),
       onPress: () => {
         analytics.logEvent('Flexible transport', 'Book by phone url opened', {
@@ -186,7 +180,7 @@ const useActionButtons = (cityZone?: CityZone) => {
       id: `more_info_action`,
       icon: ExternalLink,
       text: t(CityBoxMessageTexts.actionButtons.moreInfo),
-      interactiveColor: interactiveAccentColor,
+      secondary: true,
       accessibilityHint: t(dictionary.appNavigation.a11yHintForExternalContent),
       onPress: () => {
         analytics.logEvent('Flexible transport', 'More info url opened', {

--- a/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/components/DebugOverride.tsx
+++ b/src/stacks-hierarchy/Root_TabNavigatorStack/TabNav_ProfileStack/components/DebugOverride.tsx
@@ -18,7 +18,7 @@ export const DebugOverride = ({name, overrideVal, setOverride}: Props) => {
       <ThemeText typography="heading__m">{cleanUpDescription(name)}</ThemeText>
       <RadioSegments
         activeIndex={overrideVal ? 2 : overrideVal === undefined ? 1 : 0}
-        color={theme.color.interactive[3]}
+        color={theme.color.interactive[2]}
         style={{marginTop: theme.spacing.small}}
         options={[
           {


### PR DESCRIPTION
The main change is making buttons that used interactive sets 1 and
3 secondary instead.

Also made the backgroundColor prop on secondary/tertiary buttons
optional. It is seldom necessary anymore as the app now is mainly
light in light mode and dark it dark mode. Having it obligatory
was more risk than benefit, as passing the wrong background color
prop would give wrong background color on the button.

Some reference images in linked issue.
